### PR TITLE
added raiden_udp_ports fixture. #314

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -60,6 +60,7 @@ from raiden.tests.fixtures import (
     port_generator,
     blockchain_rpc_ports,
     blockchain_p2p_ports,
+    raiden_udp_ports,
 )
 
 __all__ = (
@@ -113,6 +114,7 @@ __all__ = (
     'port_generator',
     'blockchain_rpc_ports',
     'blockchain_p2p_ports',
+    'raiden_udp_ports',
 
     'pytest_addoption',
     'logging_level',

--- a/raiden/tests/fixtures/__init__.py
+++ b/raiden/tests/fixtures/__init__.py
@@ -59,6 +59,7 @@ from raiden.tests.fixtures.variables import (
     port_generator,
     blockchain_rpc_ports,
     blockchain_p2p_ports,
+    raiden_udp_ports,
 )
 
 __all__ = (
@@ -112,4 +113,5 @@ __all__ = (
     'port_generator',
     'blockchain_rpc_ports',
     'blockchain_p2p_ports',
+    'raiden_udp_ports',
 )

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -110,6 +110,7 @@ def cached_genesis(request, blockchain_type):
 
     raiden_apps = create_apps(
         blockchain_services,
+        request.getfixturevalue('raiden_udp_ports'),
         request.getfixturevalue('transport_class'),
         request.config.option.verbose,
         request.getfixturevalue('send_ping_time'),

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -35,6 +35,7 @@ def raiden_chain(
         deposit,
         settle_timeout,
         blockchain_services,
+        raiden_udp_ports,
         transport_class,
         cached_genesis,
         send_ping_time,
@@ -52,6 +53,7 @@ def raiden_chain(
 
     raiden_apps = create_apps(
         blockchain_services.blockchain_services,
+        raiden_udp_ports,
         transport_class,
         verbosity,
         send_ping_time,
@@ -83,6 +85,7 @@ def raiden_network(
         deposit,
         settle_timeout,
         blockchain_services,
+        raiden_udp_ports,
         transport_class,
         send_ping_time,
         max_unresponsive_time,
@@ -92,6 +95,7 @@ def raiden_network(
 
     raiden_apps = create_apps(
         blockchain_services.blockchain_services,
+        raiden_udp_ports,
         transport_class,
         verbosity,
         send_ping_time,

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -191,3 +191,14 @@ def blockchain_p2p_ports(blockchain_number_of_nodes, port_generator):
         next(port_generator)
         for _ in range(blockchain_number_of_nodes)
     ]
+
+
+@pytest.fixture
+def raiden_udp_ports(number_of_nodes, port_generator):
+    """ A list of unique port numbers to be used by the raiden apps for the udp
+    protocol.
+    """
+    return [
+        next(port_generator)
+        for _ in range(number_of_nodes)
+    ]

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -245,6 +245,7 @@ def create_sequential_channels(
 
 def create_apps(
         blockchain_services,
+        raiden_udp_ports,
         transport_class,
         verbosity,
         send_ping_time,
@@ -256,8 +257,14 @@ def create_apps(
         for this test to work in a mac both virtual interfaces must be created
         prior to the test execution::
 
-            ifconfig lo:0 127.0.0.10
-            ifconfig lo:1 127.0.0.11
+            MacOSX (tested on 10.11.5):
+                         interface       ip address netmask
+                ifconfig lo0       alias 127.0.0.10 255.255.255.0
+                ifconfig lo0       alias 127.0.0.11 255.255.255.0
+
+            Alternative syntax:
+                ifconfig lo:0 127.0.0.10
+                ifconfig lo:1 127.0.0.11
     """
     # pylint: disable=too-many-locals
     half_of_nodes = len(blockchain_services) // 2
@@ -265,7 +272,7 @@ def create_apps(
 
     apps = []
     for idx, blockchain in enumerate(blockchain_services):
-        port = INITIAL_PORT + idx
+        port = raiden_udp_ports[idx]
         private_key = blockchain.private_key
         nodeid = privatekey_to_address(private_key)
 


### PR DESCRIPTION
Needed unique port numbers for the UDP socket otherwise it wouldn't
rebind the address between tests.