### PR TITLE
Remove type from contract docstrings

### DIFF
--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -11,18 +11,17 @@ library ChannelManagerLibrary {
         Token token;
     }
 
-    /// @notice getChannelsAddresses to get all channels
+    /// @notice Get all channels
     /// @dev Get all channels
-    /// @return channels (address[]) all the channels
+    /// @return all the channels
     function getChannelsAddresses(Data storage self) returns (address[] channels) {
         channels = self.all_channels;
     }
 
-    /// @notice getChannelsForNode(address) to get channels that 
-    /// the address participates in.
+    /// @notice Get channels that the address participates in.
     /// @dev Get channels where the given address participates.
-    /// @param node_address (address) the address of the node
-    /// @return (address[]) of the channel's addresses that node_address participates.
+    /// @param node_address The address of the node
+    /// @return The channels that the node_address participates in
     function getChannelsForNode(Data storage self, address node_address)
         constant
         returns (address[])
@@ -30,11 +29,11 @@ library ChannelManagerLibrary {
         return self.node_channels[node_address];
     }
 
-    /// @notice getChannelWith(address) to get the address of the unique channel of two parties.
+    /// @notice Get the address of the unique channel of two parties.
     /// @dev Get the channel of two parties
-    /// @param caller_address (address) the address of the caller
-    /// @param partner (address) the address of the partner
-    /// @return channel (address) the address of the NettingChannelContract of the two parties.
+    /// @param caller_address The address of the caller
+    /// @param partner The address of the partner
+    /// @return The address of the NettingChannelContract of the two parties.
     function getChannelWith(Data storage self, address caller_address, address partner)
         constant
         returns (address, bool, uint, uint)
@@ -53,11 +52,11 @@ library ChannelManagerLibrary {
         return (0x0, false, 0, 0);
     }
 
-    /// @notice newChannel(address, uint) to create a new payment channel between two parties
+    /// @notice Create a new payment channel between two parties
     /// @dev Create a new channel between two parties
-    /// @param partner (address) the address of the partner
-    /// @param settle_timeout (uint) the settle timeout in blocks
-    /// @return (address) the address of the NettingChannelContract.
+    /// @param partner The address of the partner
+    /// @param settle_timeout The settle timeout in blocks
+    /// @return The address of the NettingChannelContract.
     function newChannel(
         Data storage self,
         address caller_address,
@@ -78,13 +77,13 @@ library ChannelManagerLibrary {
         self.all_channels.push(channel_address);
     }
 
-    /// @notice deleteChannel(address) to remove a channel after it's been settled
+    /// @notice Remove a channel after it's been settled
     /// @dev Remove channel after it's been settled
-    /// @param caller_address (address) the address of the caller
-    /// @param partner (address) address of the partner
-    /// @param channel_address (address) address of the channel to be closed
-    /// @param caller_index (uint) index of the caller in our channels
-    /// @param partner_index (uint) index of the partner in partner_channels
+    /// @param caller_address Τhe address of the caller
+    /// @param partner Αddress of the partner
+    /// @param channel_address Αddress of the channel to be closed
+    /// @param caller_index Τhe index of the caller in our channels
+    /// @param partner_index Index of the partner in partner_channels
     function deleteChannel(
         Data storage self,
         address caller_address,
@@ -117,10 +116,10 @@ library ChannelManagerLibrary {
         self.node_channels[partner] = partner_channels;
     }
 
-    /// @notice contractExists(address) to check if a contract is deployed at given address
+    /// @notice Check if a contract is deployed at given address
     /// @dev Check if a channel is deployed at address
-    /// @param _addr (address) the address to check for a deployed contract
-    /// @return (bool) true if contract exists, false if not
+    /// @param _addr The address to check for a deployed contract
+    /// @return True if contract exists, false if not
     function contractExists(Data storage self, address _addr) returns (bool) {
         uint size;
         assembly {

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -78,14 +78,14 @@ library NettingChannelLibrary {
         _;
     }
 
-    /// @notice deposit(uint) to deposit amount to channel.
+    /// @notice Deposit amount to channel.
     /// @dev Deposit an amount to the channel. At least one of the participants
     /// must deposit before the channel is opened.
-    /// @param caller_address (address) the address of the invoker of the function
-    /// @param channel_address (address) the address of the channel
-    /// @param amount (uint) the amount to be deposited to the address
-    /// @return success (bool) if the transfer was successful
-    /// @return balance (uint256) the new balance of the invoker
+    /// @param caller_address The address of the invoker of the function
+    /// @param channel_address The address of the channel
+    /// @param amount The amount to be deposited to the address
+    /// @return Success if the transfer was successful
+    /// @return The new balance of the invoker
     function deposit(
         Data storage self,
         address caller_address,
@@ -132,9 +132,9 @@ library NettingChannelLibrary {
         return (false, 0);
     }
 
-    /// @notice partner() to get the partner or other participant of the channel
+    /// @notice Get the partner or other participant of the channel
     /// @dev Get the other participating party of the channel
-    /// @return (address) the partner of the calling party
+    /// @return The partner of the calling party
     function partner(Data storage self, address one_address) constant returns (address) {
         Participant[2] storage participants = self.participants;
         Participant storage node1 = participants[0];
@@ -191,8 +191,8 @@ library NettingChannelLibrary {
     /// @param caller_address The address of the participant closing the channel
     /// @param their_transfer The latest known transfer of the other participant
     ///                       to the channel. Can also be empty, in which case
-    //                        we are attempting to close a channel without any
-    //                        transfers.
+    ///                       we are attempting to close a channel without any
+    ///                       transfers.
     /// @param our_transfer Optionally provide the caller's own latest transfer
     ///                     as a courtesy to the other party in order to save
     ///                     them a blockchain transaction. Can also be empty.
@@ -279,7 +279,7 @@ library NettingChannelLibrary {
         return sender.node_address;
     }
 
-    /// @notice updateTransfer Updates (disputes) the state after closing.
+    /// @notice Updates (disputes) the state after closing.
     /// @param caller_address The counterparty to the channel. The participant
     ///                       that did not close the channel.
     /// @param their_transfer The transfer the counterparty believes is the
@@ -308,11 +308,11 @@ library NettingChannelLibrary {
         // TODO check if outdated and penalize
     }
 
-    /// @notice unlock(bytes, bytes, bytes32) to unlock a locked transfer
+    /// @notice Unlock a locked transfer
     /// @dev Unlock a locked transfer
-    /// @param locked_encoded (bytes) the lock
-    /// @param merkle_proof (bytes) the merkle proof
-    /// @param secret (bytes32) the secret
+    /// @param locked_encoded The lock
+    /// @param merkle_proof The merkle proof
+    /// @param secret The secret
     function unlock(
         Data storage self,
         address caller_address,
@@ -373,9 +373,9 @@ library NettingChannelLibrary {
         self.locks[hashlock] = true;
     }
 
-    /// @notice settle() to settle the balance between the two parties
+    /// @notice Settles the balance between the two parties
     /// @dev Settles the balances of the two parties fo the channel
-    /// @return participants (Participant[2]) the participants with netted balances
+    /// @return The participants with netted balances
     function settle(Data storage self, address caller_address)
         notSettledButClosed(self)
         timeoutOver(self)


### PR DESCRIPTION
The type of the parameters should not be added in the docstrings since
it's already available from the language itself. Additionally the
function name and signatures are not needed since a docstring always
documents the function that is following right underneath it.