### PR TITLE
transport must be stopped after protocol

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -49,5 +49,9 @@ class App(object):  # pylint: disable=too-few-public-methods
         )
 
     def stop(self):
-        self.transport.stop()
         self.raiden.stop()
+
+        # The transport must be stopped after the protocol. The protocol can be
+        # running multiple threads of execution and it expects the protocol to
+        # be available.
+        self.transport.stop()

--- a/raiden/tests/unit/test_transport.py
+++ b/raiden/tests/unit/test_transport.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import time
+
 import pytest
 import gevent
 from ethereum import slogging
@@ -11,11 +13,25 @@ from raiden.tests.utils.messages import setup_messages_cb
 slogging.configure(':DEBUG')
 
 
+class IntervalCheck(object):
+    def __init__(self):
+        self.t1 = time.time()
+
+    def inside(self, tolerance):
+        t2 = time.time()
+        assert abs(t2 - self.t1) < tolerance
+        self.t1 = t2
+
+    def stepped(self, span, tolerance):
+        t2 = time.time()
+        assert abs(t2 - (self.t1 + span)) < tolerance
+        self.t1 = t2
+
+
 @pytest.mark.parametrize('blockchain_type', ['mock'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('transport_class', [UDPTransport])
 def test_throttle_policy_ping(monkeypatch, raiden_network):
-
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
     # initial policy is DummyPolicy
@@ -33,28 +49,60 @@ def test_throttle_policy_ping(monkeypatch, raiden_network):
 
     messages = setup_messages_cb()
 
-    # we will send 10 pings and let them trickle in according to our policy:
+    # In total 10 packets will be sent and the timing interval will be asserted.
+    packets = list()
     for nonce in range(10):
         ping = Ping(nonce=nonce)
         app0.raiden.sign(ping)
-        app0.raiden.protocol.send_async(app1.raiden.address, ping)
+        packets.append(ping)
 
-    # each side has two initial tokens available
-    gevent.sleep(0.01)
-    assert len(messages) == 4  # Ping, Ack
+    # We need to take into account some indeterminism of task switching and the
+    # additional time for the Ack, let's allow for a 10% difference of the
+    # "perfect" value of a message every 0.5s
+    token_refill = 0.5
+    tolerance = 0.05
 
-    # per additional second two more tokens become available
-    gevent.sleep(3)
-    assert len(messages) == 16  # Ping, Ack
+    # time sensitive test, the interval is instantiated just before the protocol
+    # is used.
+    check = IntervalCheck()
 
-    # one more interval and all could be sent
-    gevent.sleep(1)
-    assert len(messages) == 20  # Ping, Ack
+    # send all the packets, the throughput must be limited by the policy
+    events = [
+        app0.raiden.protocol.send_async(app1.raiden.address, p)
+        for p in packets
+    ]
 
-    # sanity check for messages order
-    assert decode(messages[0]).nonce == 0
-    decoded = decode(messages[-1])
-    assert isinstance(decoded, Ack)
-    last_ping = Ping(nonce=9)
-    app0.raiden.sign(last_ping)
-    assert decoded.echo == sha3(last_ping.encode() + app1.raiden.address)
+    # Each token corresponds to a single message, the initial capacity is 2
+    # meaning the first burst is of 2 packets.
+    events[1].wait()
+    check.inside(tolerance)
+
+    assert len(messages) == 4  # two Pings and the corresponding Acks
+
+    # Now check the fill_rate for the remaining packets
+    for i in range(2, 10):
+        events[i].wait()
+        check.stepped(token_refill, tolerance)
+
+    # all 10 Pings and their Acks
+    assert len(messages) == 20
+
+    # sanity check messages
+    pings = list()
+    pings_raw = list()
+    acks = list()
+    for packet in messages:
+        message = decode(packet)
+
+        if isinstance(message, Ping):
+            pings.append(message)
+            pings_raw.append(packet)
+
+        if isinstance(message, Ack):
+            acks.append(message)
+
+    for nonce, message in enumerate(pings):
+        assert message.nonce == nonce
+
+    for ping_packet, ack in zip(pings_raw, acks):
+        assert ack.echo == sha3(ping_packet + app1.raiden.address)


### PR DESCRIPTION
If the transport is stopped before all the protocol greenlets an error
might occur if the protocol tries to send an message forward like an
Ack.