### PR TITLE
Reveal Secret message

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -91,7 +91,8 @@ class SignedMessage(Message):
         field = packed.fields_spec[-1]
         assert field.name == 'signature', 'signature is not the last field'
 
-        message_data = packed.data[:-field.size_bytes]  # XXX: this slice must be from the end of the buffer
+        # this slice must be from the end of the buffer
+        message_data = packed.data[:-field.size_bytes]
         signature = signing.sign(message_data, private_key)
 
         packed.data[-field.size_bytes:] = signature
@@ -122,6 +123,7 @@ class Ack(Message):
     cmdid = messages.ACK
 
     def __init__(self, sender, echo):
+        super(Ack, self).__init__()
         self.sender = sender
         self.echo = echo
 
@@ -174,7 +176,9 @@ class LocksrootRejected(SignedMessage):
     @staticmethod
     def unpack(packed):
         rejected = LocksrootRejected(packed.echo)
-        rejected.signature = packed.data[-signature_field.size_bytes:]  # XXX: this slice must be from the end of the buffer
+
+        # this slice must be from the end of the buffer
+        rejected.signature = packed.data[-signature_field.size_bytes:]
 
         # LocksrootRejected.size includes the signature size
         start = LocksrootRejectedNamedbuffer.size - signature_field.size_bytes
@@ -194,8 +198,12 @@ class LocksrootRejected(SignedMessage):
         size = LocksrootRejectedNamedbuffer.size + len(self.secrets) * secret_field.size_bytes
 
         if size > 1200:  # RaidenProtocol.max_message_size:
-            log.error('cannot encode all the secrets, the resulting packed would be too large and ignored')
-            raise RuntimeError('cannot encode all the secrets, the resulting packed would be too large and ignored')
+            msg = (
+                'cannot encode all the secrets, the resulting packed would be '
+                ' too large and ignored'
+            )
+            log.error(msg)
+            raise RuntimeError(msg)
 
         data = bytearray(size)
         data[0] = self.cmdid
@@ -221,43 +229,54 @@ class SecretRequest(SignedMessage):
     """ Requests the secret which unlocks a hashlock. """
     cmdid = messages.SECRETREQUEST
 
-    def __init__(self, identifier, hashlock):
+    def __init__(self, identifier, hashlock, amount):
         super(SecretRequest, self).__init__()
         self.identifier = identifier
         self.hashlock = hashlock
+        self.amount = amount
 
     def __repr__(self):
-        return '<{} [hashlock:{}]>'.format(
+        return '<{} [hashlock:{} amount:{}]>'.format(
             self.__class__.__name__,
             pex(self.hashlock),
+            self.amount,
         )
 
     @staticmethod
     def unpack(packed):
-        secret_request = SecretRequest(packed.identifier, packed.hashlock)
+        secret_request = SecretRequest(packed.identifier, packed.hashlock, packed.amount)
         secret_request.signature = packed.signature
         return secret_request
 
     def pack(self, packed):
         packed.identifier = self.identifier
         packed.hashlock = self.hashlock
+        packed.amount = self.amount
         packed.signature = self.signature
 
 
 class Secret(SignedMessage):
-    """ Provides the secret to a hashlock. """
+    """ Message used to do state changes on a partner Raiden Channel.
+
+    Locksroot changes need to be synchronized among both participants, the
+    protocol is for only the side unlocking to send the Secret message allowing
+    the other party to withdraw.
+    """
     cmdid = messages.SECRET
 
-    def __init__(self, identifier, secret):
+    def __init__(self, identifier, secret, asset):
         super(Secret, self).__init__()
         self.identifier = identifier
         self.secret = secret
+        self.asset = asset
         self._hashlock = None
 
     def __repr__(self):
-        return '<{} [hashlock:{} hash:{}]>'.format(
+        return '<{} [sender:{} hashlock:{} asset:{} hash:{}]>'.format(
             self.__class__.__name__,
+            pex(self.sender),
             pex(self.hashlock),
+            pex(self.asset),
             pex(self.hash),
         )
 
@@ -269,12 +288,51 @@ class Secret(SignedMessage):
 
     @staticmethod
     def unpack(packed):
-        secret = Secret(packed.identifier, packed.secret)
+        secret = Secret(packed.identifier, packed.secret, packed.asset)
         secret.signature = packed.signature
         return secret
 
     def pack(self, packed):
         packed.identifier = self.identifier
+        packed.secret = self.secret
+        packed.asset = self.asset
+        packed.signature = self.signature
+
+
+class RevealSecret(SignedMessage):
+    """ Message used to reveal a secret to party know to have interest in it.
+
+    This message is not sufficient for state changes in the raiden Channel, the
+    reason is that a node participating in split transfer or in both mediated
+    transfer for an exchange might can reveal the secret to it's partners, but
+    that must not update the internal channel state.
+    """
+    cmdid = messages.REVEALSECRET
+
+    def __init__(self, secret):
+        super(RevealSecret, self).__init__()
+        self.secret = secret
+        self._hashlock = None
+
+    def __repr__(self):
+        return '<{} [hashlock:{}]>'.format(
+            self.__class__.__name__,
+            pex(self.hashlock),
+        )
+
+    @property
+    def hashlock(self):
+        if self._hashlock is None:
+            self._hashlock = sha3(self.secret)
+        return self._hashlock
+
+    @staticmethod
+    def unpack(packed):
+        reveal_secret = RevealSecret(packed.secret)
+        reveal_secret.signature = packed.signature
+        return reveal_secret
+
+    def pack(self, packed):
         packed.secret = self.secret
         packed.signature = self.signature
 
@@ -681,6 +739,7 @@ CMDID_TO_CLASS = {
     messages.LOCKSROOT_REJECTED: LocksrootRejected,
     messages.SECRETREQUEST: SecretRequest,
     messages.SECRET: Secret,
+    messages.REVEALSECRET: RevealSecret,
     messages.DIRECTTRANSFER: DirectTransfer,
     # LockedTransfer is not intended to be sent across the wire, it is a
     # "marker" for messages with locks

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -199,7 +199,7 @@ class LocksrootRejected(SignedMessage):
 
         if size > 1200:  # RaidenProtocol.max_message_size:
             msg = (
-                'cannot encode all the secrets, the resulting packed would be '
+                'cannot encode all the secrets, the resulting packed would be'
                 ' too large and ignored'
             )
             log.error(msg)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -196,14 +196,14 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
             bool: True if a correspoding task is found, False otherwise.
         """
         # allow multiple managers to register for the hashlock (used for exchanges)
-        found = False
+        found = 0
 
         for asset_manager in self.managers_by_asset_address.values():
             task = asset_manager.transfermanager.transfertasks.get(hashlock)
 
             if task is not None:
                 task.on_response(message)
-                found = True
+                found += 1
 
         return found
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -83,6 +83,8 @@ class LogListenerTask(Task):
             events_poll_timeout (float): How long the tasks should sleep before
                 polling again.
         """
+        # pylint: disable=too-many-arguments
+
         super(LogListenerTask, self).__init__()
 
         self.listener_name = listener_name
@@ -122,7 +124,7 @@ class LogListenerTask(Task):
 
                     try:
                         self.callback(originating_contract, event)
-                    except:
+                    except:  # pylint: disable=bare-except
                         log.exception('unexpected exception on log listener')
 
             self.timeout = Timeout(self.sleep_time)  # wait() will call cancel()
@@ -181,7 +183,7 @@ class AlarmTask(Task):
                 for callback in self.callbacks:
                     try:
                         result = callback(current_block)
-                    except:
+                    except:  # pylint: disable=bare-except
                         log.exception('unexpected exception on alarm')
                     else:
                         if result is REMOVE_CALLBACK:
@@ -212,7 +214,10 @@ class AlarmTask(Task):
 
 class StartMediatedTransferTask(Task):
     def __init__(self, transfermanager, amount, identifier, target, done_result):
+        # pylint: disable=too-many-arguments
+
         super(StartMediatedTransferTask, self).__init__()
+
         self.amount = amount
         self.identifier = identifier
         self.address = transfermanager.assetmanager.raiden.address
@@ -226,7 +231,7 @@ class StartMediatedTransferTask(Task):
             pex(self.address),
         )
 
-    def _run(self):  # pylint: disable=method-hidden,too-many-locals
+    def _run(self):  # noqa pylint: disable=method-hidden,too-many-locals
         amount = self.amount
         identifier = self.identifier
         target = self.target
@@ -293,7 +298,11 @@ class StartMediatedTransferTask(Task):
 
             # `target` received the MediatedTransfer
             elif response.sender == target and isinstance(response, SecretRequest):
-                secret_message = Secret(mediated_transfer.identifier, secret)
+                secret_message = Secret(
+                    mediated_transfer.identifier,
+                    secret,
+                    mediated_transfer.asset,
+                )
                 raiden.sign(secret_message)
                 raiden.send_async(target, secret_message)
 
@@ -315,7 +324,9 @@ class StartMediatedTransferTask(Task):
                         # critical read/write section
                         # The channel and it's queue must be locked, a transfer
                         # must not be created while we update the balance_proof.
-                        forward_channel.claim_lock(secret)
+                        if forward_channel.partner_state.balance_proof.is_unclaimed(hashlock):
+                            forward_channel.release_lock(secret)
+
                         raiden.send_async(next_hop, secret_message)
                         # /critical write section
 
@@ -344,7 +355,7 @@ class StartMediatedTransferTask(Task):
 
         self.done_result.set(False)  # all paths failed
 
-    def send_and_wait_valid(self, raiden, path, mediated_transfer):  # pylint: disable=no-self-use
+    def send_and_wait_valid(self, raiden, path, mediated_transfer):  # noqa pylint: disable=no-self-use
         """ Send the `mediated_transfer` and wait for either a message from
         `target` or the `next_hop`.
 
@@ -437,7 +448,8 @@ class MediateTransferTask(Task):  # pylint: disable=too-many-instance-attributes
             pex(self.address)
         )
 
-    def _run(self):  # pylint: disable=method-hidden,too-many-locals,too-many-branches,too-many-statements
+    def _run(self):
+        # pylint: disable=method-hidden,too-many-locals
         fee = self.fee
         transfer = self.originating_transfer
 
@@ -452,6 +464,7 @@ class MediateTransferTask(Task):  # pylint: disable=too-many-instance-attributes
 
         lock_expiration = transfer.lock.expiration - raiden.config['reveal_timeout']
         lock_timeout = lock_expiration - raiden.chain.block_number()
+        lock_hashlock = transfer.lock.hashlock
 
         # there are no guarantees that the next_hop will follow the same route
         routes = assetmanager.get_best_routes(
@@ -478,7 +491,7 @@ class MediateTransferTask(Task):  # pylint: disable=too-many-instance-attributes
                 transfer.lock.amount,
                 transfer.identifier,
                 lock_expiration,
-                transfer.lock.hashlock,
+                lock_hashlock,
             )
             raiden.sign(mediated_transfer)
 
@@ -534,7 +547,9 @@ class MediateTransferTask(Task):  # pylint: disable=too-many-instance-attributes
                     # secret, so we know this `response` message secret matches
                     # the secret from the `next_hop`
                     if isinstance(response, Secret) and response.sender == transfer.sender:
-                        originating_channel.claim_lock(response.secret)
+                        if originating_channel.our_state.balance_proof.is_unclaimed(lock_hashlock):
+                            originating_channel.withdraw_lock(response.secret)
+
                         self.transfermanager.on_hashlock_result(transfer.lock.hashlock, True)
                         return
 
@@ -631,6 +646,7 @@ class EndMediatedTransferTask(Task):
         assetmanager = self.transfermanager.assetmanager
         originating_channel = assetmanager.get_channel_by_partner_address(mediated_transfer.sender)
         raiden = assetmanager.raiden
+        hashlock = mediated_transfer.lock.hashlock
 
         log.debug(
             'END MEDIATED TRANSFER %s -> %s identifier:%s msghash:%s hashlock:%s',
@@ -643,7 +659,8 @@ class EndMediatedTransferTask(Task):
 
         secret_request = SecretRequest(
             mediated_transfer.identifier,
-            mediated_transfer.lock.hashlock
+            hashlock,
+            mediated_transfer.lock.amount,
         )
         raiden.sign(secret_request)
 
@@ -660,22 +677,28 @@ class EndMediatedTransferTask(Task):
         # updated
         originating_channel.register_secret(response.secret)
 
-        secret_message = Secret(mediated_transfer.identifier, response.secret)
+        secret_message = Secret(
+            mediated_transfer.identifier,
+            response.secret,
+            mediated_transfer.asset,
+        )
+
         raiden.sign(secret_message)
         raiden.send_async(mediated_transfer.sender, secret_message)
 
         # wait for the secret from `sender` to claim the lock
-        while True:
+        while originating_channel.our_state.balance_proof.is_unclaimed(hashlock):
             response = self.response_message.wait()
             # critical write section
             self.response_message = AsyncResult()
             # /critical write section
 
             if isinstance(response, Secret) and response.sender == mediated_transfer.sender:
-                originating_channel.claim_lock(response.secret)
-                self.transfermanager.endtask_transfer_mapping[self] = self.originating_transfer
-                self.transfermanager.on_hashlock_result(mediated_transfer.lock.hashlock, True)
-                return
+                if originating_channel.our_state.balance_proof.is_unclaimed(hashlock):
+                    originating_channel.withdraw_lock(response.secret)
+
+        self.transfermanager.endtask_transfer_mapping[self] = self.originating_transfer
+        self.transfermanager.on_hashlock_result(mediated_transfer.lock.hashlock, True)
 
     def send_and_wait_valid(self, raiden, mediated_transfer, secret_request):
         message_timeout = raiden.config['msg_timeout']

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -2,7 +2,7 @@
 import pytest
 from ethereum.utils import sha3
 
-from raiden.raiden_service import DEFAULT_SETTLE_TIMEOUT
+from raiden.raiden_service import DEFAULT_REVEAL_TIMEOUT, DEFAULT_SETTLE_TIMEOUT
 from raiden.tasks import DEFAULT_EVENTS_POLL_TIMEOUT
 from raiden.network.rpc.client import DEFAULT_POLL_TIMEOUT
 from raiden.network.transport import UDPTransport
@@ -19,6 +19,12 @@ DEFAULT_DEPOSIT = 200
 def settle_timeout():
     """ NettingChannel default settle timeout. """
     return DEFAULT_SETTLE_TIMEOUT
+
+
+@pytest.fixture
+def reveal_timeout():
+    """ NettingChannel default settle timeout. """
+    return DEFAULT_REVEAL_TIMEOUT
 
 
 @pytest.fixture


### PR DESCRIPTION
The bulk of the changes was to split the shared responsabilities for the `Secret` message and the `claim_lock` method.

This PR does:
- Adds the `amount` field for issue #112 
- Prepares the `Secret` message for #66 

Please review of #151 before merging.