### PR TITLE
Expose tokenswap in api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -234,7 +234,7 @@ Possible Responses
 Token Swaps
 ------------
 
-You can perform a token swap by using the token_swap endpoint. A swap consists of two users agreeing on atomically exchanging two different tokens at a particular exchange rate.
+You can perform a token swap by using the ``token_swaps`` endpoint. A swap consists of two users agreeing on atomically exchanging two different tokens at a particular exchange rate.
 
 By making a ``PUT`` request to ``/api/<version>/token_swaps/<target_address>/<identifier>`` you can either initiate or participate in a token swap with a specific user. The details, along with the role, come as part of the json payload.
 
@@ -268,6 +268,8 @@ and the taker (in our case ``0x61c808d82a3ac53231750dadc13c777b59310bd9``) would
         "receiving_amount": 42,
         "receiving_token": "0xea674fdde714fd979de3edf0f56aa9716b898ec8"
     }
+
+Please note that the sending/reveiving amount and token is always from the perspective of each node. That is why you see the reverse values in the two different examples.
 
 Example Response
 ^^^^^^^^^^^^^^^^

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -236,14 +236,14 @@ Token Swaps
 
 You can perform a token swap by using the token_swap endpoint. A swap consists of two users agreeing on atomically exchanging two different tokens at a particular exchange rate.
 
-By making a ``PUT`` request to ``/api/<version>/token_swaps/<identifier>`` you can either initiate or participate in a token swap. The details, along with the role, come as part of the json payload.
+By making a ``PUT`` request to ``/api/<version>/token_swaps/<target_address>/<identifier>`` you can either initiate or participate in a token swap with a specific user. The details, along with the role, come as part of the json payload.
 
 Example Request
 ^^^^^^^^^^^^^^^
 
-The maker would do
+The maker (in our case ``0xbbc5ee8be95683983df67260b0ab033c237bde60``) would do
 
-``PUT /api/1/token_swaps/1337``
+``PUT /api/1/token_swaps/0x61c808d82a3ac53231750dadc13c777b59310bd9/1337``
 
 with payload
 ::
@@ -256,7 +256,9 @@ with payload
         "receiving_token": "0x2a65aca4d5fc5b5c859090a6c34d164135398226"
     }
 
-and the taker would use the same endpoint but with the following payload
+and the taker (in our case ``0x61c808d82a3ac53231750dadc13c777b59310bd9``) would use:
+``PUT /api/1/token_swaps/0xbbc5ee8be95683983df67260b0ab033c237bde60/1337``
+
 ::
 
     {

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -231,7 +231,62 @@ Possible Responses
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+
 
+Token Swaps
+------------
 
+You can perform a token swap by using the token_swap endpoint. A swap consists of two users agreeing on atomically exchanging two different tokens at a particular exchange rate.
+
+By making a ``PUT`` request to ``/api/<version>/token_swaps/<identifier>`` you can either initiate or participate in a token swap. The details, along with the role, come as part of the json payload.
+
+Example Request
+^^^^^^^^^^^^^^^
+
+The maker would do
+
+``PUT /api/1/token_swaps/1337``
+
+with payload
+::
+
+    {
+        "role": "maker",
+        "sending_amount": 42,
+        "sending_token": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+        "receiving_amount": 76,
+        "receiving_token": "0x2a65aca4d5fc5b5c859090a6c34d164135398226"
+    }
+
+and the taker would use the same endpoint but with the following payload
+::
+
+    {
+        "role": "taken",
+        "sending_amount": 76,
+        "sending_token": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
+        "receiving_amount": 42,
+        "receiving_token": "0xea674fdde714fd979de3edf0f56aa9716b898ec8"
+    }
+
+Example Response
+^^^^^^^^^^^^^^^^
+``200 OK``
+
+Possible Responses
+^^^^^^^^^^^^^^^^^^
+
++------------------+---------------------------+
+| HTTP Code        | Condition                 |
++==================+===========================+
+| 201 Created      | For succesful Creation    |
++------------------+---------------------------+
+| 400 Bad Request  | If the provided json is in|
+|                  | some way malformed        |
++------------------+---------------------------+
+| 408 Request      | If the token swap         |
+|     Timeout      | operation times out       |
++------------------+---------------------------+
+| 500 Server Error | Internal Raiden node error|
++------------------+---------------------------+
 
 Channel Management
 ==================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -260,7 +260,7 @@ and the taker would use the same endpoint but with the following payload
 ::
 
     {
-        "role": "taken",
+        "role": "taker",
         "sending_amount": 76,
         "sending_token": "0x2a65aca4d5fc5b5c859090a6c34d164135398226",
         "receiving_amount": 42,

--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -71,7 +71,14 @@ class ChannelNew(object):
 
 class ChannelNewBalance(object):
 
-    def __init__(self, netting_channel_address, token_address, participant_address, new_balance, block_number):
+    def __init__(
+            self,
+            netting_channel_address,
+            token_address,
+            participant_address,
+            new_balance,
+            block_number):
+
         self.netting_channel_address = netting_channel_address
         self.token_address = token_address
         self.participant_address = participant_address

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -102,7 +102,7 @@ class APIServer(object):
         )
         self.add_resource(
             TokenSwapsResource,
-            '/token_swaps/<int:identifier>'
+            '/token_swaps/<hexaddress:target_address>/<int:identifier>'
         )
 
     def _register_type_converters(self, additional_mapping=None):
@@ -302,21 +302,21 @@ class RestAPI(object):
 
     def token_swap(
             self,
+            target_address,
             identifier,
             role,
             sending_token,
             sending_amount,
             receiving_token,
             receiving_amount):
+
         if role == 'maker':
             self.raiden_api.exchange(
                 from_token=sending_token,
                 from_amount=sending_amount,
                 to_token=receiving_token,
                 to_amount=receiving_amount,
-                # TODO: What should target_address be, how is the identifier
-                # used inside the token swap to identify the target?
-                target_address=None,
+                target_address=target_address,
             )
         elif role == 'taker':
             self.raiden_api.expect_exchange(
@@ -325,9 +325,7 @@ class RestAPI(object):
                 from_amount=sending_amount,
                 to_token=receiving_token,
                 to_amount=receiving_amount,
-                # TODO: What should target_address be, how is the identifier
-                # used inside the token swap to identify the target?
-                target_address=None,
+                target_address=target_address,
             )
         else:
             # should never happen, role is validated in the schema

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -62,7 +62,8 @@ class BaseSchema(Schema):
 
     @post_load
     def make_object(self, data):
-        # this will depend on the Schema used, which has its object class in the class Meta attributes
+        # this will depend on the Schema used, which has its object class
+        # in the class Meta attributes
         decoding_class = self.opts.decoding_class
         return decoding_class(**data)
 
@@ -72,8 +73,9 @@ class BaseListSchema(Schema):
 
     @pre_load
     def wrap_data_envelope(self, data):
-        # because the EventListSchema and ChannelListSchema ojects need to have some field ('data'),
-        # the data has to be enveloped in the internal representation to comply with the Schema
+        # because the EventListSchema and ChannelListSchema objects need to
+        # have some field ('data'), the data has to be enveloped in the internal
+        # representation to comply with the Schema
         data = dict(data=data)
         return data
 
@@ -100,7 +102,7 @@ class EventRequestSchema(BaseSchema):
 
 class TokenSchema(BaseSchema):
     """Simple token schema only with an address field. In the future we could
-add other attributes like 'name'"""
+    add other attributes like 'name'"""
     address = AddressField()
 
     class Meta:
@@ -171,3 +173,24 @@ class ChannelListSchema(BaseListSchema):
     class Meta:
         strict = True
         decoding_class = ChannelList
+
+
+class TokenSwapsSchema(BaseSchema):
+    # The identifier is actually returned properly without this, but if this
+    # is included we get a "missing" error.
+    # XXX: Lef does not like this. Find out why flask behaves like that.
+    # identifier = fields.Integer(required=True)
+
+    role = fields.String(
+        required=True,
+        validate=validate.OneOf(['maker', 'taker']),
+        location='json',
+    )
+    sending_amount = fields.Integer(required=True, location='json')
+    sending_token = AddressField(required=True, location='json')
+    receiving_amount = fields.Integer(required=True, location='json')
+    receiving_token = AddressField(required=True, location='json')
+
+    class Meta:
+        strict = True
+        decoding_class = dict

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -6,6 +6,7 @@ from flask import Blueprint
 from raiden.api.v1.encoding import (
     ChannelRequestSchema,
     EventRequestSchema,
+    TokenSwapsSchema,
 )
 
 
@@ -120,4 +121,23 @@ class ChannelEventsResource(BaseResource):
             kwargs['channel_address'],
             kwargs['from_block'],
             kwargs['to_block']
+        )
+
+
+class TokenSwapsResource(BaseResource):
+
+    put_schema = TokenSwapsSchema()
+
+    def __init__(self, **kwargs):
+        super(TokenSwapsResource, self).__init__(**kwargs)
+
+    @use_kwargs(put_schema)
+    def put(self, **kwargs):
+        return self.rest_api.token_swap(
+            kwargs['identifier'],
+            kwargs['role'],
+            kwargs['sending_token'],
+            kwargs['sending_amount'],
+            kwargs['receiving_token'],
+            kwargs['receiving_amount'],
         )

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -133,11 +133,4 @@ class TokenSwapsResource(BaseResource):
 
     @use_kwargs(put_schema)
     def put(self, **kwargs):
-        return self.rest_api.token_swap(
-            kwargs['identifier'],
-            kwargs['role'],
-            kwargs['sending_token'],
-            kwargs['sending_amount'],
-            kwargs['receiving_token'],
-            kwargs['receiving_amount'],
-        )
+        return self.rest_api.token_swap(**kwargs)

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -132,5 +132,21 @@ class TokenSwapsResource(BaseResource):
         super(TokenSwapsResource, self).__init__(**kwargs)
 
     @use_kwargs(put_schema)
-    def put(self, **kwargs):
-        return self.rest_api.token_swap(**kwargs)
+    def put(
+            self,
+            target_address,
+            identifier,
+            role,
+            sending_token,
+            sending_amount,
+            receiving_token,
+            receiving_amount):
+        return self.rest_api.token_swap(
+            target_address=target_address,
+            identifier=identifier,
+            role=role,
+            sending_token=sending_token,
+            sending_amount=sending_amount,
+            receiving_token=receiving_token,
+            receiving_amount=receiving_amount
+        )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -417,13 +417,8 @@ class RaidenAPI(object):
         return channel
 
     def exchange(self, from_token, from_amount, to_token, to_amount, target_address):
-        from_token_bin = safe_address_decode(from_token)
-        to_token_bin = safe_address_decode(to_token)
-        target_bin = safe_address_decode(target_address)
-
         try:
-            self.raiden.get_manager_by_token_address(from_token_bin)
-            self.raiden.get_manager_by_token_address(from_token_bin)
+            self.raiden.get_manager_by_token_address(from_token)
         except UnknownTokenAddress as e:
             log.error(
                 'no token manager for %s',
@@ -433,11 +428,11 @@ class RaidenAPI(object):
 
         task = StartExchangeTask(
             self.raiden,
-            from_token_bin,
+            from_token,
             from_amount,
-            to_token_bin,
+            to_token,
             to_amount,
-            target_bin,
+            target_address,
         )
         task.start()
         return task

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -569,9 +569,13 @@ def test_api_token_swaps(api_test_server, api_test_context, api_raiden_service):
         'receiving_amount': 76,
         'receiving_token': '0x2a65aca4d5fc5b5c859090a6c34d164135398226'
     }
-    api_test_context.specify_tokenswap_input(tokenswap_obj, None)
+    api_test_context.specify_tokenswap_input(
+        tokenswap_obj,
+        "0x61c808d82a3ac53231750dadc13c777b59310bd9",
+        1337
+    )
     request = grequests.put(
-        'http://localhost:5001/api/1/token_swaps/1337',
+        'http://localhost:5001/api/1/token_swaps/0x61c808d82a3ac53231750dadc13c777b59310bd9/1337',
         json=tokenswap_obj
     )
     response = request.send().response
@@ -584,9 +588,13 @@ def test_api_token_swaps(api_test_server, api_test_context, api_raiden_service):
         'receiving_amount': 42,
         'receiving_token': '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
     }
-    api_test_context.specify_tokenswap_input(tokenswap_obj, 1337)
+    api_test_context.specify_tokenswap_input(
+        tokenswap_obj,
+        "0xbbc5ee8be95683983df67260b0ab033c237bde60",
+        1337
+    )
     request = grequests.put(
-        'http://localhost:5001/api/1/token_swaps/1337',
+        'http://localhost:5001/api/1/token_swaps/0xbbc5ee8be95683983df67260b0ab033c237bde60/1337',
         json=tokenswap_obj
     )
     response = request.send().response

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -559,3 +559,35 @@ def test_break_blockchain_events(
         'event_type': 'ChannelSettled',
         'block_number': 35,
     }
+
+
+def test_api_token_swaps(api_test_server, api_test_context, api_raiden_service):
+    tokenswap_obj = {
+        'role': 'maker',
+        'sending_amount': 42,
+        'sending_token': '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
+        'receiving_amount': 76,
+        'receiving_token': '0x2a65aca4d5fc5b5c859090a6c34d164135398226'
+    }
+    api_test_context.specify_tokenswap_input(tokenswap_obj, None)
+    request = grequests.put(
+        'http://localhost:5001/api/1/token_swaps/1337',
+        json=tokenswap_obj
+    )
+    response = request.send().response
+    assert_proper_response(response)
+
+    tokenswap_obj = {
+        'role': 'taker',
+        'sending_amount': 76,
+        'sending_token': '0x2a65aca4d5fc5b5c859090a6c34d164135398226',
+        'receiving_amount': 42,
+        'receiving_token': '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
+    }
+    api_test_context.specify_tokenswap_input(tokenswap_obj, 1337)
+    request = grequests.put(
+        'http://localhost:5001/api/1/token_swaps/1337',
+        json=tokenswap_obj
+    )
+    response = request.send().response
+    assert_proper_response(response)

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -571,7 +571,7 @@ def test_api_token_swaps(api_test_server, api_test_context, api_raiden_service):
     }
     api_test_context.specify_tokenswap_input(
         tokenswap_obj,
-        "0x61c808d82a3ac53231750dadc13c777b59310bd9",
+        '0x61c808d82a3ac53231750dadc13c777b59310bd9',
         1337
     )
     request = grequests.put(
@@ -590,7 +590,7 @@ def test_api_token_swaps(api_test_server, api_test_context, api_raiden_service):
     }
     api_test_context.specify_tokenswap_input(
         tokenswap_obj,
-        "0xbbc5ee8be95683983df67260b0ab033c237bde60",
+        '0xbbc5ee8be95683983df67260b0ab033c237bde60',
         1337
     )
     request = grequests.put(

--- a/raiden/tests/fixtures/api.py
+++ b/raiden/tests/fixtures/api.py
@@ -107,6 +107,16 @@ def api_raiden_service(
         'get_channel_events',
         api_test_context.get_channel_events
     )
+    monkeypatch.setattr(
+        raiden_service.api,
+        'exchange',
+        api_test_context.exchange
+    )
+    monkeypatch.setattr(
+        raiden_service.api,
+        'expect_exchange',
+        api_test_context.expect_exchange
+    )
 
     # also make sure that the test server's raiden_api uses this mock
     # raiden service

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -58,6 +58,18 @@ class ApiTestContext():
         makes it through the REST api"""
         self.channel_for_events = address_decoder(channel_address)
 
+    def specify_tokenswap_input(self, tokenswap_input, identifier):
+        """We don't test the actual tokenswap but only that the input makes it
+        to the backend in the expected format"""
+        self.tokenswap_input = dict(tokenswap_input)
+        self.tokenswap_input['sending_token'] = address_decoder(
+            self.tokenswap_input['sending_token']
+        )
+        self.tokenswap_input['receiving_token'] = address_decoder(
+            self.tokenswap_input['receiving_token']
+        )
+        self.tokenswap_input['identifier'] = identifier
+
     def get_network_events(self, from_block, to_block):
         return_list = list()
         for event in self.events:
@@ -220,3 +232,25 @@ class ApiTestContext():
 
     def get_channel(self, channel_address):
         return self.find_channel_by_address(channel_address)
+
+    def _check_tokenswap_input(self, argname, input_argname, kwargs):
+        if kwargs[argname] != self.tokenswap_input[input_argname]:
+            raise ValueError(
+                'Expected "{}" for {} but got "{}"'.format(
+                    self.tokenswap_input[input_argname],
+                    input_argname,
+                    kwargs[argname])
+            )
+
+    def exchange(self, **kwargs):
+        self._check_tokenswap_input('from_token', 'sending_token', kwargs)
+        self._check_tokenswap_input('from_amount', 'sending_amount', kwargs)
+        self._check_tokenswap_input('to_token', 'receiving_token', kwargs)
+        self._check_tokenswap_input('to_amount', 'receiving_amount', kwargs)
+
+    def expect_exchange(self, **kwargs):
+        self._check_tokenswap_input('identifier', 'identifier', kwargs)
+        self._check_tokenswap_input('from_token', 'sending_token', kwargs)
+        self._check_tokenswap_input('from_amount', 'sending_amount', kwargs)
+        self._check_tokenswap_input('to_token', 'receiving_token', kwargs)
+        self._check_tokenswap_input('to_amount', 'receiving_amount', kwargs)

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -58,7 +58,7 @@ class ApiTestContext():
         makes it through the REST api"""
         self.channel_for_events = address_decoder(channel_address)
 
-    def specify_tokenswap_input(self, tokenswap_input, identifier):
+    def specify_tokenswap_input(self, tokenswap_input, target_address, identifier):
         """We don't test the actual tokenswap but only that the input makes it
         to the backend in the expected format"""
         self.tokenswap_input = dict(tokenswap_input)
@@ -69,6 +69,7 @@ class ApiTestContext():
             self.tokenswap_input['receiving_token']
         )
         self.tokenswap_input['identifier'] = identifier
+        self.tokenswap_input['target_address'] = address_decoder(target_address)
 
     def get_network_events(self, from_block, to_block):
         return_list = list()


### PR DESCRIPTION
Close #465

- RaidenAPI's exchange() now accepts binary encoded addresses. The conversion happens at
  the REST API instead.

- Created the token_swaps endpoint which exposes the token swap task

- Tests for the aforementioned API endpoint