### PR TITLE
Fix refund transfer on_message processing

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1322,7 +1322,7 @@ class RaidenMessageHandler(object):
     def message_refundtransfer(self, message):
         self.raiden.greenlet_task_dispatcher.dispatch_message(
             message,
-            message.hashlock,
+            message.lock.hashlock,
         )
 
         if message.identifier in self.raiden.identifier_statemanager:


### PR DESCRIPTION
For Refund Transfers the hashlock is kept inside the lock structure

Was getting this kind of error when running tests:

```
raiden/tests/unit/test_transfer.py ..x....ERROR:raiden.network.protocol unexpected exception raised.
Traceback (most recent call last):
  File "/home/lefteris/ew/raiden/raiden/network/protocol.py", line 357, in receive
    self.raiden.on_message(message, echohash)
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 1246, in on_message
    self.message_refundtransfer(message)
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 1325, in message_refundtransfer
    message.hashlock,
AttributeError: 'RefundTransfer' object has no attribute 'hashlock'
```

Was not killing the tests and was not erroring since it is inside the greenlet.