### PR TITLE
Channel manager delete

### DIFF
--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -96,16 +96,16 @@ contract ChannelManagerContract {
         address[] storage partner_channels = node_channels[partner];
 
         if (settled_channel != 0) {
-            // Checking the channel was settled indirectly. Once the channel is
-            // settled it kill itself, so address must not have code.
+            // Check if the channel was settled. Once a channel is
+            // settled it kills itself, so address must not have code.
             require(!contractExists(settled_channel));
             ChannelDeleted(msg.sender, partner);
         }
 
         address new_channel = data.newChannel(partner, settle_timeout);
 
-        // replace the channel address in-place
         if (settled_channel != 0) {
+            // if an old channel existed, replace the channel address in-place
             uint channels_idx = all_channels_index[settled_channel];
             uint caller_idx = node_index[msg.sender][partner];
             uint partner_idx = node_index[partner][msg.sender];
@@ -114,8 +114,8 @@ contract ChannelManagerContract {
             caller_channels[caller_idx] = new_channel;
             partner_channels[partner_idx] = new_channel;
 
-        // first channel open among the participants, create a new entry
         } else {
+            // first channel opening between the participants, create a new entry
             all_channels.push(new_channel);
             caller_channels.push(new_channel);
             partner_channels.push(new_channel);

--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -9,16 +9,14 @@ import "./ChannelManagerLibrary.sol";
 contract ChannelManagerContract {
     using ChannelManagerLibrary for ChannelManagerLibrary.Data;
     ChannelManagerLibrary.Data data;
-    // All open channels for a specific token
+
     address[] all_channels;
-    // All open channels for a given node
     mapping(address => address[]) node_channels;
-    // The two participants of a specific channel
-    mapping(address => address[2]) channel_participants;
-    // Index of a channel between two parties.
-    // This is used to keep track of the position of a partner in `node_channels`
+
+    // These two mappings keep track of the channel address position within the
+    // all_channels and node_channels arrays, the values are used to update the
+    // addresses once a new channel is opened.
     mapping(address => mapping(address => uint)) node_index;
-    // Index of a specific channel in `all_channels`
     mapping(address => uint) all_channels_index;
 
     event ChannelNew(
@@ -39,27 +37,29 @@ contract ChannelManagerContract {
 
     /// @notice Get all channels
     /// @return All the open channels
-    function getChannelsAddresses() constant returns (address[] channels) {
-        channels = all_channels;
+    function getChannelsAddresses() constant returns (address[]) {
+        return all_channels;
     }
 
     /// @notice Get all participants of all channels
     /// @return All participants in all channels
-    function getChannelsParticipants() constant returns (address[] channels) {
+    function getChannelsParticipants() constant returns (address[]) {
         uint i;
         uint pos;
-        address channel;
         address[] memory result;
+        NettingChannelContract channel;
 
         result = new address[](all_channels.length * 2);
 
         pos = 0;
         for (i = 0; i < all_channels.length; i++) {
-            channel = all_channels[i];
+            channel = NettingChannelContract(all_channels[i]);
 
-            result[pos] = channel_participants[channel][0];
+            var (address1, , address2, ) = channel.addressAndBalance();
+
+            result[pos] = address1;
             pos += 1;
-            result[pos] = channel_participants[channel][1];
+            result[pos] = address2;
             pos += 1;
         }
 
@@ -90,104 +90,60 @@ contract ChannelManagerContract {
     /// @param partner The address you want to open a channel with
     /// @param settle_timeout The desired settlement timeout period
     /// @return The address of the newly created channel
-    function newChannel(address partner, uint settle_timeout) returns (address channel) {
-        address channel_address;
+    function newChannel(address partner, uint settle_timeout) returns (address) {
+        address settled_channel = getChannelWith(partner);
+        address[] storage caller_channels = node_channels[msg.sender];
+        address[] storage partner_channels = node_channels[partner];
 
-        channel_address = getChannelWith(partner);
-        // Check if channel is present in the node_channels mapping within the Data struct
-        if (channel_address != 0x0) {
-            require(!contractExists(channel_address));
-            // Delete channel if contract has self destructed
-            deleteChannel(partner, channel_address);
+        if (settled_channel != 0) {
+            // Checking the channel was settled indirectly. Once the channel is
+            // settled it kill itself, so address must not have code.
+            require(!contractExists(settled_channel));
+            ChannelDeleted(msg.sender, partner);
         }
 
-        channel = data.newChannel(partner, settle_timeout);
+        address new_channel = data.newChannel(partner, settle_timeout);
 
-        // Push channel address to array keeping track of all channels
-        all_channels.push(channel);
-        // Keep track of the index of the channel in the array
-        all_channels_index[channel] = all_channels.length - 1;
+        // replace the channel address in-place
+        if (settled_channel != 0) {
+            uint channels_idx = all_channels_index[settled_channel];
+            uint caller_idx = node_index[msg.sender][partner];
+            uint partner_idx = node_index[partner][msg.sender];
 
-        // Push channel address to the array keeping track of open channels
-        // for msg.sender
-        node_channels[msg.sender].push(channel);
-        // Keep track of the index of the channel in the array
-        node_index[msg.sender][partner] = node_channels[msg.sender].length - 1;
+            all_channels[channels_idx] = new_channel;
+            caller_channels[caller_idx] = new_channel;
+            partner_channels[partner_idx] = new_channel;
 
-        // Push channel address to the array keeping track of open channels
-        // for the partner
-        node_channels[partner].push(channel);
-        // Keep track of the index of the channel in the array
-        node_index[partner][msg.sender] = node_channels[partner].length - 1;
+        // first channel open among the participants, create a new entry
+        } else {
+            all_channels.push(new_channel);
+            caller_channels.push(new_channel);
+            partner_channels.push(new_channel);
 
-        // add the two participants to the mapping keeping track of all channel participants
-        channel_participants[channel] = [msg.sender, partner];
+            all_channels_index[new_channel] = all_channels.length - 1;
+            node_index[msg.sender][partner] = caller_channels.length - 1;
+            node_index[partner][msg.sender] = partner_channels.length - 1;
+        }
 
-        ChannelNew(channel, msg.sender, partner, settle_timeout);
+        ChannelNew(new_channel, msg.sender, partner, settle_timeout);
+        return new_channel;
     }
 
     /// @notice Check if a contract exists
     /// @param channel The address to check whether a contract is deployed or not
     /// @return True if a contract exists, false otherwise
-    function contractExists(address channel) private constant returns (bool exists) {
+    function contractExists(address channel) private constant returns (bool) {
         uint size;
-        exists = false;
+
         assembly {
             size := extcodesize(channel)
         }
+
         if (size > 0) {
-            exists = true;
+            return true;
         }
-    }
 
-    /// @dev Delete a channel that's been settled
-    /// @param partner The address of the partner of the channel
-    /// @param channel_address The address to be deleted
-    function deleteChannel(address partner, address channel_address) private {
-        // throw if the channel has already been deleted
-        assert(data.getChannelWith(partner) != 0x0);
-
-        address[] storage our_channels = node_channels[msg.sender];
-        address[] storage partner_channels = node_channels[partner];
-        uint caller_index = node_index[msg.sender][partner];
-        uint partner_index = node_index[partner][msg.sender];
-
-        // get the last element of the array
-        address our_last_element = our_channels[our_channels.length - 1];
-        // move the last element to the index of the element to be deleted
-        our_channels[caller_index] = our_last_element;
-        // decrease the size of the array by one
-        our_channels.length--;
-        // update the index of the moved element
-        node_index[msg.sender][our_last_element] = caller_index;
-        // set the index of the deleted element to 0
-        // TODO: write test to make sure that setting it to 0 doesn't cause problems
-        node_index[msg.sender][partner] = 0;
-
-        // same procedure as above, but just removing the element from the partner array
-        address their_last_element = partner_channels[partner_channels.length - 1];
-        partner_channels[partner_index] = their_last_element;
-        partner_channels.length--;
-        node_index[partner][their_last_element] = partner_index;
-        node_index[partner][msg.sender] = 0;
-
-        // remove address from all_channels
-        // get the index of the channel to me removed
-        uint i = all_channels_index[channel_address];
-        // set the last element to be at the index of removed element
-        all_channels[i] = all_channels[all_channels.length - 1];
-        // decrease array length by one
-        all_channels.length--;
-        // update index of moved element
-        all_channels_index[all_channels[i]] = i;
-        // set index of deleted element to 0
-        all_channels_index[channel_address] = 0;
-
-        node_channels[msg.sender] = our_channels;
-        node_channels[partner] = partner_channels;
-
-        data.deleteChannel(partner);
-        ChannelDeleted(msg.sender, partner);
+        return false;
     }
 
     function () { revert(); }

--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -37,15 +37,16 @@ library ChannelManagerLibrary {
             settle_timeout
         );
 
-        self.channel_addresses[partyHash(msg.sender, partner)] = channel_address;
+        bytes32 party_hash = partyHash(msg.sender, partner);
+        self.channel_addresses[party_hash] = channel_address;
     }
 
     /// @notice Remove a channel after it's been settled
     /// @param partner of the partner
     function deleteChannel(Data storage self, address partner) internal
     {
-        // remove channel from channel_addresses.
-        self.channel_addresses[partyHash(msg.sender, partner)] = 0x0;
+        bytes32 party_hash = partyHash(msg.sender, partner);
+        self.channel_addresses[party_hash] = 0x0;
     }
 
     /// @notice Get the hash of the two addresses
@@ -55,10 +56,8 @@ library ChannelManagerLibrary {
     function partyHash(address address_one, address address_two) private constant returns (bytes32) {
         if (address_one < address_two) {
             return sha3(address_one, address_two);
-        } else if (address_one > address_two){
-            return sha3(address_two, address_one);
         } else {
-            revert(); // if the two addresses provided are identical
+            return sha3(address_two, address_one);
         }
     }
 

--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -57,6 +57,9 @@ library ChannelManagerLibrary {
         if (address_one < address_two) {
             return sha3(address_one, address_two);
         } else {
+            // The two participants can't be the same here due to this check in
+            // the netting channel constructor:
+            // https://github.com/raiden-network/raiden/blob/e17d96db375d31b134ae7b4e2ad2c1f905b47857/raiden/smart_contracts/NettingChannelContract.sol#L27
             return sha3(address_two, address_one);
         }
     }

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -161,6 +161,9 @@ def test_getchannelwith_must_return_zero_for_non_existing_channels(
         # can not open a channel with itself
         if addr != sender_addr:
             tester_channelmanager.newChannel(addr, settle_timeout, sender=sender_key)
+        else:
+            with pytest.raises(TransactionFailed):
+                tester_channelmanager.newChannel(addr, settle_timeout, sender=sender_key)
 
 
 def test_channelmanager_start_with_zero_entries(
@@ -227,8 +230,8 @@ def test_reopen_channel(
         settle_timeout,
         tester_channelmanager,
         tester_state):
-    """ A new channel can be open after the old one is settled, when this
-    happens the channel manager must update it's internal data strucutres to
+    """ A new channel can be opened after the old one is settled. When this
+    happens the channel manager must update its internal data structures to
     point to the new channel address.
     """
 
@@ -282,11 +285,12 @@ def test_reopen_regression_bad_index_update(
         settle_timeout,
         tester_channelmanager,
         tester_state):
-    """ deleteChannel used the wrong addres to update the mapping:
+    """ deleteChannel used the wrong address to update the node_index mapping.
+        Correct usage would be
 
         (addr0, addr1) => channel_idx
 
-    Instead of overwriting the exiting index, a new entry was added as:
+    But instead of overwriting the existing index, a new entry was added as:
 
         (addr0, channel_addr) => channel_idx
     """

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -10,29 +10,26 @@ from raiden.tests.utils.tester import (
 )
 
 
+def netting_channel_settled(tester_state, nettingchannel, pkey, settle_timeout):
+    nettingchannel.close('', sender=pkey)
+    tester_state.mine(number_of_blocks=settle_timeout + 1)
+    nettingchannel.settle(sender=pkey)
+    tester_state.mine(1)
+
+
 def test_channelnew_event(
         settle_timeout,
+        tester_channelmanager,
         private_keys,
-        tester_state,
-        tester_events,
-        tester_registry,
-        tester_token):
+        tester_events):
     """ When a new channel is created the channel new event must be emitted. """
 
     pkey0 = private_keys[0]
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(private_keys[1])
 
-    channel_manager = new_channelmanager(
-        pkey0,
-        tester_state,
-        tester_events.append,
-        tester_registry,
-        tester_token,
-    )
-
     # pylint: disable=no-member
-    netting_channel_address1_hex = channel_manager.newChannel(
+    netting_channel_address1_hex = tester_channelmanager.newChannel(
         address1,
         settle_timeout,
         sender=pkey0,
@@ -64,9 +61,12 @@ def test_channeldeleted_event(
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
 
-    nettingchannel.close('', sender=pkey0)
-    tester_state.mine(number_of_blocks=settle_timeout + 1)
-    nettingchannel.settle(sender=pkey0)
+    netting_channel_settled(
+        tester_state,
+        nettingchannel,
+        pkey0,
+        settle_timeout,
+    )
 
     # old entry will be deleted when calling newChannel
     tester_channelmanager.newChannel(
@@ -150,16 +150,17 @@ def test_getchannelwith_must_return_zero_for_non_existing_channels(
     """
     addresses = map(privatekey_to_address, private_keys)
 
-    test_key = private_keys[0]
-    test_addr = privatekey_to_address(test_key)
+    sender_key = private_keys[0]
+    sender_addr = privatekey_to_address(sender_key)
+    null_addr = '0' * 40
+
     for addr in addresses:
-        if addr == test_addr:
-            continue
+        channel_address = tester_channelmanager.getChannelWith(addr, sender=sender_key)
+        assert channel_address == null_addr
 
-        channel_address = tester_channelmanager.getChannelWith(addr, sender=test_key)
-        assert channel_address == '0' * 40
-
-        tester_channelmanager.newChannel(addr, settle_timeout, sender=test_key)
+        # can not open a channel with itself
+        if addr != sender_addr:
+            tester_channelmanager.newChannel(addr, settle_timeout, sender=sender_key)
 
 
 def test_channelmanager_start_with_zero_entries(
@@ -222,33 +223,99 @@ def test_channelmanager(private_keys, settle_timeout, tester_channelmanager):
 
 
 def test_reopen_channel(
+        private_keys,
         settle_timeout,
         tester_channelmanager,
-        tester_nettingcontracts,
         tester_state):
-    """ Reopen must be possible after settlement. """
+    """ A new channel can be open after the old one is settled, when this
+    happens the channel manager must update it's internal data strucutres to
+    point to the new channel address.
+    """
 
-    pkey0, pkey1, nettingchannel = tester_nettingcontracts[0]
-    address1 = privatekey_to_address(pkey1)
+    log = list()
+    pkey = private_keys[0]
 
-    nettingchannel.close('', sender=pkey0)
-    tester_state.mine(number_of_blocks=settle_timeout + 1)
-    nettingchannel.settle(sender=pkey0)
+    channels = list()
+    old_channel_addresses = list()
+    for partner_pkey in private_keys[1:]:
+        nettingcontract = new_nettingcontract(
+            pkey, partner_pkey, tester_state, log.append, tester_channelmanager, settle_timeout,
+        )
+        channels.append(nettingcontract)
 
-    tester_state.mine(1)
-    assert tester_state.block.get_code(nettingchannel.address) != 0
+        address = privatekey_to_address(partner_pkey)
+        channel_address = tester_channelmanager.getChannelWith(
+            address,
+            sender=pkey,
+        )
+        old_channel_addresses.append(channel_address)
 
-    # Now that channel with address1 is settled a new one can be opened.
-    # Old entry will be deleted when calling newChannel
+    for nettingchannel in channels:
+        netting_channel_settled(
+            tester_state,
+            nettingchannel,
+            pkey,
+            settle_timeout,
+        )
+
+    channels = list()
+    for partner_pkey in private_keys[1:]:
+        nettingcontract = new_nettingcontract(
+            pkey, partner_pkey, tester_state, log.append, tester_channelmanager, settle_timeout,
+        )
+        channels.append(nettingcontract)
+
+    # there must be a single entry for each participant
+    for partner_pkey in private_keys[1:]:
+        address = privatekey_to_address(partner_pkey)
+        channel_address = tester_channelmanager.getChannelWith(
+            address,
+            sender=pkey,
+        )
+        assert channel_address
+        assert channel_address not in old_channel_addresses
+
+
+@pytest.mark.parametrize('number_of_nodes', [5])
+def test_reopen_regression_bad_index_update(
+        private_keys,
+        settle_timeout,
+        tester_channelmanager,
+        tester_state):
+    """ deleteChannel used the wrong addres to update the mapping:
+
+        (addr0, addr1) => channel_idx
+
+    Instead of overwriting the exiting index, a new entry was added as:
+
+        (addr0, channel_addr) => channel_idx
+    """
+    pkey0 = private_keys[0]
+    pkey1 = private_keys[1]
+    pkey2 = private_keys[2]
+    addr1 = privatekey_to_address(pkey1)
+
     tester_channelmanager.newChannel(
-        address1,
+        addr1,
         settle_timeout,
         sender=pkey0,
     )
 
-    # make sure the old channel is properly selfdestructed
-    tester_state.mine(1)
-    assert tester_state.block.get_code(nettingchannel.address) != 0
+    log = list()
+    nettingchannel = new_nettingcontract(
+        pkey0, pkey2, tester_state, log.append, tester_channelmanager, settle_timeout,
+    )
+
+    netting_channel_settled(
+        tester_state,
+        nettingchannel,
+        pkey0,
+        settle_timeout,
+    )
+
+    nettingchannel = new_nettingcontract(
+        pkey0, pkey2, tester_state, log.append, tester_channelmanager, settle_timeout,
+    )
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])


### PR DESCRIPTION
Merge after: https://github.com/raiden-network/raiden/pull/729

The channel manager deletes the channel only when a new one is created on top.

The old implementation first cleared the netting channel from its data structures, and followed to re-add the new channel to the same data structures. While doing so, the indeces update mixed addresses values, example:

    node_index[msg.sender][our_last_element] = caller_index;

`our_last_element` is a *channel address*, while node_index maps a *node address* to an array position.

To properly handle the above case a new mapping would be required, instead of adding yet another mapping I streamlined the code, instead of remove-to-add this patch just overwrite the new netting channel address on top of the old entry.
