### PR TITLE
removed unused local variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   global:
     - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.0-facc47cb.tar.gz'
     - GETH_VERSION='1.6.0'
-    - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.10/solc'
-    - SOLC_VERSION='0.4.10'
+    - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.11/solc-static-linux'
+    - SOLC_VERSION='v0.4.11'
   matrix:
     - TEST_TYPE='unit'
     - TEST_TYPE='smart_contracts'

--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -49,8 +49,6 @@ contract ChannelManagerContract {
         uint i;
         uint pos;
         address channel;
-        address participant1;
-        address participant2;
         address[] memory result;
 
         result = new address[](all_channels.length * 2);

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -236,10 +236,8 @@ library NettingChannelLibrary {
         notSettledButClosed(self)
     {
         uint amount;
-        uint partner_id;
         uint8 index;
         uint64 expiration;
-        bytes32 el;
         bytes32 h;
         bytes32 hashlock;
 

--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -28,7 +28,6 @@ contract Registry {
         returns (address)
     {
         address manager_address;
-        ChannelManagerContract manager;
 
         manager_address = new ChannelManagerContract(token_address);
 


### PR DESCRIPTION
After updating to solidity version 0.4.11 solc now warns about unused
local variables. Due to this a couple of unused variables were found and
removed from the smart contracts.

Furthermore this PR updates solidity to version 0.4.11 in travis