### PR TITLE
Reduce the number of geth nodes in tests to 1

### DIFF
--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -156,7 +156,7 @@ def blockchain_number_of_nodes():
     nodes. Used for all geth clusters and ignored for tester and
     mock.
     """
-    return 3
+    return 1
 
 
 @pytest.fixture

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -152,7 +152,7 @@ def blockchain_type(request):
 
 @pytest.fixture
 def blockchain_number_of_nodes():
-    """ Number of nodes in a the cluster, not the same as the number of raiden
+    """ Number of nodes in the cluster, not the same as the number of raiden
     nodes. Used for all geth clusters and ignored for tester and
     mock.
     """


### PR DESCRIPTION
Without propagation between nodes I expect tests to run a lot more reliable
(see #389).

We had a prior issue #258 about this, which conclusion was mislead by the bugs
fixed in #391.