### PR TITLE
Fixed speed_decoding.py and added identifier to RefundTransfer

### DIFF
--- a/raiden/benchmark/speed_decoding.py
+++ b/raiden/benchmark/speed_decoding.py
@@ -4,15 +4,20 @@ from __future__ import print_function
 import contextlib
 import timeit
 
+import secp256k1
+
 from raiden.utils import sha3, privatekey_to_address
+from raiden.messages import decode
 from raiden.messages import (
-    Ack, Ping, SecretRequest, Secret, DirectTransfer, Lock, LockedTransfer,
-    MediatedTransfer, RefundTransfer, TransferTimeout, ConfirmTransfer, decode,
+    Ack, ConfirmTransfer, DirectTransfer, Lock, MediatedTransfer, Ping,
+    RefundTransfer, Secret, SecretRequest, TransferTimeout,
 )
 
+GLOBAL_CTX = secp256k1.lib.secp256k1_context_create(secp256k1.ALL_FLAGS)
 
-PRIVKEY = 'x' * 32
-ADDRESS = privatekey_to_address(PRIVKEY)
+PRIVKEY_BIN = 'x' * 32
+PRIVKEY = secp256k1.PrivateKey(PRIVKEY_BIN, ctx=GLOBAL_CTX, raw=True)
+ADDRESS = privatekey_to_address(PRIVKEY_BIN)
 HASH = sha3(PRIVKEY)
 ITERATIONS = 1000000  # timeit default
 
@@ -39,76 +44,84 @@ def test_ack(iterations=ITERATIONS):
 
 def test_ping(iterations=ITERATIONS):
     msg = Ping(nonce=0)
-    msg.sign(PRIVKEY)
+    msg.sign(PRIVKEY, ADDRESS)
     run_timeit('Ping', msg, iterations=iterations)
 
 
-# def test_rejected(iterations=ITERATIONS):
-#     msg = Rejected(HASH, 1, [])
-#     msg.sign(PRIVKEY)
-#     run_timeit('Rejected', msg, iterations=iterations)
-# def test_rejected_with_args(iterations=ITERATIONS):
-#     msg = Rejected(HASH, 1, [1, 2, 3])
-#     run_timeit('Rejected with args', msg, iterations=iterations)
+# TODO: LOCKSROOT_REJECTED
 
 
 def test_secret_request(iterations=ITERATIONS):
+    identifier = 1
     hashlock = HASH
     msg = SecretRequest(
-        1,  # TODO: fill in identifier
+        identifier,
         hashlock
     )
-    msg.sign(PRIVKEY)
+    msg.sign(PRIVKEY, ADDRESS)
     run_timeit('SecretRequest', msg, iterations=iterations)
 
 
 def test_secret(iterations=ITERATIONS):
+    identifier = 1
     secret = HASH
     msg = Secret(
-        1,  # TODO: fill in identifier
+        identifier,
         secret
     )
-    msg.sign(PRIVKEY)
+    msg.sign(PRIVKEY, ADDRESS)
     run_timeit('Secret', msg, iterations=iterations)
 
 
 def test_direct_transfer(iterations=ITERATIONS):
+    identifier = 1
     nonce = 1
     asset = ADDRESS
     balance = 1
     recipient = ADDRESS
     locksroot = HASH
 
-    msg = DirectTransfer(nonce, asset, balance, recipient, locksroot)
-    msg.sign(PRIVKEY)
-    run_timeit('DirectTransfer', msg, iterations=iterations)
-
-
-def test_locked_transfer(iterations=ITERATIONS):
-    amount = 1
-    expiration = 1
-    hashlock = sha3(ADDRESS)
-    lock = Lock(amount, expiration, hashlock)
-
-    nonce = 1
-    asset = ADDRESS
-    balance = 1
-    recipient = ADDRESS
-    locksroot = sha3(ADDRESS)
-    msg = LockedTransfer(
-        1,  # TODO: fill in identifier
+    msg = DirectTransfer(
+        identifier,
         nonce,
         asset,
         balance,
         recipient,
         locksroot,
-        lock
     )
-    msg.sign(PRIVKEY)
-    run_timeit('LockedTransfer', msg, iterations=iterations)
+    msg.sign(PRIVKEY, ADDRESS)
+    run_timeit('DirectTransfer', msg, iterations=iterations)
+
+
+# LockedTransfer cannot be encoded/decoded because it's not sent throught the
+# wire
+# def test_locked_transfer(iterations=ITERATIONS):
+#     identifier = 1
+#     amount = 1
+#     expiration = 1
+#     hashlock = sha3(ADDRESS)
+#     lock = Lock(amount, expiration, hashlock)
+#
+#     nonce = 1
+#     asset = ADDRESS
+#     balance = 1
+#     recipient = ADDRESS
+#     locksroot = sha3(ADDRESS)
+#     msg = LockedTransfer(
+#         identifier,
+#         nonce,
+#         asset,
+#         balance,
+#         recipient,
+#         locksroot,
+#         lock
+#     )
+#     msg.sign(PRIVKEY, ADDRESS)
+#     run_timeit('LockedTransfer', msg, iterations=iterations)
 
 
 def test_mediated_transfer(iterations=ITERATIONS):
+    identifier = 1
     amount = 1
     expiration = 1
     hashlock = sha3(ADDRESS)
@@ -121,9 +134,19 @@ def test_mediated_transfer(iterations=ITERATIONS):
     locksroot = sha3(ADDRESS)
     target = ADDRESS
     initiator = ADDRESS
-    msg = MediatedTransfer(nonce, asset, balance, recipient, locksroot,
-                           lock, target, initiator, fee=0)
-    msg.sign(PRIVKEY)
+    msg = MediatedTransfer(
+        identifier,
+        nonce,
+        asset,
+        balance,
+        recipient,
+        locksroot,
+        lock,
+        target,
+        initiator,
+        fee=0,
+    )
+    msg.sign(PRIVKEY, ADDRESS)
 
     run_timeit('MediatedTranfer', msg, iterations=iterations)
 
@@ -134,13 +157,22 @@ def test_cancel_transfer(iterations=ITERATIONS):
     hashlock = sha3(ADDRESS)
     lock = Lock(amount, expiration, hashlock)
 
+    identifier = 1
     nonce = 1
     asset = ADDRESS
-    balance = 1
+    transferred_amount = 1
     recipient = ADDRESS
     locksroot = sha3(ADDRESS)
-    msg = RefundTransfer(nonce, asset, balance, recipient, locksroot, lock)
-    msg.sign(PRIVKEY)
+    msg = RefundTransfer(
+        identifier,
+        nonce,
+        asset,
+        transferred_amount,
+        recipient,
+        locksroot,
+        lock,
+    )
+    msg.sign(PRIVKEY, ADDRESS)
     run_timeit('RefundTransfer', msg, iterations=iterations)
 
 
@@ -148,18 +180,19 @@ def test_transfer_timeout(iterations=ITERATIONS):
     echo = HASH
     hashlock = HASH
     msg = TransferTimeout(echo, hashlock)
-    msg.sign(PRIVKEY)
+    msg.sign(PRIVKEY, ADDRESS)
     run_timeit('TransferTimeout', msg, iterations=iterations)
 
 
 def test_confirm_transfer(iterations=ITERATIONS):
     hashlock = HASH
     msg = ConfirmTransfer(hashlock)
-    msg.sign(PRIVKEY)
+    msg.sign(PRIVKEY, ADDRESS)
     run_timeit('ConfirmTransfer', msg, iterations=iterations)
 
 
 def test_all(iterations=ITERATIONS):
+    test_mediated_transfer(iterations=iterations)
     test_ack(iterations=iterations)
     test_ping(iterations=iterations)
     # needs the args type
@@ -167,8 +200,7 @@ def test_all(iterations=ITERATIONS):
     # test_reject_with_args(iterations=iterations)
     test_secret_request(iterations=iterations)
     test_direct_transfer(iterations=iterations)
-    test_locked_transfer(iterations=iterations)
-    test_mediated_transfer(iterations=iterations)
+    # test_locked_transfer(iterations=iterations)
     test_cancel_transfer(iterations=iterations)
     test_transfer_timeout(iterations=iterations)
     test_confirm_transfer(iterations=iterations)
@@ -188,7 +220,7 @@ def benchmark_alternatives():
     address = privatekey_to_address(privkey)
 
     m0 = Ping(nonce=0)
-    m0.sign(privkey)
+    m0.sign(privkey, ADDRESS)
 
     l1 = Lock(100, 50, sha3(address))
     m1 = MediatedTransfer(
@@ -201,7 +233,7 @@ def benchmark_alternatives():
         address,
         address,
     )
-    m1.sign(privkey)
+    m1.sign(privkey, ADDRESS)
 
     m2 = Ack(address, sha3(privkey))
     """
@@ -222,7 +254,12 @@ def benchmark_alternatives():
             code = code_base.format(variable_name)
 
             exec(code)
-            print('{} encoded {} size: {}'.format(codec_name, message, len(d)))  # noqa pylint: disable=undefined-variable
+
+            print('{} encoded {} size: {}'.format(
+                codec_name,
+                message,
+                len(d),  # NOQA pylint: disable=undefined-variable
+            ))
 
             result = timeit.timeit(code, setup, number=10000)
             print('{} {} (en)(de)coding speed: {}'.format(codec_name, message, result))

--- a/raiden/benchmark/speed_decoding.py
+++ b/raiden/benchmark/speed_decoding.py
@@ -93,33 +93,6 @@ def test_direct_transfer(iterations=ITERATIONS):
     run_timeit('DirectTransfer', msg, iterations=iterations)
 
 
-# LockedTransfer cannot be encoded/decoded because it's not sent throught the
-# wire
-# def test_locked_transfer(iterations=ITERATIONS):
-#     identifier = 1
-#     amount = 1
-#     expiration = 1
-#     hashlock = sha3(ADDRESS)
-#     lock = Lock(amount, expiration, hashlock)
-#
-#     nonce = 1
-#     asset = ADDRESS
-#     balance = 1
-#     recipient = ADDRESS
-#     locksroot = sha3(ADDRESS)
-#     msg = LockedTransfer(
-#         identifier,
-#         nonce,
-#         asset,
-#         balance,
-#         recipient,
-#         locksroot,
-#         lock
-#     )
-#     msg.sign(PRIVKEY, ADDRESS)
-#     run_timeit('LockedTransfer', msg, iterations=iterations)
-
-
 def test_mediated_transfer(iterations=ITERATIONS):
     identifier = 1
     amount = 1
@@ -195,15 +168,14 @@ def test_all(iterations=ITERATIONS):
     test_mediated_transfer(iterations=iterations)
     test_ack(iterations=iterations)
     test_ping(iterations=iterations)
-    # needs the args type
-    # test_reject(iterations=iterations)
-    # test_reject_with_args(iterations=iterations)
     test_secret_request(iterations=iterations)
     test_direct_transfer(iterations=iterations)
-    # test_locked_transfer(iterations=iterations)
     test_cancel_transfer(iterations=iterations)
     test_transfer_timeout(iterations=iterations)
     test_confirm_transfer(iterations=iterations)
+
+    # LockedTransfer cannot be encoded/decoded
+    # LocksrootRejected needs an additional argument
 
 
 def benchmark_alternatives():

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -202,13 +202,14 @@ RefundTransfer = namedbuffer(
         cmdid(REFUNDTRANSFER),  # [0:1]
         pad(3),                 # [1:4]
         nonce,                  # [4:12]
-        expiration,             # [12:20]
-        asset,                  # [20:40]
-        recipient,              # [40:60]
-        locksroot,
-        transferred_amount,
-        amount,
-        hashlock,
+        identifier,             # [12:20]
+        expiration,             # [20:28]
+        asset,                  # [28:48]
+        recipient,              # [48:68]
+        locksroot,              # [68:100]
+        transferred_amount,     # [100:132]
+        amount,                 # [132:164]
+        hashlock,               # [164:196]
         signature,
     ]
 )

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -433,6 +433,7 @@ class LockedTransfer(SignedMessage):
 
     def to_refundtransfer(self):
         return RefundTransfer(
+            self.identifier,
             self.nonce,
             self.asset,
             self.transferred_amount,
@@ -596,6 +597,7 @@ class RefundTransfer(LockedTransfer):
         )
 
         locked_transfer = RefundTransfer(
+            packed.identifier,
             packed.nonce,
             packed.asset,
             packed.transferred_amount,


### PR DESCRIPTION
updated the `speed_decoding.py` to use the new `sign` method.
added the identifier field to the refund message and for the netting channel decoder.