### PR TITLE
Bugfix remove withdraw lock

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -433,9 +433,10 @@ class Channel(object):
         else:
             if log.isEnabledFor(logging.WARN):
                 log.warn(
-                    'Received a transfer were the sender %s who is not '
-                    'a part of the channel',
+                    'Received a transfer with sender %s who is not '
+                    'a part of the channel %s',
                     pex(transfer.sender),
+                    pex(transfer.channel)
                 )
             raise UnknownAddress(transfer)
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -408,34 +408,6 @@ class Channel(object):
 
         self.partner_state.release_lock(self.our_state, secret)
 
-    def withdraw_lock(self, secret):
-        """ A lock was released by the sender, withdraw its funds and update
-        the state.
-        """
-        hashlock = sha3(secret)
-
-        if not self.our_state.balance_proof.is_known(hashlock):
-            msg = "The secret doesn't withdraw any hashlock. hashlock:{} token:{}".format(
-                pex(hashlock),
-                pex(self.token_address),
-            )
-            raise ValueError(msg)
-
-        lock = self.our_state.balance_proof.get_lock_by_hashlock(hashlock)
-
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                'TOKEN WITHDRAWN %s < %s token:%s hashlock:%s lockhash:%s amount:%s',
-                pex(self.our_state.address),
-                pex(self.partner_state.address),
-                pex(self.token_address),
-                pex(hashlock),
-                pex(sha3(lock.as_bytes)),
-                lock.amount,
-            )
-
-        self.our_state.release_lock(self.partner_state, secret)
-
     def register_transfer(self, block_number, transfer):
         """ Register a signed transfer, updating the channel's state accordingly. """
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -461,10 +461,9 @@ class Channel(object):
         else:
             if log.isEnabledFor(logging.WARN):
                 log.warn(
-                    'Received a transfer from %s with recipient %s who is not '
+                    'Received a transfer were the sender %s who is not '
                     'a part of the channel',
                     pex(transfer.sender),
-                    pex(transfer.recipient),
                 )
             raise UnknownAddress(transfer)
 

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -129,8 +129,6 @@ class StateMachineEventHandler(object):
             self.raiden.send_async(event.receiver, reveal_message)
 
         elif isinstance(event, SendBalanceProof):
-            # TODO: issue #189
-
             # unlock and update remotely (send the Secret message)
             self.raiden.handle_secret(
                 event.identifier,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -489,13 +489,13 @@ class RaidenService(object):
             # withdraw a pending lock
             if channel.our_state.balance_proof.is_unclaimed(hashlock):
                 if partner_secret_message:
-                    matching_sender = (
-                        partner_secret_message.sender == channel.partner_state.address
+                    is_balance_proof = (
+                        partner_secret_message.sender == channel.partner_state.address and
+                        partner_secret_message.channel == channel.channel_address
                     )
-                    matching_token = partner_secret_message.channel == channel.channel_address
 
-                    if matching_sender and matching_token:
-                        channel.withdraw_lock(secret)
+                    if is_balance_proof:
+                        channel.register_transfer(partner_secret_message)
                         channels_to_remove.append(channel)
                     else:
                         channel.register_secret(secret)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -238,7 +238,7 @@ def test_settled_lock(token_addresses, raiden_network, settle_timeout, reveal_ti
     unlock_proof = back_channel.our_state.balance_proof.compute_proof_for_lock(secret, lock)
 
     # Update the hashlock
-    claim_lock(raiden_network, token, secret)
+    claim_lock(raiden_network, identifier, token, secret)
     direct_transfer(app0, app1, token, amount)
 
     # The direct transfer locksroot must remove the unlocked lock and update

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -479,7 +479,7 @@ def test_interwoven_transfers(number_of_transfers, raiden_network, settle_timeou
             transfer = transfers_list[i - 1]
             secret = transfers_secret[i - 1]
 
-            # synchronized clamining
+            # synchronized claiming
             secret_message = channel0.create_secret(
                 identifier,
                 secret,


### PR DESCRIPTION
The function `RaidenService:handle_secret` was discarding the secret balance proof and updating its local state directly by using the method `withdraw_lock`.

This PR fixes `handle_secret`, removes the method  `withdraw_lock` from the `NettingChannel`, and fixes the tests that called it directly.