### PR TITLE
Allowed receiving locks with a large expiration

### DIFF
--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -261,6 +261,8 @@ library NettingChannelLibrary {
         }
         counterparty.withdrawn_locks[hashlock] = true;
 
+        // The lock must not have expired, it does not matter how far in the
+        // future it would have expired
         require(expiration >= block.number);
 
         if (hashlock != sha3(secret)) {

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -134,10 +134,14 @@ def try_new_route(state):
         # The initiator doesn't need to learn the secret, so there is no need
         # to decrement reveal_timeout from the lock timeout.
         #
-        # A value larger than settle_timeout could be used but wouldn't
-        # improve, since the next hop will take settle_timeout as an upper
-        # limit for expiration.
+        # The lock_expiration could be set to a value larger than
+        # settle_timeout, this is not useful since the next hop will take this
+        # channel settle_timeout as an upper limit for expiration.
+        #
+        # The two nodes will most likely disagree on latest block, as far as
+        # the expiration goes this is no problem.
         lock_expiration = state.block_number + try_route.settle_timeout
+
         identifier = state.transfer.identifier
 
         transfer = LockedTransferState(


### PR DESCRIPTION
Races will occur among partner nodes in respect to the latest block
number.

To avoid failure under this scenario, where *next hop* is not enforcing
the received expiration to be lower than settlement timeout:

The *initiator* learns first about a new block and uses it's number as
the base to compute a lock expiration, then the *next hop* receives the
transfer prior to learning about the same block.