### PR TITLE
Proposed hotfix for issue 253

### DIFF
--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -20,6 +20,7 @@ from raiden.tests.utils.tests import cleanup_tasks
 from raiden.tests.utils.tester_client import tester_deploy_contract, BlockChainServiceTesterMock
 from raiden.network.rpc.client import (
     patch_send_transaction,
+    patch_send_message,
     BlockChainService,
 )
 from raiden.tests.utils.blockchain import (
@@ -355,6 +356,7 @@ def _jsonrpc_services(
     if registry_address is None:
         address = privatekey_to_address(deploy_key)
         patch_send_transaction(deploy_client)
+        patch_send_message(deploy_client)
 
         registry_path = get_contract_path('Registry.sol')
         registry_contracts = compile_file(registry_path, libraries=dict())

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -10,7 +10,9 @@ from ethereum.utils import denoms
 from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import default_gasprice
 
-from raiden.network.rpc.client import decode_topic, patch_send_transaction
+from raiden.network.rpc.client import (
+    decode_topic, patch_send_transaction, patch_send_message
+)
 from raiden.utils import privatekey_to_address, get_contract_path
 from raiden.blockchain.abi import CHANNEL_MANAGER_ABI
 
@@ -183,6 +185,7 @@ def test_blockchain(
         print_communication=False,
     )
     patch_send_transaction(jsonrpc_client)
+    patch_send_message(jsonrpc_client)
 
     humantoken_path = get_contract_path('HumanStandardToken.sol')
     humantoken_contracts = compile_file(humantoken_path, libraries=dict())

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -9,7 +9,7 @@ from ethereum.utils import decode_hex
 from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import default_gasprice
 from raiden.utils import get_contract_path
-from raiden.network.rpc.client import patch_send_transaction
+from raiden.network.rpc.client import patch_send_transaction, patch_send_message
 
 
 # ordered list of solidity files to deploy for the raiden registry
@@ -54,6 +54,7 @@ def deploy_files(contract_files, client):
 
 def deploy_all(client):
     patch_send_transaction(client)
+    patch_send_message(client)
     deployed = dict()
     deployed.update(deploy_files(RAIDEN_CONTRACT_FILES, client))
     deployed.update(deploy_files(DISCOVERY_CONTRACT_FILES, client))
@@ -79,6 +80,7 @@ if __name__ == "__main__":
         print_communication=False,
     )
     patch_send_transaction(client)
+    patch_send_message(client)
     deployed = deploy_all(client)
 
     if args.pretty:

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -3,7 +3,7 @@ from pyethapp.jsonrpc import default_gasprice
 from ethereum.utils import sha3
 from ethereum._solidity import compile_file
 from raiden.utils import get_contract_path
-from raiden.network.rpc.client import patch_send_transaction
+from raiden.network.rpc.client import patch_send_transaction, patch_send_message
 
 
 def connect(host='127.0.0.1',
@@ -19,6 +19,7 @@ def connect(host='127.0.0.1',
         use_ssl=use_ssl,
     )
     patch_send_transaction(client)
+    patch_send_message(client)
     return client
 
 


### PR DESCRIPTION
This lets the jsonrpc client's `tinyrpc` transport use a `requests.Session` instance in order to reuse addresses/ports.

(hot-) fixes #253 

