### PR TITLE
Healthcheck

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -110,6 +110,15 @@ _options = [
         default=None,
         type=str,
     ),
+    click.option(
+        '--max-unresponsive-time',
+        help=(
+            'Max time in seconds for which an address can send no packets and '
+            'still be considered healthy'
+        ),
+        default=10,
+        type=int,
+    ),
 ]
 
 
@@ -130,7 +139,8 @@ def app(address,
         discovery_contract_address,
         listen_address,
         logging,
-        logfile):
+        logfile,
+        max_unresponsive_time):
 
     slogging.configure(logging, log_file=logfile)
 
@@ -140,6 +150,7 @@ def app(address,
     config = App.default_config.copy()
     config['host'] = listen_host
     config['port'] = listen_port
+    config['max_unresponsive_time'] = max_unresponsive_time
 
     accmgr = AccountManager(keystore_path)
     if not accmgr.accounts:

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -114,9 +114,18 @@ _options = [
         '--max-unresponsive-time',
         help=(
             'Max time in seconds for which an address can send no packets and '
-            'still be considered healthy'
+            'still be considered healthy. Give 0 in order to disable healthcheck.'
         ),
-        default=10,
+        default=120,
+        type=int,
+    ),
+    click.option(
+        '--send-ping-time',
+        help=(
+            'Time in seconds after which if we have received no message from a '
+            'node we have a connection with, we are going to send a PING message'
+        ),
+        default=60,
         type=int,
     ),
 ]
@@ -140,7 +149,8 @@ def app(address,
         listen_address,
         logging,
         logfile,
-        max_unresponsive_time):
+        max_unresponsive_time,
+        send_ping_time):
 
     slogging.configure(logging, log_file=logfile)
 
@@ -151,6 +161,7 @@ def app(address,
     config['host'] = listen_host
     config['port'] = listen_port
     config['max_unresponsive_time'] = max_unresponsive_time
+    config['send_ping_time'] = send_ping_time
 
     accmgr = AccountManager(keystore_path)
     if not accmgr.accounts:

--- a/raiden/channelgraph.py
+++ b/raiden/channelgraph.py
@@ -86,4 +86,5 @@ class ChannelGraph(object):
         self.graph.add_edge(from_, to_)
 
     def remove_path(self, from_, to_):
-        raise NotImplementedError()
+        """ Remove an edge from the network. """
+        self.graph.remove_edge(from_, to_)

--- a/raiden/channelgraph.py
+++ b/raiden/channelgraph.py
@@ -76,7 +76,7 @@ class ChannelGraph(object):
         ]
 
     def has_path(self, source, target):
-        """ Return True if there is a path connectin source and target, False
+        """ Return True if there is a path connecting source and target, False
         otherwise.
         """
         return networkx.has_path(self.graph, source, target)

--- a/raiden/console.py
+++ b/raiden/console.py
@@ -152,7 +152,6 @@ class ConsoleTools(object):
         self._discovery = discovery
         self.settle_timeout = settle_timeout
         self.reveal_timeout = reveal_timeout
-        self._ping_nonces = defaultdict(int)
         self.deposit = self._raiden.api.deposit
 
     def create_token(
@@ -228,8 +227,8 @@ class ConsoleTools(object):
             print("Error: peer {} not found in discovery".format(peer))
             return
 
-        nonce = self._ping_nonces[peer]
-        self._ping_nonces[peer] += 1
+        nonce = self._raiden.protocol.ping_nonces[peer]
+        self._raiden.protocol.ping_nonces[peer] += 1
         msg = Ping(nonce)
         self._raiden.sign(msg)
         return self._raiden.protocol.send_and_wait(peer.decode('hex'), msg)

--- a/raiden/console.py
+++ b/raiden/console.py
@@ -3,7 +3,6 @@ import cStringIO
 import json
 import sys
 import time
-from collections import defaultdict
 from logging import StreamHandler, Formatter
 
 import gevent
@@ -18,7 +17,6 @@ from pyethapp.utils import bcolors as bc
 from pyethapp.jsonrpc import address_encoder
 from pyethapp.console_service import GeventInputHook, SigINTHandler
 
-from raiden.messages import Ping
 from raiden.utils import events, get_contract_path
 
 # ipython needs to accept "--gui gevent" option
@@ -214,12 +212,14 @@ class ConsoleTools(object):
         return channel_manager
 
     def ping(self, peer, timeout=0):
-        """See, if a peer is discoverable and up.
-
-            :peer string: the hex-encoded (ethereum) address of the peer.
-            :timeout int: The number of seconds to wait for the peer to acknowledge
-                          our ping
-            :return boolean: True if ping succeeded, False otherwise (timeout)
+        """
+        See, if a peer is discoverable and up.
+           Args:
+                peer (string): the hex-encoded (ethereum) address of the peer.
+                timeout (int): The number of seconds to wait for the peer to
+                               acknowledge our ping
+        Returns:
+            success (boolean): True if ping succeeded, False otherwise.
         """
         # Check, if peer is discoverable
         try:

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -163,6 +163,7 @@ class RaidenProtocol(object):
                     pex(receiver_address),
                 )
 
+            self.last_received_time[receiver_address] = time.time()
             self.address_queue[key] = NotifyingQueue()
             self.address_greenlet[receiver_address] = gevent.spawn(
                 self._send_queued_messages,
@@ -251,11 +252,11 @@ class RaidenProtocol(object):
         self._ping_nonces[receiver_address] += 1
 
         message = Ping(nonce)
-        self._raiden.sign(message)
+        self.raiden.sign(message)
 
         if log.isEnabledFor(logging.INFO):
             log.info(
-                'SENDING PING %s > %s %s',
+                'SENDING PING %s > %s',
                 pex(self.raiden.address),
                 pex(receiver_address)
             )

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -261,11 +261,15 @@ class RaidenProtocol(object):
                 pex(receiver_address)
             )
 
+        message_data = message.encode()
+        echohash = sha3(message_data + receiver_address)
+        if echohash not in self.echohash_asyncresult:
+            self.echohash_asyncresult[echohash] = WaitAck(AsyncResult(), receiver_address)
         # Just like ACK, a PING message is sent directly. No need for queuing
         self.transport.send(
             self.raiden,
             self.discovery.get(receiver_address),
-            message.encode()
+            message_data
         )
 
     def receive(self, data):

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import time
 from collections import namedtuple
 
 import gevent
@@ -72,6 +73,10 @@ class RaidenProtocol(object):
 
         # Maps the echo hash `sha3(message + address)` to a WaitAck tuple
         self.echohash_asyncresult = dict()
+
+        # Maps an address to timestamp representing last time any kind of messsage
+        # was received for that address
+        self.last_received_time = dict()
 
     def stop_async(self):
         for greenlet in self.address_greenlet.itervalues():
@@ -249,6 +254,8 @@ class RaidenProtocol(object):
 
         # We ignore the sending endpoint as this can not be known w/ UDP
         message = decode(data)
+        # note down the time we got a message from the address
+        self.last_received_time[message.sender] = time.time()
 
         if isinstance(message, Ack):
             waitack = self.echohash_asyncresult[message.echo]

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -32,6 +32,9 @@ class NotifyingQueue(Event):
         self._queue.put(item)
         self.set()
 
+    def empty(self):
+        return self._queue.empty()
+
     def get(self, block=True, timeout=None):
         """ Removes and returns an item from the queue. """
         value = self._queue.get(block, timeout)

--- a/raiden/raiden_protocol.py
+++ b/raiden/raiden_protocol.py
@@ -263,14 +263,16 @@ class RaidenProtocol(object):
 
         message_data = message.encode()
         echohash = sha3(message_data + receiver_address)
+        async_result = AsyncResult()
         if echohash not in self.echohash_asyncresult:
-            self.echohash_asyncresult[echohash] = WaitAck(AsyncResult(), receiver_address)
+            self.echohash_asyncresult[echohash] = WaitAck(async_result, receiver_address)
         # Just like ACK, a PING message is sent directly. No need for queuing
         self.transport.send(
             self.raiden,
             self.discovery.get(receiver_address),
             message_data
         )
+        return async_result
 
     def receive(self, data):
         # ignore large packets

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -93,7 +93,7 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
 
         alarm = AlarmTask(chain)
         alarm.start()
-        if config['max_unresponsive_time'] != 0:
+        if config['max_unresponsive_time'] >= 0:
             self.healthcheck = HealthcheckTask(
                 self,
                 config['send_ping_time'],

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -93,7 +93,7 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
 
         alarm = AlarmTask(chain)
         alarm.start()
-        if config['max_unresponsive_time'] >= 0:
+        if config['max_unresponsive_time'] > 0:
             self.healthcheck = HealthcheckTask(
                 self,
                 config['send_ping_time'],

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -95,8 +95,7 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
         alarm.start()
         if config['max_unresponsive_time'] != 0:
             self.healthcheck = HealthcheckTask(
-                self.protocol,
-                None,  # TODO: properly provide the channel graph
+                self,
                 config['send_ping_time'],
                 config['max_unresponsive_time']
             )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -13,7 +13,7 @@ from raiden.assetmanager import AssetManager
 from raiden.transfermanager import Exchange, ExchangeKey
 from raiden.blockchain.abi import CHANNEL_MANAGER_ABI, REGISTRY_ABI
 from raiden.channelgraph import ChannelGraph
-from raiden.tasks import AlarmTask, LogListenerTask, StartExchangeTask
+from raiden.tasks import AlarmTask, LogListenerTask, StartExchangeTask, HealthcheckTask
 from raiden.encoding import messages
 from raiden.messages import SignedMessage
 from raiden.raiden_protocol import RaidenProtocol
@@ -93,6 +93,16 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
 
         alarm = AlarmTask(chain)
         alarm.start()
+        if config['max_unresponsive_time'] != 0:
+            self.healthcheck = HealthcheckTask(
+                self.protocol,
+                None,  # TODO: properly provide the channel graph
+                config['send_ping_time'],
+                config['max_unresponsive_time']
+            )
+            self.healthcheck.start()
+        else:
+            self.healthcheck = None
 
         self.api = RaidenAPI(self)
         self.alarm = alarm
@@ -284,10 +294,13 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
             for task in asset_manager.transfermanager.transfertasks.itervalues():
                 task.kill()
 
+        wait_for = [self.alarm]
         self.alarm.stop_async()
+        if self.healthcheck is not None:
+            self.healthcheck.stop_async()
+            wait_for.append(self.healthcheck)
         self.protocol.stop_async()
 
-        wait_for = [self.alarm]
         wait_for.extend(self.event_listeners)
         wait_for.extend(self.protocol.address_greenlet.itervalues())
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -176,8 +176,7 @@ class HealthcheckTask(Task):
                             receiver_address not in self.protocol.last_received_time or
                             elapsed_time > self.send_ping_time
                     ):
-                        # TODO: Send ping
-                        pass
+                        self.protocol.send_ping(receiver_address)
                     elif elapsed_time > self.max_unresponsive_time:
                         # TODO: Remove address from graph
                         pass

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -9,6 +9,8 @@ from gevent.event import AsyncResult
 from gevent.queue import Empty, Queue
 from gevent.timeout import Timeout
 
+from random import randint
+
 from ethereum import slogging
 from ethereum.utils import sha3
 
@@ -179,6 +181,8 @@ class HealthcheckTask(Task):
                     elapsed_time = (
                         time.time() - self.protocol.last_received_time[receiver_address]
                     )
+                    # Add a randomized delay in the loop to not clog the network
+                    gevent.sleep(randint(0, int(0.2 * self.send_ping_time)))
                     if elapsed_time > self.max_unresponsive_time:
                         # remove the node from the graph
                         asset_manager = self.raiden.get_manager_by_asset_address(
@@ -670,9 +674,9 @@ class MediateTransferTask(BaseMediatedTransferTask):
             )
 
         maximum_expiration = (
-            originating_channel.settle_timeout
-            + raiden.chain.block_number()
-            - 2  # decrement as a safety measure to avoid limit errors
+            originating_channel.settle_timeout +
+            raiden.chain.block_number() -
+            2  # decrement as a safety measure to avoid limit errors
         )
 
         # Ignore locks that expire after settle_timeout

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -175,10 +175,10 @@ class HealthcheckTask(Task):
             for key, queue in self.protocol.address_queue.iteritems():
                 receiver_address = key[0]
                 asset_address = key[1]
-                try:
-                    queue.peek(block=False, timeout=None)
-                except:  # If peek raises the Empty Exception
-                    elapsed_time = time.time() - self.protocol.last_received_time[receiver_address]
+                if queue.empty():
+                    elapsed_time = (
+                        time.time() - self.protocol.last_received_time[receiver_address]
+                    )
                     if elapsed_time > self.max_unresponsive_time:
                         # remove the node from the graph
                         asset_manager = self.raiden.get_manager_by_asset_address(

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -37,6 +37,8 @@ from raiden.tests.fixtures import (
     tester_nettingcontracts,
     tester_channels,
 
+    send_ping_time,
+    max_unresponsive_time,
     settle_timeout,
     reveal_timeout,
     events_poll_timeout,
@@ -85,6 +87,8 @@ __all__ = (
     'tester_nettingcontracts',
     'tester_channels',
 
+    'send_ping_time',
+    'max_unresponsive_time',
     'settle_timeout',
     'reveal_timeout',
     'events_poll_timeout',

--- a/raiden/tests/fixtures/__init__.py
+++ b/raiden/tests/fixtures/__init__.py
@@ -36,6 +36,8 @@ from raiden.tests.fixtures.tester import (
 )
 
 from raiden.tests.fixtures.variables import (
+    send_ping_time,
+    max_unresponsive_time,
     settle_timeout,
     reveal_timeout,
     events_poll_timeout,
@@ -83,6 +85,8 @@ __all__ = (
     'tester_nettingcontracts',
     'tester_channels',
 
+    'send_ping_time',
+    'max_unresponsive_time',
     'settle_timeout',
     'reveal_timeout',
     'events_poll_timeout',

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -112,6 +112,8 @@ def cached_genesis(request, blockchain_type):
         blockchain_services,
         request.getfixturevalue('transport_class'),
         request.config.option.verbose,
+        request.getfixturevalue('send_ping_time'),
+        request.getfixturevalue('max_unresponsive_time'),
     )
 
     if 'raiden_network' in request.fixturenames:

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -36,7 +36,9 @@ def raiden_chain(
         settle_timeout,
         blockchain_services,
         transport_class,
-        cached_genesis):
+        cached_genesis,
+        send_ping_time,
+        max_unresponsive_time):
 
     if len(assets_addresses) > 1:
         raise ValueError('raiden_chain only works with a single asset')
@@ -52,6 +54,8 @@ def raiden_chain(
         blockchain_services.blockchain_services,
         transport_class,
         verbosity,
+        send_ping_time,
+        max_unresponsive_time
     )
 
     if not cached_genesis:
@@ -80,6 +84,8 @@ def raiden_network(
         settle_timeout,
         blockchain_services,
         transport_class,
+        send_ping_time,
+        max_unresponsive_time,
         cached_genesis):
 
     verbosity = request.config.option.verbose
@@ -88,6 +94,8 @@ def raiden_network(
         blockchain_services.blockchain_services,
         transport_class,
         verbosity,
+        send_ping_time,
+        max_unresponsive_time
     )
 
     if not cached_genesis:

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -74,6 +74,24 @@ def transport_class():
 
 
 @pytest.fixture
+def send_ping_time():
+    """
+    Time in seconds after which if we have received no message from a node we
+    have a connection with, we are going to send a PING message
+    """
+    return 0
+
+
+@pytest.fixture
+def max_unresponsive_time():
+    """
+    Max time in seconds for which an address can send no packets and still
+    be considered healthy. Give 0 in order to disable healthcheck.
+    """
+    return 0  # Default is no healthcheck for tests
+
+
+@pytest.fixture
 def privatekey_seed():
     """ Private key template, allow different keys to be used for each test to
     avoid collisions.

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -5,7 +5,9 @@ import gevent
 import pytest
 from ethereum import slogging
 
-from raiden.messages import decode, Ack, DirectTransfer, RefundTransfer
+from raiden.messages import decode, Ack, DirectTransfer, Ping, RefundTransfer
+from raiden.network.transport import UnreliableTransport
+from raiden.tasks import DEFAULT_HEALTHCHECK_POLL_TIMEOUT
 from raiden.tests.utils.messages import setup_messages_cb, MessageLogger
 from raiden.tests.utils.transfer import assert_synched_channels, channel, direct_transfer, transfer
 from raiden.tests.utils.network import CHAIN
@@ -237,3 +239,44 @@ def test_cancel_transfer(raiden_chain, asset, deposit):
 
     app2_messages = mlogger.get_node_messages(pex(app2.raiden.address), only='sent')
     assert isinstance(app2_messages[-1], RefundTransfer)
+
+
+@pytest.mark.parametrize('blockchain_type', ['mock'])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('send_ping_time', [3])
+@pytest.mark.parametrize('max_unresponsive_time', [120])
+@pytest.mark.parametrize('transport_class', [UnreliableTransport])
+def test_healthcheck(raiden_network):
+    app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
+    UnreliableTransport.droprate = 10  # Let's allow some messages to go through
+    UnreliableTransport.network.counter = 1
+    messages = setup_messages_cb()
+
+    asset_manager0 = app0.raiden.managers_by_asset_address.values()[0]
+    asset_manager1 = app1.raiden.managers_by_asset_address.values()[0]
+
+    assert asset_manager0.asset_address == asset_manager1.asset_address
+    assert app1.raiden.address in asset_manager0.partneraddress_channel
+
+    amount = 10
+    app0.raiden.api.transfer(
+        asset_manager0.asset_address,
+        amount,
+        target=app1.raiden.address,
+    )
+
+    gevent.sleep(2)
+    # At this point we should have send a direct transfer and got back the ack
+    assert len(messages) == 2  # DirectTransfer, Ack
+    assert isinstance(decode(messages[0]), DirectTransfer)
+    assert isinstance(decode(messages[1]), Ack)
+
+    # now let's make things interesting and drop every message
+    UnreliableTransport.droprate = 1
+    UnreliableTransport.network.counter = 0
+    gevent.sleep(3)
+
+    # At least 1 ping should have been sent by now but gotten no response
+    assert len(messages) >= 3
+    for msg in messages[2:]:
+        assert isinstance(decode(msg), Ping)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -34,14 +34,24 @@ def check_channel(app1, app2, netting_channel_address):
     assert app1_details['partner_balance'] == app2_details['our_balance']
 
 
-def create_app(privatekey_bin, chain, discovery, transport_class, port,
-               host='127.0.0.1'):
+def create_app(
+        privatekey_bin,
+        chain,
+        discovery,
+        transport_class,
+        send_ping_time,
+        max_unresponsive_time,
+        port,
+        host='127.0.0.1',
+):
     ''' Instantiates an Raiden app with the given configuration. '''
     config = copy.deepcopy(App.default_config)
 
     config['port'] = port
     config['host'] = host
     config['privatekey_hex'] = privatekey_bin.encode('hex')
+    config['send_ping_time'] = send_ping_time
+    config['max_unresponsive_time'] = max_unresponsive_time
 
     return App(
         config,
@@ -194,7 +204,9 @@ def create_sequential_channels(
         assets_addresses,
         channels_per_node,
         deposit,
-        settle_timeout):
+        settle_timeout,
+        send_ping_time,
+        max_unresponsive_time):
     """ Create a fully connected network with `num_nodes`, the nodes are
     connect sequentially.
 
@@ -233,7 +245,12 @@ def create_sequential_channels(
     )
 
 
-def create_apps(blockchain_services, transport_class, verbosity):
+def create_apps(
+        blockchain_services,
+        transport_class,
+        verbosity,
+        send_ping_time,
+        max_unresponsive_time):
     """ Create the apps.
 
     Note:
@@ -271,8 +288,10 @@ def create_apps(blockchain_services, transport_class, verbosity):
             blockchain,
             discovery,
             transport_class,
+            send_ping_time,
+            max_unresponsive_time,
             port=port,
-            host=host,
+            host=host
         )
         apps.append(app)
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -204,9 +204,7 @@ def create_sequential_channels(
         assets_addresses,
         channels_per_node,
         deposit,
-        settle_timeout,
-        send_ping_time,
-        max_unresponsive_time):
+        settle_timeout):
     """ Create a fully connected network with `num_nodes`, the nodes are
     connect sequentially.
 


### PR DESCRIPTION
Fixes #203.

- Keep all received messages timestamp
- Adding a Healthcheck task
    - For every peer in the address queue check if he the last received message time is greater than `send_ping_time. If so, then send a ping.
    - If the last received message time is greater than `max_unresponsive_time` remove the peer.
- Tests for healthcheck for both normal peers but also bad/unresponsive peers