### PR TITLE
Fix settle timeout problems

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -159,10 +159,10 @@ class RaidenAPI(object):
         if settle_timeout is None:
             settle_timeout = self.raiden.config['settle_timeout']
 
-        if settle_timeout < self.raiden.config['settle_timeout']:
-            raise InvalidSettleTimeout('Configured minimum `settle_timeout` is {} blocks.'.format(
-                self.raiden.config['settle_timeout']
-            ))
+        if settle_timeout <= reveal_timeout:
+            raise InvalidSettleTimeout(
+                'reveal_timeout can not be larger-or-equal to settle_timeout'
+            )
 
         if not isaddress(token_address):
             raise InvalidAddress('Expected binary address format for token in channel open')

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -210,7 +210,14 @@ class ChannelGraph(object):
         self.channelmanager_address = channelmanager_address
 
         for details in channels_details:
-            self.add_channel(details)
+            try:
+                self.add_channel(details)
+            except ValueError as e:
+                log.warn(
+                    "Error at registering opened channel contract. Perhaps contract is invalid?",
+                    error=str(e),
+                    channel_address=pex(details.channel_address)
+                )
 
     def __eq__(self, other):
         if isinstance(other, ChannelGraph):


### PR DESCRIPTION
This PR does two things:

1. Allow us to have a configurable settle timeout less than the default one. For some reason the API call was taking the default as the minimum.
2. If a channel has already been opened in the blockchain with invalid parameters we can recover from the error and simply ignore it.