### PR TITLE
Use slogging kwargs instead of string format

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -220,7 +220,7 @@ class RaidenAPI(object):
         netting_channel.deposit(amount)
         # Wait until the balance has been updated via a state transition triggered
         # by processing the `ChannelNewBalance` event
-        wait_timeout_secs = 60
+        wait_timeout_secs = 60  # FIXME: unconfigurable timeout
         if not channel.wait_for_balance_update(
                 old_balance,
                 wait_timeout_secs,
@@ -506,6 +506,15 @@ class RaidenAPI(object):
         graph = self.raiden.token_to_channelgraph[token_address]
         if not graph.has_path(self.raiden.address, target):
             raise NoPathError('No path to address found')
+
+        log.debug(
+            'initiating transfer',
+            initiator=pex(self.raiden.address),
+            target=pex(target),
+            token=pex(token_address),
+            amount=amount,
+            identifier=identifier
+        )
 
         async_result = self.raiden.transfer_async(
             token_address,

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -341,13 +341,13 @@ class Channel(object):
 
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(
-                    'SECRET REGISTERED node:%s %s > %s token:%s hashlock:%s amount:%s',
-                    pex(self.our_state.address),
-                    pex(self.our_state.address),
-                    pex(self.partner_state.address),
-                    pex(self.token_address),
-                    pex(hashlock),
-                    lock.amount,
+                    'SECRET REGISTERED',
+                    node=pex(self.our_state.address),
+                    from_=pex(self.our_state.address),
+                    to=pex(self.partner_state.address),
+                    token=pex(self.token_address),
+                    hashlock=pex(hashlock),
+                    amount=lock.amount,
                 )
 
             self.our_state.register_secret(secret)
@@ -357,13 +357,13 @@ class Channel(object):
 
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(
-                    'SECRET REGISTERED node:%s %s > %s token:%s hashlock:%s amount:%s',
-                    pex(self.our_state.address),
-                    pex(self.partner_state.address),
-                    pex(self.our_state.address),
-                    pex(self.token_address),
-                    pex(hashlock),
-                    lock.amount,
+                    'SECRET REGISTERED',
+                    node=pex(self.our_state.address),
+                    from_=pex(self.partner_state.address),
+                    to=pex(self.our_state.address),
+                    token=pex(self.token_address),
+                    hashlock=pex(hashlock),
+                    amount=lock.amount,
                 )
 
             self.partner_state.register_secret(secret)
@@ -393,10 +393,10 @@ class Channel(object):
         else:
             if log.isEnabledFor(logging.WARN):
                 log.warn(
-                    'Received a transfer with sender %s who is not '
-                    'a part of the channel %s',
-                    pex(transfer.sender),
-                    pex(transfer.channel)
+                    'Received a transfer from party that is not a part of the channel',
+                    node=self.our_state.address,
+                    from_=pex(transfer.sender),
+                    channel=pex(transfer.channel)
                 )
             raise UnknownAddress(transfer)
 
@@ -439,6 +439,9 @@ class Channel(object):
                     pex(transfer.sender),
                     from_state.nonce,
                     transfer.nonce,
+                    from_=pex(transfer.sender),
+                    expected_nonce=from_state.nonce,
+                    nonce=transfer.nonce,
                 )
             raise InvalidNonce(transfer)
 
@@ -456,12 +459,12 @@ class Channel(object):
             if expected_locksroot != transfer.locksroot:
                 if log.isEnabledFor(logging.ERROR):
                     log.error(
-                        'LOCKSROOT MISMATCH node:%s %s > %s lockhash:%s lockhashes:%s',
-                        pex(self.our_state.address),
-                        pex(from_state.address),
-                        pex(to_state.address),
-                        pex(sha3(transfer.lock.as_bytes)),
-                        lpex(to_state.balance_proof.unclaimed_merkletree()),
+                        'LOCKSROOT MISMATCH',
+                        node=pex(self.our_state.address),
+                        from_=pex(from_state.address),
+                        to=pex(to_state.address),
+                        lockhash=pex(sha3(transfer.lock.as_bytes)),
+                        lockhashes=lpex(to_state.balance_proof.unclaimed_merkletree()),
                         expected_locksroot=pex(expected_locksroot),
                         received_locksroot=pex(transfer.locksroot),
                     )
@@ -498,11 +501,11 @@ class Channel(object):
         if transfer.transferred_amount < from_state.transferred_amount:
             if log.isEnabledFor(logging.ERROR):
                 log.error(
-                    'NEGATIVE TRANSFER node:%s %s > %s %s',
-                    pex(self.our_state.address),
-                    pex(from_state.address),
-                    pex(to_state.address),
-                    transfer,
+                    'NEGATIVE TRANSFER',
+                    node=pex(self.our_state.address),
+                    from_=pex(from_state.address),
+                    to=pex(to_state.address),
+                    transfer=transfer,
                 )
 
             raise ValueError('Negative transfer')
@@ -541,12 +544,12 @@ class Channel(object):
         if isinstance(transfer, LockedTransfer):
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(
-                    'REGISTERED LOCK node:%s %s > %s currentlocksroot:%s lockhashes:%s',
-                    pex(self.our_state.address),
-                    pex(from_state.address),
-                    pex(to_state.address),
-                    pex(to_state.balance_proof.merkleroot_for_unclaimed()),
-                    lpex(to_state.balance_proof.unclaimed_merkletree()),
+                    'REGISTERED LOCK',
+                    node=pex(self.our_state.address),
+                    from_=pex(from_state.address),
+                    to=pex(to_state.address),
+                    currentlocksroot=pex(to_state.balance_proof.merkleroot_for_unclaimed()),
+                    lockhashes=lpex(to_state.balance_proof.unclaimed_merkletree()),
 
                     lock_amount=transfer.lock.amount,
                     lock_expiration=transfer.lock.expiration,
@@ -574,16 +577,14 @@ class Channel(object):
 
         if log.isEnabledFor(logging.DEBUG):
             log.debug(
-                'REGISTERED TRANSFER node:%s %s > %s '
-                'transfer:%s transferred_amount:%s nonce:%s '
-                'current_locksroot:%s',
-                pex(self.our_state.address),
-                pex(from_state.address),
-                pex(to_state.address),
-                repr(transfer),
-                from_state.transferred_amount,
-                from_state.nonce,
-                pex(to_state.balance_proof.merkleroot_for_unclaimed()),
+                'REGISTERED TRANSFER',
+                node=pex(self.our_state.address),
+                from_=pex(from_state.address),
+                to=pex(to_state.address),
+                transfer=repr(transfer),
+                transferred_amount=from_state.transferred_amount,
+                nonce=from_state.nonce,
+                current_locksroot=pex(to_state.balance_proof.merkleroot_for_unclaimed()),
             )
 
     def create_directtransfer(self, amount, identifier):

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -508,10 +508,10 @@ class RaidenProtocol(object):
 
         if log.isEnabledFor(logging.DEBUG):
             log.debug(
-                'new queue created for (%s, %s) > %s',
-                pex(self.raiden.address),
-                pex(token_address),
-                pex(receiver_address),
+                'new queue created for',
+                node=pex(self.raiden.address),
+                token=pex(token_address),
+                remote=pex(receiver_address),
             )
 
         return queue
@@ -574,10 +574,11 @@ class RaidenProtocol(object):
 
         if log.isEnabledFor(logging.INFO):
             log.info(
-                'SENDING ACK %s > %s %s',
-                pex(self.raiden.address),
-                pex(receiver_address),
-                ack_message,
+                'SENDING ACK',
+                node=pex(self.raiden.address),
+                from_=pex(self.raiden.address),
+                to=pex(receiver_address),
+                message=ack_message,
             )
 
         messagedata = ack_message.encode()
@@ -657,18 +658,18 @@ class RaidenProtocol(object):
             if waitack is None:
                 if log.isEnabledFor(logging.INFO):
                     log.info(
-                        'ACK FOR UNKNOWN ECHO node:%s echohash:%s',
-                        pex(self.raiden.address),
-                        pex(message.echo)
+                        'ACK FOR UNKNOWN ECHO',
+                        node=pex(self.raiden.address),
+                        echohash=pex(message.echo)
                     )
 
             else:
                 if log.isEnabledFor(logging.INFO):
                     log.info(
-                        'ACK RECEIVED node:%s receiver:%s echohash:%s',
-                        pex(self.raiden.address),
-                        pex(waitack.receiver_address),
-                        pex(message.echo)
+                        'ACK RECEIVED',
+                        node=pex(self.raiden.address),
+                        receiver=pex(waitack.receiver_address),
+                        echohash=pex(message.echo)
                     )
 
                 waitack.async_result.set(True)
@@ -676,10 +677,10 @@ class RaidenProtocol(object):
         elif isinstance(message, SignedMessage):
             if log.isEnabledFor(logging.INFO):
                 log.info(
-                    'MESSAGE RECEIVED node:%s echohash:%s %s',
-                    pex(self.raiden.address),
-                    pex(echohash),
-                    message,
+                    'MESSAGE RECEIVED',
+                    node=pex(self.raiden.address),
+                    echohash=pex(echohash),
+                    message=message,
                 )
 
             try:
@@ -710,6 +711,6 @@ class RaidenProtocol(object):
 
         elif log.isEnabledFor(logging.ERROR):
             log.error(
-                'Invalid message %s',
-                data.encode('hex'),
+                'Invalid message',
+                message=data.encode('hex'),
             )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -879,9 +879,9 @@ class RaidenService(object):
 
         if not direct_channel.can_transfer:
             log.info(
-                'DIRECT CHANNEL %s > %s is closed or has no funding',
-                pex(direct_channel.our_state.address),
-                pex(direct_channel.partner_state.address),
+                'DIRECT CHANNEL is closed or has no funding',
+                from_=pex(direct_channel.our_state.address),
+                to=pex(direct_channel.partner_state.address),
             )
 
             async_result = self._mediated_transfer(
@@ -893,10 +893,10 @@ class RaidenService(object):
 
         elif amount > direct_channel.distributable:
             log.info(
-                'DIRECT CHANNEL %s > %s doesnt have enough funds [%s]',
-                pex(direct_channel.our_state.address),
-                pex(direct_channel.partner_state.address),
-                amount,
+                'DIRECT CHANNEL does not have enough funds',
+                from_=pex(direct_channel.our_state.address),
+                to=pex(direct_channel.partner_state.address),
+                amount=amount,
             )
 
             async_result = self._mediated_transfer(

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -144,6 +144,7 @@ class BaseMediatedTransferTask(Task):
                 current_block,
                 self.__class__,
                 pex(transfer),
+                block_number=current_block,
             )
 
         yield TIMEOUT
@@ -434,9 +435,9 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
         if log.isEnabledFor(logging.DEBUG):
             node_address = raiden.address
             log.debug(
-                'MAKER TOKEN SWAP FAILED initiator:%s to_nodeaddress:%s',
-                pex(node_address),
-                pex(to_nodeaddress),
+                'MAKER TOKEN SWAP FAILED',
+                from_=pex(node_address),
+                to=pex(to_nodeaddress),
             )
 
         # all routes failed
@@ -493,8 +494,8 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
             if response is None:
                 if log.isEnabledFor(logging.DEBUG):
                     log.debug(
-                        'MAKER SWAP TIMED OUT hashlock:%s',
-                        pex(from_token_transfer.lock.hashlock),
+                        'MAKER SWAP TIMED OUT',
+                        hashlock=pex(from_token_transfer.lock.hashlock),
                     )
 
                 return None
@@ -621,9 +622,9 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
             if log.isEnabledFor(logging.DEBUG):
                 node_address = raiden.address
                 log.debug(
-                    'TAKER TOKEN SWAP FAILED, NO ROUTES initiator:%s from_nodeaddress:%s',
-                    pex(node_address),
-                    pex(maker_address),
+                    'TAKER TOKEN SWAP FAILED, NO ROUTES',
+                    from_=pex(node_address),
+                    to=pex(maker_address),
                 )
 
             return
@@ -637,11 +638,11 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
 
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(
-                    'TAKER TOKEN SWAP %s -> %s msghash:%s hashlock:%s',
-                    pex(maker_paying_transfer.target),
-                    pex(maker_address),
-                    pex(maker_paying_transfer.hash),
-                    pex(hashlock),
+                    'TAKER TOKEN SWAP',
+                    from_=pex(maker_paying_transfer.target),
+                    to=pex(maker_address),
+                    msghash=pex(maker_paying_transfer.hash),
+                    hashlock=pex(hashlock),
                 )
 
             # make a paying MediatedTransfer with same hashlock/identifier and the
@@ -666,9 +667,9 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
 
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(
-                    'EXCHANGE TRANSFER NEW PATH path:%s hashlock:%s',
-                    lpex(taker_paying_hop),
-                    pex(hashlock),
+                    'EXCHANGE TRANSFER NEW PATH',
+                    path=lpex(taker_paying_hop),
+                    hashlock=pex(hashlock),
                 )
 
             # register the task to receive Refund/Secrect/RevealSecret messages
@@ -747,9 +748,9 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
                 if log.isEnabledFor(logging.DEBUG):
                     node_address = raiden.address
                     log.debug(
-                        'TAKER TOKEN SWAP FAILED initiator:%s from_nodeaddress:%s',
-                        pex(node_address),
-                        pex(maker_address),
+                        'TAKER TOKEN SWAP FAILED',
+                        from_=pex(node_address),
+                        to=pex(maker_address),
                     )
 
                 self.async_result.set(False)
@@ -761,9 +762,9 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
         if log.isEnabledFor(logging.DEBUG):
             node_address = raiden.address
             log.debug(
-                'TAKER TOKEN SWAP FAILED initiator:%s from_nodeaddress:%s',
-                pex(node_address),
-                pex(maker_address),
+                'TAKER TOKEN SWAP FAILED',
+                from_=pex(node_address),
+                to=pex(maker_address),
             )
 
         self.async_result.set(False)
@@ -810,9 +811,9 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
 
             if response is None:
                 log.error(
-                    'TAKER SWAP TIMED OUT node:%s hashlock:%s',
-                    pex(raiden.address),
-                    pex(mediated_transfer.lock.hashlock),
+                    'TAKER SWAP TIMED OUT',
+                    node=pex(raiden.address),
+                    hashlock=pex(mediated_transfer.lock.hashlock),
                 )
                 return (response, secret)
 


### PR DESCRIPTION
This allows to make use of the json-logging for log collection and
filtering/aggregation.