### PR TITLE
move channel manager code into the library

### DIFF
--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -5,55 +5,80 @@ import "./NettingChannelContract.sol";
 
 library ChannelManagerLibrary {
     struct Data {
-        mapping(bytes32 => address) channel_addresses;
         Token token;
+
+        address[] all_channels;
+        mapping(bytes32 => uint) partyhash_to_channelpos;
+
+        mapping(address => address[]) nodeaddress_to_channeladdresses;
+        mapping(address => mapping(address => uint)) node_index;
     }
 
-    /// @notice Get the address of the unique channel of two parties.
+    /// @notice Get the address of channel with a partner
     /// @param partner The address of the partner
-    /// @return The address of the NettingChannelContract of the two parties.
-    function getChannelWith(Data storage self, address partner)
-        constant
-        returns (address)
-    {
+    /// @return The address of the channel
+    function getChannelWith(Data storage self, address partner) constant returns (address) {
         bytes32 party_hash = partyHash(msg.sender, partner);
-        return self.channel_addresses[party_hash];
+        uint channel_pos = self.partyhash_to_channelpos[party_hash];
+
+        if (channel_pos != 0) {
+            return self.all_channels[channel_pos - 1];
+        }
     }
 
     /// @notice Create a new payment channel between two parties
     /// @param partner The address of the partner
     /// @param settle_timeout The settle timeout in blocks
-    /// @return The address of the NettingChannelContract.
-    function newChannel(
-        Data storage self,
-        address partner,
-        uint settle_timeout)
-        returns (address channel_address)
+    /// @return The address of the newly created NettingChannelContract.
+    function newChannel(Data storage self, address partner, uint settle_timeout)
+        returns (address)
     {
-        channel_address = new NettingChannelContract(
+        address[] storage caller_channels = self.nodeaddress_to_channeladdresses[msg.sender];
+        address[] storage partner_channels = self.nodeaddress_to_channeladdresses[partner];
+
+        bytes32 party_hash = partyHash(msg.sender, partner);
+        uint channel_pos = self.partyhash_to_channelpos[party_hash];
+
+        address new_channel_address = new NettingChannelContract(
             self.token,
             msg.sender,
             partner,
             settle_timeout
         );
 
-        bytes32 party_hash = partyHash(msg.sender, partner);
-        self.channel_addresses[party_hash] = channel_address;
-    }
+        if (channel_pos != 0) {
+            // Check if the channel was settled. Once a channel is settled it
+            // kills itself, so address must not have code.
+            address settled_channel = self.all_channels[channel_pos - 1];
+            require(!contractExists(settled_channel));
 
-    /// @notice Remove a channel after it's been settled
-    /// @param partner of the partner
-    function deleteChannel(Data storage self, address partner) internal
-    {
-        bytes32 party_hash = partyHash(msg.sender, partner);
-        self.channel_addresses[party_hash] = 0x0;
+            uint caller_pos = self.node_index[msg.sender][partner];
+            uint partner_pos = self.node_index[partner][msg.sender];
+
+            // replace the channel address in-place
+            self.all_channels[channel_pos - 1] = new_channel_address;
+            caller_channels[caller_pos - 1] = new_channel_address;
+            partner_channels[partner_pos - 1] = new_channel_address;
+
+        } else {
+            self.all_channels.push(new_channel_address);
+            caller_channels.push(new_channel_address);
+            partner_channels.push(new_channel_address);
+
+            // using the 1-index, 0 is used for the absence of a value
+            self.partyhash_to_channelpos[party_hash] = self.all_channels.length;
+            self.node_index[msg.sender][partner] = caller_channels.length;
+            self.node_index[partner][msg.sender] = partner_channels.length;
+        }
+
+        return new_channel_address;
     }
 
     /// @notice Get the hash of the two addresses
     /// @param address_one address of one party
     /// @param address_two of the other party
     /// @return The sha3 hash of both parties sorted by size of address
-    function partyHash(address address_one, address address_two) private constant returns (bytes32) {
+    function partyHash(address address_one, address address_two) internal constant returns (bytes32) {
         if (address_one < address_two) {
             return sha3(address_one, address_two);
         } else {
@@ -64,4 +89,16 @@ library ChannelManagerLibrary {
         }
     }
 
+    /// @notice Check if a contract exists
+    /// @param channel The address to check whether a contract is deployed or not
+    /// @return True if a contract exists, false otherwise
+    function contractExists(address channel) private constant returns (bool) {
+        uint size;
+
+        assembly {
+            size := extcodesize(channel)
+        }
+
+        return size > 0;
+    }
 }


### PR DESCRIPTION
- Moved most of the logic into the library to increase code reuse.
- Removed all_channels_index storage variable.