### PR TITLE
Remove `block_number` attribute from `add_channel`

### DIFF
--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -201,7 +201,7 @@ class ChannelGraph(object):
         self.channelmanager_address = channelmanager_address
 
         for details in channels_details:
-            self.add_channel(details, block_number)
+            self.add_channel(details)
 
     def __eq__(self, other):
         if isinstance(other, ChannelGraph):
@@ -219,7 +219,7 @@ class ChannelGraph(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def add_channel(self, details, block_number):
+    def add_channel(self, details):
         channel_address = details.channel_address
         partner_state = details.partner_state
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -561,7 +561,7 @@ class RaidenService(object):
         )
 
         graph = self.channelgraphs[token_address]
-        graph.add_channel(details, serialized_channel.block_number)
+        graph.add_channel(details)
         channel = graph.address_channel.get(
             serialized_channel.channel_address,
         )
@@ -684,10 +684,9 @@ class RaidenService(object):
         netting_channel = self.chain.netting_channel(channel_address)
         self.pyethapp_blockchain_events.add_netting_channel_listener(netting_channel)
 
-        block_number = self.get_block_number()
         detail = self.get_channel_details(token_address, netting_channel)
         graph = self.channelgraphs[token_address]
-        graph.add_channel(detail, block_number)
+        graph.add_channel(detail)
 
     def connection_manager_for_token(self, token_address):
         if not isaddress(token_address):


### PR DESCRIPTION
The attribute is not used inside the function and further complicates the (De-)Serialization of channels. I removed it, as proposed in the issue this fixes #745.