### PR TITLE
tests: added timeout of 1min for each integration test

### DIFF
--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -13,6 +13,7 @@ from raiden.utils import privatekey_to_address, get_contract_path
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['blockchain:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [0])
@@ -143,6 +144,7 @@ def test_new_netting_contract(raiden_network, asset_amount, settle_timeout):
     assert netting_channel_02.detail(peer2_address)['our_balance'] == 130
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['blockchain:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_blockchain(

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -13,7 +13,7 @@ from raiden.utils import privatekey_to_address, get_contract_path
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize('privatekey_seed', ['blockchain:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [0])

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -11,6 +11,7 @@ from raiden.tests.utils.transfer import (
 )
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['fullnetwork:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [2])

--- a/raiden/tests/integration/test_endpointregistry.py
+++ b/raiden/tests/integration/test_endpointregistry.py
@@ -5,6 +5,7 @@ from raiden.utils import make_address, get_contract_path, privatekey_to_address
 from raiden.network.discovery import ContractDiscovery
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('poll_timeout', [80])
 def test_endpointregistry(private_keys, blockchain_services):

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -13,6 +13,7 @@ from raiden.tests.utils.blockchain import wait_until_block
 from raiden.tests.utils.network import CHAIN
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['event_new_channel:{}'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
@@ -87,6 +88,7 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     )
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.xfail(reason='out-of-gas for unlock and settle')
 @pytest.mark.parametrize('privatekey_seed', ['event_new_channel:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -23,6 +23,7 @@ slogging.configure(':DEBUG')
 
 
 @pytest.mark.xfail(reson='issue #198')
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['settlement:{}'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_settlement(raiden_network, settle_timeout, reveal_timeout):
@@ -121,6 +122,7 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     assert channel1.external_state.settled_block != 0
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['settled_lock:{}'])
 @pytest.mark.parametrize('number_of_nodes', [4])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
@@ -192,6 +194,7 @@ def test_settled_lock(assets_addresses, raiden_network, settle_timeout, reveal_t
 
 
 @pytest.mark.xfail()
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize('privatekey_seed', ['start_end_attack:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_start_end_attack(asset_address, raiden_chain, deposit):


### PR DESCRIPTION
Some runs in travis take longer than 10min to fail because of the travis' default timeout, instead of waiting for the travis failure that doesnt output log information this PR uses an explicit 1min timeout for each integratoin test.