### PR TITLE
Do not invoke contract compilation at file import

### DIFF
--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -3,6 +3,8 @@ import os
 import json
 import hashlib
 
+from threading import Lock
+
 from ethereum import _solidity
 from ethereum.abi import event_id, normalize_name, ContractTranslator
 
@@ -95,44 +97,47 @@ class ContractManager():
 
     def __init__(self):
         self.is_instantiated = False
+        self.lock = Lock()
 
     def instantiate(self):
-        self.human_standard_token_compiled = get_static_or_compile(
-            get_contract_path('HumanStandardToken.sol'),
-            'HumanStandardToken',
-            combined='abi',
-        )
+        with self.lock:
+            if self.is_instantiated:
+                return
 
-        self.channel_manager_compiled = get_static_or_compile(
-            get_contract_path('ChannelManagerContract.sol'),
-            'ChannelManagerContract',
-            combined='abi',
-        )
+            self.human_standard_token_compiled = get_static_or_compile(
+                get_contract_path('HumanStandardToken.sol'),
+                'HumanStandardToken',
+                combined='abi',
+            )
 
-        self.endpoint_registry_compiled = get_static_or_compile(
-            get_contract_path('EndpointRegistry.sol'),
-            'EndpointRegistry',
-            combined='abi',
-        )
+            self.channel_manager_compiled = get_static_or_compile(
+                get_contract_path('ChannelManagerContract.sol'),
+                'ChannelManagerContract',
+                combined='abi',
+            )
 
-        self.netting_channel_compiled = get_static_or_compile(
-            get_contract_path('NettingChannelContract.sol'),
-            'NettingChannelContract',
-            combined='abi',
-        )
+            self.endpoint_registry_compiled = get_static_or_compile(
+                get_contract_path('EndpointRegistry.sol'),
+                'EndpointRegistry',
+                combined='abi',
+            )
 
-        self.registry_compiled = get_static_or_compile(
-            get_contract_path('Registry.sol'),
-            'Registry',
-            combined='abi',
-        )
+            self.netting_channel_compiled = get_static_or_compile(
+                get_contract_path('NettingChannelContract.sol'),
+                'NettingChannelContract',
+                combined='abi',
+            )
 
-        self.is_instantiated = True
+            self.registry_compiled = get_static_or_compile(
+                get_contract_path('Registry.sol'),
+                'Registry',
+                combined='abi',
+            )
+
+            self.is_instantiated = True
 
     def get_abi(self, contract_name):
-        if not self.is_instantiated:
-            self.instantiate()
-
+        self.instantiate()
         compiled = getattr(self, '{}_compiled'.format(contract_name))
         return compiled['abi']
 

--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -10,7 +10,35 @@ from ethereum.abi import event_id, normalize_name, ContractTranslator
 
 from raiden.utils import get_contract_path
 
-__all__ = ('CONTRACT_MANAGER',)
+__all__ = (
+    'CONTRACT_MANAGER',
+
+    'CONTRACT_CHANNEL_MANAGER',
+    'CONTRACT_ENDPOINT_REGISTRY',
+    'CONTRACT_HUMAN_STANDARD_TOKEN',
+    'CONTRACT_NETTING_CHANNEL',
+    'CONTRACT_REGISTRY',
+
+    'EVENT_CHANNEL_NEW',
+    'EVENT_CHANNEL_NEW_BALANCE',
+    'EVENT_CHANNEL_CLOSED',
+    'EVENT_CHANNEL_SECRET_REVEALED',
+    'EVENT_CHANNEL_SETTLED',
+    'EVENT_TOKEN_ADDED',
+)
+
+CONTRACT_CHANNEL_MANAGER = 'channel_manager'
+CONTRACT_ENDPOINT_REGISTRY = 'endpoint_registry'
+CONTRACT_HUMAN_STANDARD_TOKEN = 'human_standard_token'
+CONTRACT_NETTING_CHANNEL = 'netting_channel'
+CONTRACT_REGISTRY = 'registry'
+
+EVENT_CHANNEL_NEW = 'ChannelNew'
+EVENT_CHANNEL_NEW_BALANCE = 'ChannelNewBalance'
+EVENT_CHANNEL_CLOSED = 'ChannelClosed'
+EVENT_CHANNEL_SECRET_REVEALED = 'ChannelSecretRevealed'
+EVENT_CHANNEL_SETTLED = 'ChannelSettled'
+EVENT_TOKEN_ADDED = 'TokenAdded'
 
 
 def get_event(full_abi, event_name):
@@ -98,6 +126,14 @@ class ContractManager():
     def __init__(self):
         self.is_instantiated = False
         self.lock = Lock()
+        self.event_to_contract = dict(
+            ChannelNew=CONTRACT_CHANNEL_MANAGER,
+            ChannelNewBalance=CONTRACT_NETTING_CHANNEL,
+            ChannelClosed=CONTRACT_NETTING_CHANNEL,
+            ChannelSecretRevealed=CONTRACT_NETTING_CHANNEL,
+            ChannelSettled=CONTRACT_NETTING_CHANNEL,
+            TokenAdded=CONTRACT_REGISTRY,
+        )
 
     def instantiate(self):
         with self.lock:
@@ -145,21 +181,7 @@ class ContractManager():
         """ Not really generic, as it maps event names to events of specific contracts,
         but it is good enough for what we want to accomplish.
         """
-        if event_name == 'TokenAdded':
-            event = get_event(self.get_abi('registry'), event_name)
-        elif event_name == 'ChannelNew':
-            event = get_event(self.get_abi('channel_manager'), event_name)
-        elif event_name == 'ChannelNewBalance':
-            event = get_event(self.get_abi('netting_channel'), event_name)
-        elif event_name == 'ChannelClosed':
-            event = get_event(self.get_abi('netting_channel'), event_name)
-        elif event_name == 'ChannelSecretRevealed':
-            event = get_event(self.get_abi('netting_channel'), event_name)
-        elif event_name == 'ChannelSettled':
-            event = get_event(self.get_abi('netting_channel'), event_name)
-        else:
-            raise ValueError('Unknown event: {}'.format(event_name))
-
+        event = get_event(self.get_abi(self.event_to_contract[event_name]), event_name)
         return event_id(*get_eventname_types(event))
 
     def get_translator(self, contract_name):

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -4,11 +4,7 @@ from collections import namedtuple, defaultdict
 
 from pyethapp.jsonrpc import address_decoder
 
-from raiden.blockchain.abi import (
-    REGISTRY_TRANSLATOR,
-    CHANNEL_MANAGER_TRANSLATOR,
-    NETTING_CHANNEL_TRANSLATOR,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 from raiden.utils import pex
 from raiden.network.rpc.client import new_filter, Filter
 
@@ -110,7 +106,7 @@ def get_all_channel_manager_events(
 
     return get_contract_events(
         pyethapp_chain,
-        CHANNEL_MANAGER_TRANSLATOR,
+        CONTRACT_MANAGER.get_translator('channel_manager'),
         channel_manager_address,
         events,
         from_block,
@@ -129,7 +125,7 @@ def get_all_registry_events(
     """
     return get_contract_events(
         pyethapp_chain,
-        REGISTRY_TRANSLATOR,
+        CONTRACT_MANAGER.get_translator('registry'),
         registry_address,
         events,
         from_block,
@@ -149,7 +145,7 @@ def get_all_netting_channel_events(
 
     return get_contract_events(
         pyethapp_chain,
-        NETTING_CHANNEL_TRANSLATOR,
+        CONTRACT_MANAGER.get_translator('netting_channel'),
         netting_channel_address,
         events,
         from_block,
@@ -285,7 +281,7 @@ class PyethappBlockchainEvents(object):
         self.add_event_listener(
             'Registry {}'.format(pex(registry_address)),
             tokenadded,
-            REGISTRY_TRANSLATOR,
+            CONTRACT_MANAGER.get_translator('registry'),
         )
 
     def add_channel_manager_listener(self, channel_manager_proxy):
@@ -295,7 +291,7 @@ class PyethappBlockchainEvents(object):
         self.add_event_listener(
             'ChannelManager {}'.format(pex(manager_address)),
             channelnew,
-            CHANNEL_MANAGER_TRANSLATOR,
+            CONTRACT_MANAGER.get_translator('channel_manager'),
         )
 
     def add_netting_channel_listener(self, netting_channel_proxy):
@@ -305,7 +301,7 @@ class PyethappBlockchainEvents(object):
         self.add_event_listener(
             'NettingChannel Event {}'.format(pex(channel_address)),
             netting_channel_events,
-            NETTING_CHANNEL_TRANSLATOR,
+            CONTRACT_MANAGER.get_translator('netting_channel'),
         )
 
     def add_proxies_listeners(self, pyethapp_proxies):

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -4,7 +4,14 @@ from collections import namedtuple, defaultdict
 
 from pyethapp.jsonrpc import address_decoder
 
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import (
+    CONTRACT_MANAGER,
+    CONTRACT_CHANNEL_MANAGER,
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_HUMAN_STANDARD_TOKEN,
+    CONTRACT_NETTING_CHANNEL,
+    CONTRACT_REGISTRY,
+)
 from raiden.utils import pex
 from raiden.network.rpc.client import new_filter, Filter
 
@@ -106,7 +113,7 @@ def get_all_channel_manager_events(
 
     return get_contract_events(
         pyethapp_chain,
-        CONTRACT_MANAGER.get_translator('channel_manager'),
+        CONTRACT_MANAGER.get_translator(CONTRACT_CHANNEL_MANAGER),
         channel_manager_address,
         events,
         from_block,
@@ -125,7 +132,7 @@ def get_all_registry_events(
     """
     return get_contract_events(
         pyethapp_chain,
-        CONTRACT_MANAGER.get_translator('registry'),
+        CONTRACT_MANAGER.get_translator(CONTRACT_REGISTRY),
         registry_address,
         events,
         from_block,
@@ -145,7 +152,7 @@ def get_all_netting_channel_events(
 
     return get_contract_events(
         pyethapp_chain,
-        CONTRACT_MANAGER.get_translator('netting_channel'),
+        CONTRACT_MANAGER.get_translator(CONTRACT_NETTING_CHANNEL),
         netting_channel_address,
         events,
         from_block,
@@ -281,7 +288,7 @@ class PyethappBlockchainEvents(object):
         self.add_event_listener(
             'Registry {}'.format(pex(registry_address)),
             tokenadded,
-            CONTRACT_MANAGER.get_translator('registry'),
+            CONTRACT_MANAGER.get_translator(CONTRACT_REGISTRY),
         )
 
     def add_channel_manager_listener(self, channel_manager_proxy):

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -7,8 +7,6 @@ from pyethapp.jsonrpc import address_decoder
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
     CONTRACT_CHANNEL_MANAGER,
-    CONTRACT_ENDPOINT_REGISTRY,
-    CONTRACT_HUMAN_STANDARD_TOKEN,
     CONTRACT_NETTING_CHANNEL,
     CONTRACT_REGISTRY,
 )

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -32,15 +32,7 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
 )
-from raiden.blockchain.abi import (
-    TOKENADDED_EVENTID,
-    CHANNEL_MANAGER_ABI,
-    CHANNELNEW_EVENTID,
-    ENDPOINT_REGISTRY_ABI,
-    HUMAN_TOKEN_ABI,
-    NETTING_CHANNEL_ABI,
-    REGISTRY_ABI,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 solidity = _solidity.get_solidity()  # pylint: disable=invalid-name
@@ -480,7 +472,7 @@ class Discovery(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            ENDPOINT_REGISTRY_ABI,
+            CONTRACT_MANAGER.get_abi('endpoint_registry'),
             address_encoder(discovery_address),
         )
 
@@ -546,7 +538,7 @@ class Token(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            HUMAN_TOKEN_ABI,
+            CONTRACT_MANAGER.get_abi('human_standard_token'),
             address_encoder(token_address),
         )
 
@@ -616,7 +608,7 @@ class Registry(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            REGISTRY_ABI,
+            CONTRACT_MANAGER.get_abi('registry'),
             address_encoder(registry_address),
         )
 
@@ -676,7 +668,7 @@ class Registry(object):
         ]
 
     def tokenadded_filter(self, from_block=None, to_block=None):
-        topics = [TOKENADDED_EVENTID]
+        topics = [CONTRACT_MANAGER.get_event_id('TokenAdded')]
 
         registry_address_bin = self.proxy.address
         filter_id_raw = new_filter(
@@ -715,7 +707,7 @@ class ChannelManager(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            CHANNEL_MANAGER_ABI,
+            CONTRACT_MANAGER.get_abi('channel_manager'),
             address_encoder(manager_address),
         )
 
@@ -819,11 +811,7 @@ class ChannelManager(object):
         Return:
             Filter: The filter instance.
         """
-        # participant_address_hex = address_encoder(privatekey_to_address(self.client.privkey))
-        # topics = [
-        #     CHANNELNEW_EVENTID, [node_address_hex, None], [None, node_address_hex],
-        # ]
-        topics = [CHANNELNEW_EVENTID]
+        topics = [CONTRACT_MANAGER.get_event_id('ChannelNew')]
 
         channel_manager_address_bin = self.proxy.address
         filter_id_raw = new_filter(
@@ -862,7 +850,7 @@ class NettingChannel(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            NETTING_CHANNEL_ABI,
+            CONTRACT_MANAGER.get_abi('netting_channel'),
             address_encoder(channel_address),
         )
 

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -32,7 +32,17 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
 )
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import (
+    CONTRACT_MANAGER,
+    CONTRACT_CHANNEL_MANAGER,
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_HUMAN_STANDARD_TOKEN,
+    CONTRACT_NETTING_CHANNEL,
+    CONTRACT_REGISTRY,
+
+    EVENT_CHANNEL_NEW,
+    EVENT_TOKEN_ADDED,
+)
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 solidity = _solidity.get_solidity()  # pylint: disable=invalid-name
@@ -472,7 +482,7 @@ class Discovery(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            CONTRACT_MANAGER.get_abi('endpoint_registry'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_ENDPOINT_REGISTRY),
             address_encoder(discovery_address),
         )
 
@@ -538,7 +548,7 @@ class Token(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            CONTRACT_MANAGER.get_abi('human_standard_token'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
             address_encoder(token_address),
         )
 
@@ -608,7 +618,7 @@ class Registry(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            CONTRACT_MANAGER.get_abi('registry'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY),
             address_encoder(registry_address),
         )
 
@@ -668,7 +678,7 @@ class Registry(object):
         ]
 
     def tokenadded_filter(self, from_block=None, to_block=None):
-        topics = [CONTRACT_MANAGER.get_event_id('TokenAdded')]
+        topics = [CONTRACT_MANAGER.get_event_id(EVENT_TOKEN_ADDED)]
 
         registry_address_bin = self.proxy.address
         filter_id_raw = new_filter(
@@ -707,7 +717,7 @@ class ChannelManager(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            CONTRACT_MANAGER.get_abi('channel_manager'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
             address_encoder(manager_address),
         )
 
@@ -811,7 +821,7 @@ class ChannelManager(object):
         Return:
             Filter: The filter instance.
         """
-        topics = [CONTRACT_MANAGER.get_event_id('ChannelNew')]
+        topics = [CONTRACT_MANAGER.get_event_id(EVENT_CHANNEL_NEW)]
 
         channel_manager_address_bin = self.proxy.address
         filter_id_raw = new_filter(
@@ -850,7 +860,7 @@ class NettingChannel(object):
             ))
 
         proxy = jsonrpc_client.new_abi_contract(
-            CONTRACT_MANAGER.get_abi('netting_channel'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL),
             address_encoder(channel_address),
         )
 

--- a/raiden/tests/fixtures/abi.py
+++ b/raiden/tests/fixtures/abi.py
@@ -1,24 +1,30 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import (
+    CONTRACT_MANAGER,
+    CONTRACT_CHANNEL_MANAGER,
+    CONTRACT_HUMAN_STANDARD_TOKEN,
+    CONTRACT_NETTING_CHANNEL,
+    CONTRACT_REGISTRY,
+)
 
 
 @pytest.fixture(scope='session')
 def token_abi():
-    return CONTRACT_MANAGER.get_abi('human_standard_token')
+    return CONTRACT_MANAGER.get_abi(CONTRACT_HUMAN_STANDARD_TOKEN)
 
 
 @pytest.fixture(scope='session')
 def registry_abi():
-    return CONTRACT_MANAGER.get_abi('registry')
+    return CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY)
 
 
 @pytest.fixture(scope='session')
 def channel_manager_abi():
-    return CONTRACT_MANAGER.get_abi('channel_manager')
+    return CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER)
 
 
 @pytest.fixture(scope='session')
 def netting_channel_abi():
-    return CONTRACT_MANAGER.get_abi('netting_channel')
+    return CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL)

--- a/raiden/tests/fixtures/abi.py
+++ b/raiden/tests/fixtures/abi.py
@@ -1,29 +1,24 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from raiden.blockchain.abi import (
-    HUMAN_TOKEN_ABI,
-    CHANNEL_MANAGER_ABI,
-    NETTING_CHANNEL_ABI,
-    REGISTRY_ABI,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 
 
 @pytest.fixture(scope='session')
 def token_abi():
-    return HUMAN_TOKEN_ABI
+    return CONTRACT_MANAGER.get_abi('human_standard_token')
 
 
 @pytest.fixture(scope='session')
 def registry_abi():
-    return REGISTRY_ABI
+    return CONTRACT_MANAGER.get_abi('registry')
 
 
 @pytest.fixture(scope='session')
 def channel_manager_abi():
-    return CHANNEL_MANAGER_ABI
+    return CONTRACT_MANAGER.get_abi('channel_manager')
 
 
 @pytest.fixture(scope='session')
 def netting_channel_abi():
-    return NETTING_CHANNEL_ABI
+    return CONTRACT_MANAGER.get_abi('netting_channel')

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -14,7 +14,7 @@ from raiden.network.rpc.client import (
     decode_topic, patch_send_transaction, patch_send_message
 )
 from raiden.utils import privatekey_to_address, get_contract_path
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import CONTRACT_MANAGER, CONTRACT_CHANNEL_MANAGER
 
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 
@@ -246,7 +246,7 @@ def test_blockchain(
     assert token_proxy.address == event['token_address'].decode('hex')
 
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
-        CONTRACT_MANAGER.get_abi('channel_manager'),
+        CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
         channel_manager_address,
     )
 

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -14,7 +14,7 @@ from raiden.network.rpc.client import (
     decode_topic, patch_send_transaction, patch_send_message
 )
 from raiden.utils import privatekey_to_address, get_contract_path
-from raiden.blockchain.abi import CHANNEL_MANAGER_ABI
+from raiden.blockchain.abi import CONTRACT_MANAGER
 
 solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
 
@@ -246,7 +246,7 @@ def test_blockchain(
     assert token_proxy.address == event['token_address'].decode('hex')
 
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
-        CHANNEL_MANAGER_ABI,
+        CONTRACT_MANAGER.get_abi('channel_manager'),
         channel_manager_address,
     )
 

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -12,7 +12,12 @@ from raiden.tests.utils.transfer import (
 )
 from raiden.tests.utils.blockchain import wait_until_block
 from raiden.tests.utils.network import CHAIN
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import (
+    CONTRACT_MANAGER,
+    EVENT_CHANNEL_CLOSED,
+    EVENT_CHANNEL_NEW_BALANCE,
+    EVENT_CHANNEL_SETTLED,
+)
 from raiden.blockchain.events import (
     ALL_EVENTS,
     get_all_channel_manager_events,
@@ -214,7 +219,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     events = get_all_netting_channel_events(
         app0.raiden.chain,
         netcontract_address,
-        events=[CONTRACT_MANAGER.get_event_id('ChannelNewBalance')],
+        events=[CONTRACT_MANAGER.get_event_id(EVENT_CHANNEL_NEW_BALANCE)],
     )
 
     assert len(all_netting_channel_events) == 1
@@ -243,7 +248,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     events = get_all_netting_channel_events(
         app0.raiden.chain,
         netcontract_address,
-        events=[CONTRACT_MANAGER.get_event_id('ChannelClosed')],
+        events=[CONTRACT_MANAGER.get_event_id(EVENT_CHANNEL_CLOSED)],
     )
 
     assert len(all_netting_channel_events) == 2
@@ -273,7 +278,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     events = get_all_netting_channel_events(
         app0.raiden.chain,
         netcontract_address,
-        events=[CONTRACT_MANAGER.get_event_id('ChannelSettled')],
+        events=[CONTRACT_MANAGER.get_event_id(EVENT_CHANNEL_SETTLED)],
     )
 
     assert len(all_netting_channel_events) == 3

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -12,11 +12,7 @@ from raiden.tests.utils.transfer import (
 )
 from raiden.tests.utils.blockchain import wait_until_block
 from raiden.tests.utils.network import CHAIN
-from raiden.blockchain.abi import (
-    CHANNELNEWBALANCE_EVENTID,
-    CHANNELCLOSED_EVENTID,
-    CHANNELSETTLED_EVENTID,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 from raiden.blockchain.events import (
     ALL_EVENTS,
     get_all_channel_manager_events,
@@ -218,7 +214,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     events = get_all_netting_channel_events(
         app0.raiden.chain,
         netcontract_address,
-        events=[CHANNELNEWBALANCE_EVENTID],
+        events=[CONTRACT_MANAGER.get_event_id('ChannelNewBalance')],
     )
 
     assert len(all_netting_channel_events) == 1
@@ -247,7 +243,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     events = get_all_netting_channel_events(
         app0.raiden.chain,
         netcontract_address,
-        events=[CHANNELCLOSED_EVENTID],
+        events=[CONTRACT_MANAGER.get_event_id('ChannelClosed')],
     )
 
     assert len(all_netting_channel_events) == 2
@@ -277,7 +273,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     events = get_all_netting_channel_events(
         app0.raiden.chain,
         netcontract_address,
-        events=[CHANNELSETTLED_EVENTID],
+        events=[CONTRACT_MANAGER.get_event_id('ChannelSettled')],
     )
 
     assert len(all_netting_channel_events) == 3

--- a/raiden/tests/smart_contracts/netting_channel/test_invariants.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_invariants.py
@@ -3,7 +3,7 @@ import pytest
 from ethereum import tester
 from ethereum.tester import TransactionFailed
 
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import CONTRACT_MANAGER, CONTRACT_NETTING_CHANNEL
 from raiden.constants import (
     NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
 )
@@ -41,7 +41,7 @@ def test_nettingchannel_minimum_settle_timeout(private_keys, tester_channelmanag
 
     netting_channel = tester.ABIContract(
         tester_state,
-        CONTRACT_MANAGER.get_translator('netting_channel'),
+        CONTRACT_MANAGER.get_translator(CONTRACT_NETTING_CHANNEL),
         netting_channel_address0_hex,
         log_listener=log_listener,
         default_key=INVALID_KEY,

--- a/raiden/tests/smart_contracts/netting_channel/test_invariants.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_invariants.py
@@ -3,9 +3,7 @@ import pytest
 from ethereum import tester
 from ethereum.tester import TransactionFailed
 
-from raiden.blockchain.abi import (
-    NETTING_CHANNEL_TRANSLATOR,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 from raiden.constants import (
     NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
 )
@@ -43,7 +41,7 @@ def test_nettingchannel_minimum_settle_timeout(private_keys, tester_channelmanag
 
     netting_channel = tester.ABIContract(
         tester_state,
-        NETTING_CHANNEL_TRANSLATOR,
+        CONTRACT_MANAGER.get_translator('netting_channel'),
         netting_channel_address0_hex,
         log_listener=log_listener,
         default_key=INVALID_KEY,

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -5,12 +5,7 @@ from ethereum.utils import decode_hex
 from raiden.constants import (
     NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
 )
-from raiden.blockchain.abi import (
-    CHANNEL_MANAGER_ABI,
-    NETTING_CHANNEL_ABI,
-    HUMAN_TOKEN_ABI,
-    REGISTRY_ABI,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 from raiden.channel import Channel, ChannelEndState
 from raiden.utils import privatekey_to_address
 
@@ -44,7 +39,7 @@ def approve_and_deposit(tester_token, nettingcontract, deposit, key):
 
 
 def create_tokenproxy(tester_state, tester_token_address, log_listener):
-    translator = tester.ContractTranslator(HUMAN_TOKEN_ABI)
+    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('human_standard_token'))
     token_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -56,7 +51,7 @@ def create_tokenproxy(tester_state, tester_token_address, log_listener):
 
 
 def create_registryproxy(tester_state, tester_registry_address, log_listener):
-    translator = tester.ContractTranslator(REGISTRY_ABI)
+    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('registry'))
     registry_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -68,7 +63,7 @@ def create_registryproxy(tester_state, tester_registry_address, log_listener):
 
 
 def create_channelmanager_proxy(tester_state, tester_channelmanager_address, log_listener):
-    translator = tester.ContractTranslator(CHANNEL_MANAGER_ABI)
+    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('channel_manager'))
     channel_manager_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -80,7 +75,7 @@ def create_channelmanager_proxy(tester_state, tester_channelmanager_address, log
 
 
 def create_nettingchannel_proxy(tester_state, tester_nettingchannel_address, log_listener):
-    translator = tester.ContractTranslator(NETTING_CHANNEL_ABI)
+    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('netting_channel'))
     netting_channel_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -177,7 +172,9 @@ def new_nettingcontract(our_key, partner_key, tester_state, log_listener,
     )
     tester_state.mine(number_of_blocks=1)
 
-    nettingchannel_translator = tester.ContractTranslator(NETTING_CHANNEL_ABI)
+    nettingchannel_translator = tester.ContractTranslator(
+        CONTRACT_MANAGER.get_abi('netting_channel')
+    )
 
     nettingchannel = tester.ABIContract(
         tester_state,

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -5,7 +5,13 @@ from ethereum.utils import decode_hex
 from raiden.constants import (
     NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
 )
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import (
+    CONTRACT_MANAGER,
+    CONTRACT_CHANNEL_MANAGER,
+    CONTRACT_HUMAN_STANDARD_TOKEN,
+    CONTRACT_NETTING_CHANNEL,
+    CONTRACT_REGISTRY,
+)
 from raiden.channel import Channel, ChannelEndState
 from raiden.utils import privatekey_to_address
 
@@ -39,7 +45,9 @@ def approve_and_deposit(tester_token, nettingcontract, deposit, key):
 
 
 def create_tokenproxy(tester_state, tester_token_address, log_listener):
-    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('human_standard_token'))
+    translator = tester.ContractTranslator(
+        CONTRACT_MANAGER.get_abi(CONTRACT_HUMAN_STANDARD_TOKEN)
+    )
     token_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -51,7 +59,7 @@ def create_tokenproxy(tester_state, tester_token_address, log_listener):
 
 
 def create_registryproxy(tester_state, tester_registry_address, log_listener):
-    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('registry'))
+    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY))
     registry_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -63,7 +71,9 @@ def create_registryproxy(tester_state, tester_registry_address, log_listener):
 
 
 def create_channelmanager_proxy(tester_state, tester_channelmanager_address, log_listener):
-    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('channel_manager'))
+    translator = tester.ContractTranslator(
+        CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER)
+    )
     channel_manager_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -75,7 +85,9 @@ def create_channelmanager_proxy(tester_state, tester_channelmanager_address, log
 
 
 def create_nettingchannel_proxy(tester_state, tester_nettingchannel_address, log_listener):
-    translator = tester.ContractTranslator(CONTRACT_MANAGER.get_abi('netting_channel'))
+    translator = tester.ContractTranslator(
+        CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL)
+    )
     netting_channel_abi = tester.ABIContract(
         tester_state,
         translator,
@@ -173,7 +185,7 @@ def new_nettingcontract(our_key, partner_key, tester_state, log_listener,
     tester_state.mine(number_of_blocks=1)
 
     nettingchannel_translator = tester.ContractTranslator(
-        CONTRACT_MANAGER.get_abi('netting_channel')
+        CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL)
     )
 
     nettingchannel = tester.ABIContract(

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -17,7 +17,17 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
 )
-from raiden.blockchain.abi import CONTRACT_MANAGER
+from raiden.blockchain.abi import (
+    CONTRACT_MANAGER,
+    CONTRACT_CHANNEL_MANAGER,
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_HUMAN_STANDARD_TOKEN,
+    CONTRACT_NETTING_CHANNEL,
+    CONTRACT_REGISTRY,
+
+    EVENT_CHANNEL_NEW,
+    EVENT_TOKEN_ADDED,
+)
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 FILTER_ID_GENERATOR = count()
@@ -327,7 +337,7 @@ class DiscoveryTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            CONTRACT_MANAGER.get_abi('endpoint_registry'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_ENDPOINT_REGISTRY),
             address,
             default_key=private_key,
         )
@@ -368,7 +378,7 @@ class TokenTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            CONTRACT_MANAGER.get_abi('human_standard_token'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
             address,
             default_key=private_key,
         )
@@ -398,7 +408,7 @@ class RegistryTesterMock(object):
 
         self.registry_proxy = tester.ABIContract(
             self.tester_state,
-            CONTRACT_MANAGER.get_abi('registry'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY),
             self.address,
             default_key=private_key,
         )
@@ -431,7 +441,7 @@ class RegistryTesterMock(object):
 
     def tokenadded_filter(self, **kwargs):
         """May also receive from_block, to_block but they are not used here"""
-        topics = [CONTRACT_MANAGER.get_event_id('TokenAdded')]
+        topics = [CONTRACT_MANAGER.get_event_id(EVENT_TOKEN_ADDED)]
         filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR))
         self.tester_state.block.log_listeners.append(filter_.event)
         return filter_
@@ -448,7 +458,7 @@ class ChannelManagerTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            CONTRACT_MANAGER.get_abi('channel_manager'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
             address,
             default_key=private_key,
         )
@@ -516,7 +526,7 @@ class ChannelManagerTesterMock(object):
         return result
 
     def channelnew_filter(self):
-        topics = [CONTRACT_MANAGER.get_event_id('ChannelNew')]
+        topics = [CONTRACT_MANAGER.get_event_id(EVENT_CHANNEL_NEW)]
         filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR))
         self.tester_state.block.log_listeners.append(filter_.event)
         return filter_
@@ -533,7 +543,7 @@ class NettingChannelTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            CONTRACT_MANAGER.get_abi('netting_channel'),
+            CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL),
             address,
             default_key=private_key,
         )

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -17,15 +17,7 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
 )
-from raiden.blockchain.abi import (
-    TOKENADDED_EVENTID,
-    CHANNEL_MANAGER_ABI,
-    CHANNELNEW_EVENTID,
-    ENDPOINT_REGISTRY_ABI,
-    HUMAN_TOKEN_ABI,
-    NETTING_CHANNEL_ABI,
-    REGISTRY_ABI,
-)
+from raiden.blockchain.abi import CONTRACT_MANAGER
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 FILTER_ID_GENERATOR = count()
@@ -335,7 +327,7 @@ class DiscoveryTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            ENDPOINT_REGISTRY_ABI,
+            CONTRACT_MANAGER.get_abi('endpoint_registry'),
             address,
             default_key=private_key,
         )
@@ -376,7 +368,7 @@ class TokenTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            HUMAN_TOKEN_ABI,
+            CONTRACT_MANAGER.get_abi('human_standard_token'),
             address,
             default_key=private_key,
         )
@@ -406,7 +398,7 @@ class RegistryTesterMock(object):
 
         self.registry_proxy = tester.ABIContract(
             self.tester_state,
-            REGISTRY_ABI,
+            CONTRACT_MANAGER.get_abi('registry'),
             self.address,
             default_key=private_key,
         )
@@ -439,7 +431,7 @@ class RegistryTesterMock(object):
 
     def tokenadded_filter(self, **kwargs):
         """May also receive from_block, to_block but they are not used here"""
-        topics = [TOKENADDED_EVENTID]
+        topics = [CONTRACT_MANAGER.get_event_id('TokenAdded')]
         filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR))
         self.tester_state.block.log_listeners.append(filter_.event)
         return filter_
@@ -456,7 +448,7 @@ class ChannelManagerTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            CHANNEL_MANAGER_ABI,
+            CONTRACT_MANAGER.get_abi('channel_manager'),
             address,
             default_key=private_key,
         )
@@ -524,7 +516,7 @@ class ChannelManagerTesterMock(object):
         return result
 
     def channelnew_filter(self):
-        topics = [CHANNELNEW_EVENTID]
+        topics = [CONTRACT_MANAGER.get_event_id('ChannelNew')]
         filter_ = FilterTesterMock(self.address, topics, next(FILTER_ID_GENERATOR))
         self.tester_state.block.log_listeners.append(filter_.event)
         return filter_
@@ -541,7 +533,7 @@ class NettingChannelTesterMock(object):
 
         self.proxy = tester.ABIContract(
             tester_state,
-            NETTING_CHANNEL_ABI,
+            CONTRACT_MANAGER.get_abi('netting_channel'),
             address,
             default_key=private_key,
         )


### PR DESCRIPTION
Until now anything that imported `raiden/blockchain/abi.py` invoked the
compilation of our contracts in order to get the ABI and some other
attributes.

This PR moves the logic to a class that is initialized at import but not
instantiated there. The ABI and other contract attributes are lazily
evaluated. In other words the first time something is required only then
are the contracts compiled.

Finally now we can do `raiden --help` without waiting 5-6 seconds.