### PR TITLE
Implement throttling #174

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -2,7 +2,7 @@
 from ethereum.utils import decode_hex
 
 from raiden.raiden_service import RaidenService, DEFAULT_REVEAL_TIMEOUT, DEFAULT_SETTLE_TIMEOUT
-from raiden.network.transport import UDPTransport
+from raiden.network.transport import UDPTransport, TokenBucket
 from raiden.utils import pex
 
 INITIAL_PORT = 40001
@@ -19,12 +19,19 @@ class App(object):  # pylint: disable=too-few-public-methods
         settle_timeout=DEFAULT_SETTLE_TIMEOUT,
         # how long to wait for a transfer until TimeoutTransfer is sent (time in milliseconds)
         msg_timeout=100.00,
+        # throttle policy for token bucket
+        throttle_capacity=10.,
+        throttle_fill_rate=10.,
     )
 
     def __init__(self, config, chain, discovery, transport_class=UDPTransport):
         self.config = config
         self.discovery = discovery
         self.transport = transport_class(config['host'], config['port'])
+        self.transport.throttle_policy = TokenBucket(
+            config['throttle_capacity'],
+            config['throttle_fill_rate']
+        )
         self.raiden = RaidenService(
             chain,
             decode_hex(config['privatekey_hex']),

--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -62,11 +62,13 @@ class TokenBucket(object):
 class UDPTransport(object):
     """ Node communication using the UDP protocol. """
 
-    def __init__(self,
-                 host,
-                 port,
-                 protocol=None,
-                 throttle_policy=DummyPolicy()):
+    def __init__(
+            self,
+            host,
+            port,
+            protocol=None,
+            throttle_policy=DummyPolicy()):
+
         self.protocol = protocol
         self.server = DatagramServer((host, port), handle=self.receive)
         self.server.start()
@@ -137,11 +139,13 @@ class DummyTransport(object):
     network = DummyNetwork()
     on_recv_cbs = []  # debugging
 
-    def __init__(self,
-                 host,
-                 port,
-                 protocol=None,
-                 throttle_policy=DummyPolicy()):
+    def __init__(
+            self,
+            host,
+            port,
+            protocol=None,
+            throttle_policy=DummyPolicy()):
+
         self.host = host
         self.port = port
         self.protocol = protocol

--- a/raiden/tests/unit/test_transport.py
+++ b/raiden/tests/unit/test_transport.py
@@ -22,9 +22,11 @@ def test_throttle_policy_ping(monkeypatch, raiden_network):
     assert isinstance(app0.raiden.protocol.transport.throttle_policy, DummyPolicy)
 
     for app in (app0, app1):
-        monkeypatch.setattr(app.raiden.protocol.transport,
-                            'throttle_policy',
-                            TokenBucket(capacity=2, fill_rate=2))
+        monkeypatch.setattr(
+            app.raiden.protocol.transport,
+            'throttle_policy',
+            TokenBucket(capacity=2, fill_rate=2)
+        )
 
     # monkey patching successful
     assert app0.raiden.protocol.transport.throttle_policy.capacity == 2.

--- a/raiden/tests/unit/test_transport.py
+++ b/raiden/tests/unit/test_transport.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import pytest
+import gevent
+from ethereum import slogging
+
+from raiden.utils import sha3
+from raiden.messages import Ping, Ack, decode
+from raiden.network.transport import UDPTransport, TokenBucket, DummyPolicy
+from raiden.tests.utils.messages import setup_messages_cb
+
+slogging.configure(':DEBUG')
+
+
+@pytest.mark.parametrize('blockchain_type', ['mock'])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('transport_class', [UDPTransport])
+def test_throttle_policy_ping(monkeypatch, raiden_network):
+
+    app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
+
+    # initial policy is DummyPolicy
+    assert isinstance(app0.raiden.protocol.transport.throttle_policy, DummyPolicy)
+
+    for app in (app0, app1):
+        monkeypatch.setattr(app.raiden.protocol.transport,
+                            'throttle_policy',
+                            TokenBucket(capacity=2, fill_rate=2))
+
+    # monkey patching successful
+    assert app0.raiden.protocol.transport.throttle_policy.capacity == 2.
+
+    messages = setup_messages_cb()
+
+    # we will send 10 pings and let them trickle in according to our policy:
+    for nonce in range(10):
+        ping = Ping(nonce=nonce)
+        app0.raiden.sign(ping)
+        app0.raiden.protocol.send_async(app1.raiden.address, ping)
+
+    # each side has two initial tokens available
+    gevent.sleep(0.01)
+    assert len(messages) == 4  # Ping, Ack
+
+    # per additional second two more tokens become available
+    gevent.sleep(3)
+    assert len(messages) == 16  # Ping, Ack
+
+    # one more interval and all could be sent
+    gevent.sleep(1)
+    assert len(messages) == 20  # Ping, Ack
+
+    # sanity check for messages order
+    assert decode(messages[0]).nonce == 0
+    decoded = decode(messages[-1])
+    assert isinstance(decoded, Ack)
+    last_ping = Ping(nonce=9)
+    app0.raiden.sign(last_ping)
+    assert decoded.echo == sha3(last_ping.encode() + app1.raiden.address)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -7,6 +7,7 @@ from ethereum import slogging
 
 from raiden.app import App, INITIAL_PORT
 from raiden.network.discovery import Discovery
+from raiden.network.transport import DummyPolicy
 from raiden.utils import privatekey_to_address
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -53,12 +54,14 @@ def create_app(
     config['send_ping_time'] = send_ping_time
     config['max_unresponsive_time'] = max_unresponsive_time
 
-    return App(
+    app = App(
         config,
         chain,
         discovery,
         transport_class,
     )
+    app.raiden.protocol.transport.throttle_policy = DummyPolicy()
+    return app
 
 
 def setup_channels(asset_address, app_pairs, deposit, settle_timeout):


### PR DESCRIPTION
This implements a token bucket algorithm for throttling, see
https://en.wikipedia.org/wiki/Token_bucket

The default policy in use is a `DummyPolicy`, a dummy provider that does not
restrict the aomunt of messages.

In `app.py` the default now is a TokenBucket policy of

    capacity=10, fill_rate=10

This fixes #174 