### PR TITLE
Fix test_settlement

### DIFF
--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -642,7 +642,7 @@ class Channel(object):
                 # do not call settle if already settled, the event polling
                 # might be lagging behind.
                 settled_block = self.external_state.query_settled()
-                if settled_block != 0:
+                if settled_block != 0 and self.external_state._settled_block != 0:
                     self.external_state.set_settled(settled_block)
                     log.info('channel automatically settled')
                     return

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -441,7 +441,8 @@ class ChannelExternalState(object):
                 callback(block_number)
 
     def query_settled(self):
-        # FIXME: the if None: return 0 constraint should be ensured on the proxy side
+        # FIXME: the if None: return 0 constraint should be ensured on the
+        # proxy side; see also #394
         return self.netting_channel.settled() or 0
 
     def query_transferred_amount(self, participant_address):
@@ -658,7 +659,8 @@ class Channel(object):
 
         closed = self.external_state.closed_block != 0
         after_settle_timeout = block_number >= (
-            self.external_state.closed_block + self.settle_timeout)
+            self.external_state.closed_block + self.settle_timeout
+        )
 
         if closed and after_settle_timeout:
             gevent.spawn(_settle)  # don't block the alarm

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -656,9 +656,11 @@ class Channel(object):
             except:
                 log.exception('Timedout while calling settle')
 
-        if (self.external_state.closed_block != 0 and block_number >= (
-                self.external_state.closed_block + self.settle_timeout)):
+        closed = self.external_state.closed_block != 0
+        after_settle_timeout = block_number >= (
+            self.external_state.closed_block + self.settle_timeout)
 
+        if closed and after_settle_timeout:
             gevent.spawn(_settle)  # don't block the alarm
             return REMOVE_CALLBACK
 

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -652,20 +652,9 @@ class Channel(object):
                 return
 
             try:
-                # TODO: to remove unecessary JSON-RPC calls, change to an
-                # async version of settle and stop polling if the
-                # settle_event was set
                 self.external_state.settle()
             except:
                 log.exception('Timedout while calling settle')
-
-            # wait for the settle event, it could be our transaction or our
-            # partner's
-            self.settle_event.wait(0.5)
-
-            if self.settle_event.is_set():
-                log.info('channel automatically settled')
-                return
 
         if (self.external_state.closed_block != 0 and block_number >= (
                 self.external_state.closed_block + self.settle_timeout)):

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -432,7 +432,8 @@ class ChannelExternalState(object):
     def set_settled(self, block_number):
         # ensure callbacks are only called once
         if self._settled_block != 0 and self._settled_block != block_number:
-            raise RuntimeError('channel is already settled on different block')
+            raise RuntimeError('channel is already settled on different block %s %s'
+                               % self._settled_block, block_number)
         else:
             self._settled_block = block_number
 

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -663,7 +663,9 @@ class Channel(object):
                     log.info('channel automatically settled')
                     return
 
-        if self.external_state.closed_block + self.settle_timeout >= block_number:
+        if (self.external_state.closed_block != 0 and block_number >= (
+                self.external_state.closed_block + self.settle_timeout)):
+
             gevent.spawn(_settle)  # don't block the alarm
             return REMOVE_CALLBACK
 

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -410,6 +410,7 @@ class ChannelExternalState(object):
         return self._settled_block
 
     def set_opened(self, block_number):
+        # TODO: ensure the same callback logic as in set_settled
         if self._opened_block != 0:
             raise RuntimeError('channel is already open')
 
@@ -419,6 +420,7 @@ class ChannelExternalState(object):
             callback(block_number)
 
     def set_closed(self, block_number):
+        # TODO: ensure the same callback logic as in set_settled
         if self._closed_block != 0:
             raise RuntimeError('channel is already closed')
 
@@ -428,13 +430,14 @@ class ChannelExternalState(object):
             callback(block_number)
 
     def set_settled(self, block_number):
-        if self._settled_block != 0:
-            raise RuntimeError('channel is already settled')
+        # ensure callbacks are only called once
+        if self._settled_block != 0 and self._settled_block != block_number:
+            raise RuntimeError('channel is already settled on different block')
+        else:
+            self._settled_block = block_number
 
-        self._settled_block = block_number
-
-        for callback in self.callbacks_settled:
-            callback(block_number)
+            for callback in self.callbacks_settled:
+                callback(block_number)
 
     def query_settled(self):
         return self.netting_channel.settled()
@@ -642,7 +645,7 @@ class Channel(object):
                 # do not call settle if already settled, the event polling
                 # might be lagging behind.
                 settled_block = self.external_state.query_settled()
-                if settled_block != 0 and self.external_state._settled_block != 0:
+                if settled_block != 0:
                     self.external_state.set_settled(settled_block)
                     log.info('channel automatically settled')
                     return

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -643,30 +643,29 @@ class Channel(object):
 
     def blockalarm_for_settle(self, block_number):
         def _settle():
-            for _ in range(3):
-                # do not call settle if already settled, the event polling
-                # might be lagging behind.
-                settled_block = self.external_state.query_settled()
-                if settled_block != 0:
-                    self.external_state.set_settled(settled_block)
-                    log.info('channel automatically settled')
-                    return
+            # do not call settle if already settled, the event polling
+            # might be lagging behind.
+            settled_block = self.external_state.query_settled()
+            if settled_block != 0:
+                self.external_state.set_settled(settled_block)
+                log.info('channel automatically settled')
+                return
 
-                try:
-                    # TODO: to remove unecessary JSON-RPC calls, change to an
-                    # async version of settle and stop polling if the
-                    # settle_event was set
-                    self.external_state.settle()
-                except:
-                    log.exception('Timedout while calling settle')
+            try:
+                # TODO: to remove unecessary JSON-RPC calls, change to an
+                # async version of settle and stop polling if the
+                # settle_event was set
+                self.external_state.settle()
+            except:
+                log.exception('Timedout while calling settle')
 
-                # wait for the settle event, it could be our transaction or our
-                # partner's
-                self.settle_event.wait(0.5)
+            # wait for the settle event, it could be our transaction or our
+            # partner's
+            self.settle_event.wait(0.5)
 
-                if self.settle_event.is_set():
-                    log.info('channel automatically settled')
-                    return
+            if self.settle_event.is_set():
+                log.info('channel automatically settled')
+                return
 
         if (self.external_state.closed_block != 0 and block_number >= (
                 self.external_state.closed_block + self.settle_timeout)):

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -433,7 +433,7 @@ class ChannelExternalState(object):
         # ensure callbacks are only called once
         if self._settled_block != 0 and self._settled_block != block_number:
             raise RuntimeError('channel is already settled on different block %s %s'
-                               % self._settled_block, block_number)
+                               % (self._settled_block, block_number))
         else:
             self._settled_block = block_number
 
@@ -441,7 +441,8 @@ class ChannelExternalState(object):
                 callback(block_number)
 
     def query_settled(self):
-        return self.netting_channel.settled()
+        # FIXME: the if None: return 0 constraint should be ensured on the proxy side
+        return self.netting_channel.settled() or 0
 
     def query_transferred_amount(self, participant_address):
         return self.netting_channel.transferred_amount(participant_address)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -229,7 +229,7 @@ def test_start_end_attack(tokens_addresses, raiden_chain, deposit, reveal_timeou
     The attacker needs to use two addresses (A1 and A2) and connect both to the
     hub H, once connected a mediated transfer is initialized from A1 to A2
     through H, once the node A2 receives the mediated transfer the attacker
-    uses the know secret and reveal to close and settles the channel H-A2,
+    uses the known secret and reveal to close and settles the channel H-A2,
     without revealing the secret to H's raiden node.
 
     The intention is to make the hub transfer the token but for him to be

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -111,6 +111,10 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
         None,
     )
     wait_until_block(chain0, chain0.block_number() + 1)
+
+    assert channel0.close_event.wait(timeout=15)
+    assert channel1.close_event.wait(timeout=15)
+
     assert channel0.external_state.closed_block != 0
     assert channel1.external_state.closed_block != 0
     assert channel0.external_state.settled_block == 0
@@ -129,6 +133,8 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     settle_expiration = chain0.block_number() + settle_timeout + 2
     wait_until_block(chain0, settle_expiration)
 
+    assert channel0.settle_event.wait(timeout=15)
+    assert channel1.settle_event.wait(timeout=15)
     # settle must be called by the apps triggered by the ChannelClose event,
     # and the channels must update it's state based on the ChannelSettled event
     assert channel0.external_state.settled_block != 0

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -143,8 +143,8 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     address0 = app0.raiden.address
     address1 = app1.raiden.address
 
-    assert token.balance_of(address0.encode('hex')) == balance0 + deposit0 + amount
-    assert token.balance_of(address1.encode('hex')) == balance1 + deposit1 - amount
+    assert token.balance_of(address0) == balance0 + deposit0 + amount
+    assert token.balance_of(address1) == balance1 + deposit1 - amount
 
 
 @pytest.mark.timeout(240)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -240,7 +240,7 @@ def test_start_end_attack(tokens_addresses, raiden_chain, deposit, reveal_timeou
     token = tokens_addresses[0]
     app0, app1, app2 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
-    # the attacker owns app0 and app2 and creates a transfer throught app1
+    # the attacker owns app0 and app2 and creates a transfer through app1
     identifier = 1
     expiration = reveal_timeout + 5
     secret = pending_mediated_transfer(

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -669,9 +669,9 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     initial_balance1 = token.balance_of(address1.encode('hex'))
 
     # Alice sends Bob 10 tokens
-    amount = 10
+    amount_alice1 = 10
     direct_transfer = channel0.create_directtransfer(
-        amount,
+        amount_alice1,
         1  # TODO: fill in identifier
     )
     direct_transfer.sign(privatekey0, address0)
@@ -680,9 +680,9 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     alice_old_transaction = direct_transfer
 
     # Bob sends Alice 50 tokens
-    amount = 50
+    amount_bob1 = 50
     direct_transfer = channel1.create_directtransfer(
-        amount,
+        amount_bob1,
         1  # TODO: fill in identifier
     )
     direct_transfer.sign(privatekey1, address1)
@@ -691,9 +691,9 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     bob_last_transaction = direct_transfer
 
     # Finally Alice sends Bob 60 tokens
-    amount = 60
+    amount_alice2 = 60
     direct_transfer = channel0.create_directtransfer(
-        amount,
+        amount_alice2,
         1  # TODO: fill in identifier
     )
     direct_transfer.sign(privatekey0, address0)
@@ -709,8 +709,11 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     chain0 = app0.raiden.chain
     wait_until_block(chain0, chain0.block_number() + 1)
 
-    # wait until the settle timeout has passed
-    settle_expiration = chain0.block_number() + settle_timeout
+    assert channel0.external_state.closed_block != 0
+    assert channel1.external_state.closed_block != 0
+
+    # wait until the settle timeout has passed + time to mine/propagate the tx
+    settle_expiration = chain0.block_number() + settle_timeout + 3
     wait_until_block(chain0, settle_expiration)
 
     # check that the channel is properly settled and that Bob's client
@@ -718,5 +721,7 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     assert channel0.external_state.settled_block != 0
     assert channel1.external_state.settled_block != 0
     assert token.balance_of(channel0.external_state.netting_channel.address.encode('hex')) == 0
-    assert token.balance_of(address0.encode('hex')) == initial_balance0 + deposit - 70 + 50
-    assert token.balance_of(address1.encode('hex')) == initial_balance1 + deposit + 70 - 50
+    total_alice = amount_alice1 + amount_alice2
+    total_bob = amount_bob1
+    assert token.balance_of(address0.encode('hex')) == initial_balance0 + deposit - total_alice + total_bob
+    assert token.balance_of(address1.encode('hex')) == initial_balance1 + deposit + total_alice - total_bob

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -665,8 +665,8 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     address0 = privatekey_to_address(privatekey0.private_key)
     address1 = privatekey_to_address(privatekey1.private_key)
     token = app0.raiden.chain.token(channel0.token_address)
-    initial_balance0 = token.balance_of(address0.encode('hex'))
-    initial_balance1 = token.balance_of(address1.encode('hex'))
+    initial_balance0 = token.balance_of(address0)
+    initial_balance1 = token.balance_of(address1)
 
     # Alice sends Bob 10 tokens
     amount_alice1 = 10
@@ -727,8 +727,8 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     # automatically called updateTransfer() to reflect the actual transactions
     assert channel0.external_state.settled_block != 0
     assert channel1.external_state.settled_block != 0
-    assert token.balance_of(channel0.external_state.netting_channel.address.encode('hex')) == 0
+    assert token.balance_of(channel0.external_state.netting_channel.address) == 0
     total_alice = amount_alice1 + amount_alice2
     total_bob = amount_bob1
-    assert token.balance_of(address0.encode('hex')) == initial_balance0 + deposit - total_alice + total_bob
-    assert token.balance_of(address1.encode('hex')) == initial_balance1 + deposit + total_alice - total_bob
+    assert token.balance_of(address0) == initial_balance0 + deposit - total_alice + total_bob
+    assert token.balance_of(address1) == initial_balance1 + deposit + total_alice - total_bob

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -712,9 +712,13 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     assert channel0.external_state.closed_block != 0
     assert channel1.external_state.closed_block != 0
 
-    # wait until the settle timeout has passed + time to mine/propagate the tx
-    settle_expiration = chain0.block_number() + settle_timeout + 3
+    # wait until the settle timeout has passed
+    settle_expiration = chain0.block_number() + settle_timeout
     wait_until_block(chain0, settle_expiration)
+
+    # the settle event must be set
+    assert channel0.settle_event.wait(timeout=60)
+    assert channel1.settle_event.wait(timeout=60)
 
     # check that the channel is properly settled and that Bob's client
     # automatically called updateTransfer() to reflect the actual transactions

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -709,6 +709,9 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     chain0 = app0.raiden.chain
     wait_until_block(chain0, chain0.block_number() + 1)
 
+    assert channel0.close_event.wait(timeout=25)
+    assert channel1.close_event.wait(timeout=25)
+
     assert channel0.external_state.closed_block != 0
     assert channel1.external_state.closed_block != 0
 

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -2,7 +2,6 @@
 from __future__ import division
 
 import pytest
-import gevent
 from ethereum import slogging
 
 from raiden.tests.utils.blockchain import wait_until_block
@@ -713,10 +712,6 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     # wait until the settle timeout has passed
     settle_expiration = chain0.block_number() + settle_timeout
     wait_until_block(chain0, settle_expiration)
-    # manually call settle (automatic settling does not seem to work)
-    # TODO: ^ Find out why
-    channel1.external_state.settle()
-    gevent.sleep(1)
 
     # check that the channel is properly settled and that Bob's client
     # automatically called updateTransfer() to reflect the actual transactions

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -751,8 +751,6 @@ def test_transfer_from_outdated(raiden_network, settle_timeout):
     tester_state.mine(1)
     gevent.sleep(.5)
     tester_state.mine(number_of_blocks=settle_timeout + 1)
-    app0.raiden.api.settle(token_manager0.token_address, app1.raiden.address)
-    gevent.sleep(.5)
 
     assert channel0.external_state.settled_block != 0
     assert channel1.external_state.settled_block != 0

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -753,6 +753,9 @@ def test_transfer_from_outdated(raiden_network, settle_timeout):
         app1.raiden.chain.block_number() + 1
     )
 
+    assert channel0.close_event.wait(timeout=25)
+    assert channel1.close_event.wait(timeout=25)
+
     assert channel0.external_state.closed_block != 0
     assert channel1.external_state.closed_block != 0
 
@@ -760,6 +763,9 @@ def test_transfer_from_outdated(raiden_network, settle_timeout):
         app0.raiden.chain,
         app0.raiden.chain.block_number() + settle_timeout,
     )
+
+    assert channel0.settle_event.wait(timeout=25)
+    assert channel1.settle_event.wait(timeout=25)
 
     assert channel0.external_state.settled_block != 0
     assert channel1.external_state.settled_block != 0

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -27,6 +27,7 @@ from raiden.tests.utils.transfer import assert_synched_channels, channel, direct
 from raiden.tests.utils.network import CHAIN
 from raiden.utils import pex, sha3, privatekey_to_address
 from raiden.raiden_service import NoPathError
+from raiden.tests.utils.blockchain import wait_until_block
 
 # pylint: disable=too-many-locals,too-many-statements,line-too-long
 slogging.configure(':DEBUG')
@@ -720,7 +721,6 @@ def test_transfer_to_unknownchannel(raiden_network, private_keys):
 @pytest.mark.parametrize('settle_timeout', [30])
 def test_transfer_from_outdated(raiden_network, settle_timeout):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
-    tester_state = app0.raiden.chain.tester_state
 
     token_manager0 = app0.raiden.managers_by_token_address.values()[0]
     token_manager1 = app1.raiden.managers_by_token_address.values()[0]
@@ -740,7 +740,6 @@ def test_transfer_from_outdated(raiden_network, settle_timeout):
         amount,
         target=app1.raiden.address,
     )
-    gevent.sleep(1)
 
     assert_synched_channels(
         channel0, balance0 - amount, [],
@@ -748,9 +747,19 @@ def test_transfer_from_outdated(raiden_network, settle_timeout):
     )
 
     app1.raiden.api.close(token_manager0.token_address, app0.raiden.address)
-    tester_state.mine(1)
-    gevent.sleep(.5)
-    tester_state.mine(number_of_blocks=settle_timeout + 1)
+
+    wait_until_block(
+        app1.raiden.chain,
+        app1.raiden.chain.block_number() + 1
+    )
+
+    assert channel0.external_state.closed_block != 0
+    assert channel1.external_state.closed_block != 0
+
+    wait_until_block(
+        app0.raiden.chain,
+        app0.raiden.chain.block_number() + settle_timeout,
+    )
 
     assert channel0.external_state.settled_block != 0
     assert channel1.external_state.settled_block != 0


### PR DESCRIPTION
This fixes the automatic settlement as tested in `tests/integration/test_settlement.py::test_settlement` and allows to remove the pytest skip on travis-CI. Due to the applied fixes a couple of other tests that apparently adjusted to the formerly broken behavior needed changes, too. 

There were a couple of issues that lead us to start skipping the test and I'd like you to give the PR a thorough review -- to ensure it fixes what it is supposed to fix and also to learn:
- The main cause for the ["flakyness"](https://github.com/raiden-network/raiden/issues/389) of the test was an incorrect [Yoda-style](https://en.wikipedia.org/wiki/Yoda_conditions) boolean comparison in the [`blockalarm_for_settle`](https://github.com/raiden-network/raiden/pull/391/commits/3bac2c5158db69ef484f56bb3713f6e99e162973). I believe there is no reason for Yoda-boolean in python and we should avoid it, because it is harder to reason about it (the bug went unnoticed for several months).
- The flakyness of `test_settlement.py::test_settlement` was most likely caused by the sometimes late spawned `_settle` task (which could only then run successfully).
- Due to the skipped test in CI, we also missed a [breaking change for the arguments to `close`](https://github.com/raiden-network/raiden/commit/e82f7b3e5725f68d08c1791ff8a25515bfbd7232), which [was also fixed](https://github.com/raiden-network/raiden/pull/391/files#diff-9161c3328a41e5b779ebb4d7966b8abcR109).
- `test_settlement.py::test_settlement` [missed to properly check the postconditions](https://github.com/raiden-network/raiden/pull/391/files#diff-9161c3328a41e5b779ebb4d7966b8abcR142). Due to a [padding mismatch for the secret](https://github.com/raiden-network/raiden/pull/391/files#diff-9161c3328a41e5b779ebb4d7966b8abcR53) the [unlock call](https://github.com/raiden-network/raiden/pull/391/files#diff-9161c3328a41e5b779ebb4d7966b8abcR125) never succeeded before (i.e. there were assets lost). See also #395.
- I increased some of the pytest-timeouts to let the tests pass consistently here. I believe we should use timeouts **only** as a last resort to keep the test suite from locking up completely, but never to "speed things up".
- One of the other tests [affected by the fix]() already [suspected something fishy](https://github.com/raiden-network/raiden/pull/391/files#diff-e9ba3bf3caea82260af91c81e3782dbaL716) -- I suggest we should take the time to investigate odd behavior instead of coding around it :)
- ~~I added an [explicit context switch](https://github.com/konradkonrad/raiden/blob/99ba6e5066694af9f6bd0a025c778a1b86626106/raiden/tests/utils/blockchain.py#L44-L51) to the `wait_until_block` pattern, and applied it to all tests I touched. This [wasn't enough in all instances](https://github.com/raiden-network/raiden/pull/391/commits/fe7cfc2e49915f3dd5559a65551920c7db790d85) and I'd like to get your opinion on a best-practice for coroutine testing.~~

There are a couple of follow up issues:
- #393 -- issuing callbacks for lifecycle changes
- #394 -- channel proxy return values
- #395 -- hashlock/secret padding pitfall
- #396 -- debug tooling
- #397 -- review skip/xfail test markers

This fixes #390 :) :)