### PR TITLE
Ensure that extraData is hex-encoded when creating genesis block

### DIFF
--- a/tools/genesis_builder.py
+++ b/tools/genesis_builder.py
@@ -26,7 +26,7 @@ def mk_genesis(accounts, initial_alloc=denoms.ether * 100000000):
     :return: genesis dict
     """
     genesis = GENESIS_STUB.copy()
-    genesis['extraData'] = CLUSTER_NAME
+    genesis['extraData'] = '0x' + CLUSTER_NAME.encode('hex')
     genesis['alloc'] = {
         account: {
             'balance': str(initial_alloc)


### PR DESCRIPTION
Related to issue #618 this hex-encodes the 'extraData' value in the genesis block JSON as per https://github.com/ethereum/wiki/wiki/Ethereum-Chain-Spec-Format#subformat-genesis