### PR TITLE
Rename unlock to withdraw in all remaining places

### DIFF
--- a/raiden/blockchain/net_contract.py
+++ b/raiden/blockchain/net_contract.py
@@ -416,7 +416,7 @@ class NettingChannelContract(object):
         # elif state.state == STATE_THIRDPARTY and state.transfer.nonce < transfer.nonce:
         #     state.transfer = transfer
 
-    def unlock(self, ctx, locked_encoded, merkleproof_encoded, secret):
+    def withdraw(self, ctx, locked_encoded, merkleproof_encoded, secret):
         if self.settled is not 0:
             raise RuntimeError('Contract is settled.')
 

--- a/raiden/channel.py
+++ b/raiden/channel.py
@@ -472,8 +472,8 @@ class ChannelExternalState(object):
     def update_transfer(self, our_address, partner_transfer):
         return self.netting_channel.update_transfer(our_address, partner_transfer)
 
-    def unlock(self, our_address, unlock_proofs):
-        return self.netting_channel.unlock(our_address, unlock_proofs)
+    def withdraw(self, our_address, unlock_proofs):
+        return self.netting_channel.withdraw(our_address, unlock_proofs)
 
     def settle(self):
         return self.netting_channel.settle()
@@ -621,7 +621,7 @@ class Channel(object):
         self.external_state.update_transfer(self.our_state.address, transfer)
 
         unlock_proofs = balance_proof.get_known_unlocks()
-        self.external_state.unlock(self.our_state.address, unlock_proofs)
+        self.external_state.withdraw(self.our_state.address, unlock_proofs)
 
     def get_state_for(self, node_address_bin):
         if self.our_state.address == node_address_bin:

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -301,7 +301,7 @@ def test_secret_revealed(raiden_chain, deposit, settle_timeout, events_poll_time
     netting_channel.close(app2.raiden.address, balance_proof.transfer, None)
 
     # reveal it through the blockchain (this needs to emit the SecretRevealed event)
-    netting_channel.unlock(
+    netting_channel.withdraw(
         app2.raiden.address,
         [proof],
     )

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -197,9 +197,9 @@ def test_settled_lock(tokens_addresses, raiden_network, settle_timeout, reveal_t
         last_transfer,
     )
 
-    # check that the double unlock will failed
+    # check that the double unlock will fail
     with pytest.raises(Exception):
-        back_channel.external_state.netting_channel.unlock(
+        back_channel.external_state.netting_channel.withdraw(
             app1.raiden.address,
             [(unlock_proof, secret_transfer.lock.as_bytes, secret)],
         )
@@ -271,7 +271,7 @@ def test_start_end_attack(tokens_addresses, raiden_chain, deposit, reveal_timeou
     wait_until_block(app2.raiden.chain, attack_transfer.lock.expiration - 1)
 
     # since the attacker knows the secret he can net the lock
-    attack_channel.netting_channel.unlock(
+    attack_channel.netting_channel.withdraw(
         [(unlock_proof, attack_transfer.lock, secret)],
     )
     # XXX: verify that the secret was publicized


### PR DESCRIPTION
Some places were missed and are causing failures. This should fix them.