### PR TITLE
do not clear the proof argument in check_proof

### DIFF
--- a/raiden/mtree.py
+++ b/raiden/mtree.py
@@ -82,8 +82,9 @@ def build_lst(elements):
 
 
 def check_proof(proof, root, hash_):
-    while len(proof):
-        hash_ = hash_pair(hash_, proof.pop(0))
+    for x in proof:
+        hash_ = hash_pair(hash_, x)
+
     return hash_ == root
 
 


### PR DESCRIPTION
check_proof did clear the proof argument. There's no good reason to do
that and it's just waiting to bite you. One of the tests in
test_mtree.py already compares empty lists...

So, don't modify the proof argument.
