### PR TITLE
Disallow using the same port for two instances

### DIFF
--- a/raiden/network/stunsock.py
+++ b/raiden/network/stunsock.py
@@ -60,12 +60,6 @@ def open_bare_socket(
         socket.SOCK_DGRAM  # UDP
     )
 
-    sock.setsockopt(
-        socket.SOL_SOCKET,
-        socket.SO_REUSEADDR,
-        1
-    )
-
     try:
         sock.bind(
             (source_ip, source_port)


### PR DESCRIPTION
Fixes isue #833. Prevents two raiden instances from listening on the same UDP port.