### PR TITLE
Workaround for error on IP address encoding at UPnP setup #754

### DIFF
--- a/raiden/network/upnpsock.py
+++ b/raiden/network/upnpsock.py
@@ -15,7 +15,7 @@ NON_MAPPABLE = [
 
 
 def valid_mappable_ipv4(address):
-    if unicode(address, errors='ignore') in NON_MAPPABLE:
+    if unicode(address) in NON_MAPPABLE:
         return False
     parsed = None
     try:


### PR DESCRIPTION
Issue #754

Unsure what caused this error but disabling error ignoring works fine for now.