### PR TITLE
Check available memory before running the geth miner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: true
 
 language: python
 python:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pytest-timeout>=1.2.0
 pytest-random>=0.02
 pytest-cov
 grequests
+psutil
 
 # Debugging
 pdbpp>=0.8.3<1.0.0


### PR DESCRIPTION
If the system running the tests doesn't have enough memory to keep all
the DAG in the main memory the POW process will be slower than expected,
resulting in test flakiness, specifically for the tests that depend on
the confirmation of transactions, since this is a hard to diagnose
problem this commit adds an explicit check for the free memory and fails
the tests early. Note this will only fail the tests that are using the
geth miner, nothing happens with the purely unit/tester tests.