### PR TITLE
Properly handle exception for duplicated channels

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -5,6 +5,7 @@ from gevent.event import AsyncResult
 
 from ethereum import slogging
 
+from raiden.exceptions import DuplicatedChannel
 from raiden.api.python import RaidenAPI
 from raiden.utils import pex
 from raiden.transfer.state import (
@@ -228,14 +229,15 @@ class ConnectionManager(object):
                         self.token_address,
                         partner
                     )
-                    self.api.deposit(
-                        self.token_address,
-                        partner,
-                        self.initial_funding_per_partner
-                    )
                 # this can fail because of a race condition, where the channel partner opens first
-                except Exception as e:
-                    log.error('could not open a channel', exc_info=e)
+                except DuplicatedChannel:
+                    log.error('partner opened channel first')
+
+                self.api.deposit(
+                    self.token_address,
+                    partner,
+                    self.initial_funding_per_partner
+                )
 
     def find_new_partners(self, number):
         """Search the token network for potential channel partners.

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -19,6 +19,7 @@ from pyethapp.jsonrpc import (
 from pyethapp.rpc_client import topic_encoder, JSONRPCClient, block_tag_encoder
 import requests
 
+from raiden.exceptions import DuplicatedChannelError
 from raiden import messages
 from raiden.exceptions import (
     UnknownAddress,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -19,7 +19,6 @@ from pyethapp.jsonrpc import (
 from pyethapp.rpc_client import topic_encoder, JSONRPCClient, block_tag_encoder
 import requests
 
-from raiden.exceptions import DuplicatedChannelError
 from raiden import messages
 from raiden.exceptions import (
     UnknownAddress,

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from itertools import count
 
 from ethereum import tester, slogging, _solidity
+from ethereum.tester import TransactionFailed
 from ethereum.abi import ContractTranslator
 from ethereum.utils import decode_hex, encode_hex
 from ethereum._solidity import solidity_get_contract_key
@@ -10,7 +11,10 @@ from pyethapp.jsonrpc import address_decoder
 from pyethapp.rpc_client import deploy_dependencies_symbols, dependencies_order_of_build
 
 from raiden import messages
-from raiden.exceptions import UnknownAddress
+from raiden.exceptions import (
+    UnknownAddress,
+    DuplicatedChannelError,
+)
 from raiden.constants import NETTINGCHANNEL_SETTLE_TIMEOUT_MIN, DISCOVERY_REGISTRATION_GAS
 from raiden.utils import (
     get_contract_path,
@@ -518,8 +522,9 @@ class ChannelManagerTesterMock(object):
 
         try:
             netting_channel_address_hex = self.proxy.newChannel(other, settle_timeout)
-        except tester.TransactionFailed:
-            raise Exception('Duplicated channel')
+
+        except TransactionFailed:
+            raise DuplicatedChannelError('Duplicated channel')
 
         self.tester_state.mine(number_of_blocks=1)
 


### PR DESCRIPTION
There is a race condition for connecting with newcomers to a token network: if the connection manager's channel target is not satisfied, it will open a channel with addresses that appear. If the newcomer first opened the channel with us, we will catch an Exception.
*edit*: the same race condition can happen during the initial `connect()` call.

We now expect the `DuplicatedChannel` exception and only `deposit` to the new channel in such cases.