### PR TITLE
Add graph edge when registering channel

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -181,7 +181,10 @@ def get_relevant_proxies(pyethapp_chain, node_address, registry_address):
             try:
                 netting_channels.append(pyethapp_chain.netting_channel(channel_address))
             except AddressWithoutCode:
-                log.debug('Invalid netting channel: %r', channel_address)
+                log.debug(
+                    'Settled channel found when starting raiden. Safely ignored',
+                    channel_address=pex(channel_address)
+                )
         manager_channels[channel_manager_address] = netting_channels
 
     proxies = PyethappProxies(

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -247,6 +247,7 @@ class ChannelGraph(object):
             details.reveal_timeout,
             details.settle_timeout,
         )
+        self.add_path(details.our_state.address, partner_state.address)
 
         self.partneraddress_to_channel[partner_state.address] = channel
         self.address_to_channel[channel_address] = channel


### PR DESCRIPTION
Before we were only registering the node in the graph when getting the
`ChannelNew` event. If Raiden restarts and we restore either from the
Channel Manager or from the saved channels then we won't add the channel
to the Graph and will end up not finding a path.