### PR TITLE
Add caching for blocknumber/discovery/filter rpc.

### DIFF
--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -4,6 +4,7 @@ import time
 from collections import namedtuple
 from collections import defaultdict
 
+import time
 import gevent
 from gevent.queue import Queue
 from gevent.event import AsyncResult, Event
@@ -61,9 +62,12 @@ class RaidenProtocol(object):
     max_retries = 5
     max_message_size = 1200
 
+    DISCOVERY_CACHE_TTL = 60.
+
     def __init__(self, transport, discovery, raiden):
         self.transport = transport
         self.discovery = discovery
+        self.discovery_cache_by_receiver = {}
         self.raiden = raiden
 
         # Messages are sent in-order for each partner
@@ -104,7 +108,17 @@ class RaidenProtocol(object):
         # Note: this task can be killed at any time
 
         queue = self.address_queue[(receiver_address, queue_name)]
-        host_port = self.discovery.get(receiver_address)
+
+        time_now = time.time()
+        needs_update = True
+        if receiver_address in self.discovery_cache_by_receiver:
+            host_port, last_time = self.discovery_cache_by_receiver[receiver_address]
+            if time_now - last_time < self.DISCOVERY_CACHE_TTL:
+                needs_update = False
+
+        if needs_update:
+            host_port = self.discovery.get(receiver_address)
+            self.discovery_cache_by_receiver[receiver_address] = (host_port, time_now)
 
         while queue.wait():
             # avoid reserializing the message and calculate it's hash
@@ -233,7 +247,17 @@ class RaidenProtocol(object):
         if not isinstance(message, Ack):
             raise ValueError('Use send_Ack only for Ack messages or Erorrs')
 
-        host_port = self.discovery.get(receiver_address)
+        time_now = time.time()
+        needs_update = True
+        if receiver_address in self.discovery_cache_by_receiver:
+            host_port, last_time = self.discovery_cache_by_receiver[receiver_address]
+            if time_now - last_time < self.DISCOVERY_CACHE_TTL:
+                needs_update = False
+
+        if needs_update:
+            host_port = self.discovery.get(receiver_address)
+            self.discovery_cache_by_receiver[receiver_address] = (host_port, time_now)
+
         messagedata = message.encode()
 
         if log.isEnabledFor(logging.INFO):

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import gevent
 import rlp
+import time
 from ethereum import slogging
 from ethereum import _solidity
 from ethereum.transactions import Transaction
@@ -103,6 +104,8 @@ class BlockChainService(object):
     """ Exposes the blockchain's state through JSON-RPC. """
     # pylint: disable=too-many-instance-attributes,unused-argument
 
+    BLOCKNUMBER_CACHE_TTL = 2.
+
     def __init__(
             self,
             privatekey_bin,
@@ -134,13 +137,19 @@ class BlockChainService(object):
         self.node_address = privatekey_to_address(privatekey_bin)
         self.poll_timeout = poll_timeout
         self.default_registry = self.registry(registry_address)
+        self.cached_block_number = (None, None)
 
     def set_verbosity(self, level):
         if level:
             self.client.print_communication = True
 
     def block_number(self):
-        return self.client.blocknumber()
+        number, last_time = self.cached_block_number
+        time_now = time.time()
+        if last_time is None or time_now - last_time > self.BLOCKNUMBER_CACHE_TTL:
+            number = self.client.blocknumber()
+            self.cached_block_number = (number, time_now)
+        return number
 
     def next_block(self):
         target_block_number = self.block_number() + 1
@@ -266,15 +275,28 @@ class BlockChainService(object):
 
 
 class Filter(object):
+
+    CHANGES_CACHE_TTL = 2.
+    # XXX: limited to having a single object per filter_id
+    _last_filter_calls = {}
+
     def __init__(self, jsonrpc_client, filter_id_raw):
         self.filter_id_raw = filter_id_raw
         self.client = jsonrpc_client
+        self._last_filter_calls[self.filter_id_raw] = None
 
     def changes(self):
+        time_now = time.time()
+        last_time = self._last_filter_calls[self.filter_id_raw]
+        if last_time is not None and time_now - last_time < self.CHANGES_CACHE_TTL:
+            return []
+
         filter_changes = self.client.call(
             'eth_getFilterChanges',
             self.filter_id_raw,
         )
+
+        self._last_filter_calls[self.filter_id_raw] = time_now
 
         # geth could return None
         if filter_changes is None:


### PR DESCRIPTION
This was the approach to RPC caching added to the `orchestration` branch. Opening this PR mostly for discussion. I don't think this is a nice solution but it does the job and increases `raiden` throughput by many times.