### PR TITLE
CLI rework

### DIFF
--- a/raiden/__main__.py
+++ b/raiden/__main__.py
@@ -5,6 +5,9 @@ def main():
     import gevent.monkey
     gevent.monkey.patch_all()
     from raiden.ui.cli import run
+    # auto_envvar_prefix on a @click.command will cause all options to be
+    # available also through environment variables prefixed with given prefix
+    # http://click.pocoo.org/6/options/#values-from-environment-variables
     run(auto_envvar_prefix='RAIDEN')
 
 

--- a/raiden/__main__.py
+++ b/raiden/__main__.py
@@ -5,7 +5,7 @@ def main():
     import gevent.monkey
     gevent.monkey.patch_all()
     from raiden.ui.cli import run
-    run()
+    run(auto_envvar_prefix='RAIDEN')
 
 
 if __name__ == "__main__":

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -74,7 +74,7 @@ class APIServer(object):
     api_server = APIServer(rest_api)
 
     # run the server
-    api_server.run(5001, debug=True)
+    api_server.run('127.0.0.1', 5001, debug=True)
     ```
     """
 
@@ -153,10 +153,8 @@ class APIServer(object):
             resource_class_kwargs={'rest_api_object': self.rest_api}
         )
 
-    def run(self, port, **kwargs):
-        if 'host' in kwargs:
-            raise ValueError('The server host is hardcoded, can\'t set it')
-        self.flask_app.run(port=port, host='localhost', **kwargs)
+    def run(self, host='127.0.0.1', port=5001, **kwargs):
+        self.flask_app.run(host=host, port=port, **kwargs)
 
 
 class RestAPI(object):

--- a/raiden/main.py
+++ b/raiden/main.py
@@ -5,4 +5,7 @@ from raiden.ui.cli import run
 
 
 if __name__ == '__main__':
+    # auto_envvar_prefix on a @click.command will cause all options to be
+    # available also through environment variables prefixed with given prefix
+    # http://click.pocoo.org/6/options/#values-from-environment-variables
     run(auto_envvar_prefix='RAIDEN')

--- a/raiden/main.py
+++ b/raiden/main.py
@@ -5,4 +5,4 @@ from raiden.ui.cli import run
 
 
 if __name__ == '__main__':
-    run()
+    run(auto_envvar_prefix='RAIDEN')

--- a/raiden/tests/fixtures/api.py
+++ b/raiden/tests/fixtures/api.py
@@ -42,7 +42,7 @@ def api_backend(rest_api_port_number):
     # TODO: Find out why tests fail with debug=True
     server = Greenlet.spawn(
         api_server.run,
-        rest_api_port_number,
+        port=rest_api_port_number,
         debug=False,
         use_evalex=False,
     )

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -33,7 +33,6 @@ OPTIONS = [
               'a keystore file exists in your local system.'),
         default=None,
         type=str,
-        envvar='ETH_ADDRESS',
     ),
     click.option(
         '--keystore-path',

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -120,12 +120,10 @@ OPTIONS = [
         default=True,
     ),
     click.option(
-        '--api-port',
-        help=(
-            'Port for the RPC server to run from'
-        ),
-        default=5001,
-        type=int,
+        '--api-address',
+        help='"host:port" for the RPC server to listen on.',
+        default="127.0.0.1:5001",
+        type=str,
     ),
 ]
 
@@ -152,7 +150,7 @@ def app(address,
         logfile,
         max_unresponsive_time,
         send_ping_time,
-        api_port,
+        api_address,
         rpc,
         console):
 
@@ -163,12 +161,14 @@ def app(address,
 
     # config_file = args.config_file
     (listen_host, listen_port) = split_endpoint(listen_address)
+    (api_host, api_port) = split_endpoint(api_address)
 
     config = App.DEFAULT_CONFIG.copy()
     config['host'] = listen_host
     config['port'] = listen_port
     config['console'] = console
     config['rpc'] = rpc
+    config['api_host'] = api_host
     config['api_port'] = api_port
     config['socket'] = socket
 
@@ -314,16 +314,17 @@ def run(ctx, **kwargs):
 
             Greenlet.spawn(
                 api_server.run,
+                ctx.params['api_host'],
                 ctx.params['api_port'],
                 debug=False,
                 use_evalex=False
             )
 
             print(
-                "The RPC server is now running at http://localhost:{}/.\n\n"
+                "The RPC server is now running at http://{}:{}/.\n\n"
                 "See the Raiden documentation for all available endpoints at\n"
                 "https://github.com/raiden-network/raiden/blob/master/docs/Rest-Api.rst".format(
-                    ctx.params['api_port'],
+                    ctx.params['api_host'], ctx.params['api_port'],
                 )
             )
 


### PR DESCRIPTION
These small adjusts allows to run raiden entirely on a docker container.
`--api-address` allows the API to be exposed to the world (e.g: `0.0.0.0:5001`), and thus still accept connections even when contained.
`--address` now also accepts its data from a environment variable, `ETH_ADDRESS`.
Account password also can be passed through another environment variable, `ETH_PASSWORD`, which didn't get exposed through click/command line option to avoid it being visible through process/command line listing tools, like `ps aux`.
TODO: document those options in proper place.