### PR TITLE
Deactivate re-sends after X tries without ACK

### DIFF
--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -109,7 +109,7 @@ class DummyTransport(object):
 
 
 class UnreliableTransport(DummyTransport):
-    """ A transport that simulates random loses of UDP messages. """
+    """ A transport that simulates random losses of UDP messages. """
 
     droprate = 2  # drop every Nth message
 

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -113,15 +113,21 @@ class RaidenProtocol(object):
             # ack_result can be False
             while waitack.ack_result.wait(timeout=self.try_interval) is None:
                 retries_left -= 1
-                # TODO: fix the graph
-                # if retries_left < 1:
-                #     if log.isEnabledFor(logging.ERROR):
-                #         log.error(
-                #                'DEACTIVATED MSG resents %s %s',
-                #                pex(receiver_address),
-                #                message,
-                #         )
-                #         return
+
+                # TODO: The graph should be updated and the node should be marked
+                #       as temporarily unreachable, so that get_best_routes don't
+                #       try this route when looking for a path.
+                # XXX: How should it be marked available again?
+
+                if retries_left < 1:
+                    if log.isEnabledFor(logging.ERROR):
+                        log.error(
+                               'DEACTIVATED MSG resents %s %s',
+                               pex(receiver_address),
+                               message,
+                        )
+                    waitack.ack_result.set(False)
+                    break
 
                 if log.isEnabledFor(logging.INFO):
                     log.info(

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -122,9 +122,9 @@ class RaidenProtocol(object):
                 if retries_left < 1:
                     if log.isEnabledFor(logging.ERROR):
                         log.error(
-                               'DEACTIVATED MSG resents %s %s',
-                               pex(receiver_address),
-                               message,
+                            'DEACTIVATED MSG resents %s %s',
+                            pex(receiver_address),
+                            message,
                         )
                     waitack.ack_result.set(False)
                     break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-timeout
 pysha3
 pyethapp>=1.5.0
 ipython<5.0.0


### PR DESCRIPTION
This fixes the Ping when node is unreachable due message resend not being disabled.

Would add the TODO/XXX related code to update the graph but will open a new issue for that and work on other branch because this already solves the general problem.