### PR TITLE
change data structure of Registry and Channel Manager

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -83,11 +83,11 @@ def patch_send_transaction(client, nonce_offset=0):
         client.send_transaction = send_transaction
 
 
-def new_filter(jsonrpc_client, contract_address, topics):
+def new_filter(jsonrpc_client, contract_address, topics, from_block="latest", to_block="latest"):
     """ Custom new filter implementation to handle bad encoding from geth rpc. """
     json_data = {
-        'fromBlock': '',
-        'toBlock': '',
+        'fromBlock': from_block,
+        'toBlock': to_block,
         'address': address_encoder(normalize_address(contract_address)),
         'topics': [topic_encoder(topic) for topic in topics],
     }
@@ -490,11 +490,11 @@ class Registry(object):
             channel_manager_address=pex(channel_manager_address_bin),
         )
 
-    def asset_addresses(self):
-        return [
-            address_decoder(address)
-            for address in self.proxy.assetAddresses.call(startgas=self.startgas)
-        ]
+    # def asset_addresses(self):
+        # return [
+            # address_decoder(address)
+            # for address in self.proxy.assetAddresses.call(startgas=self.startgas)
+        # ]
 
     def manager_addresses(self):
         return [
@@ -506,7 +506,7 @@ class Registry(object):
         topics = [ASSETADDED_EVENTID]
 
         registry_address_bin = self.proxy.address
-        filter_id_raw = new_filter(self.client, registry_address_bin, topics)
+        filter_id_raw = new_filter(self.client, registry_address_bin, topics, 0)  # start at block 0
 
         return Filter(
             self.client,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -41,12 +41,19 @@ solidity = _solidity.get_solidity()  # pylint: disable=invalid-name
 
 # Coding standard for this module:
 #
-# - Be sure to reflect changes to this module in the test
-#   implementations. [tests/utils/*_client.py]
-# - Expose a synchronous interface by default
-#   - poll for the transaction hash
-#   - check if the proper events were emited
-#   - use `call` and `transact` to interact with pyethapp.rpc_client proxies
+# We have addtional Mock implementation that are quite usefull for testing
+# purposes, since all implementations need to work with the same code bases
+# their interfaces must match exactly, so be sure to reflect the change from
+# one into another. [tests/utils/*_client.py]
+#
+# The Json RPC implementation is based upon the pyethapp.rpc_client, this
+# client exposes object proxies for calling a contract as a usual python
+# object, for this module it was opted to expose a _synchronous_ interface to
+# the user by default, this interface should send the transaction, poll for
+# it's execution and if possible check if it was sucessfully executed, if not
+# report an error. Also, it was chosen to use an explicit coding, not reallying
+# on the `constant` modifier for `call`s and explicity passing the available
+# gas for the transaction and it's value.
 
 
 def patch_send_transaction(client, nonce_offset=0):
@@ -134,10 +141,6 @@ class BlockChainService(object):
         self.node_address = privatekey_to_address(privatekey_bin)
         self.poll_timeout = poll_timeout
         self.default_registry = self.registry(registry_address)
-
-    def set_verbosity(self, level):
-        if level:
-            self.client.print_communication = True
 
     def block_number(self):
         return self.client.blocknumber()
@@ -486,7 +489,6 @@ class Registry(object):
         log.info(
             'add_asset called',
             asset_address=pex(asset_address),
-            registry_address=pex(self.address),
             channel_manager_address=pex(channel_manager_address_bin),
         )
 
@@ -567,7 +569,7 @@ class ChannelManager(object):
             other,
             settle_timeout,
             startgas=self.startgas,
-            gasprice=self.gasprice,
+            gasprice=self.gasprice * 2,
         )
         self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
 
@@ -594,19 +596,19 @@ class ChannelManager(object):
 
         return netting_channel_address_bin
 
-    def channels_addresses(self):
-        # for simplicity the smart contract return a shallow list where every
-        # second item forms a tuple
-        channel_flat_encoded = self.proxy.getChannelsParticipants.call(startgas=self.startgas)
+    # def channels_addresses(self):
+        # # for simplicity the smart contract return a shallow list where every
+        # # second item forms a tuple
+        # channel_flat_encoded = self.proxy.getChannelsParticipants.call(startgas=self.startgas)
 
-        channel_flat = [
-            address_decoder(channel)
-            for channel in channel_flat_encoded
-        ]
+        # channel_flat = [
+            # address_decoder(channel)
+            # for channel in channel_flat_encoded
+        # ]
 
-        # [a,b,c,d] -> [(a,b),(c,d)]
-        channel_iter = iter(channel_flat)
-        return zip(channel_iter, channel_iter)
+        # # [a,b,c,d] -> [(a,b),(c,d)]
+        # channel_iter = iter(channel_flat)
+        # return zip(channel_iter, channel_iter)
 
     def channels_by_participant(self, participant_address):  # pylint: disable=invalid-name
         """ Return a list of channel address that `participant_address` is a participant. """
@@ -633,7 +635,7 @@ class ChannelManager(object):
         topics = [CHANNELNEW_EVENTID]
 
         channel_manager_address_bin = self.proxy.address
-        filter_id_raw = new_filter(self.client, channel_manager_address_bin, topics)
+        filter_id_raw = new_filter(self.client, channel_manager_address_bin, topics, 0)
 
         return Filter(
             self.client,
@@ -684,12 +686,6 @@ class NettingChannel(object):
     def detail(self, our_address):
         data = self.proxy.addressAndBalance.call(startgas=self.startgas)
         settle_timeout = self.proxy.settleTimeout.call(startgas=self.startgas)
-
-        if data == '':
-            raise RuntimeError('addressAndBalance call failed.')
-
-        if settle_timeout == '':
-            raise RuntimeError('settleTimeout call failed.')
 
         if address_decoder(data[0]) == our_address:
             return {

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -12,7 +12,6 @@ from secp256k1 import PrivateKey
 from raiden.assetmanager import AssetManager
 from raiden.transfermanager import Exchange, ExchangeKey, UnknownAddress
 from raiden.blockchain.abi import CHANNEL_MANAGER_ABI, REGISTRY_ABI
-from raiden.network.channelgraph import ChannelGraph
 from raiden.tasks import AlarmTask, LogListenerTask, StartExchangeTask, HealthcheckTask
 from raiden.encoding import messages
 from raiden.messages import SignedMessage
@@ -265,8 +264,8 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
         channel_listener.start()
         self.event_listeners.append(channel_listener)
 
-        asset_address_bin = channel_manager.asset_address()
-        channel_manager_address_bin = channel_manager.address
+        # asset_address_bin = channel_manager.asset_address()
+        # channel_manager_address_bin = channel_manager.address
         # edges = channel_manager.channels_addresses()
         # channel_graph = ChannelGraph(edges)
 
@@ -721,7 +720,7 @@ class RaidenEventHandler(object):
             self,
             asset_address_bin,
             channel_manager_address_bin,
-            asset_manager.channelgraph,
+            manager.channelgraph,
         )
 
         self.managers_by_asset_address[asset_address_bin] = asset_manager

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -233,8 +233,6 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
 
         assetadded = registry.assetadded_filter()
 
-        all_manager_addresses = registry.manager_addresses()
-
         task_name = 'Registry {}'.format(pex(registry.address))
         asset_listener = LogListenerTask(
             task_name,
@@ -246,10 +244,6 @@ class RaidenService(object):  # pylint: disable=too-many-instance-attributes
         self.event_listeners.append(asset_listener)
 
         self.registries.append(registry)
-
-        for manager_address in all_manager_addresses:
-            channel_manager = self.chain.manager(manager_address)
-            self.register_channel_manager(channel_manager)
 
     def register_channel_manager(self, channel_manager):
         """ Discover and register the channels for the given asset. """

--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -21,92 +21,16 @@ contract ChannelManagerContract {
         data.token = Token(token_address);
     }
 
-    // XXX: move this to the library, if possible
-    // variable length arrays from inside the evm is not supported
-    // function getAllChannels() constant returns (address[]) {
-    //     return data.getAllChannels();
-    // }
-    // function getChannelsForNode(address nodeAddress) constant returns (address[]) {
-    //     return data.getChannelsForNode(nodeAddress);
-    // }
-    // function getChannelsParticipants() constant returns (address[]) {
-    //     return data.getChannelsParticipants();
-    // }
-    function getChannelsAddresses() constant returns (address[]) {
-        return data.all_channels;
+    function getChannelsParticipants() constant returns (uint channels) {
+        return data.total_channels;
     }
 
-    function getChannelsParticipants() constant returns (address[] channels) {
-        uint i;
-        uint pos;
-        address channel;
-        address participant1;
-        address participant2;
-        address[] memory result;
-
-        result = new address[](data.all_channels.length * 2);
-
-        pos = 0;
-        for (i = 0; i < data.all_channels.length; i++) {
-            channel = data.all_channels[i];
-
-            (participant1, , participant2, ) = NettingChannelContract(channel).addressAndBalance();
-
-            result[pos] = participant1;
-            pos += 1;
-            result[pos] = participant2;
-            pos += 1;
-        }
-
-        return result;
-    }
-
-    function nettingContractsByAddress(address node_address) constant returns (address[]){
-        uint i;
-        uint count;
-        address channel;
-        address participant1;
-        address participant2;
-        address[] memory result;
-
-        count = 0;
-        for (i=0; i<data.all_channels.length; i++) {
-            channel = data.all_channels[i];
-
-            (participant1, , participant2, ) = NettingChannelContract(channel).addressAndBalance();
-
-            if (participant1 == node_address) {
-                count += 1;
-            } else if (participant2 == node_address) {
-                count += 1;
-            }
-        }
-
-        result = new address[](count);
-        count -= 1;
-        for (i = 0; i < data.all_channels.length; i++) {
-            channel = data.all_channels[i];
-
-            (participant1, , participant2, ) = NettingChannelContract(channel).addressAndBalance();
-
-            if (participant1 == node_address) {
-                result[count] = channel;
-                count -= 1;
-            } else if (participant2 == node_address) {
-                result[count] = channel;
-                count -= 1;
-            }
-        }
-
-        return result;
+    function nettingContractsByAddress(address node_address) constant returns (uint){
+        return data.number_of_open_channels[node_address];
     }
 
     function tokenAddress () constant returns (address) {
         return data.token;
-    }
-
-    function getChannelsForNode(address node_address) constant returns (address[]) {
-        return data.node_channels[node_address];
     }
 
     function getChannelWith(address partner) constant returns (address) {

--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -6,28 +6,11 @@ import "./NettingChannelContract.sol";
 library ChannelManagerLibrary {
     // TODO: experiment with a sorted data structure
     struct Data {
-        mapping(address => address[]) node_channels;
-        address[] all_channels;
+        mapping(address => mapping(address => bool)) channels;
+        mapping(address => mapping(address => address)) channel_addresses;
+        uint total_channels;
+        mapping(address => uint) number_of_open_channels;
         Token token;
-    }
-
-    /// @notice getChannelsAddresses to get all channels
-    /// @dev Get all channels
-    /// @return channels (address[]) all the channels
-    function getChannelsAddresses(Data storage self) returns (address[] channels) {
-        channels = self.all_channels;
-    }
-
-    /// @notice getChannelsForNode(address) to get channels that 
-    /// the address participates in.
-    /// @dev Get channels where the given address participates.
-    /// @param node_address (address) the address of the node
-    /// @return (address[]) of the channel's addresses that node_address participates.
-    function getChannelsForNode(Data storage self, address node_address)
-        constant
-        returns (address[])
-    {
-        return self.node_channels[node_address];
     }
 
     /// @notice getChannelWith(address) to get the address of the unique channel of two parties.
@@ -38,19 +21,10 @@ library ChannelManagerLibrary {
         constant
         returns (address)
     {
-        uint i;
-        address[] our_channels = self.node_channels[msg.sender];
-        address channel;
-
-        for (i = 0; i < our_channels.length; ++i) {
-            channel = our_channels[i];
-
-            if (NettingChannelContract(channel).partner(msg.sender) == partner) {
-                return channel;
-            }
+        if(!self.channels[msg.sender][partner]) {
+            throw;
         }
-
-        throw;
+        return self.channel_addresses[msg.sender][partner];
     }
 
     /// @notice newChannel(address, uint) to create a new payment channel between two parties
@@ -64,15 +38,11 @@ library ChannelManagerLibrary {
         uint settle_timeout)
         returns (address)
     {
-        address channel_address;
-        uint i;
-
-        address[] storage existing_channels = self.node_channels[msg.sender];
-        for (i = 0; i < existing_channels.length; i++) {
-            if (NettingChannelContract(existing_channels[i]).partner(msg.sender) == partner) {
-                throw;
-            }
+        if (self.channels[msg.sender][partner]) {
+            throw;
         }
+
+        address channel_address;
 
         channel_address = new NettingChannelContract(
             self.token,
@@ -81,9 +51,13 @@ library ChannelManagerLibrary {
             settle_timeout
         );
 
-        self.node_channels[msg.sender].push(channel_address);
-        self.node_channels[partner].push(channel_address);
-        self.all_channels.push(channel_address);
+        self.channels[msg.sender][partner] = true;
+        self.channels[partner][msg.sender] = true;
+        self.channel_addresses[msg.sender][partner] = channel_address;
+        self.channel_addresses[partner][msg.sender] = channel_address;
+        self.number_of_open_channels[msg.sender]++;
+        self.number_of_open_channels[partner]++;
+        self.total_channels++;
 
         return channel_address;
     }

--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -4,7 +4,6 @@ import "./ChannelManagerContract.sol";
 
 contract Registry {
     mapping(address => address) public registry;
-    address[] public assets;
 
     event AssetAdded(address asset_address, address channel_manager_address);
 
@@ -30,7 +29,6 @@ contract Registry {
         manager_address = new ChannelManagerContract(asset_address);
 
         registry[asset_address] = manager_address;
-        assets.push(asset_address);
 
         AssetAdded(asset_address, manager_address);
 
@@ -45,13 +43,16 @@ contract Registry {
         return registry[asset_address];
     }
 
+    /*
     function assetAddresses()
         constant
         returns (address[])
     {
         return assets;
     }
+    */
 
+    /*
     function channelManagerAddresses()
         constant
         returns (address[])
@@ -69,6 +70,7 @@ contract Registry {
 
         return result;
     }
+    */
 
     function () { throw; }
 }

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -29,6 +29,7 @@ def test_event_new_channel(
 
     # old way
     # asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
+    assert tester_state.blocks[0].transaction_list == []
 
     asset_address = assets_addresses[0]
     assert app0.raiden.managers_by_asset_address.keys()

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -17,12 +17,20 @@ from raiden.tests.utils.network import CHAIN
 @pytest.mark.parametrize('privatekey_seed', ['event_new_channel:{}'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
-def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_timeout, assets_addresses, tester_state):
+def test_event_new_channel(
+        raiden_chain,
+        deposit,
+        settle_timeout,
+        events_poll_timeout,
+        assets_addresses,
+        tester_state,
+    ):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
     tester_state.mine(1)
     # old way
     # asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
+    print app0.raiden.registries
 
     asset_address = assets_addresses[0]
     assert app0.raiden.managers_by_asset_address.keys()

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -17,13 +17,15 @@ from raiden.tests.utils.network import CHAIN
 @pytest.mark.parametrize('privatekey_seed', ['event_new_channel:{}'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
-def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_timeout, assets_addresses):
+def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_timeout, assets_addresses, tester_state):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
+    tester_state.mine(1)
     # old way
     # asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
 
     asset_address = assets_addresses[0]
+    assert app0.raiden.managers_by_asset_address.keys()
 
     # assert len(app0.raiden.chain.manager_by_asset(asset_address).channels_addresses) == 0
     assert len(app0.raiden.managers_by_asset_address[asset_address].address_channel) == 0

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -17,11 +17,15 @@ from raiden.tests.utils.network import CHAIN
 @pytest.mark.parametrize('privatekey_seed', ['event_new_channel:{}'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
-def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_timeout):
+def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_timeout, assets_addresses):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
-    asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
+    # old way
+    # asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
 
+    asset_address = assets_addresses[0]
+
+    # assert len(app0.raiden.chain.manager_by_asset(asset_address).channels_addresses) == 0
     assert len(app0.raiden.managers_by_asset_address[asset_address].address_channel) == 0
     assert len(app1.raiden.managers_by_asset_address[asset_address].address_channel) == 0
 

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -27,10 +27,8 @@ def test_event_new_channel(
     ):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
-    tester_state.mine(1)
     # old way
     # asset_address = app0.raiden.chain.default_registry.asset_addresses()[0]
-    print app0.raiden.registries
 
     asset_address = assets_addresses[0]
     assert app0.raiden.managers_by_asset_address.keys()

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -63,7 +63,7 @@ def test_channelmanager(tester_state, tester_token, tester_events,
         }
     )
 
-    participants_count = len(channel_manager.getChannelsParticipants())
+    participants_count = channel_manager.getChannelsParticipants()
     assert participants_count == 0, 'newly deployed contract must be empty'
 
     netting_channel_translator = ContractTranslator(netting_channel_abi)
@@ -96,7 +96,7 @@ def test_channelmanager(tester_state, tester_token, tester_events,
     with pytest.raises(TransactionFailed):
         channel_manager.getChannelWith(inexisting_address)
 
-    assert len(channel_manager.getChannelsParticipants()) == 2
+    assert channel_manager.getChannelsParticipants() == 1
 
     netting_contract_proxy1 = ABIContract(
         tester_state,
@@ -120,11 +120,11 @@ def test_channelmanager(tester_state, tester_token, tester_events,
     address1_channels = channel_manager.nettingContractsByAddress(address1)
     inexisting_channels = channel_manager.nettingContractsByAddress(inexisting_address)
 
-    assert len(msg_sender_channels) == 2
-    assert len(address1_channels) == 1
-    assert len(inexisting_channels) == 0
+    assert msg_sender_channels == 2
+    assert address1_channels == 1
+    assert inexisting_channels == 0
 
-    assert len(channel_manager.getChannelsParticipants()) == 4
+    assert channel_manager.getChannelsParticipants() == 2
 
     channelnew_event = tester_events[-1]
     assert channelnew_event == {

--- a/raiden/tests/smart_contracts/test_registry.py
+++ b/raiden/tests/smart_contracts/test_registry.py
@@ -39,12 +39,6 @@ def test_registry(tester_registry, tester_events):
             sender=privatekey0,
         )
 
-    addresses = tester_registry.assetAddresses(sender=privatekey0)
-
-    assert len(addresses) == 2
-    assert addresses[0] == asset_address1.encode('hex')
-    assert addresses[1] == asset_address2.encode('hex')
-
     assert len(tester_events) == 2
 
     assert tester_events[0]['_event_type'] == 'AssetAdded'

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -29,6 +29,8 @@ from raiden.blockchain.abi import (
     REGISTRY_ABI,
 )
 
+import testrpc
+
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 FILTER_ID_GENERATOR = count()
 
@@ -159,11 +161,14 @@ class ChannelExternalStateTester(object):
 
 
 class FilterTesterMock(object):
-    def __init__(self, contract_address, topics, filter_id_raw):
+    def __init__(self, contract_address, topics, filter_id_raw, from_block, to_block, state):
         self.filter_id_raw = filter_id_raw
         self.contract_address = contract_address
         self.topics = topics
         self.events = list()
+        self.from_block = from_block
+        self.to_block = to_block
+        self.block = state.block.number
 
     def changes(self):
         events = self.events
@@ -171,13 +176,25 @@ class FilterTesterMock(object):
         return events
 
     def event(self, event):
+        for block in state.blocks:
+            event_generator = filters.process_block(
+                block,
+                self.from_block,
+                self.to_block,
+                self.contract_address,
+                self.topics,
+            )
+            for i in event_generator:
+                print(i)
+                self.events.append(i)
+
         # TODO: implement OR
-        if event.topics == self.topics and event.address == self.contract_address:
-            self.events.append({
-                'topics': event.topics,
-                'data': event.data,
-                'address': event.address,
-            })
+        # if event.topics == self.topics and event.address == self.contract_address:
+            # self.events.append({
+                # 'topics': event.topics,
+                # 'data': event.data,
+                # 'address': event.address,
+            # })
 
             # HACK: trigger all the listeners to update the app's states. An
             # alternative implemenation would to use `raiden.event_listeners`
@@ -437,7 +454,7 @@ class RegistryTesterMock(object):
 
     def assetadded_filter(self):
         topics = [ASSETADDED_EVENTID]
-        filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR))
+        filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR), 0, "latest", self.tester_state)
         self.tester_state.block.log_listeners.append(filter_.event)
         return filter_
 
@@ -517,7 +534,7 @@ class ChannelManagerTesterMock(object):
 
     def channelnew_filter(self):
         topics = [CHANNELNEW_EVENTID]
-        filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR))
+        filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR), 0, "latest", self.tester_state)
         self.tester_state.block.log_listeners.append(filter_.event)
         return filter_
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -214,9 +214,6 @@ class BlockChainServiceTesterMock(object):
         self.address_registry = dict()
         self.asset_manager = dict()
 
-    def set_verbosity(self, level):
-        pass
-
     def block_number(self):
         return self.tester_state.block.number
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -422,13 +422,13 @@ class RegistryTesterMock(object):
         self.registry_proxy.addAsset(asset_address)
         self.tester_state.mine(number_of_blocks=1)
 
-    def asset_addresses(self):
-        result = [
-            address.decode('hex')
-            for address in self.registry_proxy.assetAddresses()
-        ]
-        self.tester_state.mine(number_of_blocks=1)
-        return result
+    # def asset_addresses(self):
+        # result = [
+            # address.decode('hex')
+            # for address in self.registry_proxy.assetAddresses()
+        # ]
+        # self.tester_state.mine(number_of_blocks=1)
+        # return result
 
     def manager_addresses(self):
         result = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ u-msgpack-python
 repoze.lru
 gevent-websocket==0.9.4
 sphinx
+eth-testrpc


### PR DESCRIPTION
This PR solves the issue #232 

It does so by changing the data structures of the smart contracts to use mappings instead of arrays to keep track of channels. We can no longer use the functions that return all addresses of some kind, but we can iterate through all events on the blockchain in order to get that same information.