### PR TITLE
Fix RLP dependency version error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pysha3
 # temporary until https://github.com/ethereum/pyethapp/pull/184 comes upstream (see also setup.py)
 -e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
 ipython<5.0.0
-rlp>=0.4.3
+rlp>=0.4.3<=0.4.6
 secp256k1==0.12.1
 pycryptodome>=3.4.3
 miniupnpc


### PR DESCRIPTION
In order to work around issue ethereum/pyethereum#412 pyrlp has downgraded their rlp dependency to version <=0.4.6

https://github.com/ethereum/pydevp2p/commit/1b4647f500bdb495c77518e55b94b97a1125739c

This prevents the following error while doing `python setup.py develop`

> error: rlp 0.4.7 is installed but rlp<=0.4.6,>=0.4.4 is required by set(['devp2p'])
