### PR TITLE
Don't swallow errors when talking to GH API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ feature level. All proof of concept releases will have version numbers in the
 
 #### Developer notice:
 
-To create a proof of concept release, install [`bumpversion`](https://github.com/peritus/bumpversion)
-and call
+To create a proof of concept release, install [`bumpversion`](https://github.com/peritus/bumpversion), update your
+`master` branch to the latest upstream version (i.e. `git checkout master && git pull --rebase`), then call
 
 ```
 prepare_poc_release.sh

--- a/prepare_poc_release.sh
+++ b/prepare_poc_release.sh
@@ -43,6 +43,11 @@ https://api.github.com/repos/raiden-network/raiden/pulls -d'{
     "head": "'"$RELEASE_BRANCH"'"
 }')
 
+echo $RESULT
+echo "--^ This should have created a pull request titled '$RELEASE_BRANCH'."
+
+echo "If there is no PR, you should rollback your changes and start over."
+
 GH_OTP=""
 
 PR_URL=$(echo $RESULT|cut -d' ' -f 3|cut -b2-|rev|cut -b3-|rev)


### PR DESCRIPTION
This is part of the reason why 0.0.3 release got messed up --
the API request errored, but the script didn't give any usable
feedback.