### PR TITLE
MacOSX port resuse fix #314

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -140,6 +140,13 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        '--initial-port',
+        type=int,
+        default=29870,
+        help='Base port number used to avoid conflicts while running parallel tests.',
+    )
+
+    parser.addoption(
         '--log-config',
         default=None,
     )

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -12,6 +12,7 @@ from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import address_decoder, address_encoder, default_gasprice
 
 from raiden.utils import privatekey_to_address, get_contract_path, safe_lstrip_hex
+from raiden.network.transport import DummyTransport
 from raiden.tests.fixtures.tester import tester_state
 from raiden.tests.utils.blockchain import GENESIS_STUB, DEFAULT_BALANCE_BIN
 from raiden.tests.utils.mock_client import BlockChainServiceMock, MOCK_REGISTRY_ADDRESS
@@ -111,7 +112,7 @@ def cached_genesis(request, blockchain_type):
     raiden_apps = create_apps(
         blockchain_services,
         request.getfixturevalue('raiden_udp_ports'),
-        request.getfixturevalue('transport_class'),
+        DummyTransport,  # Do not use a UDP server to avoid port reuse in MacOSX
         request.config.option.verbose,
         request.getfixturevalue('send_ping_time'),
         request.getfixturevalue('max_unresponsive_time'),

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -166,9 +166,9 @@ def blockchain_private_keys(blockchain_number_of_nodes, blockchain_key_seed):
 
 
 @pytest.fixture(scope='session')
-def port_generator():
+def port_generator(request):
     """ count generator used to get a unique port number. """
-    return count(29870)
+    return count(request.config.option.initial_port)
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,10 @@ deps =
 commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst {posargs:./raiden/}
 
 [testenv:smart_contracts]
-commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst ./raiden/tests/smart_contracts {posargs}
+commands = coverage run --append -m py.test --initial-port=2000 --blockchain-type=tester --exitfirst ./raiden/tests/smart_contracts {posargs}
 
 [testenv:integration]
-commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst ./raiden/tests/integration {posargs}
+commands = coverage run --append -m py.test --initial-port=3000 --blockchain-type=tester --exitfirst ./raiden/tests/integration {posargs}
 
 [testenv:unit]
-commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst ./raiden/tests/unit {posargs}
+commands = coverage run --append -m py.test --initial-port=4000 --blockchain-type=tester --exitfirst ./raiden/tests/unit {posargs}


### PR DESCRIPTION
- do not use a udp protocol for generating the genesis block, as this
will bind the port and the test itself cannot rebind.
- added the py.test command line argument to allow parallel tests to
start from different base ports.