### PR TITLE
Use pyethapp default_gasprice for contract deploy

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -5,7 +5,7 @@ from ethereum import slogging
 from ethereum import _solidity
 from ethereum.transactions import Transaction
 from ethereum.utils import denoms, int_to_big_endian, encode_hex, normalize_address
-from pyethapp.jsonrpc import address_encoder, address_decoder, data_decoder
+from pyethapp.jsonrpc import address_encoder, address_decoder, data_decoder, default_gasprice
 from pyethapp.rpc_client import topic_encoder, JSONRPCClient
 
 from raiden import messages
@@ -248,6 +248,7 @@ class BlockChainService(object):
             contracts,
             dict(),
             constructor_parameters,
+            gasprice=default_gasprice,
             timeout=self.poll_timeout,
         )
         return proxy.address

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -9,7 +9,7 @@ import pytest
 from ethereum import slogging
 from ethereum._solidity import compile_file
 from pyethapp.rpc_client import JSONRPCClient
-from pyethapp.jsonrpc import address_decoder, address_encoder
+from pyethapp.jsonrpc import address_decoder, address_encoder, default_gasprice
 
 from raiden.utils import privatekey_to_address, get_contract_path, safe_lstrip_hex
 from raiden.tests.fixtures.tester import tester_state
@@ -361,6 +361,7 @@ def _jsonrpc_services(
             registry_contracts,
             dict(),
             tuple(),
+            gasprice=default_gasprice,
             timeout=poll_timeout,
         )
         registry_address = registry_proxy.address

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -6,6 +6,7 @@ from ethereum import _solidity
 from ethereum._solidity import compile_file
 from ethereum.utils import denoms
 from pyethapp.rpc_client import JSONRPCClient
+from pyethapp.jsonrpc import default_gasprice
 
 from raiden.network.rpc.client import decode_topic, patch_send_transaction
 from raiden.utils import privatekey_to_address, get_contract_path
@@ -184,6 +185,7 @@ def test_blockchain(
         humantoken_contracts,
         dict(),
         (total_asset, 'raiden', 2, 'Rd'),
+        gasprice=default_gasprice,
         timeout=poll_timeout,
     )
 
@@ -195,6 +197,7 @@ def test_blockchain(
         registry_contracts,
         dict(),
         tuple(),
+        gasprice=default_gasprice,
         timeout=poll_timeout,
     )
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -16,7 +16,7 @@ from ethereum.utils import denoms
 from gevent.event import Event
 from IPython.lib.inputhook import inputhook_manager
 from pyethapp.utils import bcolors as bc
-from pyethapp.jsonrpc import address_encoder
+from pyethapp.jsonrpc import address_encoder, default_gasprice
 from pyethapp.console_service import GeventInputHook, SigINTHandler
 
 from raiden.utils import events, get_contract_path
@@ -161,7 +161,7 @@ class ConsoleTools(object):
             symbol='RDT',
             decimals=2,
             timeout=60,
-            gasprice=denoms.shannon * 20,
+            gasprice=default_gasprice,
             auto_register=True):
         """Create a proxy for a new HumanStandardToken (ERC20), that is
         initialized with Args(below).

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -5,8 +5,9 @@ import os
 import json
 
 from ethereum._solidity import compile_contract
-from ethereum.utils import denoms, decode_hex
+from ethereum.utils import decode_hex
 from pyethapp.rpc_client import JSONRPCClient
+from pyethapp.jsonrpc import default_gasprice
 from raiden.utils import get_contract_path
 from raiden.network.rpc.client import patch_send_transaction
 
@@ -44,7 +45,7 @@ def deploy_files(contract_files, client):
             compiled_contracts,
             libraries,
             '',
-            gasprice=denoms.shannon * 20
+            gasprice=default_gasprice
         )
         libraries[name] = proxy.address
     return {name: addr.encode('hex') for name, addr in libraries.items()}

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -1,5 +1,6 @@
 from pyethapp.rpc_client import JSONRPCClient
-from ethereum.utils import sha3, denoms
+from pyethapp.jsonrpc import default_gasprice
+from ethereum.utils import sha3
 from ethereum._solidity import compile_file
 from raiden.utils import get_contract_path
 from raiden.network.rpc.client import patch_send_transaction
@@ -18,7 +19,7 @@ def connect(host="127.0.0.1",
 def create_and_distribute_token(client, receivers,
                                 amount_per_receiver=1000,
                                 name=None,
-                                gasprice=denoms.shannon * 20,
+                                gasprice=default_gasprice,
                                 timeout=120):
     """Create a new ERC-20 token and distribute it among `receivers`.
     If `name` is None, the name will be derived from hashing all receivers.


### PR DESCRIPTION
This fixes the
`raiden/tests/integration/test_blockchainservice.py::test_new_netting_contract` test