### PR TITLE
Use eth_getLogs to fetch events. Fix #452

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -12,7 +12,7 @@ from raiden.blockchain.abi import (
     CONTRACT_REGISTRY,
 )
 from raiden.utils import pex
-from raiden.network.rpc.client import new_filter, Filter
+from raiden.network.rpc.client import get_filter_events
 
 from raiden.transfer.mediated_transfer.state_change import (
     ContractReceiveTokenAdded,
@@ -77,21 +77,13 @@ def get_contract_events(
     # one using `eth_getLogs`. It will require changes in all testing frameworks
     # to be implemented though.
 
-    filter_ = None
-    pyethapp_client = pyethapp_chain.client
-    try:
-        filter_id_raw = new_filter(
-            pyethapp_client,
-            contract_address,
-            topics=topics,
-            from_block=from_block,
-            to_block=to_block
-        )
-        filter_ = Filter(pyethapp_client, filter_id_raw)
-        events = filter_.getall()
-    finally:
-        if filter_ is not None:
-            filter_.uninstall()
+    events = get_filter_events(
+        pyethapp_chain.client,
+        contract_address,
+        topics=topics,
+        from_block=from_block,
+        to_block=to_block
+    )
 
     result = []
     for event in events:

--- a/raiden/ui/web/src/app/components/event-list/event-list.component.html
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.html
@@ -1,5 +1,5 @@
 <div class="ui-widget-header" style="padding:4px 10px;border-bottom: 0 none">
-  <i class="fa fa-search" style="margin:4px 4px 0 0"></i>
+  <i class="fa fa-fw" [ngClass]="loading ? 'fa-spinner fa-pulse' : 'fa-search'" style="margin:4px 4px 0 0"></i>
   <input #gb type="text" pInputText size="25" placeholder="Filter" class="ui-inputtext ui-corner-all ui-state-default">
 </div>
 <p-dataTable [value]="events$ | async" expandableRows="true" paginator="true" [rows]="10" resizableColumns="true" [globalFilter]="gb">

--- a/raiden/ui/web/src/app/components/event-list/event-list.component.ts
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { RaidenService } from '../../services/raiden.service';
 import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
+import { RaidenService } from '../../services/raiden.service';
 import { Event, EventsParam } from '../../models/event';
 
 const INTERVAL = 5000;
+const BLOCK_START = 1422953; // block where the registry contract was deployed
 
 @Component({
     selector: 'app-event-list',
@@ -17,14 +19,21 @@ export class EventListComponent implements OnInit {
     @Output() activity: EventEmitter<void> = new EventEmitter<void>();
 
     public events$: Observable<Event[]>;
+    public loading = true;
 
     constructor(private raidenService: RaidenService) { }
 
     ngOnInit() {
-        let next_block: number | undefined;
+        let from: number = BLOCK_START;
+        let first = true;
         const data_excl = ['event_type', 'block_number', 'timestamp'];
-        this.events$ = Observable.timer(0, INTERVAL)
-            .switchMap(() => this.raidenService.getEvents(this.eventsParam, next_block))
+        const firerSub: BehaviorSubject<void> = new BehaviorSubject(null);
+        this.events$ = firerSub
+            .do(() => this.loading = true)
+            .switchMap(() => this.raidenService.getEvents(
+                    this.eventsParam,
+                    from)
+                .finally(() => this.loading = false))
             .map((events) => events.map((event) =>
                 <Event>Object.assign(event,
                     {
@@ -35,28 +44,19 @@ export class EventListComponent implements OnInit {
                 ))
             )
             .do((newEvents) => {
-                if (newEvents.length > 0 && next_block !== undefined) {
+                if (newEvents.length > 0 && !first) {
                     this.activity.emit();
                 }
-                if (next_block === undefined) {
-                    next_block = 0;
-                }
+                first = false;
+                from = this.raidenService.blockNumber + 1;
             })
             .scan((oldEvents, newEvents) => {
                 // this scan/reducer agregates new events (since next_block) with old ones,
                 // updating next_block if needed. If no next_block previously,
                 // it means it fetched all events, so use only newEvents
                 newEvents.reverse(); // most recent first
-                const events = next_block ? [...newEvents, ...oldEvents] :
+                const events = !first ? [...newEvents, ...oldEvents] :
                     newEvents.length > 0 ? newEvents : oldEvents;
-                const max_block = Math.max(
-                    ...newEvents
-                        .map((event) => event.block_number)
-                        .filter((block_number) => !isNaN(block_number))
-                );
-                if (max_block > 0) {
-                    next_block = max_block + 1;
-                }
                 for (const event of events) {
                     if (event.block_number > 0 && !event.timestamp) {
                         this.raidenService.blocknumberToDate(event.block_number)
@@ -64,6 +64,7 @@ export class EventListComponent implements OnInit {
                     }
                 }
                 return events;
-            }, []);
+            }, [])
+            .do(() => setTimeout(() => firerSub.next(null), INTERVAL));
     }
 }

--- a/raiden/ui/web/src/app/services/raiden.service.ts
+++ b/raiden/ui/web/src/app/services/raiden.service.ts
@@ -34,6 +34,10 @@ export class RaidenService {
         return this._identifier++;
     }
 
+    get blockNumber(): number {
+        return this.config.web3.eth.blockNumber;
+    }
+
     public getRaidenAddress(): Observable<string> {
         return this.http.get(`${this.config.api}/address`)
             .map((response) => this.raidenAddress = response.json().our_address)
@@ -177,7 +181,7 @@ export class RaidenService {
 
     public getEvents(
         eventsParam: EventsParam,
-        fromBlock?: number | undefined): Observable<Event[]> {
+        fromBlock?: number): Observable<Event[]> {
         let path: string;
         if (eventsParam.channel) {
             path = `channels/${eventsParam.channel}`;


### PR DESCRIPTION
Also, fix events fetching in webUI so it can get only events since contracts are deployed (avoid querying whole chain), and after initial events fetch, fetch only `latest` block. This should make webUI and events watching usable with **geth**.