### PR TITLE
Travis: Flake8 only once and fail fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ install:
   - pip install -r requirements-dev.txt
 
 before_script:
+  - flake8 raiden/ tools/ --exclude */ansible/
   - ./.travis/make_dag.sh
 
 script:
-  - flake8 raiden/ tools/ --exclude */ansible/
   - coverage run -m py.test --travis-fold=always -vvvvvv --log-config='raiden:DEBUG' --random $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE
 
 after_success:


### PR DESCRIPTION
The flake8 command was failing but the rest of the build was still
running and marked as failure only after the entire test suite was run
through. This is a travis issue as can be seen
[here](https://github.com/travis-ci/travis-ci/issues/1066).

Also moved it to be ran before the travis matrix commands.