### PR TITLE
Check that address has code before adding a Token

### DIFF
--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -14,7 +14,15 @@ contract Registry {
     }
 
     modifier doesNotExist(address _address) {
+        // Check if it's already registered or token contract missing
         require(registry[_address] == 0x0);
+        uint size;
+        assembly {
+            size := extcodesize(_address)
+        }
+        if (size == 0) {
+            throw;
+        }
         _;
     }
 

--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -16,8 +16,7 @@ contract Registry {
     modifier doesNotExist(address _address) {
         // Check if it's already registered or token contract is invalid.
         // We assume if it has a valid totalSupply() function it's a valid Token contract
-        if (registry[_address] != 0x0)
-            throw;
+        require(registry[_address] == 0x0);
         Token token = Token(_address);
         token.totalSupply();
         _;

--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -14,15 +14,12 @@ contract Registry {
     }
 
     modifier doesNotExist(address _address) {
-        // Check if it's already registered or token contract missing
-        require(registry[_address] == 0x0);
-        uint size;
-        assembly {
-            size := extcodesize(_address)
-        }
-        if (size == 0) {
+        // Check if it's already registered or token contract is invalid.
+        // We assume if it has a valid totalSupply() function it's a valid Token contract
+        if (registry[_address] != 0x0)
             throw;
-        }
+        Token token = Token(_address);
+        token.totalSupply();
         _;
     }
 

--- a/raiden/tests/fixtures/tester.py
+++ b/raiden/tests/fixtures/tester.py
@@ -91,7 +91,7 @@ def tester_state(deploy_key, private_keys, tester_blockgas_limit):
 
 
 @pytest.fixture
-def tester_token_address(private_keys, token_amount, tester_state):
+def tester_token_address(private_keys, token_amount, tester_state, sender_index=0):
     standard_token_path = get_contract_path('StandardToken.sol')
     human_token_path = get_contract_path('HumanStandardToken.sol')
 
@@ -112,7 +112,7 @@ def tester_token_address(private_keys, token_amount, tester_state):
         language='solidity',
         libraries=human_token_libraries,
         constructor_parameters=[token_amount, 'raiden', 0, 'rd'],
-        sender=private_keys[0],
+        sender=private_keys[sender_index],
     )
     tester_state.mine(number_of_blocks=1)
 

--- a/raiden/tests/smart_contracts/test_registry.py
+++ b/raiden/tests/smart_contracts/test_registry.py
@@ -4,43 +4,18 @@ import pytest
 from ethereum import slogging
 from ethereum import tester
 
-from raiden.utils import sha3, get_contract_path
+from raiden.tests.fixtures.tester import tester_token_address
+from raiden.utils import sha3
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
-
-
-def deploy_token(state, sender_key):
-    human_token_path = get_contract_path('HumanStandardToken.sol')
-    standard_token_path = get_contract_path('StandardToken.sol')
-    standard_token = state.abi_contract(
-        None,
-        path=standard_token_path,
-        language='solidity',
-    )
-    contract_libraries = {
-        'StandardToken': standard_token.address.encode('hex'),
-    }
-    token = state.abi_contract(
-        None,
-        sender=sender_key,
-        path=human_token_path,
-        language='solidity',
-        libraries=contract_libraries,
-        constructor_parameters=[10000, 'raiden', 0, 'rd'],
-    )
-    return token
 
 
 def test_registry(tester_registry, tester_events, private_keys, tester_state):
     privatekey0 = tester.DEFAULT_KEY
 
-    token1 = deploy_token(tester_state, private_keys[0])
-    token2 = deploy_token(tester_state, private_keys[1])
-    token3 = deploy_token(tester_state, private_keys[2])
-
-    token_address1 = token1.address
-    token_address2 = token2.address
-    unregistered_address = token3.address
+    token_address1 = tester_token_address(private_keys, 100, tester_state, 0)
+    token_address2 = tester_token_address(private_keys, 100, tester_state, 1)
+    unregistered_address = tester_token_address(private_keys, 100, tester_state, 2)
 
     contract_address1 = tester_registry.addToken(token_address1, sender=privatekey0)
     channel_manager_address1 = tester_registry.channelManagerByToken(


### PR DESCRIPTION
Before registering a token and creating a channel manager for it we have
to at least make sure the address has code, so that it can correspond to
a token contract.

To even be more pedantic and certain we could even check if the token contract returns a `>= 0` reply to the `function totalSupply() constant returns (uint256 supply);` call. All ERC20 contracts should have this function.