### PR TITLE
Handle invalid settle timeout in REST API open_channel

### DIFF
--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -397,6 +397,10 @@ Possible Responses
 | 400 Bad Request  | If the provided json is in|
 |                  | some way malformed        |
 +------------------+---------------------------+
+| 409 Conflict     | If the input is invalid,  |
+|                  | such as too low settle    |
+|                  | timeout                   |
++------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -25,6 +25,7 @@ from raiden.exceptions import (
     NoPathError,
     InvalidAddress,
     InvalidAmount,
+    InvalidSettleTimeout,
     InvalidState,
     InsufficientFunds,
 )
@@ -153,7 +154,7 @@ class RaidenAPI(object):
             settle_timeout = self.raiden.config['settle_timeout']
 
         if settle_timeout < self.raiden.config['settle_timeout']:
-            raise ValueError('Configured minimum `settle_timeout` is {} blocks.'.format(
+            raise InvalidSettleTimeout('Configured minimum `settle_timeout` is {} blocks.'.format(
                 self.raiden.config['settle_timeout']
             ))
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -12,6 +12,7 @@ from pyethapp.jsonrpc import address_encoder
 from raiden.exceptions import (
     InvalidAddress,
     InvalidAmount,
+    InvalidSettleTimeout,
     NoPathError,
 )
 from raiden.api.v1.encoding import (
@@ -206,11 +207,14 @@ class RestAPI(object):
         )
 
     def open(self, partner_address, token_address, settle_timeout, balance=None):
-        raiden_service_result = self.raiden_api.open(
-            token_address,
-            partner_address,
-            settle_timeout
-        )
+        try:
+            raiden_service_result = self.raiden_api.open(
+                token_address,
+                partner_address,
+                settle_timeout
+            )
+        except (InvalidAddress, InvalidSettleTimeout) as e:
+            return make_response(str(e), httplib.CONFLICT)
 
         if balance:
             # make initial deposit

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -41,6 +41,12 @@ class InvalidAmount(RaidenError):
     pass
 
 
+class InvalidSettleTimeout(RaidenError):
+    """ Raised when the user provided timeout value is less than the minimum
+    settle timeout"""
+    pass
+
+
 class NoPathError(RaidenError):
     """ Raised when there is no path to the requested target address in the
     payment network.

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -16,7 +16,8 @@ from raiden.transfer.state import (
     CHANNEL_STATE_SETTLED,
 )
 from raiden.utils import pex, isaddress
-from raiden.exceptions import InvalidAddress
+from raiden.exceptions import InvalidAddress, InvalidSettleTimeout
+from raiden.constants import NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
 
 
 class NettingChannelMock(object):
@@ -217,6 +218,17 @@ class ApiTestContext():
             partner_address,
             settle_timeout=None,
             reveal_timeout=None):
+
+        if settle_timeout < NETTINGCHANNEL_SETTLE_TIMEOUT_MIN:
+            raise InvalidSettleTimeout('Configured minimum `settle_timeout` is {} blocks.'.format(
+                NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
+            ))
+
+        if not isaddress(token_address):
+            raise InvalidAddress('Expected binary address format for token in channel open')
+
+        if not isaddress(partner_address):
+            raise InvalidAddress('Expected binary address format for partner in channel open')
 
         reveal_value = reveal_timeout if reveal_timeout is not None else self.reveal_timeout
         channel = self.make_channel(


### PR DESCRIPTION
Fix https://github.com/raiden-network/raiden/issues/743