### PR TITLE
tests: checking for gas usage

### DIFF
--- a/raiden/tests/fixtures/tester.py
+++ b/raiden/tests/fixtures/tester.py
@@ -4,7 +4,6 @@ import ethereum.db
 import ethereum.blocks
 import ethereum.config
 from ethereum import tester
-from ethereum import processblock
 from ethereum.utils import int_to_addr, zpad
 from pyethapp.jsonrpc import address_decoder, data_decoder, quantity_decoder
 
@@ -20,25 +19,6 @@ from raiden.tests.utils.tester import (
     new_nettingcontract,
 )
 from raiden.tests.utils.tester_client import ChannelExternalStateTester
-from raiden.network.rpc.client import GAS_LIMIT
-
-
-def monkey_patch_tester():
-    original_apply_transaction = processblock.apply_transaction
-
-    def apply_transaction(block, transaction):
-        start_gas = block.gas_used
-        result = original_apply_transaction(block, transaction)
-        end_gas = block.gas_used
-
-        assert end_gas - start_gas <= GAS_LIMIT
-
-        return result
-
-    tester.processblock.apply_transaction = apply_transaction
-
-
-monkey_patch_tester()
 
 
 @pytest.fixture


### PR DESCRIPTION
Added an assert for gas usage.

We are using a [fairly large gas block limit](https://github.com/raiden-network/raiden/blob/040fcb15e3b6aec3953a7c947b0d83bf7dac82e1/raiden/tests/fixtures/tester.py#L24-L33) to avoid `mine`ing too often, this assert will prevent functions that use too much gas.