### PR TITLE
Separate generation of Merkle tree from compute_proof_for_locks

### DIFF
--- a/raiden/channel/balance_proof.py
+++ b/raiden/channel/balance_proof.py
@@ -209,7 +209,7 @@ class BalanceProof(object):
             self.hashlock_unlockedlocks.itervalues(),
         )
 
-        tree = self.generate_merkle_tree();
+        tree = self.generate_merkle_tree()
 
         return [
             self.compute_proof_for_lock(


### PR DESCRIPTION
Fix #248

As per issue #248 

I've made the tree parameter optional in compute_proof_for_lock to keep compatibility with any code outside of balance_proof.py that might use this (only tests within the raiden repository but not sure if there might be anything outside of this repository that uses it).