### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ truffle/.bash_history
 
 # never check in .static-abi.json files
 *.static-abi.json
+
+# ignore node_modules
+raiden/raidenwebui/node_modules/


### PR DESCRIPTION
After `npm i`, there will be ~730 packages downloaded to
`raiden/raidenwebui/node_modules` -- we should not add these to the
repository.