### PR TITLE
Check recipient in nettingchannel

### DIFF
--- a/raiden/tests/smart_contracts/netting_channel/DecoderTester.sol
+++ b/raiden/tests/smart_contracts/netting_channel/DecoderTester.sol
@@ -11,7 +11,7 @@ contract DecoderTester {
         return NettingChannelLibrary.getTransferRawAddress(signed_transfer);
     }
 
-    function decodeTransfer(bytes transfer_raw) returns (uint64 nonce, bytes32 locksroot, uint256 transferred_amount) {
+    function decodeTransfer(bytes transfer_raw) returns (uint64 nonce, address recipient, bytes32 locksroot, uint256 transferred_amount) {
         return NettingChannelLibrary.decodeTransfer(transfer_raw);
     }
 }

--- a/raiden/tests/smart_contracts/netting_channel/test_close.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_close.py
@@ -81,11 +81,12 @@ def test_close_accepts_only_transfer_from_participants(tester_channels, private_
     """ Close must not accept a transfer from a non participant. """
     pkey0, _, nettingchannel, channel0, _ = tester_channels[0]
     nonparticipant_key = private_keys[2]
+    opened_block = nettingchannel.opened(sender=pkey0)
 
     # make a transfer where pkey0 is the target
     transfer_nonparticipant = DirectTransfer(
         identifier=1,
-        nonce=1,
+        nonce=1 + (opened_block * (2 ** 32)),
         token=channel0.token_address,
         transferred_amount=10,
         recipient=channel0.our_address,
@@ -100,6 +101,30 @@ def test_close_accepts_only_transfer_from_participants(tester_channels, private_
 
     with pytest.raises(TransactionFailed):
         nettingchannel.close(transfer_nonparticipant_data, sender=pkey0)
+
+
+@pytest.mark.parametrize('number_of_nodes', [3])
+def test_close_wrong_recipient(tester_channels, private_keys):
+    """ Close must not accept a transfer aimed at a non recipient. """
+    pkey0, pkey1, nettingchannel, channel0, _ = tester_channels[0]
+    opened_block = nettingchannel.opened(sender=pkey0)
+    nonparticipant_address = privatekey_to_address(private_keys[2])
+
+    # make a transfer where the recipient is totally wrong
+    transfer_wrong_recipient = DirectTransfer(
+        identifier=1,
+        nonce=1 + (opened_block * (2 ** 32)),
+        token=channel0.token_address,
+        transferred_amount=10,
+        recipient=nonparticipant_address,
+        locksroot='',
+    )
+
+    transfer_wrong_recipient.sign(PrivateKey(pkey1), privatekey_to_address(pkey1))
+    transfer_wrong_recipient_data = str(transfer_wrong_recipient.packed().data)
+
+    with pytest.raises(TransactionFailed):
+        nettingchannel.close(transfer_wrong_recipient_data, sender=pkey0)
 
 
 def test_close_called_multiple_times(tester_state, tester_nettingcontracts):

--- a/raiden/tests/smart_contracts/netting_channel/test_decoder_netting_channel.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_decoder_netting_channel.py
@@ -34,11 +34,13 @@ def assert_decoder_results(message, decoder):
 
     (
         nonce_decoded,
+        recipient_address_decoded,
         locksroot_decoded,
         transferred_amount_decoded
     ) = decoder.decodeTransfer(transfer_raw)
 
     assert message.nonce == nonce_decoded
+    assert message.recipient == address_decoder(recipient_address_decoded)
     assert message.transferred_amount == transferred_amount_decoded
     assert message.locksroot == locksroot_decoded
 

--- a/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
@@ -362,6 +362,7 @@ def test_withdraw_fails_with_partial_merkle_proof(
     direct_transfer = make_direct_transfer(
         nonce=nonce,
         locksroot=merkle_tree.merkleroot,
+        recipient=privatekey_to_address(pkey1)
     )
 
     address = privatekey_to_address(pkey0)
@@ -412,6 +413,7 @@ def test_withdraw_tampered_merkle_proof(tree, tester_channels, tester_state, set
     direct_transfer = make_direct_transfer(
         nonce=nonce,
         locksroot=merkle_tree.merkleroot,
+        recipient=privatekey_to_address(pkey1)
     )
 
     address = privatekey_to_address(pkey0)
@@ -474,6 +476,7 @@ def test_withdraw_tampered_lock_amount(
         nonce=nonce,
         locksroot=merkle_tree.merkleroot,
         token=tester_token.address,
+        recipient=privatekey_to_address(pkey1)
     )
 
     address = privatekey_to_address(pkey0)


### PR DESCRIPTION
Fix #601 

- Add tests for checking if the recipient of a
  messaged submitted via close() or updateTransfer() is actually a
  participant of the channel.

- In some tests in test_close.py and test_updateTransfer the nonce was
  incorrectly specofied  and the test was failing due to the nonce and not
  due to the expected failure.

- Add a check in both `updateTransfer()` and `close()` that makes sure the recipient of a message we try to close/update with is indeed the expected channel participant.