### PR TITLE
Return 201 and other non-200 rest status code when needed

### DIFF
--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -106,6 +106,8 @@ If a Token is not registered (i.e.: A channel manager for that token does not ex
 
 We can do that by doing a ``PUT`` request to the endpoint ``/api/<version>/tokens/<token_address>``. The request should return the deployed channel manager's address.
 
+If the token is already registered then a 401 Conflict error is returned.
+
 Example Request
 ^^^^^^^^^^^^^^^
 
@@ -113,9 +115,16 @@ Example Request
 
 Example Response
 ^^^^^^^^^^^^^^^^
-``200 OK`` and
++------------------+---------------------------+
+| HTTP Code        | Condition                 |
++==================+===========================+
+| 201 Created      | For succesful Registration|
++------------------+---------------------------+
+| 409 Conflict     | If the token is already   |
+|                  | registered                |
++------------------+---------------------------+
 
-::
+And with a 201 response we also get::
 
     {"channel_manager_address": "0x2a65aca4d5fc5b5c859090a6c34d164135398226"}
 

--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -106,7 +106,7 @@ If a Token is not registered (i.e.: A channel manager for that token does not ex
 
 We can do that by doing a ``PUT`` request to the endpoint ``/api/<version>/tokens/<token_address>``. The request should return the deployed channel manager's address.
 
-If the token is already registered then a 401 Conflict error is returned.
+If the token is already registered then a 409 Conflict error is returned.
 
 Example Request
 ^^^^^^^^^^^^^^^
@@ -320,7 +320,7 @@ Please note that the sending/reveiving amount and token is always from the persp
 
 Example Response
 ^^^^^^^^^^^^^^^^
-``200 OK``
+``201 CREATED``
 
 Possible Responses
 ^^^^^^^^^^^^^^^^^^

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -221,7 +221,7 @@ class RestAPI(object):
             )
 
         result = self.channel_schema.dump(channel_to_api_dict(raiden_service_result))
-        return jsonify(result.data)
+        return jsonify_with_response(data=result.data, status_code=httplib.CREATED)
 
     def deposit(self, token_address, partner_address, amount):
 
@@ -447,6 +447,8 @@ class RestAPI(object):
                 'Provided invalid token swap role {}'.format(role),
                 httplib.BAD_REQUEST,
             )
+
+        return jsonify_with_response(dict(), httplib.CREATED)
 
 
 @parser.error_handler

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -255,7 +255,7 @@ def test_api_open_and_deposit_channel(
     )
     response = request.send().response
 
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
     response = response.json()
     expected_response = channel_data_obj
     expected_response['balance'] = 0
@@ -281,7 +281,7 @@ def test_api_open_and_deposit_channel(
     )
     response = request.send().response
 
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
     response = response.json()
     expected_response = channel_data_obj
     expected_response['balance'] = balance
@@ -429,7 +429,7 @@ def test_api_channel_state_change_errors(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
     response = response.json()
     channel_address = response['channel_address']
 
@@ -542,7 +542,7 @@ def test_api_tokens(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
 
     partner_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     token_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
@@ -557,7 +557,7 @@ def test_api_tokens(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
 
     # and now let's get the token list
     request = grequests.get(
@@ -592,7 +592,7 @@ def test_query_partners_by_token(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
     response = response.json()
     first_channel_address = response['channel_address']
 
@@ -602,7 +602,7 @@ def test_query_partners_by_token(
         json=channel_data_obj,
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
     response = response.json()
     second_channel_address = response['channel_address']
 
@@ -614,7 +614,7 @@ def test_query_partners_by_token(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, httplib.CREATED)
 
     # and now let's query our partners per token for the first token
     request = grequests.get(

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -357,7 +357,7 @@ def test_api_open_close_and_settle_channel(
     response = request.send().response
 
     balance = 0
-    assert_proper_response(response)
+    assert_proper_response(response, status_code=httplib.CREATED)
     response = response.json()
     expected_response = channel_data_obj
     expected_response['balance'] = balance
@@ -854,7 +854,7 @@ def test_api_token_swaps(
         json=tokenswap_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, status_code=httplib.CREATED)
 
     tokenswap_obj = {
         'role': 'taker',
@@ -879,7 +879,7 @@ def test_api_token_swaps(
         json=tokenswap_obj
     )
     response = request.send().response
-    assert_proper_response(response)
+    assert_proper_response(response, status_code=httplib.CREATED)
 
 
 def test_api_transfers(

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -25,11 +25,11 @@ from raiden.settings import (
 )
 
 
-def assert_proper_response(response):
+def assert_proper_response(response, status_code=httplib.OK):
     """ Make sure the API response is of the proper type"""
     assert (
         response and
-        response.status_code == httplib.OK and
+        response.status_code == status_code and
         response.headers['Content-Type'] == 'application/json'
     )
 
@@ -990,6 +990,14 @@ def test_register_token(api_backend, api_test_context, api_raiden_service):
         token_address=token_address)
     )
     response = request.send().response
-    assert_proper_response(response)
-    response = response.json()
-    assert 'channel_manager_address' in response
+    assert_proper_response(response, status_code=httplib.CREATED)
+    assert 'channel_manager_address' in response.json()
+
+    # now try to reregister it and get the error
+    request = grequests.put(api_url_for(
+        api_backend,
+        'registertokenresource',
+        token_address=token_address)
+    )
+    response = request.send().response
+    assert response is not None and response.status_code == httplib.CONFLICT

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -69,6 +69,25 @@ def test_register_token(raiden_chain, token_addresses):
 
 
 @pytest.mark.parametrize('blockchain_type', ['tester'])
+@pytest.mark.parametrize('channels_per_node', [0])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('register_tokens', [False])
+@pytest.mark.parametrize('number_of_tokens', [1])
+def test_register_token(raiden_chain, token_addresses):
+    app0, _ = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
+
+    api0 = RaidenAPI(app0.raiden)
+    assert not api0.manager_address_if_token_registered(token_addresses[0])
+    manager_0token = api0.register_token(token_addresses[0])
+
+    assert manager_0token == api0.manager_address_if_token_registered(token_addresses[0])
+
+    # Exception if we try to reregister
+    with pytest.raises(ValueError):
+        api0.register_token(token_addresses[0])
+
+
+@pytest.mark.parametrize('blockchain_type', ['tester'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_transfer_to_unknownchannel(raiden_network):

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -69,25 +69,6 @@ def test_register_token(raiden_chain, token_addresses):
 
 
 @pytest.mark.parametrize('blockchain_type', ['tester'])
-@pytest.mark.parametrize('channels_per_node', [0])
-@pytest.mark.parametrize('number_of_nodes', [2])
-@pytest.mark.parametrize('register_tokens', [False])
-@pytest.mark.parametrize('number_of_tokens', [1])
-def test_register_token(raiden_chain, token_addresses):
-    app0, _ = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
-
-    api0 = RaidenAPI(app0.raiden)
-    assert not api0.manager_address_if_token_registered(token_addresses[0])
-    manager_0token = api0.register_token(token_addresses[0])
-
-    assert manager_0token == api0.manager_address_if_token_registered(token_addresses[0])
-
-    # Exception if we try to reregister
-    with pytest.raises(ValueError):
-        api0.register_token(token_addresses[0])
-
-
-@pytest.mark.parametrize('blockchain_type', ['tester'])
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_transfer_to_unknownchannel(raiden_network):


### PR DESCRIPTION
We were not following the api spec and returning `200 OK` in places where `201 CREATED` should have been returned. This PR fixes that.