### PR TITLE
Enforce dict naming using `x_to_y`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,13 @@ Lists of objects:
 
 Mappings/dicts:
 
-`<name>s_to_<name>s`, e.g. `tokenaddresses_to_taskmanagers`
+If it is a simple one to one mapping
+
+`<name>_to_<name>`, e.g. `tokenaddress_to_taskmanager`
+
+If the mapped to object is a list then add an `s`
+
+`<name>_to_<name>s`, e.g. `tokenaddress_to_taskmanagers = defaultdict(list())`
 
 #### Solidity
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -409,7 +409,7 @@ class RaidenAPI(object):
 
         elif token_address:
             graph = self.raiden.channelgraphs[token_address]
-            token_channels = graph.address_channel.values()
+            token_channels = graph.address_to_channel.values()
             return token_channels
 
         elif partner_address:
@@ -424,7 +424,7 @@ class RaidenAPI(object):
         else:
             all_channels = list()
             for graph in self.raiden.channelgraphs.itervalues():
-                all_channels.extend(graph.address_channel.itervalues())
+                all_channels.extend(graph.address_to_channel.itervalues())
 
             return all_channels
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -172,7 +172,7 @@ class RaidenAPI(object):
             partner_address,
             settle_timeout,
         )
-        while netcontract_address not in self.raiden.chain.address_contract:
+        while netcontract_address not in self.raiden.chain.address_to_nettingchannel:
             gevent.sleep(self.raiden.alarm.wait_time)
 
         graph = self.raiden.channelgraphs[token_address]

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -306,8 +306,8 @@ class RaidenAPI(object):
             taker_token,
             taker_amount,
         )
-        self.raiden.swapkeys_greenlettasks[key] = task
-        self.raiden.swapkeys_tokenswaps[key] = token_swap
+        self.raiden.swapkey_to_greenlettask[key] = task
+        self.raiden.swapkey_to_tokenswap[key] = token_swap
 
         return async_result
 
@@ -372,7 +372,7 @@ class RaidenAPI(object):
             taker_address,
         )
 
-        self.raiden.swapkeys_tokenswaps[key] = token_swap
+        self.raiden.swapkey_to_tokenswap[key] = token_swap
 
     def get_channel_list(self, token_address=None, partner_address=None):
         """Returns a list of channels associated with the optionally given

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -176,9 +176,9 @@ class RaidenAPI(object):
             gevent.sleep(self.raiden.alarm.wait_time)
 
         graph = self.raiden.channelgraphs[token_address]
-        while partner_address not in graph.partneraddress_channel:
+        while partner_address not in graph.partneraddress_to_channel:
             gevent.sleep(self.raiden.alarm.wait_time)
-        channel = graph.partneraddress_channel[partner_address]
+        channel = graph.partneraddress_to_channel[partner_address]
         return channel
 
     def deposit(self, token_address, partner_address, amount):
@@ -192,7 +192,7 @@ class RaidenAPI(object):
             raise InvalidAddress('Expected binary address format for partner in channel deposit')
 
         graph = self.raiden.channelgraphs[token_address]
-        channel = graph.partneraddress_channel[partner_address]
+        channel = graph.partneraddress_to_channel[partner_address]
         netcontract_address = channel.external_state.netting_channel.address
         assert len(netcontract_address)
 
@@ -403,7 +403,7 @@ class RaidenAPI(object):
             graph = self.raiden.channelgraphs[token_address]
 
             # Let it raise the KeyError
-            channel = graph.partneraddress_channel[partner_address]
+            channel = graph.partneraddress_to_channel[partner_address]
 
             return [channel]
 
@@ -414,9 +414,9 @@ class RaidenAPI(object):
 
         elif partner_address:
             partner_channels = [
-                graph.partneraddress_channel[partner_address]
+                graph.partneraddress_to_channel[partner_address]
                 for graph in self.raiden.channelgraphs.itervalues()
-                if partner_address in graph.partneraddress_channel
+                if partner_address in graph.partneraddress_to_channel
             ]
 
             return partner_channels
@@ -512,7 +512,7 @@ class RaidenAPI(object):
             raise InvalidAddress('partner_address is not valid.')
 
         graph = self.raiden.channelgraphs[token_address]
-        channel = graph.partneraddress_channel[partner_address]
+        channel = graph.partneraddress_to_channel[partner_address]
 
         first_transfer = None
         if channel.received_transfers:
@@ -541,7 +541,7 @@ class RaidenAPI(object):
             raise InvalidAddress('partner_address is not valid.')
 
         graph = self.raiden.channelgraphs[token_address]
-        channel = graph.partneraddress_channel[partner_address]
+        channel = graph.partneraddress_to_channel[partner_address]
 
         if channel.can_transfer:
             raise InvalidState('channel is still open.')

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -165,7 +165,7 @@ class RaidenAPI(object):
             raise InvalidAddress('Expected binary address format for partner in channel open')
 
         channel_manager = self.raiden.chain.manager_by_token(token_address)
-        assert token_address in self.raiden.channelgraphs
+        assert token_address in self.raiden.token_to_channelgraph
 
         netcontract_address = channel_manager.new_netting_channel(
             self.raiden.address,
@@ -175,7 +175,7 @@ class RaidenAPI(object):
         while netcontract_address not in self.raiden.chain.address_to_nettingchannel:
             gevent.sleep(self.raiden.alarm.wait_time)
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         while partner_address not in graph.partneraddress_to_channel:
             gevent.sleep(self.raiden.alarm.wait_time)
         channel = graph.partneraddress_to_channel[partner_address]
@@ -191,7 +191,7 @@ class RaidenAPI(object):
         if not isaddress(partner_address):
             raise InvalidAddress('Expected binary address format for partner in channel deposit')
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         channel = graph.partneraddress_to_channel[partner_address]
         netcontract_address = channel.external_state.netting_channel.address
         assert len(netcontract_address)
@@ -272,7 +272,7 @@ class RaidenAPI(object):
                 'Address for taker is not in expected binary format in token swap'
             )
 
-        channelgraphs = self.raiden.channelgraphs
+        channelgraphs = self.raiden.token_to_channelgraph
 
         if taker_token not in channelgraphs:
             log.error('Unknown token {}'.format(pex(taker_token)))
@@ -345,7 +345,7 @@ class RaidenAPI(object):
                 'Address for taker is not in expected binary format in expect_token_swap'
             )
 
-        channelgraphs = self.raiden.channelgraphs
+        channelgraphs = self.raiden.token_to_channelgraph
 
         if taker_token not in channelgraphs:
             log.error('Unknown token {}'.format(pex(taker_token)))
@@ -400,7 +400,7 @@ class RaidenAPI(object):
             raise InvalidAddress('Expected binary address format for partner in get_channel_list')
 
         if token_address and partner_address:
-            graph = self.raiden.channelgraphs[token_address]
+            graph = self.raiden.token_to_channelgraph[token_address]
 
             # Let it raise the KeyError
             channel = graph.partneraddress_to_channel[partner_address]
@@ -408,14 +408,14 @@ class RaidenAPI(object):
             return [channel]
 
         elif token_address:
-            graph = self.raiden.channelgraphs[token_address]
+            graph = self.raiden.token_to_channelgraph[token_address]
             token_channels = graph.address_to_channel.values()
             return token_channels
 
         elif partner_address:
             partner_channels = [
                 graph.partneraddress_to_channel[partner_address]
-                for graph in self.raiden.channelgraphs.itervalues()
+                for graph in self.raiden.token_to_channelgraph.itervalues()
                 if partner_address in graph.partneraddress_to_channel
             ]
 
@@ -423,7 +423,7 @@ class RaidenAPI(object):
 
         else:
             all_channels = list()
-            for graph in self.raiden.channelgraphs.itervalues():
+            for graph in self.raiden.token_to_channelgraph.itervalues():
                 all_channels.extend(graph.address_to_channel.itervalues())
 
             return all_channels
@@ -439,7 +439,7 @@ class RaidenAPI(object):
 
     def get_tokens_list(self):
         """Returns a list of tokens the node knows about"""
-        tokens_list = list(self.raiden.channelgraphs.iterkeys())
+        tokens_list = list(self.raiden.token_to_channelgraph.iterkeys())
         return tokens_list
 
     def transfer_and_wait(
@@ -484,7 +484,7 @@ class RaidenAPI(object):
         if not isaddress(target):
             raise InvalidAddress('target address is not valid.')
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         if not graph.has_path(self.raiden.address, target):
             raise NoPathError('No path to address found')
 
@@ -511,7 +511,7 @@ class RaidenAPI(object):
         if not isaddress(partner_address):
             raise InvalidAddress('partner_address is not valid.')
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         channel = graph.partneraddress_to_channel[partner_address]
 
         first_transfer = None
@@ -540,7 +540,7 @@ class RaidenAPI(object):
         if not isaddress(partner_address):
             raise InvalidAddress('partner_address is not valid.')
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         channel = graph.partneraddress_to_channel[partner_address]
 
         if channel.can_transfer:
@@ -564,7 +564,7 @@ class RaidenAPI(object):
                 'Expected binary address format for token in get_token_network_events'
             )
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
 
         return get_all_channel_manager_events(
             self.raiden.chain,

--- a/raiden/encoding/format.py
+++ b/raiden/encoding/format.py
@@ -40,18 +40,18 @@ def buffer_for(klass):
 
 
 def compute_slices(fields_spec):
-    names_slices = dict()
+    name_to_slice = dict()
     start = 0
 
     for field in fields_spec:
         end = start + field.size_bytes
 
         if not isinstance(field, Pad):  # do not create slices for paddings
-            names_slices[field.name] = slice(start, end)
+            name_to_slice[field.name] = slice(start, end)
 
         start = end
 
-    return names_slices
+    return name_to_slice
 
 
 def namedbuffer(buffer_name, fields_spec):  # noqa (ignore ciclomatic complexity)

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -88,7 +88,7 @@ class StateMachineEventHandler(object):
         if isinstance(event, SendMediatedTransfer):
             receiver = event.receiver
             fee = 0
-            graph = self.raiden.channelgraphs[event.token]
+            graph = self.raiden.token_to_channelgraph[event.token]
             channel = graph.partneraddress_to_channel[receiver]
 
             mediated_transfer = channel.create_mediatedtransfer(
@@ -138,7 +138,7 @@ class StateMachineEventHandler(object):
         elif isinstance(event, SendRefundTransfer):
             receiver = event.receiver
             fee = 0
-            graph = self.raiden.channelgraphs[event.token]
+            graph = self.raiden.token_to_channelgraph[event.token]
             channel = graph.partneraddress_to_channel[receiver]
 
             refund_transfer = channel.create_refundtransfer(
@@ -210,7 +210,7 @@ class StateMachineEventHandler(object):
         participant2 = state_change.participant2
 
         token_address = self.raiden.manager_token[manager_address]
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         graph.add_path(participant1, participant2)
 
         connection_manager = self.raiden.connection_manager_for_token(token_address)
@@ -232,7 +232,7 @@ class StateMachineEventHandler(object):
         balance = state_change.balance
         block_number = state_change.block_number
 
-        graph = self.raiden.channelgraphs[token_address]
+        graph = self.raiden.token_to_channelgraph[token_address]
         channel = graph.address_to_channel[channel_address]
         channel_state = channel.get_state_for(participant_address)
 

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -233,7 +233,7 @@ class StateMachineEventHandler(object):
         block_number = state_change.block_number
 
         graph = self.raiden.channelgraphs[token_address]
-        channel = graph.address_channel[channel_address]
+        channel = graph.address_to_channel[channel_address]
         channel_state = channel.get_state_for(participant_address)
 
         if channel_state.contract_balance != balance:

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -209,7 +209,7 @@ class StateMachineEventHandler(object):
         participant1 = state_change.participant1
         participant2 = state_change.participant2
 
-        token_address = self.raiden.manager_token[manager_address]
+        token_address = self.raiden.manager_to_token[manager_address]
         graph = self.raiden.token_to_channelgraph[token_address]
         graph.add_path(participant1, participant2)
 

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -89,7 +89,7 @@ class StateMachineEventHandler(object):
             receiver = event.receiver
             fee = 0
             graph = self.raiden.channelgraphs[event.token]
-            channel = graph.partneraddress_channel[receiver]
+            channel = graph.partneraddress_to_channel[receiver]
 
             mediated_transfer = channel.create_mediatedtransfer(
                 self.raiden.get_block_number(),
@@ -139,7 +139,7 @@ class StateMachineEventHandler(object):
             receiver = event.receiver
             fee = 0
             graph = self.raiden.channelgraphs[event.token]
-            channel = graph.partneraddress_channel[receiver]
+            channel = graph.partneraddress_to_channel[receiver]
 
             refund_transfer = channel.create_refundtransfer(
                 self.raiden.get_block_number(),

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -173,13 +173,13 @@ class RaidenMessageHandler(object):
         )
 
     def message_directtransfer(self, message):
-        if message.token not in self.raiden.channelgraphs:
+        if message.token not in self.raiden.token_to_channelgraph:
             raise UnknownTokenAddress('Unknown token address {}'.format(pex(message.token)))
 
         if message.token in self.blocked_tokens:
             raise TransferUnwanted()
 
-        graph = self.raiden.channelgraphs[message.token]
+        graph = self.raiden.token_to_channelgraph[message.token]
 
         if not graph.has_channel(self.raiden.address, message.sender):
             raise UnknownAddress(
@@ -239,7 +239,7 @@ class RaidenMessageHandler(object):
             self.message_tokenswap(message)
             return
 
-        graph = self.raiden.channelgraphs[message.token]
+        graph = self.raiden.token_to_channelgraph[message.token]
 
         if not graph.has_channel(self.raiden.address, message.sender):
             raise UnknownAddress(

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -188,7 +188,7 @@ class RaidenMessageHandler(object):
                 )
             )
 
-        channel = graph.partneraddress_channel[message.sender]
+        channel = graph.partneraddress_to_channel[message.sender]
 
         if channel.state != CHANNEL_STATE_OPENED:
             raise TransferWhenClosed(
@@ -248,7 +248,7 @@ class RaidenMessageHandler(object):
                 )
             )
 
-        channel = graph.partneraddress_channel[message.sender]
+        channel = graph.partneraddress_to_channel[message.sender]
 
         if channel.state != CHANNEL_STATE_OPENED:
             raise TransferWhenClosed(

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -235,7 +235,7 @@ class RaidenMessageHandler(object):
 
         # TODO: add a separate message for token swaps to simplify message
         # handling (issue #487)
-        if key in self.raiden.swapkeys_tokenswaps:
+        if key in self.raiden.swapkey_to_tokenswap:
             self.message_tokenswap(message)
             return
 
@@ -277,14 +277,14 @@ class RaidenMessageHandler(object):
 
         # If we are the maker the task is already running and waiting for the
         # taker's MediatedTransfer
-        task = self.raiden.swapkeys_greenlettasks.get(key)
+        task = self.raiden.swapkey_to_greenlettask.get(key)
         if task:
             task.response_queue.put(message)
 
         # If we are the taker we are receiving the maker transfer and should
         # start our new task
         else:
-            token_swap = self.raiden.swapkeys_tokenswaps[key]
+            token_swap = self.raiden.swapkey_to_tokenswap[key]
             task = TakerTokenSwapTask(
                 self.raiden,
                 token_swap,
@@ -292,4 +292,4 @@ class RaidenMessageHandler(object):
             )
             task.start()
 
-            self.raiden.swapkeys_greenlettasks[key] = task
+            self.raiden.swapkey_to_greenlettask[key] = task

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -194,7 +194,7 @@ class ChannelGraph(object):
             raise ValueError('token_address must be a valid address')
 
         graph = make_graph(edge_list)
-        self.address_channel = dict()
+        self.address_to_channel = dict()
         self.graph = graph
         self.our_address = our_address
         self.partneraddress_to_channel = dict()
@@ -207,7 +207,7 @@ class ChannelGraph(object):
     def __eq__(self, other):
         if isinstance(other, ChannelGraph):
             return (
-                self.address_channel == other.address_channel and
+                self.address_to_channel == other.address_to_channel and
                 # networkx.classes.graph.Graph has no __eq__
                 self.graph.__dict__ == other.graph.__dict__ and
                 self.our_address == other.our_address and
@@ -234,7 +234,7 @@ class ChannelGraph(object):
         )
 
         self.partneraddress_to_channel[partner_state.address] = channel
-        self.address_channel[channel_address] = channel
+        self.address_to_channel[channel_address] = channel
 
     def get_channel_by_contract_address(self, netting_channel_address):
         """ Return the channel with `netting_channel_address`.
@@ -242,7 +242,7 @@ class ChannelGraph(object):
         Raises:
             KeyError: If there is no channel with netting_channel_address.
         """
-        return self.address_channel[netting_channel_address]
+        return self.address_to_channel[netting_channel_address]
 
     def get_shortest_paths(self, source, target):
         """Compute all shortest paths in the graph.

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -137,7 +137,7 @@ def get_best_routes(
 
     while neighbors_heap:
         _, partner_address = heappop(neighbors_heap)
-        channel = channel_graph.partneraddress_channel[partner_address]
+        channel = channel_graph.partneraddress_to_channel[partner_address]
 
         # don't send the message backwards
         if partner_address == previous_address:
@@ -197,7 +197,7 @@ class ChannelGraph(object):
         self.address_channel = dict()
         self.graph = graph
         self.our_address = our_address
-        self.partneraddress_channel = dict()
+        self.partneraddress_to_channel = dict()
         self.token_address = token_address
         self.channelmanager_address = channelmanager_address
 
@@ -211,7 +211,7 @@ class ChannelGraph(object):
                 # networkx.classes.graph.Graph has no __eq__
                 self.graph.__dict__ == other.graph.__dict__ and
                 self.our_address == other.our_address and
-                self.partneraddress_channel == other.partneraddress_channel and
+                self.partneraddress_to_channel == other.partneraddress_to_channel and
                 self.token_address == other.token_address and
                 self.channelmanager_address == other.channelmanager_address
             )
@@ -233,7 +233,7 @@ class ChannelGraph(object):
             details.settle_timeout,
         )
 
-        self.partneraddress_channel[partner_state.address] = channel
+        self.partneraddress_to_channel[partner_state.address] = channel
         self.address_channel[channel_address] = channel
 
     def get_channel_by_contract_address(self, netting_channel_address):
@@ -293,4 +293,4 @@ class ChannelGraph(object):
     def channel_can_transfer(self, partner_address):
         """ True if the channel with `partner_address` is open and has spendable funds. """
         # TODO: check if the partner's network is alive
-        return self.partneraddress_channel[partner_address].can_transfer
+        return self.partneraddress_to_channel[partner_address].can_transfer

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -14,7 +14,7 @@ class Discovery(object):
     """ Mock mapping address: host, port """
 
     def __init__(self):
-        self.nodeid_hostport = dict()
+        self.nodeid_to_hostport = dict()
 
     def register(self, node_address, host, port):
         if not isaddress(node_address):
@@ -28,16 +28,16 @@ class Discovery(object):
         if not isinstance(port, (int, long)):
             raise ValueError('port must be a valid number')
 
-        self.nodeid_hostport[node_address] = (host, port)
+        self.nodeid_to_hostport[node_address] = (host, port)
 
     def get(self, node_address):
         try:
-            return self.nodeid_hostport[node_address]
+            return self.nodeid_to_hostport[node_address]
         except KeyError:
             raise InvalidAddress('Unknown address {}'.format(pex(node_address)))
 
     def nodeid_by_host_port(self, host_port):
-        for nodeid, value_hostport in self.nodeid_hostport.items():
+        for nodeid, value_hostport in self.nodeid_to_hostport.items():
             if value_hostport == host_port:
                 return nodeid
         return None

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -234,12 +234,12 @@ class BlockChainService(object):
             poll_timeout=DEFAULT_POLL_TIMEOUT,
             **kwargs):
 
-        self.address_token = dict()
-        self.address_discovery = dict()
-        self.address_manager = dict()
-        self.address_contract = dict()
-        self.address_registry = dict()
-        self.token_manager = dict()
+        self.address_to_token = dict()
+        self.address_to_discovery = dict()
+        self.address_to_channelmanager = dict()
+        self.address_to_nettingchannel = dict()
+        self.address_to_registry = dict()
+        self.token_to_channelmanager = dict()
 
         jsonrpc_client = JSONRPCClient(
             privkey=privatekey_bin,
@@ -301,41 +301,41 @@ class BlockChainService(object):
 
     def token(self, token_address):
         """ Return a proxy to interact with a token. """
-        if token_address not in self.address_token:
-            self.address_token[token_address] = Token(
+        if token_address not in self.address_to_token:
+            self.address_to_token[token_address] = Token(
                 self.client,
                 token_address,
                 poll_timeout=self.poll_timeout,
             )
 
-        return self.address_token[token_address]
+        return self.address_to_token[token_address]
 
     def discovery(self, discovery_address):
         """ Return a proxy to interact with the discovery. """
-        if discovery_address not in self.address_discovery:
-            self.address_discovery[discovery_address] = Discovery(
+        if discovery_address not in self.address_to_discovery:
+            self.address_to_discovery[discovery_address] = Discovery(
                 self.client,
                 discovery_address,
                 poll_timeout=self.poll_timeout,
             )
 
-        return self.address_discovery[discovery_address]
+        return self.address_to_discovery[discovery_address]
 
     def netting_channel(self, netting_channel_address):
         """ Return a proxy to interact with a NettingChannelContract. """
-        if netting_channel_address not in self.address_contract:
+        if netting_channel_address not in self.address_to_nettingchannel:
             channel = NettingChannel(
                 self.client,
                 netting_channel_address,
                 poll_timeout=self.poll_timeout,
             )
-            self.address_contract[netting_channel_address] = channel
+            self.address_to_nettingchannel[netting_channel_address] = channel
 
-        return self.address_contract[netting_channel_address]
+        return self.address_to_nettingchannel[netting_channel_address]
 
     def manager(self, manager_address):
         """ Return a proxy to interact with a ChannelManagerContract. """
-        if manager_address not in self.address_manager:
+        if manager_address not in self.address_to_channelmanager:
             manager = ChannelManager(
                 self.client,
                 manager_address,
@@ -344,10 +344,10 @@ class BlockChainService(object):
 
             token_address = manager.token_address()
 
-            self.token_manager[token_address] = manager
-            self.address_manager[manager_address] = manager
+            self.token_to_channelmanager[token_address] = manager
+            self.address_to_channelmanager[manager_address] = manager
 
-        return self.address_manager[manager_address]
+        return self.address_to_channelmanager[manager_address]
 
     def manager_by_token(self, token_address):
         """ Find the channel manager for `token_address` and return a proxy to
@@ -356,7 +356,7 @@ class BlockChainService(object):
         If the token is not already registered it raises `JSONRPCClientReplyError`,
         since we try to instantiate a Channel manager with an empty address.
         """
-        if token_address not in self.token_manager:
+        if token_address not in self.token_to_channelmanager:
             token = self.token(token_address)  # check that the token exists
             manager_address = self.default_registry.manager_address_by_token(token.address)
             manager = ChannelManager(
@@ -365,20 +365,20 @@ class BlockChainService(object):
                 poll_timeout=self.poll_timeout,
             )
 
-            self.token_manager[token_address] = manager
-            self.address_manager[manager_address] = manager
+            self.token_to_channelmanager[token_address] = manager
+            self.address_to_channelmanager[manager_address] = manager
 
-        return self.token_manager[token_address]
+        return self.token_to_channelmanager[token_address]
 
     def registry(self, registry_address):
-        if registry_address not in self.address_registry:
-            self.address_registry[registry_address] = Registry(
+        if registry_address not in self.address_to_registry:
+            self.address_to_registry[registry_address] = Registry(
                 self.client,
                 registry_address,
                 poll_timeout=self.poll_timeout,
             )
 
-        return self.address_registry[registry_address]
+        return self.address_to_registry[registry_address]
 
     def uninstall_filter(self, filter_id_raw):
         self.client.call('eth_uninstallFilter', filter_id_raw)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -104,7 +104,7 @@ def load_snapshot(serialization_file):
 def save_snapshot(serialization_file, raiden):
     all_channels = [
         ChannelSerialization(channel)
-        for network in raiden.channelgraphs.values()
+        for network in raiden.token_to_channelgraph.values()
         for channel in network.address_to_channel.values()
     ]
 
@@ -170,7 +170,7 @@ class RaidenService(object):
         )
         transport.protocol = protocol
 
-        self.channelgraphs = dict()
+        self.token_to_channelgraph = dict()
         self.manager_token = dict()
         self.swapkeys_tokenswaps = dict()
         self.swapkeys_greenlettasks = dict()
@@ -272,7 +272,7 @@ class RaidenService(object):
         state_change = Block(blocknumber)
         self.state_machine_event_handler.log_and_dispatch_to_all_tasks(state_change)
 
-        for graph in self.channelgraphs.itervalues():
+        for graph in self.token_to_channelgraph.itervalues():
             for channel in graph.address_to_channel.itervalues():
                 channel.state_transition(state_change)
 
@@ -281,7 +281,7 @@ class RaidenService(object):
         self._blocknumber = blocknumber
 
     def set_node_network_state(self, node_address, network_state):
-        for graph in self.channelgraphs.itervalues():
+        for graph in self.token_to_channelgraph.itervalues():
             channel = graph.partneraddress_to_channel.get(node_address)
 
             if channel:
@@ -300,7 +300,7 @@ class RaidenService(object):
             on_statechange(state_change)
 
     def find_channel_by_address(self, netting_channel_address_bin):
-        for graph in self.channelgraphs.itervalues():
+        for graph in self.token_to_channelgraph.itervalues():
             channel = graph.address_to_channel.get(netting_channel_address_bin)
 
             if channel is not None:
@@ -558,7 +558,7 @@ class RaidenService(object):
             channel_details['settle_timeout'],
         )
 
-        graph = self.channelgraphs[token_address]
+        graph = self.token_to_channelgraph[token_address]
         graph.add_channel(details)
         channel = graph.address_to_channel.get(
             serialized_channel.channel_address,
@@ -631,7 +631,7 @@ class RaidenService(object):
             )
 
             self.manager_token[manager_address] = token_address
-            self.channelgraphs[token_address] = graph
+            self.token_to_channelgraph[token_address] = graph
 
             self.tokens_to_connectionmanagers[token_address] = ConnectionManager(
                 self,
@@ -670,7 +670,7 @@ class RaidenService(object):
         )
 
         self.manager_token[manager_address] = token_address
-        self.channelgraphs[token_address] = graph
+        self.token_to_channelgraph[token_address] = graph
 
         self.tokens_to_connectionmanagers[token_address] = ConnectionManager(
             self,
@@ -683,7 +683,7 @@ class RaidenService(object):
         self.pyethapp_blockchain_events.add_netting_channel_listener(netting_channel)
 
         detail = self.get_channel_details(token_address, netting_channel)
-        graph = self.channelgraphs[token_address]
+        graph = self.token_to_channelgraph[token_address]
         graph.add_channel(detail)
 
     def connection_manager_for_token(self, token_address):
@@ -696,7 +696,7 @@ class RaidenService(object):
         return manager
 
     def leave_all_token_networks_async(self):
-        token_addresses = self.channelgraphs.keys()
+        token_addresses = self.token_to_channelgraph.keys()
         leave_results = []
         for token_address in token_addresses:
             try:
@@ -713,7 +713,7 @@ class RaidenService(object):
 
         connection_managers = [
             self.connection_manager_for_token(token_address) for
-            token_address in self.channelgraphs
+            token_address in self.token_to_channelgraph
         ]
 
         def blocks_to_wait():
@@ -803,7 +803,7 @@ class RaidenService(object):
             - Network speed, making the transfer sufficiently fast so it doesn't
               timeout.
         """
-        graph = self.channelgraphs[token_address]
+        graph = self.token_to_channelgraph[token_address]
 
         if identifier is None:
             identifier = create_default_identifier()
@@ -900,8 +900,13 @@ class RaidenService(object):
 
     def start_mediated_transfer(self, token_address, amount, identifier, target):
         # pylint: disable=too-many-locals
+<<<<<<< HEAD
         graph = self.channelgraphs[token_address]
         available_routes = get_best_routes(
+=======
+        graph = self.token_to_channelgraph[token_address]
+        routes = get_best_routes(
+>>>>>>> Rename raiden_service channelgraph dict
             graph,
             self.protocol.nodeaddresses_networkstatuses,
             self.address,
@@ -971,7 +976,7 @@ class RaidenService(object):
         amount = message.lock.amount
         target = message.target
         token = message.token
-        graph = self.channelgraphs[token]
+        graph = self.token_to_channelgraph[token]
 
         available_routes = get_best_routes(
             graph,
@@ -1005,7 +1010,7 @@ class RaidenService(object):
         self.identifier_to_statemanagers[identifier].append(state_manager)
 
     def target_mediated_transfer(self, message):
-        graph = self.channelgraphs[message.token]
+        graph = self.token_to_channelgraph[message.token]
         from_channel = graph.partneraddress_to_channel[message.sender]
         from_route = channel_to_routestate(from_channel, message.sender)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -900,13 +900,9 @@ class RaidenService(object):
 
     def start_mediated_transfer(self, token_address, amount, identifier, target):
         # pylint: disable=too-many-locals
-<<<<<<< HEAD
-        graph = self.channelgraphs[token_address]
-        available_routes = get_best_routes(
-=======
+
         graph = self.token_to_channelgraph[token_address]
-        routes = get_best_routes(
->>>>>>> Rename raiden_service channelgraph dict
+        available_routes = get_best_routes(
             graph,
             self.protocol.nodeaddresses_networkstatuses,
             self.address,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -105,7 +105,7 @@ def save_snapshot(serialization_file, raiden):
     all_channels = [
         ChannelSerialization(channel)
         for network in raiden.channelgraphs.values()
-        for channel in network.address_channel.values()
+        for channel in network.address_to_channel.values()
     ]
 
     all_queues = list()
@@ -273,7 +273,7 @@ class RaidenService(object):
         self.state_machine_event_handler.log_and_dispatch_to_all_tasks(state_change)
 
         for graph in self.channelgraphs.itervalues():
-            for channel in graph.address_channel.itervalues():
+            for channel in graph.address_to_channel.itervalues():
                 channel.state_transition(state_change)
 
         # To avoid races, only update the internal cache after all the state
@@ -301,7 +301,7 @@ class RaidenService(object):
 
     def find_channel_by_address(self, netting_channel_address_bin):
         for graph in self.channelgraphs.itervalues():
-            channel = graph.address_channel.get(netting_channel_address_bin)
+            channel = graph.address_to_channel.get(netting_channel_address_bin)
 
             if channel is not None:
                 return channel
@@ -560,7 +560,7 @@ class RaidenService(object):
 
         graph = self.channelgraphs[token_address]
         graph.add_channel(details)
-        channel = graph.address_channel.get(
+        channel = graph.address_to_channel.get(
             serialized_channel.channel_address,
         )
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -572,12 +572,12 @@ class RaidenService(object):
         # is no point in re-registering the hashlocks.
         #
         # all_hashlocks = itertools.chain(
-        #     serialized_channel.our_balance_proof.hashlock_pendinglocks.keys(),
-        #     serialized_channel.our_balance_proof.hashlock_unclaimedlocks.keys(),
-        #     serialized_channel.our_balance_proof.hashlock_unlockedlocks.keys(),
-        #     serialized_channel.partner_balance_proof.hashlock_pendinglocks.keys(),
-        #     serialized_channel.partner_balance_proof.hashlock_unclaimedlocks.keys(),
-        #     serialized_channel.partner_balance_proof.hashlock_unlockedlocks.keys(),
+        #     serialized_channel.our_balance_proof.hashlocks_to_pendinglocks.keys(),
+        #     serialized_channel.our_balance_proof.hashlocks_to_unclaimedlocks.keys(),
+        #     serialized_channel.our_balance_proof.hashlocks_to_unlockedlocks.keys(),
+        #     serialized_channel.partner_balance_proof.hashlocks_to_pendinglocks.keys(),
+        #     serialized_channel.partner_balance_proof.hashlocks_to_unclaimedlocks.keys(),
+        #     serialized_channel.partner_balance_proof.hashlocks_to_unlockedlocks.keys(),
         # )
         # for hashlock in all_hashlocks:
         #     register_channel_for_hashlock(channel, hashlock)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -282,7 +282,7 @@ class RaidenService(object):
 
     def set_node_network_state(self, node_address, network_state):
         for graph in self.channelgraphs.itervalues():
-            channel = graph.partneraddress_channel.get(node_address)
+            channel = graph.partneraddress_to_channel.get(node_address)
 
             if channel:
                 channel.network_state = network_state
@@ -808,7 +808,7 @@ class RaidenService(object):
         if identifier is None:
             identifier = create_default_identifier()
 
-        direct_channel = graph.partneraddress_channel.get(target)
+        direct_channel = graph.partneraddress_to_channel.get(target)
         if direct_channel:
             async_result = self._direct_or_mediated_transfer(
                 token_address,
@@ -982,7 +982,7 @@ class RaidenService(object):
             message.sender,
         )
 
-        from_channel = graph.partneraddress_channel[message.sender]
+        from_channel = graph.partneraddress_to_channel[message.sender]
         from_route = channel_to_routestate(from_channel, message.sender)
 
         our_address = self.address
@@ -1006,7 +1006,7 @@ class RaidenService(object):
 
     def target_mediated_transfer(self, message):
         graph = self.channelgraphs[message.token]
-        from_channel = graph.partneraddress_channel[message.sender]
+        from_channel = graph.partneraddress_to_channel[message.sender]
         from_route = channel_to_routestate(from_channel, message.sender)
 
         from_transfer = lockedtransfer_from_message(message)

--- a/raiden/tests/benchmark/profile_transfer.py
+++ b/raiden/tests/benchmark/profile_transfer.py
@@ -239,7 +239,7 @@ def profile_transfer(num_nodes=10, channels_per_node=2):
     main_app = apps[0]
 
     # channels
-    main_graph = main_app.raiden.channelgraphs[tokens[0]]
+    main_graph = main_app.raiden.token_to_channelgraph[tokens[0]]
 
     # search for a path of length=2 A > B > C
     num_hops = 2

--- a/raiden/tests/benchmark/speed.py
+++ b/raiden/tests/benchmark/speed.py
@@ -84,7 +84,7 @@ def setup_apps(amount, tokens, num_transfers, num_nodes, channels_per_node):
 
 def test_throughput(apps, tokens, num_transfers, amount):
     def start_transfers(curr_app, curr_token, num_transfers):
-        graph = curr_app.raiden.channelgraphs[curr_token]
+        graph = curr_app.raiden.token_to_channelgraph[curr_token]
 
         all_paths = graph.get_paths_of_length(
             source=curr_app.raiden.address,
@@ -127,7 +127,7 @@ def test_throughput(apps, tokens, num_transfers, amount):
 def test_latency(apps, tokens, num_transfers, amount):
     def start_transfers(idx, curr_token, num_transfers):
         curr_app = apps[idx]
-        graph = curr_app.raiden.channelgraphs[curr_token]
+        graph = curr_app.raiden.token_to_channelgraph[curr_token]
 
         all_paths = graph.get_paths_of_length(
             source=curr_app.raiden.address,

--- a/raiden/tests/benchmark/speed_simulation.py
+++ b/raiden/tests/benchmark/speed_simulation.py
@@ -121,7 +121,7 @@ def setup_tps(
 
 
 def random_transfer(app, token, transfer_amount):
-    channelgraph = app.raiden.token_managers[token].channelgraph
+    channelgraph = app.raiden.token_to_channelmanagers[token].channelgraph
 
     nodes = channelgraph.graph.nodes()
     nodes.remove(app.raiden.address)

--- a/raiden/tests/benchmark/speed_transfer.py
+++ b/raiden/tests/benchmark/speed_transfer.py
@@ -98,8 +98,8 @@ def transfer_speed(num_transfers=100, max_locked=100):  # pylint: disable=too-ma
     )
 
     app0, app1 = apps  # pylint: disable=unbalanced-tuple-unpacking
-    channel0 = app0.raiden.channelgraphs[tokens[0]].address_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[tokens[0]].address_channel.values()[0]
+    channel0 = app0.raiden.channelgraphs[tokens[0]].address_to_channel.values()[0]
+    channel1 = app1.raiden.channelgraphs[tokens[0]].address_to_channel.values()[0]
 
     expiration = app0.raiden.chain.block_number() + DEFAULT_REVEAL_TIMEOUT + 3
 

--- a/raiden/tests/benchmark/speed_transfer.py
+++ b/raiden/tests/benchmark/speed_transfer.py
@@ -98,8 +98,8 @@ def transfer_speed(num_transfers=100, max_locked=100):  # pylint: disable=too-ma
     )
 
     app0, app1 = apps  # pylint: disable=unbalanced-tuple-unpacking
-    channel0 = app0.raiden.channelgraphs[tokens[0]].address_to_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[tokens[0]].address_to_channel.values()[0]
+    channel0 = app0.raiden.token_to_channelgraph[tokens[0]].address_to_channel.values()[0]
+    channel1 = app1.raiden.token_to_channelgraph[tokens[0]].address_to_channel.values()[0]
 
     expiration = app0.raiden.chain.block_number() + DEFAULT_REVEAL_TIMEOUT + 3
 

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -325,7 +325,7 @@ def test_secret_revealed(raiden_chain, deposit, settle_timeout, events_poll_time
     proof = balance_proof.compute_proof_for_lock(secret, lock)
 
     # the secret hasn't been revealed yet (through messages)
-    assert len(balance_proof.hashlock_pendinglocks) == 1
+    assert len(balance_proof.hashlocks_to_pendinglocks) == 1
     proofs = list(balance_proof.get_known_unlocks())
     assert len(proofs) == 0
 

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -52,8 +52,8 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
 
     token_address = app0.raiden.chain.default_registry.token_addresses()[0]
 
-    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 0
-    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 0
+    assert len(app0.raiden.token_to_channelgraph[token_address].address_to_channel) == 0
+    assert len(app1.raiden.token_to_channelgraph[token_address].address_to_channel) == 0
 
     token0 = app0.raiden.chain.token(token_address)
     graph0 = app0.raiden.chain.manager_by_token(token_address)
@@ -72,11 +72,11 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     gevent.sleep(events_poll_timeout)
 
     # channel is created but not opened and without funds
-    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app0.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
+    assert len(app1.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel0 = app0.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, 0, [],
@@ -89,11 +89,11 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     gevent.sleep(events_poll_timeout)
 
     # channel is open but single funded
-    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app0.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
+    assert len(app1.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel0 = app0.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, deposit, [],
@@ -106,11 +106,11 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     gevent.sleep(events_poll_timeout)
 
     # channel is open and funded by both participants
-    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app0.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
+    assert len(app1.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel0 = app0.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, deposit, [],
@@ -128,8 +128,8 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
 
     token_address = app0.raiden.chain.default_registry.token_addresses()[0]
 
-    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 0
-    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 0
+    assert len(app0.raiden.token_to_channelgraph[token_address].address_to_channel) == 0
+    assert len(app1.raiden.token_to_channelgraph[token_address].address_to_channel) == 0
 
     token0 = app0.raiden.chain.token(token_address)
     manager0 = app0.raiden.chain.manager_by_token(token_address)
@@ -195,11 +195,11 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     gevent.sleep(events_poll_timeout * 2)
 
     # channel is created but not opened and without funds
-    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app0.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
+    assert len(app1.raiden.token_to_channelgraph[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel0 = app0.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.token_to_channelgraph[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, 0, [],

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -52,8 +52,8 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
 
     token_address = app0.raiden.chain.default_registry.token_addresses()[0]
 
-    assert len(app0.raiden.channelgraphs[token_address].address_channel) == 0
-    assert len(app1.raiden.channelgraphs[token_address].address_channel) == 0
+    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 0
+    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 0
 
     token0 = app0.raiden.chain.token(token_address)
     graph0 = app0.raiden.chain.manager_by_token(token_address)
@@ -72,11 +72,11 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     gevent.sleep(events_poll_timeout)
 
     # channel is created but not opened and without funds
-    assert len(app0.raiden.channelgraphs[token_address].address_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_channel) == 1
+    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_channel.values()[0]
+    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, 0, [],
@@ -89,11 +89,11 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     gevent.sleep(events_poll_timeout)
 
     # channel is open but single funded
-    assert len(app0.raiden.channelgraphs[token_address].address_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_channel) == 1
+    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_channel.values()[0]
+    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, deposit, [],
@@ -106,11 +106,11 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     gevent.sleep(events_poll_timeout)
 
     # channel is open and funded by both participants
-    assert len(app0.raiden.channelgraphs[token_address].address_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_channel) == 1
+    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_channel.values()[0]
+    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, deposit, [],
@@ -128,8 +128,8 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
 
     token_address = app0.raiden.chain.default_registry.token_addresses()[0]
 
-    assert len(app0.raiden.channelgraphs[token_address].address_channel) == 0
-    assert len(app1.raiden.channelgraphs[token_address].address_channel) == 0
+    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 0
+    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 0
 
     token0 = app0.raiden.chain.token(token_address)
     manager0 = app0.raiden.chain.manager_by_token(token_address)
@@ -195,11 +195,11 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     gevent.sleep(events_poll_timeout * 2)
 
     # channel is created but not opened and without funds
-    assert len(app0.raiden.channelgraphs[token_address].address_channel) == 1
-    assert len(app1.raiden.channelgraphs[token_address].address_channel) == 1
+    assert len(app0.raiden.channelgraphs[token_address].address_to_channel) == 1
+    assert len(app1.raiden.channelgraphs[token_address].address_to_channel) == 1
 
-    channel0 = app0.raiden.channelgraphs[token_address].address_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs[token_address].address_channel.values()[0]
+    channel0 = app0.raiden.channelgraphs[token_address].address_to_channel.values()[0]
+    channel1 = app1.raiden.channelgraphs[token_address].address_to_channel.values()[0]
 
     assert_synched_channels(
         channel0, 0, [],

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -48,8 +48,8 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
 
     setup_messages_cb()
 
-    alice_graph = alice_app.raiden.channelgraphs.values()[0]
-    bob_graph = bob_app.raiden.channelgraphs.values()[0]
+    alice_graph = alice_app.raiden.token_to_channelgraph.values()[0]
+    bob_graph = bob_app.raiden.token_to_channelgraph.values()[0]
     assert alice_graph.token_address == bob_graph.token_address
 
     alice_bob_channel = alice_graph.partneraddress_to_channel[bob_app.raiden.address]
@@ -353,8 +353,8 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit, reveal_timeout
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_automatic_dispute(raiden_network, deposit, settle_timeout):
     app0, app1 = raiden_network
-    channel0 = app0.raiden.channelgraphs.values()[0].partneraddress_to_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs.values()[0].partneraddress_to_channel.values()[0]
+    channel0 = app0.raiden.token_to_channelgraph.values()[0].partneraddress_to_channel.values()[0]
+    channel1 = app1.raiden.token_to_channelgraph.values()[0].partneraddress_to_channel.values()[0]
     privatekey0 = app0.raiden.private_key
     privatekey1 = app1.raiden.private_key
     address0 = privatekey_to_address(privatekey0.secret)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -52,8 +52,8 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     bob_graph = bob_app.raiden.channelgraphs.values()[0]
     assert alice_graph.token_address == bob_graph.token_address
 
-    alice_bob_channel = alice_graph.partneraddress_channel[bob_app.raiden.address]
-    bob_alice_channel = bob_graph.partneraddress_channel[alice_app.raiden.address]
+    alice_bob_channel = alice_graph.partneraddress_to_channel[bob_app.raiden.address]
+    bob_alice_channel = bob_graph.partneraddress_to_channel[alice_app.raiden.address]
 
     alice_deposit = alice_bob_channel.balance
     bob_deposit = bob_alice_channel.balance
@@ -70,7 +70,7 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     secret = 'secretsecretsecretsecretsecretse'
     hashlock = sha3(secret)
 
-    assert bob_app.raiden.address in alice_graph.partneraddress_channel
+    assert bob_app.raiden.address in alice_graph.partneraddress_to_channel
 
     nettingaddress0 = alice_bob_channel.external_state.netting_channel.address
     nettingaddress1 = bob_alice_channel.external_state.netting_channel.address
@@ -353,8 +353,8 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit, reveal_timeout
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_automatic_dispute(raiden_network, deposit, settle_timeout):
     app0, app1 = raiden_network
-    channel0 = app0.raiden.channelgraphs.values()[0].partneraddress_channel.values()[0]
-    channel1 = app1.raiden.channelgraphs.values()[0].partneraddress_channel.values()[0]
+    channel0 = app0.raiden.channelgraphs.values()[0].partneraddress_to_channel.values()[0]
+    channel1 = app1.raiden.channelgraphs.values()[0].partneraddress_to_channel.values()[0]
     privatekey0 = app0.raiden.private_key
     privatekey1 = app1.raiden.private_key
     address0 = privatekey_to_address(privatekey0.secret)

--- a/raiden/tests/integration/test_snapshotting.py
+++ b/raiden/tests/integration/test_snapshotting.py
@@ -40,7 +40,7 @@ def test_snapshotting(raiden_network, token_addresses):
 
         for serialized_channel in data['channels']:
             network = app.raiden.channelgraphs[serialized_channel.token_address]
-            running_channel = network.address_channel[serialized_channel.channel_address]
+            running_channel = network.address_to_channel[serialized_channel.channel_address]
             assert running_channel.serialize() == serialized_channel
 
         for queue in data['queues']:

--- a/raiden/tests/integration/test_snapshotting.py
+++ b/raiden/tests/integration/test_snapshotting.py
@@ -39,7 +39,7 @@ def test_snapshotting(raiden_network, token_addresses):
         data = load_snapshot(app.raiden.serialization_file)
 
         for serialized_channel in data['channels']:
-            network = app.raiden.channelgraphs[serialized_channel.token_address]
+            network = app.raiden.token_to_channelgraph[serialized_channel.token_address]
             running_channel = network.address_to_channel[serialized_channel.channel_address]
             assert running_channel.serialize() == serialized_channel
 

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -78,7 +78,7 @@ def test_transfer_to_unknownchannel(raiden_network):
     graph1 = app1.raiden.channelgraphs.values()[0]
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     with pytest.raises(NoPathError):
         RaidenAPI(app0.raiden).transfer(

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -74,8 +74,8 @@ def test_register_token(raiden_chain, token_addresses):
 def test_transfer_to_unknownchannel(raiden_network):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     assert graph0.token_address == graph1.token_address
     assert app1.raiden.address in graph0.partneraddress_to_channel
@@ -100,7 +100,7 @@ def test_token_swap(raiden_network, deposit, settle_timeout):
     maker_address = app0.raiden.address
     taker_address = app1.raiden.address
 
-    maker_token, taker_token = app0.raiden.channelgraphs.keys()[:2]
+    maker_token, taker_token = app0.raiden.token_to_channelgraph.keys()[:2]
     maker_amount = 70
     taker_amount = 30
 

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -409,8 +409,8 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel.values()[0]
-    channel1 = graph1.partneraddress_channel.values()[0]
+    channel0 = graph0.partneraddress_to_channel.values()[0]
+    channel1 = graph1.partneraddress_to_channel.values()[0]
 
     contract_balance0 = channel0.contract_balance
     contract_balance1 = channel1.contract_balance
@@ -516,8 +516,8 @@ def test_transfer(raiden_network, token_addresses):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    app0_partners = graph0.partneraddress_channel.keys()
-    app1_partners = graph1.partneraddress_channel.keys()
+    app0_partners = graph0.partneraddress_to_channel.keys()
+    app1_partners = graph1.partneraddress_to_channel.keys()
 
     assert channel0.token_address == channel1.token_address
     assert app0_token == app1_token
@@ -575,8 +575,8 @@ def test_locked_transfer(raiden_network, settle_timeout):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel.values()[0]
-    channel1 = graph1.partneraddress_channel.values()[0]
+    channel0 = graph0.partneraddress_to_channel.values()[0]
+    channel1 = graph1.partneraddress_to_channel.values()[0]
 
     balance0 = channel0.balance
     balance1 = channel1.balance
@@ -642,8 +642,8 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel.values()[0]
-    channel1 = graph1.partneraddress_channel.values()[0]
+    channel0 = graph0.partneraddress_to_channel.values()[0]
+    channel1 = graph1.partneraddress_to_channel.values()[0]
 
     balance0 = channel0.balance
     balance1 = channel1.balance

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -358,8 +358,8 @@ def test_python_channel():
 def test_setup(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    tokens0 = app0.raiden.channelgraphs.keys()
-    tokens1 = app1.raiden.channelgraphs.keys()
+    tokens0 = app0.raiden.token_to_channelgraph.keys()
+    tokens1 = app1.raiden.token_to_channelgraph.keys()
 
     assert len(tokens0) == 1
     assert len(tokens1) == 1
@@ -406,8 +406,8 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
 
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel.values()[0]
     channel1 = graph1.partneraddress_to_channel.values()[0]
@@ -510,11 +510,11 @@ def test_transfer(raiden_network, token_addresses):
     address0 = channel0.our_state.address
     address1 = channel1.our_state.address
 
-    app0_token = app0.raiden.channelgraphs.keys()[0]
-    app1_token = app1.raiden.channelgraphs.keys()[0]
+    app0_token = app0.raiden.token_to_channelgraph.keys()[0]
+    app1_token = app1.raiden.token_to_channelgraph.keys()[0]
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     app0_partners = graph0.partneraddress_to_channel.keys()
     app1_partners = graph1.partneraddress_to_channel.keys()
@@ -572,8 +572,8 @@ def test_transfer(raiden_network, token_addresses):
 def test_locked_transfer(raiden_network, settle_timeout):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel.values()[0]
     channel1 = graph1.partneraddress_to_channel.values()[0]
@@ -639,8 +639,8 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
     """
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel.values()[0]
     channel1 = graph1.partneraddress_to_channel.values()[0]

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -84,7 +84,7 @@ class MediatedTransferTestHelper(object):
         self.graph = graph
         self.token_address = graph.token_address
         self.ams_by_address = dict(
-            (app.raiden.address, app.raiden.channelgraphs)
+            (app.raiden.address, app.raiden.token_to_channelgraph)
             for app in self.raiden_network
         )
 
@@ -131,8 +131,8 @@ def test_transfer(raiden_network):
 
     messages = setup_messages_cb()
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
     channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
@@ -178,7 +178,7 @@ def test_transfer(raiden_network):
 def test_mediated_transfer(raiden_network):
     alice_app = raiden_network[0]
 
-    graph = alice_app.raiden.channelgraphs.values()[0]
+    graph = alice_app.raiden.token_to_channelgraph.values()[0]
     token_address = graph.token_address
     mt_helper = MediatedTransferTestHelper(raiden_network, graph)
 
@@ -309,8 +309,8 @@ def test_healthcheck_with_normal_peer(raiden_network):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
     messages = setup_messages_cb()
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     assert graph0.token_address == graph1.token_address
     assert app1.raiden.address in graph0.partneraddress_to_channel
@@ -371,7 +371,7 @@ def test_healthcheck_with_bad_peer(raiden_network, nat_keepalive_retries, nat_ke
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_receive_directtransfer_unknown(raiden_network):
     app0 = raiden_network[0]  # pylint: disable=unbalanced-tuple-unpacking
-    graph0 = app0.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
 
     other_key = PrivateKey(HASH)
     other_address = privatekey_to_address(HASH)
@@ -391,7 +391,7 @@ def test_receive_directtransfer_unknown(raiden_network):
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_receive_mediatedtransfer_unknown(raiden_network):
     app0 = raiden_network[0]  # pylint: disable=unbalanced-tuple-unpacking
-    graph0 = app0.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
 
     other_key = PrivateKey(HASH)
     other_address = privatekey_to_address(HASH)
@@ -418,7 +418,7 @@ def test_receive_mediatedtransfer_unknown(raiden_network):
 def test_receive_hashlocktransfer_unknown(raiden_network):
     app0 = raiden_network[0]  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
 
     other_key = PrivateKey(HASH2)
     other_address = privatekey_to_address(HASH2)
@@ -451,8 +451,8 @@ def test_receive_hashlocktransfer_unknown(raiden_network):
 def test_receive_directtransfer_outoforder(raiden_network, private_keys):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
     channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
@@ -501,7 +501,7 @@ def test_receive_mediatedtransfer_outoforder(raiden_network, private_keys):
     alice_app = raiden_network[0]
     messages = setup_messages_cb()
 
-    graph = alice_app.raiden.channelgraphs.values()[0]
+    graph = alice_app.raiden.token_to_channelgraph.values()[0]
     token_address = graph.token_address
 
     mt_helper = MediatedTransferTestHelper(raiden_network, graph)
@@ -550,7 +550,7 @@ def test_receive_mediatedtransfer_outoforder(raiden_network, private_keys):
 def test_receive_mediatedtransfer_invalid_address(raiden_network, private_keys):
     alice_app = raiden_network[0]
 
-    graph = alice_app.raiden.channelgraphs.values()[0]
+    graph = alice_app.raiden.token_to_channelgraph.values()[0]
     token_address = graph.token_address
 
     mt_helper = MediatedTransferTestHelper(raiden_network, graph)
@@ -600,8 +600,8 @@ def test_receive_mediatedtransfer_invalid_address(raiden_network, private_keys):
 def test_receive_directtransfer_wrongtoken(raiden_network, private_keys):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
     channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
@@ -647,8 +647,8 @@ def test_receive_directtransfer_wrongtoken(raiden_network, private_keys):
 def test_receive_directtransfer_invalidlocksroot(raiden_network, private_keys):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
     channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
@@ -695,8 +695,8 @@ def test_receive_directtransfer_invalidlocksroot(raiden_network, private_keys):
 def test_transfer_from_outdated(raiden_network, settle_timeout):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    graph0 = app0.raiden.channelgraphs.values()[0]
-    graph1 = app1.raiden.channelgraphs.values()[0]
+    graph0 = app0.raiden.token_to_channelgraph.values()[0]
+    graph1 = app1.raiden.token_to_channelgraph.values()[0]
 
     channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
     channel1 = graph1.partneraddress_to_channel[app0.raiden.address]

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -89,7 +89,7 @@ class MediatedTransferTestHelper(object):
         )
 
     def get_channel(self, from_, to_):
-        return self.ams_by_address[from_][self.token_address].partneraddress_channel[to_]
+        return self.ams_by_address[from_][self.token_address].partneraddress_to_channel[to_]
 
     def get_paths_of_length(self, initiator_address, num_hops):
         """
@@ -134,14 +134,14 @@ def test_transfer(raiden_network):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel[app1.raiden.address]
-    channel1 = graph1.partneraddress_channel[app0.raiden.address]
+    channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
+    channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
 
     balance0 = channel0.balance
     balance1 = channel1.balance
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     amount = 10
     target = app1.raiden.address
@@ -313,7 +313,7 @@ def test_healthcheck_with_normal_peer(raiden_network):
     graph1 = app1.raiden.channelgraphs.values()[0]
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     amount = 10
     target = app1.raiden.address
@@ -454,14 +454,14 @@ def test_receive_directtransfer_outoforder(raiden_network, private_keys):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel[app1.raiden.address]
-    channel1 = graph1.partneraddress_channel[app0.raiden.address]
+    channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
+    channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
 
     balance0 = channel0.balance
     balance1 = channel1.balance
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     amount = 10
     target = app1.raiden.address
@@ -603,14 +603,14 @@ def test_receive_directtransfer_wrongtoken(raiden_network, private_keys):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel[app1.raiden.address]
-    channel1 = graph1.partneraddress_channel[app0.raiden.address]
+    channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
+    channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
 
     balance0 = channel0.balance
     balance1 = channel1.balance
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     amount = 10
     result = app0.raiden.transfer_async(
@@ -650,14 +650,14 @@ def test_receive_directtransfer_invalidlocksroot(raiden_network, private_keys):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel[app1.raiden.address]
-    channel1 = graph1.partneraddress_channel[app0.raiden.address]
+    channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
+    channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
 
     balance0 = channel0.balance
     balance1 = channel1.balance
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     amount = 10
     result = app0.raiden.transfer_async(
@@ -698,14 +698,14 @@ def test_transfer_from_outdated(raiden_network, settle_timeout):
     graph0 = app0.raiden.channelgraphs.values()[0]
     graph1 = app1.raiden.channelgraphs.values()[0]
 
-    channel0 = graph0.partneraddress_channel[app1.raiden.address]
-    channel1 = graph1.partneraddress_channel[app0.raiden.address]
+    channel0 = graph0.partneraddress_to_channel[app1.raiden.address]
+    channel1 = graph1.partneraddress_to_channel[app0.raiden.address]
 
     balance0 = channel0.balance
     balance1 = channel1.balance
 
     assert graph0.token_address == graph1.token_address
-    assert app1.raiden.address in graph0.partneraddress_channel
+    assert app1.raiden.address in graph0.partneraddress_to_channel
 
     amount = 10
     result = app0.raiden.transfer_async(

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -112,7 +112,7 @@ def run_smoketests(raiden_service, test_config, debug=False):
 
         assert len(raiden_service.channelgraphs.values()) == 1
         graph = raiden_service.channelgraphs.values()[0]
-        channel = graph.partneraddress_channel[TEST_PARTNER_ADDRESS.decode('hex')]
+        channel = graph.partneraddress_to_channel[TEST_PARTNER_ADDRESS.decode('hex')]
         assert channel.can_transfer
         assert channel.contract_balance == channel.distributable == TEST_DEPOSIT_AMOUNT
         assert channel.state == CHANNEL_STATE_OPENED

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -110,8 +110,8 @@ def run_smoketests(raiden_service, test_config, debug=False):
         discovery = chain.address_to_discovery.values()[0]
         assert discovery.endpoint_by_address(raiden_service.address) != TEST_ENDPOINT
 
-        assert len(raiden_service.channelgraphs.values()) == 1
-        graph = raiden_service.channelgraphs.values()[0]
+        assert len(raiden_service.token_to_channelgraph.values()) == 1
+        graph = raiden_service.token_to_channelgraph.values()[0]
         channel = graph.partneraddress_to_channel[TEST_PARTNER_ADDRESS.decode('hex')]
         assert channel.can_transfer
         assert channel.contract_balance == channel.distributable == TEST_DEPOSIT_AMOUNT

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -102,12 +102,12 @@ def run_smoketests(raiden_service, test_config, debug=False):
             chain.default_registry.token_addresses() ==
             [test_config['contracts']['token_address'].decode('hex')]
         )
-        assert len(chain.address_discovery.keys()) == 1
+        assert len(chain.address_to_discovery.keys()) == 1
         assert (
-            chain.address_discovery.keys()[0] ==
+            chain.address_to_discovery.keys()[0] ==
             test_config['contracts']['discovery_address'].decode('hex')
         )
-        discovery = chain.address_discovery.values()[0]
+        discovery = chain.address_to_discovery.values()[0]
         assert discovery.endpoint_by_address(raiden_service.address) != TEST_ENDPOINT
 
         assert len(raiden_service.channelgraphs.values()) == 1

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -205,12 +205,12 @@ class BlockChainServiceTesterMock(object):
         self.node_address = privatekey_to_address(private_key)
         self.default_registry = default_registry
 
-        self.address_token = dict()
-        self.address_discovery = dict()
-        self.address_manager = dict()
-        self.address_contract = dict()
-        self.address_registry = dict()
-        self.token_manager = dict()
+        self.address_to_token = dict()
+        self.address_to_discovery = dict()
+        self.address_to_channelmanager = dict()
+        self.address_to_nettingchannel = dict()
+        self.address_to_registry = dict()
+        self.token_to_channelmanager = dict()
 
     def set_verbosity(self, level):
         pass
@@ -228,40 +228,40 @@ class BlockChainServiceTesterMock(object):
 
     def token(self, token_address):
         """ Return a proxy to interact with an token. """
-        if token_address not in self.address_token:
-            self.address_token[token_address] = TokenTesterMock(
+        if token_address not in self.address_to_token:
+            self.address_to_token[token_address] = TokenTesterMock(
                 self.tester_state,
                 self.private_key,
                 token_address,
             )
 
-        return self.address_token[token_address]
+        return self.address_to_token[token_address]
 
     def discovery(self, discovery_address):
-        if discovery_address not in self.address_discovery:
-            self.address_discovery[discovery_address] = DiscoveryTesterMock(
+        if discovery_address not in self.address_to_discovery:
+            self.address_to_discovery[discovery_address] = DiscoveryTesterMock(
                 self.tester_state,
                 self.private_key,
                 discovery_address,
             )
 
-        return self.address_discovery[discovery_address]
+        return self.address_to_discovery[discovery_address]
 
     def netting_channel(self, netting_channel_address):
         """ Return a proxy to interact with a NettingChannelContract. """
-        if netting_channel_address not in self.address_contract:
+        if netting_channel_address not in self.address_to_nettingchannel:
             channel = NettingChannelTesterMock(
                 self.tester_state,
                 self.private_key,
                 netting_channel_address,
             )
-            self.address_contract[netting_channel_address] = channel
+            self.address_to_nettingchannel[netting_channel_address] = channel
 
-        return self.address_contract[netting_channel_address]
+        return self.address_to_nettingchannel[netting_channel_address]
 
     def manager(self, manager_address):
         """ Return a proxy to interact with a ChannelManagerContract. """
-        if manager_address not in self.address_manager:
+        if manager_address not in self.address_to_channelmanager:
             manager = ChannelManagerTesterMock(
                 self.tester_state,
                 self.private_key,
@@ -270,10 +270,10 @@ class BlockChainServiceTesterMock(object):
 
             token_address = manager.token_address()
 
-            self.token_manager[token_address] = manager
-            self.address_manager[manager_address] = manager
+            self.token_to_channelmanager[token_address] = manager
+            self.address_to_channelmanager[manager_address] = manager
 
-        return self.address_manager[manager_address]
+        return self.address_to_channelmanager[manager_address]
 
     def manager_by_token(self, token_address):
         """ Find the channel manager for `token_address` and return a proxy to
@@ -282,7 +282,7 @@ class BlockChainServiceTesterMock(object):
         If the token is not already registered it raises `TransactionFailed` when
         we do `self.registry_proxy.channelManagerByToken(token_address)`
         """
-        if token_address not in self.token_manager:
+        if token_address not in self.token_to_channelmanager:
             manager_address = self.default_registry.manager_address_by_token(token_address)
             manager = ChannelManagerTesterMock(
                 self.tester_state,
@@ -290,20 +290,20 @@ class BlockChainServiceTesterMock(object):
                 manager_address,
             )
 
-            self.token_manager[token_address] = manager
-            self.address_manager[manager_address] = manager
+            self.token_to_channelmanager[token_address] = manager
+            self.address_to_channelmanager[manager_address] = manager
 
-        return self.token_manager[token_address]
+        return self.token_to_channelmanager[token_address]
 
     def registry(self, registry_address):
-        if registry_address not in self.address_registry:
-            self.address_registry[registry_address] = RegistryTesterMock(
+        if registry_address not in self.address_to_registry:
+            self.address_to_registry[registry_address] = RegistryTesterMock(
                 self.tester_state,
                 self.private_key,
                 registry_address,
             )
 
-        return self.address_registry[registry_address]
+        return self.address_to_registry[registry_address]
 
     def uninstall_filter(self, filter_id_raw):
         pass

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -12,7 +12,7 @@ from raiden.channel.netting_channel import Channel
 def channel(app0, app1, token):
     """ Nice to read shortcut to get the channel. """
     graph = app0.raiden.channelgraphs[token]
-    return graph.partneraddress_channel[app1.raiden.address]
+    return graph.partneraddress_to_channel[app1.raiden.address]
 
 
 def sleep(initiator_app, target_app, token, multiplier=1):
@@ -60,7 +60,7 @@ def transfer(initiator_app, target_app, token, amount, identifier):
 def direct_transfer(initiator_app, target_app, token, amount, identifier=None):
     """ Nice to read shortcut to make a DirectTransfer. """
     graph = initiator_app.raiden.channelgraphs[token]
-    has_channel = target_app.raiden.address in graph.partneraddress_channel
+    has_channel = target_app.raiden.address in graph.partneraddress_to_channel
     assert has_channel, 'there is not a direct channel'
 
     async_result = initiator_app.raiden.transfer_async(
@@ -80,7 +80,7 @@ def mediated_transfer(initiator_app, target_app, token, amount, identifier=None)
     # pylint: disable=too-many-arguments
 
     graph = initiator_app.raiden.channelgraphs[token]
-    has_channel = target_app.raiden.address in graph.partneraddress_channel
+    has_channel = target_app.raiden.address in graph.partneraddress_to_channel
 
     if has_channel:
         raise NotImplementedError(

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -11,7 +11,7 @@ from raiden.channel.netting_channel import Channel
 
 def channel(app0, app1, token):
     """ Nice to read shortcut to get the channel. """
-    graph = app0.raiden.channelgraphs[token]
+    graph = app0.raiden.token_to_channelgraph[token]
     return graph.partneraddress_to_channel[app1.raiden.address]
 
 
@@ -19,7 +19,7 @@ def sleep(initiator_app, target_app, token, multiplier=1):
     """ Sleep long enough to conclude a transfer from `initiator_app` to
     `target_app`.
     """
-    graph = initiator_app.raiden.channelgraphs[token]
+    graph = initiator_app.raiden.token_to_channelgraph[token]
     path = list(graph.channelgraph.get_shortest_paths(
         initiator_app.raiden.address,
         target_app.raiden.address,
@@ -59,7 +59,7 @@ def transfer(initiator_app, target_app, token, amount, identifier):
 
 def direct_transfer(initiator_app, target_app, token, amount, identifier=None):
     """ Nice to read shortcut to make a DirectTransfer. """
-    graph = initiator_app.raiden.channelgraphs[token]
+    graph = initiator_app.raiden.token_to_channelgraph[token]
     has_channel = target_app.raiden.address in graph.partneraddress_to_channel
     assert has_channel, 'there is not a direct channel'
 
@@ -79,7 +79,7 @@ def mediated_transfer(initiator_app, target_app, token, amount, identifier=None)
     """
     # pylint: disable=too-many-arguments
 
-    graph = initiator_app.raiden.channelgraphs[token]
+    graph = initiator_app.raiden.token_to_channelgraph[token]
     has_channel = target_app.raiden.address in graph.partneraddress_to_channel
 
     if has_channel:

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -236,13 +236,13 @@ def assert_locked(channel0, outstanding_locks):
     # a locked transfer is registered in the _partner_ state
     hashroot = Merkletree(sha3(lock.as_bytes) for lock in outstanding_locks).merkleroot
 
-    assert len(channel0.our_state.balance_proof.hashlock_pendinglocks) == len(outstanding_locks)
+    assert len(channel0.our_state.balance_proof.hashlocks_to_pendinglocks) == len(outstanding_locks)
     assert channel0.our_state.balance_proof.merkleroot_for_unclaimed() == hashroot
     assert channel0.our_state.locked() == sum(lock.amount for lock in outstanding_locks)
     assert channel0.outstanding == sum(lock.amount for lock in outstanding_locks)
 
     for lock in outstanding_locks:
-        assert lock.hashlock in channel0.our_state.balance_proof.hashlock_pendinglocks
+        assert lock.hashlock in channel0.our_state.balance_proof.hashlocks_to_pendinglocks
 
 
 def assert_balance(channel0, balance, outstanding, distributable):

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -236,7 +236,9 @@ def assert_locked(channel0, outstanding_locks):
     # a locked transfer is registered in the _partner_ state
     hashroot = Merkletree(sha3(lock.as_bytes) for lock in outstanding_locks).merkleroot
 
-    assert len(channel0.our_state.balance_proof.hashlocks_to_pendinglocks) == len(outstanding_locks)
+    assert len(channel0.our_state.balance_proof.hashlocks_to_pendinglocks) == len(
+        outstanding_locks
+    )
     assert channel0.our_state.balance_proof.merkleroot_for_unclaimed() == hashroot
     assert channel0.our_state.locked() == sum(lock.amount for lock in outstanding_locks)
     assert channel0.outstanding == sum(lock.amount for lock in outstanding_locks)

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -319,8 +319,8 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
         to_amount = tokenswap.to_amount
         to_nodeaddress = tokenswap.to_nodeaddress
 
-        from_graph = raiden.channelgraphs[from_token]
-        to_graph = raiden.channelgraphs[to_token]
+        from_graph = raiden.token_to_channelgraph[from_token]
+        to_graph = raiden.token_to_channelgraph[to_token]
 
         from_routes = get_best_routes(
             from_graph,
@@ -579,10 +579,10 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
         taker_receiving_token = maker_paying_transfer.token
         taker_paying_token = maker_receiving_token
 
-        from_graph = raiden.channelgraphs[taker_receiving_token]
+        from_graph = raiden.token_to_channelgraph[taker_receiving_token]
         from_channel = from_graph.partneraddress_to_channel[maker_payer_hop]
 
-        to_graph = raiden.channelgraphs[maker_receiving_token]
+        to_graph = raiden.token_to_channelgraph[maker_receiving_token]
 
         # update the channel's distributable and merkle tree
         from_channel.register_transfer(

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -381,7 +381,7 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
 
             elif isinstance(to_mediated_transfer, MediatedTransfer):
                 to_hop = to_mediated_transfer.sender
-                to_channel = to_graph.partneraddress_channel[to_hop]
+                to_channel = to_graph.partneraddress_to_channel[to_hop]
 
                 to_channel.register_transfer(
                     raiden.get_block_number(),
@@ -410,7 +410,7 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
                     hashlock,
                 )
 
-                to_channel = to_graph.partneraddress_channel[to_mediated_transfer.sender]
+                to_channel = to_graph.partneraddress_to_channel[to_mediated_transfer.sender]
                 self._wait_for_unlock_or_close(
                     raiden,
                     to_graph,
@@ -580,7 +580,7 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
         taker_paying_token = maker_receiving_token
 
         from_graph = raiden.channelgraphs[taker_receiving_token]
-        from_channel = from_graph.partneraddress_channel[maker_payer_hop]
+        from_channel = from_graph.partneraddress_to_channel[maker_payer_hop]
 
         to_graph = raiden.channelgraphs[maker_receiving_token]
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -271,7 +271,7 @@ class ConsoleTools(object):
         token = self._chain.token(token_address)
 
         # Obtain the token manager
-        graph = self._raiden.channelgraphs[token_address]
+        graph = self._raiden.token_to_channelgraph[token_address]
         assert graph
 
         # Get the channel
@@ -319,7 +319,7 @@ class ConsoleTools(object):
         token_address = safe_address_decode(token_address_hex)
         peer_address = safe_address_decode(peer_address_hex)
 
-        graph = self._raiden.channelgraphs[token_address]
+        graph = self._raiden.token_to_channelgraph[token_address]
         assert graph
 
         channel = graph.partneraddress_to_channel[peer_address]

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -275,7 +275,7 @@ class ConsoleTools(object):
         assert graph
 
         # Get the channel
-        channel = graph.partneraddress_channel[peer_address]
+        channel = graph.partneraddress_to_channel[peer_address]
         assert channel
 
         # Collect data
@@ -322,7 +322,7 @@ class ConsoleTools(object):
         graph = self._raiden.channelgraphs[token_address]
         assert graph
 
-        channel = graph.partneraddress_channel[peer_address]
+        channel = graph.partneraddress_to_channel[peer_address]
         netcontract_address = channel.external_state.netting_channel.address
         assert netcontract_address
 


### PR DESCRIPTION
As per our [contributing guide](https://github.com/raiden-network/raiden/blob/master/CONTRIBUTING.md) tried to enforce the proper dict naming at least in the core part of our code. Did not change dicts that are used only in tests.

There were variables like `token_manager` which were impossible to determine by simply reading the code that they were a mapping of `token` to `manager` (what manager??). It sounded more like a variable that holds a token manager (which btw does not exist). 

It was very difficult to read the code with variables like that so I finally went ahead and made the change to make it more readable.

I also took the liberty to make a change in our rule for naming dicts.

Using plural in the dictionaries is fine, but I strongly prefer it if we don't without a good reason. A mapping is better described by `name_to_name` and plural should be used to determine if it's a mapping to a list of the mapped objects.

Using that naming rule:

`token_to_address` and `token_to_addresses` have different meanings. One is an one to one mapping while the other is to a list of addresses. 

I edited the contribution guide to explain the above.