### PR TITLE
WebUI requests/busy indicator

### DIFF
--- a/raiden/ui/web/src/app/app.component.css
+++ b/raiden/ui/web/src/app/app.component.css
@@ -86,9 +86,7 @@
   .topnav .toggle-btn {
     display: block;
     cursor: pointer;
-    position: absolute;
-    right: 10px;
-    top: 10px;
+    margin: 10px 10px 0px 0px;
     z-index: 10 !important;
     padding: 3px;
     background-color: #ffffff;
@@ -137,13 +135,22 @@ body {
     font-size: 17px;
 }
 
+.topnav a.busy {
+    padding: 9px;
+}
+
+.topnav a.busy .counter {
+    font-weight: 700;
+    font-size: 14px;
+}
+
 /* Change the color of links on hover */
 .topnav a:hover {
     background-color: #ddd;
     color: black;
 }
 
-.topnav strong {
+.topnav .address {
     float: left;
     display: block;
     color: #f2f2f2;

--- a/raiden/ui/web/src/app/app.component.html
+++ b/raiden/ui/web/src/app/app.component.html
@@ -1,8 +1,14 @@
 <div class="topnav" id="myTopnav">
   <img src="assets/favicon.png">
   <a target="_blank" href="http://raiden.network/">Raiden Network</a>
-  <strong>{{raidenAddress}}</strong>
-  <i class="fa fa-bars fa-2x toggle-btn" (click)="menuCollapsed=!menuCollapsed"></i>
+  <strong class="address">{{raidenAddress}}</strong>
+  <i class="fa fa-bars fa-2x toggle-btn pull-right" (click)="menuCollapsed=!menuCollapsed"></i>
+  <a class="busy pull-right" *ngIf="raidenService.requestsCnt$ | async; let reqCnt">
+    <span class="fa-stack">
+      <i class="fa fa-spinner fa-pulse fa-fw fa-stack-2x"></i>
+      <i class="fa fa-stack-1x counter">{{ reqCnt }}</i>
+    </span>
+  </a>
 </div>
 <div class="nav-side-menu" [class.collapsed]="menuCollapsed">
   <div class="menu-list">

--- a/raiden/ui/web/src/app/app.component.html
+++ b/raiden/ui/web/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="topnav" id="myTopnav">
   <img src="assets/favicon.png">
-  <a target="_blank" href="http://raiden.network/">Raiden</a>
+  <a target="_blank" href="http://raiden.network/">Raiden Network</a>
   <strong>{{raidenAddress}}</strong>
   <i class="fa fa-bars fa-2x toggle-btn" (click)="menuCollapsed=!menuCollapsed"></i>
 </div>

--- a/raiden/ui/web/src/app/app.module.ts
+++ b/raiden/ui/web/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpModule, Http } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 import { DataTableModule, SharedModule, DataListModule, CarouselModule,
     ButtonModule, AccordionModule, GrowlModule, DialogModule, SplitButtonModule,
     TabViewModule, DropdownModule, MessagesModule, MenuModule,
@@ -61,7 +61,7 @@ export function ConfigLoader(raidenConfig: RaidenConfig) {
         BrowserModule,
         FormsModule,
         ReactiveFormsModule,
-        HttpModule,
+        HttpClientModule,
         DataTableModule,
         SharedModule,
         DataListModule,

--- a/raiden/ui/web/src/app/components/channel-table/channel-table.component.ts
+++ b/raiden/ui/web/src/app/components/channel-table/channel-table.component.ts
@@ -86,24 +86,17 @@ export class ChannelTableComponent implements OnInit {
                     this.tempChannel.token_address,
                     this.tempChannel.partner_address,
                     this.amount)
-                    .subscribe(
-                    (response) => {
-                        this.showMessage(response);
-                    }
-                    );
+                    .subscribe((response) => this.showMessage(response));
                 break;
             case 'deposit':
                 this.raidenService.depositToChannel(
                     this.tempChannel.channel_address,
-                    this.amount).subscribe((response) => {
-                        this.showMessage(response);
-                    });
+                    this.amount)
+                    .subscribe((response) => this.showMessage(response));
                 break;
             case 'close':
                 this.raidenService.closeChannel(this.tempChannel.channel_address)
-                    .subscribe((response) => {
-                        this.showMessage(response);
-                    });
+                    .subscribe((response) => this.showMessage(response));
                 break;
             case 'settle':
                 this.raidenService.settleChannel(this.tempChannel.channel_address)

--- a/raiden/ui/web/src/app/components/transfer-dialog/transfer-dialog.component.ts
+++ b/raiden/ui/web/src/app/components/transfer-dialog/transfer-dialog.component.ts
@@ -70,8 +70,8 @@ export class TransferDialogComponent implements OnInit, OnDestroy {
             value['token_address'],
             value['target_address'],
             value['amount'])
-            .subscribe((res) => {
-                if (res.ok) {
+            .subscribe((response) => {
+                if ('target_address' in response && 'identifier' in response) {
                     this.sharedService.msg({
                         severity: 'success',
                         summary: 'Transfer successful',
@@ -82,7 +82,7 @@ export class TransferDialogComponent implements OnInit, OnDestroy {
                     this.sharedService.msg({
                         severity: 'error',
                         summary: 'Transfer error',
-                        detail: `An error ocurred. See the logs for details.`,
+                        detail: JSON.stringify(response),
                     });
                 }
             });

--- a/raiden/ui/web/src/app/services/raiden.config.ts
+++ b/raiden/ui/web/src/app/services/raiden.config.ts
@@ -1,20 +1,24 @@
 import { Injectable } from '@angular/core';
-import { Http } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 declare var Web3;
+
+interface RDNConfig {
+    raiden: string;
+    web3: string;
+};
 
 @Injectable()
 export class RaidenConfig {
-    public config: { raiden: string, web3: string };
+    public config: RDNConfig;
     public api: string;
     public web3: any;
 
-    constructor(private http: Http) { }
+    constructor(private http: HttpClient) { }
 
     load(url: string) {
         return new Promise((resolve) => {
-            this.http.get(url)
-                .map((response) => response.json())
-                .subscribe((config: { raiden: string, web3: string }) => {
+            this.http.get<RDNConfig>(url)
+                .subscribe((config) => {
                     this.config = config;
                     this.api = config.raiden;
                     this.web3 = new Web3(new Web3.providers.HttpProvider(config.web3));

--- a/raiden/ui/web/src/app/services/raiden.service.ts
+++ b/raiden/ui/web/src/app/services/raiden.service.ts
@@ -115,6 +115,7 @@ export class RaidenService {
         console.log(`${this.config.api}/transfers/${tokenAddress}/${partnerAddress}`);
         return this.http.post(`${this.config.api}/transfers/${tokenAddress}/${partnerAddress}`,
             JSON.stringify(data), options)
+            .map((res) => res.json())
             .catch((error) => this.handleError(error));
     }
 


### PR DESCRIPTION
This PR adds an indicator in the top right corner of the app, indicating how much requests are currently pending/on-the-fly. In the future, we plan also to add a menu to this indicator, showing a list of current requests, and, maybe, the possibility of cancelling any of them.
Fix #916 
This PR also moves RaidenService to the new Angular 4.3 HttpClient implementation.
Changed _Raiden_ to _Raiden Network_ on the top navbar.
Fixed channel transfer message color from red to blue.
Made some minor changes to events handling, so less requests will be made against *geth*, improving performance.