### PR TITLE
Tests blockchain tester

### DIFF
--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -66,6 +66,12 @@ channel_manager_compiled = _solidity.compile_contract(
     combined='abi',
 )
 
+endpoint_registry_compiled = _solidity.compile_contract(
+    get_contract_path('EndpointRegistry.sol'),
+    'EndpointRegistry',
+    combined='abi',
+)
+
 netting_channel_compiled = _solidity.compile_contract(
     get_contract_path('NettingChannelContract.sol'),
     'NettingChannelContract',
@@ -84,6 +90,7 @@ HUMAN_TOKEN_ABI = human_token_compiled['abi']
 CHANNEL_MANAGER_ABI = channel_manager_compiled['abi']
 NETTING_CHANNEL_ABI = netting_channel_compiled['abi']
 REGISTRY_ABI = registry_compiled['abi']
+ENDPOINT_REGISTRY_ABI = endpoint_registry_compiled['abi']
 
 ASSETADDED_EVENT = get_event(REGISTRY_ABI, 'AssetAdded')
 ASSETADDED_EVENTID = event_id(*get_eventname_types(ASSETADDED_EVENT))

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -1,21 +1,10 @@
 # -*- coding: utf-8 -*-
-from ethereum import _solidity
-
 from raiden.utils import (
     host_port_to_endpoint,
     isaddress,
     pex,
     split_endpoint,
-    get_contract_path,
 )
-from raiden.network.rpc.client import DEFAULT_POLL_TIMEOUT
-
-discovery_contract_compiled = _solidity.compile_contract(
-    get_contract_path('EndpointRegistry.sol'),
-    'EndpointRegistry',
-    combined='abi',
-)
-DISCOVERY_CONTRACT_ABI = discovery_contract_compiled['abi']
 
 
 class Discovery(object):
@@ -42,8 +31,9 @@ class Discovery(object):
 
 
 class ContractDiscovery(Discovery):
-    """On chain smart contract raiden node discovery: allows to register endpoints (host, port) for
-    your ethereum-/raiden-address and looking up endpoints for other ethereum-/raiden-addressess.
+    """ Raiden node discovery.
+
+    Allows to registering and lookup by endpoint (host, port) for node_address.
     """
 
     def __init__(self, node_address, discovery_proxy):
@@ -57,10 +47,12 @@ class ContractDiscovery(Discovery):
             raise ValueError('You can only register your own endpoint.')
 
         endpoint = host_port_to_endpoint(host, port)
-        self.discovery_proxy.register_endpoint(endpoint)
+        self.discovery_proxy.register_endpoint(node_address, endpoint)
 
     def get(self, node_address):
-        return self.discovery_proxy.endpoint_by_address(node_address)
+        endpoint = self.discovery_proxy.endpoint_by_address(node_address)
+        host_port = split_endpoint(endpoint)
+        return host_port
 
     def nodeid_by_host_port(self, host_port):
         host, port = host_port

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -33,7 +33,7 @@ class Discovery(object):
 class ContractDiscovery(Discovery):
     """ Raiden node discovery.
 
-    Allows to registering and lookup by endpoint (host, port) for node_address.
+    Allows registering and looking up by endpoint (host, port) for node_address.
     """
 
     def __init__(self, node_address, discovery_proxy):

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -14,7 +14,6 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
-    split_endpoint,
 )
 from raiden.blockchain.abi import (
     ASSETADDED_EVENTID,
@@ -344,7 +343,10 @@ class Discovery(object):
         self.gasprice = gasprice
         self.poll_timeout = poll_timeout
 
-    def register_endpoint(self, endpoint):
+    def register_endpoint(self, node_address, endpoint):
+        if node_address != self.client.sender:
+            raise ValueError('node_address doesnt match this node address')
+
         transaction_hash = self.proxy.registerEndpoint.transact(endpoint)
 
         self.client.poll(
@@ -359,7 +361,7 @@ class Discovery(object):
         if endpoint is '':
             raise KeyError('Unknow address {}'.format(pex(node_address_bin)))
 
-        return split_endpoint(endpoint)
+        return endpoint
 
     def address_by_endpoint(self, endpoint):
         address = self.proxy.findAddressByEndpoint.call(endpoint)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -308,8 +308,9 @@ class Filter(object):
 
 
 class Discovery(object):
-    """On chain smart contract raiden node discovery: allows to register endpoints (host, port) for
-    your ethereum-/raiden-address and looking up endpoints for other ethereum-/raiden-addressess.
+    """On chain smart contract raiden node discovery: allows registering
+    endpoints (host, port) for your ethereum-/raiden-address and looking up
+    endpoints for other ethereum-/raiden-addressess.
     """
 
     def __init__(
@@ -327,7 +328,7 @@ class Discovery(object):
         )
 
         if result == '0x':
-            raise ValueError('Disocvery address {} does not contain code'.format(
+            raise ValueError('Discovery address {} does not contain code'.format(
                 address_encoder(discovery_address),
             ))
 
@@ -345,7 +346,7 @@ class Discovery(object):
 
     def register_endpoint(self, node_address, endpoint):
         if node_address != self.client.sender:
-            raise ValueError('node_address doesnt match this node address')
+            raise ValueError("node_address doesnt match this node's address")
 
         transaction_hash = self.proxy.registerEndpoint.transact(endpoint)
 
@@ -359,7 +360,7 @@ class Discovery(object):
         endpoint = self.proxy.findEndpointByAddress.call(node_address_hex)
 
         if endpoint is '':
-            raise KeyError('Unknow address {}'.format(pex(node_address_bin)))
+            raise KeyError('Unknown address {}'.format(pex(node_address_bin)))
 
         return endpoint
 

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -143,11 +143,20 @@ def test_new_netting_contract(raiden_network, asset_amount, settle_timeout):
     assert netting_channel_02.detail(peer2_address)['our_balance'] == 130
 
 
-@pytest.mark.parametrize('blockchain_type', ['geth'])
 @pytest.mark.parametrize('privatekey_seed', ['blockchain:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
-def test_blockchain(blockchain_backend, private_keys, number_of_nodes, poll_timeout):
+def test_blockchain(
+        blockchain_type,
+        blockchain_backend,  # required to start the geth backend
+        private_keys,
+        poll_timeout):
     # pylint: disable=too-many-locals
+
+    # this test is for interaction with a blockchain using json-rpc, so it
+    # doesnt make sense to execute it against mock or tester
+    if blockchain_type not in ('geth',):
+        return
+
     addresses = [
         privatekey_to_address(priv)
         for priv in private_keys

--- a/raiden/tests/integration/test_endpointregistry.py
+++ b/raiden/tests/integration/test_endpointregistry.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from ethereum import _solidity
-
 from raiden.utils import make_address, get_contract_path, privatekey_to_address
 from raiden.network.discovery import ContractDiscovery
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -14,7 +14,6 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
-    split_endpoint,
 )
 from raiden.blockchain.abi import (
     ASSETADDED_EVENTID,
@@ -339,7 +338,10 @@ class DiscoveryTesterMock(object):
             default_key=private_key,
         )
 
-    def register_endpoint(self, endpoint):
+    def register_endpoint(self, node_address, endpoint):
+        if node_address != privatekey_to_address(self.private_key):
+            raise ValueError('node_address doesnt match this node address')
+
         self.proxy.registerEndpoint(endpoint)
         self.tester_state.mine(number_of_blocks=1)
 
@@ -350,7 +352,7 @@ class DiscoveryTesterMock(object):
         if endpoint is '':
             raise KeyError('Unknow address {}'.format(pex(node_address_bin)))
 
-        return split_endpoint(endpoint)
+        return endpoint
 
     def address_by_endpoint(self, endpoint):
         address = self.proxy.findAddressByEndpoint(endpoint)


### PR DESCRIPTION
This PR removes the `geth` requirement from some integration tests, all tests will be executed on top of `blockchain_type=tester` when the `--blockchain-type=tester` flag is supplied.