### PR TITLE
Explicit waits in some routes and 'reveal_timeout' option in 'open' calls

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -357,7 +357,8 @@ Example Request
         "partner_address": "0x61c808d82a3ac53231750dadc13c777b59310bd9",
         "token_address": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
         "balance": 35000000,
-        "settle_timeout": 100
+        "settle_timeout": 100,
+        "reveal_timeout": 30
     }
 
 
@@ -378,7 +379,8 @@ Example Response
         "token_address": "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
         "balance": 35000000,
         "state": "open",
-        "settle_timeout": 100
+        "settle_timeout": 100,
+        "reveal_timeout": 30
     }
 
 Possible Responses

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -486,7 +486,7 @@ class RaidenAPI(object):
             amount,
             target,
             identifier=None,
-            timeout=None):
+            timeout=60):
         """ Do a transfer with `target` with the given `amount` of `token_address`. """
         # pylint: disable=too-many-arguments
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -395,12 +395,11 @@ class RestAPI(object):
             identifier = create_default_identifier()
 
         try:
-            transfer_result = self.raiden_api.transfer_and_wait(
+            transfer_result = self.raiden_api.transfer(
                 token_address=token_address,
                 target=target_address,
                 amount=amount,
-                identifier=identifier,
-                timeout=60
+                identifier=identifier
             )
         except (InvalidAmount, InvalidAddress, NoPathError) as e:
             return make_response(str(e), httplib.CONFLICT)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -388,11 +388,12 @@ class RestAPI(object):
             identifier = create_default_identifier()
 
         try:
-            transfer_result = self.raiden_api.transfer(
+            transfer_result = self.raiden_api.transfer_and_wait(
                 token_address=token_address,
                 target=target_address,
                 amount=amount,
-                identifier=identifier
+                identifier=identifier,
+                timeout=60
             )
         except (InvalidAmount, InvalidAddress, NoPathError) as e:
             return make_response(str(e), httplib.CONFLICT)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -251,12 +251,19 @@ class RestAPI(object):
             status_code=httplib.CREATED
         )
 
-    def open(self, partner_address, token_address, settle_timeout, balance=None):
+    def open(
+            self,
+            partner_address,
+            token_address,
+            settle_timeout=None,
+            reveal_timeout=None,
+            balance=None):
         try:
             raiden_service_result = self.raiden_api.open(
                 token_address,
                 partner_address,
-                settle_timeout
+                settle_timeout,
+                reveal_timeout,
             )
         except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
                 AddressWithoutCode, NoTokenManager, DuplicatedChannelError) as e:

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -29,6 +29,7 @@ from raiden.api.objects import (
 )
 from raiden.settings import (
     DEFAULT_SETTLE_TIMEOUT,
+    DEFAULT_REVEAL_TIMEOUT,
     DEFAULT_JOINABLE_FUNDS_TARGET,
     DEFAULT_INITIAL_CHANNEL_TARGET,
 )
@@ -202,6 +203,7 @@ class ChannelRequestSchema(BaseSchema):
     token_address = AddressField(required=True)
     partner_address = AddressField(required=True)
     settle_timeout = fields.Integer(missing=DEFAULT_SETTLE_TIMEOUT)
+    reveal_timeout = fields.Integer(missing=DEFAULT_REVEAL_TIMEOUT)
     balance = fields.Integer(default=None, missing=None)
     state = fields.String(
         default=None,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -20,15 +20,12 @@ def create_blueprint():
 
 
 class BaseResource(Resource):
-    def __init__(self, **kwargs):
-        super(BaseResource, self).__init__()
-        self.rest_api = kwargs['rest_api_object']
+    def __init__(self, rest_api_object, **kwargs):
+        super(BaseResource, self).__init__(**kwargs)
+        self.rest_api = rest_api_object
 
 
 class AddressResource(BaseResource):
-
-    def __init__(self, **kwargs):
-        super(AddressResource, self).__init__(**kwargs)
 
     def get(self):
         return self.rest_api.get_our_address()
@@ -39,9 +36,6 @@ class ChannelsResource(BaseResource):
     put_schema = ChannelRequestSchema(
         exclude=('channel_address', 'state'),
     )
-
-    def __init__(self, **kwargs):
-        super(ChannelsResource, self).__init__(**kwargs)
 
     def get(self):
         """
@@ -57,11 +51,8 @@ class ChannelsResource(BaseResource):
 class ChannelsResourceByChannelAddress(BaseResource):
 
     patch_schema = ChannelRequestSchema(
-        exclude=('token_address', 'partner_address', 'settle_timeout', 'channel_address'),
+        only=('balance', 'state'),
     )
-
-    def __init__(self, **kwargs):
-        super(ChannelsResourceByChannelAddress, self).__init__(**kwargs)
 
     @use_kwargs(patch_schema, locations=('json',))
     def patch(self, **kwargs):
@@ -73,9 +64,6 @@ class ChannelsResourceByChannelAddress(BaseResource):
 
 class TokensResource(BaseResource):
 
-    def __init__(self, **kwargs):
-        super(TokensResource, self).__init__(**kwargs)
-
     def get(self):
         """
         this translates to 'get all token addresses we have channels open for'
@@ -85,9 +73,6 @@ class TokensResource(BaseResource):
 
 class PartnersResourceByTokenAddress(BaseResource):
 
-    def __init__(self, **kwargs):
-        super(PartnersResourceByTokenAddress, self).__init__(**kwargs)
-
     def get(self, **kwargs):
         return self.rest_api.get_partners_by_token(**kwargs)
 
@@ -96,27 +81,24 @@ class NetworkEventsResource(BaseResource):
 
     get_schema = EventRequestSchema()
 
-    def __init__(self, **kwargs):
-        super(NetworkEventsResource, self).__init__(**kwargs)
-
     @use_kwargs(get_schema, locations=('query',))
-    def get(self, **kwargs):
-        return self.rest_api.get_network_events(kwargs['from_block'], kwargs['to_block'])
+    def get(self, from_block, to_block):
+        return self.rest_api.get_network_events(
+            from_block=from_block,
+            to_block=to_block,
+        )
 
 
 class TokenEventsResource(BaseResource):
 
     get_schema = EventRequestSchema()
 
-    def __init__(self, **kwargs):
-        super(TokenEventsResource, self).__init__(**kwargs)
-
     @use_kwargs(get_schema, locations=('query',))
-    def get(self, **kwargs):
+    def get(self, token_address, from_block, to_block):
         return self.rest_api.get_token_network_events(
-            kwargs['token_address'],
-            kwargs['from_block'],
-            kwargs['to_block']
+            token_address=token_address,
+            from_block=from_block,
+            to_block=to_block,
         )
 
 
@@ -124,21 +106,16 @@ class ChannelEventsResource(BaseResource):
 
     get_schema = EventRequestSchema()
 
-    def __init__(self, **kwargs):
-        super(ChannelEventsResource, self).__init__(**kwargs)
-
     @use_kwargs(get_schema, locations=('query',))
-    def get(self, **kwargs):
+    def get(self, channel_address, from_block, to_block):
         return self.rest_api.get_channel_events(
-            kwargs['channel_address'],
-            kwargs['from_block'],
-            kwargs['to_block']
+            channel_address=channel_address,
+            from_block=from_block,
+            to_block=to_block,
         )
 
 
 class RegisterTokenResource(BaseResource):
-    def __init__(self, **kwargs):
-        super(RegisterTokenResource, self).__init__(**kwargs)
 
     def put(self, token_address):
         return self.rest_api.register_token(token_address)
@@ -147,9 +124,6 @@ class RegisterTokenResource(BaseResource):
 class TokenSwapsResource(BaseResource):
 
     put_schema = TokenSwapsSchema()
-
-    def __init__(self, **kwargs):
-        super(TokenSwapsResource, self).__init__(**kwargs)
 
     @use_kwargs(put_schema)
     def put(
@@ -175,11 +149,8 @@ class TokenSwapsResource(BaseResource):
 class TransferToTargetResource(BaseResource):
 
     post_schema = TransferSchema(
-        exclude=('initiator_address', 'target_address', 'token_address')
+        only=('amount', 'identifier'),
     )
-
-    def __init__(self, **kwargs):
-        super(TransferToTargetResource, self).__init__(**kwargs)
 
     @use_kwargs(post_schema, locations=('json',))
     def post(self, token_address, target_address, amount, identifier):
@@ -194,9 +165,6 @@ class TransferToTargetResource(BaseResource):
 class ConnectionsResource(BaseResource):
 
     put_schema = ConnectionsConnectSchema()
-
-    def __init__(self, **kwargs):
-        super(ConnectionsResource, self).__init__(**kwargs)
 
     @use_kwargs(put_schema)
     def put(self, token_address, funds, initial_channel_target, joinable_funds_target):

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-import time
 
-import gevent
 from gevent.event import Event
 from ethereum import slogging
 from ethereum.utils import encode_hex
@@ -846,15 +844,6 @@ class Channel(object):
 
             if self.external_state.opened_block == 0:
                 self.external_state.set_opened(block_number)
-
-    def wait_for_balance_update(self, old_balance, wait_time=60, sleep_for=1):
-        """Intended to be called inside an event loop to wait for a change in
-        contract balance. This function will preemptively wait and return when
-        the balance changed."""
-        start = time.time()
-        while time.time() - start < wait_time and self.contract_balance == old_balance:
-            gevent.sleep(sleep_for)
-        return self.contract_balance != old_balance
 
     def serialize(self):
         return ChannelSerialization(self)

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -145,6 +145,7 @@ def test_channel_to_api_dict():
         'token_address': token_address,
         'partner_address': partner_address,
         'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
         'balance': our_balance,
         'state': CHANNEL_STATE_OPENED
     }
@@ -286,6 +287,7 @@ def test_api_open_and_deposit_channel(
         'partner_address': second_partner_address,
         'token_address': token_address,
         'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
         'balance': balance
     }
     request = grequests.put(
@@ -322,6 +324,7 @@ def test_api_open_and_deposit_channel(
         'partner_address': first_partner_address,
         'token_address': token_address,
         'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
         'state': CHANNEL_STATE_OPENED,
         'balance': balance
     }
@@ -344,6 +347,7 @@ def test_api_open_and_deposit_channel(
         'partner_address': second_partner_address,
         'token_address': token_address,
         'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
         'state': CHANNEL_STATE_OPENED,
         'balance': balance
     }
@@ -399,6 +403,7 @@ def test_api_open_close_and_settle_channel(
         'partner_address': partner_address,
         'token_address': token_address,
         'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
         'state': CHANNEL_STATE_CLOSED,
         'balance': balance
     }
@@ -420,6 +425,7 @@ def test_api_open_close_and_settle_channel(
         'partner_address': partner_address,
         'token_address': token_address,
         'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
         'state': CHANNEL_STATE_SETTLED,
         'balance': balance
     }
@@ -458,10 +464,12 @@ def test_api_channel_state_change_errors(
     partner_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
     settle_timeout = 1650
+    reveal_timeout = 30
     channel_data_obj = {
         'partner_address': partner_address,
         'token_address': token_address,
-        'settle_timeout': settle_timeout
+        'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
     }
     request = grequests.put(
         api_url_for(api_backend, 'channelsresource'),

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -255,10 +255,12 @@ def test_api_open_and_deposit_channel(
     first_partner_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
     settle_timeout = 1650
+    reveal_timeout = 30
     channel_data_obj = {
         'partner_address': first_partner_address,
         'token_address': token_address,
-        'settle_timeout': settle_timeout
+        'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
     }
     request = grequests.put(
         api_url_for(api_backend, 'channelsresource'),
@@ -356,10 +358,12 @@ def test_api_open_close_and_settle_channel(
     partner_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
     settle_timeout = 1650
+    reveal_timeout = 30
     channel_data_obj = {
         'partner_address': partner_address,
         'token_address': token_address,
-        'settle_timeout': settle_timeout
+        'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
     }
     request = grequests.put(
         api_url_for(api_backend, 'channelsresource'),
@@ -431,10 +435,12 @@ def test_api_open_channel_invalid_input(
     partner_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
     settle_timeout = NETTINGCHANNEL_SETTLE_TIMEOUT_MIN - 1
+    reveal_timeout = 30
     channel_data_obj = {
         'partner_address': partner_address,
         'token_address': token_address,
-        'settle_timeout': settle_timeout
+        'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
     }
     request = grequests.put(
         api_url_for(api_backend, 'channelsresource'),

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 import string
+import gevent
+import time
 
 from coincurve import PrivateKey
 from ethereum.utils import remove_0x_head
@@ -150,3 +152,22 @@ def fix_tester_storage(storage):
         new_val = '0x%064x' % int(val, 16)
         new_storage[new_key] = new_val
     return new_storage
+
+
+def wait_until(func, wait_for=None, sleep_for=1):
+    """Preemptively (gevent) test for a function and wait for it to return a
+    truth value and returns it, or None if a timeout is given and the function
+    didn't return inside time timeout
+    Args:
+        func (callable): a function to be evaluated, use lambda if parameters are required
+        wait_for (float, integer, None): the maximum time to wait, or None for infinite loop
+        sleep_form (float, integer): how much to gevent.sleep between calls
+    Returns:
+        func(): result of func, if truth value, or None"""
+    start = time.time()
+    res = func()
+    while (True if wait_for is None else (time.time() - start < wait_for))\
+            and not res:
+        gevent.sleep(sleep_for)
+        res = func()
+    return res or None

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -131,6 +131,7 @@ def channel_to_api_dict(channel):
         'token_address': channel.token_address,
         'partner_address': channel.partner_address,
         'settle_timeout': channel.settle_timeout,
+        'reveal_timeout': channel.reveal_timeout,
         'balance': channel.distributable,
         'state': channel.state
     }


### PR DESCRIPTION
This PR makes mainly two changes:
- Add `wait_until` helper function and use it through the API to preemptively wait for some condition (made in the form of a `lambda`) to become true. Mainly, it adds timeouts for `open` and `transfer`, which were both presenting the issue on requests getting stuck and not providing correct responses to the API calls. This change may fail, and further testing is required.
- Support `reveal_timeout` in `open` API calls, so we can provide this option through webUI.