### PR TITLE
untangle and cleanup raiden.mtree

### DIFF
--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -15,7 +15,7 @@ from raiden.messages import (
     LockedTransfer,
     TransferTimeout,
 )
-from raiden.mtree import merkleroot
+from raiden.mtree import merkleroot, get_proof
 from raiden.utils import sha3, pex, lpex
 from raiden.tasks import REMOVE_CALLBACK
 
@@ -252,8 +252,7 @@ class BalanceProof(object):
         # forcing bytes because ethereum.abi doesnt work with bytearray
         lock_encoded = bytes(lock.as_bytes)
         lock_hash = sha3(lock_encoded)
-        merkle_proof = [lock_hash]
-        merkleroot(merkletree, merkle_proof)
+        merkle_proof = get_proof(merkletree, lock_hash)
 
         return UnlockProof(
             merkle_proof,

--- a/raiden/mtree.py
+++ b/raiden/mtree.py
@@ -62,28 +62,22 @@ class Merkletree(object):
         return self._layers[-1][0]
 
     def make_proof(self, element):
+        """ The proof contains all elements between `element` and `root`.
+            If on all of [element] + proof is recursively hash_pair applied one
+            gets the root.
+        """
         return merkleproof_from_layers(self._layers, self._layers[0].index(element))
 
 
-def merkleroot(elements, proof=None):
+def merkleroot(elements):
     """
     Args:
         elements (List[str]): List of hashes that make the merkletree.
-        proof (list): Empty or list with a single element for which a proof shall be
-            built. The resulting proof will be in proof, i.e. the list
-            is modified in place.
-
-            The proof contains all elements between `element` and `root`.
-            If on all of [element] + proof is recursively hash_pair applied one
-            gets the root.
 
     Returns:
         str: The root element of the merkle tree.
     """
-    tree = Merkletree(elements)
-    if proof:
-        proof[:] = tree.make_proof(proof[0])
-    return tree.merkleroot
+    return Merkletree(elements).merkleroot
 
 
 

--- a/raiden/tests/test_mtree.py
+++ b/raiden/tests/test_mtree.py
@@ -36,8 +36,8 @@ def test_one():
     hash_0 = 'a' * 32
 
     merkle_tree = [hash_0]
-    merkle_proof = [hash_0]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_0)
+    merkle_root = merkleroot(merkle_tree)
 
     assert merkle_proof == []
     assert merkle_root == hash_0
@@ -50,15 +50,15 @@ def test_two():
 
     merkle_tree = [hash_0, hash_1]
 
-    merkle_proof = [hash_0]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_0)
+    merkle_root = merkleroot(merkle_tree)
 
     assert merkle_proof == [hash_1]
     assert merkle_root == keccak(hash_0 + hash_1)
     assert check_proof(merkle_proof, merkle_root, hash_0)
 
-    merkle_proof = [hash_1]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_1)
+    merkle_root = merkleroot(merkle_tree)
 
     assert merkle_proof == [hash_0]
     assert merkle_root == keccak(hash_0 + hash_1)
@@ -79,22 +79,22 @@ def test_three():
     assert keccak(hash_0 + hash_1) == hash_01
     calculated_root = keccak(hash_2 + hash_01)
 
-    merkle_proof = [hash_0]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_0)
+    merkle_root = merkleroot(merkle_tree)
 
     assert merkle_proof == [hash_1, hash_2]
     assert merkle_root == calculated_root
     assert check_proof(merkle_proof, merkle_root, hash_0)
 
-    merkle_proof = [hash_1]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_1)
+    merkle_root = merkleroot(merkle_tree)
 
     assert merkle_proof == [hash_0, hash_2]
     assert merkle_root == calculated_root
     assert check_proof(merkle_proof, merkle_root, hash_1)
 
-    merkle_proof = [hash_2]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_2)
+    merkle_root = merkleroot(merkle_tree)
 
     # with an odd number of values, the last value wont appear by itself in the
     # proof since it isn't hashed with another value
@@ -109,8 +109,8 @@ def test_get_proof():
 
     merkle_tree = [hash_0, hash_1]
 
-    merkle_proof = [hash_0]  # modified in place
-    merkle_root = merkleroot(merkle_tree, merkle_proof)
+    merkle_proof = get_proof(merkle_tree, hash_0)
+    merkle_root = merkleroot(merkle_tree)
     assert check_proof(merkle_proof, merkle_root, hash_0)
 
     second_merkle_proof = get_proof(merkle_tree, hash_0, merkle_root)
@@ -126,8 +126,8 @@ def test_many(tree_up_to=10):
         ]
 
         for value in merkle_tree:
-            merkle_proof = [value]
-            merkle_root = merkleroot(merkle_tree, merkle_proof)
+            merkle_proof = get_proof(merkle_tree, value)
+            merkle_root = merkleroot(merkle_tree)
             second_proof = get_proof(merkle_tree, value, merkle_root)
 
             assert check_proof(merkle_proof, merkle_root, value) is True


### PR DESCRIPTION
The previous implementation of merkleroot was hard to understand, since
it tried to do several things at the same time.

I've tried to untangle that and now we've got separate functions to
- iterate pairwise over a list of elements
- compute the layers of the merkletree
- create proofs from the merkletree layers

I've also added a Merkletree class, which is initialized with a list of
hashes. This allows to compute multiple proofs for the same tree without
recomputing hashes all the time.

The merkleroot function still exists, but eventually it will be removed.

This is work-in-progress in order to resolve issue #202.