### PR TITLE
Proccess message edge cases with invalid attributes

### DIFF
--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -45,7 +45,13 @@ class InvalidSecret(Exception):
 
 
 class InvalidLocksRoot(Exception):
-    pass
+    def __init__(self, expected_locksroot, got_locksroot):
+        Exception.__init__(
+            self,
+            'Locksroot mismatch. Expected {} but got {}'.format(
+                pex(expected_locksroot),
+                pex(got_locksroot)
+            ))
 
 
 class InvalidLockTime(Exception):
@@ -156,10 +162,7 @@ class BalanceProof(object):
         unclaimed_locksroot = self.merkleroot_for_unclaimed()
 
         if direct_transfer.locksroot != unclaimed_locksroot:
-            raise ValueError('locksroot mismatch expected:{} sent:{}'.format(
-                pex(unclaimed_locksroot),
-                pex(direct_transfer.locksroot),
-            ))
+            raise InvalidLocksRoot(unclaimed_locksroot, direct_transfer.locksroot)
 
         self.transfer = direct_transfer
         self.hashlock_unlockedlocks = dict()
@@ -876,7 +879,7 @@ class Channel(object):
                         received_locksroot=pex(transfer.locksroot),
                     )
 
-                raise InvalidLocksRoot(transfer)
+                raise InvalidLocksRoot(expected_locksroot, transfer.locksroot)
 
             # As a receiver: If the lock expiration is larger than the settling
             # time a secret could be revealed after the channel is settled and

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -11,7 +11,7 @@ from ethereum import slogging
 
 from raiden.messages import decode, Ack, Ping, SignedMessage
 from raiden.transfermanager import UnknownAddress, UnknownAssetAddress
-from raiden.channel import InvalidNonce
+from raiden.channel import InvalidLocksRoot, InvalidNonce
 from raiden.utils import isaddress, sha3, pex
 
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -336,13 +336,9 @@ class RaidenProtocol(object):
             except (UnknownAddress, InvalidNonce):
                 # Do not send ACK for these cases
                 return
-            except UnknownAssetAddress as e:
+            except (UnknownAssetAddress, InvalidLocksRoot) as e:
                 if log.isEnabledFor(logging.WARN):
-                    log.warn(
-                        'Message with unknown asset address %s received from %s',
-                        pex(e.asset_address),
-                        pex(message.sender)
-                    )
+                    log.warn(str(e))
                 return
 
             # only send the Ack if the message was handled without exceptions

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -10,7 +10,7 @@ from gevent.event import AsyncResult, Event
 from ethereum import slogging
 
 from raiden.messages import decode, Ack, Ping, SignedMessage
-from raiden.transfermanager import UnknownAddress
+from raiden.transfermanager import UnknownAddress, UnknownAssetAddress
 from raiden.channel import InvalidNonce
 from raiden.utils import isaddress, sha3, pex
 
@@ -335,6 +335,14 @@ class RaidenProtocol(object):
                 self.raiden.on_message(message, echohash)
             except (UnknownAddress, InvalidNonce):
                 # Do not send ACK for these cases
+                return
+            except UnknownAssetAddress as e:
+                if log.isEnabledFor(logging.WARN):
+                    log.warn(
+                        'Message with unknown asset address %s received from %s',
+                        pex(e.asset_address),
+                        pex(message.sender)
+                    )
                 return
 
             # only send the Ack if the message was handled without exceptions

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -636,12 +636,55 @@ def test_receive_directtransfer_wrongasset(raiden_network, private_keys):
         channel1, balance1 + amount, []
     )
 
-    # and now send one more direct transfer with the same nonce, simulating
-    # an out-of-order/resent message that arrives late
+    # and now send one more direct transfer with a mistaken asset address
     direct_transfer = DirectTransfer(
         identifier=asset_manager0.transfermanager.create_default_identifier(app1.raiden.address),
-        nonce=1,
+        nonce=2,
         asset=HASH[0:20],
+        transferred_amount=10,
+        recipient=app1.raiden.address,
+        locksroot=HASH,
+    )
+    app0_key = PrivateKey(private_keys[0])
+    sign_and_send(direct_transfer, app0_key, app0.raiden.address, app1)
+
+
+@pytest.mark.parametrize('blockchain_type', ['mock'])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('channels_per_node', [1])
+def test_receive_directtransfer_invalidlocksroot(raiden_network, private_keys):
+    app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
+
+    asset_manager0 = app0.raiden.managers_by_asset_address.values()[0]
+    asset_manager1 = app1.raiden.managers_by_asset_address.values()[0]
+
+    channel0 = asset_manager0.partneraddress_channel[app1.raiden.address]
+    channel1 = asset_manager1.partneraddress_channel[app0.raiden.address]
+
+    balance0 = channel0.balance
+    balance1 = channel1.balance
+
+    assert asset_manager0.asset_address == asset_manager1.asset_address
+    assert app1.raiden.address in asset_manager0.partneraddress_channel
+
+    amount = 10
+    app0.raiden.api.transfer(
+        asset_manager0.asset_address,
+        amount,
+        target=app1.raiden.address,
+    )
+    gevent.sleep(1)
+
+    assert_synched_channels(
+        channel0, balance0 - amount, [],
+        channel1, balance1 + amount, []
+    )
+
+    # and now send one more direct transfer with the recipient not set correctly
+    direct_transfer = DirectTransfer(
+        identifier=asset_manager0.transfermanager.create_default_identifier(app1.raiden.address),
+        nonce=2,
+        asset=asset_manager0.asset_address,
         transferred_amount=10,
         recipient=app1.raiden.address,
         locksroot=HASH,

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -680,7 +680,7 @@ def test_receive_directtransfer_invalidlocksroot(raiden_network, private_keys):
         channel1, balance1 + amount, []
     )
 
-    # and now send one more direct transfer with the recipient not set correctly
+    # and now send one more direct transfer with the locksoot not set correctly
     direct_transfer = DirectTransfer(
         identifier=asset_manager0.transfermanager.create_default_identifier(app1.raiden.address),
         nonce=2,

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -603,3 +603,48 @@ def test_receive_mediatedtransfer_invalid_address(raiden_network, private_keys):
             target_app = app
             break
     sign_and_send(mediated_transfer, alice_key, alice_address, target_app)
+
+
+@pytest.mark.parametrize('blockchain_type', ['mock'])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('channels_per_node', [1])
+def test_receive_directtransfer_wrongasset(raiden_network, private_keys):
+    app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
+
+    asset_manager0 = app0.raiden.managers_by_asset_address.values()[0]
+    asset_manager1 = app1.raiden.managers_by_asset_address.values()[0]
+
+    channel0 = asset_manager0.partneraddress_channel[app1.raiden.address]
+    channel1 = asset_manager1.partneraddress_channel[app0.raiden.address]
+
+    balance0 = channel0.balance
+    balance1 = channel1.balance
+
+    assert asset_manager0.asset_address == asset_manager1.asset_address
+    assert app1.raiden.address in asset_manager0.partneraddress_channel
+
+    amount = 10
+    app0.raiden.api.transfer(
+        asset_manager0.asset_address,
+        amount,
+        target=app1.raiden.address,
+    )
+    gevent.sleep(1)
+
+    assert_synched_channels(
+        channel0, balance0 - amount, [],
+        channel1, balance1 + amount, []
+    )
+
+    # and now send one more direct transfer with the same nonce, simulating
+    # an out-of-order/resent message that arrives late
+    direct_transfer = DirectTransfer(
+        identifier=asset_manager0.transfermanager.create_default_identifier(app1.raiden.address),
+        nonce=1,
+        asset=HASH[0:20],
+        transferred_amount=10,
+        recipient=app1.raiden.address,
+        locksroot=HASH,
+    )
+    app0_key = PrivateKey(private_keys[0])
+    sign_and_send(direct_transfer, app0_key, app0.raiden.address, app1)

--- a/raiden/transfermanager.py
+++ b/raiden/transfermanager.py
@@ -36,9 +36,11 @@ class UnknownAddress(Exception):
 
 
 class UnknownAssetAddress(Exception):
-    def __init__(self, address):
-        # self.asset_address = '0x' + address.encode('hex')
-        self.asset_address = address
+    def __init__(self, address, sender):
+        Exception.__init__(
+            self,
+            'Message with unknown asset address {} received'.format(pex(address))
+        )
 
 
 class TransferManager(object):

--- a/raiden/transfermanager.py
+++ b/raiden/transfermanager.py
@@ -35,6 +35,12 @@ class UnknownAddress(Exception):
     pass
 
 
+class UnknownAssetAddress(Exception):
+    def __init__(self, address):
+        # self.asset_address = '0x' + address.encode('hex')
+        self.asset_address = address
+
+
 class TransferManager(object):
     """ Manages all transfers done through this node. """
 

--- a/raiden/transfermanager.py
+++ b/raiden/transfermanager.py
@@ -36,7 +36,7 @@ class UnknownAddress(Exception):
 
 
 class UnknownAssetAddress(Exception):
-    def __init__(self, address, sender):
+    def __init__(self, address):
         Exception.__init__(
             self,
             'Message with unknown asset address {} received'.format(pex(address))


### PR DESCRIPTION
This PR is for:

- Unknown address in a message
- Unknown asset address in a message
- Locksroot that can't be matched to the expected locksroot

It is also a part of #72 

