### PR TITLE
Fix tmux_test.sh

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -6,7 +6,7 @@ import click
 import gevent
 import gevent.monkey
 from ethereum import slogging
-from ethereum.utils import encode_hex, decode_hex
+from ethereum.utils import decode_hex
 
 from raiden.app import App
 from raiden.settings import INITIAL_PORT
@@ -150,8 +150,9 @@ def app(address,  # pylint: disable=too-many-arguments,too-many-locals
 
         address = addresses[idx]
 
-    privatekey = accmgr.get_privkey(address)
-    config['privatekey_hex'] = encode_hex(privatekey)
+    privatekey_hex = accmgr.get_privkey(address)
+    config['privatekey_hex'] = privatekey_hex
+    privatekey = decode_hex(privatekey_hex)
 
     endpoint = eth_rpc_endpoint
 
@@ -176,14 +177,16 @@ def app(address,  # pylint: disable=too-many-arguments,too-many-locals
 
     discovery = ContractDiscovery(
         blockchain_service.node_address,
-        blockchain_service.discovery(discovery_contract_address)
+        blockchain_service.discovery(
+            decode_hex(discovery_contract_address)
+        )
     )
 
     return App(config, blockchain_service, discovery)
 
 
 @click.option(  # FIXME: implement NAT-punching
-    '--external_listen_address',
+    '--external-listen-address',
     help='external "host:port" where the raiden service can be contacted on (through NAT).',
     default='',
     type=str,

--- a/tools/ansible/run-scenario.yaml
+++ b/tools/ansible/run-scenario.yaml
@@ -91,7 +91,7 @@
 
     - name: execute raidens asynchronously
       shell:
-        cmd: "{{ ansible_env.HOME }}/raidenvenv/bin/python {{ scenario_runner }} $(cat {{ ansible_env.HOME }}/raiden_flags.txt) --privatekey=$(cat {{ ansible_env.HOME }}/{{ item }}/privatekey.txt) --listen_address={{ ansible_ec2_local_ipv4 }}:{{ item }} --scenario={{ ansible_env.HOME }}/{{ item }}/scenario.json --logging=':WARNING' --logfile=raiden-{{ item }}.log --stage_prefix=raiden-{{ item }} --results_filename={{ ansible_ec2_public_ipv4 }}-{{ item }}.json"
+        cmd: "{{ ansible_env.HOME }}/raidenvenv/bin/python {{ scenario_runner }} $(cat {{ ansible_env.HOME }}/raiden_flags.txt) --privatekey=$(cat {{ ansible_env.HOME }}/{{ item }}/privatekey.txt) --listen-address={{ ansible_ec2_local_ipv4 }}:{{ item }} --scenario={{ ansible_env.HOME }}/{{ item }}/scenario.json --logging=':WARNING' --logfile=raiden-{{ item }}.log --stage-prefix=raiden-{{ item }} --results-filename={{ ansible_ec2_public_ipv4 }}-{{ item }}.json"
         chdir: "{{ user_home }}"
       async: 1200
       poll: 0

--- a/tools/config_builder.py
+++ b/tools/config_builder.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import json
-import random
 
 import click
 
@@ -93,6 +92,21 @@ def accounts(ctx, hosts, nodes_per_host):
 
 
 @click.argument(
+    'password',
+    type=str,
+)
+@click.argument(
+    'privatekey',
+    type=str,
+)
+@cli.command()
+@click.pass_context
+def private_to_account(ctx, privatekey, password):
+    account = Account.new(password.encode('ascii'), key=privatekey.encode('ascii'))
+    print account.dump()
+
+
+@click.argument(
     'hosts',
     nargs=-1,
     type=str,
@@ -136,7 +150,7 @@ def build_scenario(ctx, hosts, nodes_per_host, nodes_per_transfer):
     for asset_num in range(total_assets):
         data_for_asset = {
             "name": str(asset_num),
-            "channels": addresses[index : index + nodes_per_transfer],
+            "channels": addresses[index:index + nodes_per_transfer],
             "transfers_with_amount": {
                 addresses[index + nodes_per_transfer - 1]: 3000,
             }
@@ -315,10 +329,13 @@ config_builder.py account_file
 
 config_builder.py merge state_dump.json genesis.json
 -> merge the deployed contracts of state_dump.json into genesis.json and create
-a new genesis.json."""
+a new genesis.json.
+
+config_builder.py private_to_account deadbeef...feedbead password
+-> encrypt the privatekey "deadbeef...feadbead" with "password" and print json accountfile.
+"""
 
     print usage_text
-
 
 if __name__ == '__main__':
     cli(obj={})  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter

--- a/tools/create_compilation_dump.py
+++ b/tools/create_compilation_dump.py
@@ -99,8 +99,8 @@ def deploy_all(token_groups=None):
             account_alloc[key] = safe_lstrip_hex(value)
 
     raiden_flags = (
-        '--registry_contract_address {Registry}'
-        ' --discovery_contract_address {EndpointRegistry}'
+        '--registry-contract-address {Registry}'
+        ' --discovery-contract-address {EndpointRegistry}'
     ).format(**deployed)
 
     blockchain_config = dict(

--- a/tools/process_results.py
+++ b/tools/process_results.py
@@ -8,11 +8,11 @@ import click
 
 @click.command()
 @click.option(
-        '--results_dir',
+        '--results-dir',
         required=True,
         help='Directory with output json files from orchestration run.'
 )
-@click.option('--plot_filename', default='', help='Plot historic data to file.')
+@click.option('--plot-filename', default='', help='Plot historic data to file.')
 def process_results(results_dir, plot_filename):
     results = []
 

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -29,15 +29,15 @@ log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
     type=str,
 )
 @click.option(  # noqa
-    '--registry_contract_address',
+    '--registry-contract-address',
     type=str,
 )
 @click.option(  # noqa
-    '--discovery_contract_address',
+    '--discovery-contract-address',
     type=str,
 )
 @click.option(  # noqa
-    '--listen_address',
+    '--listen-address',
     type=str,
 )
 @click.option(  # noqa
@@ -55,11 +55,11 @@ log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
     type=click.File()
 )
 @click.option(  # noqa
-    '--stage_prefix',
+    '--stage-prefix',
     type=str
 )
 @click.option(  # noqa
-    '--results_filename',
+    '--results-filename',
     type=str
 )
 @click.command()

--- a/tools/tmuxtest.sh
+++ b/tools/tmuxtest.sh
@@ -36,7 +36,7 @@ function followlog() {
     logfile=$2
     tmux split-window -v -t "${target}"
     tmux resize-pane -t "${target}" -y 10
-    tmux send-keys -t "${target}" "sleep 10 && tail -f ${logfile}" C-m
+    tmux send-keys -t "${target}" "touch ${logfile} && tail -f ${logfile}" C-m
 }
 
 TEMP=$(mktemp -d "/tmp/raiden.XXXXX")

--- a/tools/tmuxtest.sh
+++ b/tools/tmuxtest.sh
@@ -154,9 +154,14 @@ am2=raiden.get_manager_by_asset_address('${TOKEN2}'.decode('hex'))
     tmux send-keys -t raiden:2 "geth --datadir ${TEMP} --password ${TEMP}/password account new" C-m
     tmux send-keys -t raiden:2 "geth --minerthreads 1 --nodiscover --rpc --rpcport ${GETHPORT} --mine --etherbase 0 --datadir ${TEMP}" C-m
 
-    tmux send-keys -t raiden:3 "$(printf "$RAIDEN_TEMPLATE" 40001 "${PRIVKEY1}" "${LOG1}")" C-m
-    tmux send-keys -t raiden:4 "$(printf "$RAIDEN_TEMPLATE" 40002 "${PRIVKEY2}" "${LOG2}")" C-m
-    tmux send-keys -t raiden:5 "$(printf "$RAIDEN_TEMPLATE" 40003 "${PRIVKEY3}" "${LOG3}")" C-m
+    tmux send-keys -t raiden:3 "$(printf "$RAIDEN_TEMPLATE" 40001 "${KEYSTORE1}" "${ADDRESS1}" "${LOG1}")" C-m
+    tmux send-keys -t raiden:4 "$(printf "$RAIDEN_TEMPLATE" 40002 "${KEYSTORE2}" "${ADDRESS2}" "${LOG2}")" C-m
+    tmux send-keys -t raiden:5 "$(printf "$RAIDEN_TEMPLATE" 40003 "${KEYSTORE3}" "${ADDRESS3}" "${LOG3}")" C-m
+    # wait for all password prompts to appear:
+    sleep 20
+    tmux send-keys -t raiden:3 "$(printf "nopassword")" C-m
+    tmux send-keys -t raiden:4 "$(printf "nopassword")" C-m
+    tmux send-keys -t raiden:5 "$(printf "nopassword")" C-m
 
     followlog raiden:3 $LOG1
     followlog raiden:4 $LOG2

--- a/tools/tmuxtest.sh
+++ b/tools/tmuxtest.sh
@@ -205,11 +205,13 @@ am2=raiden.get_manager_by_token_address('${TOKEN2}'.decode('hex'))
     tmux send-keys -t raiden:4 "${RAIDEN_VARIABLE_TEMPLATE}" C-m
     tmux send-keys -t raiden:5 "${RAIDEN_VARIABLE_TEMPLATE}" C-m
 
-    tmux send-keys -t raiden:3 "identifier = 1  # change this for each new transfer"
-    tmux send-keys -t raiden:3 "raiden.api.expect_exchange(identifier, '${TOKEN1}'.decode('hex'), 100, '${TOKEN2}'.decode('hex'), 70,  '${ADDRESS3}'.decode('hex'))"
+    tmux send-keys -t raiden:3 "identifier = 1  # change this for each new transfer" C-m
+    # exchange is not yet implemented
+    # tmux send-keys -t raiden:3 "raiden.api.expect_exchange(identifier, '${TOKEN1}'.decode('hex'), 100, '${TOKEN2}'.decode('hex'), 70,  '${ADDRESS3}'.decode('hex'))"
 
-    tmux send-keys -t raiden:5 "identifier = 1  # change this for each new transfer"
-    tmux send-keys -t raiden:5 "raiden.api.exchange(identifier, '${TOKEN1}'.decode('hex'), 100, '${TOKEN2}'.decode('hex'), 70,  '${ADDRESS1}'.decode('hex'))"
+    tmux send-keys -t raiden:5 "identifier = 1  # change this for each new transfer" C-m
+    # exchange is not yet implemented
+    # tmux send-keys -t raiden:5 "raiden.api.exchange(identifier, '${TOKEN1}'.decode('hex'), 100, '${TOKEN2}'.decode('hex'), 70,  '${ADDRESS1}'.decode('hex'))"
 }
 
 echo

--- a/tools/tmuxtest.sh
+++ b/tools/tmuxtest.sh
@@ -99,16 +99,27 @@ TOKEN1=$(jq -r ".config.token_groups[\"${ADDRESS1}\"]" $GENESIS)
 TOKEN2=$(jq -r ".config.token_groups[\"${ADDRESS2}\"]" $GENESIS)
 TOKEN3=$(jq -r ".config.token_groups[\"${ADDRESS3}\"]" $GENESIS)
 
-LOG1=${TEMP}/node1
-LOG2=${TEMP}/node2
-LOG3=${TEMP}/node3
+mkdir -p ${TEMP}/node{1..3}/keystore
+
+KEYSTORE1=${TEMP}/node1/keystore
+KEYSTORE2=${TEMP}/node2/keystore
+KEYSTORE3=${TEMP}/node3/keystore
+
+tools/config_builder.py private_to_account $PRIVKEY1 nopassword > ${KEYSTORE1}/raidenaccount.json
+tools/config_builder.py private_to_account $PRIVKEY2 nopassword > ${KEYSTORE2}/raidenaccount.json
+tools/config_builder.py private_to_account $PRIVKEY3 nopassword > ${KEYSTORE3}/raidenaccount.json
+
+LOG1=${TEMP}/node1/raiden.log
+LOG2=${TEMP}/node2/raiden.log
+LOG3=${TEMP}/node3/raiden.log
 
 RAIDEN_CONTRACTS=$(jq -r .config.raidenFlags $GENESIS)
 
-RAIDEN_TEMPLATE="python raiden/app.py \
-    --eth_rpc_endpoint 127.0.0.1:${GETHPORT} \
-    --listen_address 0.0.0.0:%s \
-    --privatekey=%s \
+RAIDEN_TEMPLATE="raiden \
+    --eth-rpc-endpoint 127.0.0.1:${GETHPORT} \
+    --listen-address 0.0.0.0:%s \
+    --keystore-path=%s \
+    --address=%s \
     $RAIDEN_CONTRACTS \
     --logging ':DEBUG' \
     --logfile %s"

--- a/tools/tmuxtest.sh
+++ b/tools/tmuxtest.sh
@@ -128,12 +128,12 @@ RAIDEN_VARIABLE_TEMPLATE="
 raiden1='${ADDRESS1}'
 raiden2='${ADDRESS2}'
 raiden3='${ADDRESS3}'
-asset1='${TOKEN1}'
-asset2='${TOKEN2}'
-asset3='${TOKEN3}'
-am1=raiden.get_manager_by_asset_address('${TOKEN1}'.decode('hex'))
-am2=raiden.get_manager_by_asset_address('${TOKEN2}'.decode('hex'))
-# am3=raiden.get_manager_by_asset_address('${TOKEN3}'.decode('hex'))"
+token1='${TOKEN1}'
+token2='${TOKEN2}'
+token3='${TOKEN3}'
+am1=raiden.get_manager_by_token_address('${TOKEN1}'.decode('hex'))
+am2=raiden.get_manager_by_token_address('${TOKEN2}'.decode('hex'))
+# am3=raiden.get_manager_by_token_address('${TOKEN3}'.decode('hex'))"
 
 [ "$SETUP_TMUX" -eq 1 ] && {
     info "creating the tmux windows/panels"
@@ -175,18 +175,18 @@ am2=raiden.get_manager_by_asset_address('${TOKEN2}'.decode('hex'))
 [ "$SETUP_CHANNELS" -eq 1 ] && {
     info "configuring the raiden channels"
     printf "      %64s %40s %s\n" PRIVKEY ADDRESS CHANNELS
-    echo "node1 ${PRIVKEY1} ${ADDRESS1} both assets with balance"
-    echo "node2 ${PRIVKEY2} ${ADDRESS2} both assets with balance"
-    echo "node3 ${PRIVKEY3} ${ADDRESS3} both assets but asset2 has no balance"
+    echo "node1 ${PRIVKEY1} ${ADDRESS1} both tokens with balance"
+    echo "node2 ${PRIVKEY2} ${ADDRESS2} both tokens with balance"
+    echo "node3 ${PRIVKEY3} ${ADDRESS3} both tokens but token2 has no balance"
 
-    # assume the genesis file alredy has distributed asset to all nodes
+    # assume the genesis file alredy has distributed token to all nodes
 
-    tmux send-keys -t raiden:3 "tools.register_asset('${TOKEN1}')" C-m
-    tmux send-keys -t raiden:3 "tools.register_asset('${TOKEN2}')" C-m
-    # tmux send-keys -t raiden:3 "tools.register_asset('${TOKEN3}')" C-m
+    tmux send-keys -t raiden:3 "tools.register_token('${TOKEN1}')" C-m
+    tmux send-keys -t raiden:3 "tools.register_token('${TOKEN2}')" C-m
+    # tmux send-keys -t raiden:3 "tools.register_token('${TOKEN3}')" C-m
 
-    tmux send-keys -t raiden:4 "import time; time.sleep(10)  # wait for asset registration"  C-m
-    tmux send-keys -t raiden:5 "import time; time.sleep(10 + 10)  # wait for asset registration and channel openning"  C-m
+    tmux send-keys -t raiden:4 "import time; time.sleep(10)  # wait for token registration"  C-m
+    tmux send-keys -t raiden:5 "import time; time.sleep(10 + 10)  # wait for token registration and channel openning"  C-m
 
     tmux send-keys -t raiden:3 "tools.open_channel_with_funding('${TOKEN1}', '${ADDRESS2}', 100)" C-m
     tmux send-keys -t raiden:3 "tools.open_channel_with_funding('${TOKEN2}', '${ADDRESS2}', 100)" C-m


### PR DESCRIPTION
The script missed a lot of changes. 
This PR makes it functional again, it is a neat little helper for a DEMO:
- creates a private `geth` backend
- deploys the raiden contracts
- creates tokens/balances for several clients
- starts all clients
- creates example channels
- drops all clients into CLI interface -> take your DEMO from here