### PR TITLE
Check the socket is open prior to sending ACKs

### DIFF
--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -423,17 +423,17 @@ class RaidenProtocol(object):
         self.transport.start()
 
     def stop_and_wait(self):
-        # Stop handling incoming packets, but doen't close the socket. The
+        # Stop handling incoming packets, but don't close the socket. The
         # socket can only be safely closed after all outgoing tasks are stopped
         self.transport.stop_accepting()
 
-        # Stop processesing the outgoing queues
+        # Stop processing the outgoing queues
         self.event_stop.set()
         gevent.wait(self.greenlets)
 
-        # All outgoing tasks are stopped, now it's safe to close the socket, at
+        # All outgoing tasks are stopped. Now it's safe to close the socket. At
         # this point there might be some incoming message being processed,
-        # keeping is not useful for these.
+        # keeping the socket open is not useful for these.
         self.transport.stop()
 
         # Set all the pending results to False

--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -108,6 +108,9 @@ class UDPTransport(object):
     def stop(self):
         self.server.stop()
 
+    def stop_accepting(self):
+        self.server.stop_accepting()
+
     def start(self):
         assert not self.server.started
         self.server.start()
@@ -176,6 +179,9 @@ class DummyTransport(object):
         self.protocol.receive(data)
 
     def stop(self):
+        pass
+
+    def stop_accepting(self):
         pass
 
     def start(self):


### PR DESCRIPTION
The protocol may stop while an incoming packet is being handled, when
the `RaidenProtocol:receive` finish processing the incoming packet and
tries to send the ACK the transport layer may be already stopped and the
socket closed.