### PR TITLE
Make raiden compatible with openssl v1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# temporary (?) until pyelliptic maintainers make it compatible with openssl>=1.1
+-e git+https://github.com/LefterisJP/pyelliptic@make_compatible_with_openssl1_1#egg=pyelliptic
 pysha3
 # temporary until new version of pyethereum is released, that supports solc >= v0.4.9
 -e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ history = ''
 
 install_requires_replacements = {
     "-e git+https://github.com/LefterisJP/pyethapp@use_new_solc_combinedjson_key#egg=pyethapp": "pyethapp",
+    "-e git+https://github.com/LefterisJP/pyelliptic@make_compatible_with_openssl1_1#egg=pyelliptic": "pyelliptic",
 }
 
 install_requires = list(set(


### PR DESCRIPTION
Until this PR: https://github.com/yann2192/pyelliptic/pull/56 for
pyelliptic gets merged we need to manually import the fix for OpenSSL
v1.1 to be able to use Raiden in systems where OpenSLL has been upgraded
above that version.