### PR TITLE
tests: better testenv tests execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
   - ./.travis/make_dag.sh
 
 script:
-  - coverage run -m py.test -s $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE
+  - coverage run -m py.test --random -s $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE
 
 after_success:
   - coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,3 @@ omit =
     */.pyenv/*
     */tests/*
     */site-packages/*
-
-[tool:pytest]
-addopts = --random

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,20 @@
 [tox]
 envlist = py27,coverage
 
+[testenv]
+deps =
+    -rrequirements.txt
+    coverage>=4.0
+commands =
+    coverage erase
+    coverage run --append -m py.test --exitfirst {posargs:./raiden/tests/unit ./raiden/tests/smart_contracts ./raiden/tests/integration}
+
+[testenv:flake8]
+deps =
+    flake8
+commands=
+    flake8  --exit-zero raiden/ tools/
+
 [testenv:devenv]
 envdir = devenv
 basepython = python2.7
@@ -19,19 +33,3 @@ commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst
 
 [devenv:unit]
 commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst ./raiden/tests/unit {posargs}
-
-[testenv:flake8]
-deps =
-    flake8
-commands=
-    flake8  --exit-zero raiden/ tools/
-
-[testenv]
-deps =
-    -rrequirements.txt
-    coverage>=4.0
-commands =
-    coverage erase
-    coverage run --append -m py.test --exitfirst ./raiden/tests/smart_contracts {posargs}
-    coverage run --append -m py.test --exitfirst ./raiden/tests/integration {posargs}
-    coverage run --append -m py.test --exitfirst ./raiden/tests/unit {posargs}


### PR DESCRIPTION
posargs didn't work quite well, since the testenv had three py.test
commands trying to specify the tests to run from the command line would
run it three times

using a single commands allow the user to overwrite the tests that
should be executed through the command line, we can keep the priority of
tests from the faster to slower ones and keep the failfast flag.