### PR TITLE
Accept messages with expired locks.

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -526,22 +526,6 @@ class Channel(object):
 
                 raise ValueError('Lock expires after the settlement period.')
 
-            # If the lock expires within the unsafe_period we cannot accept the
-            # transfer, since there is not enough time to properly settle
-            # on-chain.
-            end_unsafe_period = block_number + self.reveal_timeout
-            expires_unsafe = transfer.lock.expiration < end_unsafe_period
-
-            if expires_unsafe:
-                log.error(
-                    'Lock expires within the unsafe_period.',
-                    lock_expiration=transfer.lock.expiration,
-                    current_block=block_number,
-                    reveal_timeout=self.reveal_timeout,
-                )
-
-                raise ValueError('Lock expires within the unsafe_period.')
-
         # only check the balance if the locksroot matched
         if transfer.transferred_amount < from_state.transferred_amount:
             if log.isEnabledFor(logging.ERROR):

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -716,17 +716,17 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
 
 
 def test_channel_must_accept_expired_locks():
-    """ A node may go offline for an undetermined period of time, when it comes
-    back online it must accept the messages that are waiting, otherwise the
-    partner node won't make progress with its queue.
+    """ A node may go offline for an undetermined period of time, and when it
+    comes back online it must accept the messages that are waiting, otherwise
+    the partner node won't make progress with its queue.
 
     If a N node goes offline for a number B of blocks, and the partner does not
     close the channel, when N comes back online some of the messages from its
-    partner may become expired, neverthless these messages are ordered and must
-    be accept for the partner to make progress with its queue.
+    partner may become expired. Neverthless these messages are ordered and must
+    be accepted for the partner to make progress with its queue.
 
     Note: Accepting a message with an expired lock does *not* imply the token
-    transfer happen, and the receiver node must *not* forward the transfer,
+    transfer happened, and the receiver node must *not* forward the transfer,
     only accept the message allowing the partner to progress with its message
     queue.
     """

--- a/raiden/tests/utils/messages.py
+++ b/raiden/tests/utils/messages.py
@@ -110,11 +110,20 @@ def make_mediated_transfer(
         token=ADDRESS,
         transferred_amount=0,
         amount=1,
+        expiration=1,
         locksroot='',
         recipient=ADDRESS,
         target=ADDRESS,
         initiator=ADDRESS,
         fee=0):
+
+    lock = make_lock(
+        amount=amount,
+        expiration=expiration,
+    )
+
+    if locksroot == '':
+        locksroot = sha3(lock.as_bytes)
 
     return MediatedTransfer(
         identifier,
@@ -123,7 +132,7 @@ def make_mediated_transfer(
         transferred_amount,
         recipient,
         locksroot,
-        make_lock(amount=amount),
+        lock,
         target,
         initiator,
         fee


### PR DESCRIPTION
- A node may go offline while there are locked transfers in-transit /
waiting confirmation.
- If the node comes back online *after* any of these transfers have
expired, it *must* accept them to allow progress. This happens because
the partner/sender must order the messages to keep the messages
consistent, and the sender has no logic to  #recompute/remove outdated
messages from the queue. Without accepting outdated messages the
protocol won't make progress.

Note: Accepting a message with an outdated lock is only to progress the
queue, the transfer wont complete because of it, even if the secret is
learned afterwards, and the message wont be mediated because there
isn't enough blocks left to safely mediate a transfer.