### PR TITLE
address_encoder not required and using function new_contract_proxy

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -509,18 +509,18 @@ class Token(object):
 
         result = jsonrpc_client.call(
             'eth_getCode',
-            address_encoder(token_address),
+            token_address,
             'latest',
         )
 
         if result == '0x':
             raise ValueError('Token address {} does not contain code'.format(
-                address_encoder(token_address),
+                token_address,
             ))
 
-        proxy = jsonrpc_client.new_abi_contract(
+        proxy = jsonrpc_client.new_contract_proxy(
             HUMAN_TOKEN_ABI,
-            address_encoder(token_address),
+            token_address,
         )
 
         self.address = token_address


### PR DESCRIPTION
```
In [20]: chain.token('0x1754b5b446916a15bb8c5cc3923c3d7bb6b5eacc')
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-20-7fa258545e35> in <module>()
----> 1 chain.token('0x1754b5b446916a15bb8c5cc3923c3d7bb6b5eacc')

/home/krishna/raidenforked/raiden/raiden/network/rpc/client.pyc in token(self, token_address)
    276                 self.client,
    277                 token_address,
--> 278                 poll_timeout=self.poll_timeout,
    279             )
    280 

/home/krishna/raidenforked/raiden/raiden/network/rpc/client.pyc in __init__(self, jsonrpc_client, token_address, startgas, gasprice, poll_timeout)
    510         result = jsonrpc_client.call(
    511             'eth_getCode',
--> 512             address_encoder(token_address),
    513             'latest',
    514         )

/home/krishna/Envs/env2/src/pyethapp/pyethapp/jsonrpc.pyc in address_encoder(address)
    406 
    407 def address_encoder(address):
--> 408     assert len(address) in (20, 0)
    409     return '0x' + encode_hex(address)
    410 

```

Fixes the AssertionError that we were getting, which will allow us to get a proxy to the token. As well as used the new function in pyethapp called `new_contract_proxy` instead of `new_abi_contract`

```[14] > /home/krishna/Envs/env2/src/pyethapp/pyethapp/rpc_client.py(197)new_contract_proxy()
-> def new_contract_proxy(self, contract_interface, address):
(Pdb++) l
192  	
193  	    def new_abi_contract(self, contract_interface, address):
194  	        warnings.warn('deprecated, use new_contract_proxy', DeprecationWarning)
195  	        return self.new_contract_proxy(contract_interface, address)
196  	
197  ->	    def new_contract_proxy(self, contract_interface, address):
198  	        """ Return a proxy for interacting with a smart contract.
199  	
200  	        Args:
201  	            contract_interface: The contract interface as defined by the json.
202  	            address: The contract's address.
```