### PR TITLE
Use nonce ranges

### DIFF
--- a/raiden/assetmanager.py
+++ b/raiden/assetmanager.py
@@ -119,10 +119,12 @@ class AssetManager(object):  # pylint: disable=too-many-instance-attributes
         our_state = ChannelEndState(
             channel_details['our_address'],
             channel_details['our_balance'],
+            self.raiden.chain.block_number,
         )
         partner_state = ChannelEndState(
             channel_details['partner_address'],
             channel_details['partner_balance'],
+            self.raiden.chain.block_number,
         )
 
         external_state = ChannelExternalState(

--- a/raiden/assetmanager.py
+++ b/raiden/assetmanager.py
@@ -119,12 +119,12 @@ class AssetManager(object):  # pylint: disable=too-many-instance-attributes
         our_state = ChannelEndState(
             channel_details['our_address'],
             channel_details['our_balance'],
-            self.raiden.chain.block_number,
+            netting_channel.opened,
         )
         partner_state = ChannelEndState(
             channel_details['partner_address'],
             channel_details['partner_balance'],
-            self.raiden.chain.block_number,
+            netting_channel.opened,
         )
 
         external_state = ChannelExternalState(

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -283,14 +283,8 @@ class ChannelEndState(object):
         # 0 is used in the netting contract to represent the lack of a
         # transfer, so this value must start at 1
         if isinstance(get_block_number, int):
-            # if get_block_number == 0:
-                # self.nonce = 1 * (1  * (2 ** 32))
-            # else:
             self.nonce = 1 * (get_block_number * (2 ** 32))
         else:
-            # if get_block_number() == 0:
-                # self.nonce = 1 * (1 * (2 ** 32))
-            # else:
             self.nonce = 1 * (get_block_number() * (2 ** 32))
 
         # contains the last known message with a valid signature and

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -520,6 +520,10 @@ class Channel(object):
         self.settle_timeout = settle_timeout
         self.external_state = external_state
 
+        # use nonce ranges
+        self.our_state.nonce = our_state.nonce * (external_state.opened_block * (2 ** 32))
+        self.partner_state.nonce = partner_state.nonce * (external_state.opened_block * (2 ** 32))
+
         self.open_event = Event()
         self.close_event = Event()
         self.settle_event = Event()

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -283,8 +283,14 @@ class ChannelEndState(object):
         # 0 is used in the netting contract to represent the lack of a
         # transfer, so this value must start at 1
         if isinstance(get_block_number, int):
+            # if get_block_number == 0:
+                # self.nonce = 1 * (1  * (2 ** 32))
+            # else:
             self.nonce = 1 * (get_block_number * (2 ** 32))
         else:
+            # if get_block_number() == 0:
+                # self.nonce = 1 * (1 * (2 ** 32))
+            # else:
             self.nonce = 1 * (get_block_number() * (2 ** 32))
 
         # contains the last known message with a valid signature and

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -268,7 +268,7 @@ class BalanceProof(object):
 class ChannelEndState(object):
     """ Tracks the state of one of the participants in a channel. """
 
-    def __init__(self, participant_address, participant_balance):
+    def __init__(self, participant_address, participant_balance, get_block_number):
         # since ethereum only uses integral values we cannot use float/Decimal
         if not isinstance(participant_balance, (int, long)):
             raise ValueError('participant_balance must be an integer.')
@@ -282,7 +282,7 @@ class ChannelEndState(object):
         # sequential nonce, current value has not been used.
         # 0 is used in the netting contract to represent the lack of a
         # transfer, so this value must start at 1
-        self.nonce = 1
+        self.nonce = 1 * (get_block_number * (2 ** 32))
 
         # contains the last known message with a valid signature and
         # transferred_amount, the secrets revealed since that transfer, and the
@@ -519,10 +519,6 @@ class Channel(object):
         self.reveal_timeout = reveal_timeout
         self.settle_timeout = settle_timeout
         self.external_state = external_state
-
-        # use nonce ranges
-        self.our_state.nonce = our_state.nonce * (external_state.opened_block * (2 ** 32))
-        self.partner_state.nonce = partner_state.nonce * (external_state.opened_block * (2 ** 32))
 
         self.open_event = Event()
         self.close_event = Event()

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -282,7 +282,10 @@ class ChannelEndState(object):
         # sequential nonce, current value has not been used.
         # 0 is used in the netting contract to represent the lack of a
         # transfer, so this value must start at 1
-        self.nonce = 1 * (get_block_number * (2 ** 32))
+        if isinstance(get_block_number, int):
+            self.nonce = 1 * (get_block_number * (2 ** 32))
+        else:
+            self.nonce = 1 * (get_block_number() * (2 ** 32))
 
         # contains the last known message with a valid signature and
         # transferred_amount, the secrets revealed since that transfer, and the

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -281,7 +281,8 @@ class ChannelEndState(object):
 
         # sequential nonce, current value has not been used.
         # 0 is used in the netting contract to represent the lack of a
-        # transfer, so this value must start at 1
+        # the nonce value must be inside the netting channel allowed range
+        # that is defined in terms of the opened block
         if isinstance(get_block_number, int):
             self.nonce = 1 * (get_block_number * (2 ** 32))
         else:

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -172,7 +172,7 @@ def test_reopen_channel(
     address2 = tester.a2
 
     # We need to close the channel before it can be deleted, to do so we need
-    # one transfer to call closeSingleTransfer(0
+    # one transfer to call closeSingleTransfer()
     transfer_amount = 10
     identifier = 1
     direct_transfer = channel0.create_directtransfer(
@@ -193,14 +193,14 @@ def test_reopen_channel(
     )
     tester_state.mine(number_of_blocks=settle_timeout + 1)
 
-    # delete the channel needs to update the manager's state
+    # deleting the channel needs to update the manager's state
     number_of_channels = len(tester_channelmanager.getChannelsAddresses(sender=privatekey0_raw))
 
     nettingchannel.settle(sender=privatekey0_raw)
 
     tester_state.mine(1)
 
-    # now a single new channel can be open
+    # now a single new channel can be opened
     # if channel with address is settled a new can be opened
     # old entry will be deleted when calling newChannel
     netting_channel_address1_hex = tester_channelmanager.newChannel(

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -11,8 +11,12 @@ from secp256k1 import PrivateKey
 from raiden.tests.utils.tester import new_channelmanager
 
 
-def test_channelnew_event(settle_timeout, tester_state, tester_events,
-                          tester_registry, tester_token):
+def test_channelnew_event(
+        settle_timeout,
+        tester_state,
+        tester_events,
+        tester_registry,
+        tester_token):
 
     privatekey0 = tester.DEFAULT_KEY
     address0 = tester.DEFAULT_ACCOUNT
@@ -42,10 +46,13 @@ def test_channelnew_event(settle_timeout, tester_state, tester_events,
     }
 
 
-def test_channelmanager(tester_state, tester_token, tester_events,
-                        tester_channelmanager_library_address, settle_timeout,
-                        netting_channel_abi):
-    # pylint: disable=too-many-locals,too-many-statements
+def test_channelmanager(
+        tester_state,
+        tester_token,
+        tester_events,
+        tester_channelmanager_library_address,
+        settle_timeout,
+        netting_channel_abi): # pylint: disable=too-many-locals,too-many-statements
 
     address0 = tester.DEFAULT_ACCOUNT
     address1 = tester.a1
@@ -150,8 +157,13 @@ def test_channelmanager(tester_state, tester_token, tester_events,
     #    channel_manager.key(sha3('address1')[:20], sha3('address1')[:20])
 
 @pytest.mark.xfail
-def test_reopen_channel(tester_state, tester_channelmanager, tester_channels, settle_timeout,
-                       netting_channel_abi):
+def test_reopen_channel(
+        tester_state,
+        tester_channelmanager,
+        tester_channels,
+        settle_timeout,
+        netting_channel_abi):
+
     privatekey0_raw, privatekey1_raw, nettingchannel, channel0, _ = tester_channels[0]
 
     privatekey0 = PrivateKey(privatekey0_raw, ctx=GLOBAL_CTX, raw=True)

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -3,8 +3,10 @@ import pytest
 
 from ethereum import tester
 from ethereum.utils import encode_hex, sha3
-from raiden.utils import get_contract_path
+from raiden.utils import get_contract_path, privatekey_to_address
+from raiden.encoding.signing import GLOBAL_CTX
 from ethereum.tester import ABIContract, ContractTranslator, TransactionFailed
+from secp256k1 import PrivateKey
 
 from raiden.tests.utils.tester import new_channelmanager
 
@@ -146,3 +148,81 @@ def test_channelmanager(tester_state, tester_token, tester_events,
     # assert k1 == sha3(vs[0] + vs[1])
     # with pytest.raises(TransactionFailed):
     #    channel_manager.key(sha3('address1')[:20], sha3('address1')[:20])
+
+@pytest.mark.xfail
+def test_reopen_channel(tester_state, tester_channelmanager, tester_channels, settle_timeout,
+                       netting_channel_abi):
+    privatekey0_raw, privatekey1_raw, nettingchannel, channel0, _ = tester_channels[0]
+
+    privatekey0 = PrivateKey(privatekey0_raw, ctx=GLOBAL_CTX, raw=True)
+    address0 = privatekey_to_address(privatekey0_raw)
+    address1 = privatekey_to_address(privatekey1_raw)
+    address2 = tester.a2
+
+    # We need to close the channel before it can be deleted, to do so we need
+    # one transfer to call closeSingleTransfer(0
+    transfer_amount = 10
+    identifier = 1
+    direct_transfer = channel0.create_directtransfer(
+        transfer_amount,
+        identifier,
+    )
+    direct_transfer.sign(privatekey0, address0)
+    direct_transfer_data = str(direct_transfer.packed().data)
+
+    should_be_nonce = nettingchannel.opened(sender=privatekey0_raw) * (2**32)
+    should_be_nonce_plus_one = (nettingchannel.opened(sender=privatekey0_raw) + 1) * (2**32)
+    assert should_be_nonce <= direct_transfer.nonce < should_be_nonce_plus_one
+
+    # settle the channel should not change the channel manager state
+    nettingchannel.closeSingleTransfer(
+        direct_transfer_data,
+        sender=privatekey1_raw,
+    )
+    tester_state.mine(number_of_blocks=settle_timeout + 1)
+
+    # delete the channel needs to update the manager's state
+    number_of_channels = len(tester_channelmanager.getChannelsAddresses(sender=privatekey0_raw))
+
+    nettingchannel.settle(sender=privatekey0_raw)
+
+    tester_state.mine(1)
+
+    # now a single new channel can be open
+    # if channel with address is settled a new can be opened
+    # old entry will be deleted when calling newChannel
+    netting_channel_address1_hex = tester_channelmanager.newChannel(
+        address1,
+        settle_timeout,
+        sender=privatekey0_raw,
+    )
+
+    netting_channel_translator = ContractTranslator(netting_channel_abi)
+
+    netting_contract_proxy1 = ABIContract(
+        tester_state,
+        netting_channel_translator,
+        netting_channel_address1_hex,
+    )
+
+    # transfer not in nonce range
+    with pytest.raises(TransactionFailed):
+        netting_contract_proxy1.closeSingleTransfer(
+            direct_transfer_data,
+            sender=privatekey0_raw,
+        )
+
+    # channel already exists
+    with pytest.raises(TransactionFailed):
+        tester_channelmanager.newChannel(
+            address1,
+            settle_timeout,
+            sender=privatekey0_raw,
+        )
+
+    # opening a new channel that did not exist before
+    netting_channel_address2_hex = tester_channelmanager.newChannel(
+        address2,
+        settle_timeout,
+        sender=privatekey0_raw,
+    )

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -43,6 +43,7 @@ def make_external_state():
 
 
 def test_end_state():
+    netting_channel = NettingChannelMock()
     asset_address = make_address()
     privkey1, address1 = make_privkey_address()
     address2 = make_address()
@@ -55,8 +56,8 @@ def test_end_state():
     lock_expiration = 10
     lock_hashlock = sha3(lock_secret)
 
-    state1 = ChannelEndState(address1, balance1)
-    state2 = ChannelEndState(address2, balance2)
+    state1 = ChannelEndState(address1, balance1, netting_channel.opened)
+    state2 = ChannelEndState(address2, balance2, netting_channel.opened)
 
     assert state1.contract_balance == balance1
     assert state2.contract_balance == balance2
@@ -187,6 +188,7 @@ def test_end_state():
 
 
 def test_invalid_timeouts():
+    netting_channel = NettingChannelMock()
     asset_address = make_address()
     reveal_timeout = 5
     settle_timeout = 15
@@ -196,8 +198,8 @@ def test_invalid_timeouts():
     balance1 = 10
     balance2 = 10
 
-    our_state = ChannelEndState(address1, balance1)
-    partner_state = ChannelEndState(address2, balance2)
+    our_state = ChannelEndState(address1, balance1, netting_channel.opened)
+    partner_state = ChannelEndState(address2, balance2, netting_channel.opened)
     external_state = make_external_state()
 
     # do not allow a reveal timeout larger than the settle timeout
@@ -237,6 +239,7 @@ def test_invalid_timeouts():
 
 
 def test_python_channel():
+    netting_channel = NettingChannelMock()
     asset_address = make_address()
     privkey1, address1 = make_privkey_address()
     address2 = make_address()
@@ -247,8 +250,8 @@ def test_python_channel():
     reveal_timeout = 5
     settle_timeout = 15
 
-    our_state = ChannelEndState(address1, balance1)
-    partner_state = ChannelEndState(address2, balance2)
+    our_state = ChannelEndState(address1, balance1, netting_channel.opened)
+    partner_state = ChannelEndState(address2, balance2, netting_channel.opened)
     external_state = make_external_state()
 
     test_channel = Channel(

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -104,10 +104,12 @@ def channel_from_nettingcontract(our_key, netting_contract, external_state, reve
     our_state = ChannelEndState(
         our_address,
         our_balance,
+        external_state.opened_block,
     )
     partner_state = ChannelEndState(
         partner_address,
         partner_balance,
+        external_state.opened_block,
     )
 
     channel = Channel(

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -121,6 +121,7 @@ class ChannelExternalStateTester(object):
     def get_block_number(self):
         return self.tester_state.block.number
 
+    @property
     def opened_block(self):
         return self.proxy.opened()
 


### PR DESCRIPTION
This PR adds nonce ranges to the netting channels. This makes sure that once #191 allows for channels to be reopened, the same transfers cannot be used again.

Tests for reopening a channel and for nonce ranges have also been added, but they are marked as `xfail` until #191 is done.

With this PR I believe that #39 can be closed