### PR TITLE
removed lock expiration check from netting channel

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -633,27 +633,13 @@ class Channel(object):
             locksroot=current_locksroot,
         )
 
-    def create_lockedtransfer(self, block_number, amount, identifier, expiration, hashlock):
+    def create_lockedtransfer(self, amount, identifier, expiration, hashlock):
         """ Return a LockedTransfer message.
 
         This message needs to be signed and registered with the channel before sent.
         """
-        timeout = expiration - block_number
-
         if not self.can_transfer:
             raise ValueError('Transfer not possible, no funding or channel closed.')
-
-        # the expiration cannot be lower than the reveal timeout (otherwise we
-        # dont have enough time to listen for the ChannelSecretRevealed event)
-        if timeout <= self.reveal_timeout:
-            log.debug(
-                'Lock expiration is lower than reveal timeout.',
-                expiration=expiration,
-                block_number=block_number,
-                reveal_timeout=self.reveal_timeout,
-            )
-
-            raise ValueError('Invalid expiration.')
 
         from_ = self.our_state
         to_ = self.partner_state
@@ -685,7 +671,6 @@ class Channel(object):
 
     def create_mediatedtransfer(
             self,
-            block_number,
             transfer_initiator,
             transfer_target,
             fee,
@@ -708,7 +693,6 @@ class Channel(object):
         """
 
         locked_transfer = self.create_lockedtransfer(
-            block_number,
             amount,
             identifier,
             expiration,
@@ -724,7 +708,6 @@ class Channel(object):
 
     def create_refundtransfer(
             self,
-            block_number,
             transfer_initiator,
             transfer_target,
             fee,
@@ -734,7 +717,6 @@ class Channel(object):
             hashlock):
 
         locked_transfer = self.create_lockedtransfer(
-            block_number,
             amount,
             identifier,
             expiration,

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -93,7 +93,6 @@ class StateMachineEventHandler(object):
             channel = graph.partneraddress_to_channel[receiver]
 
             mediated_transfer = channel.create_mediatedtransfer(
-                self.raiden.get_block_number(),
                 event.initiator,
                 event.target,
                 fee,
@@ -143,7 +142,6 @@ class StateMachineEventHandler(object):
             channel = graph.partneraddress_to_channel[receiver]
 
             refund_transfer = channel.create_refundtransfer(
-                self.raiden.get_block_number(),
                 event.initiator,
                 event.target,
                 fee,

--- a/raiden/tests/benchmark/speed_transfer.py
+++ b/raiden/tests/benchmark/speed_transfer.py
@@ -108,7 +108,6 @@ def transfer_speed(num_transfers=100, max_locked=100):  # pylint: disable=too-ma
     for i, amount in enumerate(amounts):
         hashlock = sha3(secrets[i])
         locked_transfer = channel0.create_lockedtransfer(
-            app0.raiden.get_block_number(),
             amount=amount,
             identifier=1,  # TODO: fill in identifier
             expiration=expiration,

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -82,7 +82,6 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     identifier = 1
     fee = 0
     transfermessage = alice_bob_channel.create_mediatedtransfer(
-        alice_app.raiden.get_block_number(),
         alice_app.raiden.address,
         bob_app.raiden.address,
         fee,
@@ -286,7 +285,6 @@ def test_close_channel_lack_of_balance_proof(
     identifier = 1
     expiration = app0.raiden.get_block_number() + reveal_timeout * 2
     transfer = channel01.create_mediatedtransfer(
-        app0.raiden.get_block_number(),
         app0.raiden.address,
         app1.raiden.address,
         fee,

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -317,7 +317,6 @@ def test_python_channel():
     expiration = block_number + settle_timeout - 5
     identifier = 1
     mediatedtransfer = test_channel.create_mediatedtransfer(
-        block_number,
         address1,
         address2,
         fee,
@@ -431,7 +430,6 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
         block_number = app0.raiden.chain.block_number()
         expiration = block_number + settle_timeout - 1
         mediated_transfer = channel0.create_mediatedtransfer(
-            block_number,
             transfer_initiator=app0.raiden.address,
             transfer_target=app1.raiden.address,
             fee=0,
@@ -592,7 +590,6 @@ def test_locked_transfer(raiden_network, settle_timeout):
     hashlock = sha3(secret)
 
     mediated_transfer = channel0.create_mediatedtransfer(
-        block_number,
         transfer_initiator=app0.raiden.address,
         transfer_target=app1.raiden.address,
         fee=0,
@@ -657,7 +654,6 @@ def test_register_invalid_transfer(raiden_network, settle_timeout):
     hashlock = sha3(secret)
 
     transfer1 = channel0.create_mediatedtransfer(
-        block_number,
         transfer_initiator=app0.raiden.address,
         transfer_target=app1.raiden.address,
         fee=0,

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -130,7 +130,6 @@ def pending_mediated_transfer(app_chain, token, amount, identifier, expiration):
             hashlock = sha3(secret)
 
         transfer_ = from_channel.create_mediatedtransfer(
-            from_app.raiden.get_block_number(),
             initiator_app.raiden.address,
             target_app.raiden.address,
             fee,
@@ -320,7 +319,6 @@ def make_mediated_transfer(
     fee = 0
 
     mediated_transfer = channel.create_mediatedtransfer(  # pylint: disable=redefined-outer-name
-        block_number,
         initiator,
         target,
         fee,

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -349,7 +349,6 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
             )
 
             from_mediated_transfer = from_channel.create_mediatedtransfer(
-                raiden.get_block_number(),
                 raiden.address,
                 to_nodeaddress,
                 fee,
@@ -648,7 +647,6 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
             # make a paying MediatedTransfer with same hashlock/identifier and the
             # taker's paying token/amount
             taker_paying_transfer = taker_paying_channel.create_mediatedtransfer(
-                raiden.get_block_number(),
                 raiden.address,
                 maker_address,
                 fee,


### PR DESCRIPTION
The netting channel is not at a position to properly check the
expiration of the lock. The expiration of the lock is defined by the
transfer task, and it takes into account the current pending number of
block until settlement, the payer lock.expiration, and the channel
reveal_timeout configuration. Once the function to create the locked
transfer is called the lock expiration was already decremented the
reveal timeout and the additional blocks are not required for safety.

An alternative to remove the check from the netting channel is to
provide the base expiration, and the create_lockedtransfer method then
decrements the reveal_timeout prior to creating the transfer, this
allows the channel and the transfer task that there are the required
number of blocks for safety.