### PR TITLE
Add missing files+packages to setuptools

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include requirements.txt
+include raiden/smart_contracts/*

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,12 @@ setup(
     author_email='heiko@brainbot.com',
     url='https://github.com/heikoheiko/raiden',
     packages=[
-        'raiden'
+        'raiden',
+        'raiden.encoding',
+        'raiden.utils',
+        'raiden.blockchain',
+        'raiden.network',
+        'raiden.network.rpc',
     ],
     include_package_data=True,
     license='BSD',


### PR DESCRIPTION
Fix setup to create a complete package allowing external apps to import raiden.