### PR TITLE
Add registry address to serialized data

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -81,6 +81,7 @@ from raiden.messages import (
 from raiden.network.protocol import (
     RaidenProtocol,
 )
+from raiden.constants import ROPSTEN_REGISTRY_ADDRESS
 from raiden.connection_manager import ConnectionManager
 from raiden.utils import (
     isaddress,
@@ -125,6 +126,7 @@ def save_snapshot(serialization_file, raiden):
         'receivedhashes_to_acks': raiden.protocol.receivedhashes_to_acks,
         'nodeaddresses_to_nonces': raiden.protocol.nodeaddresses_to_nonces,
         'transfers': raiden.identifier_to_statemanagers,
+        'registry_address': ROPSTEN_REGISTRY_ADDRESS,
     }
 
     with open(serialization_file, 'wb') as handler:
@@ -279,8 +281,13 @@ class RaidenService(object):
 
     def restore_from_snapshots(self):
         data = load_snapshot(self.serialization_file)
+        data_exists_and_is_recent = (
+            data is not None and
+            'registry_address' in data and
+            data['registry_address'] == ROPSTEN_REGISTRY_ADDRESS
+        )
 
-        if data:
+        if data_exists_and_is_recent:
             for channel in data['channels']:
                 try:
                     self.restore_channel(channel)


### PR DESCRIPTION
If we start raiden after a contract upgrade we will get an exception due
to a key error due to trying to load channels from non-existing channel
managers.

```
No handlers could be found for logger "filelock"
DEBUG:raiden.tasks      starting block number block_number=1527082
DEBUG:eth.chain.tx      deserialized tx tx=54b07621
Traceback (most recent call last):
  File "/home/lefteris/.virtualenvs/raiden/bin/raiden", line 11, in <module>
    load_entry_point('raiden', 'console_scripts', 'raiden')()
  File "/home/lefteris/ew/raiden/raiden/__main__.py", line 11, in main
    run(auto_envvar_prefix='RAIDEN')
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 443, in run
    app_ = ctx.invoke(app, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 354, in app
    return App(config, blockchain_service, discovery)
  File "/home/lefteris/ew/raiden/raiden/app.py", line 77, in __init__
    config,
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 273, in __init__
    self.restore_from_snapshots()
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 286, in restore_from_snapshots
    self.restore_channel(channel)
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 586, in restore_channel                                                                                                                                                                                             graph = self.token_to_channelgraph[token_address]
KeyError: '\x9a\xbaR\x9d\xb3\xff-\x84\t\xa1\xdaL\x9e\xb1H\x87\x9b\x04g\x00'
```

In order to mitigate for such a scenario we are adding the registry
address to the serialized data, and if it's a different address we do
not load the data.