### PR TITLE
Add register token endpoint to api

### DIFF
--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -104,15 +104,12 @@ Registering a Token
 
 If a Token is not registered (i.e.: A channel manager for that token does not exist in the network) then we need to register it by deploying a Channel Manager contract for that token.
 
-We can do that by doing a ``PUT`` request to the endpoint ``/api/<version>/tokens`` with the address as payload. The request should return the deployed manager's address.
+We can do that by doing a ``PUT`` request to the endpoint ``/api/<version>/tokens/<token_address>``. The request should return the deployed channel manager's address.
 
 Example Request
 ^^^^^^^^^^^^^^^
 
-``PUT /api/1/tokens`` with payload:::
-
-
-    {"token_address": "0xea674fdde714fd979de3edf0f56aa9716b898ec8"}
+``PUT /api/1/tokens/0xea674fdde714fd979de3edf0f56aa9716b898ec8``
 
 Example Response
 ^^^^^^^^^^^^^^^^

--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -96,6 +96,32 @@ Example Response
 
     {"our_address": "0x2a65aca4d5fc5b5c859090a6c34d164135398226"}
 
+Deploying
+=========
+
+Registering a Token
+-------------------
+
+If a Token is not registered (i.e.: A channel manager for that token does not exist in the network) then we need to register it by deploying a Channel Manager contract for that token.
+
+We can do that by doing a ``PUT`` request to the endpoint ``/api/<version>/tokens`` with the address as payload. The request should return the deployed manager's address.
+
+Example Request
+^^^^^^^^^^^^^^^
+
+``PUT /api/1/tokens`` with payload:::
+
+
+    {"token_address": "0xea674fdde714fd979de3edf0f56aa9716b898ec8"}
+
+Example Response
+^^^^^^^^^^^^^^^^
+``200 OK`` and
+
+::
+
+    {"channel_manager_address": "0x2a65aca4d5fc5b5c859090a6c34d164135398226"}
+
 Querying Information About Channels and Tokens
 ===============================================
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -80,13 +80,11 @@ class RaidenAPI(object):
         """ Will register the token at `token_address` with raiden. If it's already
         registered, will throw an exception."""
         try:
-            channel_manager = self.raiden.chain.manager_by_token(token_address)
+            self.raiden.chain.manager_by_token(token_address)
         except:
-            self.raiden.chain.default_registry.add_token(token_address)
-            channel_manager = self.raiden.chain.manager_by_token(token_address)
-            # Register the channel manager with the raiden registry
-            self.raiden.register_channel_manager(channel_manager.address)
-            return channel_manager.address
+            channel_manager_address = self.raiden.chain.default_registry.add_token(token_address)
+            self.raiden.register_channel_manager(channel_manager_address)
+            return channel_manager_address
 
         # If we get the channel manager correctly then, error
         raise ValueError("Token already registered")

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -65,6 +65,13 @@ class RaidenAPI(object):
 
         raise ValueError("Channel not found")
 
+    def manager_address_if_token_registered(self, token_address):
+        try:
+            manager = self.raiden.chain.manager_by_token(token_address)
+            return manager.channel_manager_address
+        except:
+            return None
+
     def register_token(self, token_address):
         self.raiden.chain.default_registry.add_token(token_address)
         channel_manager = self.raiden.chain.manager_by_token(token_address)

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -66,16 +66,30 @@ class RaidenAPI(object):
         raise ValueError("Channel not found")
 
     def manager_address_if_token_registered(self, token_address):
+        """
+        If the token is registered then, return the channel manager address.
+        Returns None otherwise.
+        """
         try:
             manager = self.raiden.chain.manager_by_token(token_address)
-            return manager.channel_manager_address
+            return manager.address
         except:
             return None
 
     def register_token(self, token_address):
-        self.raiden.chain.default_registry.add_token(token_address)
-        channel_manager = self.raiden.chain.manager_by_token(token_address)
-        return channel_manager.channel_manager_address
+        """ Will register the token at `token_address` with raiden. If it's already
+        registered, will throw an exception."""
+        try:
+            channel_manager = self.raiden.chain.manager_by_token(token_address)
+        except:
+            self.raiden.chain.default_registry.add_token(token_address)
+            channel_manager = self.raiden.chain.manager_by_token(token_address)
+            # Register the channel manager with the raiden registry
+            self.raiden.register_channel_manager(channel_manager.address)
+            return channel_manager.address
+
+        # If we get the channel manager correctly then, error
+        raise ValueError("Token already registered")
 
     def connect_token_network(
         self,

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -65,6 +65,11 @@ class RaidenAPI(object):
 
         raise ValueError("Channel not found")
 
+    def register_token(self, token_address):
+        self.raiden.chain.default_registry.add_token(token_address)
+        channel_manager = self.raiden.chain.manager_by_token(token_address)
+        return channel_manager.channel_manager_address
+
     def connect_token_network(
         self,
         token_address,

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -2,6 +2,8 @@
 import gevent
 from gevent.event import AsyncResult
 from ethereum import slogging
+from ethereum.tester import TransactionFailed
+from pyethapp.rpc_client import JSONRPCClientReplyError
 
 from raiden.blockchain.events import (
     ALL_EVENTS,
@@ -73,7 +75,7 @@ class RaidenAPI(object):
         try:
             manager = self.raiden.chain.manager_by_token(token_address)
             return manager.address
-        except:
+        except (JSONRPCClientReplyError, TransactionFailed):
             return None
 
     def register_token(self, token_address):

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -29,6 +29,7 @@ from raiden.api.v1.resources import (
     TokensResource,
     PartnersResourceByTokenAddress,
     NetworkEventsResource,
+    RegisterTokenResource,
     TokenEventsResource,
     ChannelEventsResource,
     TokenSwapsResource,
@@ -114,6 +115,10 @@ class APIServer(object):
             PartnersResourceByTokenAddress,
             '/tokens/<hexaddress:token_address>/partners'
         )
+        self.add_resource(
+            RegisterTokenResource,
+            '/tokens/<hexaddress:token_address>'
+        )
         self.add_resource(NetworkEventsResource, '/events/network')
         self.add_resource(
             TokenEventsResource,
@@ -175,6 +180,14 @@ class RestAPI(object):
 
     def get_our_address(self):
         return {'our_address': address_encoder(self.raiden_api.address)}
+
+    def register_token(self, token_address):
+        try:
+            manager_address = self.raiden.chain.manager_by_token(token_address)
+        except:
+            manager_address = self.raiden_api.register_token(token_address)
+
+        return jsonify(dict(channel_manager_address=address_encoder(manager_address)))
 
     def open(self, partner_address, token_address, settle_timeout, balance=None):
         raiden_service_result = self.raiden_api.open(

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -182,9 +182,8 @@ class RestAPI(object):
         return {'our_address': address_encoder(self.raiden_api.address)}
 
     def register_token(self, token_address):
-        try:
-            manager_address = self.raiden.chain.manager_by_token(token_address)
-        except:
+        manager_address = self.raiden_api.manager_address_if_token_registered(token_address)
+        if manager_address is None:
             manager_address = self.raiden_api.register_token(token_address)
 
         return jsonify(dict(channel_manager_address=address_encoder(manager_address)))

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -144,6 +144,7 @@ class RegisterTokenResource(BaseResource):
     def put(self, token_address):
         return self.rest_api.register_token(token_address)
 
+
 class TokenSwapsResource(BaseResource):
 
     put_schema = TokenSwapsSchema()

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -137,6 +137,13 @@ class ChannelEventsResource(BaseResource):
         )
 
 
+class RegisterTokenResource(BaseResource):
+    def __init__(self, **kwargs):
+        super(RegisterTokenResource, self).__init__(**kwargs)
+
+    def put(self, token_address):
+        return self.rest_api.register_token(token_address)
+
 class TokenSwapsResource(BaseResource):
 
     put_schema = TokenSwapsSchema()

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -664,6 +664,7 @@ class Registry(object):
             registry_address=pex(self.address),
             channel_manager_address=pex(channel_manager_address_bin),
         )
+        return channel_manager_address_bin
 
     def token_addresses(self):
         return [

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -352,6 +352,9 @@ class BlockChainService(object):
     def manager_by_token(self, token_address):
         """ Find the channel manager for `token_address` and return a proxy to
         interact with it.
+
+        If the token is not already registered it raises `JSONRPCClientReplyError`,
+        since we try to instantiate a Channel manager with an empty address.
         """
         if token_address not in self.token_manager:
             token = self.token(token_address)  # check that the token exists

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -980,3 +980,16 @@ def test_connect_and_leave_token_network(
     assert channels[0]['state'] == CHANNEL_STATE_SETTLED
     assert channels[1]['state'] == CHANNEL_STATE_SETTLED
     assert channels[2]['state'] == CHANNEL_STATE_SETTLED
+
+
+def test_register_token(api_backend, api_test_context, api_raiden_service):
+    token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
+    request = grequests.put(api_url_for(
+        api_backend,
+        'registertokenresource',
+        token_address=token_address)
+    )
+    response = request.send().response
+    assert_proper_response(response)
+    response = response.json()
+    assert 'channel_manager_address' in response

--- a/raiden/tests/fixtures/api.py
+++ b/raiden/tests/fixtures/api.py
@@ -101,6 +101,12 @@ def api_raiden_service(
     monkeypatch.setattr(api, 'expect_token_swap', api_test_context.expect_token_swap)
     monkeypatch.setattr(api, 'connect_token_network', api_test_context.connect)
     monkeypatch.setattr(api, 'leave_token_network', api_test_context.leave)
+    monkeypatch.setattr(api, 'register_token', api_test_context.register_token)
+    monkeypatch.setattr(
+        api,
+        'manager_address_if_token_registered',
+        api_test_context.manager_address_if_token_registered
+    )
 
     # also make sure that the test server's raiden_api uses this mock
     # raiden service

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -49,7 +49,6 @@ def test_get_channel_list(raiden_network, token_addresses):
         )
 
 
-@pytest.mark.parametrize('blockchain_type', ['tester'])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('register_tokens', [False])

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -57,7 +57,8 @@ def test_register_token(raiden_chain, token_addresses):
     app0, _ = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
 
     api0 = RaidenAPI(app0.raiden)
-    assert not api0.manager_address_if_token_registered(token_addresses[0])
+    assert api0.manager_address_if_token_registered(token_addresses[0]) is None
+
     manager_0token = api0.register_token(token_addresses[0])
 
     assert manager_0token == api0.manager_address_if_token_registered(token_addresses[0])

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -50,6 +50,25 @@ def test_get_channel_list(raiden_network, token_addresses):
 
 
 @pytest.mark.parametrize('blockchain_type', ['tester'])
+@pytest.mark.parametrize('channels_per_node', [0])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('register_tokens', [False])
+@pytest.mark.parametrize('number_of_tokens', [1])
+def test_register_token(raiden_chain, token_addresses):
+    app0, _ = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
+
+    api0 = RaidenAPI(app0.raiden)
+    assert not api0.manager_address_if_token_registered(token_addresses[0])
+    manager_0token = api0.register_token(token_addresses[0])
+
+    assert manager_0token == api0.manager_address_if_token_registered(token_addresses[0])
+
+    # Exception if we try to reregister
+    with pytest.raises(ValueError):
+        api0.register_token(token_addresses[0])
+
+
+@pytest.mark.parametrize('blockchain_type', ['tester'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_transfer_to_unknownchannel(raiden_network):

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -44,6 +44,7 @@ class ApiTestContext():
         self.channel_schema = ChannelSchema()
         self.channel_list_schema = ChannelListSchema()
         self.reveal_timeout = reveal_timeout
+        self.tokens_to_manager_address = dict()
 
     def add_events(self, events):
         self.events += events
@@ -159,6 +160,18 @@ class ApiTestContext():
             reveal_timeout,
             settle_timeout,
         )
+
+    def register_token(self, token_address):
+        self.tokens.add(token_address)
+        manager_address = make_address()
+        self.tokens_to_manager_address[token_address] = manager_address
+        return manager_address
+
+    def manager_address_if_token_registered(self, token_address):
+        if token_address not in self.tokens:
+            return None
+
+        return self.tokens_to_manager_address(token_address)
 
     def make_channel_and_add(self):
         channel = self.make_channel()

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -171,7 +171,7 @@ class ApiTestContext():
         if token_address not in self.tokens:
             return None
 
-        return self.tokens_to_manager_address(token_address)
+        return self.tokens_to_manager_address[token_address]
 
     def make_channel_and_add(self):
         channel = self.make_channel()

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -278,6 +278,9 @@ class BlockChainServiceTesterMock(object):
     def manager_by_token(self, token_address):
         """ Find the channel manager for `token_address` and return a proxy to
         interact with it.
+
+        If the token is not already registered it raises `TransactionFailed` when
+        we do `self.registry_proxy.channelManagerByToken(token_address)`
         """
         if token_address not in self.token_manager:
             manager_address = self.default_registry.manager_address_by_token(token_address)

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -423,6 +423,8 @@ class RegistryTesterMock(object):
     def add_token(self, token_address):
         self.registry_proxy.addToken(token_address)
         self.tester_state.mine(number_of_blocks=1)
+        channel_manager_address_hex = self.registry_proxy.channelManagerByToken(token_address)
+        return channel_manager_address_hex.decode('hex')
 
     def token_addresses(self):
         result = [


### PR DESCRIPTION
Add a REST API endpoint for the token registration along with tests for it.

In an upcoming PR will fix the return code/responses if you try to reregister.