### PR TITLE
Api deposit() updates channel balance

### DIFF
--- a/docs/Rest-Api.rst
+++ b/docs/Rest-Api.rst
@@ -397,6 +397,10 @@ Possible Responses
 | 400 Bad Request  | If the provided json is in|
 |                  | some way malformed        |
 +------------------+---------------------------+
+| 408 Request      | If the deposit event was  |
+|     Timeout      | not read in time by the   |
+|                  | ethereum node             |
++------------------+---------------------------+
 | 409 Conflict     | If the input is invalid,  |
 |                  | such as too low settle    |
 |                  | timeout                   |
@@ -533,6 +537,10 @@ Possible Responses
 +------------------+---------------------------+
 | 400 Bad Request  | If the provided json is in|
 |                  | some way malformed        |
++------------------+---------------------------+
+| 408 Request      | If the deposit event was  |
+|     Timeout      | not read in time by the   |
+|                  | ethereum node             |
 +------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -213,8 +213,11 @@ class RaidenAPI(object):
         token.approve(netcontract_address, amount)
 
         # Obtain the netting channel and fund it by depositing the amount
+        old_balance = channel.contract_balance
         netting_channel = self.raiden.chain.netting_channel(netcontract_address)
         netting_channel.deposit(amount)
+        # Also make sure to update the netting_channel.py contract balance
+        channel.our_state.update_contract_balance(old_balance + amount)
 
         return channel
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import gevent
 
 from gevent.event import Event
 from ethereum import slogging
@@ -771,6 +772,14 @@ class Channel(object):
 
             if self.external_state.opened_block == 0:
                 self.external_state.set_opened(block_number)
+
+    def wait_for_balance_update(self, old_balance, wait_time):
+        """Intended to be called inside a greenlet to wait for a change in
+        contract balance. This function has no timeout. Timeout should be given
+        in gevent.wait()"""
+        while self.contract_balance == old_balance:
+            gevent.sleep(wait_time)
+        return True
 
     def serialize(self):
         return ChannelSerialization(self)

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -129,3 +129,9 @@ class UnknownTokenAddress(RaidenError):
 
 class STUNUnavailableException(RaidenError):
     pass
+
+
+class EthNodeCommunicationError(RaidenError):
+    """ Raised when something unexpected has happened during
+    communication with the underlying ethereum node"""
+    pass

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -111,11 +111,6 @@ def test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
 
     api0 = RaidenAPI(app0.raiden)
 
-    # Make sure that the deposit event is not processed to assert that our
-    # test does not accidentally succeed due to the event having been processed
-    # and not due to the deposit() API call code path.
-    app0.raiden.alarm.remove_callback(app0.raiden.poll_blockchain_events)
-
     token_address = token_addresses[0]
     channel_0_1 = channel(app0, app1, token_address)
     old_balance = channel_0_1.contract_balance


### PR DESCRIPTION
This PR addresses only a part of the issue https://github.com/raiden-network/raiden/issues/808.

> Another issue can be seen in this example: as seen in the PATCH request, channel balance isn't being updated, and following requests to /api/1/channels also return old balance.

The API call returned the channel without updating its balance. This PR makes sure that this no longer happens.

Note: The balance would eventually get updated, when the node received and processesed the `ChannelNewBalance` event.