### PR TITLE
Compile WebUI files in setup.py build

### DIFF
--- a/raiden/ui/web/README.md
+++ b/raiden/ui/web/README.md
@@ -1,13 +1,14 @@
 # Helper guide to install and test the Raiden UI
 
-* Once you come in the raidenwebui folder please run
+* Once you come in the `raiden/ui/web/` folder please run
+
 > **npm install**.
 
 This will install all the dependencies needed by Angular to run the project.
 
 * We make Cross domain requests to many servers including the Geth Server and Raiden API server we need to proxy our requests hence run the server in this way.
 
-> **ng serve --proxy-config proxy.config.json**
+> **ng serve --proxy-config proxy.config.json --base-href /ui/ --deploy-url /ui/ --delete-output-path false**
 
 You can read more about this [here](https://github.com/angular/angular-cli/blob/master/docs/documentation/stories/proxy.md)
 
@@ -15,9 +16,15 @@ You can read more about this [here](https://github.com/angular/angular-cli/blob/
 
 > **./node_modules/.bin/ng**
 
-* You can also run it with a simple
+* You can also run *serve* command with
 
 > **npm start**
+
+* You can build production-ready UI files with
+
+**npm run build:prod**
+
+It'll lay in the `dist` subfolder, and can be served directly by flask API.
 
 * Inside the folder src/assets/config we have a config.development.json. This file contains configuration details about host port etc for the raiden as well as geth because we query both the api servers simultaneously. We need to change this file so that it can pick up details according our local configuration.
 ```

--- a/raiden/ui/web/package.json
+++ b/raiden/ui/web/package.json
@@ -38,11 +38,11 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.2.1",
+    "@angular/cli": "1.2.4",
     "@angular/compiler-cli": "4.3.1",
     "@types/jasmine": "2.5.53",
     "@types/jquery": "3.2.9",
-    "@types/node": "8.0.14",
+    "@types/node": "8.0.16",
     "codelyzer": "3.1.2",
     "jasmine-core": "2.6.4",
     "jasmine-spec-reporter": "4.1.1",
@@ -53,7 +53,7 @@
     "karma-jasmine": "1.1.0",
     "karma-jasmine-html-reporter": "0.2.2",
     "protractor": "5.1.2",
-    "ts-node": "3.2.0",
+    "ts-node": "3.3.0",
     "tslint": "5.5.0",
     "typescript": "2.4.2"
   }

--- a/raiden/ui/web/package.json
+++ b/raiden/ui/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "npm run serve",
-    "serve": "ng serve --proxy-config proxy.config.json",
+    "serve": "ng serve --proxy-config proxy.config.json --base-href /ui/ --deploy-url /ui/ --delete-output-path false",
     "build": "npm run build:prod",
     "build:dev": "ng build",
     "build:prod": "ng build --prod --aot",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ class BuildPyCommand(build_py):
 
     def run(self):
         self.run_command('compile_contracts')
-        self.run_command('compile_webui')
         # ensure smoketest_config.json is generated
         from raiden.tests.utils.smoketest import load_or_create_smoketest_config
         load_or_create_smoketest_config()

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,15 @@ class CompileWebUI(Command):
             )
         )
 
+        npm_version = subprocess.check_output([npm, '--version'])
+        # require npm 5.x.x or later
+        if not int(npm_version.split('.')[0]) >= 5:
+            self.announce(
+                'NPM 5.x or later required. Skipping webUI compilation',
+                level=distutils.log.WARN,
+            )
+            return
+
         command = [npm, 'install']
         self.announce('Running %r in %r' % (command, cwd), level=distutils.log.INFO)
         subprocess.check_call(command, cwd=cwd)


### PR DESCRIPTION
Modify `setup.py` to also compile webUI files in `setup.py build`, iff `npm` is available at build time. If not, just skip webUI compilation. It should install `raiden/ui/web/node_modules` npm modules and generate files in `raiden/ui//web/dist` folder, without impacting files outside webUI folders.