### PR TITLE
Add transfer details to EventTransferReceivedSuccess

### DIFF
--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -34,6 +34,8 @@ from raiden.transfer.mediated_transfer.events import (
     SendRefundTransfer,
     SendRevealSecret,
     SendSecretRequest,
+    EventUnlockSuccess,
+    EventUnlockFailed,
 )
 from raiden.utils import sha3
 
@@ -180,9 +182,16 @@ class StateMachineEventHandler(object):
         elif isinstance(event, EventTransferSentFailed):
             for result in self.raiden.identifier_to_results[event.identifier]:
                 result.set(False)
-
         elif isinstance(event, UNEVENTEFUL_EVENTS):
             pass
+        elif isinstance(event, EventUnlockSuccess):
+            pass
+        elif isinstance(event, EventUnlockFailed):
+            log.error(
+                'UnlockFailed!',
+                initiator=event.initiator,
+                expiration=event.expiration
+            )
 
         elif isinstance(event, ContractSendChannelClose):
             graph = self.raiden.token_to_channelgraph[event.token]

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -34,15 +34,12 @@ from raiden.transfer.mediated_transfer.events import (
     SendRefundTransfer,
     SendRevealSecret,
     SendSecretRequest,
-    EventUnlockSuccess,
-    EventUnlockFailed,
 )
 from raiden.utils import sha3
 
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
 UNEVENTEFUL_EVENTS = (
     EventTransferReceivedSuccess,
-    EventUnlockFailed,
     EventUnlockSuccess,
     EventWithdrawFailed,
     EventWithdrawSuccess,
@@ -183,8 +180,6 @@ class StateMachineEventHandler(object):
             for result in self.raiden.identifier_to_results[event.identifier]:
                 result.set(False)
         elif isinstance(event, UNEVENTEFUL_EVENTS):
-            pass
-        elif isinstance(event, EventUnlockSuccess):
             pass
         elif isinstance(event, EventUnlockFailed):
             log.error(

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -213,6 +213,8 @@ class RaidenMessageHandler(object):
 
         receive_success = EventTransferReceivedSuccess(
             message.identifier,
+            amount,
+            message.sender,
         )
         self.raiden.transaction_log.log_events(
             state_change_id,

--- a/raiden/tests/unit/functional/test_directtransferlog.py
+++ b/raiden/tests/unit/functional/test_directtransferlog.py
@@ -152,4 +152,6 @@ def test_target_log_directransfer_successevent(
     ]
     assert sucessful_received_transfers[0] == EventTransferReceivedSuccess(
         identifier,
+        amount,
+        app0.raiden.address,
     )

--- a/raiden/tests/unit/test_operators.py
+++ b/raiden/tests/unit/test_operators.py
@@ -115,14 +115,17 @@ def test_event_operators():
     assert a != c
     assert not a == c
 
-    a = EventTransferReceivedSuccess(2)
-    b = EventTransferReceivedSuccess(2)
-    c = EventTransferReceivedSuccess(3)
+    a = EventTransferReceivedSuccess(2, 5, sha3('initiator'))
+    b = EventTransferReceivedSuccess(2, 5, sha3('initiator'))
+    c = EventTransferReceivedSuccess(3, 5, sha3('initiator'))
+    d = EventTransferReceivedSuccess(3, 5, sha3('other initiator'))
 
     assert a == b
     assert not a != b
     assert a != c
     assert not a == c
+    assert c != d
+    assert not c == d
 
 
 def test_message_operators():

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -76,15 +76,19 @@ class EventTransferReceivedSuccess(Event):
         there is no correspoding `EventTransferReceivedFailed`.
     """
 
-    def __init__(self, identifier):
+    def __init__(self, identifier, amount, initiator):
         self.identifier = identifier
+        self.amount = amount
+        self.initiator = initiator
 
     def __eq__(self, other):
         if not isinstance(other, EventTransferReceivedSuccess):
             return False
 
         return (
-            self.identifier == other.identifier
+            self.identifier == other.identifier and
+            self.amount == other.amount and
+            self.initiator == other.initiator
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -199,7 +199,7 @@ def clear_if_finalized(iteration):
     elif state.state == 'balance_proof':
         transfer_success = EventTransferReceivedSuccess(
             state.from_transfer.identifier,
-            state.from_transfer.total_amount,
+            state.from_transfer.amount,
             state.from_transfer.initiator,
         )
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -199,7 +199,10 @@ def clear_if_finalized(iteration):
     elif state.state == 'balance_proof':
         transfer_success = EventTransferReceivedSuccess(
             state.from_transfer.identifier,
+            state.from_transfer.total_amount,
+            state.from_transfer.initiator,
         )
+
         unlock_success = EventWithdrawSuccess(
             state.from_transfer.identifier,
             state.from_transfer.hashlock,


### PR DESCRIPTION
This allows a transfer target to reason about received transfers by other means than only matching identifiers with out of band payment requests.

This is e.g. necessary for #651 (an "echo node").
