### PR TITLE
Adjust TCP TIME_WAIT parameters for sockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: required
 
 language: python
 python:
@@ -30,6 +30,12 @@ before_install:
   - export PATH=$PATH:$HOME/.bin
   - ./.travis/download_geth.sh
   - ./.travis/download_solc.sh
+  # Tweaking TCP parameters for socket TIME_WAIT
+  # Sources:
+  # http://stackoverflow.com/questions/6426253/tcp-tw-reuse-vs-tcp-tw-recycle-which-to-use-or-both
+  # http://www.speedguide.net/articles/linux-tweaking-121
+  - sudo sysctl -w net.ipv4.tcp_fin_timeout=15
+  - sudo sysctl -w net.ipv4.tcp_tw_reuse=1
 
 install:
   - pip install -U pip


### PR DESCRIPTION
We have had a lot of Connection errors in tests due to lack of available
ports to open. The solution as discovered by @utzig is to tweak kernel
parameters.

For more information on what each one does look here:

http://stackoverflow.com/questions/6426253/tcp-tw-reuse-vs-tcp-tw-recycle-which-to-use-or-both
http://www.speedguide.net/articles/linux-tweaking-121#TCP_Parameters_to_consider