### PR TITLE
adding logic to allow to parties to open a new channel after settling

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -574,10 +574,13 @@ class ChannelManager(object):
         # TODO: raise if the transaction failed because there is an existing
         # channel in place
 
-        netting_channel_address_encoded = self.proxy.getChannelWith.call(
+        netting_channel_results_encoded = self.proxy.getChannelWith.call(
             other,
             startgas=self.startgas,
         )
+
+        # address is at index 0
+        netting_channel_address_encoded = netting_channel_results_encoded[0]
 
         if not netting_channel_address_encoded:
             log.error('netting_channel_address failed', peer1=pex(peer1), peer2=pex(peer2))

--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -109,13 +109,17 @@ contract ChannelManagerContract {
         return data.node_channels[node_address];
     }
 
-    function getChannelWith(address partner) constant returns (address) {
-        return data.getChannelWith(partner);
+    function getChannelWith(address partner) constant returns (address, bool, uint, uint) {
+        return data.getChannelWith(msg.sender, partner);
     }
 
     function newChannel(address partner, uint settle_timeout) returns (address channel) {
-        channel = data.newChannel(partner, settle_timeout);
+        channel = data.newChannel(msg.sender, partner, settle_timeout);
         ChannelNew(channel, msg.sender, partner, settle_timeout);
+    }
+
+    function contractExists(address channel) returns (bool) {
+        return data.contractExists(channel);
     }
 
     function () { throw; }

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -72,6 +72,11 @@ library NettingChannelLibrary {
         _;
     }
 
+    modifier channelSettled(Data storage self) {
+        if (self.settled == 0) throw;
+        _;
+    }
+
     /// @notice deposit(uint) to deposit amount to channel.
     /// @dev Deposit an amount to the channel. At least one of the participants
     /// must deposit before the channel is opened.
@@ -412,6 +417,8 @@ library NettingChannelLibrary {
                 throw;
             }
         }
+
+        kill(self);
     }
 
     function getTransferRawAddress(bytes memory signed_transfer) private returns (bytes memory, address) {
@@ -622,5 +629,9 @@ library NettingChannelLibrary {
         for (uint i = start; i < end; i ++) { //python style slice
             n[i-start] = a[i];
         }
+    }
+
+    function kill(Data storage self) channelSettled(self) {
+        selfdestruct(0x00000000000000000000);
     }
 }

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -73,7 +73,8 @@ library NettingChannelLibrary {
     }
 
     modifier channelSettled(Data storage self) {
-        if (self.settled == 0) throw;
+        if (self.settled == 0)
+            throw;
         _;
     }
 
@@ -625,9 +626,9 @@ library NettingChannelLibrary {
             throw;
         }
 
-        n = new bytes(end-start);
-        for (uint i = start; i < end; i ++) { //python style slice
-            n[i-start] = a[i];
+        n = new bytes(end - start);
+        for (uint i = start; i < end; i++) { //python style slice
+            n[i - start] = a[i];
         }
     }
 

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -122,7 +122,7 @@ def test_channelmanager(
     assert len(previous_events) + 1 == len(tester_events), 'ChannelNew event must be fired.'
 
     assert channel_manager.getChannelWith(address1)[0] == netting_channel_address1_hex
-    assert channel_manager.getChannelWith(address2)[0]== netting_channel_address2_hex
+    assert channel_manager.getChannelWith(address2)[0] == netting_channel_address2_hex
 
     msg_sender_channels = channel_manager.nettingContractsByAddress(tester.DEFAULT_ACCOUNT)
     address1_channels = channel_manager.nettingContractsByAddress(address1)

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -101,9 +101,8 @@ def test_channelmanager(
     with pytest.raises(TransactionFailed):
         channel_manager.newChannel(address1, settle_timeout)
 
-    # should trow if there is no channel for the given address
-    with pytest.raises(TransactionFailed):
-        channel_manager.getChannelWith(inexisting_address)
+    # should be false if there is no channel for the given address
+    assert not channel_manager.getChannelWith(inexisting_address)[1]
 
     assert len(channel_manager.getChannelsParticipants()) == 2
 
@@ -122,8 +121,8 @@ def test_channelmanager(
     )
     assert len(previous_events) + 1 == len(tester_events), 'ChannelNew event must be fired.'
 
-    assert channel_manager.getChannelWith(address1) == netting_channel_address1_hex
-    assert channel_manager.getChannelWith(address2) == netting_channel_address2_hex
+    assert channel_manager.getChannelWith(address1)[0] == netting_channel_address1_hex
+    assert channel_manager.getChannelWith(address2)[0]== netting_channel_address2_hex
 
     msg_sender_channels = channel_manager.nettingContractsByAddress(tester.DEFAULT_ACCOUNT)
     address1_channels = channel_manager.nettingContractsByAddress(address1)
@@ -156,7 +155,6 @@ def test_channelmanager(
     # with pytest.raises(TransactionFailed):
     #    channel_manager.key(sha3('address1')[:20], sha3('address1')[:20])
 
-@pytest.mark.xfail
 def test_reopen_channel(
         tester_state,
         tester_channelmanager,


### PR DESCRIPTION
This PR fixes #93 and should be favored instead of #191.

It makes it possible to open a channel with the same partner after settling. Replay attacks has been taken care of by #287 and #211. 

Right now the code is not very effective and quite expensive to run gas wise, but this should become a lot cheaper once PR #250 is implemented. 