### PR TITLE
Fix name typo and better document exception

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -43,5 +43,6 @@ class InsufficientFunds(RaidenError):
     pass
 
 
-class NoHash32Error(Exception):
+class HashLengthNot32(Exception):
+    """The length of a 32 bytes hash is not as expected"""
     pass

--- a/raiden/mtree.py
+++ b/raiden/mtree.py
@@ -4,7 +4,7 @@ from __future__ import division
 from ethereum.utils import encode_hex
 
 from raiden.utils import keccak
-from raiden.exceptions import NoHash32Error
+from raiden.exceptions import HashLengthNot32
 
 
 def hash_pair(first, second):
@@ -52,7 +52,7 @@ def merkleproof_from_layers(layers, idx):
 
 class Merkletree(object):
     def __init__(self, elements):
-        self._layers = list(merkletreelayers(build_lst(elements)))
+        self._layers = list(merkletreelayers(build_list(elements)))
 
     @property
     def merkleroot(self):
@@ -73,17 +73,19 @@ def merkleroot(elements):
 
     Returns:
         str: The root element of the merkle tree.
+    Raises:
+        HashLengthNot32: The length of one of the elements is not 32
     """
     return Merkletree(elements).merkleroot
 
 
-def build_lst(elements):
+def build_list(elements):
     result = list()
 
     for item in set(elements):
         if item:
             if len(item) != 32:
-                raise NoHash32Error()
+                raise HashLengthNot32()
 
             result.append(item)
 

--- a/raiden/tests/unit/test_mtree.py
+++ b/raiden/tests/unit/test_mtree.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from raiden.mtree import merkleroot, check_proof, get_proof, NoHash32Error
+from raiden.mtree import merkleroot, check_proof, get_proof, HashLengthNot32
 from raiden.utils import keccak
 
 
@@ -15,7 +15,7 @@ def test_multiple_empty():
 
 
 def test_non_hash():
-    with pytest.raises(NoHash32Error):
+    with pytest.raises(HashLengthNot32):
         merkleroot(['not32bytes', 'neither'])
 
 


### PR DESCRIPTION
- `build_lst` -> `build_list`
- Rename and document the exception thrown if a hash is not 32 bytes in length