### PR TITLE
Updated Documentation to help future Devs

### DIFF
--- a/docs/Overview-And-Guide.rst
+++ b/docs/Overview-And-Guide.rst
@@ -58,7 +58,7 @@ After syncing the chain, create an account on the Ropsten testnet by navigating 
 
      http://127.0.0.1:8180
 
-After account creation, launch raiden with the path of your keystore supplied and the RPC endpoint of the parity client (defaults show): 
+After account creation, launch raiden with the path of your keystore supplied and the RPC endpoint of the parity client (defaults show)::
 
      raiden --keystore-path "~/.local/share/io.parity.ethereum/keys/test" --eth-rpc-endpoint "127.0.0.1:8545"
 

--- a/docs/Overview-And-Guide.rst
+++ b/docs/Overview-And-Guide.rst
@@ -45,3 +45,22 @@ After you have done that you can proceed to install the dependencies::
 
     pip install --upgrade -r requirements.txt
     python setup.py develop
+
+You will also need an ethereum client that is connected to the Ropsten testnet.  In example, download the parity client::
+
+    sudo snap install parity --edge && sudo cp /snap/parity/current/bin/parity /usr/bin/parity
+
+Run the parity client and let it sync to the Ropsten testnet::
+
+     parity --chain ropsten --bootnodes "enode://20c9ad97c081d63397d7b685a412227a40e23c8bdc6688c6f37e97cfbc22d2b4d1db1510d8f61e6a8866ad7f0e17c02b14182d37ea7c3c8b9c2683aeb6b733a1@52.169.14.227:30303,enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@13.84.180.240:30303"
+
+After syncing the chain, create an account on the Ropsten testnet by navigating to the url that parity shows.  It is usually::
+
+     http://127.0.0.1:8180
+
+After account creation, launch raiden with the path of your keystore supplied and the RPC endpoint of the parity client (defaults show): 
+
+     raiden --keystore-path "~/.local/share/io.parity.ethereum/keys/test" --eth-rpc-endpoint "127.0.0.1:8545"
+
+Select the ethereum account when prompted, and type in the account's password. 
+ 


### PR DESCRIPTION
I updated the documentation to include examples of how to work with parity and Ropsten testnet.  The old documentation uses pyethapp, which as far as I know, can only work with Morden.  

