### PR TITLE
fix test_mtree.py/test_empty

### DIFF
--- a/raiden/tests/test_mtree.py
+++ b/raiden/tests/test_mtree.py
@@ -5,8 +5,9 @@ from raiden.mtree import merkleroot, check_proof, get_proof, NoHash32Error
 from raiden.utils import keccak
 
 
-def test_empy():
-    assert merkleroot('') == ''
+def test_empty():
+    assert merkleroot([]) == ''
+    assert merkleroot(['']) == ''
 
 
 def test_multiple_empty():


### PR DESCRIPTION
besides the typo, the function called merkleroot with the first argument
being the empty string.

This looks like it should have been an empty list or a list containing
the empty string. Both of these cases are now tested in test_empty.