### PR TITLE
Remove duplicated property from netting channel

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -208,7 +208,7 @@ class Channel(object):
 
     @property
     def contract_balance(self):
-        """ Return the amount of token used to open the channel. """
+        """Return the total amount of token we deposited in the channel"""
         return self.our_state.contract_balance
 
     @property

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -200,10 +200,6 @@ class Channel(object):
         return self.partner_state.address
 
     @property
-    def deposit(self):
-        return self.our_state.contract_balance
-
-    @property
     def can_transfer(self):
         return (
             self.state == CHANNEL_STATE_OPENED and

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -83,7 +83,7 @@ class ConnectionManager(object):
                 token_address=pex(self.token_address),
                 open_channels=len(open_channels),
                 sum_deposits=sum(
-                    channel.deposit for channel in open_channels
+                    channel.contract_balance for channel in open_channels
                 ),
                 funds=funds,
             )
@@ -286,7 +286,7 @@ class ConnectionManager(object):
         """
         if self.funds > 0:
             remaining = self.funds - sum(
-                channel.deposit for channel in self.open_channels
+                channel.contract_balance for channel in self.open_channels
             )
             assert isinstance(remaining, int)
             return remaining

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -242,7 +242,7 @@ class StateMachineEventHandler(object):
         connection_manager = self.raiden.connection_manager_for_token(
             token_address
         )
-        if channel.deposit == 0:
+        if channel.contract_balance == 0:
             gevent.spawn(
                 connection_manager.join_channel,
                 participant_address,

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -211,8 +211,8 @@ def test_settled_lock(token_addresses, raiden_network, settle_timeout, reveal_ti
     forward_channel = channel(app0, app1, token)
     back_channel = channel(app1, app0, token)
 
-    deposit0 = forward_channel.deposit
-    deposit1 = back_channel.deposit
+    deposit0 = forward_channel.contract_balance
+    deposit1 = back_channel.contract_balance
 
     token_contract = app0.raiden.chain.token(token)
     balance0 = token_contract.balance_of(address0)


### PR DESCRIPTION
The properties `deposit` and `contract_balance` are redundant. So far
most code inside `raiden` uses `contract_balance`. In order to prevent
mixed usage and to avoid the semantic clash with the `deposit(amount)`
function, I removed the `deposit` property.