### PR TITLE
Consistent usage of a single close() function

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -14,6 +14,7 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
+    get_encoded_transfers
 )
 from raiden.blockchain.abi import (
     ASSETADDED_EVENTID,
@@ -780,15 +781,13 @@ class NettingChannel(object):
     def settled(self):
         return self.proxy.settled.call()
 
-    def close(self, our_address, first_transfer, second_transfer):
+    def close(self, our_address, their_transfer, our_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        first_encoded = first_transfer.encode() if first_transfer else ""
-        second_encoded = second_transfer.encode() if second_transfer else ""
-
+        their_encoded, our_encoded = get_encoded_transfers(their_transfer, our_transfer)
         transaction_hash = self.proxy.close.transact(
-            first_encoded,
-            second_encoded,
+            their_encoded,
+            our_encoded,
             startgas=self.startgas,
             gasprice=self.gasprice,
         )
@@ -796,8 +795,8 @@ class NettingChannel(object):
         log.info(
             'close called',
             contract=pex(self.address),
-            first_transfer=first_transfer,
-            second_transfer=second_transfer,
+            their_transfer=their_transfer,
+            our_transfer=our_transfer,
         )
 
     def update_transfer(self, our_address, their_transfer):

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -783,52 +783,22 @@ class NettingChannel(object):
     def close(self, our_address, first_transfer, second_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        if first_transfer and second_transfer:
-            first_encoded = first_transfer.encode()
-            second_encoded = second_transfer.encode()
+        first_encoded = first_transfer.encode() if first_transfer else ""
+        second_encoded = second_transfer.encode() if second_transfer else ""
 
-            transaction_hash = self.proxy.close.transact(
-                first_encoded,
-                second_encoded,
-                startgas=self.startgas,
-                gasprice=self.gasprice,
-            )
-            self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-
-            log.info(
-                'close called',
-                contract=pex(self.address),
-                first_transfer=first_transfer,
-                second_transfer=second_transfer,
-            )
-
-        elif first_transfer:
-            first_encoded = first_transfer.encode()
-
-            transaction_hash = self.proxy.closeSingleTransfer.transact(
-                first_encoded,
-                startgas=self.startgas,
-                gasprice=self.gasprice,
-            )
-            self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-
-            log.info('close called', contract=pex(self.address), first_transfer=first_transfer)
-
-        elif second_transfer:
-            second_encoded = second_transfer.encode()
-
-            transaction_hash = self.proxy.closeSingleTransfer.transact(
-                second_encoded,
-                startgas=self.startgas,
-                gasprice=self.gasprice,
-            )
-            self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-
-            log.info('close called', contract=pex(self.address), second_transfer=second_transfer)
-
-        else:
-            # TODO: allow to close nevertheless
-            raise ValueError('channel wasnt used')
+        transaction_hash = self.proxy.close.transact(
+            first_encoded,
+            second_encoded,
+            startgas=self.startgas,
+            gasprice=self.gasprice,
+        )
+        self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+        log.info(
+            'close called',
+            contract=pex(self.address),
+            first_transfer=first_transfer,
+            second_transfer=second_transfer,
+        )
 
     def update_transfer(self, our_address, their_transfer):
         """`our_address` is an argument used only in mock_client.py but is also

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -63,16 +63,6 @@ contract NettingChannelContract {
         return data.addressAndBalance();
     }
 
-    function closeWithoutTransfer() {
-        data.close(msg.sender, "", "");
-        ChannelClosed(msg.sender, data.closed);
-    }
-
-    function closeSingleTransfer(bytes signed_transfer) {
-        data.close(msg.sender, signed_transfer, "");
-        ChannelClosed(msg.sender, data.closed);
-    }
-
     function close(bytes theirs_encoded, bytes ours_encoded) {
         data.close(msg.sender, theirs_encoded, ours_encoded);
         ChannelClosed(msg.sender, data.closed);

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -52,7 +52,7 @@ def test_channelmanager(
         tester_events,
         tester_channelmanager_library_address,
         settle_timeout,
-        netting_channel_abi): # pylint: disable=too-many-locals,too-many-statements
+        netting_channel_abi):  # pylint: disable=too-many-locals,too-many-statements
 
     address0 = tester.DEFAULT_ACCOUNT
     address1 = tester.a1
@@ -143,17 +143,6 @@ def test_channelmanager(
         'settle_timeout': settle_timeout,
     }
 
-    # uncomment private in function to run test
-    # assert channel_manager.numberOfItems(netting_channel_creator1) == 2
-    # assert channel_manager.numberOfItems(sha3('address1')[:20]) == 1
-    # assert channel_manager.numberOfItems(sha3('iDontExist')[:20]) == 0
-    # vs = sorted((sha3('address1')[:20], sha3('address2')[:20]))
-    # k0 = channel_manager.key(sha3('address1')[:20], sha3('address2')[:20])
-    # assert k0 == sha3(vs[0] + vs[1])
-    # k1 = channel_manager.key(sha3('address2')[:20], sha3('address1')[:20])
-    # assert k1 == sha3(vs[0] + vs[1])
-    # with pytest.raises(TransactionFailed):
-    #    channel_manager.key(sha3('address1')[:20], sha3('address1')[:20])
 
 def test_reopen_channel(
         tester_state,

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -176,12 +176,10 @@ def test_reopen_channel(
     # settle the channel should not change the channel manager state
     nettingchannel.close(
         direct_transfer_data,
+        "",
         sender=privatekey1_raw,
     )
     tester_state.mine(number_of_blocks=settle_timeout + 1)
-
-    # deleting the channel needs to update the manager's state
-    number_of_channels = len(tester_channelmanager.getChannelsAddresses(sender=privatekey0_raw))
 
     nettingchannel.settle(sender=privatekey0_raw)
 
@@ -221,7 +219,7 @@ def test_reopen_channel(
         )
 
     # opening a new channel that did not exist before
-    netting_channel_address2_hex = tester_channelmanager.newChannel(
+    tester_channelmanager.newChannel(
         address2,
         settle_timeout,
         sender=privatekey0_raw,

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -170,7 +170,7 @@ def test_reopen_channel(
     address2 = tester.a2
 
     # We need to close the channel before it can be deleted, to do so we need
-    # one transfer to call closeSingleTransfer()
+    # one transfer to pass in close()
     transfer_amount = 10
     identifier = 1
     direct_transfer = channel0.create_directtransfer(
@@ -185,7 +185,7 @@ def test_reopen_channel(
     assert should_be_nonce <= direct_transfer.nonce < should_be_nonce_plus_one
 
     # settle the channel should not change the channel manager state
-    nettingchannel.closeSingleTransfer(
+    nettingchannel.close(
         direct_transfer_data,
         sender=privatekey1_raw,
     )
@@ -217,8 +217,9 @@ def test_reopen_channel(
 
     # transfer not in nonce range
     with pytest.raises(TransactionFailed):
-        netting_contract_proxy1.closeSingleTransfer(
+        netting_contract_proxy1.close(
             direct_transfer_data,
+            "",
             sender=privatekey0_raw,
         )
 

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -213,10 +213,10 @@ def test_closewithouttransfer_settle(
     initial_balance1 = tester_token.balanceOf(address1, sender=privatekey1)
 
     with pytest.raises(TransactionFailed):
-        nettingchannel.closeWithoutTransfer(sender=unknown_key)
+        nettingchannel.close(sender=unknown_key)
 
     previous_events = list(tester_events)
-    nettingchannel.closeWithoutTransfer(sender=privatekey0)
+    nettingchannel.close("", "", sender=privatekey0)
     assert len(previous_events) + 1 == len(tester_events)
 
     block_number = tester_state.block.number
@@ -313,7 +313,7 @@ def test_closewithouttransfer_badalice(
     channelBA.register_transfer(AB_Transfer1)
     AB_Transfer1_data = str(AB_Transfer1.packed().data)
 
-    nettingchannel.closeWithoutTransfer(sender=privatekeyA_raw)
+    nettingchannel.close("", "", sender=privatekeyA_raw)
 
     nettingchannel.updateTransfer(
         AB_Transfer1_data,
@@ -356,10 +356,10 @@ def test_closesingle_settle(
     direct_transfer_data = str(direct_transfer.packed().data)
 
     with pytest.raises(TransactionFailed):
-        nettingchannel.closeSingleTransfer(sender=unknown_key)
+        nettingchannel.close(sender=unknown_key)
 
     previous_events = list(tester_events)
-    nettingchannel.closeSingleTransfer(direct_transfer_data, sender=privatekey1_raw)
+    nettingchannel.close(direct_transfer_data, "", sender=privatekey1_raw)
     assert len(previous_events) + 1 == len(tester_events)
 
     block_number = tester_state.block.number
@@ -854,8 +854,9 @@ def test_unlock(tester_token, tester_channels, tester_events, tester_state):
 
     channel1.register_secret(secret1)
 
-    nettingchannel.closeSingleTransfer(
+    nettingchannel.close(
         mediated_transfer1_data,
+        "",
         sender=privatekey1_raw,
     )
 
@@ -938,7 +939,7 @@ def test__if_updater_made_mistake(
     channelBA.register_transfer(BA_Transfer0)
     BA_Transfer0_data = str(BA_Transfer0.packed().data)
 
-    nettingchannel.closeSingleTransfer(BA_Transfer0_data, sender=privatekeyA_raw)
+    nettingchannel.close(BA_Transfer0_data, "", sender=privatekeyA_raw)
     nettingchannel.updateTransfer(
         AB_Transfer0_data,
         sender=privatekeyB_raw,

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -14,6 +14,7 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
+    get_encoded_transfers
 )
 from raiden.blockchain.abi import (
     ASSETADDED_EVENTID,
@@ -629,21 +630,20 @@ class NettingChannelTesterMock(object):
             data[2],
         ))
 
-    def close(self, our_address, first_transfer, second_transfer):
+    def close(self, our_address, their_transfer, our_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        first_encoded = first_transfer.encode() if first_transfer else ""
-        second_encoded = second_transfer.encode() if second_transfer else ""
+        their_encoded, our_encoded = get_encoded_transfers(their_transfer, our_transfer)
         self.proxy.close(
-            first_encoded,
-            second_encoded,
+            their_encoded,
+            our_encoded,
         )
         self.tester_state.mine(number_of_blocks=1)
         log.info(
             'close called',
             contract=pex(self.address),
-            first_transfer=first_transfer,
-            second_transfer=second_transfer,
+            their_transfer=their_transfer,
+            our_transfer=our_transfer,
         )
 
     def update_transfer(self, our_address, first_transfer):

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -632,39 +632,19 @@ class NettingChannelTesterMock(object):
     def close(self, our_address, first_transfer, second_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        if first_transfer and second_transfer:
-            first_encoded = first_transfer.encode()
-            second_encoded = second_transfer.encode()
-
-            self.proxy.close(
-                first_encoded,
-                second_encoded,
-            )
-            self.tester_state.mine(number_of_blocks=1)
-            log.info(
-                'close called',
-                contract=pex(self.address),
-                first_transfer=first_transfer,
-                second_transfer=second_transfer,
-            )
-
-        elif first_transfer:
-            first_encoded = first_transfer.encode()
-
-            self.proxy.closeSingleTransfer(first_encoded)
-            self.tester_state.mine(number_of_blocks=1)
-            log.info('close called', contract=pex(self.address), first_transfer=first_transfer)
-
-        elif second_transfer:
-            second_encoded = second_transfer.encode()
-
-            self.proxy.closeSingleTransfer.transact(second_encoded)
-            self.tester_state.mine(number_of_blocks=1)
-            log.info('close called', contract=pex(self.address), second_transfer=second_transfer)
-
-        else:
-            # TODO: allow to close nevertheless
-            raise ValueError('channel wasnt used')
+        first_encoded = first_transfer.encode() if first_transfer else ""
+        second_encoded = second_transfer.encode() if second_transfer else ""
+        self.proxy.close(
+            first_encoded,
+            second_encoded,
+        )
+        self.tester_state.mine(number_of_blocks=1)
+        log.info(
+            'close called',
+            contract=pex(self.address),
+            first_transfer=first_transfer,
+            second_transfer=second_transfer,
+        )
 
     def update_transfer(self, our_address, first_transfer):
         """`our_address` is an argument used only in mock_client.py but is also

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -136,3 +136,15 @@ def safe_lstrip_hex(val):
     if isinstance(val, basestring):
         return remove_0x_head(val)
     return val
+
+
+def get_encoded_transfers(their_transfer, our_transfer):
+    """Check for input sanity and return the encoded version of the transfers"""
+    if not their_transfer and our_transfer:
+        raise ValueError(
+            "There is no reason to provide our_transfer when their_transfer"
+            " is not provided"
+        )
+    their_encoded = their_transfer.encode() if their_transfer else ""
+    our_encoded = our_transfer.encode() if our_transfer else ""
+    return their_encoded, our_encoded


### PR DESCRIPTION
There is no reason to have 3 different `close()` functions remaining in the code. With this PR I am making the interface to the channelclosing, consistent across the codebase.