### PR TITLE
Fix 892

### DIFF
--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -1,12 +1,13 @@
 pragma solidity ^0.4.11;
 
 import "./Token.sol";
+import "./Utils.sol";
 import "./ChannelManagerLibrary.sol";
 
 // for each token a manager will be deployed, to reduce gas usage for manager
 // deployment the logic is moved into a library and this contract will work
 // only as a proxy/state container.
-contract ChannelManagerContract {
+contract ChannelManagerContract is Utils {
     using ChannelManagerLibrary for ChannelManagerLibrary.Data;
     ChannelManagerLibrary.Data data;
 
@@ -40,10 +41,19 @@ contract ChannelManagerContract {
         address[] memory result;
         NettingChannelContract channel;
 
-        result = new address[](data.all_channels.length * 2);
+        uint open_channels_num = 0;
+        for (i = 0; i < data.all_channels.length; i++) {
+            if (contractExists(data.all_channels[i])) {
+                open_channels_num += 1;
+            }
+        }
+        result = new address[](open_channels_num * 2);
 
         pos = 0;
         for (i = 0; i < data.all_channels.length; i++) {
+            if (!contractExists(data.all_channels[i])) {
+                continue;
+            }
             channel = NettingChannelContract(data.all_channels[i]);
 
             var (address1, , address2, ) = channel.addressAndBalance();

--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -89,6 +89,9 @@ library ChannelManagerLibrary {
         }
     }
 
+    /// TODO: Find a way to remove this function duplication from Utils.sol here
+    ///       At the moment libraries can't inherit so we need to add this here
+    ///       explicitly.
     /// @notice Check if a contract exists
     /// @param channel The address to check whether a contract is deployed or not
     /// @return True if a contract exists, false otherwise

--- a/raiden/smart_contracts/Utils.sol
+++ b/raiden/smart_contracts/Utils.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.11;
+
+contract Utils {
+    /// @notice Check if a contract exists
+    /// @param channel The address to check whether a contract is deployed or not
+    /// @return True if a contract exists, false otherwise
+    function contractExists(address channel) constant returns (bool) {
+        uint size;
+
+        assembly {
+            size := extcodesize(channel)
+        }
+
+        return size > 0;
+    }
+}

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -6,7 +6,6 @@ from ethereum.tester import TransactionFailed
 from ethereum.utils import encode_hex
 
 from raiden.utils import privatekey_to_address, sha3
-from raiden.tests.utils.blockchain import wait_until_block
 from raiden.tests.utils.tester import (
     new_channelmanager,
     new_nettingcontract,


### PR DESCRIPTION
Fix #892 

If one channel from a token network has been settled then a call to `channel_manager.getChannelsParticipants()` would always return an empty list. This PR fixes it by making sure that the returned list skips any contracts already settled, by checking if they got code or not.