### PR TITLE
Add ne operator overloading

### DIFF
--- a/raiden/tests/unit/test_operators.py
+++ b/raiden/tests/unit/test_operators.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from raiden.utils import sha3
+from raiden.transfer.state_change import (
+    ActionCancelTransfer,
+    ActionTransferDirect,
+    Block,
+    ReceiveTransferDirect,
+)
+from raiden.transfer.state import (
+    RouteState,
+    RoutesState,
+)
+from raiden.transfer.events import (
+    EventTransferSentSuccess,
+    EventTransferSentFailed,
+    EventTransferReceivedSuccess,
+)
+from raiden.transfer.mediated_transfer.state import LockedTransferState
+from raiden.messages import Ack
+
+
+ADDRESS = sha3('foo')[:20]
+ADDRESS2 = sha3('boo')[:20]
+ADDRESS3 = sha3('coo')[:20]
+ADDRESS4 = sha3('goo')[:20]
+SECRET = 'secret'
+HASH = sha3(SECRET)
+HASH2 = sha3('joo')
+
+
+def test_transfer_statechange_operators():
+    a = Block(2)
+    b = Block(2)
+    c = Block(3)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+    a = ActionCancelTransfer(2)
+    b = ActionCancelTransfer(2)
+    c = ActionCancelTransfer(3)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+    a = ActionTransferDirect(2, 2, ADDRESS, ADDRESS)
+    b = ActionTransferDirect(2, 2, ADDRESS, ADDRESS)
+    c = ActionTransferDirect(3, 4, ADDRESS, ADDRESS2)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+    a = ReceiveTransferDirect(2, 2, ADDRESS, ADDRESS)
+    b = ReceiveTransferDirect(2, 2, ADDRESS, ADDRESS)
+    c = ReceiveTransferDirect(3, 4, ADDRESS, ADDRESS2)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+
+def test_state_operators():
+    a_route = RouteState('opened', ADDRESS, ADDRESS2, 5, 5, 5, 5)
+    b_route = RouteState('opened', ADDRESS, ADDRESS2, 5, 5, 5, 5)
+    c_route = RouteState('closed', ADDRESS3, ADDRESS2, 1, 2, 3, 4)
+
+    assert a_route == b_route
+    assert not a_route != b_route
+    assert a_route != c_route
+    assert not a_route == c_route
+
+    d_route = RouteState('opened', ADDRESS4, ADDRESS, 1, 2, 3, 4)
+    a = RoutesState([a_route, d_route])
+    b = RoutesState([a_route, d_route])
+    c = RoutesState([a_route, c_route])
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+    a = LockedTransferState(1, 2, ADDRESS, ADDRESS2, ADDRESS3, 4, HASH, 'secret')
+    b = LockedTransferState(1, 2, ADDRESS, ADDRESS2, ADDRESS3, 4, HASH, 'secret')
+    c = LockedTransferState(2, 4, ADDRESS3, ADDRESS4, ADDRESS, 4, HASH, 'secret')
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+
+def test_event_operators():
+    a = EventTransferSentSuccess(2)
+    b = EventTransferSentSuccess(2)
+    c = EventTransferSentSuccess(3)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+    a = EventTransferSentFailed(2, 'BECAUSE')
+    b = EventTransferSentFailed(2, 'BECAUSE')
+    c = EventTransferSentFailed(3, 'UNKNOWN')
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+    a = EventTransferReceivedSuccess(2)
+    b = EventTransferReceivedSuccess(2)
+    c = EventTransferReceivedSuccess(3)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c
+
+
+def test_message_operators():
+    a = Ack(ADDRESS, HASH)
+    b = Ack(ADDRESS, HASH)
+    c = Ack(ADDRESS2, HASH2)
+
+    assert a == b
+    assert not a != b
+    assert a != c
+    assert not a == c

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -37,6 +37,9 @@ class EventTransferSentSuccess(Event):
             self.identifier == other.identifier
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class EventTransferSentFailed(Event):
     """ Event emitted by the payer when a transfer has failed.
@@ -59,6 +62,9 @@ class EventTransferSentFailed(Event):
             self.reason == other.reason
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class EventTransferReceivedSuccess(Event):
     """ Event emitted when a payee has received a payment.
@@ -80,3 +86,6 @@ class EventTransferReceivedSuccess(Event):
         return (
             self.identifier == other.identifier
         )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -201,6 +201,9 @@ class LockedTransferState(State):
 
         return False
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class MediationPairState(State):
     """ State for a mediated transfer.

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -84,6 +84,9 @@ class RouteState(State):
             )
         return False
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class RoutesState(State):
     """ Routing state.
@@ -133,3 +136,6 @@ class RoutesState(State):
             )
 
         return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -22,6 +22,9 @@ class Block(StateChange):
             self.block_number == other.block_number
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __str__(self):
         return 'Block({})'.format(self.block_number)
 
@@ -69,6 +72,9 @@ class ActionCancelTransfer(StateChange):
             self.identifier == other.identifier
         )
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __str__(self):
         return 'ActionCancelTransfer(identifier:{})'.format(
             self.identifier,
@@ -98,6 +104,9 @@ class ActionTransferDirect(StateChange):
             self.token_address == other.token_address and
             self.node_address == other.node_address
         )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __str__(self):
         return (
@@ -135,6 +144,9 @@ class ReceiveTransferDirect(StateChange):
             self.token_address == other.token_address and
             self.sender == other.sender
         )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __str__(self):
         return (


### PR DESCRIPTION
In some of our code we were overloading the `==` operator using `__eq__`. As can be seen in [this](http://jcalderone.livejournal.com/32837.html) article that does not also overload the `!=` operator automatically which can lead to some really nasty bugs in the future.

This PR makes sure we always got a corresponding `__ne__` to each `__eq__` and also adds tests for this.