### PR TITLE
Accept optional (http/https) protocols and optional port for rpc ends

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -54,6 +54,6 @@ def host_port_to_endpoint(host, port):
 
 
 def split_endpoint(endpoint):
-    host, port = endpoint.split(':')
+    host, port = endpoint.split(':')[:2]
     port = int(port)
     return (host, port)


### PR DESCRIPTION
Enables raiden to receive an rpc endpoint as URL.

Now can accept: `https://host:port`, `https://host`, `http://host:port`, `http://host`, `host:port`.

Making `https` connections requires an update to `pyethapp`.