### PR TITLE
Do not block during startup (#511)

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -290,12 +290,13 @@ def run(ctx, **kwargs):
 
         app_ = ctx.invoke(app, **kwargs)
 
-        app_.discovery.register(
+        # spawn address registration to avoid block while waiting for the next block
+        registry_event = gevent.spawn(
+            app_.discovery.register,
             app_.raiden.address,
             mapped_socket.external_ip,
             mapped_socket.external_port,
         )
-
         app_.raiden.register_registry(app_.raiden.chain.default_registry.address)
 
         domain_list = []
@@ -330,6 +331,7 @@ def run(ctx, **kwargs):
             console = Console(app_)
             console.start()
 
+        registry_event.join()
         # wait for interrupt
         event = gevent.event.Event()
         gevent.signal(signal.SIGQUIT, event.set)


### PR DESCRIPTION
Juist opening a normal PR from: https://github.com/raiden-network/raiden/pull/627

As address/socket pair registration requires confirmation of the
tx, polling until it appears in the next block introduces a delay
until other services/cli can be started. This fix spawns a
separate gevent for the registration to speed up the startup.