### PR TITLE
Update documentation for tokens endpoint

### DIFF
--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -172,8 +172,7 @@ Possible Responses
 Querying all traded Tokens
 --------------------------
 
-By making a ``GET`` request to ``/api/<version>/tokens`` you can get a list of addresses of all
-tokens we have channels open for.
+By making a ``GET`` request to ``/api/<version>/tokens`` you get a list of addresses of all registered tokens.
 
 
 Example Request


### PR DESCRIPTION
The documentation for the `/api/1/tokens` endpoint gave the reader the
idea that it only returned the tokens that the user was participating
in, but the call actually returns all registered tokens. So the
documentation has been updated to reflect this.