### PR TITLE
Fix the compilation of contract ABI in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ class CompileContracts(Command):
 
     def run(self):
         os.environ['STORE_PRECOMPILED'] = 'yes'
-        from raiden.blockchain import abi
+        from raiden.blockchain.abi import CONTRACT_MANAGER
+        CONTRACT_MANAGER.instantiate()
 
 
 with open('README.md') as readme_file:


### PR DESCRIPTION
A previous change I had made inadvertedly broke the static abi
compilation of contracts via setup.py. This should fix it.