### PR TITLE
Check for `availabe` memory instead of `free`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ install:
   - pip install flake8
   - pip install -r requirements-dev.txt
 
+before_script:
+  - ./.travis/make_dag.sh
+
 script:
   - flake8 raiden/ tools/ --exclude */ansible/
   - coverage run -m py.test --travis-fold=always -vvvvvv --log-config='raiden:DEBUG' --random $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE

--- a/.travis/make_dag.sh
+++ b/.travis/make_dag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p $HOME/.ethash
+
+# this will generate the DAG once, travis is configured to cache it and
+# subsequent calls will not regenerate
+geth makedag 0 $HOME/.ethash

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -234,9 +234,10 @@ def geth_create_blockchain(
     # memory paging, otherwise the proof-of-work will be extremely slow
     # increasing the flakiness of the tests.
     memory = psutil.virtual_memory()
-    if memory.free < DAGSIZE:
+    if memory.available < DAGSIZE * 1.5:
         raise RuntimeError(
-            'To properly run the tests with a geth miner at least 1GB of free memory is required.'
+            'To properly run the tests with a geth miner '
+            'at least 1.5 GB of available memory is required.'
         )
 
     nodes_configuration = []


### PR DESCRIPTION
The memory check in the blockchain fixture should not expect the DAG size of `free` memory since systems tend to use up `free` memory for caching. Instead we check now for `available` memory which includes memory currently used in caches.