### PR TITLE
Fix AppImage creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ bundle:
 	-(docker rm bundler)
 	docker run --name bundler --privileged -e ARCH=x86_64 -e APP=raiden -e LOWERAPP=raiden --workdir / --entrypoint /bin/bash raidenbundler -c 'source functions.sh && generate_appimage'
 	mkdir -p dist
-	docker cp bundler:/out/raiden--x86_64.AppImage dist/raiden--x86_64.AppImage
+	docker cp bundler:/out/raiden-.glibcPRIVATE-x86_64.AppImage dist/raiden--x86_64.AppImage
 	docker rm bundler
 
 test_bundle_docker := docker run --privileged --rm -v $(shell pwd)/dist:/data

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:12.04.5
 # install build dependencies
 RUN apt-get update && \
  apt-get install -y curl wget automake build-essential git-core libffi-dev \ 
- libgmp-dev libssl-dev libtool pkg-config fuse
+ libgmp-dev libssl-dev libtool pkg-config fuse libsqlite3-dev
 
 # prepare AppDir
 RUN bash -c 'mkdir -p /raiden.AppDir/usr/{local,bin,share,lib}/'
@@ -40,7 +40,7 @@ RUN mkdir -p /apps && \
     git checkout $RAIDEN_VERSION && \
     sed -s 's/^-e //' requirements.txt > _requirements.txt && \
     /raiden.AppDir/usr/bin/pip install -r _requirements.txt && \
-    PATH=/raiden.AppDir/usr/bin:$PATH /usr/bin/env python setup.py compile_contracts install && \
+    PATH=/raiden.AppDir/usr/bin:$PATH /usr/bin/env python setup.py compile_contracts build install && \
     find /raiden.AppDir/ -iname '*.pyo' -exec rm {} \; && \
     rm /raiden.AppDir/usr/lib/libpython*.a
 

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -90,4 +90,4 @@ RUN sed -i -s '1 s/^\#\!.*python\(.*\)/#!\/usr\/bin\/env python\1/' /raiden.AppD
 RUN apt-get -y install python
 
 # how to build AppImage
-RUN echo "\n\nRun these commands to generate the AppImage:\n\tdocker run --name bundler --privileged -e ARCH=x86_64 -e APP=raiden -e LOWERAPP=raiden --workdir / --entrypoint /bin/bash raidenbundler -c 'source functions.sh && generate_appimage'\ndocker cp bundler:raiden--x86_64.AppImage .\n\tdocker rm bundler\n\n"
+RUN echo "\n\nRun these commands to generate the AppImage:\n\tdocker run --name bundler --privileged -e ARCH=x86_64 -e APP=raiden -e LOWERAPP=raiden --workdir / --entrypoint /bin/bash raidenbundler -c 'source functions.sh && generate_appimage'\ndocker cp bundler:/out/raiden-.glibcPRIVATE-x86_64.AppImage dist/raiden--x86_64.AppImage\n\tdocker rm bundler\n\n"

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:12.04.5
 
 # install build dependencies
 RUN apt-get update && \
- apt-get install -y curl wget automake build-essential git-core libffi-dev \ 
+ apt-get install -y curl wget automake build-essential git-core libffi-dev \
  libgmp-dev libssl-dev libtool pkg-config fuse libsqlite3-dev
 
 # prepare AppDir
@@ -18,7 +18,7 @@ RUN curl -o Python-2.7.12.tar.xz https://www.python.org/ftp/python/2.7.12/Python
     cd Python-2.7.12 &&\
     ./configure --prefix=/raiden.AppDir/usr && \
     make && \
-    make install && \ 
+    make install && \
     cd .. && \
     rm -r Python-2.7.12*
 
@@ -33,14 +33,31 @@ RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/downl
 # use --build-arg RAIDEN_VERSION=v0.0.3 to build a specific (tagged) version
 ARG RAIDEN_VERSION
 
-# install raiden (replacing all --editable requirements)
+# install node for webui
+RUN curl -L -o /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-x64.tar.gz && \
+    cd /tmp && \
+    tar xzvf node.tar.gz &&\
+    mkdir /tmp/node_modules && \
+    chmod -R a+rwX /tmp/node_modules
+
+# clone raiden
 RUN mkdir -p /apps && \
-    git clone https://github.com/raiden-network/raiden.git /apps/raiden && \
-    cd /apps/raiden  && \ 
-    git checkout $RAIDEN_VERSION && \
+    git clone https://github.com/raiden-network/raiden.git /apps/raiden
+
+WORKDIR /apps/raiden
+
+# install requirements (replacing all --editable requirements)
+RUN git checkout $RAIDEN_VERSION && \
     sed -s 's/^-e //' requirements.txt > _requirements.txt && \
-    /raiden.AppDir/usr/bin/pip install -r _requirements.txt && \
-    PATH=/raiden.AppDir/usr/bin:$PATH /usr/bin/env python setup.py compile_contracts build install && \
+    /raiden.AppDir/usr/bin/pip install -r _requirements.txt
+
+# build & install raiden with contracts, webui and smoketest
+RUN echo "recursive-include raiden/ui/web/dist *" >> MANIFEST.in && \
+    USER=root \
+    NPM_CONFIG_PREFIX=/tmp/node_modules \
+    NODE_PATH=/tmp/node_modules \
+    PATH=/tmp/node-v8.2.1-linux-x64/bin:/raiden.AppDir/usr/bin:$PATH \
+    /usr/bin/env python setup.py compile_contracts compile_webui build install && \
     find /raiden.AppDir/ -iname '*.pyo' -exec rm {} \; && \
     rm /raiden.AppDir/usr/lib/libpython*.a
 

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -47,6 +47,31 @@ After you have done that you can proceed to install the dependencies::
 
 You will also need an Ethereum client that is connected to the Ropsten testnet. See below for guidelines on how to connect with both Parity and Geth.
 
+.. _binary_releases:
+
+(Optional) AppImage
+**************************
+
+For easier installation and portability, we create `AppImage <http://appimage.org/>`_ releases, that should work on most 64bit GNU/Linux distributions. For official releases, you will find the AppImage on the `github release page <https://github.com/raiden-network/raiden/releases>`_. AppImages are built from the main github repository, you will need to have ``make`` and ``docker`` installed.
+
+Building it
+-----------
+
+Calling::
+
+    make bundle
+
+will build ``raiden`` with all dependencies (including the webUI) inside a docker container and copy the build
+artifact to ``dist/raiden--x86_64.AppImage``. If you want to build a specific (git-tagged or branched) version, you can provide the git checkout target e.g. like this::
+
+    RAIDEN_VERSION=v1.0.0 make bundle
+
+Using it
+--------
+
+The release artifact ``raiden--x86_64.AppImage`` is an executable that takes the same commandline flags as the main
+``raiden`` script. See `AppImage Documentation <https://github.com/AppImage/AppImageKit/blob/appimagetool/master/README.md>`_ for advanced integration with your distribution.
+
 .. _running_raiden:
 
 Firing it up
@@ -85,4 +110,4 @@ After account creation, launch Raiden with the path of your keystore supplied an
 Select the Ethereum account when prompted, and type in the account's password.
 
 
-See the :doc:`API walkthrough <api_walkthrough>` for further intstructions on how to interact with Raiden.
+See the :doc:`API walkthrough <api_walkthrough>` for further instructions on how to interact with Raiden.


### PR DESCRIPTION
The AppImage creation was outdated: 
- the smoketest configuration was not included
- sqlite3 was missing
- the artifact filename changed
- the webUI was not included.

This PR fixes that.