### PR TITLE
Noroutes test

### DIFF
--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -92,7 +92,15 @@ def channel_to_routestate(channel, node_address):
 
 def ordered_neighbors(nx_graph, our_address, target_address):
     paths = list()
-    for neighbor in networkx.all_neighbors(nx_graph, our_address):
+
+    try:
+        all_neighbors = networkx.all_neighbors(nx_graph, our_address)
+    except networkx.NetworkXError:
+        # If `our_address` is not in the graph, no channels opened with the
+        # address
+        return []
+
+    for neighbor in all_neighbors:
         try:
             length = networkx.shortest_path_length(
                 nx_graph,
@@ -276,7 +284,10 @@ class ChannelGraph(object):
 
     def has_path(self, source_address, target_address):
         """ True if there is a connecting path regardless of the number of hops. """
-        return networkx.has_path(self.graph, source_address, target_address)
+        try:
+            return networkx.has_path(self.graph, source_address, target_address)
+        except networkx.NetworkXError:
+            return False
 
     def has_channel(self, source_address, target_address):
         """ True if there is a channel connecting both addresses. """

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -902,7 +902,9 @@ class RaidenService(object):
     def start_mediated_transfer(self, token_address, amount, identifier, target):
         # pylint: disable=too-many-locals
 
+        async_result = AsyncResult()
         graph = self.token_to_channelgraph[token_address]
+
         available_routes = get_best_routes(
             graph,
             self.protocol.nodeaddresses_networkstatuses,
@@ -911,6 +913,10 @@ class RaidenService(object):
             amount,
             None,
         )
+
+        if not available_routes:
+            async_result.set(False)
+            return async_result
 
         self.protocol.start_health_check(target)
 
@@ -958,7 +964,6 @@ class RaidenService(object):
 
         state_manager = StateManager(initiator.state_transition, None)
         self.state_machine_event_handler.log_and_dispatch(state_manager, init_initiator)
-        async_result = AsyncResult()
 
         # TODO: implement the network timeout raiden.config['msg_timeout'] and
         # cancel the current transfer if it hapens (issue #374)

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -173,6 +173,52 @@ def test_transfer(raiden_network):
 
 
 @pytest.mark.parametrize('blockchain_type', ['tester'])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('channels_per_node', [0])
+def test_transfer_channels(raiden_network, token_addresses):
+    """ When the node has no channels it should fail without raising exceptions. """
+    token_address = token_addresses[0]
+    app0, app1 = raiden_network
+
+    amount = 10
+    async_result = app0.raiden.transfer_async(
+        token_address,
+        amount,
+        app1.raiden.address,
+    )
+
+    assert async_result.wait() is False
+
+
+@pytest.mark.parametrize('blockchain_type', ['tester'])
+@pytest.mark.parametrize('number_of_nodes', [4])
+@pytest.mark.parametrize('channels_per_node', [1])
+def test_transfer_noroutes(raiden_network, token_addresses):
+    """ When there are no routes it should fail without raising exceptions. """
+    # Topology:
+    #   App0 <-> App1 App2 <-> App3
+    #
+    app0, _, app2, app3 = raiden_network
+
+    token_address = token_addresses[0]
+
+    amount = 10
+    async_result = app0.raiden.transfer_async(
+        token_address,
+        amount,
+        app2.raiden.address,
+    )
+    assert async_result.wait() is False
+
+    async_result = app0.raiden.transfer_async(
+        token_address,
+        amount,
+        app3.raiden.address,
+    )
+    assert async_result.wait() is False
+
+
+@pytest.mark.parametrize('blockchain_type', ['tester'])
 @pytest.mark.parametrize('channels_per_node', [2])
 @pytest.mark.parametrize('number_of_nodes', [10])
 def test_mediated_transfer(raiden_network):


### PR DESCRIPTION
merge after: https://github.com/raiden-network/raiden/pull/724

Handle networkx exceptions when there are no routes for the given target, and set the async result to False.