### PR TITLE
Improve rpc client concurrency

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -102,17 +102,10 @@ def patch_send_transaction(client, nonce_offset=0):
             query_time = now()
             needs_update = abs(query_time - client.last_nonce_update) > UPDATE_INTERVAL
             not_initialized = client.current_nonce is None
-            log.DEV(
-                "get_nonce called",
-                needs_update=needs_update,
-                not_initialized=not_initialized,
-                current=client.current_nonce,
-                instance=hex(id(client))[-4:]
-            )
             if needs_update or not_initialized:
                 nonce = _query_nonce()
                 while nonce < client.current_nonce:
-                    log.DEV(
+                    log.debug(
                         "nonce on server too low",
                         server=nonce,
                         local=client.current_nonce


### PR DESCRIPTION
#### Improve rpc calls to `eth_sendTransaction` to be more stable in situations of high concurrency

In situations with high concurrency there are two potential error conditions with our current nonce querying method:

1) the remote (blockchain rpc service) may not have updated the pending transaction count in time
2) two transactions may ask for the transaction count/nonce concurrently

I added a local nonce counter to avoid cases of 1) and added a locking Semaphore block around the newly introduced `get_nonce` method to avoid cases of 2) (see `raiden/network/rpc/client.py`).
