### PR TITLE
Rename pregenerate_dag fixture for clarity

### DIFF
--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -87,7 +87,7 @@ def dagpath():
 
 
 @pytest.fixture(autouse=True)
-def pregenerate_dag(request, blockchain_type, dagpath):
+def ensure_dag_is_generated(request, blockchain_type, dagpath):
     missing_dag = (
         not os.path.exists(dagpath) or
         os.path.getsize(dagpath) != EPOCH0_DAGSIZE


### PR DESCRIPTION
As
[this](https://github.com/raiden-network/raiden/pull/665#discussion_r126122831)
comment shows it is easy to mistake the functionality of the fixture due
to its name.

I assumed that the DAG is pregenerated once per session, while in fact
the fixture simply ensures it is there by generating it if it is not and
doing nothing if it is.

Renamed for clarity.