### PR TITLE
Change account endowment for tests, for safety

### DIFF
--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -22,8 +22,8 @@ from raiden.settings import GAS_LIMIT_HEX
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 
-DEFAULT_BALANCE = denoms.turing * 1
-DEFAULT_BALANCE_BIN = str(denoms.turing * 1)
+DEFAULT_BALANCE = denoms.ether * 10000000
+DEFAULT_BALANCE_BIN = str(denoms.ether * 10000000)
 DEFAULT_PASSPHRASE = 'notsosecret'  # Geth's account passphrase
 
 GENESIS_STUB = {


### PR DESCRIPTION
Thanks to the [sanity checks](https://github.com/ethereum/go-ethereum/issues/3734) introduced by geth we found out that pyethereum had a [denomination that was too big](https://github.com/ethereum/pyethereum/pull/439).

In any case let's change the test account balance to a more sensible amount with this PR.