### PR TITLE
Programmatic api only accepts binary addresses

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -9,7 +9,6 @@ import gevent
 from gevent.event import AsyncResult
 from ethereum import slogging
 from ethereum.utils import encode_hex
-from pyethapp.jsonrpc import address_decoder
 from secp256k1 import PrivateKey
 
 from raiden.constants import UINT64_MAX

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -105,7 +105,6 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
-    safe_address_decode,
     sha3,
     GLOBAL_CTX,
 )

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -149,7 +149,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     )
 
     events = app0.raiden.api.get_token_network_events(
-        token_address=address_encoder(token_address),
+        token_address=token_address,
         from_block=0,
         to_block='latest',
     )
@@ -182,7 +182,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     netting_channel0.deposit(app0.raiden.address, deposit)
 
     all_netting_channel_events = app0.raiden.api.get_channel_events(
-        channel_address=address_encoder(netcontract_address),
+        channel_address=netcontract_address,
         from_block=0,
         to_block='latest',
     )
@@ -210,7 +210,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     channel0.external_state.close(app0.raiden.address, '')
 
     all_netting_channel_events = app0.raiden.api.get_channel_events(
-        channel_address=address_encoder(netcontract_address),
+        channel_address=netcontract_address,
         from_block=0,
         to_block='latest',
     )
@@ -239,7 +239,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     channel1.external_state.settle()
 
     all_netting_channel_events = app0.raiden.api.get_channel_events(
-        channel_address=address_encoder(netcontract_address),
+        channel_address=netcontract_address,
         from_block=0,
         to_block='latest',
     )

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -15,6 +15,7 @@ from raiden.transfer.state import (
     CHANNEL_STATE_CLOSED,
     CHANNEL_STATE_SETTLED,
 )
+from raiden.utils import pex
 
 
 class NettingChannelMock(object):
@@ -94,7 +95,7 @@ class ApiTestContext():
         if token_address != self.token_for_channelnew:
             raise ValueError(
                 'Unexpected token address: "{}"  during channelnew '
-                'query'.format(token_address)
+                'query'.format(pex(token_address))
             )
         for event in self.events:
             expected_event_type = event['_event_type'] == 'ChannelNew'
@@ -112,7 +113,7 @@ class ApiTestContext():
         if channel_address != self.channel_for_events:
             raise ValueError(
                 'Unexpected channel address: "{}"  during channel events '
-                'query'.format(channel_address)
+                'query'.format(pex(channel_address))
             )
 
         for event in self.events:

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -55,6 +55,7 @@ GLOBAL_CTX = secp256k1.lib.secp256k1_context_create(secp256k1.ALL_FLAGS)
 
 def safe_address_decode(address):
     try:
+        address = safe_lstrip_hex(address)
         address = address.decode('hex')
     except TypeError:
         pass


### PR DESCRIPTION
It seems the functions of the programmatic API were not consistent in what they were accepting and this caused problems when contacted via the Rest API.

As discussed during the retreat, this PR is trying to enforce each different area (rest api, console tools) to do their own decoding to binary and assert that the programmatic API only gets binary address formats.