### PR TITLE
Do not close/settle channels at shutdown

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -364,4 +364,4 @@ def run(ctx, **kwargs):
         gevent.signal(signal.SIGINT, event.set)
         event.wait()
 
-        app_.stop(leave_channels=True)
+        app_.stop(leave_channels=False)


### PR DESCRIPTION
From our discussions on restartability/recoverability we should not be
closing all channels by default at shutdown unless otherwise
specifically requested.