### PR TITLE
Fix for #785: channel with self

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -18,6 +18,7 @@ from raiden.exceptions import (
     InvalidState,
     InvalidSettleTimeout,
     NoPathError,
+    SamePeerAddress,
 )
 from raiden.api.v1.encoding import (
     ChannelSchema,
@@ -244,7 +245,7 @@ class RestAPI(object):
                 partner_address,
                 settle_timeout
             )
-        except (InvalidAddress, InvalidSettleTimeout) as e:
+        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress) as e:
             return make_response(str(e), httplib.CONFLICT)
 
         if balance:

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -58,6 +58,12 @@ class NoPathError(RaidenError):
     pass
 
 
+class SamePeerAddress(RaidenError):
+    """ Raised when a user tries to create a channel where the address of both
+    peers is the same.
+    """
+
+
 # TODO: Use more descriptive exceptions than this
 class InvalidState(RaidenError):
     """ Raised when the user requested action cannot be done due to the current

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -43,6 +43,7 @@ from raiden.blockchain.abi import (
     EVENT_CHANNEL_NEW,
     EVENT_TOKEN_ADDED,
 )
+from raiden.exceptions import SamePeerAddress
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 solidity = _solidity.get_solidity()  # pylint: disable=invalid-name
@@ -751,6 +752,9 @@ class ChannelManager(object):
             raise ValueError('settle_timeout must be larger-or-equal to {}'.format(
                 NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
             ))
+
+        if peer1 == peer2:
+            raise SamePeerAddress('Peer1 and peer2 must not be equal')
 
         if privatekey_to_address(self.client.privkey) == peer1:
             other = peer2

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -28,6 +28,7 @@ from raiden.blockchain.abi import (
     EVENT_CHANNEL_NEW,
     EVENT_TOKEN_ADDED,
 )
+from raiden.exceptions import SamePeerAddress
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 FILTER_ID_GENERATOR = count()
@@ -486,6 +487,9 @@ class ChannelManagerTesterMock(object):
 
         if not isaddress(peer2):
             raise ValueError('The peer2 must be a valid address')
+
+        if peer1 == peer2:
+            raise SamePeerAddress('peer1 and peer2 must not be equal')
 
         if settle_timeout < NETTINGCHANNEL_SETTLE_TIMEOUT_MIN:
             raise ValueError('settle_timeout must be larger-or-equal to {}'.format(


### PR DESCRIPTION
This fixes a situation where someone attempts to create channel with both peers set to the same address.  Instead of "Duplicate channel" more useful exception info is raised. 
The requirement is also checked in the solidity contract.