### PR TITLE
Fix failing unlock test + minor modifier improvement

### DIFF
--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -56,8 +56,8 @@ library NettingChannelLibrary {
         _;
     }
 
-    modifier notClosingAddress(Data storage self) {
-        if (msg.sender == self.closing_address)
+    modifier notClosingAddress(Data storage self, address caller) {
+        if (caller == self.closing_address)
             throw;
         _;
     }
@@ -257,7 +257,7 @@ library NettingChannelLibrary {
     function updateTransfer(Data storage self, address caller_address, bytes signed_transfer)
         notSettledButClosed(self)
         stillTimeout(self)
-        notClosingAddress(self)
+        notClosingAddress(self, caller_address)
     {
         uint64 nonce;
         bytes memory transfer_raw;

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -324,8 +324,6 @@ library NettingChannelLibrary {
             throw;
         }
 
-        (expiration, amount, hashlock) = decodeLock(locked_encoded);
-
         if (expiration < block.number)
             throw;
 

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -319,7 +319,8 @@ library NettingChannelLibrary {
         bytes32 el;
 
         (expiration, amount, hashlock) = decodeLock(locked_encoded);
-        if (self.locks[sha3(locked_encoded)]) {
+
+        if (self.locks[hashlock]) {
             throw;
         }
 
@@ -361,7 +362,7 @@ library NettingChannelLibrary {
             throw;
 
         participant.unlocked.push(Lock(expiration, amount, hashlock));
-        self.locks[sha3(locked_encoded)] = true;
+        self.locks[hashlock] = true;
     }
 
     /// @notice settle() to settle the balance between the two parties

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -788,12 +788,10 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
             sender=privatekey1_raw,
         )
 
-    # transfer = channel1.partner_state.balance_proof.transfer
     unlock_proofs = list(channel1.our_state.balance_proof.get_known_unlocks())
 
     assert len(unlock_proofs) == 1
 
-    # channel1.external_state.update_transfer(channel1.our_state.address, transfer)
     channel1.external_state.unlock(channel1.our_state.address, unlock_proofs)
 
     # already unlock, shoud fail

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -795,7 +795,7 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
     assert len(unlock_proofs) == 1
 
     channel1.external_state.update_transfer(channel1.our_state.address, transfer)
-    channel1.external_state.unlock(channel1.our_state.address, unlock_proofs)
+    channel0.external_state.unlock(channel0.our_state.address, unlock_proofs)
 
     # already unlock, shoud fail
     with pytest.raises(TransactionFailed):
@@ -805,5 +805,5 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
             proof.lock_encoded,
             ''.join(proof.merkle_proof),
             proof.secret,
-            sender=privatekey1,
+            sender=privatekey0_raw,
         )

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -716,7 +716,6 @@ def test_update_mediated_transfer(settle_timeout, tester_state, tester_channels,
     # - add locked amounts and assert that they are respected
 
 
-@pytest.mark.xfail()
 def test_unlock(tester_token, tester_channels, tester_events, tester_state):
     privatekey0_raw, privatekey1_raw, nettingchannel, channel0, channel1 = tester_channels[0]
     privatekey0 = PrivateKey(privatekey0_raw, ctx=GLOBAL_CTX, raw=True)
@@ -789,13 +788,13 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
             sender=privatekey1_raw,
         )
 
-    transfer = channel1.partner_state.balance_proof.transfer
+    # transfer = channel1.partner_state.balance_proof.transfer
     unlock_proofs = list(channel1.our_state.balance_proof.get_known_unlocks())
 
     assert len(unlock_proofs) == 1
 
-    channel1.external_state.update_transfer(channel1.our_state.address, transfer)
-    channel0.external_state.unlock(channel0.our_state.address, unlock_proofs)
+    # channel1.external_state.update_transfer(channel1.our_state.address, transfer)
+    channel1.external_state.unlock(channel1.our_state.address, unlock_proofs)
 
     # already unlock, shoud fail
     with pytest.raises(TransactionFailed):


### PR DESCRIPTION
This PR fixes the failing unlock test from issue #198 . The problem was that the wrong party was trying to unlock. The test is still marked as xfails however since the function call that is expected to fail doesn't fail. This will be fixed when issue #96 is taken care of. But now at least the tests are correct. 

Also I've made a small change to a modifier. This is done since the NettingChannelLibrary.sol should not use `msg.sender`
