### PR TITLE
Add smoketest command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ truffle/.bash_history
 
 # ignore node_modules
 raiden/raidenwebui/node_modules/
+
+# never check in the smoketest_config.json
+smoketest_config.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,11 @@ install:
   - pip install pytest-travis-fold
   - pip install flake8
   - pip install -r requirements-dev.txt
+  - pip install .
 
 before_script:
   - flake8 raiden/ tools/
+  - raiden smoketest
   - ./.travis/make_dag.sh
 
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include requirements.txt
 include raiden/smart_contracts/*
+include raiden/smoketest_config.json
 prune raiden/tests

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -13,7 +13,7 @@ from ethereum._solidity import compile_file
 from pyethapp.rpc_client import JSONRPCClient
 from pyethapp.jsonrpc import address_decoder, address_encoder, default_gasprice
 
-from raiden.utils import privatekey_to_address, get_contract_path
+from raiden.utils import privatekey_to_address, get_contract_path, fix_tester_storage
 from raiden.network.transport import DummyTransport
 from raiden.tests.fixtures.tester import tester_state
 from raiden.tests.utils.blockchain import GENESIS_STUB, DEFAULT_BALANCE_BIN
@@ -204,16 +204,7 @@ def cached_genesis(request, blockchain_type):
         # Both keys and values of the account storage associative array
         # must now be encoded with 64 hex digits
         if account_alloc['storage']:
-            new_storage = dict()
-            for key, val in account_alloc['storage'].iteritems():
-                # account_to_dict() from pyethereum can return 0x for a storage
-                # position. That is an invalid way of representing 0x0, which we
-                # have to take care of here.
-                new_key = '0x%064x' % int(key if key != '0x' else '0x0', 16)
-                new_val = '0x%064x' % int(val, 16)
-                new_storage[new_key] = new_val
-
-            account_alloc['storage'] = new_storage
+            account_alloc['storage'] = fix_tester_storage(account_alloc['storage'])
 
         # code must be hex encoded with 0x prefix
         account_alloc['code'] = account_alloc.get('code', '')

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -53,7 +53,7 @@ def _token_addresses(
         participants,
         register):
     """ Deploy `number_of_tokens` ERC20 token instances with `token_amount` minted and
-    distributed among `blockchain_services`. Optionally the instances will be `register`ed with
+    distributed among `blockchain_services`. Optionally the instances will be registered with
     the raiden registry.
     Args:
         token_amount (int): number of units that will be created per token

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -50,9 +50,18 @@ def _token_addresses(
         token_amount,
         number_of_tokens,
         deploy_service,
-        blockchain_services,
+        participants,
         register):
-
+    """ Deploy `number_of_tokens` ERC20 token instances with `token_amount` minted and
+    distributed among `blockchain_services`. Optionally the instances will be `register`ed with
+    the raiden registry.
+    Args:
+        token_amount (int): number of units that will be created per token
+        number_of_tokens (int): number of token instances that will be created
+        deploy_service (BlockchainService): the blockchain connection that will deploy
+        participants (list(address)): participant addresses that will receive tokens
+        register (bool): switch to control registration with the raiden Registry contract
+    """
     result = list()
     for _ in range(number_of_tokens):
         if register:
@@ -72,10 +81,10 @@ def _token_addresses(
 
         # only the creator of the token starts with a balance (deploy_service),
         # transfer from the creator to the other nodes
-        for transfer_to in blockchain_services:
+        for transfer_to in participants:
             deploy_service.token(token_address).transfer(
-                privatekey_to_address(transfer_to.private_key),
-                token_amount // len(blockchain_services),
+                transfer_to,
+                token_amount // len(participants),
             )
 
     return result
@@ -130,11 +139,12 @@ def cached_genesis(request, blockchain_type):
     # create_network only registers the tokens,
     # the contracts must be deployed previously
     register = True
+    participants = [privatekey_to_address(privatekey) for privatekey in private_keys]
     token_contract_addresses = _token_addresses(
         request.getfixturevalue('token_amount'),
         request.getfixturevalue('number_of_tokens'),
         deploy_service,
-        blockchain_services,
+        participants,
         register
     )
 
@@ -242,8 +252,7 @@ def cached_genesis(request, blockchain_type):
 
 @pytest.fixture
 def register_tokens():
-    """Should fixture generated tokens be registered with raiden (default: True)
-    """
+    """ Should fixture generated tokens be registered with raiden (default: True). """
     return True
 
 
@@ -255,6 +264,16 @@ def token_addresses(
         blockchain_services,
         cached_genesis,
         register_tokens):
+    """ Fixture that yields `number_of_tokens` ERC20 token addresses, where the
+    `token_amount` (per token) is distributed among the addresses behind `blockchain_services` and
+    potentially pre-registered with the raiden Registry.
+    The following arguments can control the behavior:
+
+    Args:
+        token_amount (int): the overall number of units minted per token
+        number_of_tokens (int): the number of token instances
+        register_tokens (bool): controls if tokens will be registered with raiden Registry
+    """
 
     if cached_genesis:
         token_addresses = [
@@ -262,11 +281,15 @@ def token_addresses(
             for token_address in cached_genesis['config']['tokenAddresses']
         ]
     else:
+        participants = [
+            privatekey_to_address(blockchain_service.private_key) for
+            blockchain_service in blockchain_services.blockchain_services
+        ]
         token_addresses = _token_addresses(
             token_amount,
             number_of_tokens,
             blockchain_services.deploy_service,
-            blockchain_services.blockchain_services,
+            participants,
             register_tokens
         )
 

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -114,8 +114,8 @@ def geth_bare_genesis(genesis_path, private_keys):
 
     Args:
         genesis_path (str): the path in which the genesis block is written.
-        private_keys list(str): iterable list of privatekeys which accounts will have a
-                    premined balance available.
+        private_keys list(str): iterable list of privatekeys whose corresponding accounts will
+                    have a premined balance available.
     """
     account_addresses = [
         privatekey_to_address(key)

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -19,7 +19,7 @@ from pyethapp.rpc_client import JSONRPCClient
 from requests import ConnectionError
 
 from raiden.utils import privatekey_to_address
-from raiden.settings import GAS_LIMIT_HEX
+from raiden.tests.utils.genesis import GENESIS_STUB
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -27,26 +27,6 @@ DEFAULT_BALANCE = denoms.ether * 10000000
 DEFAULT_BALANCE_BIN = str(denoms.ether * 10000000)
 DEFAULT_PASSPHRASE = 'notsosecret'  # Geth's account passphrase
 DAGSIZE = 1073739912
-
-GENESIS_STUB = {
-    'config': {
-        'homesteadBlock': 0,
-        'eip150Block': 0,
-        'eip150Hash': '0x0000000000000000000000000000000000000000000000000000000000000000',
-        'eip155Block': 0,
-        'eip158Block': 0,
-    },
-    'nonce': '0x0',
-    'mixhash': '0x0000000000000000000000000000000000000000000000000000000000000000',
-    'difficulty': '0x1',
-    'coinbase': '0x0000000000000000000000000000000000000000',
-    'timestamp': '0x00',
-    'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
-    'extraData': '0x' + 'raiden'.encode('hex'),
-    'gasLimit': GAS_LIMIT_HEX,
-    # add precompile addresses with minimal balance to avoid deletion
-    'alloc': {'%040x' % precompile: {"balance": "0x1"} for precompile in range(256)}
-}
 
 
 def wait_until_block(chain, block):

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -130,13 +130,12 @@ def geth_create_account(datadir, privkey):
 
 
 def geth_bare_genesis(genesis_path, private_keys):
-    """Creates a bare genesis inside `datadir`.
+    """Writes a bare genesis to `genesis_path`.
 
     Args:
-        datadir (str): the datadir in which the blockchain is initialized.
-
-    Returns:
-        str: The path to the genisis file.
+        genesis_path (str): the path in which the genesis block is written.
+        private_keys list(str): iterable list of privatekeys which accounts will have a
+                    premined balance available.
     """
     account_addresses = [
         privatekey_to_address(key)

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -31,8 +31,12 @@ DAGSIZE = 1073739912
 GENESIS_STUB = {
     'config': {
         'homesteadBlock': 0,
+        'eip150Block': 0,
+        'eip150Hash': '0x0000000000000000000000000000000000000000000000000000000000000000',
+        'eip155Block': 0,
+        'eip158Block': 0,
     },
-    'nonce': '0x0000000000000042',
+    'nonce': '0x0',
     'mixhash': '0x0000000000000000000000000000000000000000000000000000000000000000',
     'difficulty': '0x1',
     'coinbase': '0x0000000000000000000000000000000000000000',
@@ -40,6 +44,8 @@ GENESIS_STUB = {
     'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
     'extraData': '0x' + 'raiden'.encode('hex'),
     'gasLimit': GAS_LIMIT_HEX,
+    # add precompile addresses with minimal balance to avoid deletion
+    'alloc': {'%040x' % precompile: {"balance": "0x1"} for precompile in range(256)}
 }
 
 
@@ -144,7 +150,7 @@ def geth_bare_genesis(genesis_path, private_keys):
         for address in account_addresses
     }
     genesis = GENESIS_STUB.copy()
-    genesis['alloc'] = alloc
+    genesis['alloc'].update(alloc)
 
     with open(genesis_path, 'w') as handler:
         json.dump(genesis, handler)

--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -16,6 +16,6 @@ GENESIS_STUB = {
     'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
     'extraData': '0x' + 'raiden'.encode('hex'),
     'gasLimit': GAS_LIMIT_HEX,
-    # add precompile addresses with minimal balance to avoid deletion
-    'alloc': {'%040x' % precompile: {"balance": "0x1"} for precompile in range(256)}
+    # add procompiled addresses with minimal balance to avoid deletion
+    'alloc': {'%040x' % procompiled: {"balance": "0x1"} for procompiled in range(256)}
 }

--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8
+from raiden.settings import GAS_LIMIT_HEX
+GENESIS_STUB = {
+    'config': {
+        'homesteadBlock': 0,
+        'eip150Block': 0,
+        'eip150Hash': '0x0000000000000000000000000000000000000000000000000000000000000000',
+        'eip155Block': 0,
+        'eip158Block': 0,
+    },
+    'nonce': '0x0',
+    'mixhash': '0x0000000000000000000000000000000000000000000000000000000000000000',
+    'difficulty': '0x1',
+    'coinbase': '0x0000000000000000000000000000000000000000',
+    'timestamp': '0x00',
+    'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
+    'extraData': '0x' + 'raiden'.encode('hex'),
+    'gasLimit': GAS_LIMIT_HEX,
+    # add precompile addresses with minimal balance to avoid deletion
+    'alloc': {'%040x' % precompile: {"balance": "0x1"} for precompile in range(256)}
+}

--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -16,6 +16,6 @@ GENESIS_STUB = {
     'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
     'extraData': '0x' + 'raiden'.encode('hex'),
     'gasLimit': GAS_LIMIT_HEX,
-    # add procompiled addresses with minimal balance to avoid deletion
-    'alloc': {'%040x' % procompiled: {"balance": "0x1"} for procompiled in range(256)}
+    # add precompiled addresses with minimal balance to avoid deletion
+    'alloc': {'%040x' % precompiled: {"balance": "0x1"} for precompiled in range(256)}
 }

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -114,7 +114,7 @@ def run_smoketests(raiden_service, test_config, debug=False):
         graph = raiden_service.channelgraphs.values()[0]
         channel = graph.partneraddress_channel[TEST_PARTNER_ADDRESS.decode('hex')]
         assert channel.can_transfer
-        assert channel.deposit == channel.distributable == TEST_DEPOSIT_AMOUNT
+        assert channel.contract_balance == channel.distributable == TEST_DEPOSIT_AMOUNT
         assert channel.state == CHANNEL_STATE_OPENED
     except Exception:
         error = traceback.format_exc()

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -20,7 +20,7 @@ from raiden.tests.utils.tester_client import (
 from raiden.utils import get_contract_path, get_project_root, fix_tester_storage
 from raiden.blockchain.abi import contract_checksum
 from raiden.transfer.state import CHANNEL_STATE_OPENED
-from raiden.tests.utils import blockchain
+from raiden.tests.utils.genesis import GENESIS_STUB
 from raiden.tests.fixtures import tester_state
 
 # the smoketest will assert that a different endpoint got successfully registered
@@ -258,7 +258,7 @@ def deploy_and_open_channel_alloc(deployment_key):
 
 
 def complete_genesis():
-    smoketest_genesis = blockchain.GENESIS_STUB.copy()
+    smoketest_genesis = GENESIS_STUB.copy()
     smoketest_genesis['config']['clique'] = {'period': 1, 'epoch': 30000}
     smoketest_genesis['extraData'] = '0x{:0<64}{:0<170}'.format(
         'raiden'.encode('hex'),

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -112,7 +112,6 @@ def run_smoketests(raiden_service, test_config, debug=False):
         discovery = chain.address_discovery.values()[0]
         assert discovery.endpoint_by_address(raiden_service.address) != TEST_ENDPOINT
 
-        raiden_service.register_registry(chain.default_registry.address)
         assert len(raiden_service.channelgraphs.values()) == 1
         graph = raiden_service.channelgraphs.values()[0]
         channel = graph.partneraddress_channel[TEST_PARTNER_ADDRESS.decode('hex')]

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+import os
+import time
+import json
+import subprocess
+import shlex
+import tempfile
+import distutils
+import pdb
+import traceback
+from string import Template
+
+from ethereum._solidity import get_solidity
+
+from raiden.tests.utils.tester_client import (
+    tester_deploy_contract,
+    BlockChainServiceTesterMock,
+    NettingChannelTesterMock,
+)
+from raiden.utils import get_contract_path, get_project_root, fix_tester_storage
+from raiden.blockchain.abi import contract_checksum
+from raiden.transfer.state import CHANNEL_STATE_OPENED
+from raiden.tests.utils import blockchain
+from raiden.tests.fixtures import tester_state
+
+# the smoketest will assert that a different endpoint got successfully registered
+TEST_ENDPOINT = '9.9.9.9:9999'
+TEST_PARTNER_ADDRESS = '2' * 40
+TEST_DEPOSIT_AMOUNT = 5
+
+RST_DATADIR = tempfile.mkdtemp()
+os.environ['RST_DATADIR'] = RST_DATADIR
+
+GENESIS_PATH = Template('$RST_DATADIR/genesis.json').substitute(os.environ)
+
+# Environment variables in the command for datadir and ports allow customization.
+# We use DEFAULT_ETH_COMMAND, unless '$RST_ETH_COMMAND' is defined (all environment variables
+# specific to the raiden smoke test are prefixed 'RST_' for Raiden Smoke Test).
+# For customization, set the environment variable to fit your client like this:
+# RST_ETH_COMMAND="ethereum --p2p-port \$RST_P2P_PORT --rpc-port \$RST_RPC_PORT \
+#        --data-dir \$RST_DATADIR" raiden smoketest
+
+DEFAULT_ETH_COMMAND = """
+$RST_GETH_BINARY
+    --nodiscover
+    --nat none
+    --port 0
+    --ipcdisable
+    --rpc
+    --rpcaddr 127.0.0.1
+    --rpcport $RST_RPC_PORT
+    --mine
+    --etherbase 0
+    --unlock 0
+    --networkid 627
+    --verbosity 3
+    --datadir $RST_DATADIR
+"""
+RST_GETH_BINARY = distutils.spawn.find_executable('geth')
+if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:
+    os.environ['RST_GETH_BINARY'] = RST_GETH_BINARY
+
+ports = iter(range(27854, 28000))
+get_free_port = lambda: str(next(ports))
+
+RST_RPC_PORT = get_free_port()
+os.environ['RST_RPC_PORT'] = RST_RPC_PORT
+
+RST_P2P_PORT = get_free_port()
+os.environ['RST_P2P_PORT'] = RST_P2P_PORT
+
+TEST_ACCOUNT = {
+    "version": 3,
+    "crypto": {
+        "ciphertext": "4d9fecf81ca312f7b1ee1bd57196e9c51737d461d7faa019f566834d4d3d4615",
+        "cipherparams": {
+            "iv": "d19d1a6a1a66fb8d86755eeee0cc5da8"
+        },
+        "kdf": "pbkdf2",
+        "kdfparams": {
+            "dklen": 32, "c": 262144,
+            "prf": "hmac-sha256", "salt": "6725f3e185b3f0475e52507e512b1b2c"
+        },
+        "mac": "ec86b1e6188dc2e7e415fa4214153636387338dbffe2edf1b04fac6be23eead4",
+        "cipher": "aes-128-ctr",
+        "version": 1
+    },
+    "address": "67a5e21e34a58ed8d47c719fe291ddd2ea825e12"
+}
+TEST_ACCOUNT_PASSWORD = 'password'
+TEST_PRIVKEY = 'add4d310ba042468791dd7bf7f6eae85acc4dd143ffa810ef1809a6a11f2bc44'
+
+
+def run_smoketests(raiden_service, test_config, debug=False):
+    """ Test that the assembled raiden_service correctly reflects the configuration from the
+    smoketest_genesis. """
+    try:
+        chain = raiden_service.chain
+        assert (
+            chain.default_registry.address ==
+            test_config['contracts']['registry_address'].decode('hex')
+        )
+        assert (
+            chain.default_registry.token_addresses() ==
+            [test_config['contracts']['token_address'].decode('hex')]
+        )
+        assert len(chain.address_discovery.keys()) == 1
+        assert (
+            chain.address_discovery.keys()[0] ==
+            test_config['contracts']['discovery_address'].decode('hex')
+        )
+        discovery = chain.address_discovery.values()[0]
+        assert discovery.endpoint_by_address(raiden_service.address) != TEST_ENDPOINT
+
+        raiden_service.register_registry(chain.default_registry.address)
+        assert len(raiden_service.channelgraphs.values()) == 1
+        graph = raiden_service.channelgraphs.values()[0]
+        channel = graph.partneraddress_channel[TEST_PARTNER_ADDRESS.decode('hex')]
+        assert channel.can_transfer
+        assert channel.deposit == channel.distributable == TEST_DEPOSIT_AMOUNT
+        assert channel.state == CHANNEL_STATE_OPENED
+    except Exception:
+        error = traceback.format_exc()
+        if debug:
+            pdb.post_mortem()
+        return error
+
+
+def load_or_create_smoketest_config():
+    # get the contract and compiler (if available) versions
+    versions = dict()
+    for file in os.listdir(get_contract_path('')):
+        if file.endswith('.sol'):
+            versions[file] = contract_checksum(get_contract_path(file))
+    # if solc is available, record its version, too
+    if get_solidity() is not None:
+        solc_version_out, _ = subprocess.Popen(
+            [get_solidity().compiler_available(), '--version'],
+            stdout=subprocess.PIPE
+        ).communicate()
+        versions['solc'] = solc_version_out.split()[-1]
+
+    smoketest_config_path = os.path.join(
+        get_project_root(),
+        'smoketest_config.json'
+    )
+    # try to load an existing smoketest genesis config
+    smoketest_config = dict()
+    if os.path.exists(smoketest_config_path):
+        with open(smoketest_config_path) as handler:
+            smoketest_config = json.load(handler)
+        # if the file versions still fit, return the genesis config (ignore solc if not available)
+        if all(versions[key] == smoketest_config['versions'][key] for key in versions.keys()):
+            return smoketest_config
+
+    # something did not fit -- we will create the genesis
+    smoketest_config['versions'] = versions
+    raiden_config, smoketest_genesis = complete_genesis()
+    smoketest_config['genesis'] = smoketest_genesis
+    smoketest_config.update(raiden_config)
+    with open(os.path.join(get_project_root(), 'smoketest_config.json'), 'w') as handler:
+        json.dump(smoketest_config, handler)
+    return smoketest_config
+
+
+def deploy_and_open_channel_alloc(deployment_key):
+    """ Compiles, deploys and dumps a minimal raiden smart contract environment for use in a
+    genesis block. This will:
+        - deploy the raiden Registry contract stack
+        - deploy a token contract
+        - open a channel for the TEST_ACCOUNT address
+        - deploy the EndpointRegistry/discovery contract
+        - register a known value for the TEST_ACCOUNT address
+        - dump the complete state in a genesis['alloc'] compatible format
+        - return the state dump and the contract addresses
+    """
+    deployment_key_bin = deployment_key.decode('hex')
+    state = tester_state(
+        deployment_key_bin,
+        [deployment_key_bin],
+        6 * 10 ** 6
+    )
+
+    registry_address = tester_deploy_contract(
+        state,
+        deployment_key_bin,
+        'Registry',
+        get_contract_path('Registry.sol'),
+    )
+
+    discovery_address = tester_deploy_contract(
+        state,
+        deployment_key_bin,
+        'EndpointRegistry',
+        get_contract_path('EndpointRegistry.sol'),
+    )
+
+    client = BlockChainServiceTesterMock(
+        deployment_key_bin,
+        state,
+        registry_address,
+    )
+    token_address = client.deploy_and_register_token(
+        'HumanStandardToken',
+        get_contract_path('HumanStandardToken.sol'),
+        constructor_parameters=(
+            100,
+            'smoketesttoken',
+            2,
+            'RST'
+        )
+    )
+
+    manager = client.manager_by_token(token_address)
+
+    assert manager.private_key == deployment_key_bin
+    our_address = TEST_ACCOUNT['address']
+
+    channel_address = manager.new_netting_channel(
+        our_address.decode('hex'),
+        TEST_PARTNER_ADDRESS.decode('hex'),
+        50
+    )
+
+    client.token(token_address).approve(channel_address, TEST_DEPOSIT_AMOUNT)
+    channel = NettingChannelTesterMock(
+        state,
+        deployment_key_bin,
+        channel_address
+    )
+    channel.deposit(TEST_DEPOSIT_AMOUNT)
+
+    discovery = client.discovery(discovery_address)
+    discovery.proxy.registerEndpoint(TEST_ENDPOINT)
+
+    contracts = dict(
+        registry_address=registry_address,
+        token_address=token_address,
+        discovery_address=discovery_address,
+        channel_address=channel_address,
+    )
+    for k, v in contracts.iteritems():
+        contracts[k] = v.encode('hex')
+
+    alloc = dict()
+    # preserve all accounts and contracts
+    for address in state.block.state.to_dict().keys():
+        address = address.encode('hex')
+        alloc[address] = state.block.account_to_dict(address)
+
+    for account, content in alloc.iteritems():
+        alloc[account]['storage'] = fix_tester_storage(content['storage'])
+
+    return dict(
+        alloc=alloc,
+        contracts=contracts,
+    )
+
+
+def complete_genesis():
+    smoketest_genesis = blockchain.GENESIS_STUB.copy()
+    smoketest_genesis['config']['clique'] = {'period': 1, 'epoch': 30000}
+    smoketest_genesis['extraData'] = '0x{:0<64}{:0<170}'.format(
+        'raiden'.encode('hex'),
+        TEST_ACCOUNT['address'],
+    )
+    smoketest_genesis['alloc'][TEST_ACCOUNT['address']] = dict(balance=hex(10 ** 18))
+
+    raiden_config = deploy_and_open_channel_alloc(deployment_key=TEST_PRIVKEY)
+    smoketest_genesis['alloc'].update(
+        raiden_config['alloc']
+    )
+    return raiden_config, smoketest_genesis
+
+
+def init_with_genesis(smoketest_genesis):
+    with open(GENESIS_PATH, 'wb') as handler:
+        json.dump(smoketest_genesis, handler)
+
+    cmd = '$RST_GETH_BINARY --datadir $RST_DATADIR init {}'.format(GENESIS_PATH)
+    args = shlex.split(
+        Template(cmd).substitute(os.environ)
+    )
+    init = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    out, err = init.communicate()
+    assert init.returncode == 0
+    return (out, err)
+
+
+def start_ethereum(smoketest_genesis):
+    cmd = os.environ.get('RST_ETH_COMMAND', DEFAULT_ETH_COMMAND)
+    args = shlex.split(
+        Template(cmd).substitute(os.environ)
+    )
+
+    keystore = os.path.join(os.environ['RST_DATADIR'], 'keystore')
+    if not os.path.exists(keystore):
+        os.makedirs(keystore)
+    with open(os.path.join(keystore, 'account.json'), 'wb') as handler:
+        json.dump(TEST_ACCOUNT, handler)
+
+    init_out, init_err = init_with_genesis(smoketest_genesis)
+
+    ethereum_node = subprocess.Popen(
+        args,
+        universal_newlines=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    ethereum_node.stdin.write(TEST_ACCOUNT_PASSWORD + os.linesep)
+    time.sleep(.1)
+    ethereum_node.stdin.write(TEST_ACCOUNT_PASSWORD + os.linesep)
+    ethereum_config = dict(
+        rpc=os.environ['RST_RPC_PORT'],
+        keystore=keystore,
+        address=TEST_ACCOUNT['address'],
+        init_log_out=init_out,
+        init_log_err=init_err,
+    )
+    return ethereum_node, ethereum_config

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -39,7 +39,7 @@ GENESIS_PATH = Template('$RST_DATADIR/genesis.json').substitute(os.environ)
 # For customization, set the environment variable to fit your client like this:
 # RST_ETH_COMMAND="ethereum --rpc-port \$RST_RPC_PORT \
 #        --data-dir \$RST_DATADIR" raiden smoketest
-# FIXME: this does not work: the `init` phase is not customizable
+# FIXME: this does not work: the `init` phase is not customizable (gh issue #758)
 DEFAULT_ETH_COMMAND = """
 $RST_GETH_BINARY
     --nodiscover
@@ -61,7 +61,7 @@ if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:
     os.environ['RST_GETH_BINARY'] = RST_GETH_BINARY
 
 ports = iter(range(27854, 28000))
-# FIXME: get_free_port does not check for free ports
+# FIXME: get_free_port does not check for free ports (gh issue #759)
 get_free_port = lambda: str(next(ports))
 
 RST_RPC_PORT = get_free_port()

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -37,9 +37,9 @@ GENESIS_PATH = Template('$RST_DATADIR/genesis.json').substitute(os.environ)
 # We use DEFAULT_ETH_COMMAND, unless '$RST_ETH_COMMAND' is defined (all environment variables
 # specific to the raiden smoke test are prefixed 'RST_' for Raiden Smoke Test).
 # For customization, set the environment variable to fit your client like this:
-# RST_ETH_COMMAND="ethereum --p2p-port \$RST_P2P_PORT --rpc-port \$RST_RPC_PORT \
+# RST_ETH_COMMAND="ethereum --rpc-port \$RST_RPC_PORT \
 #        --data-dir \$RST_DATADIR" raiden smoketest
-
+# FIXME: this does not work: the `init` phase is not customizable
 DEFAULT_ETH_COMMAND = """
 $RST_GETH_BINARY
     --nodiscover
@@ -61,13 +61,11 @@ if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:
     os.environ['RST_GETH_BINARY'] = RST_GETH_BINARY
 
 ports = iter(range(27854, 28000))
+# FIXME: get_free_port does not check for free ports
 get_free_port = lambda: str(next(ports))
 
 RST_RPC_PORT = get_free_port()
 os.environ['RST_RPC_PORT'] = RST_RPC_PORT
-
-RST_P2P_PORT = get_free_port()
-os.environ['RST_P2P_PORT'] = RST_P2P_PORT
 
 TEST_ACCOUNT = {
     "version": 3,

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -484,7 +484,7 @@ class ChannelManagerTesterMock(object):
             ValueError: If peer1 or peer2 is not a valid address.
         """
         if not isaddress(peer1):
-            raise ValueError('The pee1 must be a valid address')
+            raise ValueError('The peer1 must be a valid address')
 
         if not isaddress(peer2):
             raise ValueError('The peer2 must be a valid address')

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -348,38 +348,37 @@ def run(ctx, **kwargs):
 
             app_ = ctx.invoke(app, **kwargs)
 
-            app_.raiden.register_registry(app_.raiden.chain.default_registry.address)
+            domain_list = []
+            if kwargs['rpccorsdomain']:
+                if ',' in kwargs['rpccorsdomain']:
+                    for domain in kwargs['rpccorsdomain'].split(','):
+                        domain_list.append(str(domain))
+                else:
+                    domain_list.append(str(kwargs['rpccorsdomain']))
 
-        domain_list = []
-        if kwargs['rpccorsdomain']:
-            if ',' in kwargs['rpccorsdomain']:
-                for domain in kwargs['rpccorsdomain'].split(','):
-                    domain_list.append(str(domain))
-            else:
-                domain_list.append(str(kwargs['rpccorsdomain']))
+            http_server = None
+            if ctx.params['rpc']:
+                raiden_api = RaidenAPI(app_.raiden)
+                rest_api = RestAPI(raiden_api)
+                api_server = APIServer(rest_api, cors_domain_list=domain_list)
+                (api_host, api_port) = split_endpoint(kwargs["api_address"])
 
-        http_server = None
-        if ctx.params['rpc']:
-            raiden_api = RaidenAPI(app_.raiden)
-            rest_api = RestAPI(raiden_api)
-            api_server = APIServer(rest_api, cors_domain_list=domain_list)
-            (api_host, api_port) = split_endpoint(kwargs["api_address"])
-
-            http_server = WSGIServer(
-                (api_host, api_port),
-                api_server.flask_app,
-                log=slogging.getLogger('flask')
-            )
-            http_server.start()
-
-            print(
-                "The Raiden API RPC server is now running at http://{}:{}/.\n\n"
-                "See the Raiden documentation for all available endpoints at\n"
-                "https://github.com/raiden-network/raiden/blob/master/docs/Rest-Api.rst".format(
-                    api_host,
-                    api_port,
+                http_server = WSGIServer(
+                    (api_host, api_port),
+                    api_server.flask_app,
+                    log=slogging.getLogger('flask')
                 )
-            )
+                http_server.start()
+
+                print(
+                    "The Raiden API RPC server is now running at http://{}:{}/.\n\n"
+                    "See the Raiden documentation for all available endpoints at\n"
+                    "https://github.com/raiden-network/raiden/blob/master"
+                    "/docs/Rest-Api.rst".format(
+                        api_host,
+                        api_port,
+                    )
+                )
 
             if ctx.params['console']:
                 console = Console(app_)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import sys
 import os
 import tempfile
+import json
 
 import signal
 import click
@@ -474,6 +475,7 @@ def smoketest(ctx, debug, **kwargs):
         append_report('geth init stderr', ethereum_config['init_log_err'].decode('utf-8'))
         append_report('ethereum stdout', out)
         append_report('ethereum stderr', err)
+        append_report('smoketest configuration', json.dumps(smoketest_config))
     if success:
         print('[5/5] smoketest successful, report was written to {}'.format(report_file))
     else:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 import os
+import tempfile
 
 import signal
 import click
@@ -22,6 +23,11 @@ from raiden.settings import (
     DEFAULT_NAT_KEEPALIVE_RETRIES,
 )
 from raiden.utils import split_endpoint
+from raiden.tests.utils.smoketest import (
+    load_or_create_smoketest_config,
+    start_ethereum,
+    run_smoketests,
+)
 
 gevent.monkey.patch_all()
 
@@ -323,25 +329,26 @@ def app(address,
     return App(config, blockchain_service, discovery)
 
 
+@click.group(invoke_without_command=True)
 @options
-@click.command()
 @click.pass_context
 def run(ctx, **kwargs):
-    from raiden.api.python import RaidenAPI
-    from raiden.ui.console import Console
+    if ctx.invoked_subcommand is None:
+        from raiden.api.python import RaidenAPI
+        from raiden.ui.console import Console
 
-    slogging.configure(kwargs['logging'], log_file=kwargs['logfile'])
+        slogging.configure(kwargs['logging'], log_file=kwargs['logfile'])
 
-    # TODO:
-    # - Ask for confirmation to quit if there are any locked transfers that did
-    # not timeout.
-    (listen_host, listen_port) = split_endpoint(kwargs['listen_address'])
-    with socket_factory(listen_host, listen_port) as mapped_socket:
-        kwargs['mapped_socket'] = mapped_socket
+        # TODO:
+        # - Ask for confirmation to quit if there are any locked transfers that did
+        # not timeout.
+        (listen_host, listen_port) = split_endpoint(kwargs['listen_address'])
+        with socket_factory(listen_host, listen_port) as mapped_socket:
+            kwargs['mapped_socket'] = mapped_socket
 
-        app_ = ctx.invoke(app, **kwargs)
+            app_ = ctx.invoke(app, **kwargs)
 
-        app_.raiden.register_registry(app_.raiden.chain.default_registry.address)
+            app_.raiden.register_registry(app_.raiden.chain.default_registry.address)
 
         domain_list = []
         if kwargs['rpccorsdomain']:
@@ -374,17 +381,102 @@ def run(ctx, **kwargs):
                 )
             )
 
-        if ctx.params['console']:
-            console = Console(app_)
-            console.start()
+            if ctx.params['console']:
+                console = Console(app_)
+                console.start()
 
-        # wait for interrupt
-        event = gevent.event.Event()
-        gevent.signal(signal.SIGQUIT, event.set)
-        gevent.signal(signal.SIGTERM, event.set)
-        gevent.signal(signal.SIGINT, event.set)
-        event.wait()
+            # wait for interrupt
+            event = gevent.event.Event()
+            gevent.signal(signal.SIGQUIT, event.set)
+            gevent.signal(signal.SIGTERM, event.set)
+            gevent.signal(signal.SIGINT, event.set)
+            event.wait()
 
         if http_server:
             http_server.stop(5)
         app_.stop(leave_channels=False)
+
+
+@run.command()
+@click.option(
+    '--debug/--no-debug',
+    default=False,
+    help='Drop into pdb on errors (default: False).'
+)
+@click.pass_context
+def smoketest(ctx, debug, **kwargs):
+    """ Test, that the raiden installation is sane.
+    """
+    report_file = tempfile.mktemp(suffix=".log")
+    open(report_file, 'w+')
+
+    def append_report(subject, data):
+        with open(report_file, 'a') as handler:
+            handler.write('{:=^80}'.format(' %s ' % subject.upper()) + os.linesep)
+            if data is not None:
+                handler.writelines([(data + os.linesep).encode('utf-8')])
+
+    append_report('raiden log', None)
+
+    print("[1/5] getting smoketest configuration")
+    smoketest_config = load_or_create_smoketest_config()
+
+    print("[2/5] starting ethereum")
+    ethereum, ethereum_config = start_ethereum(smoketest_config['genesis'])
+
+    print('[3/5] starting raiden')
+
+    # setup logging to log only into our report file
+    slogging.configure(':DEBUG', log_file=report_file)
+    root = slogging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, slogging.logging.StreamHandler):
+            root.handlers.remove(handler)
+            break
+    # setup cli arguments for starting raiden
+    args = dict(
+        discovery_contract_address=smoketest_config['contracts']['discovery_address'],
+        registry_contract_address=smoketest_config['contracts']['registry_address'],
+        eth_rpc_endpoint='http://127.0.0.1:{}'.format(ethereum_config['rpc']),
+        keystore_path=ethereum_config['keystore'],
+        address=ethereum_config['address'],
+    )
+    for option in app.params:
+        if option.name in args.keys():
+            args[option.name] = option.process_value(ctx, args[option.name])
+        else:
+            args[option.name] = option.default
+
+    password_file = os.path.join(args['keystore_path'], 'password')
+    with open(password_file, 'w') as handler:
+        handler.write('password')
+
+    args['mapped_socket'] = None
+    args['password_file'] = click.File()(password_file)
+    args['datadir'] = args['keystore_path']
+
+    # invoke the raiden app
+    app_ = ctx.invoke(app, **args)
+
+    success = False
+    try:
+        print('[4/5] running smoketests...')
+        error = run_smoketests(app_.raiden, smoketest_config, debug=debug)
+        if error is not None:
+            append_report('smoketest assertion error', error)
+        else:
+            success = True
+    finally:
+        app_.stop()
+        ethereum.send_signal(2)
+
+        err, out = ethereum.communicate()
+        append_report('geth init stdout', ethereum_config['init_log_out'].decode('utf-8'))
+        append_report('geth init stderr', ethereum_config['init_log_err'].decode('utf-8'))
+        append_report('ethereum stdout', out)
+        append_report('ethereum stderr', err)
+    if success:
+        print('[5/5] smoketest successful, report was written to {}'.format(report_file))
+    else:
+        print('[5/5] smoketest had errors, report was written to {}'.format(report_file))
+        sys.exit(1)

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -26,7 +26,8 @@ __all__ = (
     'lpex',
     'get_contract_path',
     'safe_lstrip_hex',
-    'camel_to_snake_case'
+    'camel_to_snake_case',
+    'fix_tester_storage'
 )
 
 LETTERS = string.printable
@@ -177,3 +178,21 @@ def channel_to_api_dict(channel):
         "balance": channel.contract_balance,
         "state": channel.state
     }
+
+
+def fix_tester_storage(storage):
+    """ pyethereum tester doesn't follow the canonical storage encoding:
+    Both keys and values of the account storage associative array must be encoded with 64 hex
+    digits. Also account_to_dict() from pyethereum can return 0x for a storage
+    position. That is an invalid way of representing 0x0.
+    Args:
+        storage (dict): the storage dictionary from tester
+    Returns:
+        newstorage (dict): the canonical representation
+    """
+    new_storage = dict()
+    for key, val in storage.iteritems():
+        new_key = '0x%064x' % int(key if key != '0x' else '0x0', 16)
+        new_val = '0x%064x' % int(val, 16)
+        new_storage[new_key] = new_val
+    return new_storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ flask-restful
 webargs
 marshmallow_polyfield==3.0
 Flask-Cors==3.0.2
+pytest>=3.0.4
+psutil

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,7 @@ setup(
     author='HeikoHeiko',
     author_email='heiko@brainbot.com',
     url='https://github.com/raiden-network/raiden',
-    packages=find_packages(
-        exclude=["raiden.tests", "raiden.tests.*"]
-    ),
+    packages=find_packages(),
     include_package_data=True,
     license='BSD',
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,17 @@ import os
 from setuptools import setup, find_packages
 from setuptools import Command
 from setuptools.command.test import test as TestCommand
+from setuptools.command.build_py import build_py
+
+
+class BuildPyCommand(build_py):
+
+    def run(self):
+        self.run_command('compile_contracts')
+        # ensure smoketest_config.json is generated
+        from raiden.tests.utils.smoketest import load_or_create_smoketest_config
+        load_or_create_smoketest_config()
+        build_py.run(self)
 
 
 class PyTest(TestCommand):
@@ -84,6 +95,7 @@ setup(
     cmdclass={
         'test': PyTest,
         'compile_contracts': CompileContracts,
+        'build_py': BuildPyCommand,
     },
     install_requires=install_requires,
     tests_require=test_requirements,

--- a/tools/genesis_builder.py
+++ b/tools/genesis_builder.py
@@ -27,12 +27,12 @@ def mk_genesis(accounts, initial_alloc=denoms.ether * 100000000):
     """
     genesis = GENESIS_STUB.copy()
     genesis['extraData'] = '0x' + CLUSTER_NAME.encode('hex')
-    genesis['alloc'] = {
+    genesis['alloc'].update({
         account: {
             'balance': str(initial_alloc)
         }
         for account in accounts
-    }
+    })
     # add the one-privatekey account ("1" * 64) for convenience
     genesis['alloc']['19e7e376e7c213b7e7e7e46cc70a5dd086daff2a'] = dict(balance=str(initial_alloc))
     return genesis


### PR DESCRIPTION
This adds a `raiden smoketest` command. This fixes #679.

#### Rationale
The `smoketest` allows to check the "general sanity" of a raiden installation. Intended usages are
- fail early in CI (`raiden smoketest` will be run before the `pytest` sessions)
- allow to test the raiden CLI interface -- the raiden node started during the test uses the standard `raiden [OPTIONS] COMMAND [ARGS]...` interface
- allow to test the functioning of `AppImage` builds
- help with debugging user issues

#### Operation
The `smoketest` starts a local private go-ethereum blockchain (with clique PoA) with a minimal set of raiden smart contracts already deployed. It will connect a raiden node and assert on the intended state of the raiden node after connection. So far the checks include:
- successful connection to the `Registry` contract
- successful connection to the `EndpointRegistry` contract
- successful update of the registered endpoint address for discovery
- successful collection and parsing of the (already setup) channel(s) from `Registry`

It generates a standardized report file after the test run.

#### Details
The configuration file, `smoketest_configuration.json`, is generated during the release build and shipped with the distribution. This is intended to achieve: a) allow users to run the command without the `solc` compiler and b) standardize the test results for a certain release.
However, if the installation uses a different `solc` version from the one recorded during building the distribution, the configuration will be updated and use the local `solc` compiler. The configuration that was used is included in the report file.

#### Changes tangential to the issue included
- removed redundant registry parsing from CLI (it is part of `RaidenService.__init__`)
- some refactoring to the test/fixture setup
- `raiden/tests` are now part of the distribution, so `pytest` and `psutil` became actual requirements 

#### Shortcomings
- I intended to make the ethereum client implementation customizable (see the comment block in `raiden/tests/utils/smoketest.py` prior to `DEFAULT_ETH_COMMAND`). This idea is not finished however, because the `init_with_genesis()` phase is not customizable yet. #758
- I intended to use a random free port for the ethereum rpc -- the current implementation will always use the same port. #759 