### PR TITLE
Get rid of nonce check

### DIFF
--- a/raiden/blockchain/net_contract.py
+++ b/raiden/blockchain/net_contract.py
@@ -334,7 +334,7 @@ class NettingChannelContract(object):
 
         return amount1, amount2
 
-    def close(self, ctx, first_encoded, second_encoded):
+    def close(self, ctx, first_encoded):
         """" Request the closing of the channel. Can be called once by one of
         the participants. Lock period starts counting once this method is
         called.
@@ -368,7 +368,7 @@ class NettingChannelContract(object):
         partner_state = self.participants[self.partner(ctx['msg.sender'])]
 
         # may be None, a node is not required to make a transfer
-        closer, partner = self._decode(ctx['msg.sender'], first_encoded, second_encoded)
+        closer, partner = self._decode(ctx['msg.sender'], first_encoded, None)
 
         closer_state.transfer = closer
         closer_state.transfer_from_self = closer

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -478,8 +478,8 @@ class ChannelExternalState(object):
 
         return False
 
-    def close(self, our_address, first_transfer, second_transfer):
-        return self.netting_channel.close(our_address, first_transfer, second_transfer)
+    def close(self, our_address, first_transfer):
+        return self.netting_channel.close(our_address, first_transfer)
 
     def update_transfer(self, our_address, their_transfer):
         return self.netting_channel.update_transfer(our_address, their_transfer)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -880,13 +880,12 @@ class NettingChannel(object):
     def settled(self):
         return self.proxy.settled.call()
 
-    def close(self, our_address, their_transfer, our_transfer):
+    def close(self, our_address, their_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        their_encoded, our_encoded = get_encoded_transfers(their_transfer, our_transfer)
+        their_encoded = their_transfer.encode()
         transaction_hash = self.proxy.close.transact(
             their_encoded,
-            our_encoded,
             startgas=self.startgas,
             gasprice=self.gasprice,
         )
@@ -900,7 +899,6 @@ class NettingChannel(object):
             'close called',
             contract=pex(self.address),
             their_transfer=their_transfer,
-            our_transfer=our_transfer,
         )
 
     def update_transfer(self, our_address, their_transfer):

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -601,15 +601,10 @@ class RaidenAPI(object):
         if channel.received_transfers:
             first_transfer = channel.received_transfers[-1]
 
-        second_transfer = None
-        if channel.sent_transfers:
-            second_transfer = channel.sent_transfers[-1]
-
         netting_channel = channel.external_state.netting_channel
         netting_channel.close(
             self.raiden.address,
             first_transfer,
-            second_transfer,
         )
 
         return channel_to_api_dict(channel)

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -80,9 +80,8 @@ contract NettingChannelContract {
 
     /// @notice Close the channel. Can only be called by a participant in the channel.
     /// @param theirs_encoded The last transfer recieved from our partner.
-    /// @param ours_encoded The last transfer sent to our partner.
-    function close(bytes theirs_encoded, bytes ours_encoded) {
-        data.close(msg.sender, theirs_encoded, ours_encoded);
+    function close(bytes theirs_encoded) {
+        data.close(msg.sender, theirs_encoded);
         ChannelClosed(msg.sender, data.closed);
     }
 

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -60,12 +60,13 @@ library NettingChannelLibrary {
     }
 
     modifier isCounterParty(Data storage self, address caller) {
-        Participant storage participant = self.participants[0];
-        if (participant.node_address != self.closing_address) {
-            participant = self.participants[1];
-            if (participant.node_address != caller) {
-                throw;
-            }
+        if (caller == self.closing_address) {
+            throw;
+        }
+        address participant0 = self.participants[0].node_address;
+        address participant1 = self.participants[1].node_address;
+        if (caller != participant0 && caller != participant1) {
+            throw;
         }
         _;
     }

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -108,7 +108,6 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     channel1.external_state.netting_channel.close(
         app1.raiden.address,
         transfermessage,
-        None,
     )
     wait_until_block(chain0, chain0.block_number() + 1)
 
@@ -195,7 +194,6 @@ def test_settled_lock(tokens_addresses, raiden_network, settle_timeout, reveal_t
     back_channel.external_state.netting_channel.close(
         app1.raiden.address,
         last_transfer,
-        None
     )
 
     # check that the double unlock will failed

--- a/raiden/tests/smart_contracts/DecoderTester.sol
+++ b/raiden/tests/smart_contracts/DecoderTester.sol
@@ -40,7 +40,7 @@ contract DecoderTester {
     }
 
     function testDecodeTransfer(bytes signed_transfer) returns (bool) {
-        data.close(msg.sender, signed_transfer, "");
+        data.close(msg.sender, signed_transfer);
         decoding_complete = true;
         return true;
     }

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -177,7 +177,6 @@ def test_reopen_channel(
     # settle the channel should not change the channel manager state
     nettingchannel.close(
         direct_transfer_data,
-        "",
         sender=privatekey1_raw,
     )
     tester_state.mine(number_of_blocks=settle_timeout + 1)
@@ -214,7 +213,6 @@ def test_reopen_channel(
     with pytest.raises(TransactionFailed):
         netting_contract_proxy1.close(
             direct_transfer_data,
-            "",
             sender=privatekey0_raw,
         )
 

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -1089,7 +1089,6 @@ def test_netting(
     previous_events = list(tester_events)
     nettingchannel.close(
         second_direct_transfer0_data,
-        direct_transfer1_data,
         sender=privatekey1_raw,
     )
     assert len(previous_events) + 1 == len(tester_events)
@@ -1102,6 +1101,11 @@ def test_netting(
         'closing_address': encode_hex(address1),
         'block_number': block_number,
     }
+
+    nettingchannel.updateTransfer(
+        direct_transfer1_data,
+        sender=privatekey0_raw,
+    )
 
     assert nettingchannel.closed(sender=privatekey0_raw) == block_number
     assert nettingchannel.closingAddress(sender=privatekey0_raw) == encode_hex(address1)

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -215,7 +215,7 @@ def test_closewithouttransfer_settle(
         nettingchannel.close(sender=unknown_key)
 
     previous_events = list(tester_events)
-    nettingchannel.close("", sender=privatekey0)
+    nettingchannel.close('', sender=privatekey0)
     assert len(previous_events) + 1 == len(tester_events)
 
     block_number = tester_state.block.number
@@ -312,7 +312,7 @@ def test_closewithouttransfer_badalice(
     channelBA.register_transfer(AB_Transfer1)
     AB_Transfer1_data = str(AB_Transfer1.packed().data)
 
-    nettingchannel.close("", sender=privatekeyA_raw)
+    nettingchannel.close('', sender=privatekeyA_raw)
 
     nettingchannel.updateTransfer(
         AB_Transfer1_data,

--- a/raiden/tests/smart_contracts/test_netting_channel.py
+++ b/raiden/tests/smart_contracts/test_netting_channel.py
@@ -215,7 +215,7 @@ def test_closewithouttransfer_settle(
         nettingchannel.close(sender=unknown_key)
 
     previous_events = list(tester_events)
-    nettingchannel.close("", "", sender=privatekey0)
+    nettingchannel.close("", sender=privatekey0)
     assert len(previous_events) + 1 == len(tester_events)
 
     block_number = tester_state.block.number
@@ -312,7 +312,7 @@ def test_closewithouttransfer_badalice(
     channelBA.register_transfer(AB_Transfer1)
     AB_Transfer1_data = str(AB_Transfer1.packed().data)
 
-    nettingchannel.close("", "", sender=privatekeyA_raw)
+    nettingchannel.close("", sender=privatekeyA_raw)
 
     nettingchannel.updateTransfer(
         AB_Transfer1_data,
@@ -358,7 +358,7 @@ def test_closesingle_settle(
         nettingchannel.close(sender=unknown_key)
 
     previous_events = list(tester_events)
-    nettingchannel.close(direct_transfer_data, "", sender=privatekey1_raw)
+    nettingchannel.close(direct_transfer_data, sender=privatekey1_raw)
     assert len(previous_events) + 1 == len(tester_events)
 
     block_number = tester_state.block.number
@@ -444,21 +444,18 @@ def test_close_settle(
     with pytest.raises(TransactionFailed):
         nettingchannel.close(
             str(direct_transfer0.packed().data),
-            str(direct_transfer1.packed().data),
             sender=unknown_key,
         )
     # the closing party should be the one that provides the first transfer
     with pytest.raises(TransactionFailed):
         nettingchannel.close(
             str(direct_transfer0.packed().data),
-            str(direct_transfer1.packed().data),
             sender=privatekey0_raw,
         )
 
     previous_events = list(tester_events)
     nettingchannel.close(
         str(direct_transfer0.packed().data),
-        str(direct_transfer1.packed().data),
         sender=privatekey1_raw,
     )
     assert len(previous_events) + 1 == len(tester_events)
@@ -474,6 +471,11 @@ def test_close_settle(
 
     assert nettingchannel.closed(sender=privatekey0_raw) == block_number
     assert nettingchannel.closingAddress(sender=privatekey0_raw) == encode_hex(address1)
+
+    nettingchannel.updateTransfer(
+        str(direct_transfer1.packed().data),
+        sender=privatekey0_raw,
+    )
 
     tester_state.mine(number_of_blocks=settle_timeout + 1)
 
@@ -563,14 +565,12 @@ def test_two_messages_mediated_transfer(
     with pytest.raises(TransactionFailed):
         nettingchannel.close(
             str(mediated_transfer0.packed().data),
-            str(mediated_transfer1.packed().data),
             sender=unknown_key,
         )
 
     previous_events = list(tester_events)
     nettingchannel.close(
         str(mediated_transfer0.packed().data),
-        str(mediated_transfer1.packed().data),
         sender=privatekey1_raw,
     )
     assert len(previous_events) + 1 == len(tester_events)
@@ -692,7 +692,6 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
 
     nettingchannel.close(
         second_direct_transfer0_data,
-        direct_transfer1_data,
         sender=privatekey1_raw,
     )
 
@@ -701,13 +700,6 @@ def test_update_direct_transfer(settle_timeout, tester_state, tester_channels, t
         nettingchannel.updateTransfer(
             third_direct_transfer0_data,
             sender=privatekey1_raw,
-        )
-
-    # nonce too low
-    with pytest.raises(TransactionFailed):
-        nettingchannel.updateTransfer(
-            first_direct_transfer0_data,
-            sender=privatekey0_raw,
         )
 
     nettingchannel.updateTransfer(
@@ -795,7 +787,6 @@ def test_update_mediated_transfer(
 
     nettingchannel.close(
         direct_transfer0_data,
-        direct_transfer1_data,
         sender=privatekey1_raw,
     )
 
@@ -867,7 +858,6 @@ def test_unlock(reveal_timeout, tester_token, tester_channels, tester_events, te
 
     nettingchannel.close(
         mediated_transfer1_data,
-        "",
         sender=privatekey1_raw,
     )
 
@@ -950,7 +940,7 @@ def test_if_updater_made_mistake(
     channelBA.register_transfer(BA_Transfer0)
     BA_Transfer0_data = str(BA_Transfer0.packed().data)
 
-    nettingchannel.close(BA_Transfer0_data, "", sender=privatekeyA_raw)
+    nettingchannel.close(BA_Transfer0_data, sender=privatekeyA_raw)
     nettingchannel.updateTransfer(
         AB_Transfer0_data,
         sender=privatekeyB_raw,
@@ -1002,7 +992,6 @@ def test_settlement_with_unauthorized_token_transfer(
 
     nettingchannel.close(
         str(direct_transfer0.packed().data),
-        str(direct_transfer1.packed().data),
         sender=privatekey1_raw,
     )
 
@@ -1010,6 +999,11 @@ def test_settlement_with_unauthorized_token_transfer(
 
     assert nettingchannel.closed(sender=privatekey0_raw) == block_number
     assert nettingchannel.closingAddress(sender=privatekey0_raw) == encode_hex(address1)
+
+    nettingchannel.updateTransfer(
+        str(direct_transfer1.packed().data),
+        sender=privatekey0_raw,
+    )
 
     tester_state.mine(number_of_blocks=settle_timeout + 1)
     nettingchannel.settle(sender=privatekey0_raw)

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -704,7 +704,6 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
     channel0.external_state.close(
         None,
         bob_last_transaction,
-        alice_old_transaction
     )
     chain0 = app0.raiden.chain
     wait_until_block(chain0, chain0.block_number() + 1)
@@ -714,6 +713,11 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout, reveal_timeo
 
     assert channel0.external_state.closed_block != 0
     assert channel1.external_state.closed_block != 0
+
+    channel1.external_state.update_transfer(
+        None,
+        direct_transfer,
+    )
 
     # wait until the settle timeout has passed
     settle_expiration = chain0.block_number() + settle_timeout

--- a/raiden/tests/utils/mock_client.py
+++ b/raiden/tests/utils/mock_client.py
@@ -429,25 +429,20 @@ class NettingChannelMock(object):
             'settle_timeout': self.contract.settle_timeout,
         }
 
-    def close(self, our_address, first_transfer, second_transfer):
+    def close(self, our_address, first_transfer):
         ctx = {
             'block_number': BlockChainServiceMock.block_number(),
             'msg.sender': our_address,
         }
 
         first_encoded = None
-        second_encoded = None
 
         if first_transfer is not None:
             first_encoded = first_transfer.encode()
 
-        if second_transfer is not None:
-            second_encoded = second_transfer.encode()
-
         self.contract.close(
             ctx,
             first_encoded,
-            second_encoded,
         )
 
         data = {

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -15,7 +15,6 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
-    get_encoded_transfers
 )
 from raiden.blockchain.abi import (
     TOKENADDED_EVENTID,
@@ -648,20 +647,18 @@ class NettingChannelTesterMock(object):
             data[2],
         ))
 
-    def close(self, our_address, their_transfer, our_transfer):
+    def close(self, our_address, their_transfer):
         """`our_address` is an argument used only in mock_client.py but is also
         kept here to maintain a consistent interface"""
-        their_encoded, our_encoded = get_encoded_transfers(their_transfer, our_transfer)
+        their_encoded = their_transfer.encode()
         self.proxy.close(
             their_encoded,
-            our_encoded,
         )
         self.tester_state.mine(number_of_blocks=1)
         log.info(
             'close called',
             contract=pex(self.address),
             their_transfer=their_transfer,
-            our_transfer=our_transfer,
         )
 
     def update_transfer(self, our_address, first_transfer):


### PR DESCRIPTION
This PR gets rid of the incremental nonce check since this
was a potential attack vector.
Furthermore this PR gets rid of the courtesy close. Some sort of
cooperative close should be implemented instead, but that is for another
issue.
Lastly it makes sure that `updateTransfer` can only be called once.