### PR TITLE
Fix issue #290

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   global:
-    - GETH_URL='https://github.com/ethereum/go-ethereum/releases/download/v1.4.18/geth-linux-amd64-1.4.18-ef9265d0.tar.gz'
-    - GETH_VERSION='1.4.18'
+    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz'
+    - GETH_VERSION='1.5.5'
     - SOLC_URL='https://github.com/brainbot-com/solidity-static/releases/download/v0.4.4/solc'
     - SOLC_VERSION='0.4.4'
   matrix:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -67,7 +67,7 @@ def patch_send_transaction(client, nonce_offset=0):
         """
         pending_transactions_hex = client.call(
             'eth_getTransactionCount',
-            encode_hex(sender),
+            address_encoder(sender),
             'pending',
         )
         pending_transactions = int(pending_transactions_hex, 16)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytest>=3.0.4
 pytest-timeout
 pytest-random
 pysha3
-pyethapp>=1.5.0
+-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
 ipython<5.0.0
 rlp>=0.4.3
 secp256k1==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pytest>=3.0.4
 pytest-timeout
 pytest-random
 pysha3
+# temporary until https://github.com/ethereum/pyethapp/pull/184 comes upstream (see also setup.py)
 -e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
 ipython<5.0.0
 rlp>=0.4.3

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ history = ''
 
 
 install_requires_replacements = {
+    "-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp": "pyethapp"
 }
 
 install_requires = list(set(


### PR DESCRIPTION
go ethereum implemented strict hex encoding for jsonrpc since https://github.com/ethereum/go-ethereum/pull/3355/files

We had one incorrect address encoding raiden, as well as there is an incorrect address encoding in pyethapp rpc client (see https://github.com/ethereum/pyethapp/pull/184).

In this PR I
- upgraded the `geth` version in travis to `v1.5.5`
- fixed the incorrect encoding in `raiden`
- temporarily switched the pyethapp requirement to the patched version from [pyethapp PR 184](https://github.com/ethereum/pyethapp/pull/184)