### PR TITLE
Making services a dict as required by the devp2p greenlet

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -73,7 +73,7 @@ class App(object):  # pylint: disable=too-few-public-methods
 
         # raiden.ui.console:Console assumes that a services
         # attribute is available for auto-registration
-        self.services = list()
+        self.services = dict()
 
     def __repr__(self):
         return '<{} {}>'.format(


### PR DESCRIPTION
Solves an error the devp2p greenlet. The services variable is required to be a dict. This error occurs at the start of raiden

https://gist.github.com/agatsoh/0aeeab494cb4b2958dfa86636d54c59d
