### PR TITLE
Freeze time and assert on increasing wait times #389

### DIFF
--- a/raiden/tests/unit/test_transport.py
+++ b/raiden/tests/unit/test_transport.py
@@ -32,9 +32,6 @@ class fake_time(object):
     def now(self):
         return self.count
 
-    def progress(self, amount):
-        self.count += amount
-
 
 @pytest.mark.parametrize('blockchain_type', ['mock'])
 @pytest.mark.parametrize('number_of_nodes', [2])


### PR DESCRIPTION
After #412 there was another factor of flakyness, due to the incorrect assumption that `send_async` execution was dependent on `wait()`. Instead of stepping through a fake time, this now tests that the sleep times increase according to the token refill policy.