### PR TITLE
Include `raiden/tests` in MANIFEST.in / Fix tox / Fix sdist install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include README.md
 include requirements.txt
 include raiden/smart_contracts/*
 include raiden/smoketest_config.json
-prune raiden/tests


### PR DESCRIPTION
At this point in time, we need to ship the tests with the source
distribution (the `smoketest` commmand relies on them and it needs to be
importable from `setup.py`). This commit will also fix our `tox` setup
-- it was broken, because tox uses the `sdist` package to install for
test environments.