### PR TITLE
Add restful API tests to travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   matrix:
     - TEST_TYPE='unit'
     - TEST_TYPE='smart_contracts'
+    - TEST_TYPE='api' BLOCKCHAIN_TYPE='--blockchain-type=tester'
+    - TEST_TYPE='api' BLOCKCHAIN_TYPE='--blockchain-type=geth'
 
     - TEST_TYPE='integration' BLOCKCHAIN_TYPE='--blockchain-type=tester'
     - TEST_TYPE='integration' BLOCKCHAIN_TYPE='--blockchain-type=geth --blockchain-cache'


### PR DESCRIPTION
The api tests are in their own branch of the `tests` directory tree. I defined two more test matrix entries in `.travis.yml`.