### PR TITLE
Allow to store and use precompiled ABIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ target/
 truffle/.babel.json
 truffle/environments/development/contracts/
 truffle/.bash_history
+
+# never check in .static-abi.json files
+*.static-abi.json

--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import os
 import json
 import hashlib
 
 from ethereum import _solidity
 from ethereum.abi import event_id, normalize_name
-from raiden.utils import get_contract_path, STORE_PRECOMPILED
+from raiden.utils import get_contract_path
 
 __all__ = (
     'REGISTRY_ABI',
@@ -58,7 +59,6 @@ def get_eventname_types(event_description):
 def get_static_or_compile(
         contract_path,
         contract_name,
-        store_updated=STORE_PRECOMPILED,
         **compiler_flags):
     """Search the path of `contract_path` for a file with the same name and the
     extension `.static-abi.json`. If the file exists, and the recorded checksum
@@ -72,6 +72,8 @@ def get_static_or_compile(
         file on checksum mismatch/if file does not exist.
         **compiler_flags (dict): flags that will be passed to the compiler
     """
+    # this will be set by `setup.py compile_contracts`
+    store_updated = os.environ.get('STORE_PRECOMPILED', False)
     precompiled = None
     precompiled_path = '{}.static-abi.json'.format(contract_path)
     try:

--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -99,8 +99,8 @@ def get_static_or_compile(
     return compiled
 
 
-def contract_checksum(contract_file):
-    with open(get_contract_path(contract_file)) as f:
+def contract_checksum(contract_path):
+    with open(contract_path) as f:
         checksum = hashlib.sha1(f.read()).hexdigest()
         return checksum
 

--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -65,11 +65,14 @@ def get_static_or_compile(
     matches, this will return the precompiled contract, otherwise it will
     compile it.
 
+    Writing compiled contracts to the desired file and path happens only when
+    the environment variable `STORE_PRECOMPILED` is set (to whatever value).
+    Users are not expected to ever set this value, the functionality is exposed
+    through the `setup.py compile_contracts` command.
+
     Args:
         contract_path (str): the path of the contract file
         contract_name (str): the contract name
-        store_updated (bool): if True, this will write a new `.static-abi.json`
-        file on checksum mismatch/if file does not exist.
         **compiler_flags (dict): flags that will be passed to the compiler
     """
     # this will be set by `setup.py compile_contracts`

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -30,13 +30,6 @@ __all__ = (
     'camel_to_snake_case'
 )
 
-# change this flag, if you want to raiden.blockchain.abi to store precompiled
-# ABIs:
-# >>> from raiden import utils
-# >>> utils.STORE_PRECOMPILED = True
-# >>> from raiden.blockchain import abi
-STORE_PRECOMPILED = False
-
 LETTERS = string.printable
 
 # From the secp256k1 header file:

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -30,6 +30,13 @@ __all__ = (
     'camel_to_snake_case'
 )
 
+# change this flag, if you want to raiden.blockchain.abi to store precompiled
+# ABIs:
+# >>> from raiden import utils
+# >>> utils.STORE_PRECOMPILED = True
+# >>> from raiden.blockchain import abi
+STORE_PRECOMPILED = False
+
 LETTERS = string.printable
 
 # From the secp256k1 header file:

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,10 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
     ],
-    cmdclass={'test': PyTest,
-              'compile_contracts': CompileContracts},
+    cmdclass={
+        'test': PyTest,
+        'compile_contracts': CompileContracts,
+    },
     install_requires=install_requires,
     tests_require=test_requirements,
     entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@
 
 try:
     from setuptools import setup
+    from setuptools import Command
 except ImportError:
     from distutils.core import setup
+    from distutils.cmd import Command
 from setuptools.command.test import test as TestCommand
 
 
@@ -20,6 +22,22 @@ class PyTest(TestCommand):
         import pytest
         errno = pytest.main(self.test_args)
         raise SystemExit(errno)
+
+
+class CompileContracts(Command):
+    description = "compile contracts to json"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        from raiden import utils
+        utils.STORE_PRECOMPILED = True
+        from raiden.blockchain import abi
 
 
 with open('README.md') as readme_file:
@@ -73,7 +91,8 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
     ],
-    cmdclass={'test': PyTest},
+    cmdclass={'test': PyTest,
+              'compile_contracts': CompileContracts},
     install_requires=install_requires,
     tests_require=test_requirements,
     entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 
 try:
     from setuptools import setup
@@ -35,8 +36,7 @@ class CompileContracts(Command):
         pass
 
     def run(self):
-        from raiden import utils
-        utils.STORE_PRECOMPILED = True
+        os.environ['STORE_PRECOMPILED'] = 'yes'
         from raiden.blockchain import abi
 
 


### PR DESCRIPTION
This adds tooling to read the contract ABIs from a json file instead of compiling them at runtime. It will always check the contract source files against a recorded `sha1` checksum (and compile in case of a mismatch).

Unless the environment variable `STORE_PRECOMPILED` is set, the compiled ABIs will not be stored. There is a command in `setup.py` that stores the current contract ABIs in the expected format and place.

Usage:

    python setup.py compile_contracts

Fixes #428