### PR TITLE
Try to address flaky test

### DIFF
--- a/raiden/tests/long_running/test_token_networks.py
+++ b/raiden/tests/long_running/test_token_networks.py
@@ -174,6 +174,9 @@ def test_participant_selection(
     sender = raiden_network[-1].raiden
     receiver = raiden_network[0].raiden
 
+    # wait for the receiver service to update the channel mappings:
+    while sender.address not in receiver.channelgraphs[token_address].partneraddress_channel:
+        gevent.sleep(receiver.alarm.wait_time)
     # assert there is a direct channel receiver -> sender (vv)
     receiver_channel = RaidenAPI(receiver).get_channel_list(
         token_address=token_address,


### PR DESCRIPTION
The errors specified in #691 are all related to a key error in the receivers channel list. I added a waiting loop to see if this is just a timing issue.

Suggestion: if we get 20 out of 20 passes, we can consider this a fix.

Please 
- help by restarting the [`long_running` `geth` test on travis](https://travis-ci.org/raiden-network/raiden/jobs/250731993) whenever it passes and
- take note of a successful re-run of the test in an extra comment.

**Note: please don't restart the complete build, but only the [2221.4](https://travis-ci.org/raiden-network/raiden/jobs/250731993) entry!**

If this PR ever fails with the same `KeyError` as in #691 (see below), please close the PR. 

```
# Let it raise the KeyError
channel = graph.partneraddress_channel[partner_address]
    KeyError: "F'\x1b,\xd9\xba\x1d>\xbf\xc6\xbb\xd7J\xa1zj\xb2\xf8\xd0\xae"
```