### PR TITLE
Add shortcut state transition to create EventTransferReceivedSuccess

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -90,6 +90,8 @@ class RaidenMessageHandler(object):
 
         state_change = ReceiveSecretReveal(secret, sender)
         self.raiden.state_machine_event_handler.log_and_dispatch_to_all_tasks(state_change)
+        # virtually add the ReceiveBalanceProof until we have
+        # https://github.com/raiden-network/raiden/issues/189
 
     def message_secretrequest(self, message):
         self.raiden.greenlet_task_dispatcher.dispatch_message(

--- a/raiden/tests/utils/__init__.py
+++ b/raiden/tests/utils/__init__.py
@@ -1,5 +1,19 @@
+# -*- coding: utf-8 -*-
 from functools import partial, update_wrapper
 import inspect
+
+from raiden.api.python import RaidenAPI
+
+
+def get_channel_events_for_token(app, token_address, start_block=0):
+    """ Collect all events from all channels for a given `token_address` and `app` """
+    result = list()
+    api = RaidenAPI(app.raiden)
+    channels = api.get_channel_list(token_address=token_address)
+    for channel in channels:
+        events = api.get_channel_events(channel.channel_address, start_block)
+        result.extend(events)
+    return result
 
 
 class OwnedNettingChannel(object):

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -130,6 +130,14 @@ def handle_secretreveal(state, state_change):
     return iteration
 
 
+def virtual_balanceproof(state):
+    """ This does a state transition to 'balance_proof' _without_ receiving a formal balance proof,
+    as described in https://github.com/raiden-network/raiden/issues/189.  """
+    iteration = TransitionResult(state, list())
+    state.state = 'balance_proof'
+    return iteration
+
+
 def handle_balanceproof(state, state_change):
     """ Handle a ReceiveBalanceProof state change. """
     iteration = TransitionResult(state, list())
@@ -238,5 +246,11 @@ def state_transition(state, state_change):
 
         elif isinstance(state_change, Block):
             iteration = handle_block(state, state_change)
+
+        # FIXME: We're adding a virtual transition to balance_proof
+        # until https://github.com/raiden-network/raiden/issues/189 is implemented.
+        # See `virtual_balanceproof(...)`
+        if state.state == 'reveal_secret':
+            iteration = virtual_balanceproof(state)
 
     return clear_if_finalized(iteration)


### PR DESCRIPTION
Since #189 is not implemented, we do not see `EventTransferReceivedSuccess` events (which
are a prerequisite for #651).

This PR adds a method that creates a "virtual" balance proof for the target of a mediated transfer.