### PR TITLE
tests: increased test_event_new_channel timeout

### DIFF
--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
-import pytest
 import os
 
+import pytest
 from ethereum import _solidity
 from ethereum._solidity import compile_file
 from ethereum.utils import denoms
@@ -16,7 +16,7 @@ from raiden.utils import privatekey_to_address, get_contract_path
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.parametrize('privatekey_seed', ['blockchain:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [0])

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -13,7 +13,7 @@ from raiden.tests.utils.blockchain import wait_until_block
 from raiden.tests.utils.network import CHAIN
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(90)
 @pytest.mark.parametrize('privatekey_seed', ['event_new_channel:{}'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])


### PR DESCRIPTION
the `test_event_new_channel` test is failing frequently with a timeout of a minute requiring manual intervention to rerun the build, increased it to a minute and a half. 