### PR TITLE
Add some timeouts to open and transfer

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import gevent
 from gevent.event import AsyncResult
 from ethereum import slogging
 from ethereum.tester import TransactionFailed
@@ -34,6 +33,7 @@ from raiden.exceptions import (
 from raiden.utils import (
     isaddress,
     pex,
+    wait_until,
 )
 
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -127,8 +127,12 @@ class RaidenAPI(object):
             self.raiden.chain.default_registry.add_token(token_address)
 
             # wait for registration
-            while token_address not in self.raiden.tokens_to_connectionmanagers:
-                gevent.sleep(self.raiden.alarm.wait_time)
+            wait_timeout_secs = 60
+            assert wait_until(
+                lambda: token_address in self.raiden.tokens_to_connectionmanagers,
+                wait_timeout_secs,
+                self.raiden.alarm.wait_time
+            ), "Timeout in token_address wait"
             connection_manager = self.raiden.connection_manager_for_token(token_address)
 
         connection_manager.connect(
@@ -178,12 +182,27 @@ class RaidenAPI(object):
             partner_address,
             settle_timeout,
         )
-        while netcontract_address not in self.raiden.chain.address_to_nettingchannel:
-            gevent.sleep(self.raiden.alarm.wait_time)
+        wait_timeout_secs = 60
+        if not wait_until(
+                lambda: netcontract_address in self.raiden.chain.address_to_nettingchannel,
+                wait_timeout_secs,
+                self.raiden.alarm.wait_time):
+            raise EthNodeCommunicationError(
+                'After {} seconds, the netting channel was not seen.'.format(
+                    wait_timeout_secs
+                )
+            )
 
         graph = self.raiden.token_to_channelgraph[token_address]
-        while partner_address not in graph.partneraddress_to_channel:
-            gevent.sleep(self.raiden.alarm.wait_time)
+        if not wait_until(
+                lambda: partner_address in graph.partneraddress_to_channel,
+                wait_timeout_secs,
+                self.raiden.alarm.wait_time):
+            raise EthNodeCommunicationError(
+                'After {} seconds, the channel was not seen opened.'.format(
+                    wait_timeout_secs
+                )
+            )
         channel = graph.partneraddress_to_channel[partner_address]
         return channel
 
@@ -221,8 +240,8 @@ class RaidenAPI(object):
         # Wait until the balance has been updated via a state transition triggered
         # by processing the `ChannelNewBalance` event
         wait_timeout_secs = 60
-        if not channel.wait_for_balance_update(
-                old_balance,
+        if not wait_until(
+                lambda: channel.contract_balance != old_balance,
                 wait_timeout_secs,
                 self.raiden.alarm.wait_time):
             raise EthNodeCommunicationError(
@@ -467,7 +486,7 @@ class RaidenAPI(object):
             amount,
             target,
             identifier=None,
-            timeout=None):
+            timeout=60):
         """ Do a transfer with `target` with the given `amount` of `token_address`. """
         # pylint: disable=too-many-arguments
 
@@ -477,7 +496,7 @@ class RaidenAPI(object):
             target,
             identifier,
         )
-        return async_result.wait(timeout=timeout)
+        return async_result.get(timeout=timeout)
 
     # expose a synchronous interface to the user
     token_swap = token_swap_and_wait

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -396,7 +396,7 @@ class RestAPI(object):
                 token_address=token_address,
                 target=target_address,
                 amount=amount,
-                identifier=identifier
+                identifier=identifier,
             )
         except (InvalidAmount, InvalidAddress, NoPathError) as e:
             return make_response(str(e), httplib.CONFLICT)

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-import time
 
-import gevent
 from gevent.event import Event
 from ethereum import slogging
 from ethereum.utils import encode_hex
@@ -846,15 +844,6 @@ class Channel(object):
 
             if self.external_state.opened_block == 0:
                 self.external_state.set_opened(block_number)
-
-    def wait_for_balance_update(self, old_balance, wait_time=60, sleep_for=1):
-        """Intended to be called inside an event loop to wait for a change in
-        contract balance. This function will preemptively wait and return when
-        the balance changed."""
-        start = time.time()
-        while time.time() - start < wait_time and self.contract_balance == old_balance:
-            gevent.sleep(sleep_for)
-        return self.contract_balance != old_balance
 
     def serialize(self):
         return ChannelSerialization(self)

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 import string
+import gevent
+import time
 
 from coincurve import PrivateKey
 from ethereum.utils import remove_0x_head
@@ -150,3 +152,22 @@ def fix_tester_storage(storage):
         new_val = '0x%064x' % int(val, 16)
         new_storage[new_key] = new_val
     return new_storage
+
+
+def wait_until(func, wait_for=None, sleep_for=1):
+    """Preemptively (gevent) test for a function and wait for it to return a
+    truth value and returns it, or None if a timeout is given and the function
+    didn't return inside time timeout
+    Args:
+        func (callable): a function to be evaluated, use lambda if parameters are required
+        wait_for (float, integer, None): the maximum time to wait, or None for infinite loop
+        sleep_form (float, integer): how much to gevent.sleep between calls
+    Returns:
+        func(): result of func, if truth value, or None"""
+    start = time.time()
+    res = func()
+    while (True if wait_for is None else (time.time() - start < wait_for))\
+            and not res:
+        gevent.sleep(sleep_for)
+        res = func()
+    return res or None


### PR DESCRIPTION
This should make it explicit timeout in errors like open channels hanging (avoid infinite loop) and transfer getting stuck indefinitely. It's a cleanup and some fixes tested on #895 .