### PR TITLE
create transfer with explicit block number

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -669,12 +669,12 @@ class Channel(object):
             locksroot=current_locksroot,
         )
 
-    def create_lockedtransfer(self, amount, identifier, expiration, hashlock):
+    def create_lockedtransfer(self, block_number, amount, identifier, expiration, hashlock):
         """ Return a LockedTransfer message.
 
         This message needs to be signed and registered with the channel before sent.
         """
-        timeout = expiration - self.block_number
+        timeout = expiration - block_number
 
         if not self.can_transfer:
             raise ValueError('Transfer not possible, no funding or channel closed.')
@@ -733,6 +733,7 @@ class Channel(object):
 
     def create_mediatedtransfer(
             self,
+            block_number,
             transfer_initiator,
             transfer_target,
             fee,
@@ -755,6 +756,7 @@ class Channel(object):
         """
 
         locked_transfer = self.create_lockedtransfer(
+            block_number,
             amount,
             identifier,
             expiration,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1211,6 +1211,7 @@ class StateMachineEventHandler(object):
             channel = graph.partneraddress_channel[receiver]
 
             mediated_transfer = channel.create_mediatedtransfer(
+                self.raiden.get_block_number(),
                 event.initiator,
                 event.target,
                 fee,

--- a/raiden/tests/benchmark/speed_transfer.py
+++ b/raiden/tests/benchmark/speed_transfer.py
@@ -108,6 +108,7 @@ def transfer_speed(num_transfers=100, max_locked=100):  # pylint: disable=too-ma
     for i, amount in enumerate(amounts):
         hashlock = sha3(secrets[i])
         locked_transfer = channel0.create_lockedtransfer(
+            app0.raiden.get_block_number(),
             amount=amount,
             identifier=1,  # TODO: fill in identifier
             expiration=expiration,

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -79,6 +79,7 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     identifier = 1
     fee = 0
     transfermessage = alice_bob_channel.create_mediatedtransfer(
+        alice_app.raiden.get_block_number(),
         alice_app.raiden.address,
         bob_app.raiden.address,
         fee,

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -318,6 +318,7 @@ def test_python_channel():
     expiration = block_number + settle_timeout - 5
     identifier = 1
     mediatedtransfer = test_channel.create_mediatedtransfer(
+        block_number,
         address1,
         address2,
         fee,
@@ -428,6 +429,7 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
         block_number = app0.raiden.chain.block_number()
         expiration = block_number + settle_timeout - 1
         mediated_transfer = channel0.create_mediatedtransfer(
+            block_number,
             transfer_initiator=app0.raiden.address,
             transfer_target=app1.raiden.address,
             fee=0,
@@ -576,6 +578,7 @@ def test_locked_transfer(raiden_network, settle_timeout):
     hashlock = sha3(secret)
 
     mediated_transfer = channel0.create_mediatedtransfer(
+        block_number,
         transfer_initiator=app0.raiden.address,
         transfer_target=app1.raiden.address,
         fee=0,
@@ -634,6 +637,7 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
     hashlock = sha3(secret)
 
     transfer1 = channel0.create_mediatedtransfer(
+        block_number,
         transfer_initiator=app0.raiden.address,
         transfer_target=app1.raiden.address,
         fee=0,

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -130,6 +130,7 @@ def pending_mediated_transfer(app_chain, token, amount, identifier, expiration):
             hashlock = sha3(secret)
 
         transfer_ = from_channel.create_mediatedtransfer(
+            from_app.raiden.get_block_number(),
             initiator_app.raiden.address,
             target_app.raiden.address,
             fee,
@@ -303,7 +304,8 @@ def make_mediated_transfer(
     identifier = channel.our_state.nonce
     fee = 0
 
-    mediated_transfer = channel.create_mediatedtransfer(
+    mediated_transfer = channel.create_mediatedtransfer(  # pylint: disable=redefined-outer-name
+        block_number,
         initiator,
         target,
         fee,

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -342,6 +342,7 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
             )
 
             from_mediated_transfer = from_channel.create_mediatedtransfer(
+                raiden.get_block_number(),
                 raiden.address,
                 to_nodeaddress,
                 fee,
@@ -628,6 +629,7 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
             # make a paying MediatedTransfer with same hashlock/identifier and the
             # taker's paying token/amount
             taker_paying_transfer = taker_paying_channel.create_mediatedtransfer(
+                raiden.get_block_number(),
                 raiden.address,
                 maker_address,
                 fee,


### PR DESCRIPTION
passing block number as argument to the channel instance to avoid
syncrhonization problems, were the channel is lagging behind one block
and may reject a transfer because of the block number difference.