### PR TITLE
better repr for Ack

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -51,9 +51,9 @@ class Message(MessageHashable):
     def __repr__(self):
         packed = self.packed()
 
-        return '<{klass} [{content}]>'.format(
+        return '<{klass} [msghash={msghash}]>'.format(
             klass=self.__class__.__name__,
-            content=pex(packed.data),
+            msghash=pex(sha3(packed.data)),
         )
 
     @classmethod

--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -190,5 +190,5 @@ class UnreliableTransport(DummyTransport):
             log.debug(
                 'dropped packet',
                 counter=self.network.counter,
-                data=format(pex(sha3(bytes_)))
+                msghash=format(pex(sha3(bytes_)))
             )


### PR DESCRIPTION
Instead of using pex(msg) which just printed the zero-padding, this
change uses the pex(sha3(msg)) showing a unique signature of the
message. This improves log reading/debugging.

old repr: <Ack [00000000]>
new repr: <Ack [msghash=b01a3ac6]>