### PR TITLE
Fix opened block #613

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -513,7 +513,7 @@ class RaidenAPI(object):
         graph = self.raiden.channelgraphs[token_address]
         channel = graph.partneraddress_channel[partner_address]
 
-        if channel.isopen:
+        if channel.can_transfer:
             raise InvalidState('channel is still open.')
 
         netting_channel = channel.external_state.netting_channel

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -150,9 +150,12 @@ class RaidenAPI(object):
             partner_address,
             settle_timeout,
         )
-        self.raiden.register_netting_channel(token_address, netcontract_address)
+        while netcontract_address not in self.raiden.chain.address_contract:
+            gevent.sleep(self.raiden.alarm.wait_time)
 
         graph = self.raiden.channelgraphs[token_address]
+        while partner_address not in graph.partneraddress_channel:
+            gevent.sleep(self.raiden.alarm.wait_time)
         channel = graph.partneraddress_channel[partner_address]
         return channel
 

--- a/raiden/blockchain/net_contract.py
+++ b/raiden/blockchain/net_contract.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-A pure python implementation of a contract responsable to open a channel.
+A pure python implementation of a contract responsible to open a channel.
 """
 from ethereum import slogging
 
@@ -277,8 +277,8 @@ class NettingChannelContract(object):
         participant.has_deposited = True
         participant.deposit += amount
 
-        if self.isopen and self.opened is 0:
-            # track the block were the contract was openned
+        if self.opened is 0:
+            # track the block were the contract was opened
             self.opened = block_number
 
     def partner(self, address):

--- a/raiden/blockchain/net_contract.py
+++ b/raiden/blockchain/net_contract.py
@@ -240,24 +240,6 @@ class NettingChannelContract(object):
         #   contract.
         # This implementation's settle_timeout is a "fixed waiting time"
 
-    @property
-    def isopen(self):
-        """ The contract is open after both participants have deposited, and if
-        it has not being closed.
-
-        Returns:
-            bool: True if the contract is open, False otherwise
-        """
-        # 0 is used for uninitialized values
-        if self.closed is not 0:
-            return False
-
-        # allow single funded channels
-        return any(
-            state.has_deposited
-            for state in self.participants.values()
-        )
-
     def deposit(self, address, amount, block_number):
         """ Method for `address` to make a deposit of `amount` token. """
 

--- a/raiden/blockchain/net_contract.py
+++ b/raiden/blockchain/net_contract.py
@@ -260,7 +260,7 @@ class NettingChannelContract(object):
         participant.deposit += amount
 
         if self.opened is 0:
-            # track the block were the contract was opened
+            # track the block where the contract was opened
             self.opened = block_number
 
     def partner(self, address):

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -238,8 +238,11 @@ class Channel(object):
         return self.our_state.contract_balance
 
     @property
-    def isopen(self):
-        return self.external_state.isopen()
+    def can_transfer(self):
+        return (
+            self.state == CHANNEL_STATE_OPENED and
+            self.distributable > 0
+        )
 
     @property
     def contract_balance(self):
@@ -646,7 +649,7 @@ class Channel(object):
         This message needs to be signed and registered with the channel before
         sent.
         """
-        if not self.isopen:
+        if not self.can_transfer:
             raise ValueError('The channel is closed')
 
         from_ = self.our_state
@@ -682,7 +685,7 @@ class Channel(object):
         """
         timeout = expiration - self.block_number
 
-        if not self.isopen:
+        if not self.can_transfer:
             raise ValueError('The channel is closed.')
 
         # the lock timeout cannot be larger than the settle timeout (otherwise

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -677,7 +677,7 @@ class Channel(object):
         timeout = expiration - self.block_number
 
         if not self.can_transfer:
-            raise ValueError('The channel is closed.')
+            raise ValueError('Transfer not possible, no funding or channel closed.')
 
         # the lock timeout cannot be larger than the settle timeout (otherwise
         # the smart contract cannot check the locks)

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -123,15 +123,6 @@ class ChannelExternalState(object):
 
         self.callbacks_settled.append(callback)
 
-    def isopen(self):
-        """ True if the channel is opened. A channel is opened after its first
-        deposit until close is called.
-        """
-        return (
-            self._opened_block != 0 and
-            self._closed_block == 0
-        )
-
     def close(self, our_address, partner_transfer):
         return self.netting_channel.close(our_address, partner_transfer)
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -641,7 +641,7 @@ class Channel(object):
         sent.
         """
         if not self.can_transfer:
-            raise ValueError('The channel is closed')
+            raise ValueError('Transfer not possible, no funding or channel closed.')
 
         from_ = self.our_state
         to_ = self.partner_state

--- a/raiden/channel/participant_state.py
+++ b/raiden/channel/participant_state.py
@@ -16,6 +16,9 @@ class ChannelEndState(object):
         if not isinstance(participant_balance, (int, long)):
             raise ValueError('participant_balance must be an integer.')
 
+        if not opened_block > 0:
+            raise ValueError('opened_block must be non-zero and positive (not %s)' % opened_block)
+
         self.contract_balance = participant_balance
         self.address = participant_address
 

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -7,6 +7,7 @@ from ethereum import slogging
 from raiden.api.python import RaidenAPI
 from raiden.utils import pex
 from raiden.transfer.state import (
+    CHANNEL_STATE_OPENED,
     CHANNEL_STATE_SETTLED,
 )
 
@@ -287,5 +288,5 @@ class ConnectionManager(object):
         return [
             channel for channel in
             self.api.get_channel_list(token_address=self.token_address)
-            if channel.isopen
+            if channel.state == CHANNEL_STATE_OPENED
         ]

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -196,7 +196,7 @@ class ChannelGraph(object):
             if not channel.can_transfer:
                 if log.isEnabledFor(logging.INFO):
                     log.info(
-                        'channel %s - %s is closed, ignoring',
+                        'channel %s - %s is closed or has zero funding, ignoring',
                         pex(path[0]),
                         pex(path[1]),
                     )

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -255,7 +255,7 @@ class ChannelGraph(object):
         """ Remove an edge from the network. """
         self.graph.remove_edge(from_address, to_address)
 
-    def channel_isactive(self, partner_address):
-        """ True if the channel with `partner_address` is open. """
+    def channel_cantransfer(self, partner_address):
+        """ True if the channel with `partner_address` is open and has spendable funds. """
         # TODO: check if the partner's network is alive
         return self.partneraddress_channel[partner_address].can_transfer

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -193,7 +193,7 @@ class ChannelGraph(object):
             partner = path[1]
             channel = self.partneraddress_channel[partner]
 
-            if not channel.isopen:
+            if not channel.can_transfer:
                 if log.isEnabledFor(logging.INFO):
                     log.info(
                         'channel %s - %s is closed, ignoring',
@@ -258,4 +258,4 @@ class ChannelGraph(object):
     def channel_isactive(self, partner_address):
         """ True if the channel with `partner_address` is open. """
         # TODO: check if the partner's network is alive
-        return self.partneraddress_channel[partner_address].isopen
+        return self.partneraddress_channel[partner_address].can_transfer

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -255,7 +255,7 @@ class ChannelGraph(object):
         """ Remove an edge from the network. """
         self.graph.remove_edge(from_address, to_address)
 
-    def channel_cantransfer(self, partner_address):
+    def channel_can_transfer(self, partner_address):
         """ True if the channel with `partner_address` is open and has spendable funds. """
         # TODO: check if the partner's network is alive
         return self.partneraddress_channel[partner_address].can_transfer

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -853,6 +853,9 @@ class NettingChannel(object):
         return address_decoder(self.proxy.tokenAddress.call())
 
     def detail(self, our_address):
+        """`our_address` is an argument used only in mock_client.py but is also
+        kept here to maintain a consistent interface"""
+        our_address = self.client.sender
         data = self.proxy.addressAndBalance.call(startgas=self.startgas)
         settle_timeout = self.proxy.settleTimeout.call(startgas=self.startgas)
 
@@ -890,11 +893,14 @@ class NettingChannel(object):
         settle_timeout = self.proxy.settleTimeout.call()
         return settle_timeout
 
-    def isopen(self):
+    def can_transfer(self):
         if self.proxy.closed.call() != 0:
             return False
 
-        return self.proxy.opened.call() != 0
+        return (
+            self.proxy.opened.call() != 0 and
+            self.detail(None)['our_balance'] > 0
+        )
 
     def deposit(self, our_address, amount):  # pylint: disable=unused-argument
         """`our_address` is an argument used only in mock_client.py but is also

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -946,7 +946,7 @@ class RaidenMessageHandler(object):
 
         channel = graph.partneraddress_channel[message.sender]
 
-        if not channel.can_transfer:
+        if channel.state != CHANNEL_STATE_OPENED:
             raise TransferWhenClosed(
                 'Direct transfer received for a closed channel: {}'.format(
                     pex(channel.channel_address),
@@ -975,16 +975,16 @@ class RaidenMessageHandler(object):
 
         if not graph.has_channel(self.raiden.address, message.sender):
             raise UnknownAddress(
-                'Direct transfer from node without an existing channel: {}'.format(
+                'Mediated transfer from node without an existing channel: {}'.format(
                     pex(message.sender),
                 )
             )
 
         channel = graph.partneraddress_channel[message.sender]
 
-        if not channel.can_transfer:
+        if channel.state != CHANNEL_STATE_OPENED:
             raise TransferWhenClosed(
-                'Direct transfer received for a closed channel: {}'.format(
+                'Mediated transfer received but the channel is closed: {}'.format(
                     pex(channel.channel_address),
                 )
             )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -598,7 +598,7 @@ class RaidenService(object):
 
         if not direct_channel.can_transfer:
             log.info(
-                'DIRECT CHANNEL %s > %s is closed',
+                'DIRECT CHANNEL %s > %s is closed or has no funding',
                 pex(direct_channel.our_state.address),
                 pex(direct_channel.partner_state.address),
             )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -596,7 +596,7 @@ class RaidenService(object):
         mediated transfer.
         """
 
-        if not direct_channel.isopen:
+        if not direct_channel.can_transfer:
             log.info(
                 'DIRECT CHANNEL %s > %s is closed',
                 pex(direct_channel.our_state.address),
@@ -946,7 +946,7 @@ class RaidenMessageHandler(object):
 
         channel = graph.partneraddress_channel[message.sender]
 
-        if not channel.isopen:
+        if not channel.can_transfer:
             raise TransferWhenClosed(
                 'Direct transfer received for a closed channel: {}'.format(
                     pex(channel.channel_address),
@@ -982,7 +982,7 @@ class RaidenMessageHandler(object):
 
         channel = graph.partneraddress_channel[message.sender]
 
-        if not channel.isopen:
+        if not channel.can_transfer:
             raise TransferWhenClosed(
                 'Direct transfer received for a closed channel: {}'.format(
                     pex(channel.channel_address),

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -48,7 +48,7 @@ contract NettingChannelContract {
         (success, balance) = data.deposit(amount);
 
         if (success == true) {
-            ChannelNewBalance(data.token, msg.sender, balance, data.opened);
+            ChannelNewBalance(data.token, msg.sender, balance, block.number);
         }
 
         return success;

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -35,6 +35,7 @@ contract NettingChannelContract {
 
         data.token = Token(token_address);
         data.settle_timeout = timeout;
+        data.opened = block.number;
     }
 
     /// @notice Caller makes a deposit into their channel balance.

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -48,7 +48,7 @@ contract NettingChannelContract {
         (success, balance) = data.deposit(amount);
 
         if (success == true) {
-            ChannelNewBalance(data.token, msg.sender, balance, block.number);
+            ChannelNewBalance(data.token, msg.sender, balance, 0);
         }
 
         return success;

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -83,6 +83,7 @@ library NettingChannelLibrary {
     {
         uint8 index;
 
+        require(self.opened > 0);
         require(self.closed == 0);
 
         if (self.token.balanceOf(msg.sender) < amount) {
@@ -97,10 +98,6 @@ library NettingChannelLibrary {
             balance = participant.balance;
             balance += amount;
             participant.balance = balance;
-
-            if (self.opened == 0) {
-                self.opened = block.number;
-            }
 
             return (true, balance);
         }

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -63,7 +63,7 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
 
     # check contract state
     netting_channel_01 = blockchain_service0.netting_channel(netting_address_01)
-    assert netting_channel_01.isopen() is False
+    assert netting_channel_01.can_transfer() is False
 
     # check channels
     channel_list = manager0.channels_addresses()
@@ -82,7 +82,7 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
 
     netting_channel_02 = blockchain_service0.netting_channel(netting_address_02)
 
-    assert netting_channel_02.isopen() is False
+    assert netting_channel_02.can_transfer() is False
 
     channel_list = manager0.channels_addresses()
     expected_channels = [
@@ -101,16 +101,16 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
 
     # deposit without approve should fail
     netting_channel_01.deposit(peer0_address, 100)
-    assert netting_channel_01.isopen() is False
-    assert netting_channel_02.isopen() is False
+    assert netting_channel_01.can_transfer() is False
+    assert netting_channel_02.can_transfer() is False
     assert netting_channel_01.detail(peer0_address)['our_balance'] == 0
     assert netting_channel_01.detail(peer1_address)['our_balance'] == 0
 
     # single-funded channel
     app0.raiden.chain.token(token_address).approve(netting_address_01, 100)
     netting_channel_01.deposit(peer0_address, 100)
-    assert netting_channel_01.isopen() is True
-    assert netting_channel_02.isopen() is False
+    assert netting_channel_01.can_transfer() is True
+    assert netting_channel_02.can_transfer() is False
 
     assert netting_channel_01.detail(peer0_address)['our_balance'] == 100
     assert netting_channel_01.detail(peer1_address)['our_balance'] == 0
@@ -118,16 +118,16 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
     # double-funded channel
     app0.raiden.chain.token(token_address).approve(netting_address_02, 70)
     netting_channel_02.deposit(peer0_address, 70)
-    assert netting_channel_01.isopen() is True
-    assert netting_channel_02.isopen() is True
+    assert netting_channel_01.can_transfer() is True
+    assert netting_channel_02.can_transfer() is True
 
     assert netting_channel_02.detail(peer0_address)['our_balance'] == 70
     assert netting_channel_02.detail(peer2_address)['our_balance'] == 0
 
     app2.raiden.chain.token(token_address).approve(netting_address_02, 130)
     app2.raiden.chain.netting_channel(netting_address_02).deposit(peer2_address, 130)
-    assert netting_channel_01.isopen() is True
-    assert netting_channel_02.isopen() is True
+    assert netting_channel_01.can_transfer() is True
+    assert netting_channel_02.can_transfer() is True
 
     assert netting_channel_02.detail(peer0_address)['our_balance'] == 70
     assert netting_channel_02.detail(peer2_address)['our_balance'] == 130

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -103,8 +103,8 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
     netting_channel_01.deposit(peer0_address, 100)
     assert netting_channel_01.can_transfer() is False
     assert netting_channel_02.can_transfer() is False
-    assert netting_channel_01.detail(peer0_address)['our_balance'] == 0
-    assert netting_channel_01.detail(peer1_address)['our_balance'] == 0
+    assert netting_channel_01.detail(None)['our_balance'] == 0
+    assert netting_channel_02.detail(None)['our_balance'] == 0
 
     # single-funded channel
     app0.raiden.chain.token(token_address).approve(netting_address_01, 100)
@@ -112,8 +112,8 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
     assert netting_channel_01.can_transfer() is True
     assert netting_channel_02.can_transfer() is False
 
-    assert netting_channel_01.detail(peer0_address)['our_balance'] == 100
-    assert netting_channel_01.detail(peer1_address)['our_balance'] == 0
+    assert netting_channel_01.detail(None)['our_balance'] == 100
+    assert netting_channel_02.detail(None)['our_balance'] == 0
 
     # double-funded channel
     app0.raiden.chain.token(token_address).approve(netting_address_02, 70)
@@ -121,16 +121,16 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
     assert netting_channel_01.can_transfer() is True
     assert netting_channel_02.can_transfer() is True
 
-    assert netting_channel_02.detail(peer0_address)['our_balance'] == 70
-    assert netting_channel_02.detail(peer2_address)['our_balance'] == 0
+    assert netting_channel_02.detail(None)['our_balance'] == 70
+    assert netting_channel_02.detail(None)['partner_balance'] == 0
 
     app2.raiden.chain.token(token_address).approve(netting_address_02, 130)
     app2.raiden.chain.netting_channel(netting_address_02).deposit(peer2_address, 130)
     assert netting_channel_01.can_transfer() is True
     assert netting_channel_02.can_transfer() is True
 
-    assert netting_channel_02.detail(peer0_address)['our_balance'] == 70
-    assert netting_channel_02.detail(peer2_address)['our_balance'] == 130
+    assert netting_channel_02.detail(None)['our_balance'] == 70
+    assert netting_channel_02.detail(None)['partner_balance'] == 130
 
 
 @pytest.mark.skipif(

--- a/raiden/tests/smart_contracts/netting_channel/test_deposit.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_deposit.py
@@ -98,11 +98,10 @@ def test_deposit_events(
         '_value': deposit_amount,
     }
 
-    block_number = tester_state.block.number
     assert newbalance_event == {
         '_event_type': 'ChannelNewBalance',
         'token_address': encode_hex(tester_token.address),
         'participant': encode_hex(address),
         'balance': deposit_amount,
-        'block_number': block_number,
+        'block_number': 0,  # the block number in the event is deprecated
     }

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -250,7 +250,7 @@ def test_new_channel(private_keys, tester_state, tester_channelmanager):
 
     assert channel.settleTimeout(sender=pkey0) == settle_timeout
     assert channel.tokenAddress(sender=pkey0) == tester_channelmanager.tokenAddress(sender=pkey0)
-    assert channel.opened(sender=pkey0) == 0
+    assert channel.opened(sender=pkey0) == tester_state.block.number - 1
     assert channel.closed(sender=pkey0) == 0
     assert channel.settled(sender=pkey0) == 0
 

--- a/raiden/tests/unit/test_service.py
+++ b/raiden/tests/unit/test_service.py
@@ -3,9 +3,11 @@ import pytest
 import gevent
 
 from raiden.utils import sha3
+from raiden.api.python import RaidenAPI
 from raiden.messages import Ping, Ack, decode
 from raiden.network.transport import UnreliableTransport, UDPTransport, RaidenProtocol
 from raiden.tests.utils.messages import setup_messages_cb
+from raiden.tests.utils.transfer import channel
 
 
 @pytest.mark.parametrize('blockchain_type', ['mock'])
@@ -160,3 +162,99 @@ def test_ping_ordering(raiden_network):
         assert decoded.echo == hashes[j]
 
     RaidenProtocol.repeat_messages = False
+
+
+@pytest.mark.parametrize('deposit', [0])
+def test_receive_direct_before_deposit(raiden_network):
+    """Regression test that ensures we accept incoming direct transfers, even if we don't have
+    any back channel balance.  """
+    app0, app1, app2 = raiden_network
+
+    token_address = app0.raiden.chain.default_registry.token_addresses()[0]
+    channel_0_1 = channel(app0, app1, token_address)
+    back_channel = channel(app1, app0, token_address)
+
+    assert not channel_0_1.can_transfer
+    assert not back_channel.can_transfer
+
+    deposit_amount = 2
+    transfer_amount = 1
+    api0 = RaidenAPI(app0.raiden)
+    api0.deposit(token_address, app1.raiden.address, deposit_amount)
+    gevent.sleep(app0.raiden.alarm.wait_time)
+
+    assert channel_0_1.can_transfer
+    assert not back_channel.can_transfer
+    assert back_channel.distributable == 0
+
+    api0.transfer_and_wait(token_address, transfer_amount, app1.raiden.address)
+    gevent.sleep(app1.raiden.alarm.wait_time)
+
+    assert back_channel.can_transfer
+    assert back_channel.distributable == transfer_amount
+
+
+@pytest.mark.parametrize('deposit', [0])
+def test_receive_mediated_before_deposit(raiden_network):
+    """Regression test that ensures we accept incoming mediated transfers, even if we don't have
+    any back channel balance. """
+    app_bob, app_alice, app_charly = raiden_network
+
+    token_address = app_bob.raiden.chain.default_registry.token_addresses()[0]
+    # path alice -> bob -> charly
+    alice_bob = channel(app_alice, app_bob, token_address)
+    bob_alice = channel(app_bob, app_alice, token_address)
+    bob_charly = channel(app_bob, app_charly, token_address)
+    charly_bob = channel(app_charly, app_bob, token_address)
+
+    all_channels = dict(
+        alice_bob=alice_bob,
+        bob_alice=bob_alice,
+        bob_charly=bob_charly,
+        charly_bob=charly_bob
+    )
+    with pytest.raises(KeyError):
+        channel(app_alice, app_charly, token_address)
+
+    assert not alice_bob.can_transfer
+    assert not bob_charly.can_transfer
+    assert not bob_alice.can_transfer
+
+    deposit_amount = 3
+    transfer_amount = 1
+
+    api_alice = RaidenAPI(app_alice.raiden)
+    api_alice.deposit(token_address, app_bob.raiden.address, deposit_amount)
+    gevent.sleep(app_alice.raiden.alarm.wait_time)
+
+    api_bob = RaidenAPI(app_bob.raiden)
+    api_bob.deposit(token_address, app_charly.raiden.address, deposit_amount)
+    gevent.sleep(app_bob.raiden.alarm.wait_time)
+
+    assert alice_bob.can_transfer
+    assert alice_bob.distributable == deposit_amount
+    assert bob_charly.can_transfer
+    assert bob_charly.distributable == deposit_amount
+    assert not bob_alice.can_transfer
+
+    api_alice.transfer_and_wait(token_address, transfer_amount, app_charly.raiden.address)
+    gevent.sleep(app_alice.raiden.alarm.wait_time)
+
+    assert alice_bob.distributable == deposit_amount - transfer_amount
+    assert bob_charly.distributable == deposit_amount - transfer_amount
+    assert bob_alice.distributable == transfer_amount, channel_balances(all_channels)
+    assert bob_alice.can_transfer
+    assert charly_bob.distributable == transfer_amount, channel_balances(all_channels)
+    assert charly_bob.can_transfer
+
+
+def channel_balances(name_to_channel):
+    result = dict()
+    for name, channel_ in name_to_channel.items():
+        result[name] = dict(
+            deposit=channel_.deposit,
+            balance=channel_.balance,
+            distributable=channel_.distributable,
+            locked=channel_.locked
+        )
+    return result

--- a/raiden/tests/unit/test_service.py
+++ b/raiden/tests/unit/test_service.py
@@ -182,6 +182,7 @@ def test_receive_direct_before_deposit(raiden_network):
     transfer_amount = 1
     api0 = RaidenAPI(app0.raiden)
     api0.deposit(token_address, app1.raiden.address, deposit_amount)
+    app0.raiden.chain.next_block()
     gevent.sleep(app0.raiden.alarm.wait_time)
 
     assert channel_0_1.can_transfer

--- a/raiden/tests/utils/__init__.py
+++ b/raiden/tests/utils/__init__.py
@@ -1,0 +1,26 @@
+from functools import partial, update_wrapper
+import inspect
+
+
+class OwnedNettingChannel(object):
+    """User end for NettingChannel-Mock implementations, that will fill in 'our_address'
+    if and where necessary.
+    This allows to use the same method signatures on the outside in all implementations,
+    while keeping the simple state sharing implementation of NettingChannelMock.
+    """
+    def __init__(self, our_address, netting_channel):
+        self.netting_channel = netting_channel
+        self.our_address = our_address
+        for name, value in inspect.getmembers(self.netting_channel):
+            # ignore private parts
+            if not name.startswith('__'):
+                if inspect.ismethod(value):
+                    orig_func = getattr(self.netting_channel, name)
+                    if 'our_address' in inspect.getargspec(orig_func).args:
+                        new_func = partial(orig_func, self.our_address)
+                        update_wrapper(new_func, orig_func)
+                        setattr(self, name, new_func)
+                    else:
+                        setattr(self, name, orig_func)
+                else:
+                    setattr(self, name, value)

--- a/raiden/tests/utils/mock_client.py
+++ b/raiden/tests/utils/mock_client.py
@@ -182,7 +182,7 @@ class FilterMock(object):
         return events
 
     def event(self, event):
-        if event['topics'] is None or event['topics'] == self.topics:
+        if self.topics is None or event['topics'] == self.topics:
             self.events.append(event)
 
     def uninstall(self):

--- a/raiden/tests/utils/mock_client.py
+++ b/raiden/tests/utils/mock_client.py
@@ -375,8 +375,12 @@ class NettingChannelMock(object):
     def settle_timeout(self):
         return self.contract.settle_timeout
 
-    def isopen(self):
-        return self.contract.isopen
+    def can_transfer(self, our_address):
+        return (
+            self.contract.opened > 0 and
+            self.contract.closed == 0 and
+            self.detail(our_address)['our_balance'] > 0
+        )
 
     def deposit(self, our_address, amount):
         self.contract.deposit(

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -9,7 +9,7 @@ from raiden.app import App
 from raiden.network.discovery import Discovery
 from raiden.network.transport import DummyPolicy
 from raiden.utils import privatekey_to_address
-from raiden.tests.utils.mock_client import OwnedNettingChannelMock
+from raiden.tests.utils import OwnedNettingChannel
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -17,11 +17,13 @@ CHAIN = object()  # Flag used by create a network does make a loop with the chan
 
 
 def check_channel(app1, app2, netting_channel_address):
-    netcontract1 = OwnedNettingChannelMock(
+    # proxying the NettingChannel with OwnedNettingChannel allows us to use both, tester and mock.
+    netcontract1 = OwnedNettingChannel(
         app1.raiden.address,
         app1.raiden.chain.netting_channel(netting_channel_address)
     )
-    netcontract2 = OwnedNettingChannelMock(
+
+    netcontract2 = OwnedNettingChannel(
         app2.raiden.address,
         app2.raiden.chain.netting_channel(netting_channel_address)
     )

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -16,7 +16,7 @@ log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 CHAIN = object()  # Flag used by create a network does make a loop with the channels
 
 
-def check_channel(app1, app2, netting_channel_address):
+def check_channel(app1, app2, netting_channel_address, deposit_amount):
     # proxying the NettingChannel with OwnedNettingChannel allows us to use both, tester and mock.
     netcontract1 = OwnedNettingChannel(
         app1.raiden.address,
@@ -28,8 +28,9 @@ def check_channel(app1, app2, netting_channel_address):
         app2.raiden.chain.netting_channel(netting_channel_address)
     )
 
-    assert netcontract1.can_transfer()
-    assert netcontract2.can_transfer()
+    if deposit_amount > 0:
+        assert netcontract1.can_transfer()
+        assert netcontract2.can_transfer()
 
     app1_details = netcontract1.detail()
     app2_details = netcontract2.detail()
@@ -111,6 +112,7 @@ def setup_channels(token_address, app_pairs, deposit, settle_timeout):
             first,
             second,
             netcontract_address,
+            deposit,
         )
 
         first_netting_channel = first.raiden.chain.netting_channel(netcontract_address)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -9,6 +9,7 @@ from raiden.app import App
 from raiden.network.discovery import Discovery
 from raiden.network.transport import DummyPolicy
 from raiden.utils import privatekey_to_address
+from raiden.tests.utils.mock_client import OwnedNettingChannelMock
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -16,17 +17,20 @@ CHAIN = object()  # Flag used by create a network does make a loop with the chan
 
 
 def check_channel(app1, app2, netting_channel_address):
-    netcontract1 = app1.raiden.chain.netting_channel(netting_channel_address)
-    netcontract2 = app2.raiden.chain.netting_channel(netting_channel_address)
+    netcontract1 = OwnedNettingChannelMock(
+        app1.raiden.address,
+        app1.raiden.chain.netting_channel(netting_channel_address)
+    )
+    netcontract2 = OwnedNettingChannelMock(
+        app2.raiden.address,
+        app2.raiden.chain.netting_channel(netting_channel_address)
+    )
 
     assert netcontract1.can_transfer()
     assert netcontract2.can_transfer()
 
-    assert netcontract1.can_transfer()
-    assert netcontract2.can_transfer()
-
-    app1_details = netcontract1.detail(app1.raiden.address)
-    app2_details = netcontract2.detail(app2.raiden.address)
+    app1_details = netcontract1.detail()
+    app2_details = netcontract2.detail()
 
     assert app1_details['our_address'] == app2_details['partner_address']
     assert app1_details['partner_address'] == app2_details['our_address']

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -19,11 +19,11 @@ def check_channel(app1, app2, netting_channel_address):
     netcontract1 = app1.raiden.chain.netting_channel(netting_channel_address)
     netcontract2 = app2.raiden.chain.netting_channel(netting_channel_address)
 
-    assert netcontract1.isopen()
-    assert netcontract2.isopen()
+    assert netcontract1.can_transfer()
+    assert netcontract2.can_transfer()
 
-    assert netcontract1.detail(app1.raiden.address) == netcontract2.detail(app1.raiden.address)
-    assert netcontract2.detail(app2.raiden.address) == netcontract1.detail(app2.raiden.address)
+    assert netcontract1.can_transfer()
+    assert netcontract2.can_transfer()
 
     app1_details = netcontract1.detail(app1.raiden.address)
     app2_details = netcontract2.detail(app2.raiden.address)

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -136,8 +136,8 @@ class ChannelExternalStateTester(object):
     def settled_block(self):
         return self.netting_channel.settled()
 
-    def isopen(self):
-        return self.netting_channel.isopen()
+    def can_transfer(self):
+        return self.netting_channel.can_transfer()
 
     def update_transfer(self, our_address, first_transfer, second_transfer=None):
         return self.netting_channel.update_transfer(our_address, first_transfer, second_transfer)
@@ -551,7 +551,7 @@ class NettingChannelTesterMock(object):
         self.channelsettle_filters = list()
 
         # check we are a participant of the channel
-        self.detail(privatekey_to_address(private_key))
+        self.detail(None)
 
     def token_address(self):
         result = address_decoder(self.proxy.tokenAddress())
@@ -563,7 +563,7 @@ class NettingChannelTesterMock(object):
         self.tester_state.mine(number_of_blocks=1)
         return result
 
-    def isopen(self):
+    def can_transfer(self):
         # do not mine in this method
         closed = self.proxy.closed()
 
@@ -571,8 +571,10 @@ class NettingChannelTesterMock(object):
             return False
 
         opened = self.proxy.opened()
-
-        return opened != 0
+        return (
+            opened != 0 and
+            self.detail(None)['our_balance'] > 0
+        )
 
     def deposit(self, our_address, amount):
         if privatekey_to_address(self.private_key) != our_address:
@@ -610,6 +612,8 @@ class NettingChannelTesterMock(object):
         return settled
 
     def detail(self, our_address):
+        """ FIXME: 'our_address' is only needed for the pure python mock implementation """
+        our_address = privatekey_to_address(self.private_key)
         data = self.proxy.addressAndBalance()
         self.tester_state.mine(number_of_blocks=1)
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -308,7 +308,7 @@ class ConsoleTools(object):
                      else channel.external_state.netting_channel.address.encode('hex')),
             lifecycle=dict(
                 opened_at=channel.external_state.opened_block or 'not yet',
-                open=channel.isopen,
+                can_transfer=channel.can_transfer,
                 closed_at=channel.external_state.closed_block or 'not yet',
                 settled_at=channel.external_state.settled_block or 'not yet',
             ),


### PR DESCRIPTION
This adds the proposed fixes for issue #613
In detail:
- set the NettingChannelContract opened block in the smart contract constructor
- don't call `register_netting_channel` from `RaidenAPI.open`, but wait for the event handler to process the newly created instance instead
- check the value of the `opened_block` in `ChannelEndState.__init__`, to avoid nonce ranges starting from `0`
- I also changed the reported block number in the `ChannelNewBalance` event. Previously it used the `opened` block number, which, from my point of view seems incorrect because a later call to `deposit` would always report the opened block -- since we don't need the block number #450 it is now set to `0` to let anything using the event included block number fail early.
- I changed/removed `channel.isopen()` assertions from `raiden/tests/integration/test_blockchainservice.py` -- this is due to the lifecycle model having changed. Previously the assumption was, that a deposit is necessary for a channel end to be "opened".
- I changed `isopen()` to `can_transfer()` that checks for `distributable` funds of a channel end and replaced checks for openness with `channel.state == CHANNEL_STATE_OPENED` tests
- I added regression tests for cases where transfers were not accepted due to the changed semantics.
- I added a bugfix for the `all_events_filter` of the `mock` blockchain implementation.

This fixes #613 