### PR TITLE
If address is none don't fail

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -70,7 +70,10 @@ class AccountManager(object):
                             log.warning("%s %s: %s", msg, fullpath, ex)
 
     def address_in_keystore(self, address):
-        if address is not None and address.startswith('0x'):
+        if address is None:
+            return False
+
+        if address.startswith('0x'):
             address = address[2:]
 
         return address.lower() in self.accounts


### PR DESCRIPTION
When giving no address we failed with exception:

```
  File "/home/lefteris/.virtualenvs/raiden/bin/raiden", line 11, in <module>
    load_entry_point('raiden', 'console_scripts', 'raiden')()
  File "/home/lefteris/ew/raiden/raiden/__main__.py", line 11, in main
    run(auto_envvar_prefix='RAIDEN')
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 342, in run
    app_ = ctx.invoke(app, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 210, in app
    if not accmgr.address_in_keystore(address):
  File "/home/lefteris/ew/raiden/raiden/accounts.py", line 76, in address_in_keystore
    return address.lower() in self.accounts
AttributeError: 'NoneType' object has no attribute 'lower'
```