### PR TITLE
Check token transfer failure

### DIFF
--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -393,8 +393,12 @@ library NettingChannelLibrary {
             throw;
         }
 
-        self.token.transfer(node1.node_address, node1.netted);
-        self.token.transfer(node2.node_address, node2.netted);
+        if (!self.token.transfer(node1.node_address, node1.netted)) {
+            throw;
+        }
+        if (!self.token.transfer(node2.node_address, node2.netted)) {
+            throw;
+        }
     }
 
     function getTransferRawAddress(bytes memory signed_transfer) private returns (bytes memory, address) {


### PR DESCRIPTION
We have to be checking for the failure of `token.transfer()`, because if
we don't a `channel.settle()` can succeed while the transfer of tokens
can fail which will result in the funds being stuck in the contract forever.