### PR TITLE
fixed tmux test and config_builder

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -24,11 +24,12 @@ from raiden.encoding import messages
 from raiden.messages import SignedMessage
 from raiden.network.protocol import RaidenProtocol
 from raiden.utils import (
-    privatekey_to_address,
+    channel_to_api_dict,
     isaddress,
     pex,
+    privatekey_to_address,
+    safe_address_decode,
     GLOBAL_CTX,
-    channel_to_api_dict
 )
 
 
@@ -36,15 +37,6 @@ log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 EventListener = namedtuple('EventListener', ('event_name', 'filter_', 'translator'))
-
-
-def safe_address_decode(address):
-    try:
-        address = address.decode('hex')
-    except TypeError:
-        pass
-
-    return address
 
 
 class RaidenError(Exception):

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -155,7 +155,15 @@ def app(address,  # pylint: disable=too-many-arguments,too-many-locals
 
         address = addresses[idx]
 
-    privatekey_bin = accmgr.get_privkey(address)
+    try:
+        privatekey_bin = accmgr.get_privkey(address)
+    except ValueError as e:
+        # ValueError exception raised if the password is incorrect, print the
+        # exception message and exit the process, the user may try again by
+        # re-executing Raiden.
+        print(e.message)
+        sys.exit(1)
+
     privatekey_hex = privatekey_bin.encode('hex')
     config['privatekey_hex'] = privatekey_hex
 
@@ -185,6 +193,11 @@ def app(address,  # pylint: disable=too-many-arguments,too-many-locals
             port=rpc_port,
         )
     except ValueError as e:
+        # ValueError exception raised if:
+        # - The registry contract address doesn't have code, this might happen
+        # if the connected geth process is not synced or if the wrong address
+        # is provided (e.g. using the address from a smart contract deployed on
+        # ropsten with a geth node connected to morden)
         print(e.message)
         sys.exit(1)
 

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -53,6 +53,15 @@ LETTERS = string.printable
 GLOBAL_CTX = secp256k1.lib.secp256k1_context_create(secp256k1.ALL_FLAGS)
 
 
+def safe_address_decode(address):
+    try:
+        address = address.decode('hex')
+    except TypeError:
+        pass
+
+    return address
+
+
 def keccak_256(data):
     return keccaklib.new(digest_bits=256, data=data)
 

--- a/tools/config_builder.py
+++ b/tools/config_builder.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
-
 import json
 
 import click
-
-from genesis_builder import generate_accounts, mk_genesis
-from create_compilation_dump import deploy_all
-from startcluster import RAIDEN_PORT as START_PORT
-from startcluster import create_node_configuration, to_cmd
 from pyethapp.accounts import Account
+
+from create_compilation_dump import deploy_all
+from genesis_builder import generate_accounts, mk_genesis
+from raiden.utils import safe_address_decode
+from startcluster import create_node_configuration, to_cmd
+from startcluster import RAIDEN_PORT as START_PORT
 
 
 def build_node_list(hosts, nodes_per_host):
@@ -102,7 +102,14 @@ def accounts(ctx, hosts, nodes_per_host):
 @cli.command()
 @click.pass_context
 def private_to_account(ctx, privatekey, password):
-    account = Account.new(password.encode('ascii'), key=privatekey.encode('ascii'))
+    # privatekey is provided in the console, so it's expected to be hexadecimal
+    privatekey = safe_address_decode(privatekey)
+
+    # cast the values to bytes because it is the expected type in the Crypto library
+    password = bytes(password)
+    privkey = bytes(privatekey)
+
+    account = Account.new(password, key=privkey)
     print account.dump()
 
 


### PR DESCRIPTION
- added a utility to test if raiden can be execute from inside a newly
created session with the provided configuration
- remove the `-g` flag in favor of the `-d` flag to speed up consective
executions of the script (encrypting the keystore is slow)
- fixed the config_builder.py keystore command, the private key was not
being decoded from hexadecimal
- removed the function keyword as it seems to be zsh specific