### PR TITLE
Refuse to generate addresses from wrong privatekey length

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -117,6 +117,8 @@ def publickey_to_address(publickey):
 
 
 def privatekey_to_address(private_key_bin):
+    if not len(private_key_bin) == 32:
+        raise ValueError('private_key_bin format mismatch. maybe hex encoded?')
     private_key = PrivateKey(private_key_bin)
     pubkey = private_key.public_key.format(compressed=False)
     return publickey_to_address(pubkey)


### PR DESCRIPTION
Other than `ethereum.utils.privtoaddr`, does `raiden.utils.privatekey_to_address` not support hex-encoded keys but treats all input as binary (see below for the different behavior).
This is meant to enforce sandwich encoding of addresses and keys (binary internally, hex to the outside world).

To avoid hard to detect errors after providing hex-encoded private keys, I changed the helper to refuse input of any other length than 32.

```
In [1]: from raiden.utils import privatekey_to_address

In [2]: from ethereum.utils import sha3, privtoaddr

In [3]: key = sha3('key')

In [4]: privtoaddr(key)
Out[4]: 'X1\x88\xa9\xcfw\xe1\xb2WL\xca\xe4\n\xeb\x9ax\x94\x88\xec\xa2'

In [5]: privtoaddr(key.encode('hex'))
Out[5]: 'X1\x88\xa9\xcfw\xe1\xb2WL\xca\xe4\n\xeb\x9ax\x94\x88\xec\xa2'

In [6]: privatekey_to_address(key)
Out[6]: 'X1\x88\xa9\xcfw\xe1\xb2WL\xca\xe4\n\xeb\x9ax\x94\x88\xec\xa2'

In [7]: privatekey_to_address(key.encode('hex'))
Out[7]: '\x0f/3\xe8\xd9;Z\xb39\xf3\xeb\xac\xe6"\x81\x03\x99TC\xb9'
```