### PR TITLE
Use upstream ethereum>=1.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ secp256k1==0.12.1
 pycryptodome>=3.4.3
 miniupnpc
 networkx
-# temporary until new version of pyethereum is released, that supports solc >= v0.4.9
--e git+https://github.com/LefterisJP/pyethereum@fix_solidity_key_combinedjson#egg=ethereum
+ethereum>=1.6.1
 ethereum-serpent
 repoze.lru
 gevent-websocket==0.9.4

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ history = ''
 
 install_requires_replacements = {
     "-e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp": "pyethapp",
-    "-e git+https://github.com/LefterisJP/pyethereum@fix_solidity_key_combinedjson#egg=ethereum": "ethereum"
 }
 
 install_requires = list(set(


### PR DESCRIPTION
Our forked dependency was necessary for make `ethereum` work with solidity>=0.4.9.
The PR was merged and released, so we can go back to the upstream.

Fixes #418