### PR TITLE
Compatible with geth v1.6.1, explicit from/toBlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   global:
-    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.0-facc47cb.tar.gz'
-    - GETH_VERSION='1.6.0'
+    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.1-021c3c28.tar.gz'
+    - GETH_VERSION='1.6.1'
     - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.11/solc-static-linux'
     - SOLC_VERSION='v0.4.11'
   matrix:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -178,6 +178,10 @@ def patch_send_message(client, pool_maxsize=50):
 
 def new_filter(jsonrpc_client, contract_address, topics, from_block=None, to_block=None):
     """ Custom new filter implementation to handle bad encoding from geth rpc. """
+    if isinstance(from_block, int):
+        from_block = hex(from_block)
+    if isinstance(to_block, int):
+        to_block = hex(to_block)
     json_data = {
         'fromBlock': from_block if from_block is not None else 'latest',
         'toBlock': to_block if to_block is not None else 'latest',

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -179,8 +179,8 @@ def patch_send_message(client, pool_maxsize=50):
 def new_filter(jsonrpc_client, contract_address, topics, from_block=None, to_block=None):
     """ Custom new filter implementation to handle bad encoding from geth rpc. """
     json_data = {
-        'fromBlock': from_block if from_block is not None else '',
-        'toBlock': to_block if to_block is not None else '',
+        'fromBlock': from_block if from_block is not None else 'latest',
+        'toBlock': to_block if to_block is not None else 'latest',
         'address': address_encoder(normalize_address(contract_address)),
     }
 


### PR DESCRIPTION
Fix #591

It seems that with geth v1.6.1 we get an error when giving empty
`fromBlock` or `toBlock` which is going against the spec. According to
the spec it should default to "latest". An issue is
reported for it [here](https://github.com/ethereum/go-ethereum/issues/14467).

In any case it's much better to be explicit in our RPC calls and not
rely on defaults so this PR addresses that and bumps the Travis geth
version to 1.6.1.