### PR TITLE
Utilize pyeth changes for solc >= 0.4.9

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -266,6 +266,7 @@ class BlockChainService(object):
             contracts,
             dict(),
             constructor_parameters,
+            contract_path=contract_path,
             gasprice=default_gasprice,
             timeout=self.poll_timeout,
         )

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -366,6 +366,7 @@ def _jsonrpc_services(
             registry_contracts,
             dict(),
             tuple(),
+            contract_path=registry_path,
             gasprice=default_gasprice,
             timeout=poll_timeout,
         )

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 from ethereum import _solidity
-from ethereum._solidity import compile_file
+from ethereum._solidity import compile_file, solidity_get_contract_data
 from ethereum.utils import denoms
 from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import default_gasprice
@@ -191,6 +191,7 @@ def test_blockchain(
         humantoken_contracts,
         dict(),
         (total_asset, 'raiden', 2, 'Rd'),
+        contract_path=humantoken_path,
         gasprice=default_gasprice,
         timeout=poll_timeout,
     )
@@ -203,6 +204,7 @@ def test_blockchain(
         registry_contracts,
         dict(),
         tuple(),
+        contract_path=registry_path,
         gasprice=default_gasprice,
         timeout=poll_timeout,
     )
@@ -257,8 +259,13 @@ def test_blockchain(
     assert channel_manager_address == event['channel_manager_address'].decode('hex')
     assert token_proxy.address == event['asset_address'].decode('hex')
 
+    contract_data = solidity_get_contract_data(
+        registry_contracts,
+        get_contract_path('ChannelManagerContract.sol'),
+        'ChannelManagerContract'
+    )
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
-        registry_contracts['ChannelManagerContract']['abi'],
+        contract_data['abi'],
         channel_manager_address,
     )
 

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -5,13 +5,14 @@ import os
 
 import pytest
 from ethereum import _solidity
-from ethereum._solidity import compile_file, solidity_get_contract_data
+from ethereum._solidity import compile_file
 from ethereum.utils import denoms
 from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import default_gasprice
 
 from raiden.network.rpc.client import decode_topic, patch_send_transaction
 from raiden.utils import privatekey_to_address, get_contract_path
+from raiden.blockchain.abi import CHANNEL_MANAGER_ABI
 
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 
@@ -259,13 +260,8 @@ def test_blockchain(
     assert channel_manager_address == event['channel_manager_address'].decode('hex')
     assert token_proxy.address == event['asset_address'].decode('hex')
 
-    contract_data = solidity_get_contract_data(
-        registry_contracts,
-        get_contract_path('ChannelManagerContract.sol'),
-        'ChannelManagerContract'
-    )
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
-        contract_data['abi'],
+        CHANNEL_MANAGER_ABI,
         channel_manager_address,
     )
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -179,12 +179,14 @@ class ConsoleTools(object):
         Returns:
             token_address: the hex encoded address of the new token/asset.
         """
+        contract_path = get_contract_path('HumanStandardToken.sol')
         # Deploy a new ERC20 token
         token_proxy = self._chain.client.deploy_solidity_contract(
             self._raiden.address, 'HumanStandardToken',
-            compile_file(get_contract_path('HumanStandardToken.sol')),
+            compile_file(contract_path),
             dict(),
             (initial_alloc, name, decimals, symbol),
+            contract_path=contract_path,
             gasprice=gasprice,
             timeout=timeout)
         token_address = token_proxy.address.encode('hex')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 pysha3
-# temporary until https://github.com/ethereum/pyethapp/pull/184 comes upstream (see also setup.py)
-#-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
 # temporary until new version of pyethereum is released, that supports solc >= v0.4.9
 -e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp
 ipython<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pysha3
 # temporary until https://github.com/ethereum/pyethapp/pull/184 comes upstream (see also setup.py)
 #-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
 # temporary until new version of pyethereum is released, that supports solc >= v0.4.9
--e git+https://github.com/LefterisJP/pyethapp@d1c9f39313d1facd54ee2a27d0ff6e8550ae2d64#egg=pyethapp
+-e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp
 ipython<5.0.0
 rlp>=0.4.3,<=0.4.6
 secp256k1==0.12.1
@@ -10,7 +10,7 @@ pycryptodome>=3.4.3
 miniupnpc
 networkx
 # temporary until new version of pyethereum is released, that supports solc >= v0.4.9
--e git+https://github.com/LefterisJP/pyethereum@43d184ee74df1caaf5f4ffd06343938db3839005#egg=ethereum
+-e git+https://github.com/LefterisJP/pyethereum@fix_solidity_key_combinedjson#egg=ethereum
 ethereum-serpent
 repoze.lru
 gevent-websocket==0.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,16 @@
 pysha3
 # temporary until https://github.com/ethereum/pyethapp/pull/184 comes upstream (see also setup.py)
--e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
+#-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp
+# temporary until new version of pyethereum is released, that supports solc >= v0.4.9
+-e git+https://github.com/LefterisJP/pyethapp@d1c9f39313d1facd54ee2a27d0ff6e8550ae2d64#egg=pyethapp
 ipython<5.0.0
 rlp>=0.4.3,<=0.4.6
 secp256k1==0.12.1
 pycryptodome>=3.4.3
 miniupnpc
 networkx
-ethereum>=1.3.2
+# temporary until new version of pyethereum is released, that supports solc >= v0.4.9
+-e git+https://github.com/LefterisJP/pyethereum@43d184ee74df1caaf5f4ffd06343938db3839005#egg=ethereum
 ethereum-serpent
 repoze.lru
 gevent-websocket==0.9.4

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ history = ''
 
 
 install_requires_replacements = {
-    "-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp": "pyethapp"
+#    "-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp": "pyethapp",
+    "-e git+https://github.com/LefterisJP/pyethapp@8d856c9351fb0a2dd42bc1eec8167e6e6b2fd204#egg=pyethapp": "pyethapp",
+    "-e git+https://github.com/LefterisJP/pyethereum@d1c9f39313d1facd54ee2a27d0ff6e8550ae2d64#egg=ethereum": "ethereum"
 }
 
 install_requires = list(set(

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,13 @@ history = ''
 
 install_requires_replacements = {
 #    "-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp": "pyethapp",
-    "-e git+https://github.com/LefterisJP/pyethapp@8d856c9351fb0a2dd42bc1eec8167e6e6b2fd204#egg=pyethapp": "pyethapp",
-    "-e git+https://github.com/LefterisJP/pyethereum@d1c9f39313d1facd54ee2a27d0ff6e8550ae2d64#egg=ethereum": "ethereum"
+    "-e git+https://github.com/LefterisJP/pyethapp@d1c9f39313d1facd54ee2a27d0ff6e8550ae2d64#egg=pyethapp": "pyethapp",
+    "-e git+https://github.com/LefterisJP/pyethereum@43d184ee74df1caaf5f4ffd06343938db3839005#egg=ethereum": "ethereum"
 }
 
 install_requires = list(set(
     install_requires_replacements.get(requirement.strip(), requirement.strip())
-    for requirement in open('requirements.txt')
+    for requirement in open('requirements.txt') if not requirement.lstrip().startswith('#')
 ))
 
 test_requirements = []

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ history = ''
 
 install_requires_replacements = {
 #    "-e git+https://github.com/konradkonrad/pyethapp@71f940c6d287b98a35ef524f4c5e3c13d530bfc5#egg=pyethapp": "pyethapp",
-    "-e git+https://github.com/LefterisJP/pyethapp@d1c9f39313d1facd54ee2a27d0ff6e8550ae2d64#egg=pyethapp": "pyethapp",
-    "-e git+https://github.com/LefterisJP/pyethereum@43d184ee74df1caaf5f4ffd06343938db3839005#egg=ethereum": "ethereum"
+    "-e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp": "pyethapp",
+    "-e git+https://github.com/LefterisJP/pyethereum@fix_solidity_key_combinedjson#egg=ethereum": "ethereum"
 }
 
 install_requires = list(set(

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -45,6 +45,7 @@ def deploy_files(contract_files, client):
             compiled_contracts,
             libraries,
             '',
+            contract_path=c,
             gasprice=default_gasprice
         )
         libraries[name] = proxy.address

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -22,19 +22,23 @@ def connect(host='127.0.0.1',
     return client
 
 
-def create_and_distribute_token(client, receivers,
-                                amount_per_receiver=1000,
-                                name=None,
-                                gasprice=default_gasprice,
-                                timeout=120):
+def create_and_distribute_token(
+        client,
+        receivers,
+        amount_per_receiver=1000,
+        name=None,
+        gasprice=default_gasprice,
+        timeout=120
+):
     """Create a new ERC-20 token and distribute it among `receivers`.
     If `name` is None, the name will be derived from hashing all receivers.
     """
     name = name or sha3(''.join(receivers)).encode('hex')
+    contract_path = get_contract_path('HumanStandardToken.sol')
     token_proxy = client.deploy_solidity_contract(
         client.sender,
         'HumanStandardToken',
-        compile_file(get_contract_path('HumanStandardToken.sol')),
+        compile_file(contract_path),
         dict()
         (
             len(receivers) * amount_per_receiver,
@@ -42,6 +46,7 @@ def create_and_distribute_token(client, receivers,
             2,  # decimals
             name[:4].upper()  # symbol
         ),
+        contract_path=contract_path,
         gasprice=gasprice,
         timeout=timeout
     )


### PR DESCRIPTION
In solidity [v0.4.9](https://github.com/ethereum/solidity/blob/develop/Changelog.md#049-unreleased) they introduced a new key for the combined-json-abi compile output.

Before merging we need to think if we want to have 2 hot-fixed requirements for `pyethapp` and `pyethereum`. And if yes for how long, i.e: How long would it take to create releases for both of these repos.

We are using changes introduced in:
- https://github.com/ethereum/pyethapp/pull/188
- https://github.com/ethereum/pyethereum/pull/432