### PR TITLE
Remove py27 environment from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,coverage
+envlist = coverage
 
 [pytest]
 timeout = 540


### PR DESCRIPTION
By default when we run tests with tox without specifying an environment
with the `-e` argument we run tests in both both `py27` and `coverage`
which seem to end up in two identical runs.

Thus I don't see why we should have both in the list especially since we
can manually invoke any specific environment via `-e`. The default
should be a single run. Having it in a different way makes people assume
both runs are needed.