### PR TITLE
Improve token interface and fix solc warnings

### DIFF
--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -132,8 +132,15 @@ contract ChannelManagerContract {
     /// @notice Check if a contract exists
     /// @param channel The address to check whether a contract is deployed or not
     /// @return True if a contract exists, false otherwise
-    function contractExists(address channel) private constant returns (bool) {
-        return data.contractExists(channel);
+    function contractExists(address channel) private constant returns (bool exists) {
+        uint size;
+        exists = false;
+        assembly {
+            size := extcodesize(channel)
+        }
+        if (size > 0) {
+            exists = true;
+        }
     }
 
     /// @dev Delete a channel that's been settled

--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -62,16 +62,4 @@ library ChannelManagerLibrary {
         }
     }
 
-    /// @notice Check if a contract is deployed at given address
-    /// @param _addr address to check for a deployed contract
-    /// @return if contract exists, false if not
-    function contractExists(Data storage self, address _addr) internal constant returns (bool) {
-        uint size;
-        assembly {
-            size := extcodesize(_addr)
-        }
-        if (size > 0) {
-            return true;
-        }
-    }
 }

--- a/raiden/smart_contracts/HumanStandardToken.sol
+++ b/raiden/smart_contracts/HumanStandardToken.sol
@@ -41,7 +41,7 @@ contract HumanStandardToken is StandardToken {
         string _tokenSymbol
         ) {
         balances[msg.sender] = _initialAmount;               // Give the creator all initial tokens
-        totalSupply = _initialAmount;                        // Update total supply
+        _total_supply = _initialAmount;                        // Update total supply
         name = _tokenName;                                   // Set the name for display purposes
         decimals = _decimalUnits;                            // Amount of decimals for display purposes
         symbol = _tokenSymbol;                               // Set the symbol for display purposes

--- a/raiden/smart_contracts/StandardToken.sol
+++ b/raiden/smart_contracts/StandardToken.sol
@@ -50,7 +50,12 @@ contract StandardToken is Token {
       return allowed[_owner][_spender];
     }
 
+    function totalSupply() constant returns (uint256 supply) {
+        return _total_supply;
+    }
+
+    uint256 internal _total_supply;
     mapping (address => uint256) balances;
     mapping (address => mapping (address => uint256)) allowed;
-    uint256 public totalSupply;
+
 }

--- a/raiden/smart_contracts/Token.sol
+++ b/raiden/smart_contracts/Token.sol
@@ -1,36 +1,36 @@
 pragma solidity ^0.4.0;
-contract Token {
+interface Token {
 
     /// @return total amount of tokens
-    function totalSupply() constant returns (uint256 supply) {}
+    function totalSupply() constant returns (uint256 supply);
 
     /// @param _owner The address from which the balance will be retrieved
     /// @return The balance
-    function balanceOf(address _owner) constant returns (uint256 balance) {}
+    function balanceOf(address _owner) constant returns (uint256 balance);
 
     /// @notice send `_value` token to `_to` from `msg.sender`
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return Whether the transfer was successful or not
-    function transfer(address _to, uint256 _value) returns (bool success) {}
+    function transfer(address _to, uint256 _value) returns (bool success);
 
     /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
     /// @param _from The address of the sender
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return Whether the transfer was successful or not
-    function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {}
+    function transferFrom(address _from, address _to, uint256 _value) returns (bool success);
 
     /// @notice `msg.sender` approves `_spender` to spend `_value` tokens
     /// @param _spender The address of the account able to transfer the tokens
     /// @param _value The amount of wei to be approved for transfer
     /// @return Whether the approval was successful or not
-    function approve(address _spender, uint256 _value) returns (bool success) {}
+    function approve(address _spender, uint256 _value) returns (bool success);
 
     /// @param _owner The address of the account owning tokens
     /// @param _spender The address of the account able to transfer the tokens
     /// @return Amount of remaining tokens allowed to spent
-    function allowance(address _owner, address _spender) constant returns (uint256 remaining) {}
+    function allowance(address _owner, address _spender) constant returns (uint256 remaining);
 
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);


### PR DESCRIPTION
Solc 0.4.11 introduces various warnings, including the unused local
variable warnings which pinpoing two places in the contracts where we
can improve.

One was the Token.sol contract which I turned into an interface to
properly reflect its purpose.

The other is the `contractExists()` part of ChannelManagerLibrary.sol
which should be part of the contract and not the library.