### PR TITLE
Add txpool.pricebump geth argument

### DIFF
--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -77,6 +77,7 @@ def geth_to_cmd(node, datadir, verbosity):
         '--verbosity', str(verbosity),
         '--fakepow',
         '--datadir', datadir,
+        '--txpool.pricebump', '0',
     ])
 
     log.debug('geth command: {}'.format(cmd))


### PR DESCRIPTION
This is not a correct solution for issue
https://github.com/raiden-network/raiden/issues/804, of having the
`JSONRPCClientReplyError: replacement transaction underpriced` pop up in
tests, but at least it seems to reduce its occurence.

I believe it does not hurt to have this argument in the travis tests but
as #804 states we need to find out why in some occurences we are trying
to push for a transaction with the same nonce to our geth node.