### PR TITLE
Netting channel cleanup close

### DIFF
--- a/raiden/tests/smart_contracts/DecoderTester.sol
+++ b/raiden/tests/smart_contracts/DecoderTester.sol
@@ -34,6 +34,8 @@ contract DecoderTester {
 
         data.participants[0].node_address = participant1;
         data.participants[1].node_address = participant2;
+        data.participant_index[participant1] = 1;
+        data.participant_index[participant2] = 2;
 
         data.token = Token(token_address);
         data.settle_timeout = timeout;


### PR DESCRIPTION
- Removed extraneous check for the settled variable (settled is only set if closed is set, so a check for closed is enough)
- Using index_or_throw instead of a check for each participant address
- Skipping processTransfer (one less function to follow when reading the close code)

Merge after: #502 