### PR TITLE
Fix issue 784

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -71,10 +71,14 @@ class RaidenAPI(object):
     def manager_address_if_token_registered(self, token_address):
         """
         If the token is registered then, return the channel manager address.
+        Also make sure that the channel manager is registered with the node.
+
         Returns None otherwise.
         """
         try:
             manager = self.raiden.chain.manager_by_token(token_address)
+            if not self.raiden.channel_manager_is_registered(manager.address):
+                self.raiden.register_channel_manager(manager.address)
             return manager.address
         except (JSONRPCClientReplyError, TransactionFailed):
             return None

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -201,7 +201,7 @@ class RaidenService(object):
 
         # prime the block number cache and set the callbacks
         self._blocknumber = alarm.last_block_number
-        alarm.register_callback(lambda _: self.poll_blockchain_events())
+        alarm.register_callback(self.poll_blockchain_events)
         alarm.register_callback(self.set_block_number)
 
         self.transaction_log = StateChangeLog(
@@ -293,7 +293,7 @@ class RaidenService(object):
     def get_block_number(self):
         return self._blocknumber
 
-    def poll_blockchain_events(self):
+    def poll_blockchain_events(self, current_block):
         on_statechange = self.state_machine_event_handler.on_blockchain_statechange
 
         for state_change in self.pyethapp_blockchain_events.poll_state_change():

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -640,6 +640,9 @@ class RaidenService(object):
                 graph
             )
 
+    def channel_manager_is_registered(self, manager_address):
+        return manager_address in self.manager_to_token
+
     def register_channel_manager(self, manager_address):
         manager = self.chain.manager(manager_address)
         netting_channels = [

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -293,7 +293,8 @@ class RaidenService(object):
     def get_block_number(self):
         return self._blocknumber
 
-    def poll_blockchain_events(self, current_block):
+    def poll_blockchain_events(self, current_block=None):
+        # pylint: disable=unused-argument
         on_statechange = self.state_machine_event_handler.on_blockchain_statechange
 
         for state_change in self.pyethapp_blockchain_events.poll_state_change():

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -54,6 +54,13 @@ class AlarmTask(Task):
 
         self.callbacks.append(callback)
 
+    def remove_callback(self, callback):
+        """Remove callback from the list of callbacks if it exists"""
+        try:
+            self.callbacks.remove(callback)
+        except:
+            pass
+
     def _run(self):  # pylint: disable=method-hidden
         log.debug('starting block number', block_number=self.last_block_number)
 


### PR DESCRIPTION
Fix #784 

In the issue one raiden node registers the token and the second tries to
register but fails with "token already registered" while its token list
is empty.

The Rest API call for token registration first checks if
`manager_address_if_token_registered()` and only if it's not, it proceeds with registering.

If it is registered then it returns a 409, but without having also made sure it is registered with the
node and filled in the tokens list. This registering will happen later
if the "TokenAdded" blockchain event is processed but there is a window
where we can miss it and end up with an empty token list.

This PR addresses that.