### PR TITLE
Call updatetransfer only if we did not close

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -285,8 +285,10 @@ class Channel(object):
         balance_proof = self.our_state.balance_proof
         transfer = balance_proof.transfer
 
-        # the channel was closed, update our half of the state
-        self.external_state.update_transfer(self.our_state.address, transfer)
+        # the channel was closed, update our half of the state if we need to
+        closing_address = self.external_state.netting_channel.closing_address()
+        if closing_address != self.our_state.address:
+            self.external_state.update_transfer(self.our_state.address, transfer)
 
         unlock_proofs = balance_proof.get_known_unlocks()
         self.external_state.withdraw(self.our_state.address, unlock_proofs)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -932,6 +932,9 @@ class NettingChannel(object):
     def closed(self):
         return self.proxy.closed.call()
 
+    def closing_address(self):
+        return address_decoder(self.proxy.closingAddress())
+
     def settled(self):
         return self.proxy.settled.call()
 

--- a/raiden/tests/utils/mock_client.py
+++ b/raiden/tests/utils/mock_client.py
@@ -409,6 +409,11 @@ class NettingChannelMock(object):
     def closed(self):
         return self.contract.closed
 
+    def closing_address(self):
+        closing_address = self.contract.closingAddress
+        assert len(closing_address) == 20, "Expected binary address"
+        return closing_address
+
     def settled(self):
         return self.contract.settled
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -602,6 +602,9 @@ class NettingChannelTesterMock(object):
         closed = self.proxy.closed()
         return closed
 
+    def closing_address(self):
+        return address_decoder(self.proxy.closingAddress())
+
     def settled(self):
         settled = self.proxy.settled()
         return settled


### PR DESCRIPTION
This PR does two things.

- Calls `updateTransfer()` only if we also did not close the channel.
- Returns `closing_Address` from the proxies making sure it's binary and not hex