### PR TITLE
Fix failing tests for updateTransfer

### DIFF
--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -56,6 +56,12 @@ library NettingChannelLibrary {
         _;
     }
 
+    modifier notClosingAddress(Data storage self) {
+        if (msg.sender == self.closingAddress)
+            throw;
+        _;
+    }
+
     /// @notice deposit(uint) to deposit amount to channel.
     /// @dev Deposit an amount to the channel. At least one of the participants
     /// must deposit before the channel is opened.
@@ -233,6 +239,7 @@ library NettingChannelLibrary {
     function updateTransfer(Data storage self, address callerAddress, bytes signed_transfer)
         notSettledButClosed(self)
         stillTimeout(self)
+        notClosingAddress(self)
     {
         uint64 nonce;
         bytes memory transfer_raw;
@@ -240,8 +247,8 @@ library NettingChannelLibrary {
 
         (transfer_raw, transfer_address) = getTransferRawAddress(signed_transfer);
 
-        // participant that called close cannot update
-        if (self.closingAddress == transfer_address) {
+        // transfer address must be from counter party
+        if (self.closingAddress != transfer_address) {
             throw;
         }
 

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -531,7 +531,6 @@ def test_two_messages_mediated_transfer(deposit, settle_timeout, tester_state,
     assert tester_token.balanceOf(nettingchannel.address, sender=privatekey1_raw) == 0
 
 
-@pytest.mark.xfail()
 def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, tester_events):
     privatekey0_raw, privatekey1_raw, nettingchannel, channel0, channel1 = tester_channels[0]
     privatekey0 = PrivateKey(privatekey0_raw, ctx=GLOBAL_CTX, raw=True)
@@ -642,7 +641,6 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
     # - add locked amounts and assert that they are respected
 
 
-@pytest.mark.xfail()
 def test_update_mediated_transfer(settle_timeout, tester_state, tester_channels, tester_events):
     privatekey0_raw, privatekey1_raw, nettingchannel, channel0, channel1 = tester_channels[0]
     privatekey0 = PrivateKey(privatekey0_raw, ctx=GLOBAL_CTX, raw=True)
@@ -682,7 +680,10 @@ def test_update_mediated_transfer(settle_timeout, tester_state, tester_channels,
     channel1.register_transfer(mediated_transfer0)
 
     transfer_amount = 13
-    direct_transfer1 = channel1.create_directtransfer(transfer_amount)
+    direct_transfer1 = channel1.create_directtransfer(
+        transfer_amount,
+        1  # TODO: fill in identifier
+    )
     direct_transfer1.sign(privatekey1, address1)
     direct_transfer1_data = str(direct_transfer1.packed().data)
 


### PR DESCRIPTION
This PR fixes #196 and #197 

There was a check in `updateTransfer` that dictated wrong logic. That is not fixed and a modifier has been added that makes sure that the address calling close cannot call `updateTransfer`