### PR TITLE
Prevent two instances from using a same dir

### DIFF
--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -2,6 +2,7 @@
 """ Utilities to set-up a Raiden network. """
 from __future__ import print_function, division
 
+
 from ethereum import slogging
 
 from raiden.app import App

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ marshmallow_polyfield==3.0
 Flask-Cors==3.0.2
 pytest>=3.0.4
 psutil
+filelock


### PR DESCRIPTION
This safety check will prevent two Raiden instances using a same data directory. It uses fcntl() on a known lock file path, and raiden will refuse to start if an exclusive lock for this file exists.

It doesn't prevent anyone from connecting to sqlite database or from altering contents of the data directory.