### PR TITLE
Add Identifier to Raiden API + Tests

### DIFF
--- a/raiden/benchmark/profile_transfer.py
+++ b/raiden/benchmark/profile_transfer.py
@@ -236,8 +236,8 @@ def profile_transfer(num_nodes=10, channels_per_node=2):
         result = main_api.transfer_async(
             asset_address,
             amount,
-            1,  # TODO: fill in identifier
-            target
+            target,
+            1  # TODO: fill in identifier
         )
         result.wait()
 

--- a/raiden/benchmark/speed.py
+++ b/raiden/benchmark/speed.py
@@ -78,8 +78,8 @@ def test_throughput(apps, assets, num_transfers, amount):
             async_result = api.transfer_async(
                 curr_asset,
                 amount,
-                1,  # TODO: fill in identifier
-                target)
+                target,
+                1)  # TODO: fill in identifier
             events.append(async_result)
 
         return events
@@ -122,8 +122,8 @@ def test_latency(apps, assets, num_transfers, amount):
                 async_result = api.transfer_async(
                     curr_asset,
                     amount,
-                    1,  # TODO: fill in identifier
-                    target
+                    target,
+                    1  # TODO: fill in identifier
                 )
                 async_result.wait()
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -316,14 +316,14 @@ class RaidenAPI(object):
 
         return netting_channel
 
-    def transfer_and_wait(self, asset_address, amount, identifier, target, callback=None, timeout=None):
+    def transfer_and_wait(self, asset_address, amount, target, identifier=None, callback=None, timeout=None):
         """ Do a transfer with `target` with the given `amount` of `asset_address`. """
-        async_result = self.transfer_async(asset_address, amount, identifier, target, callback)
+        async_result = self.transfer_async(asset_address, amount, target, identifier, callback)
         return async_result.wait(timeout=timeout)
 
     transfer = transfer_and_wait  # expose a synchronous interface to the user
 
-    def transfer_async(self, asset_address, amount, identifier, target, callback=None):
+    def transfer_async(self, asset_address, amount, target, identifier=None, callback=None):
         if not isinstance(amount, (int, long)):
             raise InvalidAmount('Amount not a number')
 
@@ -345,7 +345,7 @@ class RaidenAPI(object):
             raise NoPathError('No path to address found')
 
         transfer_manager = self.raiden.managers_by_asset_address[asset_address_bin].transfermanager
-        async_result = transfer_manager.transfer_async(amount, identifier, target_bin, callback=callback)
+        async_result = transfer_manager.transfer_async(amount, target_bin, identifier=identifier, callback=callback)
         return async_result
 
     def close(self, asset_address, partner_address):

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -1,13 +1,15 @@
 # -*- coding: utf8 -*-
 import pytest
+import random
 
 from raiden.tests.utils.transfer import (
     direct_transfer,
     mediated_transfer,
     channel,
-    get_sent_transfer
+    get_sent_transfer,
+    assert_identifier_correct
 )
-from raiden.utils import sha3
+
 
 @pytest.mark.parametrize('privatekey_seed', ['fullnetwork:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
@@ -19,32 +21,27 @@ def test_fullnetwork(raiden_chain):
     asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
 
     amount = 80
+    random.seed(0)
     direct_transfer(app0, app1, asset_address, amount)
     # Assert default identifier is generated correctly
-    address = app0.raiden.address
-    target = app1.raiden.address
-    # asset_manager = app0.raiden.get_manager_by_asset_address(asset_address.decode('hex'))
-    asset_manager = app0.raiden.get_manager_by_asset_address(asset_address)
-    expected_hash = sha3("{}{}{}".format(
-        address,
-        asset_manager.partneraddress_channel[target].our_state.nonce - 1,
-        asset_manager.partneraddress_channel[target].external_state.netting_channel.address
-    ))
-    expected_identifier = int(expected_hash[0:8].encode('hex'), 16)
-
     fchannel = channel(app0, app1, asset_address)
     last_transfer = get_sent_transfer(fchannel, 0)
-
-    assert last_transfer.identifier == expected_identifier
+    random.seed(0)
+    assert_identifier_correct(app0, asset_address, app1.raiden.address, last_transfer.identifier)
 
     amount = 50
     direct_transfer(app1, app2, asset_address, amount)
 
     amount = 30
+    random.seed(0)
     mediated_transfer(
         app1,
         app2,
         asset_address,
-        amount,
-        1  # TODO: fill in identifier
+        amount
     )
+    # Assert default identifier is generated correctly
+    fchannel = channel(app1, app2, asset_address)
+    last_transfer = get_sent_transfer(fchannel, 1)
+    random.seed(0)
+    assert_identifier_correct(app1, asset_address, app2.raiden.address, last_transfer.identifier)

--- a/raiden/tests/test_callbacks.py
+++ b/raiden/tests/test_callbacks.py
@@ -57,7 +57,6 @@ def test_direct_transfer_callback(raiden_network):
     app0.raiden.api.transfer(
         asset_manager0.asset_address,
         amount,
-        1,  # TODO: determine identifier
         target=app1.raiden.address,
     )
     gevent.sleep(1)

--- a/raiden/tests/test_transfer.py
+++ b/raiden/tests/test_transfer.py
@@ -41,7 +41,6 @@ def test_transfer(raiden_network):
     app0.raiden.api.transfer(
         asset_manager0.asset_address,
         amount,
-        1,  # TODO: fill in identifier
         target=app1.raiden.address,
     )
     gevent.sleep(1)
@@ -148,7 +147,6 @@ def test_mediated_transfer(raiden_network):
     alice_app.raiden.api.transfer(
         asset_address,
         amount,
-        1,  # TODO: fill in identifier
         charlie_address,
     )
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -38,7 +38,7 @@ def get_received_transfer(app_channel, transfer_number):
     return app_channel.received_transfers[transfer_number]
 
 
-def transfer(initiator_app, target_app, asset, amount):
+def transfer(initiator_app, target_app, asset, amount, identifier):
     """ Nice to read shortcut to make a transfer.
 
     The transfer is either a DirectTransfer or a MediatedTransfer, in both
@@ -49,12 +49,12 @@ def transfer(initiator_app, target_app, asset, amount):
     initiator_app.raiden.api.transfer(
         asset,
         amount,
-        1,  # TODO: fill in identifier
-        target_app.raiden.address
+        target_app.raiden.address,
+        identifier
     )
 
 
-def direct_transfer(initiator_app, target_app, asset, amount):
+def direct_transfer(initiator_app, target_app, asset, amount, identifier=None):
     """ Nice to read shortcut to make a DirectTransfer. """
     assetmanager = initiator_app.raiden.managers_by_asset_address[asset]
     has_channel = target_app.raiden.address in assetmanager.partneraddress_channel
@@ -63,8 +63,8 @@ def direct_transfer(initiator_app, target_app, asset, amount):
     initiator_app.raiden.api.transfer(
         asset,
         amount,
-        1,  # TODO: fill in identifier
-        target_app.raiden.address
+        target_app.raiden.address,
+        identifier,
     )
 
 
@@ -83,7 +83,7 @@ def mediated_transfer(initiator_app, target_app, asset, amount, identifier):  # 
         task = StartMediatedTransferTask(
             transfermanager,
             amount,
-            identifier,
+            identifier if identifier else 1,  # TODO: if not given what?
             target_app.raiden.address,
         )
         task.start()
@@ -92,8 +92,8 @@ def mediated_transfer(initiator_app, target_app, asset, amount, identifier):  # 
         initiator_app.raiden.api.transfer(
             asset,
             amount,
-            1,  # TODO: fill in identifier
-            target_app.raiden.address
+            target_app.raiden.address,
+            identifier
         )
 
 

--- a/raiden/transfermanager.py
+++ b/raiden/transfermanager.py
@@ -2,6 +2,7 @@
 import logging
 
 import gevent
+import random
 from gevent.event import AsyncResult
 from ethereum import slogging
 
@@ -61,13 +62,15 @@ class TransferManager(object):
         """
         The default message identifier value is the first 8 bytes of the sha3 of:
             - Our Address
-            - Our nonce
-            - The address of the netting channel
+            - Our target address
+            - The asset address
+            - A random 8 byte number for uniqueness
         """
-        hash = sha3("{}{}{}".format(
+        hash = sha3("{}{}{}{}".format(
             self.assetmanager.raiden.address,
-            self.assetmanager.partneraddress_channel[target].our_state.nonce,
-            self.assetmanager.partneraddress_channel[target].external_state.netting_channel.address
+            target,
+            self.assetmanager.asset_address,
+            random.randint(0, 18446744073709551614L)
         ))
         return int(hash[0:8].encode('hex'), 16)
 


### PR DESCRIPTION
This PR is based on #145. **Do not** merge until that is finished.
Also addresses #139 

- [x] Adds the identifier to the Raiden API
- [x] Provides a default value for the identifier if not given. The `sha3` of:
    1. Our address
    2. The asset address
    3.  Our nonce

- [x] Make tests for the above