### PR TITLE
Identifier for messages

### DIFF
--- a/raiden/assetmanager.py
+++ b/raiden/assetmanager.py
@@ -181,14 +181,14 @@ class AssetManager(object):
         if channel not in channels_registered:
             channels_registered.append(channel)
 
-    def handle_secret(self, secret):
+    def handle_secret(self, identifier, secret):
         """ Handle a secret that could be received from a Secret message or a
         ChannelSecretRevealed event.
         """
         hashlock = sha3(secret)
         channels_reveal = self.hashlock_channel[hashlock]
 
-        secret_message = Secret(secret)
+        secret_message = Secret(identifier, secret)
         self.raiden.sign(secret_message)
 
         while channels_reveal:

--- a/raiden/benchmark/profile_transfer.py
+++ b/raiden/benchmark/profile_transfer.py
@@ -233,7 +233,12 @@ def profile_transfer(num_nodes=10, channels_per_node=2):
 
     # measure the hot path
     with profiling.profile():
-        result = main_api.transfer_async(asset_address, amount, target)
+        result = main_api.transfer_async(
+            asset_address,
+            amount,
+            1,  # TODO: fill in identifier
+            target
+        )
         result.wait()
 
     profiling.print_all_threads()

--- a/raiden/benchmark/speed.py
+++ b/raiden/benchmark/speed.py
@@ -75,7 +75,11 @@ def test_throughput(apps, assets, num_transfers, amount):
         events = list()
 
         for i in range(num_transfers):
-            async_result = api.transfer_async(curr_asset, amount, target)
+            async_result = api.transfer_async(
+                curr_asset,
+                amount,
+                1,  # TODO: fill in identifier
+                target)
             events.append(async_result)
 
         return events
@@ -115,7 +119,12 @@ def test_latency(apps, assets, num_transfers, amount):
         def _transfer():
             api = curr_app.raiden.api
             for i in range(num_transfers):
-                async_result = api.transfer_async(curr_asset, amount, target)
+                async_result = api.transfer_async(
+                    curr_asset,
+                    amount,
+                    1,  # TODO: fill in identifier
+                    target
+                )
                 async_result.wait()
 
             finished.set()

--- a/raiden/benchmark/speed_decoding.py
+++ b/raiden/benchmark/speed_decoding.py
@@ -54,14 +54,20 @@ def test_ping(iterations=ITERATIONS):
 
 def test_secret_request(iterations=ITERATIONS):
     hashlock = HASH
-    msg = SecretRequest(hashlock)
+    msg = SecretRequest(
+        1,  # TODO: fill in identifier
+        hashlock
+    )
     msg.sign(PRIVKEY)
     run_timeit('SecretRequest', msg, iterations=iterations)
 
 
 def test_secret(iterations=ITERATIONS):
     secret = HASH
-    msg = Secret(secret)
+    msg = Secret(
+        1,  # TODO: fill in identifier
+        secret
+    )
     msg.sign(PRIVKEY)
     run_timeit('Secret', msg, iterations=iterations)
 

--- a/raiden/benchmark/speed_decoding.py
+++ b/raiden/benchmark/speed_decoding.py
@@ -95,7 +95,15 @@ def test_locked_transfer(iterations=ITERATIONS):
     balance = 1
     recipient = ADDRESS
     locksroot = sha3(ADDRESS)
-    msg = LockedTransfer(nonce, asset, balance, recipient, locksroot, lock)
+    msg = LockedTransfer(
+        1,  # TODO: fill in identifier
+        nonce,
+        asset,
+        balance,
+        recipient,
+        locksroot,
+        lock
+    )
     msg.sign(PRIVKEY)
     run_timeit('LockedTransfer', msg, iterations=iterations)
 

--- a/raiden/benchmark/speed_transfer.py
+++ b/raiden/benchmark/speed_transfer.py
@@ -79,6 +79,7 @@ def transfer_speed(num_transfers=100, max_locked=100):  # pylint: disable=too-ma
         hashlock = sha3(secrets[i])
         locked_transfer = channel0.create_lockedtransfer(
             amount=amount,
+            identifier=1,  # TODO: fill in identifier
             expiration=expiration,
             hashlock=hashlock,
         )

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -885,7 +885,7 @@ class Channel(object):
                 pex(to_state.balance_proof.merkleroot_for_unclaimed()),
             )
 
-    def create_directtransfer(self, amount):
+    def create_directtransfer(self, amount, identifier):
         """ Return a DirectTransfer message.
 
         This message needs to be signed and registered with the channel before
@@ -912,6 +912,7 @@ class Channel(object):
         current_locksroot = to_.balance_proof.merkleroot_for_unclaimed()
 
         return DirectTransfer(
+            identifier=identifier,
             nonce=from_.nonce,
             asset=self.asset_address,
             transferred_amount=transferred_amount,
@@ -919,7 +920,7 @@ class Channel(object):
             locksroot=current_locksroot,
         )
 
-    def create_lockedtransfer(self, amount, expiration, hashlock):
+    def create_lockedtransfer(self, amount, identifier, expiration, hashlock):
         """ Return a LockedTransfer message.
 
         This message needs to be signed and registered with the channel before sent.
@@ -969,6 +970,7 @@ class Channel(object):
         transferred_amount = from_.transferred_amount
 
         return LockedTransfer(
+            identifier=identifier,
             nonce=from_.nonce,
             asset=self.asset_address,
             transferred_amount=transferred_amount,
@@ -978,7 +980,7 @@ class Channel(object):
         )
 
     def create_mediatedtransfer(self, transfer_initiator, transfer_target, fee,
-                                amount, expiration, hashlock):
+                                amount, identifier, expiration, hashlock):
         """ Return a MediatedTransfer message.
 
         This message needs to be signed and registered with the channel before
@@ -986,14 +988,15 @@ class Channel(object):
 
         Args:
             transfer_initiator (address): The node that requested the transfer.
-            transfer_target (address): The node that the transfer is destinated to.
-            amount (float): How much asset is being transferred.
+            transfer_target (address): The final destination node of the transfer
+            amount (float): How much of an asset is being transfered.
             expiration (int): The maximum block number until the transfer
                 message can be received.
         """
 
         locked_transfer = self.create_lockedtransfer(
             amount,
+            identifier,
             expiration,
             hashlock,
         )
@@ -1014,6 +1017,7 @@ class Channel(object):
 
         locked_transfer = self.create_lockedtransfer(
             lock.amount,
+            1,  # TODO: Perhaps add identifier in the refund transfer too?
             lock.expiration,
             lock.hashlock,
         )

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -3,8 +3,8 @@ import struct
 
 from ethereum import slogging
 
-from raiden.encoding.format import buffer_for, make_field, namedbuffer, pad, BYTE
 from raiden.encoding.encoders import integer, optional_bytes
+from raiden.encoding.format import buffer_for, make_field, namedbuffer, pad, BYTE
 from raiden.encoding.signing import recover_publickey
 
 
@@ -61,6 +61,7 @@ log = slogging.get_logger(__name__)
 
 
 nonce = make_field('nonce', 8, '8s', integer(0, BYTE ** 8))
+identifier = make_field('identifier', 8, '8s', integer(0, BYTE ** 8))
 expiration = make_field('expiration', 8, '8s', integer(0, BYTE ** 8))
 
 asset = make_field('asset', 20, '20s')
@@ -123,8 +124,9 @@ SecretRequest = namedbuffer(
     [
         cmdid(SECRETREQUEST),  # [0:1]
         pad(3),                # [1:4]
-        hashlock,              # [4:36]
-        signature,             # [36:101]
+        identifier,            # [4:12]
+        hashlock,              # [12:46]
+        signature,             # [46:111]
     ]
 )
 
@@ -133,8 +135,9 @@ Secret = namedbuffer(
     [
         cmdid(SECRET),  # [0:1]
         pad(3),         # [1:4]
-        secret,         # [4:36]
-        signature,      # [36:101]
+        identifier,     # [4:12]
+        secret,         # [12:44]
+        signature,      # [44:109]
     ]
 )
 
@@ -143,9 +146,10 @@ DirectTransfer = namedbuffer(
     [
         cmdid(DIRECTTRANSFER),  # [0:1]
         pad(3),                 # [1:4]
-        nonce,                  # [4:12]
-        asset,                  # [12:32]
-        recipient,              # [32:52]
+        identifier,             # [4:12]
+        nonce,                  # [12:20]
+        asset,                  # [20:40]
+        recipient,              # [40:60]
         transferred_amount,
         optional_locksroot,
         optional_secret,        # TODO: remove from here and decoding in the smart contract
@@ -158,10 +162,11 @@ LockedTransfer = namedbuffer(
     [
         cmdid(LOCKEDTRANSFER),  # [0:1]
         pad(3),                 # [1:4]
-        nonce,                  # [4:12]
-        expiration,             # [12:20]
-        asset,                  # [20:40]
-        recipient,              # [40:60]
+        identifier,             # [4:12]
+        nonce,                  # [12:20]
+        expiration,             # [20:28]
+        asset,                  # [28:48]
+        recipient,              # [48:68]
         locksroot,
         transferred_amount,
         amount,
@@ -175,12 +180,13 @@ MediatedTransfer = namedbuffer(
     [
         cmdid(MEDIATEDTRANSFER),  # [0:1]
         pad(3),                   # [1:4]
-        nonce,                    # [4:12]
-        expiration,               # [12:20]
-        asset,                    # [20:40]
-        recipient,                # [40:60]
-        target,                   # [60:80]
-        initiator,                # [80:100]
+        identifier,               # [4:12]
+        nonce,                    # [12:20]
+        expiration,               # [20:28]
+        asset,                    # [28:48]
+        recipient,                # [48:68]
+        target,                   # [68:88]
+        initiator,                # [88:108]
         locksroot,
         hashlock,
         transferred_amount,

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -146,8 +146,8 @@ DirectTransfer = namedbuffer(
     [
         cmdid(DIRECTTRANSFER),  # [0:1]
         pad(3),                 # [1:4]
-        identifier,             # [4:12]
-        nonce,                  # [12:20]
+        nonce,                  # [4:12]
+        identifier,             # [12:20]
         asset,                  # [20:40]
         recipient,              # [40:60]
         transferred_amount,
@@ -162,8 +162,8 @@ LockedTransfer = namedbuffer(
     [
         cmdid(LOCKEDTRANSFER),  # [0:1]
         pad(3),                 # [1:4]
-        identifier,             # [4:12]
-        nonce,                  # [12:20]
+        nonce,                  # [4:12]
+        identifier,             # [12:20]
         expiration,             # [20:28]
         asset,                  # [28:48]
         recipient,              # [48:68]
@@ -180,8 +180,8 @@ MediatedTransfer = namedbuffer(
     [
         cmdid(MEDIATEDTRANSFER),  # [0:1]
         pad(3),                   # [1:4]
-        identifier,               # [4:12]
-        nonce,                    # [12:20]
+        nonce,                    # [4:12]
+        identifier,               # [12:20]
         expiration,               # [20:28]
         asset,                    # [28:48]
         recipient,                # [48:68]

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -276,25 +276,26 @@ class Secret(SignedMessage):
 
 
 class DirectTransfer(SignedMessage):
-    """ An direct asset exchange, used when both participants have a previously
-    openned channel.
+    """ A direct asset exchange, used when both participants have a previously
+    opened channel.
 
     Signs the unidirectional settled `balance` of `asset` to `recipient` plus
     locked transfers.
 
     Settled refers to the inclusion of formerly locked amounts.
-    Locked amounts are not included in the balance yet, but represented by the `locksroot`.
+    Locked amounts are not included in the balance yet, but represented
+    by the `locksroot`.
 
     Args:
         nonce: A sequential nonce, used to protected against replay attacks and
             to give a total order for the messages. This nonce is per
             participant, not shared.
         asset: The address of the asset being exchanged in the channel.
-        transferred_amount: The total amount of asset that wast transfered to
-            the channel partner. This value is monotonicly increasing and can
+        transferred_amount: The total amount of asset that was transfered to
+            the channel partner. This value is monotonically increasing and can
             be larger than a channels deposit, since the channels are
             bidirecional.
-        recipient: The address of raiden node participating in the channel.
+        recipient: The address of the raiden node participating in the channel.
         locksroot: The root of a merkle tree which records the current
             outstanding locks.
     """
@@ -385,16 +386,16 @@ class LockedTransfer(SignedMessage):
     """ A transfer which signs that the partner can claim `locked_amount` if
     she knows the secret to `hashlock`.
 
-    The asset amount is implicitely represented in the `locksroot` and won't be
+    The asset amount is implicitly represented in the `locksroot` and won't be
     reflected in the `transferred_amount` until the secret is revealed.
 
     This signs Carol, that she can claim locked_amount from Bob if she knows the secret to hashlock
 
     If the secret to hashlock becomes public, but Bob fails to sign Carol a netted balance,
     with an updated rootlock which reflects the deletion of the lock, then
-        Carol can request settlement on chain by providing:
-            any signed [nonce, asset, balance, recipient, locksroot, ...]
-            along a merkle proof from locksroot to the not yet netted formerly locked amount
+    Carol can request settlement on chain by providing:
+        any signed [nonce, asset, balance, recipient, locksroot, ...]
+        along a merkle proof from locksroot to the not yet netted formerly locked amount
     """
     cmdid = messages.LOCKEDTRANSFER
 
@@ -468,8 +469,8 @@ class LockedTransfer(SignedMessage):
 class MediatedTransfer(LockedTransfer):
 
     """
-    A MediatedTransfer has a `target` address to which a chain of transfers shall be established.
-    Here the `haslock` is mandatory.
+    A MediatedTransfer has a `target` address to which a chain of transfers shall
+    be established. Here the `haslock` is mandatory.
 
     `fee` is the remaining fee a recipient shall use to complete the mediated transfer.
     The recipient can deduct his own fee from the amount and lower `fee` to the remaining fee.
@@ -477,7 +478,7 @@ class MediatedTransfer(LockedTransfer):
     it can deduct a too high fee, but this would render completion of the transfer unlikely.
 
     The initiator of a mediated transfer will calculate fees based on the likely fees along the
-    path. Note, it can not determin the path, as it does not know which nodes are available.
+    path. Note, it can not determine the path, as it does not know which nodes are available.
 
     Initial `amount` should be expected received amount + fees.
 
@@ -565,8 +566,9 @@ class MediatedTransfer(LockedTransfer):
 
 
 class RefundTransfer(LockedTransfer):
-    """ Indicates that no route is available and transfer the amount back to
-    the previous node, allowing she to try another path to complete the
+    """
+    Indicates that no route is available and transfers the amount back to
+    the previous node, allowing it to try another path to complete the
     transfer.
     """
     cmdid = messages.REFUNDTRANSFER
@@ -606,13 +608,14 @@ class RefundTransfer(LockedTransfer):
 
 
 class TransferTimeout(SignedMessage):
-    """ Indicates that timeout happened during mediated transfer.
+    """
+    Indicates a timeout happened during a mediated transfer.
 
     This message is used when a node in a mediated chain doesn't consider any
-    of it's following nodes available. If node `A` is trying to send a transfer
-    to `D` throught `B1`, if `B1` consider all candidates for `c` unavailable
-    it will send a TransferTimeout back to `A`. `A` can try all other
-    candidates for `b` until it considers all it's paths unavailable.
+    of its following nodes available. If node `A` is trying to send a transfer
+    to `C` through `B` and `B` considers all candidates for `C` unavailable
+    it will send a TransferTimeout back to `A`. `A` can then try all other
+    candidates for `C` until it considers all it's paths unavailable.
     """
     cmdid = messages.TRANSFERTIMEOUT
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -221,8 +221,9 @@ class SecretRequest(SignedMessage):
     """ Requests the secret which unlocks a hashlock. """
     cmdid = messages.SECRETREQUEST
 
-    def __init__(self, hashlock):
+    def __init__(self, identifier, hashlock):
         super(SecretRequest, self).__init__()
+        self.identifier = identifier
         self.hashlock = hashlock
 
     def __repr__(self):
@@ -233,11 +234,12 @@ class SecretRequest(SignedMessage):
 
     @staticmethod
     def unpack(packed):
-        secret_request = SecretRequest(packed.hashlock)
+        secret_request = SecretRequest(packed.identifier, packed.hashlock)
         secret_request.signature = packed.signature
         return secret_request
 
     def pack(self, packed):
+        packed.identifier = self.identifier
         packed.hashlock = self.hashlock
         packed.signature = self.signature
 
@@ -246,8 +248,9 @@ class Secret(SignedMessage):
     """ Provides the secret to a hashlock. """
     cmdid = messages.SECRET
 
-    def __init__(self, secret):
+    def __init__(self, identifier, secret):
         super(Secret, self).__init__()
+        self.identifier = identifier
         self.secret = secret
         self._hashlock = None
 
@@ -266,11 +269,12 @@ class Secret(SignedMessage):
 
     @staticmethod
     def unpack(packed):
-        secret = Secret(packed.secret)
+        secret = Secret(packed.identifier, packed.secret)
         secret.signature = packed.signature
         return secret
 
     def pack(self, packed):
+        packed.identifier = self.identifier
         packed.secret = self.secret
         packed.signature = self.signature
 
@@ -302,8 +306,9 @@ class DirectTransfer(SignedMessage):
 
     cmdid = messages.DIRECTTRANSFER
 
-    def __init__(self, nonce, asset, transferred_amount, recipient, locksroot):
+    def __init__(self, identifier, nonce, asset, transferred_amount, recipient, locksroot):
         super(DirectTransfer, self).__init__()
+        self.identifier = identifier
         self.nonce = nonce
         self.asset = asset
         self.transferred_amount = transferred_amount  #: total amount of asset sent to partner
@@ -313,6 +318,7 @@ class DirectTransfer(SignedMessage):
     @staticmethod
     def unpack(packed):
         transfer = DirectTransfer(
+            packed.identifier,
             packed.nonce,
             packed.asset,
             packed.transferred_amount,
@@ -324,6 +330,7 @@ class DirectTransfer(SignedMessage):
         return transfer
 
     def pack(self, packed):
+        packed.identifier = self.identifier
         packed.nonce = self.nonce
         packed.asset = self.asset
         packed.transferred_amount = self.transferred_amount
@@ -399,8 +406,9 @@ class LockedTransfer(SignedMessage):
     """
     cmdid = messages.LOCKEDTRANSFER
 
-    def __init__(self, nonce, asset, transferred_amount, recipient, locksroot, lock):
+    def __init__(self, identifier, nonce, asset, transferred_amount, recipient, locksroot, lock):
         super(LockedTransfer, self).__init__()
+        self.identifier = identifier
         self.nonce = nonce
         self.asset = asset
         self.transferred_amount = transferred_amount
@@ -411,6 +419,7 @@ class LockedTransfer(SignedMessage):
 
     def to_mediatedtransfer(self, target, initiator='', fee=0):
         return MediatedTransfer(
+            self.identifier,
             self.nonce,
             self.asset,
             self.transferred_amount,
@@ -441,6 +450,7 @@ class LockedTransfer(SignedMessage):
         )
 
         locked_transfer = LockedTransfer(
+            packed.identifier,
             packed.nonce,
             packed.asset,
             packed.transferred_amount,
@@ -452,6 +462,7 @@ class LockedTransfer(SignedMessage):
         return locked_transfer
 
     def pack(self, packed):
+        packed.identifier = self.identifier
         packed.nonce = self.nonce
         packed.asset = self.asset
         packed.transferred_amount = self.transferred_amount
@@ -489,8 +500,8 @@ class MediatedTransfer(LockedTransfer):
 
     cmdid = messages.MEDIATEDTRANSFER
 
-    def __init__(self, nonce, asset, transferred_amount, recipient, locksroot,
-                 lock, target, initiator, fee=0):
+    def __init__(self, identifier, nonce, asset, transferred_amount, recipient,
+                 locksroot, lock, target, initiator, fee=0):
 
         if nonce > 2 ** 64:
             raise ValueError('nonce is too large')
@@ -502,6 +513,7 @@ class MediatedTransfer(LockedTransfer):
             raise ValueError('transferred_amount is too large')
 
         super(MediatedTransfer, self).__init__(
+            identifier,
             nonce,
             asset,
             transferred_amount,
@@ -534,6 +546,7 @@ class MediatedTransfer(LockedTransfer):
         )
 
         mediated_transfer = MediatedTransfer(
+            packed.identifier,
             packed.nonce,
             packed.asset,
             packed.transferred_amount,
@@ -548,6 +561,7 @@ class MediatedTransfer(LockedTransfer):
         return mediated_transfer
 
     def pack(self, packed):
+        packed.identifier = self.identifier
         packed.nonce = self.nonce
         packed.asset = self.asset
         packed.transferred_amount = self.transferred_amount

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -316,14 +316,14 @@ class RaidenAPI(object):
 
         return netting_channel
 
-    def transfer_and_wait(self, asset_address, amount, target, callback=None, timeout=None):
+    def transfer_and_wait(self, asset_address, amount, identifier, target, callback=None, timeout=None):
         """ Do a transfer with `target` with the given `amount` of `asset_address`. """
-        async_result = self.transfer_async(asset_address, amount, target, callback)
+        async_result = self.transfer_async(asset_address, amount, identifier, target, callback)
         return async_result.wait(timeout=timeout)
 
     transfer = transfer_and_wait  # expose a synchronous interface to the user
 
-    def transfer_async(self, asset_address, amount, target, callback=None):
+    def transfer_async(self, asset_address, amount, identifier, target, callback=None):
         if not isinstance(amount, (int, long)):
             raise InvalidAmount('Amount not a number')
 
@@ -345,7 +345,7 @@ class RaidenAPI(object):
             raise NoPathError('No path to address found')
 
         transfer_manager = self.raiden.managers_by_asset_address[asset_address_bin].transfermanager
-        async_result = transfer_manager.transfer_async(amount, target_bin, callback=callback)
+        async_result = transfer_manager.transfer_async(amount, identifier, target_bin, callback=callback)
         return async_result
 
     def close(self, asset_address, partner_address):

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -439,8 +439,8 @@ library NettingChannelLibrary {
         assembly {
             // cmdid [0:1]
             // pad [1:4]
-            // identifier [4:12]
-            nonce := mload(add(message, 20))             // nonce [12:20]
+            nonce := mload(add(message, 12))             // nonce [4:12]
+            // identifier [12:20]
             asset := mload(add(message, 40))             // asset [20:40]
             recipient := mload(add(message, 60))         // recipient [40:60]
             transferredAmount := mload(add(message, 92)) // transferred_amount [60:92]
@@ -473,8 +473,8 @@ library NettingChannelLibrary {
         assembly {
             // cmdid [0:1]
             // pad [1:4]
-            // identifier [4:12]
-            nonce := mload(add(message, 20))              // nonce [12:20]
+            nonce := mload(add(message, 12))              // nonce [4:12]
+            // identifier [12:20]
             expiration := mload(add(message, 28))         // expiration [20:28]
             asset := mload(add(message, 48))              // asset [28:48]
             recipient := mload(add(message, 68))          // recipient [48:68]

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -425,7 +425,7 @@ library NettingChannelLibrary {
     // TODO: use sstore instead of these temporaries
 
     function assignDirectTransfer(Participant storage participant, bytes memory message) private {
-        if (message.length != 148) {  // raw message size (without signature)
+        if (message.length != 156) {  // raw message size (without signature)
             throw;
         }
 
@@ -439,12 +439,13 @@ library NettingChannelLibrary {
         assembly {
             // cmdid [0:1]
             // pad [1:4]
-            nonce := mload(add(message, 12))            // nonce [4:12]
-            asset := mload(add(message, 32))            // asset [12:32]
-            recipient := mload(add(message, 52))        // recipient [32:52]
-            transferredAmount := mload(add(message, 84)) // transferred_amount [52:84]
-            locksroot := mload(add(message, 116))       // optional_locksroot [84:116]
-            secret := mload(add(message, 148))          // optional_secret [116:148]
+            // identifier [4:12]
+            nonce := mload(add(message, 20))             // nonce [12:20]
+            asset := mload(add(message, 40))             // asset [20:40]
+            recipient := mload(add(message, 60))         // recipient [40:60]
+            transferredAmount := mload(add(message, 92)) // transferred_amount [60:92]
+            locksroot := mload(add(message, 124))        // optional_locksroot [92:124]
+            secret := mload(add(message, 156))           // optional_secret [124:156]
         }
 
         participant.nonce = nonce;
@@ -456,7 +457,7 @@ library NettingChannelLibrary {
     }
 
     function assignMediatedTransfer(Participant storage participant, bytes memory message) private {
-        if (message.length != 260) {
+        if (message.length != 268) {
             throw;
         }
 
@@ -472,17 +473,18 @@ library NettingChannelLibrary {
         assembly {
             // cmdid [0:1]
             // pad [1:4]
-            nonce := mload(add(message, 12))        // nonce [4:12]
-            expiration := mload(add(message, 20))   // expiration [12:20]
-            asset := mload(add(message, 40))        // asset [20:40]
-            recipient := mload(add(message, 60))    // recipient [40:60]
-            // target [60:80]
-            // initiator [80:100]
-            locksroot := mload(add(message, 132))   // locksroot [100:132]
-            hashlock := mload(add(message, 164))    // hashlock [100:164]
-            transferredAmount := mload(add(message, 196)) // transferred_amount[164:196]
-            lockAmount := mload(add(message, 228))  // amount [196:228]
-            // fee := mload(add(message, 260))      // fee [228:260]
+            // identifier [4:12]
+            nonce := mload(add(message, 20))              // nonce [12:20]
+            expiration := mload(add(message, 28))         // expiration [20:28]
+            asset := mload(add(message, 48))              // asset [28:48]
+            recipient := mload(add(message, 68))          // recipient [48:68]
+            // target [68:88]
+            // initiator [88:108]
+            locksroot := mload(add(message, 140))         // locksroot [108:140]
+            hashlock := mload(add(message, 172))          // hashlock [140:172]
+            transferredAmount := mload(add(message, 204)) // transferred_amount[172:204]
+            lockAmount := mload(add(message, 236))        // amount [204:236]
+            // fee := mload(add(message, 268))            // fee [236:268]
         }
 
         participant.nonce = nonce;

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -20,4 +20,10 @@ def test_fullnetwork(raiden_chain):
     direct_transfer(app1, app2, asset_address, amount)
 
     amount = 30
-    mediated_transfer(app1, app2, asset_address, amount)
+    mediated_transfer(
+        app1,
+        app2,
+        asset_address,
+        amount,
+        1  # TODO: fill in identifier
+    )

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -100,7 +100,12 @@ def test_secret_revealed(raiden_chain, deposit, settle_timeout, events_poll_time
     channel21 = channel(app2, app1, asset_address)
     netting_channel = channel21.external_state.netting_channel
 
-    secret = pending_mediated_transfer(raiden_chain, asset_address, amount)
+    secret = pending_mediated_transfer(
+        raiden_chain,
+        asset_address,
+        amount,
+        1  # TODO: fill in identifier
+    )
     hashlock = sha3(secret)
 
     gevent.sleep(.1)  # wait for the messages

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -49,7 +49,12 @@ def test_settlement(raiden_network, settle_timeout):
     assert asset_manager0.asset_address == asset_manager1.asset_address
     assert channel0.external_state.netting_channel.address == channel1.external_state.netting_channel.address
 
-    transfermessage = channel0.create_lockedtransfer(amount, expiration, hashlock)
+    transfermessage = channel0.create_lockedtransfer(
+        amount,
+        identifier=1,  # TODO: fill in identifier
+        expiration,
+        hashlock
+    )
     app0.raiden.sign(transfermessage)
     channel0.register_transfer(transfermessage)
     channel1.register_transfer(transfermessage)
@@ -107,7 +112,12 @@ def test_settled_lock(assets_addresses, raiden_network, settle_timeout):
     app0, app1, app2, app3 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
     # mediated transfer
-    secret = pending_mediated_transfer(raiden_network, asset, amount)
+    secret = pending_mediated_transfer(
+        raiden_network,
+        asset,
+        amount,
+        1  # TODO: fill in identifier
+    )
     hashlock = sha3(secret)
 
     # get a proof for the pending transfer
@@ -174,7 +184,12 @@ def test_start_end_attack(asset_address, raiden_chain, deposit):
     app0, app1, app2 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
     # the attacker owns app0 and app2 and creates a transfer throught app1
-    secret = pending_mediated_transfer(raiden_chain, asset, amount)
+    secret = pending_mediated_transfer(
+        raiden_chain,
+        asset,
+        amount,
+        1  # TODO: fill in identifier
+    )
     hashlock = sha3(secret)
 
     attack_channel = channel(app2, app1, asset)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -51,7 +51,7 @@ def test_settlement(raiden_network, settle_timeout):
 
     transfermessage = channel0.create_lockedtransfer(
         amount,
-        identifier=1,  # TODO: fill in identifier
+        1,  # TODO: fill in identifier
         expiration,
         hashlock
     )

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -276,7 +276,10 @@ def test_closesingle_settle(deposit, settle_timeout, tester_channels,
     initial_balance1 = tester_token.balanceOf(address1, sender=privatekey1_raw)
 
     transfer_amount = 10
-    direct_transfer = channel0.create_directtransfer(transfer_amount)
+    direct_transfer = channel0.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     direct_transfer.sign(privatekey0, address0)
     direct_transfer_data = str(direct_transfer.packed().data)
 
@@ -348,11 +351,17 @@ def test_close_settle(deposit, settle_timeout, tester_state, tester_channels,
     initial_balance1 = tester_token.balanceOf(address1, sender=privatekey1_raw)
 
     transfer_amount0 = 10
-    direct_transfer0 = channel0.create_directtransfer(transfer_amount0)
+    direct_transfer0 = channel0.create_directtransfer(
+        transfer_amount0,
+        1  # TODO: fill in identifier
+    )
     direct_transfer0.sign(privatekey0, address0)
 
     transfer_amount1 = 30
-    direct_transfer1 = channel1.create_directtransfer(transfer_amount1)
+    direct_transfer1 = channel1.create_directtransfer(
+        transfer_amount1,
+        1  # TODO: fill in identifier
+    )
     direct_transfer1.sign(privatekey1, address1)
 
     with pytest.raises(TransactionFailed):
@@ -440,6 +449,7 @@ def test_two_messages_mediated_transfer(deposit, settle_timeout, tester_state,
         transfer_target=address1,
         fee=0,
         amount=lock_amount0,
+        identifier=1,  # TODO: fill in identifier
         expiration=lock_expiration0,
         hashlock=hashlock0,
     )
@@ -454,6 +464,7 @@ def test_two_messages_mediated_transfer(deposit, settle_timeout, tester_state,
         transfer_target=address0,
         fee=0,
         amount=lock_amount1,
+        identifier=1,  # TODO: fill in identifier
         expiration=lock_expiration1,
         hashlock=hashlock1,
     )
@@ -529,7 +540,10 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
     address1 = privatekey_to_address(privatekey1_raw)
 
     transfer_amount = 3
-    first_direct_transfer0 = channel0.create_directtransfer(transfer_amount)
+    first_direct_transfer0 = channel0.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     first_direct_transfer0.sign(privatekey0, address0)
     first_direct_transfer0_data = str(first_direct_transfer0.packed().data)
 
@@ -537,7 +551,10 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
     channel1.register_transfer(first_direct_transfer0)
 
     transfer_amount = 5
-    second_direct_transfer0 = channel0.create_directtransfer(transfer_amount)
+    second_direct_transfer0 = channel0.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     second_direct_transfer0.sign(privatekey0, address0)
     second_direct_transfer0_data = str(second_direct_transfer0.packed().data)
 
@@ -545,7 +562,10 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
     channel1.register_transfer(second_direct_transfer0)
 
     transfer_amount = 7
-    third_direct_transfer0 = channel0.create_directtransfer(transfer_amount)
+    third_direct_transfer0 = channel0.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     third_direct_transfer0.sign(privatekey0, address0)
     third_direct_transfer0_data = str(third_direct_transfer0.packed().data)
 
@@ -553,7 +573,10 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
     channel1.register_transfer(third_direct_transfer0)
 
     transfer_amount = 11
-    fourth_direct_transfer0 = channel0.create_directtransfer(transfer_amount)
+    fourth_direct_transfer0 = channel0.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     fourth_direct_transfer0.sign(privatekey0, address0)
     fourth_direct_transfer0_data = str(fourth_direct_transfer0.packed().data)
 
@@ -561,7 +584,10 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
     channel1.register_transfer(fourth_direct_transfer0)
 
     transfer_amount = 13
-    direct_transfer1 = channel1.create_directtransfer(transfer_amount)
+    direct_transfer1 = channel1.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     direct_transfer1.sign(privatekey1, address1)
     direct_transfer1_data = str(direct_transfer1.packed().data)
 
@@ -625,7 +651,10 @@ def test_update_mediated_transfer(settle_timeout, tester_state, tester_channels,
     address1 = privatekey_to_address(privatekey1_raw)
 
     transfer_amount = 3
-    direct_transfer0 = channel0.create_directtransfer(transfer_amount)
+    direct_transfer0 = channel0.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     direct_transfer0.sign(privatekey0, address0)
     direct_transfer0_data = str(direct_transfer0.packed().data)
 
@@ -642,6 +671,7 @@ def test_update_mediated_transfer(settle_timeout, tester_state, tester_channels,
         transfer_target=target,
         fee=0,
         amount=lock_amount,
+        identifier=1,  # TODO: fill in identifier
         expiration=lock_expiration,
         hashlock=lock_hashlock,
     )
@@ -698,6 +728,7 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
         transfer_target=target,
         fee=0,
         amount=lock_amount0,
+        identifier=1,  # TODO: fill in identifier
         expiration=lock_expiration0,
         hashlock=lock_hashlock0,
     )
@@ -719,6 +750,7 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
         transfer_target=target,
         fee=0,
         amount=lock_amount1,
+        identifier=1,  # TODO: fill in identifier
         expiration=lock_expiration1,
         hashlock=lock_hashlock1,
     )

--- a/raiden/tests/test_callbacks.py
+++ b/raiden/tests/test_callbacks.py
@@ -57,6 +57,7 @@ def test_direct_transfer_callback(raiden_network):
     app0.raiden.api.transfer(
         asset_manager0.asset_address,
         amount,
+        1,  # TODO: determine identifier
         target=app1.raiden.address,
     )
     gevent.sleep(1)

--- a/raiden/tests/test_channel.py
+++ b/raiden/tests/test_channel.py
@@ -57,6 +57,7 @@ def test_end_state():
     locksroot = state2.compute_merkleroot_with(lock)
 
     locked_transfer = LockedTransfer(
+        1,  # TODO: fill in identifier
         nonce=state1.nonce,
         asset=asset_address,
         transferred_amount=transferred_amount,
@@ -557,6 +558,7 @@ def test_register_invalid_transfer(raiden_network):
 
     # handcrafted transfer because channel.create_transfer won't create it
     transfer2 = DirectTransfer(
+        1,  # TODO: fill in identifier
         nonce=channel0.our_state.nonce,
         asset=channel0.asset_address,
         transferred_amount=channel1.balance + balance0 + amount,

--- a/raiden/tests/test_channel.py
+++ b/raiden/tests/test_channel.py
@@ -207,13 +207,22 @@ def test_channel():
     assert channel.partner_state.locked() == 0
 
     with pytest.raises(ValueError):
-        channel.create_directtransfer(-10)
+        channel.create_directtransfer(
+            -10,
+            1  # TODO: fill in identifier
+        )
 
     with pytest.raises(ValueError):
-        channel.create_directtransfer(balance1 + 10)
+        channel.create_directtransfer(
+            balance1 + 10,
+            1  # TODO: fill in identifier
+        )
 
     amount1 = 10
-    directtransfer = channel.create_directtransfer(amount1)
+    directtransfer = channel.create_directtransfer(
+        amount1,
+        1  # TODO: fill in identifier
+    )
     directtransfer.sign(privkey1, address1)
     channel.register_transfer(directtransfer)
 
@@ -236,6 +245,7 @@ def test_channel():
         address2,
         fee,
         amount2,
+        1,  # TODO: fill in identifier
         expiration,
         hashlock,
     )
@@ -346,6 +356,7 @@ def test_interwoven_transfers(number_of_transfers, raiden_network):  # pylint: d
     for i, (amount, secret) in enumerate(zip(transfers_amount, transfers_secret)):
         locked_transfer = channel0.create_lockedtransfer(
             amount=amount,
+            identifier=1,  # TODO: fill in identifier
             expiration=expiration,
             hashlock=sha3(secret),
         )
@@ -435,7 +446,10 @@ def test_transfer(raiden_network, assets_addresses):
 
     amount = 10
 
-    direct_transfer = channel0.create_directtransfer(amount=amount)
+    direct_transfer = channel0.create_directtransfer(
+        amount,
+        1  # TODO: fill in identifier
+    )
     app0.raiden.sign(direct_transfer)
     channel0.register_transfer(direct_transfer)
     channel1.register_transfer(direct_transfer)
@@ -474,6 +488,7 @@ def test_locked_transfer(raiden_network):
 
     locked_transfer = channel0.create_lockedtransfer(
         amount=amount,
+        identifier=1,  # TODO: fill in identifier
         expiration=expiration,
         hashlock=hashlock,
     )
@@ -524,6 +539,7 @@ def test_register_invalid_transfer(raiden_network):
 
     transfer1 = channel0.create_lockedtransfer(
         amount=amount,
+        identifier=1,  # TODO: fill in identifier
         expiration=expiration,
         hashlock=hashlock,
     )

--- a/raiden/tests/test_messages.py
+++ b/raiden/tests/test_messages.py
@@ -53,6 +53,7 @@ def test_mediated_transfer():
 
     lock = Lock(amount, expiration, hashlock)
     mediated_transfer = MediatedTransfer(
+        1,  # TODO: fill in identifier
         nonce,
         asset,
         balance,

--- a/raiden/tests/test_transfer.py
+++ b/raiden/tests/test_transfer.py
@@ -41,6 +41,7 @@ def test_transfer(raiden_network):
     app0.raiden.api.transfer(
         asset_manager0.asset_address,
         amount,
+        1,  # TODO: fill in identifier
         target=app1.raiden.address,
     )
     gevent.sleep(1)
@@ -147,6 +148,7 @@ def test_mediated_transfer(raiden_network):
     alice_app.raiden.api.transfer(
         asset_address,
         amount,
+        1,  # TODO: fill in identifier
         charlie_address,
     )
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -46,7 +46,12 @@ def transfer(initiator_app, target_app, asset, amount):
     will be revealed.
     """
 
-    initiator_app.raiden.api.transfer(asset, amount, target_app.raiden.address)
+    initiator_app.raiden.api.transfer(
+        asset,
+        amount,
+        1,  # TODO: fill in identifier
+        target_app.raiden.address
+    )
 
 
 def direct_transfer(initiator_app, target_app, asset, amount):
@@ -55,7 +60,12 @@ def direct_transfer(initiator_app, target_app, asset, amount):
     has_channel = target_app.raiden.address in assetmanager.partneraddress_channel
     assert has_channel, 'there is not a direct channel'
 
-    initiator_app.raiden.api.transfer(asset, amount, target_app.raiden.address)
+    initiator_app.raiden.api.transfer(
+        asset,
+        amount,
+        1,  # TODO: fill in identifier
+        target_app.raiden.address
+    )
 
 
 def mediated_transfer(initiator_app, target_app, asset, amount, identifier):  # pylint: disable=too-many-arguments
@@ -79,7 +89,12 @@ def mediated_transfer(initiator_app, target_app, asset, amount, identifier):  # 
         task.start()
         task.join()
     else:
-        initiator_app.raiden.api.transfer(asset, amount, target_app.raiden.address)
+        initiator_app.raiden.api.transfer(
+            asset,
+            amount,
+            1,  # TODO: fill in identifier
+            target_app.raiden.address
+        )
 
 
 def pending_mediated_transfer(app_chain, asset, amount, identifier):

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -58,7 +58,7 @@ def direct_transfer(initiator_app, target_app, asset, amount):
     initiator_app.raiden.api.transfer(asset, amount, target_app.raiden.address)
 
 
-def mediated_transfer(initiator_app, target_app, asset, amount):  # pylint: disable=too-many-arguments
+def mediated_transfer(initiator_app, target_app, asset, amount, identifier):  # pylint: disable=too-many-arguments
     """ Nice to read shortcut to make a MediatedTransfer.
 
     The secret will be revealed and the apps will be synchronized.
@@ -73,6 +73,7 @@ def mediated_transfer(initiator_app, target_app, asset, amount):  # pylint: disa
         task = StartMediatedTransferTask(
             transfermanager,
             amount,
+            identifier,
             target_app.raiden.address,
         )
         task.start()
@@ -81,7 +82,7 @@ def mediated_transfer(initiator_app, target_app, asset, amount):  # pylint: disa
         initiator_app.raiden.api.transfer(asset, amount, target_app.raiden.address)
 
 
-def pending_mediated_transfer(app_chain, asset, amount):
+def pending_mediated_transfer(app_chain, asset, amount, identifier):
     """ Nice to read shortcut to make a MediatedTransfer were the secret is
     _not_ revealed.
 
@@ -115,6 +116,7 @@ def pending_mediated_transfer(app_chain, asset, amount):
             target_app.raiden.address,
             fee,
             amount,
+            identifier,
             expiration,
             hashlock,
         )

--- a/raiden/transfermanager.py
+++ b/raiden/transfermanager.py
@@ -57,7 +57,7 @@ class TransferManager(object):
     def register_callback_for_result(self, callback):
         self.on_result_callbacks.append(callback)
 
-    def transfer_async(self, amount, target, callback=None):
+    def transfer_async(self, amount, identifier, target, callback=None):
         """ Transfer `amount` between this node and `target`.
 
         This method will start a asyncronous transfer, the transfer might fail
@@ -70,7 +70,10 @@ class TransferManager(object):
 
         if target in self.assetmanager.partneraddress_channel:
             channel = self.assetmanager.partneraddress_channel[target]
-            direct_transfer = channel.create_directtransfer(amount)
+            direct_transfer = channel.create_directtransfer(
+                amount,
+                1  # TODO: fill in identifier
+            )
             self.assetmanager.raiden.sign(direct_transfer)
             channel.register_transfer(direct_transfer)
             if callback:
@@ -86,6 +89,7 @@ class TransferManager(object):
             task = StartMediatedTransferTask(
                 self,
                 amount,
+                identifier,
                 target,
                 result,
             )


### PR DESCRIPTION
This PR along with #147 addresses #139.

- **Identifier Size**: 8 bytes for alignment and parity with nonce and other numeral parts of the message
- **Added identifier field in the following messages:**
    - SecretRequest
    - Secret
    - DirectTransfer
    - LockedTransfer
    - MediatedTransfer
- Identifier is now used wherever needed 