### PR TITLE
Remove `HumanStandardToken.sol` from deploy stack

### DIFF
--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -14,7 +14,6 @@ from raiden.network.rpc.client import patch_send_transaction, patch_send_message
 
 # ordered list of solidity files to deploy for the raiden registry
 RAIDEN_CONTRACT_FILES = [
-    'Token.sol',
     'NettingChannelLibrary.sol',
     'ChannelManagerLibrary.sol',
     'Registry.sol',


### PR DESCRIPTION
Deployment of `*Token` contracts is not necessary -- they are not used as libraries, only as interfaces.