### PR TITLE
Fix an import in smoketest

### DIFF
--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import shlex
 import tempfile
-import distutils
+import distutils.spawn
 import pdb
 import traceback
 from string import Template


### PR DESCRIPTION
This fixes an import in the smoketest module.

Interestingly the previous form only causes a problem when not running inside a virtualenv.

* `docker run --rm -it python:2.7 python -c 'import distutils; distutils.spawn'`

vs.

* `docker run --rm -it python:2.7 python -c 'import distutils.spawn; distutils.spawn'`
* `docker run --rm -it python:2.7 /bin/bash -c 'virtualenv /venv; /venv/bin/python -c "import distutils; distutils.spawn"'`
