### PR TITLE
Automatic channel provisioning #83

### DIFF
--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -403,7 +403,7 @@ class ChannelExternalState(object):
         # TODO: ensure the same callback logic as in set_settled
         if self._closed_block != 0 and self._closed_block != block_number:
             raise RuntimeError(
-                'channel is already closed on different block %s %s'
+                'attempted set_closed(%s) for a channel already closed on block %s'
                 % (self._closed_block, block_number)
             )
 

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -401,10 +401,14 @@ class ChannelExternalState(object):
 
     def set_closed(self, block_number):
         # TODO: ensure the same callback logic as in set_settled
-        if self._closed_block != 0:
-            raise RuntimeError('channel is already closed')
+        if self._closed_block != 0 and self._closed_block != block_number:
+            raise RuntimeError(
+                'channel is already closed on different block %s %s'
+                % (self._closed_block, block_number)
+            )
 
-        self._closed_block = block_number
+        else:
+            self._closed_block = block_number
 
         for callback in self.callbacks_closed:
             callback(block_number)

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -101,15 +101,15 @@ class ConnectionManager(object):
                     if channel[1] in [c.partner_address for c in self.open_channels]:
                         raise
 
-            # force state update
-            self.raiden.poll_blockchain_events(self.raiden.get_block_number())
+            # wait for events to propagate
+            gevent.sleep(self.raiden.alarm.wait_time)
 
             if wait_for_settle:
                 try:
                     with gevent.timeout.Timeout(timeout):
                         while any(c.state != CHANNEL_STATE_SETTLED for c in open_channels):
-                            # force state update
-                            self.raiden.poll_blockchain_events(self.raiden.get_block_number())
+                            # wait for events to propagate
+                            gevent.sleep(self.raiden.alarm.wait_time)
 
                 except gevent.timeout.Timeout:
                     log.debug(

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+import time
+
+from gevent.lock import Semaphore
+
+from ethereum import slogging
+from raiden.utils import pex
+from raiden.channel import CHANNEL_STATE_SETTLED
+
+log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+class ConnectionManager(object):
+    """
+    The ConnectionManager provides a high level abstraction for connecting to a
+    Token network.
+    Note:
+        It is initialized with 0 funds; a connection to the token network
+        will be only established _after_ calling `connect(funds)`
+    """
+    # XXX Hack: for bootstrapping the first node on a network opens a channel
+    # with this address to become visible.
+    BOOTSTRAP_ADDR_HEX = '2' * 40
+    BOOTSTRAP_ADDR = BOOTSTRAP_ADDR_HEX.decode('hex')
+
+    def __init__(
+        self,
+        raiden,
+        token_address,
+        initial_channel_target=3,  # number of channels to open immediately
+        joinable_funds_target=.4,  # amount of funds not initially assigned
+    ):
+        self.lock = Semaphore()
+        self.funds = 0
+        self.raiden = raiden
+        self.token_address = token_address
+        self.initial_channel_target = initial_channel_target
+        self.joinable_funds_target = joinable_funds_target
+        # force state update
+        self.raiden.poll_blockchain_events(self.raiden.get_block_number())
+        if self.token_address in self.raiden.channelgraphs.keys():
+            self.channelgraph = self.raiden.channelgraphs[self.token_address]
+            if len(self.channelgraph.graph.nodes()) == 0:
+                log.debug('BOOTSTRAP for existing token')
+                # make ourselves visible
+                self.raiden.api.open(
+                    self.token_address,
+                    ConnectionManager.BOOTSTRAP_ADDR
+                )
+        else:
+            log.debug(
+                'token not yet registered',
+                token=pex(self.token_address)
+            )
+            self.raiden.chain.default_registry.add_token(self.token_address)
+            # force state update
+            self.raiden.poll_blockchain_events(self.raiden.get_block_number())
+            self.channelgraph = self.raiden.channelgraphs[self.token_address]
+            # make ourselves visible
+            self.raiden.api.open(
+                self.token_address,
+                ConnectionManager.BOOTSTRAP_ADDR
+            )
+
+    def connect(self, funds):
+        """Connect to the network.
+        Use this to establish a connection with the token network.
+        Args:
+            funds (int): the amount of tokens spendable for this
+                         ConnectionManager.
+        """
+        if funds <= 0:
+            raise ValueError('connecting needs a positive value for `funds`')
+        with self.lock:
+            self.funds = funds
+            funding = self.initial_funding_per_partner
+            for partner in self.find_new_partners(self.initial_channel_target):
+                self.raiden.api.open(
+                    self.token_address,
+                    partner,
+                )
+                self.raiden.api.deposit(
+                    self.token_address,
+                    partner,
+                    funding
+                )
+
+    def leave(self, wait_for_settle=True, max_wait=30):
+        """
+        Leave the token network.
+        This implies closing all open channels and optionally wait for
+        settlement.
+        Args:
+            wait_for_settle (bool): block until successful settlement?
+            max_wait (float): maximum time to wait
+        """
+        with self.lock:
+            self.initial_channel_target = 0
+            open_channels = self.open_channels
+            channel_specs = [(
+                self.token_address,
+                c.partner_address) for c in open_channels]
+            for channel in channel_specs:
+                try:
+                    self.raiden.api.close(*channel),
+                except RuntimeError:
+                    # if the error wasn't that the channel was already closed: raise
+                    if channel[1] in [c.partner_address for c in self.open_channels]:
+                        raise
+
+            # force state update
+            self.raiden.poll_blockchain_events(self.raiden.get_block_number())
+
+            if wait_for_settle:
+                timeout = time.time() + max_wait
+                while any(c.state != CHANNEL_STATE_SETTLED for c in open_channels):
+                    # force state update
+                    self.raiden.poll_blockchain_events(self.raiden.get_block_number())
+                    if time.time() > timeout:
+                        log.debug(
+                            'timeout while waiting for settlement',
+                            unsettled=sum(
+                                1 for channel in open_channels if
+                                channel.state != CHANNEL_STATE_SETTLED
+                            ),
+                            settled=sum(
+                                1 for channel in open_channels if
+                                channel.state == CHANNEL_STATE_SETTLED
+                            )
+                        )
+                        break
+
+    def join_channel(self, partner_address, partner_deposit):
+        """Will be called, when we were selected as channel partner by another
+        node. It will fund the channel with up to the partner's deposit, but
+        not more than remaining funds or the initial funding per channel.
+
+        If the connection manager has no funds, this is a noop.
+        """
+        # not initialized
+        if self.funds <= 0:
+            return
+        # in leaving state
+        if self.initial_channel_target < 1:
+            return
+        with self.lock:
+            remaining = self.funds_remaining
+            initial = self.initial_funding_per_partner
+            joining_funds = min(
+                partner_deposit,
+                remaining,
+                initial
+            )
+            if joining_funds <= 0:
+                return
+
+            self.raiden.api.deposit(
+                self.token_address,
+                partner_address,
+                joining_funds
+            )
+            log.debug(
+                'joined a channel!',
+                funds=joining_funds,
+                me=pex(self.raiden.address),
+                partner=pex(partner_address)
+            )
+
+    def retry_connect(self):
+        """Will be called when new channels in the token network are detected.
+        If the minimum number of channels was not yet established, it will try
+        to open new channels.
+
+        If the connection manager has no funds, this is a noop.
+        """
+        # not initialized
+        if self.funds <= 0:
+            return
+        # in leaving state
+        if self.initial_channel_target == 0:
+            return
+        with self.lock:
+            if self.funds_remaining <= 0:
+                return
+            if len(self.open_channels) >= self.initial_channel_target:
+                return
+            for partner in self.find_new_partners(
+                self.initial_channel_target - len(self.open_channels)
+            ):
+                try:
+                    self.raiden.api.open(
+                        self.token_address,
+                        partner
+                    )
+                    self.raiden.api.deposit(
+                        self.token_address,
+                        partner,
+                        self.initial_funding_per_partner
+                    )
+                # this can fail because of a race condition, where the channel partner opens first
+                except Exception as e:
+                    log.error('could not open a channel', exc_info=e)
+
+    def find_new_partners(self, number):
+        """Search the token network for potential channel partners.
+        Args:
+            number (int): number of partners to return
+        """
+        known = set(c.partner_address for c in self.open_channels)
+        known = known.union({self.__class__.BOOTSTRAP_ADDR})
+        known = known.union({self.raiden.address})
+        available = set(self.channelgraph.graph.nodes()) - known
+
+        available = self._select_best_partners(available)
+        log.debug('found {} partners'.format(len(available)))
+        return available[:number]
+
+    def _select_best_partners(self, partners):
+        # FIXME: use a proper selection strategy
+        return list(partners)
+
+    @property
+    def initial_funding_per_partner(self):
+        """The calculated funding per partner depending on configuration and
+        overall funding of the ConnectionManager.
+        """
+        if self.initial_channel_target:
+            return int(
+                self.funds * (1 - self.joinable_funds_target) /
+                self.initial_channel_target
+            )
+        else:
+            return 0
+
+    @property
+    def wants_more_channels(self):
+        """True, if funds available and the `initial_channel_target` was not yet
+        reached.
+        """
+        return (
+            self.funds_remaining > 0 and
+            len(self.open_channels) < self.initial_channel_target
+        )
+
+    @property
+    def funds_remaining(self):
+        """The remaining funds after subtracting the already deposited amounts.
+        """
+        if self.funds > 0:
+            remaining = self.funds - sum(
+                channel.deposit for channel in self.open_channels
+            )
+            assert isinstance(remaining, int)
+            return remaining
+        return 0
+
+    @property
+    def open_channels(self):
+        """Shorthand for getting our open channels in this token network.
+        """
+        return [
+            channel for channel in
+            self.raiden.api.get_channel_list(token_address=self.token_address)
+            if channel.isopen
+        ]

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -81,7 +81,7 @@ class ConnectionManager(object):
     def leave(self, wait_for_settle=True, timeout=30):
         """
         Leave the token network.
-        This implies closing all open channels and optionally wait for
+        This implies closing all open channels and optionally waiting for
         settlement.
         Args:
             wait_for_settle (bool): block until successful settlement?
@@ -211,6 +211,7 @@ class ConnectionManager(object):
 
     def _select_best_partners(self, partners):
         # FIXME: use a proper selection strategy
+        # https://github.com/raiden-network/raiden/issues/576
         return list(partners)
 
     @property

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -479,6 +479,12 @@ class RaidenService(object):
             self.manager_token[manager_address] = token_address
             self.channelgraphs[token_address] = graph
 
+            self.tokens_connectionmanagers[token_address] = ConnectionManager(
+                self,
+                token_address,
+                graph
+            )
+
     def register_channel_manager(self, manager_address):
         manager = self.chain.manager(manager_address)
         netting_channels = [
@@ -512,6 +518,12 @@ class RaidenService(object):
         self.manager_token[manager_address] = token_address
         self.channelgraphs[token_address] = graph
 
+        self.tokens_connectionmanagers[token_address] = ConnectionManager(
+            self,
+            token_address,
+            graph
+        )
+
     def register_netting_channel(self, token_address, channel_address):
         netting_channel = self.chain.netting_channel(channel_address)
         self.pyethapp_blockchain_events.add_netting_channel_listener(netting_channel)
@@ -524,11 +536,10 @@ class RaidenService(object):
     def connection_manager_for_token(self, token_address):
         if not isaddress(token_address):
             raise InvalidAddress('token address is not valid.')
-        if token_address not in self.tokens_connectionmanagers.keys():
-            manager = ConnectionManager(self, token_address)
-            self.tokens_connectionmanagers[token_address] = manager
-        else:
+        if token_address in self.tokens_connectionmanagers.keys():
             manager = self.tokens_connectionmanagers[token_address]
+        else:
+            raise InvalidAddress('token is not registered.')
         return manager
 
     def stop(self):

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -38,9 +38,9 @@ def api_url_for(api_backend, endpoint, **kwargs):
 
 @pytest.mark.parametrize('blockchain_type', ['geth'])
 @pytest.mark.parametrize('number_of_nodes', [2])
-def test_channel_to_api_dict(raiden_network, tokens_addresses, settle_timeout):
+def test_channel_to_api_dict(raiden_network, token_addresses, settle_timeout):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
-    channel0 = channel(app0, app1, tokens_addresses[0])
+    channel0 = channel(app0, app1, token_addresses[0])
 
     netting_address = channel0.external_state.netting_channel.address
     netting_channel = app0.raiden.chain.netting_channel(netting_address)

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -22,6 +22,7 @@ from raiden.tests.fixtures import (
     netting_channel_abi,
 
     tokens_addresses,
+    register_tokens,
     cached_genesis,
     blockchain_services,
     blockchain_backend,
@@ -80,6 +81,7 @@ __all__ = (
     'netting_channel_abi',
 
     'tokens_addresses',
+    'register_tokens',
     'cached_genesis',
     'blockchain_services',
     'blockchain_backend',

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -21,7 +21,7 @@ from raiden.tests.fixtures import (
     channel_manager_abi,
     netting_channel_abi,
 
-    tokens_addresses,
+    token_addresses,
     register_tokens,
     cached_genesis,
     blockchain_services,
@@ -80,7 +80,7 @@ __all__ = (
     'channel_manager_abi',
     'netting_channel_abi',
 
-    'tokens_addresses',
+    'token_addresses',
     'register_tokens',
     'cached_genesis',
     'blockchain_services',

--- a/raiden/tests/fixtures/__init__.py
+++ b/raiden/tests/fixtures/__init__.py
@@ -14,7 +14,7 @@ from raiden.tests.fixtures.api import (
 )
 
 from raiden.tests.fixtures.blockchain import (
-    tokens_addresses,
+    token_addresses,
     register_tokens,
     cached_genesis,
     blockchain_services,
@@ -79,7 +79,7 @@ __all__ = (
     'channel_manager_abi',
     'netting_channel_abi',
 
-    'tokens_addresses',
+    'token_addresses',
     'register_tokens',
     'blockchain_services',
     'blockchain_backend',

--- a/raiden/tests/fixtures/__init__.py
+++ b/raiden/tests/fixtures/__init__.py
@@ -15,6 +15,7 @@ from raiden.tests.fixtures.api import (
 
 from raiden.tests.fixtures.blockchain import (
     tokens_addresses,
+    register_tokens,
     cached_genesis,
     blockchain_services,
     blockchain_backend,
@@ -79,6 +80,7 @@ __all__ = (
     'netting_channel_abi',
 
     'tokens_addresses',
+    'register_tokens',
     'blockchain_services',
     'blockchain_backend',
 

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -41,7 +41,7 @@ log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 EPOCH0_DAGSIZE = 1073739912
 
 __all__ = (
-    'tokens_addresses',
+    'token_addresses',
     'register_tokens',
     'blockchain_services',
     'blockchain_backend',
@@ -57,7 +57,7 @@ def genesis_path_from_testfunction(request):
     return str(genesis_path)  # makedir returns a py.path.LocalPath object
 
 
-def _tokens_addresses(
+def _token_addresses(
     token_amount,
     number_of_tokens,
     deploy_service,
@@ -142,7 +142,7 @@ def cached_genesis(request, blockchain_type):
     # create_network only registers the tokens,
     # the contracts must be deployed previously
     register = True
-    token_contract_addresses = _tokens_addresses(
+    token_contract_addresses = _token_addresses(
         request.getfixturevalue('token_amount'),
         request.getfixturevalue('number_of_tokens'),
         deploy_service,
@@ -247,7 +247,7 @@ def register_tokens():
 
 
 @pytest.fixture
-def tokens_addresses(
+def token_addresses(
         request,
         token_amount,
         number_of_tokens,
@@ -256,12 +256,12 @@ def tokens_addresses(
         register_tokens):
 
     if cached_genesis:
-        tokens_addresses = [
+        token_addresses = [
             address_decoder(token_address)
             for token_address in cached_genesis['config']['tokenAddresses']
         ]
     else:
-        tokens_addresses = _tokens_addresses(
+        token_addresses = _token_addresses(
             token_amount,
             number_of_tokens,
             blockchain_services.deploy_service,
@@ -269,7 +269,7 @@ def tokens_addresses(
             register_tokens
         )
 
-    return tokens_addresses
+    return token_addresses
 
 
 @pytest.fixture

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -141,12 +141,13 @@ def cached_genesis(request, blockchain_type):
 
     # create_network only registers the tokens,
     # the contracts must be deployed previously
+    register = True
     token_contract_addresses = _tokens_addresses(
         request.getfixturevalue('token_amount'),
         request.getfixturevalue('number_of_tokens'),
         deploy_service,
         blockchain_services,
-        True
+        register
     )
 
     raiden_apps = create_apps(

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -158,6 +158,7 @@ def cached_genesis(request, blockchain_type):
         request.getfixturevalue('send_ping_time'),
         request.getfixturevalue('max_unresponsive_time'),
         request.getfixturevalue('reveal_timeout'),
+        request.getfixturevalue('settle_timeout'),
     )
 
     if 'raiden_network' in request.fixturenames:

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -30,7 +30,7 @@ def _raiden_cleanup(request, raiden_apps):
 @pytest.fixture
 def raiden_chain(
         request,
-        tokens_addresses,
+        token_addresses,
         channels_per_node,
         deposit,
         settle_timeout,
@@ -42,7 +42,7 @@ def raiden_chain(
         max_unresponsive_time,
         reveal_timeout):
 
-    if len(tokens_addresses) > 1:
+    if len(token_addresses) > 1:
         raise ValueError('raiden_chain only works with a single token')
 
     assert channels_per_node in (0, 1, 2, CHAIN), (
@@ -64,7 +64,7 @@ def raiden_chain(
     if not cached_genesis:
         create_sequential_channels(
             raiden_apps,
-            tokens_addresses[0],
+            token_addresses[0],
             channels_per_node,
             deposit,
             settle_timeout,
@@ -81,7 +81,7 @@ def raiden_chain(
 @pytest.fixture
 def raiden_network(
         request,
-        tokens_addresses,
+        token_addresses,
         channels_per_node,
         deposit,
         settle_timeout,
@@ -108,7 +108,7 @@ def raiden_network(
     if not cached_genesis:
         create_network_channels(
             raiden_apps,
-            tokens_addresses,
+            token_addresses,
             channels_per_node,
             deposit,
             settle_timeout

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -58,7 +58,8 @@ def raiden_chain(
         verbosity,
         send_ping_time,
         max_unresponsive_time,
-        reveal_timeout
+        reveal_timeout,
+        settle_timeout
     )
 
     if not cached_genesis:
@@ -102,7 +103,8 @@ def raiden_network(
         verbosity,
         send_ping_time,
         max_unresponsive_time,
-        reveal_timeout
+        reveal_timeout,
+        settle_timeout
     )
 
     if not cached_genesis:

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -103,8 +103,9 @@ def test_participant_selection(
     )
 
     try:
-        # depending on the number of channels, this will fail, due to weak
+        # FIXME: depending on the number of channels, this will fail, due to weak
         # selection algorithm
+        # https://github.com/raiden-network/raiden/issues/576
         assert not any(
             len(connection_manager.open_channels) > 2 * acc
             for connection_manager in connection_managers

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -16,16 +16,9 @@ log = slogging.getLogger(__name__)
 def test_participant_selection(
     raiden_network,
     token_addresses,
-    settle_timeout,
-    reveal_timeout,
     blockchain_type
 ):
     token_address = token_addresses[0]
-
-    # adjust timeouts
-    for app in raiden_network:
-        app.raiden.config['reveal_timeout'] = reveal_timeout
-        app.raiden.config['settle_timeout'] = settle_timeout
 
     # connect the first node (will register the token if necessary)
     raiden_network[0].raiden.api.connect_token_network(token_address, 100)

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -8,6 +8,10 @@ from raiden.tests.utils.blockchain import wait_until_block
 log = slogging.getLogger(__name__)
 
 
+# TODO: add test scenarios for
+# - subsequent `connect()` calls with different `funds` arguments
+# - `connect()` calls with preexisting channels
+
 @pytest.mark.parametrize('number_of_nodes', [6])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('cached_genesis', [False])

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+import pytest
+import gevent
+from gevent.pool import Pool
+from ethereum import slogging
+
+from raiden.tests.utils.blockchain import wait_until_block
+
+log = slogging.getLogger(__name__)
+
+
+@pytest.mark.parametrize('number_of_nodes', [6])
+@pytest.mark.parametrize('channels_per_node', [0])
+@pytest.mark.parametrize('cached_genesis', [False])
+@pytest.mark.parametrize('register_tokens', [True, False])
+def test_participant_selection(
+    raiden_network,
+    tokens_addresses,
+    settle_timeout,
+    reveal_timeout,
+    blockchain_type
+):
+    token_address = tokens_addresses[0]
+
+    # adjust timeouts
+    for app in raiden_network:
+        app.raiden.config['reveal_timeout'] = reveal_timeout
+        app.raiden.config['settle_timeout'] = settle_timeout
+
+    pool = Pool()
+    calls = []
+    for num, app in enumerate(raiden_network):
+        manager = app.raiden.connection_manager_for_token(token_address)
+        chain = app.raiden.chain
+
+        calls.append((manager.connect, 100))
+
+    pool.imap(lambda x: x[0](x[1]), calls).join()
+
+    # wait some blocks to let the network connect
+    n = 15
+    if blockchain_type == 'geth':
+        wait_until_block(
+            raiden_network[-1].raiden.chain,
+            raiden_network[-1].raiden.chain.block_number() + n
+        )
+    else:
+        for i in range(n):
+            for app in raiden_network:
+                wait_until_block(
+                    app.raiden.chain,
+                    app.raiden.chain.block_number() + 1
+                )
+        # tester needs a context switch
+        gevent.sleep(1)
+
+    connection_managers = [
+        app.raiden.tokens_connectionmanagers[token_address] for app in raiden_network]
+
+    def open_channels_count(connection_managers_):
+        return [
+            connection_manager.open_channels for connection_manager in connection_managers_
+        ]
+
+    assert any(open_channels_count(connection_managers))
+    assert all(open_channels_count(connection_managers))
+
+    def not_saturated(connection_managers):
+        return [
+            1 for connection_manager in connection_managers
+            if connection_manager.open_channels < connection_manager.initial_channel_target
+        ]
+
+    chain = raiden_network[-1].raiden.chain
+    max_wait = 12
+
+    while len(not_saturated(connection_managers)) > 0:
+        wait_until_block(chain, chain.block_number() + 1)
+        max_wait -= 1
+        if max_wait <= 0:
+            break
+
+    assert len(not_saturated(connection_managers)) == 0
+
+    # Ensure unpartitioned network
+    addresses = [app.raiden.address for app in raiden_network]
+    for connection_manager in connection_managers:
+        assert all(
+            connection_manager.channelgraph.has_path(
+                connection_manager.raiden.address,
+                address
+            )
+            for address in addresses
+        )
+
+    # average channel count
+    acc = (
+        sum(len(connection_manager.open_channels) for connection_manager in connection_managers) /
+        float(len(connection_managers))
+    )
+
+    try:
+        # depending on the number of channels, this will fail, due to weak
+        # selection algorithm
+        assert not any(
+            len(connection_manager.open_channels) > 2 * acc
+            for connection_manager in connection_managers
+        )
+    except AssertionError:
+        pass
+
+    # test `leave()` method
+    connection_manager = connection_managers[0]
+    before = len(connection_manager.open_channels)
+    before_block = connection_manager.raiden.chain.block_number()
+
+    connection_manager.leave(wait_for_settle=False)
+
+    wait_until_block(
+        connection_manager.raiden.chain,
+        before_block + connection_manager.raiden.config['settle_timeout'] + 1
+    )
+    after = len(connection_manager.open_channels)
+
+    assert before > after
+    assert after == 0

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -31,19 +31,14 @@ def test_participant_selection(
 
     # wait some blocks to let the network connect
     wait_blocks = 15
-    if blockchain_type == 'geth':
-        wait_until_block(
-            raiden_network[-1].raiden.chain,
-            raiden_network[-1].raiden.chain.block_number() + wait_blocks
-        )
-    else:
-        for i in range(wait_blocks):
-            for app in raiden_network:
-                wait_until_block(
-                    app.raiden.chain,
-                    app.raiden.chain.block_number() + 1
-                )
-            # tester needs an explicit context switch :(
+    for i in range(wait_blocks):
+        for app in raiden_network:
+            wait_until_block(
+                app.raiden.chain,
+                app.raiden.chain.block_number() + 1
+            )
+        # tester needs an explicit context switch :(
+        if blockchain_type == 'tester':
             gevent.sleep(1)
 
     connection_managers = [

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -15,12 +15,12 @@ log = slogging.getLogger(__name__)
 @pytest.mark.parametrize('register_tokens', [True, False])
 def test_participant_selection(
     raiden_network,
-    tokens_addresses,
+    token_addresses,
     settle_timeout,
     reveal_timeout,
     blockchain_type
 ):
-    token_address = tokens_addresses[0]
+    token_address = token_addresses[0]
 
     # adjust timeouts
     for app in raiden_network:

--- a/raiden/tests/integration/test_provisioning.py
+++ b/raiden/tests/integration/test_provisioning.py
@@ -102,13 +102,15 @@ def test_participant_selection(
     # test `leave()` method
     connection_manager = connection_managers[0]
     before = len(connection_manager.open_channels)
-    before_block = connection_manager.raiden.chain.block_number()
 
     raiden_network[0].raiden.api.leave_token_network(token_address, wait_for_settle=False)
 
     wait_until_block(
         connection_manager.raiden.chain,
-        before_block + connection_manager.raiden.config['settle_timeout'] + 1
+        (
+            connection_manager.raiden.chain.block_number() +
+            connection_manager.raiden.config['settle_timeout'] + 1
+        )
     )
     after = len(connection_manager.open_channels)
 

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -153,11 +153,11 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 # TODO: Need to expose the netted value to use a different blockchain_type
 @pytest.mark.parametrize('blockchain_type', ['mock'])
-def test_settled_lock(tokens_addresses, raiden_network, settle_timeout, reveal_timeout):
+def test_settled_lock(token_addresses, raiden_network, settle_timeout, reveal_timeout):
     """ Any transfer following a secret revealed must update the locksroot, so
     that an attacker cannot reuse a secret to double claim a lock.
     """
-    token = tokens_addresses[0]
+    token = token_addresses[0]
     amount = 30
 
     app0, app1, app2, _ = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
@@ -220,7 +220,7 @@ def test_settled_lock(tokens_addresses, raiden_network, settle_timeout, reveal_t
 @pytest.mark.xfail(reason="test incomplete")
 @pytest.mark.parametrize('privatekey_seed', ['start_end_attack:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
-def test_start_end_attack(tokens_addresses, raiden_chain, deposit, reveal_timeout):
+def test_start_end_attack(token_addresses, raiden_chain, deposit, reveal_timeout):
     """ An attacker can try to steal tokens from a hub or the last node in a
     path.
 
@@ -235,7 +235,7 @@ def test_start_end_attack(tokens_addresses, raiden_chain, deposit, reveal_timeou
     """
     amount = 30
 
-    token = tokens_addresses[0]
+    token = token_addresses[0]
     app0, app1, app2 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
     # the attacker owns app0 and app2 and creates a transfer through app1

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -358,7 +358,7 @@ def test_python_channel():
 
 @pytest.mark.parametrize('blockchain_type', ['mock'])
 @pytest.mark.parametrize('number_of_nodes', [2])
-def test_setup(raiden_network, deposit, tokens_addresses):
+def test_setup(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
     tokens0 = app0.raiden.channelgraphs.keys()
@@ -367,7 +367,7 @@ def test_setup(raiden_network, deposit, tokens_addresses):
     assert len(tokens0) == 1
     assert len(tokens1) == 1
     assert tokens0 == tokens1
-    assert tokens0[0] == tokens_addresses[0]
+    assert tokens0[0] == token_addresses[0]
 
     token_address = tokens0[0]
     channel0 = channel(app0, app1, token_address)
@@ -493,11 +493,11 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
 
 @pytest.mark.parametrize('blockchain_type', ['mock'])
 @pytest.mark.parametrize('number_of_nodes', [2])
-def test_transfer(raiden_network, tokens_addresses):
+def test_transfer(raiden_network, token_addresses):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    channel0 = channel(app0, app1, tokens_addresses[0])
-    channel1 = channel(app1, app0, tokens_addresses[0])
+    channel0 = channel(app0, app1, token_addresses[0])
+    channel1 = channel(app1, app0, token_addresses[0])
 
     contract_balance0 = channel0.contract_balance
     contract_balance1 = channel1.contract_balance

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -6,23 +6,23 @@ from raiden.tests.utils.transfer import channel
 
 @pytest.mark.parametrize('blockchain_type', ['mock'])
 @pytest.mark.parametrize('number_of_nodes', [3])
-def test_get_channel_list(raiden_network, tokens_addresses):
+def test_get_channel_list(raiden_network, token_addresses):
     app0, app1, app2 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    channel0 = channel(app0, app1, tokens_addresses[0])
-    channel1 = channel(app1, app0, tokens_addresses[0])
-    channel2 = channel(app0, app2, tokens_addresses[0])
+    channel0 = channel(app0, app1, token_addresses[0])
+    channel1 = channel(app1, app0, token_addresses[0])
+    channel2 = channel(app0, app2, token_addresses[0])
 
     assert channel0, channel2 in app0.raiden.api.get_channel_list()
     assert channel0 in app0.raiden.api.get_channel_list(partner_address=app1.raiden.address)
-    assert channel1 in app1.raiden.api.get_channel_list(token_address=tokens_addresses[0])
-    assert channel1 in app1.raiden.api.get_channel_list(tokens_addresses[0], app0.raiden.address)
+    assert channel1 in app1.raiden.api.get_channel_list(token_address=token_addresses[0])
+    assert channel1 in app1.raiden.api.get_channel_list(token_addresses[0], app0.raiden.address)
     assert not app1.raiden.api.get_channel_list(partner_address=app2.raiden.address)
 
     pytest.raises(
         KeyError,
         app1.raiden.api.get_channel_list,
-        token_address=tokens_addresses[0],
+        token_address=token_addresses[0],
         partner_address=app2.raiden.address
     )
     pytest.raises(

--- a/raiden/tests/utils/mock_client.py
+++ b/raiden/tests/utils/mock_client.py
@@ -426,20 +426,20 @@ class NettingChannelMock(object):
             'settle_timeout': self.contract.settle_timeout,
         }
 
-    def close(self, our_address, first_transfer):
+    def close(self, our_address, their_transfer):
         ctx = {
             'block_number': BlockChainServiceMock.block_number(),
             'msg.sender': our_address,
         }
 
-        first_encoded = None
+        their_encoded = None
 
-        if first_transfer is not None:
-            first_encoded = first_transfer.encode()
+        if their_transfer is not None:
+            their_encoded = their_transfer.encode()
 
         self.contract.close(
             ctx,
-            first_encoded,
+            their_encoded,
         )
 
         data = {

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -44,6 +44,7 @@ def create_app(
         max_unresponsive_time,
         port,
         reveal_timeout,
+        settle_timeout,
         host='127.0.0.1',
 ):
     ''' Instantiates an Raiden app with the given configuration. '''
@@ -55,6 +56,7 @@ def create_app(
     config['send_ping_time'] = send_ping_time
     config['max_unresponsive_time'] = max_unresponsive_time
     config['reveal_timeout'] = reveal_timeout
+    config['settle_timeout'] = settle_timeout
 
     app = App(
         config,
@@ -252,7 +254,8 @@ def create_apps(
         verbosity,
         send_ping_time,
         max_unresponsive_time,
-        reveal_timeout):
+        reveal_timeout,
+        settle_timeout):
     """ Create the apps.
 
     Note:
@@ -300,7 +303,8 @@ def create_apps(
             max_unresponsive_time,
             port=port,
             host=host,
-            reveal_timeout=reveal_timeout
+            reveal_timeout=reveal_timeout,
+            settle_timeout=settle_timeout,
         )
         apps.append(app)
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -177,7 +177,7 @@ def network_with_minimum_channels(apps, channels_per_node):
 
 def create_network_channels(
         raiden_apps,
-        tokens_addresses,
+        token_addresses,
         channels_per_node,
         deposit,
         settle_timeout):
@@ -187,7 +187,7 @@ def create_network_channels(
     if channels_per_node is not CHAIN and channels_per_node > num_nodes:
         raise ValueError("Can't create more channels than nodes")
 
-    for token in tokens_addresses:
+    for token in token_addresses:
         if channels_per_node == CHAIN:
             app_channels = list(zip(raiden_apps[:-1], raiden_apps[1:]))
         else:
@@ -203,7 +203,7 @@ def create_network_channels(
 
 def create_sequential_channels(
         raiden_apps,
-        tokens_addresses,
+        token_addresses,
         channels_per_node,
         deposit,
         settle_timeout):
@@ -238,7 +238,7 @@ def create_sequential_channels(
         app_channels = list(zip(raiden_apps[:-1], raiden_apps[1:]))
 
     setup_channels(
-        tokens_addresses,
+        token_addresses,
         app_channels,
         deposit,
         settle_timeout,

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -643,7 +643,9 @@ class NettingChannelTesterMock(object):
     def close(self, our_address, their_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        their_encoded = their_transfer.encode()
+        their_encoded = ''
+        if their_transfer is not None:
+            their_encoded = their_transfer.encode()
         self.proxy.close(
             their_encoded,
         )


### PR DESCRIPTION
This implements the first two bulletpoints of #83:

> - [x] allow for a simplified `connect(token, available_funds)` API method that hides the `open(token, partner, funding)` steps from the user
> - [x] add a listener that will "join" freshly opened channels by depositing some `available` funds

This PR touches a couple of things:

#### Add a `ConnectionManager`
The `ConnectionManager` is intended to allow per-token token-network connection establishment and maintenance.

It provides three functions:

- `connect(funds)` to initialize a connection
- `join_channel(partner_address, partner_deposit)` to join a channel on discovery of a newly opened channel
- `retry_connect()` to create more channels on discovery of new network participants

The `ConnectionManager` follows a certain fund-splitting strategy (configured on `__init__(…)`), where a part of the funds is used to open a certain count of channels right away (which aims at establishing "upstream" connectivity), and another part is held back in order to join channels that are opened with oneself from other partners (to establish "downstream" connectivity for others).

For bootstrapping (i.e. when the very first user of a token calls `connect`), the `ConnectionManager` will open a channel with the channel partner `0x2222222222222222222222222222222222222222`. The reason for this is, that the discovery of other users is solved by looking up channel participants in the channel manager contract. Opening this "dummy channel" allows later users to find user zero.

The connection manager instances are maintained in the `RaidenService` in a per token dictionary mapping.

####  ~~Improve rpc calls to `eth_sendTransaction` to be more stable in situations of high concurrency~~

moved to #459

#### Add a fixture to control the auto-registration of tokens in tests

In order to test the full integration of the channel provisioning, I needed a situation where tokens are available, but not yet registered.

### Shortcomings

The current channel partner selection is mostly dependent on the ordering of node addresses in `raiden/network/channelgraph.py`, therefore the resulting channel graph is severely unbalanced. Here is an example for ~~200~~ 60 nodes:
```
[len(cm.open_channels) for cm in connection_managers]
>>> [53, 6, 4, 4, 7, 42, 3, 16, 8, 3, 3, 3, 3, 10, 9, 3, 42, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3] 
```