### PR TITLE
Fix overlapping addresses in views

### DIFF
--- a/raiden/raidenwebui/src/app/app.module.ts
+++ b/raiden/raidenwebui/src/app/app.module.ts
@@ -1,10 +1,11 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpModule } from '@angular/http';
+import { HttpModule, Http } from '@angular/http';
 import { DataTableModule, SharedModule, DataListModule, CarouselModule,
     ButtonModule, AccordionModule, GrowlModule, DialogModule, SplitButtonModule,
-    TabViewModule, DropdownModule, MessagesModule, MenuModule } from 'primeng/primeng';
+    TabViewModule, DropdownModule, MessagesModule, MenuModule,
+    TooltipModule } from 'primeng/primeng';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule, Routes } from '@angular/router';
 import { AppComponent } from './app.component';
@@ -20,55 +21,62 @@ import { environment } from '../environments/environment';
 import { HomeComponent } from './components/home/home.component';
 
 const appRoutes: Routes = [
-  { path: 'home', component: HomeComponent},
-  { path: '', redirectTo: '/home', pathMatch: 'full'},
-  { path: 'channels', component: ChannelTableComponent },
-  { path: 'balances', component: TokenNetworkComponent }
+    { path: 'home', component: HomeComponent },
+    { path: '', redirectTo: '/home', pathMatch: 'full' },
+    { path: 'channels', component: ChannelTableComponent },
+    { path: 'balances', component: TokenNetworkComponent }
 ];
-
-@NgModule({
-  declarations: [
-    AppComponent,
-    ChannelTableComponent,
-    EventListComponent,
-    TokenNetworkComponent,
-    HomeComponent
-  ],
-  imports: [
-    RouterModule.forRoot(appRoutes),
-    BrowserModule,
-    FormsModule,
-    ReactiveFormsModule,
-    HttpModule,
-    DataTableModule,
-    SharedModule,
-    DataListModule,
-    CarouselModule,
-    ButtonModule,
-    AccordionModule,
-    GrowlModule,
-    DialogModule,
-    SplitButtonModule,
-    TabViewModule,
-    DropdownModule,
-    MessagesModule,
-    MenuModule,
-    NoopAnimationsModule,
-  ],
-  providers: [ RaidenConfig,
-              {
-                  provide: APP_INITIALIZER,
-                  useFactory: ConfigLoader,
-                  deps: [RaidenConfig],
-                  multi: true
-              },
-              RaidenService,
-              SharedService],
-  bootstrap: [AppComponent]
-})
-export class AppModule { }
 
 export function ConfigLoader(raidenConfig: RaidenConfig) {
     // Note: this factory need to return a function (that return a promise)
     return () => raidenConfig.load(environment.configFile);
 }
+
+@NgModule({
+    declarations: [
+        AppComponent,
+        ChannelTableComponent,
+        EventListComponent,
+        TokenNetworkComponent,
+        HomeComponent,
+    ],
+    imports: [
+        RouterModule.forRoot(appRoutes),
+        BrowserModule,
+        FormsModule,
+        ReactiveFormsModule,
+        HttpModule,
+        DataTableModule,
+        SharedModule,
+        DataListModule,
+        CarouselModule,
+        ButtonModule,
+        AccordionModule,
+        GrowlModule,
+        DialogModule,
+        SplitButtonModule,
+        TabViewModule,
+        DropdownModule,
+        MessagesModule,
+        MenuModule,
+        TooltipModule,
+        NoopAnimationsModule,
+    ],
+    providers: [
+        RaidenConfig,
+        {
+            provide: APP_INITIALIZER,
+            useFactory: ConfigLoader,
+            deps: [RaidenConfig],
+            multi: true
+        },
+        SharedService,
+        {
+            provide: RaidenService,
+            useClass: RaidenService,
+            deps: [Http, RaidenConfig, SharedService],
+        }
+    ],
+    bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/raiden/raidenwebui/src/app/components/channel-table/channel-table.component.html
+++ b/raiden/raidenwebui/src/app/components/channel-table/channel-table.component.html
@@ -6,9 +6,21 @@
     <div *ngIf="channels?.length > 0; then channelData else msg"></div>
     <ng-template #channelData>
       <p-dataTable [value]="channels" class="ui-g-12">
-        <p-column field="channel_address" header="Channel"></p-column>
-        <p-column field="partner_address" header="Partner"></p-column>
-        <p-column field="token_address" header="Token"></p-column>
+        <p-column field="channel_address" header="Channel">
+          <ng-template let-col let-data="rowData" pTemplate="body">
+            <span [title]="data[col.field]">{{ data[col.field] }}</span>
+          </ng-template>
+        </p-column>
+        <p-column field="partner_address" header="Partner">
+          <ng-template let-col let-data="rowData" pTemplate="body">
+            <span [title]="data[col.field]">{{ data[col.field] }}</span>
+          </ng-template>
+        </p-column>
+        <p-column field="token_address" header="Token">
+          <ng-template let-col let-data="rowData" pTemplate="body">
+            <span [title]="data[col.field]">{{ data[col.field] }}</span>
+          </ng-template>
+        </p-column>
         <p-column field="balance" header="Balance" [style]="{width: '70px', 'text-align': 'center'}"></p-column>
         <p-column field="state" header="State" [style]="{width: '70px', 'text-align': 'center'}"></p-column>
         <p-column field="settle_timeout" header="SettleTimeout" [style]="{width: '100px', 'text-align': 'center'}"></p-column>

--- a/raiden/raidenwebui/src/app/components/event-list/event-list.component.ts
+++ b/raiden/raidenwebui/src/app/components/event-list/event-list.component.ts
@@ -10,6 +10,7 @@ import { Event } from '../../models/event';
 export class EventListComponent implements OnInit {
 
     public events: Event[];
+
     constructor(private raidenService: RaidenService) { }
 
     ngOnInit() {
@@ -19,7 +20,7 @@ export class EventListComponent implements OnInit {
     public getRaidenEvents() {
         this.raidenService.getEvents().subscribe(
             (events) => {
-                this.events = <Event[]> events;
+                this.events = <Event[]>events;
             }
         );
     }

--- a/raiden/raidenwebui/src/app/components/token-network/token-network.component.html
+++ b/raiden/raidenwebui/src/app/components/token-network/token-network.component.html
@@ -1,7 +1,11 @@
 <p-dataTable [value]="tokenBalances" [(selection)]="selectedToken" dataKey="address">
   <p-column selectionMode="single" [style]="{'width':'2.3em'}"></p-column>
   <p-column field="symbol" header="Symbol" [style]="{'width':'5em', 'text-align': 'center'}"></p-column>
-  <p-column field="address" header="Address"></p-column>
+  <p-column field="address" header="Address">
+    <ng-template let-col let-data="rowData" pTemplate="body">
+      <span [title]="data[col.field]">{{ data[col.field] }}</span>
+    </ng-template>
+  </p-column>
   <p-column field="name" header="Name"></p-column>
   <p-column field="balance" header="Balance" [style]="{width: '5em', 'text-align': 'center'}"></p-column>
   <p-footer>
@@ -14,22 +18,21 @@
 
 <p-dialog header="Join Token Network" [(visible)]="displayJoinDialog" [responsive]="true" showEffect="fade" [modal]="true" [resizable]="true" width="600">
   <div class="ui-grid ui-grid-responsive ui-fluid" *ngIf="selectedToken">
-      <div class="ui-grid-row">
-          <div class="ui-grid-col-4">
-              <label for="funds">Enter Funds to be allocated</label>
-          </div>
-          <div class="ui-grid-col-8">
-              <input pInputText type="number" [formControl]="funds" class="ui-inputtext ui-corner-all ui-state-default"/>
-          </div>
+    <div class="ui-grid-row">
+      <div class="ui-grid-col-4">
+        <label for="funds">Enter Funds to be allocated</label>
       </div>
+      <div class="ui-grid-col-8">
+        <input pInputText type="number" [formControl]="funds" class="ui-inputtext ui-corner-all ui-state-default" />
+      </div>
+    </div>
   </div>
   <p-footer>
-      <div class="ui-dialog-buttonpane ui-helper-clearfix">
-          <button type="button" pButton icon="fa-plus" label="Join"
-          (click)="joinTokenNetwork()">
+    <div class="ui-dialog-buttonpane ui-helper-clearfix">
+      <button type="button" pButton icon="fa-plus" label="Join" (click)="joinTokenNetwork()">
           </button>
-      </div>
-    </p-footer>
+    </div>
+  </p-footer>
 </p-dialog>
 
 <p-dialog header="Register New Token" [(visible)]="displayRegisterDialog" [responsive]="true" showEffect="fade" [modal]="true" width="600">

--- a/raiden/raidenwebui/src/styles.css
+++ b/raiden/raidenwebui/src/styles.css
@@ -25,3 +25,11 @@ html, body, .my-content {
 .ui-inputtext.ng-dirty.ng-valid {
     border-left: 5px solid #42A948;
 }
+
+.ui-datatable .ui-datatable-thead>tr>th,
+.ui-datatable .ui-datatable-tfoot>tr>td,
+.ui-datatable .ui-datatable-data>tr>td {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}


### PR DESCRIPTION
In Channels and Balances views, as the columns can get quite large because of the addresses, they were overlapping on narrow windows.
This patch adds ellipsis to all datatable fields, as well as "title" for addresses.
This PR shouldn't touch anything outside UI, so can be merged right away.