### PR TITLE
Bugfix remove unlock lock

### DIFF
--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -368,46 +368,6 @@ class Channel(object):
 
             self.partner_state.register_secret(secret)
 
-    def release_lock(self, secret):
-        """ Release a lock for a transfer that was initiated from this node.
-
-        Only the sender of the mediated transfer can release a lock, the
-        receiver might know the secret but it needs to wait for a message from
-        the initiator. This is because the sender needs to coordinate state
-        updates (the hashlock for the transfers that are in transit and/or in
-        queue need to be in sync with the state known by the partner).
-
-        Note:
-            Releasing a lock should always be accompanied by at least one
-            Secret message to the partner node.
-
-            The node should also release the locks for the refund transfer.
-        """
-        hashlock = sha3(secret)
-
-        if not self.partner_state.balance_proof.is_known(hashlock):
-            msg = "The secret doesn't unlock any hashlock. hashlock:{} token:{}".format(
-                pex(hashlock),
-                pex(self.token_address),
-            )
-
-            raise ValueError(msg)
-
-        lock = self.partner_state.balance_proof.get_lock_by_hashlock(hashlock)
-
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                'TOKEN UNLOCKED %s > %s token:%s hashlock:%s lockhash:%s amount:%s',
-                pex(self.our_state.address),
-                pex(self.partner_state.address),
-                pex(self.token_address),
-                pex(hashlock),
-                pex(sha3(lock.as_bytes)),
-                lock.amount,
-            )
-
-        self.partner_state.release_lock(self.our_state, secret)
-
     def register_transfer(self, block_number, transfer):
         """ Register a signed transfer, updating the channel's state accordingly. """
 

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -11,6 +11,7 @@ from raiden.messages import (
     DirectTransfer,
     Lock,
     LockedTransfer,
+    Secret,
 )
 from raiden.utils import sha3
 from raiden.tests.utils.messages import make_mediated_transfer
@@ -175,7 +176,16 @@ def test_end_state():
     assert state1.balance_proof.merkleroot_for_unclaimed() == EMPTY_MERKLE_ROOT
     assert state2.balance_proof.merkleroot_for_unclaimed() == lock_hash
 
-    state2.release_lock(state1, lock_secret)
+    secret_message = Secret(
+        identifier=1,
+        nonce=1,
+        channel=channel_address,
+        transferred_amount=transferred_amount,
+        locksroot=EMPTY_MERKLE_ROOT,
+        secret=lock_secret,
+    )
+    secret_message.sign(privkey1, address1)
+    state2.register_secretmessage(state1, secret_message)
 
     assert state1.contract_balance == balance1 + 10
     assert state2.contract_balance == balance2

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -355,7 +355,9 @@ def test_python_channel():
     assert test_channel.our_state.locked() == 0
     assert test_channel.partner_state.locked() == amount2
 
-    test_channel.release_lock(secret)
+    secret_message = test_channel.create_secret(identifier, secret)
+    secret_message.sign(privkey1, address1)
+    test_channel.register_transfer(block_number, secret_message)
 
     assert test_channel.contract_balance == balance1
     assert test_channel.balance == balance1 - amount1 - amount2


### PR DESCRIPTION
`NettingChannel:release_unlock` was not used, and should not be used, since that function allows the sender to update it's local state (transferred_amount, merkle tree) without a creating a valid balance proof, this could lead to synchronization errors.

This PR is complementary to #925 (merge after it)