### PR TITLE
Remove hydrachain dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,15 +74,9 @@ install: clean
 
 logging_settings = :info,contracts:debug
 mkfile_root := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
-stop:
-	killall hydrachain
 
 stop-geth:
 	killall -15 geth
-
-blockchain:
-	rm -f blockchain.log
-	-(hydrachain -d $(shell mktemp -d) -l $(logging_settings) -c p2p.listen_host="127.0.0.1" -c discovery.listen_host="127.0.0.1" -c jsonrpc.corsdomain='http://localhost:8080' --log-file=blockchain.log runmultiple > /dev/null 2>&1 &)
 
 blockchain-geth:
 	rm -f blockchain.log

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -7,7 +7,6 @@ from ethereum.keys import PBKDF2_CONSTANTS
 
 from raiden.tests.fixtures import *
 
-# otherwise running hydrachain will block the test
 gevent.monkey.patch_socket()
 gevent.get_hub().SYSTEM_ERROR = BaseException
 PBKDF2_CONSTANTS['c'] = 100
@@ -16,11 +15,10 @@ PBKDF2_CONSTANTS['c'] = 100
 def pytest_addoption(parser):
     parser.addoption(
         '--blockchain-type',
-        choices=['hydrachain', 'geth', 'tester', 'mock'],
+        choices=['geth', 'tester', 'mock'],
         default='geth',
     )
 
-    # might not work with all the hydrachain's loggers
     parser.addoption(
         '--log-config',
         default=None,
@@ -31,8 +29,7 @@ def pytest_addoption(parser):
 def logging_level(request):
     """ Configure the logging level.
 
-    For integration tests this also sets the geth verbosity and the hydrachain
-    loggers.
+    For integration tests this also sets the geth verbosity.
     """
     if request.config.option.log_config is not None:
         slogging.configure(request.config.option.log_config)

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -18,7 +18,6 @@ from raiden.network.rpc.client import (
 )
 from raiden.tests.utils.blockchain import (
     geth_create_blockchain,
-    hydrachain_create_blockchain,
 )
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -58,7 +57,7 @@ def assets_addresses(asset_amount, number_of_assets, blockchain_services):
 def blockchain_services(request, private_keys, poll_timeout, blockchain_backend, blockchain_type, tester_blockgas_limit):
     verbose = request.config.option.verbose
 
-    if blockchain_type in ('geth', 'hydrachain'):
+    if blockchain_type in ('geth',):
         return _jsonrpc_services(
             private_keys,
             verbose,
@@ -93,15 +92,6 @@ def blockchain_backend(request, private_keys, blockchain_private_keys,
             tmpdir,
         )
 
-    if blockchain_type == 'hydrachain':
-        return _hydrachain_blockchain(
-            request,
-            private_keys,
-            blockchain_private_keys,
-            blockchain_p2p_base_port,
-            tmpdir,
-        )
-
     if blockchain_type == 'tester':
         return ()
 
@@ -110,25 +100,6 @@ def blockchain_backend(request, private_keys, blockchain_private_keys,
 
     # check pytest_addoption
     raise ValueError('unknow cluster type {}'.format(blockchain_type))
-
-
-def _hydrachain_blockchain(request, private_keys, cluster_private_keys, p2p_base_port, tmpdir):
-    """ Helper to do proper cleanup. """
-    hydrachain_apps = hydrachain_create_blockchain(
-        private_keys,
-        cluster_private_keys,
-        p2p_base_port,
-        str(tmpdir),
-    )
-
-    def _cleanup():
-        for app in hydrachain_apps:
-            app.stop()
-
-        cleanup_tasks()
-
-    request.addfinalizer(_cleanup)
-    return hydrachain_apps
 
 
 def _geth_blockchain(request, private_keys, cluster_private_keys, p2p_base_port, tmpdir):

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -52,7 +52,7 @@ def channels_per_node():
 
 @pytest.fixture
 def poll_timeout():
-    """ Timeout in seconds for polling a cluster. Used for geth and hydrachain. """
+    """ Timeout in seconds for polling a cluster. Used for geth. """
     return DEFAULT_POLL_TIMEOUT
 
 
@@ -98,7 +98,7 @@ def blockchain_type(request):
 @pytest.fixture
 def blockchain_number_of_nodes():
     """ Number of nodes in a the cluster, not the same as the number of raiden
-    nodes. Used for all hydrachain and geth clusters and ignored for tester and
+    nodes. Used for all geth clusters and ignored for tester and
     mock.
     """
     return 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ ethereum-serpent
 u-msgpack-python
 repoze.lru
 gevent-websocket==0.9.4
-hydrachain>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ history = ''
 
 
 install_requires_replacements = {
-    'https://github.com/HydraChain/hydrachain/tarball/develop': 'hydrachain',
 }
 
 install_requires = list(set(

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,20 +1,7 @@
 ### Setup a local blockchain
 
-#### Hydrachain
-If you want to deploy the code in a hydrachain node, you need to start the blockchain:
-```
-make blockchain
-```
-# you should tail the file `blockchain.log` in order to see the network is up:
-````
-tail blockchain.log |grep "CachedBlock(\#10"
-2016-05-19 11:38:22,698 INFO:hdc.chainservice   new head head=<CachedBlock(#10 712fc415)>
-2016-05-19 11:38:22,722 INFO:hdc.chainservice   new head head=<CachedBlock(#10 712fc415)>
-2016-05-19 11:38:22,757 INFO:hdc.chainservice   new head head=<CachedBlock(#10 712fc415)>
-```
-
 #### go-ethereum
-Alternatively, there is also the option to start a go-ethereum (`geth`) cluster:
+There is the option to start a go-ethereum (`geth`) cluster:
 ```
 make blockchain-geth
 ```
@@ -24,5 +11,5 @@ make blockchain-geth
 make deploy
 
 # to start over:
-make stop
+make stop-geth
 ```


### PR DESCRIPTION
Dependencies are already tough -- removing hydrachain makes it a little
easier to keep up with all dependent versions. Also, hydrachain added
little value to the current testing framework (where it was used exclusively).