### PR TITLE
Add our_state.nonce to serialization

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -883,6 +883,8 @@ class ChannelSerialization(object):
         self.our_transferred_amount = channel_instance.our_state.transferred_amount
         self.partner_transferred_amount = channel_instance.partner_state.transferred_amount
 
+        self.our_nonce = channel_instance.our_state.nonce
+
     def __eq__(self, other):
         if isinstance(other, ChannelSerialization):
             return (
@@ -894,7 +896,8 @@ class ChannelSerialization(object):
                 self.our_balance_proof == other.our_balance_proof and
                 self.partner_balance_proof == other.partner_balance_proof and
                 self.our_transferred_amount == other.our_transferred_amount and
-                self.partner_transferred_amount == other.partner_transferred_amount
+                self.partner_transferred_amount == other.partner_transferred_amount and
+                self.our_nonce == other.our_nonce
             )
         return False
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -575,8 +575,9 @@ class RaidenService(object):
             channel_details['our_address'],
             channel_details['our_balance'],
             opened_block,
-            serialized_channel.our_transferred_amount
+            serialized_channel.our_transferred_amount,
         )
+        our_state.nonce = serialized_channel.our_nonce
 
         partner_state = ChannelEndState(
             channel_details['partner_address'],


### PR DESCRIPTION
This could be a possible solution to
https://github.com/raiden-network/raiden/issues/903.

If we have made direct transfers in a channel and then restart and use
that channel again either for direct or mediated transfers the nonce our
partner would expect would be different than the one we send since it
was not being serialized.

With this PR we serialize it.

If this PR is merged it's advised to remove your `~/.raiden` directory before restarting.