### PR TITLE
Removed transferredAmount from NettingChannelContract

### DIFF
--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -444,9 +444,6 @@ class ChannelExternalState(object):
         # proxy side; see also #394
         return self.netting_channel.settled() or 0
 
-    def query_transferred_amount(self, participant_address):
-        return self.netting_channel.transferred_amount(participant_address)
-
     def callback_on_opened(self, callback):
         if self._opened_block != 0:
             callback(self._opened_block)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -942,9 +942,6 @@ class NettingChannel(object):
 
         log.info('deposit called', contract=pex(self.address), amount=amount)
 
-    def transferred_amount(self, participant_address):
-        return self.proxy.transferredAmount(participant_address)
-
     def opened(self):
         return self.proxy.opened.call()
 

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -73,13 +73,6 @@ contract NettingChannelContract {
         return data.addressAndBalance();
     }
 
-    /// @notice Get the amount one partner has transferred to the other partner.
-    /// @param participant The address of one partner.
-    /// @return The amount one partner has transferred to the other.
-    function transferredAmount(address participant) constant returns (uint) {
-        return data.transferredAmount(participant);
-    }
-
     /// @notice Close the channel. Can only be called by a participant in the channel.
     /// @param theirs_encoded The last transfer recieved from our partner.
     function close(bytes theirs_encoded) {

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -153,15 +153,6 @@ library NettingChannelLibrary {
         return 0x0;
     }
 
-    function transferredAmount(Data storage self, address participant_address)
-        constant
-        returns (uint)
-    {
-         uint8 index = index_or_throw(self, participant_address);
-         Participant storage participant = self.participants[index];
-         return participant.transferred_amount;
-    }
-
     function addressAndBalance(Data storage self)
         constant
         returns(

--- a/raiden/tests/utils/mock_client.py
+++ b/raiden/tests/utils/mock_client.py
@@ -406,11 +406,6 @@ class NettingChannelMock(object):
         for filter_ in BlockChainServiceMock.filters[self.address]:
             filter_.event(event)
 
-    def transferred_amount(self, participant_address):
-        # TODO: Make this work if we don't drop support for the mock client
-        raise RuntimeError('transferredAmount not implemented for mock client')
-        return self.contract._get_transferred_amount(None, None)
-
     def opened(self):
         return self.contract.opened
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -603,11 +603,6 @@ class NettingChannelTesterMock(object):
         self.proxy.deposit(amount)
         self.tester_state.mine(number_of_blocks=1)
 
-    def transferred_amount(self, participant_address):
-        amount = self.proxy.transferredAmount(participant_address)
-        self.tester_state.mine(number_of_blocks=1)
-        return amount
-
     def opened(self):
         opened = self.proxy.opened()
         self.tester_state.mine(number_of_blocks=1)


### PR DESCRIPTION
The function transferredAmount was used to check if the courtesy
transaction was correct, since the courtesy transaction was removed
this function is not necessary anymore.

Note: Additionally the transferred_amount is not sufficient to detect
if the proper transaction was provided, at least the nonce should be
checked but ideally the values `nonce`,  `transferred_amount`, and
`locksroot` should be verified. This is also important for third-party
services.