### PR TITLE
Use '0x0' as default for from_block, instead of 'latest', to include logs since genesis. Fix #808

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -92,10 +92,13 @@ def get_contract_events(
         if filter_ is not None:
             filter_.uninstall()
 
-    return [
-        translator.decode_event(event['topics'], event['data'])
-        for event in events
-    ]
+    result = []
+    for event in events:
+        decoded_event = translator.decode_event(event['topics'], event['data'])
+        if event.get('block_number'):
+            decoded_event['block_number'] = event['block_number']
+        result.append(decoded_event)
+    return result
 
 
 # These helpers have a better descriptive name and provide the translator for
@@ -144,7 +147,7 @@ def get_all_netting_channel_events(
         pyethapp_chain,
         netting_channel_address,
         events=ALL_EVENTS,
-        from_block=0,
+        from_block='earliest',
         to_block='latest'):
     """ Helper to get all events of a NettingChannelContract at
     `netting_channel_address`.

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -147,7 +147,7 @@ def get_all_netting_channel_events(
         pyethapp_chain,
         netting_channel_address,
         events=ALL_EVENTS,
-        from_block='earliest',
+        from_block=0,
         to_block='latest'):
     """ Helper to get all events of a NettingChannelContract at
     `netting_channel_address`.

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -187,7 +187,7 @@ def new_filter(jsonrpc_client, contract_address, topics, from_block=None, to_blo
     if isinstance(to_block, int):
         to_block = hex(to_block)
     json_data = {
-        'fromBlock': from_block or 'earliest',
+        'fromBlock': from_block or hex(0),
         'toBlock': to_block or 'latest',
         'address': address_encoder(normalize_address(contract_address)),
     }

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -187,8 +187,8 @@ def new_filter(jsonrpc_client, contract_address, topics, from_block=None, to_blo
     if isinstance(to_block, int):
         to_block = hex(to_block)
     json_data = {
-        'fromBlock': from_block if from_block is not None else 'latest',
-        'toBlock': to_block if to_block is not None else 'latest',
+        'fromBlock': from_block if from_block else 'earliest',
+        'toBlock': to_block if to_block else 'latest',
         'address': address_encoder(normalize_address(contract_address)),
     }
 
@@ -439,11 +439,17 @@ class Filter(object):
                 decode_topic(topic)
                 for topic in log_event['topics']
             ]
+            block_number = log_event.get('blockNumber')
+            if not block_number:
+                block_number = 0
+            else:
+                block_number = int(block_number, 0)
 
             result.append({
                 'topics': topics,
                 'data': data,
                 'address': address,
+                'block_number': block_number,
             })
 
         return result

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -187,8 +187,8 @@ def new_filter(jsonrpc_client, contract_address, topics, from_block=None, to_blo
     if isinstance(to_block, int):
         to_block = hex(to_block)
     json_data = {
-        'fromBlock': from_block if from_block else 'earliest',
-        'toBlock': to_block if to_block else 'latest',
+        'fromBlock': from_block or 'earliest',
+        'toBlock': to_block or 'latest',
         'address': address_encoder(normalize_address(contract_address)),
     }
 

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -147,6 +147,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
         '_event_type': 'TokenAdded',
         'channel_manager_address': address_encoder(manager0.address),
         'token_address': address_encoder(token_address),
+        'block_number': 'ignore',
     })
 
     events = get_all_registry_events(
@@ -179,6 +180,7 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
         'netting_channel': address_encoder(netcontract_address),
         'participant1': address_encoder(app0.raiden.address),
         'participant2': address_encoder(app1.raiden.address),
+        'block_number': 'ignore',
     })
 
     events = get_all_channel_manager_events(

--- a/raiden/ui/web/src/app/components/event-list/event-list.component.ts
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.ts
@@ -43,6 +43,7 @@ export class EventListComponent implements OnInit {
                 // this scan/reducer agregates new events (since next_block) with old ones,
                 // updating next_block if needed. If no next_block previously,
                 // it means it fetched all events, so use only newEvents
+                newEvents.reverse(); // most recent first
                 const events = next_block ? [...newEvents, ...oldEvents] :
                     newEvents.length > 0 ? newEvents : oldEvents;
                 const max_block = Math.max(

--- a/raiden/ui/web/src/app/components/event-list/event-list.component.ts
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.ts
@@ -54,6 +54,12 @@ export class EventListComponent implements OnInit {
                 if (max_block > 0) {
                     next_block = max_block + 1;
                 }
+                for (const event of events) {
+                    if (event.block_number > 0 && !event.timestamp) {
+                        this.raidenService.blocknumberToDate(event.block_number)
+                            .subscribe((date) => event.timestamp = date);
+                    }
+                }
                 return events;
             }, []);
     }

--- a/raiden/ui/web/src/app/models/event.ts
+++ b/raiden/ui/web/src/app/models/event.ts
@@ -1,7 +1,7 @@
 export interface Event {
     event_type: string;
     block_number: number;
-    timestamp?: number;
+    timestamp?: Date;
     token_address?: string;
     channel_manager_address?: string;
     settle_timeout?: number;

--- a/raiden/ui/web/src/app/services/raiden.service.ts
+++ b/raiden/ui/web/src/app/services/raiden.service.ts
@@ -186,6 +186,13 @@ export class RaidenService {
         return this.config.web3.sha3(data, { encoding: 'hex' });
     }
 
+    public blocknumberToDate(block: number): Observable<Date> {
+        return Observable.bindNodeCallback(<(a: number) => any>
+                this.config.web3.eth.getBlock)(block)
+            .map((blk) => new Date(blk['timestamp'] * 1000))
+            .first();
+    }
+
     private getUsertoken(tokenAddress: string, refresh: boolean = true): Usertoken |null {
         const tokenContractInstance = this.tokenContract.at(tokenAddress);
         let userToken: Usertoken |null| undefined = this.userTokens[tokenAddress];

--- a/raiden/ui/web/src/polyfills.ts
+++ b/raiden/ui/web/src/polyfills.ts
@@ -72,6 +72,9 @@ import 'rxjs/add/observable/throw';
 import 'rxjs/add/observable/interval';
 import 'rxjs/add/observable/timer';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/bindNodeCallback';
+
+import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';


### PR DESCRIPTION
Additionally, parse and return **block_number** in events filter, so most of the events retrieved from geth node will be correctly filled with the block_number it happened.
This should fix #808