### PR TITLE
Fix the connect API endpoint token address

### DIFF
--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -264,7 +264,10 @@ class TransferSchema(BaseSchema):
 
 class ConnectionsConnectSchema(BaseSchema):
     funds = fields.Integer(required=True, location='json')
-    initial_channel_target = fields.Integer(missing=DEFAULT_INITIAL_CHANNEL_TARGET, location='json')
+    initial_channel_target = fields.Integer(
+        missing=DEFAULT_INITIAL_CHANNEL_TARGET,
+        location='json'
+    )
     joinable_funds_target = fields.Decimal(missing=DEFAULT_JOINABLE_FUNDS_TARGET, location='json')
 
     class Meta:

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -263,10 +263,9 @@ class TransferSchema(BaseSchema):
 
 
 class ConnectionsConnectSchema(BaseSchema):
-    token_address = AddressField()
-    funds = fields.Integer()
-    initial_channel_target = fields.Integer(missing=DEFAULT_INITIAL_CHANNEL_TARGET)
-    joinable_funds_target = fields.Decimal(missing=DEFAULT_JOINABLE_FUNDS_TARGET)
+    funds = fields.Integer(required=True, location='json')
+    initial_channel_target = fields.Integer(missing=DEFAULT_INITIAL_CHANNEL_TARGET, location='json')
+    joinable_funds_target = fields.Decimal(missing=DEFAULT_JOINABLE_FUNDS_TARGET, location='json')
 
     class Meta:
         strict = True
@@ -274,9 +273,8 @@ class ConnectionsConnectSchema(BaseSchema):
 
 
 class ConnectionsLeaveSchema(BaseSchema):
-    token_address = AddressField()
-    wait_for_settle = fields.Bool(missing=DEFAULT_WAIT_FOR_SETTLE)
-    timeout = fields.Integer(missing=DEFAULT_REVEAL_TIMEOUT)
+    wait_for_settle = fields.Bool(missing=DEFAULT_WAIT_FOR_SETTLE, location='json')
+    timeout = fields.Integer(missing=DEFAULT_REVEAL_TIMEOUT, location='json')
 
     class Meta:
         strict = True

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -200,7 +200,7 @@ class ConnectionsResource(BaseResource):
     def __init__(self, **kwargs):
         super(ConnectionsResource, self).__init__(**kwargs)
 
-    @use_kwargs(put_schema, locations=('json',))
+    @use_kwargs(put_schema)
     def put(self, token_address, funds, initial_channel_target, joinable_funds_target):
         return self.rest_api.connect(
             token_address=token_address,
@@ -209,7 +209,7 @@ class ConnectionsResource(BaseResource):
             joinable_funds_target=joinable_funds_target,
         )
 
-    @use_kwargs(delete_schema, locations=('json',))
+    @use_kwargs(delete_schema)
     def delete(self, token_address, wait_for_settle, timeout):
         return self.rest_api.leave(
             token_address=token_address,

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -15,7 +15,8 @@ from raiden.transfer.state import (
     CHANNEL_STATE_CLOSED,
     CHANNEL_STATE_SETTLED,
 )
-from raiden.utils import pex
+from raiden.utils import pex, isaddress
+from raiden.exceptions import InvalidAddress
 
 
 class NettingChannelMock(object):
@@ -280,6 +281,9 @@ class ApiTestContext():
             initial_channel_target,
             joinable_funds_target):
 
+        if not isaddress(token_address):
+            raise InvalidAddress('not an address %s' % pex(token_address))
+
         funding = int((funds * joinable_funds_target) / initial_channel_target)
         for i in range(0, initial_channel_target):
             channel = self.make_channel(token_address=token_address, balance=funding)
@@ -290,6 +294,9 @@ class ApiTestContext():
             token_address,
             wait_for_settle=True,
             timeout=30):
+
+        if not isaddress(token_address):
+            raise InvalidAddress('not an address %s' % pex(token_address))
 
         channels = self.get_all_channels_for_token(token_address)
         for channel in channels:


### PR DESCRIPTION
The marshmallow schema was wrong and was expecting the token_address
from the json data while it should only be found from the url.