### PR TITLE
Bootnodes and nodekeyhex seem to be unused in test

### DIFF
--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -253,9 +253,10 @@ def geth_create_blockchain(
             pub=config['pub'],
             port=config['port'],
         )
-        config['bootnodes'] = ','.join(node['enode'] for node in nodes_configuration)
-
         nodes_configuration.append(config)
+
+    for config in nodes_configuration:
+        config['bootnodes'] = ','.join(node['enode'] for node in nodes_configuration)
 
     all_keys = list(private_keys)
     all_keys.append(deploy_key)  # needs to be at the end because of the minerthreads keys


### PR DESCRIPTION
I don't see a reason to have bootnodes and as an extension nodekeyhex in
the test geth arguments.

If there is a reason then then at least the argument should be sanitized
to not be given without a value as I have seen it multiple times given
without a bootnode value in tests.

We are lucky geth accepts this at the moment, but this should not be our
default behaviour.