### PR TITLE
Fixes incompatible dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ pysha3
 # temporary until new version of pyethereum is released, that supports solc >= v0.4.9
 -e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp
 ipython<5.0.0
-rlp>=0.4.3,<=0.4.6
-secp256k1==0.12.1
+rlp>=0.4.3
+secp256k1>=0.12.1
 pycryptodome>=3.4.3
 miniupnpc
 networkx


### PR DESCRIPTION
Fixes the following 2 errors:

- `error: rlp 0.4.6 is installed but rlp==0.4.7 is required by set(['devp2p'])`
- `error: secp256k1 0.12.1 is installed but secp256k1==0.13.2 is required by set(['devp2p'])`