### PR TITLE
Register token when trying to open a channel with an unregistered token

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -631,7 +631,10 @@ class Registry(object):
 
     def manager_address_by_token(self, token_address):
         """ Return the channel manager address for the given token. """
-        return self.proxy.channelManagerByToken.call(token_address)
+        manager_address_encoded = self.proxy.channelManagerByToken.call(token_address)
+        if not manager_address_encoded or manager_address_encoded == '0x':
+            manager_address_encoded = self.add_token(token_address)
+        return manager_address_encoded
 
     def add_token(self, token_address):
         transaction_hash = estimate_and_transact(
@@ -664,6 +667,8 @@ class Registry(object):
             registry_address=pex(self.address),
             channel_manager_address=pex(channel_manager_address_bin),
         )
+
+        return channel_manager_address_encoded
 
     def token_addresses(self):
         return [


### PR DESCRIPTION
This should fix the #706 issue.
The fix is simple, but wanted to cover this usecase with tests, which are the intent of this first commit.

- [x] Create a test for open/close channel, both with registered and unregistered token
- [ ] Fix the code, registering the token if it isn't registered yet
