### PR TITLE
Do not start healthcheck for a bootstrap address

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -642,7 +642,8 @@ class RaidenService(object):
 
     def start_neighbours_healthcheck(self, graph):
         for neighbour in graph.get_neighbours():
-            self.start_health_check_for(neighbour)
+            if neighbour != ConnectionManager.BOOTSTRAP_ADDR:
+                self.start_health_check_for(neighbour)
 
     def channel_manager_is_registered(self, manager_address):
         return manager_address in self.manager_to_token


### PR DESCRIPTION
This isn't really a bug, but I think smoketest shouldn't confuse user with a traceback.