### PR TITLE
Use channel distributable in API channel call

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -175,7 +175,7 @@ def channel_to_api_dict(channel):
         "token_address": channel.token_address,
         "partner_address": channel.partner_address,
         "settle_timeout": channel.settle_timeout,
-        "balance": channel.contract_balance,
+        "balance": channel.distributable,
         "state": channel.state
     }
 


### PR DESCRIPTION
Fix #831 