### PR TITLE
disabled catch-all exception

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -242,7 +242,6 @@ class RaidenMessageHandler(object):
             return
 
         graph = self.raiden.token_to_channelgraph[message.token]
-
         if not graph.has_channel(self.raiden.address, message.sender):
             raise UnknownAddress(
                 'Mediated transfer from node without an existing channel: {}'.format(

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -730,8 +730,8 @@ class RaidenProtocol(object):
                         message.sender,
                         ack,
                     )
-                except InvalidAddress:
-                    log.debug("Couldn't send the ACK")
+                except (InvalidAddress, UnknownAddress) as e:
+                    log.debug("Couldn't send the ACK", e=e)
 
             except (UnknownAddress, InvalidNonce, TransferWhenClosed, TransferUnwanted) as e:
                 log.DEV('maybe unwanted transfer', e=e)

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -742,9 +742,6 @@ class RaidenProtocol(object):
                 if log.isEnabledFor(logging.WARN):
                     log.warn(str(e))
 
-            except:  # pylint: disable=bare-except
-                log.exception('unexpected exception raised.')
-
         # payload was not a valid message and decoding failed
         elif log.isEnabledFor(logging.ERROR):
             log.error(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -20,6 +20,7 @@ from pyethapp.rpc_client import topic_encoder, JSONRPCClient, block_tag_encoder
 import requests
 
 from raiden import messages
+from raiden.exceptions import UnknownAddress
 from raiden.constants import NETTINGCHANNEL_SETTLE_TIMEOUT_MIN, DISCOVERY_REGISTRATION_GAS
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
@@ -522,7 +523,7 @@ class Discovery(object):
         endpoint = self.proxy.findEndpointByAddress.call(node_address_hex)
 
         if endpoint == '':
-            raise KeyError('Unknown address {}'.format(pex(node_address_bin)))
+            raise UnknownAddress('Unknown address {}'.format(pex(node_address_bin)))
 
         return endpoint
 

--- a/raiden/tests/integration/test_endpointregistry.py
+++ b/raiden/tests/integration/test_endpointregistry.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from raiden.exceptions import UnknownAddress
 from raiden.utils import make_address, get_contract_path, privatekey_to_address
 from raiden.network.discovery import ContractDiscovery
 
@@ -21,10 +22,10 @@ def test_endpointregistry(private_keys, blockchain_services):
     unregistered_address = make_address()
 
     # get should raise for unregistered addresses
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownAddress):
         contract_discovery.get(my_address)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownAddress):
         contract_discovery.get(unregistered_address)
 
     assert contract_discovery.nodeid_by_host_port(('127.0.0.1', 44444)) is None
@@ -39,7 +40,7 @@ def test_endpointregistry(private_keys, blockchain_services):
     assert contract_discovery.nodeid_by_host_port(('127.0.0.1', 88888)) == my_address
     assert contract_discovery.get(my_address) == ('127.0.0.1', 88888)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownAddress):
         contract_discovery.get(unregistered_address)
 
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -10,6 +10,7 @@ from pyethapp.jsonrpc import address_decoder
 from pyethapp.rpc_client import deploy_dependencies_symbols, dependencies_order_of_build
 
 from raiden import messages
+from raiden.exceptions import UnknownAddress
 from raiden.constants import NETTINGCHANNEL_SETTLE_TIMEOUT_MIN, DISCOVERY_REGISTRATION_GAS
 from raiden.utils import (
     get_contract_path,
@@ -362,7 +363,7 @@ class DiscoveryTesterMock(object):
         endpoint = self.proxy.findEndpointByAddress(node_address_hex)
 
         if endpoint is '':
-            raise KeyError('Unknown address {}'.format(pex(node_address_bin)))
+            raise UnknownAddress('Unknown address {}'.format(pex(node_address_bin)))
 
         return endpoint
 


### PR DESCRIPTION
Disabled catch-all logging in the network protocol module to see what breaks during the tests.