### PR TITLE
Smoketest - find a free port for geth

### DIFF
--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -1,0 +1,39 @@
+import psutil
+from itertools import count
+
+
+def get_free_port(address, initial_port):
+    """Find an unused TCP port in a specified range. This should not
+      be used in misson-critical applications - a race condition may
+      occur if someone grabs the port before caller of this function
+      has chance to use it.
+      Parameters:
+          address       (string): an ip address of interface to use
+          initial_port  (int)   : port to start iteration with
+      Return:
+          iterator that will return next unused port on a specified
+            interface
+    """
+
+    try:
+        # On OSX this function requires root privileges
+        psutil.net_connections()
+    except psutil.AccessDenied:
+        return count(initial_port)
+
+    def _unused_ports():
+        for port in count(initial_port):
+            # check if the port is being used
+            connect_using_port = (
+                conn
+                for conn in psutil.net_connections()
+                if hasattr(conn, 'laddr') and
+                conn.laddr[0] == address and
+                conn.laddr[1] == port
+            )
+
+            # only generate unused ports
+            if not any(connect_using_port):
+                yield port
+
+    return _unused_ports()

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name
 import os
-from itertools import count
 
 import pytest
-import psutil
+from raiden.network.utils import get_free_port
 from ethereum.utils import sha3
 from pyethapp.jsonrpc import address_encoder
 
@@ -201,27 +200,7 @@ def blockchain_private_keys(blockchain_number_of_nodes, blockchain_key_seed):
 @pytest.fixture(scope='session')
 def port_generator(request):
     """ count generator used to get a unique port number. """
-
-    try:
-        # On OSX this function requires root privileges
-        psutil.net_connections()
-    except psutil.AccessDenied:
-        return count(request.config.option.initial_port)
-
-    def _unused_ports():
-        for port in count(request.config.option.initial_port):
-            # check if the port is being used
-            connect_using_port = (
-                conn
-                for conn in psutil.net_connections()
-                if hasattr(conn, 'laddr') and conn.laddr[1] == port
-            )
-
-            # only generate unused ports
-            if not any(connect_using_port):
-                yield port
-
-    return _unused_ports()
+    return get_free_port('127.0.0.1', request.config.option.initial_port)
 
 
 @pytest.fixture

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -22,6 +22,7 @@ from raiden.blockchain.abi import contract_checksum
 from raiden.transfer.state import CHANNEL_STATE_OPENED
 from raiden.tests.utils.genesis import GENESIS_STUB
 from raiden.tests.fixtures import tester_state
+from raiden.network.utils import get_free_port
 
 # the smoketest will assert that a different endpoint got successfully registered
 TEST_ENDPOINT = '9.9.9.9:9999'
@@ -60,12 +61,6 @@ RST_GETH_BINARY = distutils.spawn.find_executable('geth')
 if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:
     os.environ['RST_GETH_BINARY'] = RST_GETH_BINARY
 
-ports = iter(range(27854, 28000))
-# FIXME: get_free_port does not check for free ports (gh issue #759)
-get_free_port = lambda: str(next(ports))
-
-RST_RPC_PORT = get_free_port()
-os.environ['RST_RPC_PORT'] = RST_RPC_PORT
 
 TEST_ACCOUNT = {
     "version": 3,
@@ -289,6 +284,8 @@ def init_with_genesis(smoketest_genesis):
 
 
 def start_ethereum(smoketest_genesis):
+    RST_RPC_PORT = get_free_port('127.0.0.1', 27854).next()
+    os.environ['RST_RPC_PORT'] = str(RST_RPC_PORT)
     cmd = os.environ.get('RST_ETH_COMMAND', DEFAULT_ETH_COMMAND)
     args = shlex.split(
         Template(cmd).substitute(os.environ)


### PR DESCRIPTION
Find & check a free TCP port that will be later used by geth to bind the RPC interface.

Fixes #759 