### PR TITLE
Downgrade geth to 1.5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   global:
-    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.6.1-021c3c28.tar.gz'
-    - GETH_VERSION='1.6.1'
+    - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.5.9-a07539fb.tar.gz'
+    - GETH_VERSION='1.5.9'
     - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.11/solc-static-linux'
     - SOLC_VERSION='v0.4.11'
   matrix:


### PR DESCRIPTION
Since `geth makedag` is broken, we have to wait for
https://github.com/ethereum/go-ethereum/pull/14598 or something
equivalent is included in a new release.