### PR TITLE
Add Discovery-contract + service class

### DIFF
--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -10,6 +10,7 @@ discovery_contract_compiled = _solidity.compile_contract(
 )
 DISCOVERY_CONTRACT_ABI = discovery_contract_compiled['abi']
 
+
 class Discovery(object):
     """ Mock mapping address: host, port """
 
@@ -33,24 +34,25 @@ class Discovery(object):
 
         assert False
 
+
 class ContractDiscovery(Discovery):
     """
     This is the place where ethereum addresses are registered to their network sockets
     """
-    def __init__(self,rpc_client,discovery_contract_address):
+    def __init__(self, rpc_client, discovery_contract_address):
         self.discovery_proxy = rpc_client.new_abi_contract(
             DISCOVERY_CONTRACT_ABI,
             discovery_contract_address.encode('hex'),
         )
 
-    def register_endpoint(self,host,port):
-        self.discovery_proxy.registerEndpoint(''.join([host,':',port]))
+    def register_endpoint(self, host, port):
+        self.discovery_proxy.registerEndpoint(''.join([host, ':', port]))
 
-    def update_endpoint(self,host,port):
-        self.discovery_proxy.updateEndpoint(''.join([host,':',port]))
+    def update_endpoint(self, host, port):
+        self.discovery_proxy.updateEndpoint(''.join([host, ':', port]))
 
-    def find_endpoint(self,nodeid):
+    def find_endpoint(self, nodeid):
         return self.discovery_proxy.findEndpointByAddress(nodeid.encode('hex'))
 
-    def find_address(self,host,port):
-        return self.discovery_proxy.findAddressByEndpoint(''.join([host,':',port]))
+    def find_address(self, host, port):
+        return self.discovery_proxy.findAddressByEndpoint(''.join([host, ':', port]))

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -354,6 +354,7 @@ def deployed_network(request, private_keys, channels_per_node, deposit,
 
 @pytest.fixture
 def discovery_blockchain(request, private_keys, geth_cluster, poll_timeout):
+    gevent.sleep(2)
     privatekey = private_keys[0]
     address = privtoaddr(privatekey)
 

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -45,4 +45,5 @@ def test_discovery_contract(discovery_blockchain):
     contract_discovery_instance.register_endpoint('127.0.0.1', '4001')
     gevent.sleep(30)  # FIXME: this should not be necessary!
     assert contract_discovery_instance.find_address('127.0.0.1', '4001') == address.encode('hex')
-    assert contract_discovery_instance.find_endpoint(address) == '127.0.0.1:4001'
+    assert contract_discovery_instance.update_endpoint('192.162.0.1','4002')
+    assert contract_discovery_instance.find_address('192.162.0.1','4002') == address.encode('hex')

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -43,5 +43,5 @@ def test_discovery_contract(discovery_blockchain):
     contract_discovery_instance, address = discovery_blockchain
     assert isinstance(contract_discovery_instance, ContractDiscovery)
     contract_discovery_instance.register_endpoint('127.0.0.1', '4001')
-    gevent.sleep(10)  # FIXME: this should not be necessary!
+    gevent.sleep(30)  # FIXME: this should not be necessary!
     assert contract_discovery_instance.find_address('127.0.0.1', '4001') == address.encode('hex')

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -45,3 +45,4 @@ def test_discovery_contract(discovery_blockchain):
     contract_discovery_instance.register_endpoint('127.0.0.1', '4001')
     gevent.sleep(30)  # FIXME: this should not be necessary!
     assert contract_discovery_instance.find_address('127.0.0.1', '4001') == address.encode('hex')
+    assert contract_discovery_instance.find_endpoint(address) == '127.0.0.1:4001'

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -36,7 +36,8 @@ def test_endpointregistry():
     assert events[1]['_event_type'] == 'AddressUpdated'
 
 
-@pytest.mark.xfail()
+@pytest.mark.parametrize('number_of_nodes', [1])
+@pytest.mark.parametrize('poll_timeout', [50])
 def test_discovery_contract(discovery_blockchain):
     contract_discovery_instance, address = discovery_blockchain
     assert isinstance(contract_discovery_instance, ContractDiscovery)

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -1,6 +1,7 @@
 # -*- coding: utf8 -*-
 import pytest
 
+import gevent
 from ethereum import tester
 from ethereum.slogging import configure
 
@@ -42,4 +43,5 @@ def test_discovery_contract(discovery_blockchain):
     contract_discovery_instance, address = discovery_blockchain
     assert isinstance(contract_discovery_instance, ContractDiscovery)
     contract_discovery_instance.register_endpoint('127.0.0.1', '4001')
+    gevent.sleep(10)  # FIXME: this should not be necessary!
     assert contract_discovery_instance.find_address('127.0.0.1', '4001') == address.encode('hex')

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -45,5 +45,11 @@ def test_discovery_contract(discovery_blockchain):
     contract_discovery_instance.register_endpoint('127.0.0.1', '4001')
     gevent.sleep(30)  # FIXME: this should not be necessary!
     assert contract_discovery_instance.find_address('127.0.0.1', '4001') == address.encode('hex')
-    assert contract_discovery_instance.update_endpoint('192.162.0.1','4002')
-    assert contract_discovery_instance.find_address('192.162.0.1','4002') == address.encode('hex')
+    gevent.sleep(30)
+    assert contract_discovery_instance.find_endpoint(address) == '127.0.0.1:4001'
+    gevent.sleep(30)
+    contract_discovery_instance.update_endpoint('192.168.0.1','4002')
+    gevent.sleep(30)
+    assert contract_discovery_instance.find_address('192.168.0.1','4002') == address.encode('hex')
+    gevent.sleep(30)
+    assert contract_discovery_instance.find_endpoint(address) == '192.168.0.1:4002'


### PR DESCRIPTION
This gives us a rough-on-the-edges but decentralized discovery service, so clients can register their endpoints automatically.