### PR TITLE
Save and restore transferred amount

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -894,7 +894,7 @@ class ChannelSerialization(object):
                 self.our_balance_proof == other.our_balance_proof and
                 self.partner_balance_proof == other.partner_balance_proof and
                 self.our_transferred_amount == other.our_transferred_amount and
-                self.partrner_transferred_amount == other.partner_transferred_amount
+                self.partner_transferred_amount == other.partner_transferred_amount
             )
         return False
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -880,6 +880,9 @@ class ChannelSerialization(object):
         self.our_balance_proof = channel_instance.our_state.balance_proof
         self.partner_balance_proof = channel_instance.partner_state.balance_proof
 
+        self.our_transferred_amount = channel_instance.our_state.transferred_amount
+        self.partner_transferred_amount = channel_instance.partner_state.transferred_amount
+
     def __eq__(self, other):
         if isinstance(other, ChannelSerialization):
             return (
@@ -889,7 +892,9 @@ class ChannelSerialization(object):
                 self.our_address == other.our_address and
                 self.reveal_timeout == other.reveal_timeout and
                 self.our_balance_proof == other.our_balance_proof and
-                self.partner_balance_proof == other.partner_balance_proof
+                self.partner_balance_proof == other.partner_balance_proof and
+                self.our_transferred_amount == other.our_transferred_amount and
+                self.partrner_transferred_amount == other.partner_transferred_amount
             )
         return False
 

--- a/raiden/channel/participant_state.py
+++ b/raiden/channel/participant_state.py
@@ -11,7 +11,12 @@ log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
 class ChannelEndState(object):
     """ Tracks the state of one of the participants in a channel. """
 
-    def __init__(self, participant_address, participant_balance, opened_block):
+    def __init__(
+            self,
+            participant_address,
+            participant_balance,
+            opened_block,
+            transferred_amount=0):
         # since ethereum only uses integral values we cannot use float/Decimal
         if not isinstance(participant_balance, (int, long)):
             raise ValueError('participant_balance must be an integer.')
@@ -23,7 +28,7 @@ class ChannelEndState(object):
         self.address = participant_address
 
         # amount of token transferred and unlocked
-        self.transferred_amount = 0
+        self.transferred_amount = transferred_amount
 
         # Sequential nonce, current value has not been used, 0 must not be used
         # since in the netting contract it represents null.

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -563,11 +563,14 @@ class RaidenService(object):
             channel_details['our_address'],
             channel_details['our_balance'],
             opened_block,
+            serialized_channel.our_transferred_amount
         )
+
         partner_state = ChannelEndState(
             channel_details['partner_address'],
             channel_details['partner_balance'],
             opened_block,
+            serialized_channel.partner_transferred_amount
         )
 
         def register_channel_for_hashlock(channel, hashlock):

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -288,15 +288,27 @@ class RaidenService(object):
         )
 
         if data_exists_and_is_recent:
+            first_channel = True
             for channel in data['channels']:
                 try:
                     self.restore_channel(channel)
+                    first_channel = False
                 except AddressWithoutCode as e:
                     log.warn(
                         'Channel without code while restoring. Must have been '
                         'already settled while we were offline.',
                         error=str(e)
                     )
+                except AttributeError as e:
+                    if first_channel:
+                        log.warn(
+                            'AttributeError during channel restoring. If code has changed'
+                            ' then this is fine. If not then please report a bug.',
+                            error=str(e)
+                        )
+                        break
+                    else:
+                        raise
 
             for restored_queue in data['queues']:
                 self.restore_queue(restored_queue)


### PR DESCRIPTION
If we do a few direct transfers and then shut raiden down for a bit then we have a problem.

Once we restart raiden, then the channel would show we have the same balance as
before we did any transfer since it did not restore our transferred amount or our
partner's state amount.

This PR simply adds it to the pickled data and restores it.