### PR TITLE
moved addressAndBalance to the Contract only

### DIFF
--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -63,7 +63,13 @@ contract NettingChannelContract {
         address participant2,
         uint balance2)
     {
-        return data.addressAndBalance();
+        NettingChannelLibrary.Participant storage node1 = data.participants[0];
+        NettingChannelLibrary.Participant storage node2 = data.participants[1];
+
+        participant1 = node1.node_address;
+        balance1 = node1.balance;
+        participant2 = node2.node_address;
+        balance2 = node2.balance;
     }
 
     /// @notice Close the channel. Can only be called by a participant in the channel.

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -107,25 +107,6 @@ library NettingChannelLibrary {
         return (false, 0);
     }
 
-    function addressAndBalance(Data storage self)
-        constant
-        returns(
-        address participant1,
-        uint balance1,
-        address participant2,
-        uint balance2)
-    {
-        Participant[2] participants = self.participants;
-        Participant node1 = participants[0];
-        Participant node2 = participants[1];
-
-        // return by name
-        participant1 = node1.node_address;
-        balance1 = node1.balance;
-        participant2 = node2.node_address;
-        balance2 = node2.balance;
-    }
-
     /// @notice Close a channel between two parties that was used bidirectionally
     /// @param their_transfer The latest known transfer of the other participant
     ///                       to the channel. Can also be empty, in which case


### PR DESCRIPTION
Initially the idea was to keep as much of the code in the library and make the contracts just a thin layer that dispatched commands to the library, but since the removal of loops from the channel manager library that idea got lost.

This PR removes one additional function from the netting channel library that is not part of the core functionality. It is not for optimization, it is for separation of concerns.