### PR TITLE
Fix exporting of TransferReceivedSuccess

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -66,6 +66,10 @@ def normalize_events_list(old_list):
     for _event in old_list:
         new_event = dict(_event)
         new_event['event_type'] = new_event.pop('_event_type')
+        # Some of the raiden events contain accounts and as such need to
+        # be exported in hex to the outside world
+        if new_event['event_type'] == 'EventTransferReceivedSuccess':
+            new_event['initiator'] = address_encoder(new_event['initiator'])[2:]
         new_list.append(new_event)
     return new_list
 


### PR DESCRIPTION
`EventTransferReceivedSuccess` contained the initiator address in binary and that should be exported in hex. Perhaps other events also need tweaking if the same error appears, but this is a fix for #911.