### PR TITLE
Remove unneeded args from leave() Rest API call

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -262,13 +262,8 @@ class RestAPI(object):
             joinable_funds_target
         )
 
-    def leave(self, token_address, wait_for_settle=None, timeout=None):
-
-        self.raiden_api.leave_token_network(
-            token_address,
-            wait_for_settle,
-            timeout
-        )
+    def leave(self, token_address):
+        self.raiden_api.leave_token_network(token_address)
 
     def get_channel_list(self, token_address=None, partner_address=None):
         raiden_service_result = self.raiden_api.get_channel_list(token_address, partner_address)

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -273,12 +273,3 @@ class ConnectionsConnectSchema(BaseSchema):
     class Meta:
         strict = True
         decoding_class = dict
-
-
-class ConnectionsLeaveSchema(BaseSchema):
-    wait_for_settle = fields.Bool(missing=DEFAULT_WAIT_FOR_SETTLE, location='json')
-    timeout = fields.Integer(missing=DEFAULT_REVEAL_TIMEOUT, location='json')
-
-    class Meta:
-        strict = True
-        decoding_class = dict

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -29,10 +29,8 @@ from raiden.api.objects import (
 )
 from raiden.settings import (
     DEFAULT_SETTLE_TIMEOUT,
-    DEFAULT_REVEAL_TIMEOUT,
     DEFAULT_JOINABLE_FUNDS_TARGET,
     DEFAULT_INITIAL_CHANNEL_TARGET,
-    DEFAULT_WAIT_FOR_SETTLE,
 )
 from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -9,7 +9,6 @@ from raiden.api.v1.encoding import (
     TokenSwapsSchema,
     TransferSchema,
     ConnectionsConnectSchema,
-    ConnectionsLeaveSchema,
 )
 
 
@@ -195,7 +194,6 @@ class TransferToTargetResource(BaseResource):
 class ConnectionsResource(BaseResource):
 
     put_schema = ConnectionsConnectSchema()
-    delete_schema = ConnectionsLeaveSchema()
 
     def __init__(self, **kwargs):
         super(ConnectionsResource, self).__init__(**kwargs)
@@ -209,10 +207,5 @@ class ConnectionsResource(BaseResource):
             joinable_funds_target=joinable_funds_target,
         )
 
-    @use_kwargs(delete_schema)
-    def delete(self, token_address, wait_for_settle, timeout):
-        return self.rest_api.leave(
-            token_address=token_address,
-            wait_for_settle=wait_for_settle,
-            timeout=timeout,
-        )
+    def delete(self, token_address):
+        return self.rest_api.leave(token_address=token_address)

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -301,11 +301,7 @@ class ApiTestContext():
             channel = self.make_channel(token_address=token_address, balance=funding)
             self.channels.append(channel)
 
-    def leave(
-            self,
-            token_address,
-            wait_for_settle=True,
-            timeout=30):
+    def leave(self, token_address):
 
         if not isaddress(token_address):
             raise InvalidAddress('not an address %s' % pex(token_address))


### PR DESCRIPTION
In commit 75dff925b1351da6ab043a79fafb34ce37a0af97 `wait_for_settle` and
`timeout` arguments were removed from both the connection manager and
the python API leave() calls.

The Rest API call was not updated and this PR handles that.
Fix https://github.com/raiden-network/raiden/issues/744