### PR TITLE
Use block number in ChannelNewBalance event

### DIFF
--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -46,7 +46,7 @@ contract NettingChannelContract {
         (success, balance) = data.deposit(amount);
 
         if (success == true) {
-            ChannelNewBalance(data.token, msg.sender, balance, 0);
+            ChannelNewBalance(data.token, msg.sender, balance, block.number);
         }
 
         return success;

--- a/raiden/tests/smart_contracts/netting_channel/test_deposit.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_deposit.py
@@ -98,10 +98,7 @@ def test_deposit_events(
         '_value': deposit_amount,
     }
 
-    assert newbalance_event == {
-        '_event_type': 'ChannelNewBalance',
-        'token_address': encode_hex(tester_token.address),
-        'participant': encode_hex(address),
-        'balance': deposit_amount,
-        'block_number': 0,  # the block number in the event is deprecated
-    }
+    assert newbalance_event['_event_type'] == 'ChannelNewBalance'
+    assert newbalance_event['token_address'] == encode_hex(tester_token.address)
+    assert newbalance_event['participant'] == encode_hex(address)
+    assert newbalance_event['balance'] == deposit_amount

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -163,6 +163,7 @@ def test_api_channel_events(raiden_chain):
     for idx, result in enumerate(results):
         if result['block_number'] > max_block:
             max_block = result['block_number']
+            assert max_block != 0
 
         if idx == 2:
             assert result['_event_type'] == 'EventTransferSentSuccess'


### PR DESCRIPTION
This is a fix for the flaky failures we were getting on test_api_channel_events

```

=================================== FAILURES ===================================
[1m[31m______________________ test_api_channel_events[2-1-geth] _______________________[0m

raiden_chain = [<App f0ef4707>, <App a3c19cc4>]

[1m    @pytest.mark.parametrize('blockchain_type', ['geth'])[0m
[1m    @pytest.mark.parametrize('channels_per_node', [1])[0m
[1m    @pytest.mark.parametrize('number_of_nodes', [2])[0m
[1m    def test_api_channel_events(raiden_chain):[0m
[1m        app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking[0m
[1m        token_address = app0.raiden.chain.default_registry.token_addresses()[0][0m
[1m        channel_0_1 = channel(app0, app1, token_address)[0m
[1m    [0m
[1m        amount = 30[0m
[1m        direct_transfer([0m
[1m            app0,[0m
[1m            app1,[0m
[1m            token_address,[0m
[1m            amount[0m
[1m        )[0m
[1m    [0m
[1m        results = RaidenAPI(app0.raiden).get_channel_events(channel_0_1.channel_address, 0)[0m
[1m        assert len(results) == 3[0m
[1m        max_block = 0[0m
[1m        for idx, result in enumerate(results):[0m
[1m            if result['block_number'] > max_block:[0m
[1m                max_block = result['block_number'][0m
[1m    [0m
[1m            if idx == 2:[0m
[1m                assert result['_event_type'] == 'EventTransferSentSuccess'[0m
[1m            else:[0m
[1m                assert result['_event_type'] == 'ChannelNewBalance'[0m
[1m    [0m
[1m        assert max_block != 0[0m
[1m    [0m
[1m        results = RaidenAPI(app0.raiden).get_channel_events([0m
[1m            channel_0_1.channel_address, max_block + 1, max_block + 100[0m
[1m        )[0m
[1m>       assert not results[0m
[1m[31mE       AssertionError: assert not [{'_event_type': 'ChannelNewBalance', 'balance': 200, 'block_number': 0, 'participant': 'a3c19cc476be1e9061deeba48b71de0022952515', ...}][0m

[1m[31mraiden/tests/unit/api/test_python_api.py[0m:177:
AssertionError
```