### PR TITLE
Fixed order of statements RaidenService's constructor

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import logging
-
 from ethereum import slogging
 
 from raiden.messages import EnvelopeMessage
@@ -47,19 +45,15 @@ class RaidenMessageHandler(object):
 
     def on_message(self, message, msghash):  # noqa pylint: disable=unused-argument
         """ Handles `message` and sends an ACK on success. """
-        if log.isEnabledFor(logging.INFO):
-            log.info('message received', message=message)
-
         cmdid = message.cmdid
 
-        # using explicity dispatch to make the code grepable
-        if cmdid == messages.ACK:
-            pass
+        # ack and ping messages are not forwarded to the handler
+        # if cmdid == messages.ACK:
+        #     pass
+        # elif cmdid == messages.PING:
+        #     pass
 
-        elif cmdid == messages.PING:
-            pass
-
-        elif cmdid == messages.SECRETREQUEST:
+        if cmdid == messages.SECRETREQUEST:
             self.message_secretrequest(message)
 
         elif cmdid == messages.REVEALSECRET:

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -48,10 +48,6 @@ class RaidenMessageHandler(object):
         cmdid = message.cmdid
 
         # ack and ping messages are not forwarded to the handler
-        # if cmdid == messages.ACK:
-        #     pass
-        # elif cmdid == messages.PING:
-        #     pass
 
         if cmdid == messages.SECRETREQUEST:
             self.message_secretrequest(message)

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -681,10 +681,8 @@ class RaidenProtocol(object):
                     node=pex(self.raiden.address),
                     echohash=pex(echohash),
                     message=message,
+                    sender=pex(message.sender),
                 )
-
-            # ping handler does nothing
-            # self.raiden.on_message(message, echohash)
 
             ack = Ack(
                 self.raiden.address,

--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -113,6 +113,9 @@ class UDPTransport(object):
 
     def start(self):
         assert not self.server.started
+        # server.stop() clears the handle, since this may be a restart the
+        # handle must always be set
+        self.server.set_handle(self.receive)
         self.server.start()
 
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -34,7 +34,7 @@ class AlarmTask(Task):
         self.callbacks = list()
         self.stop_event = AsyncResult()
         self.chain = chain
-        self.last_block_number = self.chain.block_number()
+        self.last_block_number = None
 
         # TODO: Start with a larger wait_time and decrease it as the
         # probability of a new block increases.
@@ -56,10 +56,8 @@ class AlarmTask(Task):
 
     def remove_callback(self, callback):
         """Remove callback from the list of callbacks if it exists"""
-        try:
+        if callback in self.callbacks:
             self.callbacks.remove(callback)
-        except:
-            pass
 
     def _run(self):  # pylint: disable=method-hidden
         log.debug('starting block number', block_number=self.last_block_number)
@@ -81,6 +79,9 @@ class AlarmTask(Task):
                 sleep_time = 0.001
             else:
                 sleep_time = self.wait_time - work_time
+
+        # stopping
+        self.callbacks = list()
 
     def poll_for_new_block(self):
         current_block = self.chain.block_number()
@@ -112,6 +113,10 @@ class AlarmTask(Task):
 
             for callback in remove:
                 self.callbacks.remove(callback)
+
+    def start(self):
+        self.last_block_number = self.chain.block_number()
+        super(AlarmTask, self).start()
 
     def stop_and_wait(self):
         self.stop_event.set(True)

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -140,6 +140,8 @@ def test_fullnetwork(
         amount
     )
 
+    gevent.sleep(0.5)
+
     # This is the only possible path, the transfer must go backwards
     assert_path_mediated_transfer(
         get_sent_transfer(channel_0_3, 0),

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -9,6 +9,7 @@ from raiden.tests.utils.transfer import (
     channel,
     get_sent_transfer,
 )
+from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.log import get_all_state_changes, get_all_state_events
 from raiden.tests.utils.blockchain import wait_until_block
 from raiden.transfer.state_change import (
@@ -57,45 +58,6 @@ def assert_path_mediated_transfer(*transfers):
 
         assert first.recipient == second.sender, 'transfers are out-of-order'
         assert first.lock.expiration > second.lock.expiration, 'lock expiration is not decreasing'
-
-
-def check_nested_attrs(item, data):
-    for name, value in data.iteritems():
-        item_value = getattr(item, name)
-
-        if isinstance(value, dict):
-            if not check_nested_attrs(item_value, value):
-                return False
-
-        elif item_value != value:
-            return False
-
-    return True
-
-
-def must_contain_entry(item_list, type_, data):
-    """ A node might have duplicated state changes or code changes may change
-    order / quantity of the events.
-
-    The number of state changes is non-deterministic since it depends on the
-    number of retries from the protocol layer.
-
-    This is completely non-deterministic since the protocol retries depend on
-    timeouts and the cooperative scheduling of the running greenlets.
-    Additionally the order / quantity of greenlet switches will change as the
-    code evolves.
-
-    This utility checks the list of state changes for an entry of the correct
-    type with the expected data, ignoring *new* fields, repeated entries, and
-    unexpected entries.
-    """
-    # item_list may be composed of state changes or events
-    for item in item_list:
-        if isinstance(item, type_):
-            if check_nested_attrs(item, data):
-                return True
-
-    return False
 
 
 @pytest.mark.parametrize('channels_per_node', [1])

--- a/raiden/tests/integration/test_transfer.py
+++ b/raiden/tests/integration/test_transfer.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from raiden.tests.utils.transfer import assert_mirror, channel
+
+
+@pytest.mark.parametrize('privatekey_seed', ['test_direct_transfer_to_offline_node:{}'])
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('channels_per_node', [1])
+@pytest.mark.parametrize('number_of_tokens', [1])
+def test_direct_transfer_to_offline_node(raiden_network, token_addresses):
+    token_address = token_addresses[0]
+    app0, app1 = raiden_network
+
+    app1.raiden.stop()
+
+    amount = 10
+    target = app1.raiden.address
+    async_result = app0.raiden.transfer_async(
+        token_address,
+        amount,
+        target,
+    )
+
+    assert async_result.wait(5) is None
+
+    app1.raiden.start()
+
+    assert async_result.wait(5) is True
+
+    assert_mirror(
+        channel(app0, app1, token_address),
+        channel(app1, app0, token_address),
+    )

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -178,7 +178,7 @@ def test_token_swap(raiden_network, deposit, settle_timeout):
         taker_address,
     )
 
-    async_result.wait()
+    assert async_result.wait()
 
     # wait for the taker to receive and process the messages
     gevent.sleep(0.5)

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+
+def check_nested_attrs(item, data):
+    for name, value in data.iteritems():
+        item_value = getattr(item, name)
+
+        if isinstance(value, dict):
+            if not check_nested_attrs(item_value, value):
+                return False
+
+        elif item_value != value:
+            return False
+
+    return True
+
+
+def must_contain_entry(item_list, type_, data):
+    """ A node might have duplicated state changes or code changes may change
+    order / quantity of the events.
+
+    The number of state changes is non-deterministic since it depends on the
+    number of retries from the protocol layer.
+
+    This is completely non-deterministic since the protocol retries depend on
+    timeouts and the cooperative scheduling of the running greenlets.
+    Additionally the order / quantity of greenlet switches will change as the
+    code evolves.
+
+    This utility checks the list of state changes for an entry of the correct
+    type with the expected data, ignoring *new* fields, repeated entries, and
+    unexpected entries.
+    """
+    # item_list may be composed of state changes or events
+    for item in item_list:
+        if isinstance(item, type_):
+            if check_nested_attrs(item, data):
+                return True
+
+    return False

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -436,7 +436,7 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
             node_address = raiden.address
             log.debug(
                 'MAKER TOKEN SWAP FAILED',
-                from_=pex(node_address),
+                node=pex(node_address),
                 to=pex(to_nodeaddress),
             )
 


### PR DESCRIPTION
Merge after: #953

- To avoid races, moved the protocol start to the end of the
constructor. Messages may fail to be processed if the node is partially
instantiated.
- Moved the default registry registration out of the database guard.
- Unconditonally waiting for the endpoint registration.