### PR TITLE
Bugfix: Mediator state machine properly handle BalanceProof state change

### DIFF
--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -31,6 +31,7 @@ from raiden.transfer.mediated_transfer.events import (
     SendMediatedTransfer,
     SendRevealSecret,
     SendSecretRequest,
+    EventWithdrawSuccess,
 )
 from raiden.messages import MediatedTransfer
 
@@ -128,6 +129,12 @@ def test_mediation(
     mediator_chain = app0.raiden.chain
     settle_expiration = mediator_chain.block_number() + settle_timeout + 1
     wait_until_block(mediator_chain, settle_expiration)
+
+    app0_events = [
+        event.event_object
+        for event in get_all_state_events(app0.raiden.transaction_log)
+    ]
+    assert must_contain_entry(app0_events, EventWithdrawSuccess, {})
 
 
 @pytest.mark.parametrize('privatekey_seed', ['fullnetwork:{}'])

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -113,8 +113,6 @@ def test_mediation(
 
     token_address = token_addresses[0]
     app0, app1, app2 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
-    channel_1_0 = channel(app0, app1, token_address)
-    channel_0_2 = channel(app0, app2, token_address)
 
     identifier = 1
     amount = 1

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import gevent
 
 from raiden.utils import sha3
 from raiden.tests.utils.transfer import (
@@ -127,6 +128,9 @@ def test_mediation(
     mediator_chain = app0.raiden.chain
     settle_expiration = mediator_chain.block_number() + settle_timeout + 1
     wait_until_block(mediator_chain, settle_expiration)
+
+    # context switch needed for tester to process the EventWithdrawSuccess
+    gevent.sleep(1)
 
     app0_events = [
         event.event_object

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -844,7 +844,7 @@ def handle_balanceproof(state, state_change):
     """ Handle a ReceiveBalanceProof state change. """
     events = list()
     for pair in state.transfers_pair:
-        if pair.payer_route.channel_address == state_change.node_address:
+        if pair.payer_route.node_address == state_change.node_address:
             withdraw = EventWithdrawSuccess(
                 pair.payee_transfer.identifier,
                 pair.payee_transfer.hashlock,


### PR DESCRIPTION
Fix #917 

The constant assertions on the alarm task greenlet were due to an illegal `payer_state` being hit when the lock was set to expire.

It's all due to a small typo on the state machine that was not changing the `pair.payer_state` correctly when processing the `ReceiveBalanceProof` state change.

This PR also adds a test for it. The test (without the fix) also produces assertions in the logs, but what was missing was the `EventWithdrawSuccess` being fired for the mediator.