### PR TITLE
Make Raiden compatible with geth v1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   global:
-    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.5-ff07d548.tar.gz'
-    - GETH_VERSION='1.5.5'
+    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.0-facc47cb.tar.gz'
+    - GETH_VERSION='1.6.0'
     - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.10/solc'
     - SOLC_VERSION='0.4.10'
   matrix:

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -12,7 +12,7 @@ from ethereum._solidity import compile_file
 from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import address_decoder, address_encoder, default_gasprice
 
-from raiden.utils import privatekey_to_address, get_contract_path, safe_lstrip_hex
+from raiden.utils import privatekey_to_address, get_contract_path
 from raiden.network.transport import DummyTransport
 from raiden.tests.fixtures.tester import tester_state
 from raiden.tests.utils.blockchain import GENESIS_STUB, DEFAULT_BALANCE_BIN

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -180,7 +180,10 @@ def cached_genesis(request, blockchain_type):
         if account_alloc['storage']:
             new_storage = dict()
             for key, val in account_alloc['storage'].iteritems():
-                new_key = '0x%064x' % int(key, 16)
+                # account_to_dict() from pyethereum can return 0x for a storage
+                # position. That is an invalid way of representing 0x0, which we
+                # have to take care of here.
+                new_key = '0x%064x' % int(key if key != '0x' else '0x0', 16)
                 new_val = '0x%064x' % int(val, 16)
                 new_storage[new_key] = new_val
 

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -87,7 +87,6 @@ def geth_to_cmd(node, datadir, verbosity):
         '--ipcdisable',
         '--rpc',
         '--rpcaddr', '0.0.0.0',
-        '--jitvm=false',
         '--networkid', '627',
         '--verbosity', str(verbosity),
         '--fakepow',


### PR DESCRIPTION
([Confirmed](https://github.com/raiden-network/raiden/pull/472#issuecomment-290338547) as expected) ~I am not 100% sure if this is expected behaviour~ but with the latest geth master version custom genesis file parsing is becoming more strict.

If you append the `--blockchain-cache` argument while running the tests with latest geth then you are bound to hit the same problem.

Make sure to remove all caches before attempting to run this branch. If you don't you will still load the old cached genesis file. To do that run the following from the raiden root directory:

`rm -rf /tmp/<username>/pytest-of-<username>/pytest-* && rm -rf .cache `

Naturally replace `<username>` with your username.

In order to have the cached genesis accepted by geth the following were
done:

- Make sure that all hex is prefixed with 0x.
- Nonces must be encoded as hex strings of length 16.
- Storage key/values must be encoded as hex strings of length 64.

I am still waiting for confirmation from the geth developers if these requirements are here to stay. Let's keep this here until we hear from them.