### PR TITLE
Fix deposit not being identified and timing out

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -219,17 +219,11 @@ class RaidenAPI(object):
         netting_channel.deposit(amount)
         # Wait until the balance has been updated via a state transition triggered
         # by processing the `ChannelNewBalance` event
-        wait_for = gevent.spawn(
-            channel.wait_for_balance_update,
-            old_balance,
-            self.raiden.alarm.wait_time
-        )
         wait_timeout_secs = 60
-        gevent.wait([wait_for], timeout=wait_timeout_secs)
-
-        # If balance is still the same then that means we did not get the event
-        # after `timeout` seconds.
-        if old_balance == channel.contract_balance:
+        if not channel.wait_for_balance_update(
+                old_balance,
+                wait_timeout_secs,
+                self.raiden.alarm.wait_time):
             raise EthNodeCommunicationError(
                 'After {} seconds the deposit event was not seen by the ethereum node.'.format(
                     wait_timeout_secs

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import gevent
+import time
 
 from gevent.event import Event
 from ethereum import slogging
@@ -831,13 +832,14 @@ class Channel(object):
             if self.external_state.opened_block == 0:
                 self.external_state.set_opened(block_number)
 
-    def wait_for_balance_update(self, old_balance, wait_time):
-        """Intended to be called inside a greenlet to wait for a change in
-        contract balance. This function has no timeout. Timeout should be given
-        in gevent.wait()"""
-        while self.contract_balance == old_balance:
-            gevent.sleep(wait_time)
-        return True
+    def wait_for_balance_update(self, old_balance, wait_time=60, sleep_for=1):
+        """Intended to be called inside an event loop to wait for a change in
+        contract balance. This function will preemptively wait and return when
+        the balance changed."""
+        start = time.time()
+        while time.time() - start < wait_time and self.contract_balance == old_balance:
+            gevent.sleep(sleep_for)
+        return self.contract_balance != old_balance
 
     def serialize(self):
         return ChannelSerialization(self)


### PR DESCRIPTION
The issue was identified during webUI testing. Deposit events weren't being handled inside Raiden, and deposit http request to the API timed out, even if the event came and even showed up in the UI.
This commit fixed it, changing blocking `gevent.wait` to explicit `while` loop with `gevent.sleep`, which preempts itself in order to not block event loop from events handling.