### PR TITLE
Use explicit storage keyword in endpoint registry

### DIFF
--- a/raiden/smart_contracts/EndpointRegistry.sol
+++ b/raiden/smart_contracts/EndpointRegistry.sol
@@ -29,7 +29,7 @@ contract EndpointRegistry{
      */
     function registerEndpoint(string socket) noEmptyString(socket)
     {
-        string old_socket = address_to_socket[msg.sender];
+        string storage old_socket = address_to_socket[msg.sender];
 
         // Compare if the new socket matches the old one, if it does just return
         if (equals(old_socket, socket)) {


### PR DESCRIPTION
Fixes the new solidity warning for EndpointRegistry.

```
Warning: This is a pre-release compiler version, please do not use it in production.                                                                                                                                                                                            
EndpointRegistry.sol:32:9: Warning: Variable is declared as a storage pointer. Use an explicit "storage" keyword to silence this warning.                                                                                                                                       
        string old_socket = address_to_socket[msg.sender];                                                                                                                                                                                                                      
        ^---------------^
```