### PR TITLE
Move `get_contract_path` out of abi module

### DIFF
--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -1,14 +1,9 @@
 # -*- coding: utf8 -*-
-import os
-
 from ethereum import _solidity
 from ethereum.abi import event_id, normalize_name
-
-import raiden
+from raiden.utils import get_contract_path
 
 __all__ = (
-    'get_contract_path',
-
     'REGISTRY_ABI',
     'ASSETADDED_EVENT',
     'ASSETADDED_EVENTID',
@@ -29,12 +24,6 @@ __all__ = (
 
     'HUMAN_TOKEN_ABI',
 )
-
-
-def get_contract_path(contract_name):
-    project_directory = os.path.dirname(raiden.__file__)
-    contract_path = os.path.join(project_directory, 'smart_contracts', contract_name)
-    return os.path.realpath(contract_path)
 
 
 def get_event(full_abi, event_name):

--- a/raiden/console.py
+++ b/raiden/console.py
@@ -15,8 +15,7 @@ from gevent.event import Event
 from IPython.lib.inputhook import inputhook_manager
 
 from raiden.messages import Ping
-from raiden.blockchain.abi import get_contract_path
-from raiden.utils import events
+from raiden.utils import events, get_contract_path
 
 from pyethapp.utils import bcolors as bc
 from pyethapp.console_service import GeventInputHook, SigINTHandler

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -6,8 +6,8 @@ from raiden.utils import (
     isaddress,
     pex,
     split_endpoint,
+    get_contract_path,
 )
-from raiden.blockchain.abi import get_contract_path
 from raiden.network.rpc.client import DEFAULT_POLL_TIMEOUT
 
 discovery_contract_compiled = _solidity.compile_contract(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -9,8 +9,7 @@ from pyethapp.jsonrpc import address_encoder, address_decoder, data_decoder
 from pyethapp.rpc_client import topic_encoder, JSONRPCClient
 
 from raiden import messages
-from raiden.blockchain.abi import get_contract_path
-from raiden.utils import pex, isaddress, privatekey_to_address
+from raiden.utils import get_contract_path, pex, isaddress, privatekey_to_address
 from raiden.blockchain.abi import (
     HUMAN_TOKEN_ABI,
     CHANNEL_MANAGER_ABI,

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -6,8 +6,7 @@ from ethereum import slogging
 from ethereum._solidity import compile_file
 from pyethapp.rpc_client import JSONRPCClient
 
-from raiden.blockchain.abi import get_contract_path
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, get_contract_path
 from raiden.tests.fixtures.tester import tester_state
 from raiden.tests.utils.mock_client import BlockChainServiceMock, MOCK_REGISTRY_ADDRESS
 from raiden.tests.utils.tests import cleanup_tasks

--- a/raiden/tests/fixtures/tester.py
+++ b/raiden/tests/fixtures/tester.py
@@ -7,9 +7,9 @@ from ethereum import tester
 from ethereum.utils import int_to_addr, zpad
 from pyethapp.jsonrpc import address_decoder, data_decoder, quantity_decoder
 
-from raiden.blockchain.abi import get_contract_path
+
 from raiden.raiden_service import DEFAULT_REVEAL_TIMEOUT
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, get_contract_path
 from raiden.tests.utils.blockchain import DEFAULT_BALANCE
 from raiden.tests.utils.tester import (
     create_registryproxy,

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -7,9 +7,8 @@ from ethereum._solidity import compile_file
 from ethereum.utils import denoms
 from pyethapp.rpc_client import JSONRPCClient
 
-from raiden.blockchain.abi import get_contract_path
 from raiden.network.rpc.client import decode_topic, patch_send_transaction
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, get_contract_path
 
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 

--- a/raiden/tests/integration/test_endpointregistry.py
+++ b/raiden/tests/integration/test_endpointregistry.py
@@ -3,8 +3,7 @@ import pytest
 
 from ethereum import _solidity
 
-from raiden.utils import make_address
-from raiden.blockchain.abi import get_contract_path
+from raiden.utils import make_address, get_contract_path
 from raiden.network.discovery import ContractDiscovery
 
 

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -3,9 +3,9 @@ import pytest
 
 from ethereum import tester
 from ethereum.utils import encode_hex, sha3
+from raiden.utils import get_contract_path
 from ethereum.tester import ABIContract, ContractTranslator, TransactionFailed
 
-from raiden.blockchain.abi import get_contract_path
 from raiden.tests.utils.tester import new_channelmanager
 
 

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -1,8 +1,6 @@
 # -*- coding: utf8 -*-
-import pytest
 from ethereum import tester
-
-from raiden.blockchain.abi import get_contract_path
+from raiden.utils import get_contract_path
 
 
 def test_endpointregistry(tester_state, tester_events):

--- a/raiden/tests/smart_contracts/test_token.py
+++ b/raiden/tests/smart_contracts/test_token.py
@@ -3,7 +3,7 @@ import os
 
 from ethereum import tester
 
-from raiden.blockchain.abi import get_contract_path
+from raiden.utils import get_contract_path
 
 
 def test_token():

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -9,8 +9,7 @@ from pyethapp.jsonrpc import address_decoder
 from pyethapp.rpc_client import deploy_dependencies_symbols, dependencies_order_of_build
 
 from raiden import messages
-from raiden.blockchain.abi import get_contract_path
-from raiden.utils import pex, isaddress, privatekey_to_address
+from raiden.utils import pex, isaddress, privatekey_to_address, get_contract_path
 from raiden.blockchain.abi import (
     ASSETADDED_EVENTID,
     CHANNEL_MANAGER_ABI,

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+import os
 import sys
 import string
 import random
@@ -7,6 +8,8 @@ import secp256k1
 from Crypto.Hash import keccak as keccaklib
 from secp256k1 import PrivateKey
 from ethereum.utils import big_endian_to_int, sha3, int_to_big_endian
+
+import raiden
 
 __all__ = (
     'sha3',
@@ -22,6 +25,7 @@ __all__ = (
     'privatekey_to_address',
     'pex',
     'lpex',
+    'get_contract_path',
 )
 
 LETTERS = string.printable
@@ -114,3 +118,9 @@ def privatekey_to_address(private_key_bin):
     )
     pubkey = private_key.pubkey.serialize(compressed=False)
     return publickey_to_address(pubkey)
+
+
+def get_contract_path(contract_name):
+    project_directory = os.path.dirname(raiden.__file__)
+    contract_path = os.path.join(project_directory, 'smart_contracts', contract_name)
+    return os.path.realpath(contract_path)

--- a/tools/create_compilation_dump.py
+++ b/tools/create_compilation_dump.py
@@ -3,8 +3,7 @@
 import json
 from ethereum import tester
 from ethereum.utils import remove_0x_head
-from raiden.blockchain.abi import get_contract_path
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, get_contract_path
 
 from ethereum import slogging
 slogging.configure(":INFO")

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -7,7 +7,7 @@ import json
 from ethereum._solidity import compile_contract
 from ethereum.utils import denoms, decode_hex
 from pyethapp.rpc_client import JSONRPCClient
-from raiden.blockchain.abi import get_contract_path
+from raiden.utils import get_contract_path
 from raiden.network.rpc.client import patch_send_transaction
 
 

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -1,7 +1,7 @@
 from pyethapp.rpc_client import JSONRPCClient
 from ethereum.utils import sha3, denoms
 from ethereum._solidity import compile_file
-from raiden.blockchain.abi import get_contract_path
+from raiden.utils import get_contract_path
 from raiden.network.rpc.client import patch_send_transaction
 
 


### PR DESCRIPTION
This allows to import it without needing to compile all ABIs, which
in many cases is not necessary.