### PR TITLE
Use static solc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ python:
 cache:
   directories:
       - ~/.ethash
+      - ~/.bin
 before_install:
 - sudo add-apt-repository -y ppa:ethereum/ethereum
 - sudo apt-get update
-- sudo apt-get install -y solc ethereum
+- sudo apt-get install -y ethereum
 - mkdir -p ~/.ethash
 - geth makedag 0 ~/.ethash
+- mkdir -p ~/.bin
+- curl -L https://github.com/rainbeam/solidity-static/releases/download/v0.3.6/solc > ~/.bin/solc
+- chmod +x ~/.bin/solc
+- export PATH=$PATH:~/.bin
 install:
 - pip install -r requirements.txt
 - pip install coveralls

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -155,6 +155,8 @@ def _jsonrpc_services(private_keys, verbose, poll_timeout):
         blockchain = BlockChainService(
             privkey,
             registry_address,
+            '0.0.0.0',
+            jsonrpc_client.port,
         )
         blockchain_services.append(blockchain)
 


### PR DESCRIPTION
This uses a static version of `solc` from https://github.com/rainbeam/solidity-static/releases on travis-ci.

Note: this also includes a fix for an issue with the test fixtures that became only apparent after fixing solidity.