### PR TITLE
REST api fixes

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -29,6 +29,7 @@ from raiden.exceptions import (
     InvalidSettleTimeout,
     InvalidState,
     InsufficientFunds,
+    NoTokenManager,
 )
 from raiden.utils import (
     isaddress,
@@ -81,7 +82,7 @@ class RaidenAPI(object):
             if not self.raiden.channel_manager_is_registered(manager.address):
                 self.raiden.register_channel_manager(manager.address)
             return manager.address
-        except (JSONRPCClientReplyError, TransactionFailed):
+        except (JSONRPCClientReplyError, TransactionFailed, NoTokenManager):
             return None
 
     def register_token(self, token_address):

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -20,6 +20,9 @@ from raiden.exceptions import (
     InsufficientFunds,
     NoPathError,
     SamePeerAddress,
+    NoTokenManager,
+    AddressWithoutCode,
+    DuplicatedChannelError
 )
 from raiden.api.v1.encoding import (
     ChannelSchema,
@@ -255,7 +258,8 @@ class RestAPI(object):
                 partner_address,
                 settle_timeout
             )
-        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress) as e:
+        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
+                AddressWithoutCode, NoTokenManager, DuplicatedChannelError) as e:
             return make_response(str(e), httplib.CONFLICT)
 
         if balance:

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -141,3 +141,16 @@ class EthNodeCommunicationError(RaidenError):
     """ Raised when something unexpected has happened during
     communication with the underlying ethereum node"""
     pass
+
+
+class AddressWithoutCode(RaidenError):
+    """Raised on attempt to execute contract on address without a code."""
+    pass
+
+
+class NoTokenManager(RaidenError):
+    """Manager for a given token does not exist."""
+
+
+class DuplicatedChannelError(RaidenError):
+    """Raised if someone tries to create a channel that already exists."""


### PR DESCRIPTION
Return E409 instead of E500 for invalid inputs, such as
- token address contract contains no code
- manager for a token does not exist
- attempt to create an already existing channel