### PR TITLE
Use pytest-cov instead of coverage

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@
 pytest>=3.0.4
 pytest-timeout>=1.2.0
 pytest-random>=0.02
+pytest-cov
 
 # Debugging
 pdbpp>=0.8.3<1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     coverage erase
-    coverage run --append -m py.test --exitfirst {posargs:./raiden/tests/unit ./raiden/tests/smart_contracts ./raiden/tests/integration}
+    pytest --cov-append --exitfirst {posargs:./raiden/tests/unit ./raiden/tests/smart_contracts ./raiden/tests/integration}
 
 [testenv:flake8]
 deps =
@@ -20,13 +20,13 @@ basepython = python2.7
 usedevelop = True
 deps =
     -rrequirements-dev.txt
-commands = coverage run --append -m py.test --blockchain-type=tester --exitfirst {posargs:./raiden/}
+commands = pytest --cov-append --blockchain-type=tester --exitfirst {posargs:./raiden/}
 
 [testenv:smart_contracts]
-commands = coverage run --append -m py.test --initial-port=2000 --blockchain-type=tester --exitfirst ./raiden/tests/smart_contracts {posargs}
+commands = pytest --cov-append --initial-port=2000 --blockchain-type=tester --exitfirst ./raiden/tests/smart_contracts {posargs}
 
 [testenv:integration]
-commands = coverage run --append -m py.test --initial-port=3000 --blockchain-type=tester --exitfirst ./raiden/tests/integration {posargs}
+commands = pytest --cov-append --initial-port=3000 --blockchain-type=tester --exitfirst ./raiden/tests/integration {posargs}
 
 [testenv:unit]
-commands = coverage run --append -m py.test --initial-port=4000 --blockchain-type=tester --exitfirst ./raiden/tests/unit {posargs}
+commands = pytest --cov-append --initial-port=4000 --blockchain-type=tester --exitfirst ./raiden/tests/unit {posargs}


### PR DESCRIPTION
When using `tox` the chained calling of `coverage run -m py.test` makes `gevent`
monkeypatching hard (if not impossible). By using the pytest-cov plugin, we
can spare one level of inception.