### PR TITLE
Transfer expiration

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -252,6 +252,15 @@ class Channel(object):
     def outstanding(self):
         return self.our_state.locked()
 
+    def get_settle_expiration(self, block_number):
+        closed_block = self.external_state.closed_block
+        if closed_block != 0:
+            blocks_until_settlement = closed_block + self.settle_timeout
+        else:
+            blocks_until_settlement = block_number + self.settle_timeout
+
+        return blocks_until_settlement
+
     def channel_closed(self, block_number):  # pylint: disable=unused-argument
         balance_proof = self.our_state.balance_proof
         transfer = balance_proof.transfer
@@ -513,7 +522,7 @@ class Channel(object):
             #
             # For the receiver: A lock that expires after the settle period
             # just means there is more time to withdraw it.
-            end_settle_period = self.block_number + self.settle_timeout
+            end_settle_period = self.get_settle_expiration(self.block_number)
             expires_after_settle = transfer.lock.expiration > end_settle_period
             is_sender = transfer.sender == self.our_address
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -421,11 +421,12 @@ class Channel(object):
 
         self.our_state.release_lock(self.partner_state, secret)
 
-    def register_transfer(self, transfer):
+    def register_transfer(self, block_number, transfer):
         """ Register a signed transfer, updating the channel's state accordingly. """
 
         if transfer.recipient == self.partner_state.address:
             self.register_transfer_from_to(
+                block_number,
                 transfer,
                 from_state=self.our_state,
                 to_state=self.partner_state,
@@ -435,6 +436,7 @@ class Channel(object):
 
         elif transfer.recipient == self.our_state.address:
             self.register_transfer_from_to(
+                block_number,
                 transfer,
                 from_state=self.partner_state,
                 to_state=self.our_state,
@@ -451,7 +453,13 @@ class Channel(object):
                 )
             raise UnknownAddress(transfer)
 
-    def register_transfer_from_to(self, transfer, from_state, to_state):  # noqa pylint: disable=too-many-branches,too-many-statements
+    def register_transfer_from_to(
+            self,
+            block_number,
+            transfer,
+            from_state,
+            to_state):  # noqa pylint: disable=too-many-branches,too-many-statements
+
         """ Validates and register a signed transfer, updating the channel's state accordingly.
 
         Note:

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -102,7 +102,10 @@ class StateMachineEventHandler(object):
             )
 
             self.raiden.sign(mediated_transfer)
-            channel.register_transfer(mediated_transfer)
+            channel.register_transfer(
+                self.raiden.get_block_number(),
+                mediated_transfer,
+            )
             self.raiden.send_async(receiver, mediated_transfer)
 
         elif isinstance(event, SendRevealSecret):
@@ -149,7 +152,10 @@ class StateMachineEventHandler(object):
             )
 
             self.raiden.sign(refund_transfer)
-            channel.register_transfer(refund_transfer)
+            channel.register_transfer(
+                self.raiden.get_block_number(),
+                refund_transfer,
+            )
             self.raiden.send_async(receiver, refund_transfer)
 
         elif isinstance(event, EventTransferSentSuccess):

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -206,7 +206,10 @@ class RaidenMessageHandler(object):
         )
         state_change_id = self.raiden.transaction_log.log(state_change)
 
-        channel.register_transfer(message)
+        channel.register_transfer(
+            self.raiden.get_block_number(),
+            message,
+        )
 
         receive_success = EventTransferReceivedSuccess(
             message.identifier,
@@ -254,7 +257,11 @@ class RaidenMessageHandler(object):
                 )
             )
 
-        channel.register_transfer(message)  # raises if the message is invalid
+        # raises if the message is invalid
+        channel.register_transfer(
+            self.raiden.get_block_number(),
+            message
+        )
 
         if message.target == self.raiden.address:
             self.raiden.target_mediated_transfer(message)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -853,7 +853,10 @@ class RaidenService(object):
         else:
             direct_transfer = direct_channel.create_directtransfer(amount, identifier)
             self.sign(direct_transfer)
-            direct_channel.register_transfer(direct_transfer)
+            direct_channel.register_transfer(
+                self.get_block_number(),
+                direct_transfer,
+            )
 
             direct_transfer_state_change = ActionTransferDirect(
                 identifier,

--- a/raiden/tests/benchmark/speed_transfer.py
+++ b/raiden/tests/benchmark/speed_transfer.py
@@ -115,8 +115,15 @@ def transfer_speed(num_transfers=100, max_locked=100):  # pylint: disable=too-ma
             hashlock=hashlock,
         )
         app0.raiden.sign(locked_transfer)
-        channel0.register_transfer(locked_transfer)
-        channel1.register_transfer(locked_transfer)
+
+        channel0.register_transfer(
+            app0.raiden.get_block_number(),
+            locked_transfer,
+        )
+        channel1.register_transfer(
+            app0.raiden.get_block_number(),
+            locked_transfer,
+        )
 
         if i > max_locked:
             idx = i - max_locked

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -89,8 +89,14 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
         hashlock,
     )
     alice_app.raiden.sign(transfermessage)
-    alice_bob_channel.register_transfer(transfermessage)
-    bob_alice_channel.register_transfer(transfermessage)
+    alice_bob_channel.register_transfer(
+        alice_app.raiden.get_block_number(),
+        transfermessage,
+    )
+    bob_alice_channel.register_transfer(
+        bob_app.raiden.get_block_number(),
+        transfermessage,
+    )
 
     assert_synched_channels(
         alice_bob_channel, alice_deposit, [],
@@ -359,33 +365,54 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout):
 
     # Alice sends Bob 10 tokens
     amount_alice1 = 10
+    identifier_alice1 = 1
     alice_first_transfer = channel0.create_directtransfer(
         amount_alice1,
-        1  # TODO: fill in identifier
+        identifier_alice1,
     )
     alice_first_transfer.sign(privatekey0, address0)
-    channel0.register_transfer(alice_first_transfer)
-    channel1.register_transfer(alice_first_transfer)
+    channel0.register_transfer(
+        app0.raiden.get_block_number(),
+        alice_first_transfer,
+    )
+    channel1.register_transfer(
+        app1.raiden.get_block_number(),
+        alice_first_transfer,
+    )
 
     # Bob sends Alice 50 tokens
     amount_bob1 = 50
+    identifier_bob1 = 1
     bob_first_transfer = channel1.create_directtransfer(
         amount_bob1,
-        1  # TODO: fill in identifier
+        identifier_bob1,
     )
     bob_first_transfer.sign(privatekey1, address1)
-    channel0.register_transfer(bob_first_transfer)
-    channel1.register_transfer(bob_first_transfer)
+    channel0.register_transfer(
+        app0.raiden.get_block_number(),
+        bob_first_transfer,
+    )
+    channel1.register_transfer(
+        app1.raiden.get_block_number(),
+        bob_first_transfer,
+    )
 
     # Finally Alice sends Bob 60 tokens
+    identifier_alice2 = 2
     amount_alice2 = 60
     alice_second_transfer = channel0.create_directtransfer(
         amount_alice2,
-        1  # TODO: fill in identifier
+        identifier_alice2,
     )
     alice_second_transfer.sign(privatekey0, address0)
-    channel0.register_transfer(alice_second_transfer)
-    channel1.register_transfer(alice_second_transfer)
+    channel0.register_transfer(
+        app0.raiden.get_block_number(),
+        alice_second_transfer,
+    )
+    channel1.register_transfer(
+        app1.raiden.get_block_number(),
+        alice_second_transfer,
+    )
 
     bob_last_transaction = bob_first_transfer
 

--- a/raiden/tests/smart_contracts/netting_channel/test_close.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_close.py
@@ -65,11 +65,18 @@ def test_close_only_participant_can_close(tester_nettingcontracts):
         nettingchannel.close('', sender=nonparticipant_key)
 
 
-def test_close_first_argument_is_for_partner_transfer(tester_channels):
+def test_close_first_argument_is_for_partner_transfer(tester_state, tester_channels):
     """ Close must not accept a transfer from the closing address. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=90, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=90,
+        pkey=pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     with pytest.raises(TransactionFailed):
@@ -189,7 +196,14 @@ def test_close_tampered_identifier(tester_state, tester_channels):
     """ Messages with a tampered identifier must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=90, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=90,
+        pkey=pkey0,
+    )
     transfer0_data = transfer0.encode()
 
     tampered_transfer = DirectTransfer.decode(transfer0_data)
@@ -204,7 +218,14 @@ def test_close_tampered_nonce(tester_state, tester_channels):
     """ Messages with a tampered nonce must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=90, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=90,
+        pkey=pkey0,
+    )
     transfer0_data = transfer0.encode()
 
     tampered_transfer = DirectTransfer.decode(transfer0_data)

--- a/raiden/tests/smart_contracts/netting_channel/test_settle.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_settle.py
@@ -79,7 +79,14 @@ def test_settle_single_direct_transfer_for_closing_party(
     initial1 = tester_token.balanceOf(address1, sender=pkey0)
 
     amount = 90
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount, pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount,
+        pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     nettingchannel.close(transfer0_data, sender=pkey1)
@@ -112,7 +119,14 @@ def test_settle_single_direct_transfer_for_counterparty(
     initial1 = tester_token.balanceOf(address1, sender=pkey0)
 
     amount = 90
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount, pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount,
+        pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -144,11 +158,25 @@ def test_settle_two_direct_transfers(
     initial_balance1 = tester_token.balanceOf(address1, sender=pkey0)
 
     amount0 = 10
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount0, pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount0,
+        pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     amount1 = 30
-    transfer1 = make_direct_transfer_from_channel(channel1, channel0, amount1, pkey1)
+    block_number = tester_state.block.number
+    transfer1 = make_direct_transfer_from_channel(
+        block_number,
+        channel1,
+        channel0,
+        amount1,
+        pkey1,
+    )
     transfer1_data = str(transfer1.packed().data)
 
     nettingchannel.close(transfer1_data, sender=pkey0)
@@ -353,10 +381,24 @@ def test_two_direct_transfers(
     initial1 = tester_token.balanceOf(address1, sender=pkey0)
 
     first_amount0 = 90
-    make_direct_transfer_from_channel(channel0, channel1, first_amount0, pkey0)
+    block_number = tester_state.block.number
+    make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        first_amount0,
+        pkey0,
+    )
 
     second_amount0 = 90
-    second_direct0 = make_direct_transfer_from_channel(channel0, channel1, second_amount0, pkey0)
+    block_number = tester_state.block.number
+    second_direct0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        second_amount0,
+        pkey0,
+    )
     second_direct0_data = str(second_direct0.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -391,7 +433,14 @@ def test_mediated_after_direct_transfer(
     initial_balance1 = tester_token.balanceOf(address1, sender=pkey0)
 
     first_amount0 = 90
-    make_direct_transfer_from_channel(channel0, channel1, first_amount0, pkey0)
+    block_number = tester_state.block.number
+    make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        first_amount0,
+        pkey0,
+    )
 
     lock_expiration = tester_state.block.number + reveal_timeout + 5
     new_block = Block(tester_state.block.number)
@@ -440,11 +489,25 @@ def test_settlement_with_unauthorized_token_transfer(
     initial_balance1 = tester_token.balanceOf(address1, sender=pkey0)
 
     amount0 = 10
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount0, pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount0,
+        pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     amount1 = 30
-    transfer1 = make_direct_transfer_from_channel(channel1, channel0, amount1, pkey1)
+    block_number = tester_state.block.number
+    transfer1 = make_direct_transfer_from_channel(
+        block_number,
+        channel1,
+        channel0,
+        amount1,
+        pkey1,
+    )
     transfer1_data = str(transfer1.packed().data)
 
     extra_amount = 10
@@ -483,12 +546,26 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_state, tester_
 
     amount0 = 10
     transferred_amount0 += amount0
-    direct0 = make_direct_transfer_from_channel(channel0, channel1, amount0, pkey0)
+    block_number = tester_state.block.number
+    direct0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount0,
+        pkey0,
+    )
     direct0_data = str(direct0.packed().data)
 
     amount1 = 30
     transferred_amount1 += amount1
-    direct1 = make_direct_transfer_from_channel(channel1, channel0, amount1, pkey1)
+    block_number = tester_state.block.number
+    direct1 = make_direct_transfer_from_channel(
+        block_number,
+        channel1,
+        channel0,
+        amount1,
+        pkey1,
+    )
     direct1_data = str(direct1.packed().data)
 
     nettingchannel.close(direct1_data, sender=pkey0)

--- a/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
@@ -16,7 +16,14 @@ def test_transfer_update_event(tester_state, tester_channels, tester_events):
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     address1 = privatekey_to_address(pkey1)
 
-    direct0 = make_direct_transfer_from_channel(channel0, channel1, amount=90, pkey=pkey0)
+    block_number = tester_state.block.number
+    direct0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=90,
+        pkey=pkey0,
+    )
     direct0_data = str(direct0.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -32,11 +39,18 @@ def test_transfer_update_event(tester_state, tester_channels, tester_events):
     }
 
 
-def test_update_fails_on_open_channel(tester_channels):
+def test_update_fails_on_open_channel(tester_state, tester_channels):
     """ Cannot call updateTransfer on a open channel. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     with pytest.raises(TransactionFailed):
@@ -47,7 +61,14 @@ def test_update_not_allowed_after_settlement_period(settle_timeout, tester_chann
     """ updateTransfer cannot be called after the settlement period. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    direct0 = make_direct_transfer_from_channel(channel0, channel1, amount=70, pkey=pkey0)
+    block_number = tester_state.block.number
+    direct0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=70,
+        pkey=pkey0,
+    )
     direct0_data = str(direct0.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -57,14 +78,28 @@ def test_update_not_allowed_after_settlement_period(settle_timeout, tester_chann
         nettingchannel.updateTransfer(direct0_data, sender=pkey1)
 
 
-def test_update_not_allowed_for_the_closing_address(tester_channels):
+def test_update_not_allowed_for_the_closing_address(tester_state, tester_channels):
     """ Closing address cannot call updateTransfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
-    transfer1 = make_direct_transfer_from_channel(channel1, channel0, amount=10, pkey=pkey1)
+    block_number = tester_state.block.number
+    transfer1 = make_direct_transfer_from_channel(
+        block_number,
+        channel1,
+        channel0,
+        amount=10,
+        pkey=pkey1,
+    )
     transfer1_data = str(transfer1.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -110,7 +145,7 @@ def test_update_must_fail_with_a_nonparticipant_transfer(tester_channels, privat
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_update_must_fail_with_a_wrong_recipient(tester_channels, private_keys):
     """ updateTransfer must not accept a transfer from a non participant. """
-    pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    pkey0, pkey1, nettingchannel, channel0, _ = tester_channels[0]
     opened_block = nettingchannel.opened(sender=pkey0)
     nonparticipant_address = privatekey_to_address(private_keys[2])
 
@@ -136,11 +171,18 @@ def test_update_must_fail_with_a_wrong_recipient(tester_channels, private_keys):
         nettingchannel.updateTransfer(transfer_wrong_recipient_data, sender=pkey1)
 
 
-def test_update_called_multiple_times_same_transfer(tester_channels):
+def test_update_called_multiple_times_same_transfer(tester_state, tester_channels):
     """ updateTransfer can be called only once. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -150,14 +192,28 @@ def test_update_called_multiple_times_same_transfer(tester_channels):
         nettingchannel.updateTransfer(transfer0_data, sender=pkey1)
 
 
-def test_update_called_multiple_times_new_transfer(tester_channels):
+def test_update_called_multiple_times_new_transfer(tester_state, tester_channels):
     """ updateTransfer second call must fail even if there is a new transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
-    transfer1 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer1 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer1_data = str(transfer1.packed().data)
 
     nettingchannel.close('', sender=pkey0)
@@ -167,14 +223,28 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
         nettingchannel.updateTransfer(transfer1_data, sender=pkey1)
 
 
-def test_update_called_multiple_times_older_transfer(tester_channels):
+def test_update_called_multiple_times_older_transfer(tester_state, tester_channels):
     """ updateTransfer second call must fail even if called with an older transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
 
-    transfer0 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer0 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer0_data = str(transfer0.packed().data)
 
-    transfer1 = make_direct_transfer_from_channel(channel0, channel1, amount=10, pkey=pkey0)
+    block_number = tester_state.block.number
+    transfer1 = make_direct_transfer_from_channel(
+        block_number,
+        channel0,
+        channel1,
+        amount=10,
+        pkey=pkey0,
+    )
     transfer1_data = str(transfer1.packed().data)
 
     nettingchannel.close('', sender=pkey0)

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -300,7 +300,10 @@ def test_python_channel():
         identifier=1,
     )
     directtransfer.sign(privkey1, address1)
-    test_channel.register_transfer(directtransfer)
+    test_channel.register_transfer(
+        block_number,
+        directtransfer,
+    )
 
     assert test_channel.contract_balance == balance1
     assert test_channel.balance == balance1 - amount1
@@ -329,7 +332,10 @@ def test_python_channel():
     )
     mediatedtransfer.sign(privkey1, address1)
 
-    test_channel.register_transfer(mediatedtransfer)
+    test_channel.register_transfer(
+        block_number,
+        mediatedtransfer,
+    )
 
     assert test_channel.contract_balance == balance1
     assert test_channel.balance == balance1 - amount1
@@ -441,8 +447,14 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
 
         # synchronized registration
         app0.raiden.sign(mediated_transfer)
-        channel0.register_transfer(mediated_transfer)
-        channel1.register_transfer(mediated_transfer)
+        channel0.register_transfer(
+            block_number,
+            mediated_transfer,
+        )
+        channel1.register_transfer(
+            block_number,
+            mediated_transfer,
+        )
 
         # update test state
         distributed_amount += amount
@@ -538,8 +550,14 @@ def test_transfer(raiden_network, token_addresses):
         identifier=1,
     )
     app0.raiden.sign(direct_transfer)
-    channel0.register_transfer(direct_transfer)
-    channel1.register_transfer(direct_transfer)
+    channel0.register_transfer(
+        app0.raiden.get_block_number(),
+        direct_transfer,
+    )
+    channel1.register_transfer(
+        app1.raiden.get_block_number(),
+        direct_transfer,
+    )
 
     # check the contract is intact
     assert details0 == netting_channel.detail(address0)
@@ -588,8 +606,14 @@ def test_locked_transfer(raiden_network, settle_timeout):
         hashlock=hashlock,
     )
     app0.raiden.sign(mediated_transfer)
-    channel0.register_transfer(mediated_transfer)
-    channel1.register_transfer(mediated_transfer)
+    channel0.register_transfer(
+        app0.raiden.chain.block_number(),
+        mediated_transfer,
+    )
+    channel1.register_transfer(
+        app1.raiden.chain.block_number(),
+        mediated_transfer,
+    )
 
     # don't update balances but update the locked/distributable/outstanding
     # values
@@ -649,8 +673,14 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
 
     # register a locked transfer
     app0.raiden.sign(transfer1)
-    channel0.register_transfer(transfer1)
-    channel1.register_transfer(transfer1)
+    channel0.register_transfer(
+        app0.raiden.chain.block_number(),
+        transfer1,
+    )
+    channel1.register_transfer(
+        app1.raiden.chain.block_number(),
+        transfer1,
+    )
 
     # assert the locked transfer is registered
     assert_synched_channels(
@@ -671,10 +701,16 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
 
     # this need to fail because the allowance is incorrect
     with pytest.raises(Exception):
-        channel0.register_transfer(transfer2)
+        channel0.register_transfer(
+            app0.raiden.chain.block_number(),
+            transfer2,
+        )
 
     with pytest.raises(Exception):
-        channel1.register_transfer(transfer2)
+        channel1.register_transfer(
+            app1.raiden.chain.block_number(),
+            transfer2,
+        )
 
     # the registration of a bad transfer need fail equaly on both channels
     assert_synched_channels(

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -140,8 +140,15 @@ def pending_mediated_transfer(app_chain, token, amount, identifier, expiration):
             hashlock,
         )
         from_app.raiden.sign(transfer_)
-        from_channel.register_transfer(transfer_)
-        to_channel.register_transfer(transfer_)
+
+        from_channel.register_transfer(
+            from_app.raiden.get_block_number(),
+            transfer_,
+        )
+        to_channel.register_transfer(
+            to_app.raiden.get_block_number(),
+            transfer_,
+        )
 
     return secret
 
@@ -265,7 +272,7 @@ def increase_transferred_amount(from_channel, to_channel, amount):
     to_channel.partner_state.transferred_amount += amount
 
 
-def make_direct_transfer_from_channel(channel, partner_channel, amount, pkey):
+def make_direct_transfer_from_channel(block_number, channel, partner_channel, amount, pkey):
     """ Helper to create and register a direct transfer from `channel` to
     `partner_channel`.
     """
@@ -283,8 +290,14 @@ def make_direct_transfer_from_channel(channel, partner_channel, amount, pkey):
     # if this fails it's not the right key for the current `channel`
     assert direct_transfer.sender == channel.our_state.address
 
-    channel.register_transfer(direct_transfer)
-    partner_channel.register_transfer(direct_transfer)
+    channel.register_transfer(
+        block_number,
+        direct_transfer,
+    )
+    partner_channel.register_transfer(
+        block_number,
+        direct_transfer,
+    )
 
     return direct_transfer
 
@@ -325,8 +338,14 @@ def make_mediated_transfer(
     # if this fails it's not the right key for the current `channel`
     assert mediated_transfer.sender == channel.our_state.address
 
-    channel.register_transfer(mediated_transfer)
-    partner_channel.register_transfer(mediated_transfer)
+    channel.register_transfer(
+        block_number,
+        mediated_transfer,
+    )
+    partner_channel.register_transfer(
+        block_number,
+        mediated_transfer,
+    )
 
     if secret is not None:
         channel.register_secret(secret)

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -357,7 +357,10 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
                 hashlock,
             )
             raiden.sign(from_mediated_transfer)
-            from_channel.register_transfer(from_mediated_transfer)
+            from_channel.register_transfer(
+                raiden.get_block_number(),
+                from_mediated_transfer,
+            )
 
             # wait for the SecretRequest and MediatedTransfer
             to_mediated_transfer = self.send_and_wait_valid_state(
@@ -377,7 +380,10 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
                 to_hop = to_mediated_transfer.sender
                 to_channel = to_graph.partneraddress_channel[to_hop]
 
-                to_channel.register_transfer(to_mediated_transfer)
+                to_channel.register_transfer(
+                    raiden.get_block_number(),
+                    to_mediated_transfer,
+                )
                 raiden.register_channel_for_hashlock(to_token, to_channel, hashlock)
 
                 # A swap is composed of two mediated transfers, we need to
@@ -578,7 +584,10 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
         to_graph = raiden.channelgraphs[maker_receiving_token]
 
         # update the channel's distributable and merkle tree
-        from_channel.register_transfer(maker_paying_transfer)
+        from_channel.register_transfer(
+            raiden.get_block_number(),
+            maker_paying_transfer,
+        )
 
         # register the task to receive Refund/Secrect/RevealSecret messages
         raiden.greenlet_task_dispatcher.register_task(self, hashlock)
@@ -646,7 +655,10 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
                 hashlock,
             )
             raiden.sign(taker_paying_transfer)
-            taker_paying_channel.register_transfer(taker_paying_transfer)
+            taker_paying_channel.register_transfer(
+                raiden.get_block_number(),
+                taker_paying_transfer,
+            )
 
             if not first_transfer:
                 first_transfer = taker_paying_transfer
@@ -682,7 +694,10 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
                     raiden.greenlet_task_dispatcher.unregister_task(self, hashlock, False)
                     return
                 else:
-                    taker_paying_channel.register_transfer(response)
+                    taker_paying_channel.register_transfer(
+                        raiden.get_block_number(),
+                        response,
+                    )
 
             elif isinstance(response, RevealSecret):
                 # the secret was registered by the message handler


### PR DESCRIPTION
Adjust the setting of the settlement period's end by setting blocks_until_settlement depending on the closed_block.

Add explicit block number argument to the transfer registration