### PR TITLE
Pin coverage below 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - ./.travis/download_solc.sh
 
 install:
-  - pip install -U pip wheel coveralls
+  - pip install -U pip wheel coveralls "coverage<4.4"
   - pip install pytest-travis-fold
   - pip install flake8
   - pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ flake8
 pdbpp>=0.8.3<1.0.0
 
 # Continuous Integration
-coverage>=4.0<5.0
+coverage>=4.0<4.4
 
 # Documentation
 sphinx>=1.5.1<2.0.0


### PR DESCRIPTION
There is some exception raised with latest coverage v4.4, that wasn't
there with v4.3.4:

    Can't support concurrency=gevent with PyTracer, only threads are supported