### PR TITLE
Return proper error when trying to settle inside settlement period

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -440,7 +440,7 @@ class RestAPI(object):
             except InvalidState:
                 result = make_response(
                     'Settlement period is not yet over',
-                    httplib.BAD_REQUEST,
+                    httplib.CONFLICT,
                 )
             else:
                 result = self.channel_schema.dump(channel_to_api_dict(raiden_service_result))


### PR DESCRIPTION
Return a 400 error with proper message when trying to settle a channel inside settlement period.
Fix #792 