### PR TITLE
Remove superfluous manager_address_bin in ChannelNew events

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -986,7 +986,6 @@ class RaidenEventHandler(object):
             callback = self.get_on_event_callback(event)
             if callback:
                 callback(
-                    manager_address_bin,
                     netting_channel_address_bin,
                     participant1,
                     participant2,


### PR DESCRIPTION
@konradkonrad that's for you buddy, to fix the `ChannelNew()` errors.
It's just one commit out of the branch I am working on.