### PR TITLE
Fix argument size checks in `messages`

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -300,7 +300,7 @@ class Secret(SignedMessage):
 
 
 class RevealSecret(SignedMessage):
-    """ Message used to reveal a secret to party know to have interest in it.
+    """Message used to reveal a secret to party known to have interest in it.
 
     This message is not sufficient for state changes in the raiden Channel, the
     reason is that a node participating in split transfer or in both mediated

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -415,7 +415,7 @@ class Lock(MessageHashable):
         if amount < 0:
             raise ValueError('amount {} needs to be positive'.format(amount))
 
-        if amount > 2 ** 256:
+        if amount >= 2 ** 256:
             raise ValueError('amount {} is too large'.format(amount))
 
         assert ishash(hashlock)
@@ -562,13 +562,13 @@ class MediatedTransfer(LockedTransfer):
     def __init__(self, identifier, nonce, asset, transferred_amount, recipient,
                  locksroot, lock, target, initiator, fee=0):
 
-        if nonce > 2 ** 64:
+        if nonce >= 2 ** 64:
             raise ValueError('nonce is too large')
 
-        if fee > 2 ** 256:
+        if fee >= 2 ** 256:
             raise ValueError('fee is too large')
 
-        if transferred_amount > 2 ** 256:
+        if transferred_amount >= 2 ** 256:
             raise ValueError('transferred_amount is too large')
 
         super(MediatedTransfer, self).__init__(

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 from raiden.messages import Ping, Ack, decode, Lock, MediatedTransfer
 from raiden.utils import make_privkey_address, sha3
 
@@ -64,6 +65,98 @@ def test_mediated_transfer():
         initiator,
         fee,
     )
+    assert roundtrip_serialize_mediated_transfer(mediated_transfer)
+
+
+def make_lock_with_amount(amount):
+    return Lock(amount, 1, "a" * 32)
+
+
+def make_mediated_transfer_with_amount(amount):
+    return MediatedTransfer(
+        0,
+        1,
+        ADDRESS,
+        amount,
+        ADDRESS,
+        "",
+        make_lock_with_amount(amount),
+        ADDRESS,
+        ADDRESS,
+        0
+    )
+
+
+def make_mediated_transfer_with_nonce(nonce):
+    return MediatedTransfer(
+        0,
+        nonce,
+        ADDRESS,
+        1,
+        ADDRESS,
+        "",
+        make_lock_with_amount(1),
+        ADDRESS,
+        ADDRESS,
+        0
+    )
+
+
+def make_mediated_transfer_with_fee(fee):
+    return MediatedTransfer(
+        0,
+        1,
+        ADDRESS,
+        1,
+        ADDRESS,
+        "",
+        make_lock_with_amount(1),
+        ADDRESS,
+        ADDRESS,
+        fee
+    )
+
+
+def roundtrip_serialize_mediated_transfer(mediated_transfer):
     mediated_transfer.sign(PRIVKEY, ADDRESS)
     decoded_mediated_transfer = decode(mediated_transfer.encode())
     assert decoded_mediated_transfer == mediated_transfer
+    return True
+
+
+@pytest.mark.parametrize("amount", [-1, 2 ** 256])
+@pytest.mark.parametrize("make", [make_lock_with_amount,
+                                  make_mediated_transfer_with_amount])
+def test_amount_out_of_bounds(amount, make):
+    with pytest.raises(ValueError):
+        make(amount)
+
+
+@pytest.mark.parametrize("amount", [0, 2 ** 256 - 1])
+def test_mediated_transfer_amount_min_max(amount):
+    mediated_transfer = make_mediated_transfer_with_amount(amount)
+    assert roundtrip_serialize_mediated_transfer(mediated_transfer)
+
+
+@pytest.mark.parametrize("nonce", [2 ** 64])
+def test_mediated_transfer_nonce_out_of_bounds(nonce):
+    with pytest.raises(ValueError):
+        make_mediated_transfer_with_nonce(nonce)
+
+
+@pytest.mark.parametrize("nonce", [2 ** 64 - 1])
+def test_mediated_transfer_nonce_max(nonce):
+    mediated_transfer = make_mediated_transfer_with_nonce(nonce)
+    assert roundtrip_serialize_mediated_transfer(mediated_transfer)
+
+
+@pytest.mark.parametrize("fee", [2 ** 256])
+def test_mediated_transfer_fee_out_of_bounds(fee):
+    with pytest.raises(ValueError):
+        make_mediated_transfer_with_fee(fee)
+
+
+@pytest.mark.parametrize("fee", [0, 2 ** 256 - 1])
+def test_mediated_transfer_fee_min_max(fee):
+    mediated_transfer = make_mediated_transfer_with_fee(fee)
+    assert roundtrip_serialize_mediated_transfer(mediated_transfer)


### PR DESCRIPTION
~Fixes #187 in the proposed way.~

This now addresses several cases in `Lock` and `MediatedTransfer` and adds a unit test case for the message field limits.

Note: there are potentially other fields that should be size checked, too, which may or may not `raise` during (de-)serialization.

Stil fixes #187