### PR TITLE
handling ContractSendChannelClose

### DIFF
--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -23,6 +23,7 @@ from raiden.transfer.events import (
     EventTransferReceivedSuccess,
 )
 from raiden.transfer.mediated_transfer.events import (
+    ContractSendChannelClose,
     SendBalanceProof,
     SendMediatedTransfer,
     SendRefundTransfer,
@@ -169,6 +170,13 @@ class StateMachineEventHandler(object):
 
         elif isinstance(event, (EventTransferReceivedSuccess, EventUnlockSuccess)):
             pass
+
+        elif isinstance(event, ContractSendChannelClose):
+            graph = self.raiden.token_to_channelgraph[event.token]
+            channel = graph.address_to_channel[event.channel_address]
+
+            partner_transfer = channel.our_state.balance_proof.transfer
+            channel.external_state.close(partner_transfer)
 
         else:
             log.error('Unknown event {}'.format(type(event)))

--- a/raiden/tests/unit/transfer/mediated_transfer/factories.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/factories.py
@@ -92,7 +92,7 @@ def make_transfer(
     return transfer
 
 
-def make_from(amount, target, from_expiration, initiator=HOP6):
+def make_from(amount, target, from_expiration, initiator=HOP6, secret=None):
     from_route = make_route(
         initiator,
         available_balance=amount,
@@ -104,6 +104,7 @@ def make_from(amount, target, from_expiration, initiator=HOP6):
         target,
         from_expiration,
         identifier=0,
+        secret=secret,
     )
 
     return from_route, from_transfer

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -650,9 +650,9 @@ class NettingChannelTesterMock(object):
         their_encoded = ''
         if their_transfer is not None:
             their_encoded = their_transfer.encode()
-        self.proxy.close(
-            their_encoded,
-        )
+
+        # this transaction may fail if there is a race to close the channel
+        self.proxy.close(their_encoded)
         self.tester_state.mine(number_of_blocks=1)
         log.info(
             'close called',

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -150,8 +150,9 @@ class ContractSendChannelClose(Event):
     on-chain.
     """
 
-    def __init__(self, channel_address):
+    def __init__(self, channel_address, token):
         self.channel_address = channel_address
+        self.token = token
 
 
 class ContractSendWithdraw(Event):

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -538,7 +538,10 @@ def events_for_close(transfers_pair, block_number):
     for pair in reversed(pending_transfers_pairs):
         if is_channel_close_needed(pair, block_number):
             pair.payer_state = 'payer_waiting_close'
-            channel_close = ContractSendChannelClose(pair.payer_route.channel_address)
+            channel_close = ContractSendChannelClose(
+                pair.payer_route.channel_address,
+                pair.payer_transfer.token,
+            )
             events.append(channel_close)
 
     return events

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -143,6 +143,7 @@ class TargetState(State):
         'secret_request',
         'reveal_secret',
         'balance_proof',
+        'waiting_close',
     )
 
     def __init__(


### PR DESCRIPTION
Event close was not properly handled, the channel was not being closed when the unsafe region was entered.