### PR TITLE
Channel reverse participants

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature: `507` Making python's channels crash resilient (recoverable). Note, this is a breaking change, the serialization format of channel objects changed to a WAL compatible representation.
 * :feature:`1037` Add ``show_default`` to CLI options
 * :feature:`670` Block raiden startup until ethereum node is fully synchronized.
 * :feature:`1010` Add ``amount`` and ``target`` to ``EventTransferSentSuccess`` event

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -221,9 +221,7 @@ class RaidenMessageHandler(object):
                 )
             )
 
-        amount = message.transferred_amount - channel.partner_state.transferred_amount(
-            channel.our_state
-        )
+        amount = message.transferred_amount - channel.partner_state.transferred_amount
         state_change = ReceiveTransferDirect(
             message.identifier,
             amount,

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -108,7 +108,7 @@ def ordered_neighbors(nx_graph, our_address, target_address):
                 target_address,
             )
             heappush(paths, (length, neighbor))
-        except networkx.NetworkXNoPath:
+        except (networkx.NetworkXNoPath, networkx.NodeNotFound):
             pass
 
     return paths
@@ -304,7 +304,7 @@ class ChannelGraph(object):
         """ True if there is a connecting path regardless of the number of hops. """
         try:
             return networkx.has_path(self.graph, source_address, target_address)
-        except networkx.NetworkXError:
+        except (networkx.NodeNotFound, networkx.NetworkXNoPath):
             return False
 
     def has_channel(self, source_address, target_address):

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -515,7 +515,8 @@ class RaidenService(object):
 
         messages_to_send = []
         for channel in channels_list:
-            if channel.partner_state.balance_proof.is_unclaimed(hashlock):
+            # unlock a pending lock
+            if channel.our_state.balance_proof.is_unclaimed(hashlock):
                 secret = channel.create_secret(identifier, secret)
                 self.sign(secret)
 
@@ -532,7 +533,7 @@ class RaidenService(object):
                 channels_to_remove.append(channel)
 
             # withdraw a pending lock
-            if channel.our_state.balance_proof.is_unclaimed(hashlock):
+            if channel.partner_state.balance_proof.is_unclaimed(hashlock):
                 if partner_secret_message:
                     is_balance_proof = (
                         partner_secret_message.sender == channel.partner_state.address and

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -102,11 +102,11 @@ def test_settlement(raiden_network, settle_timeout, reveal_timeout):
     # call settle.
 
     # get proof, that locked transfermessage was in merkle tree, with locked.root
-    lock = bob_alice_channel.our_state.balance_proof.get_lock_by_hashlock(hashlock)
+    lock = bob_alice_channel.partner_state.balance_proof.get_lock_by_hashlock(hashlock)
     assert sha3(secret) == hashlock
-    unlock_proof = bob_alice_channel.our_state.balance_proof.compute_proof_for_lock(secret, lock)
+    unlock_proof = bob_alice_channel.partner_state.balance_proof.compute_proof_for_lock(secret, lock)
 
-    root = bob_alice_channel.our_state.balance_proof.merkleroot_for_unclaimed()
+    root = bob_alice_channel.partner_state.balance_proof.merkleroot_for_unclaimed()
 
     assert check_proof(
         unlock_proof.merkle_proof,
@@ -225,8 +225,8 @@ def test_settled_lock(token_addresses, raiden_network, settle_timeout, reveal_ti
 
     # Get the proof to unlock the pending lock
     secret_transfer = get_received_transfer(back_channel, 0)
-    lock = back_channel.our_state.balance_proof.get_lock_by_hashlock(hashlock)
-    unlock_proof = back_channel.our_state.balance_proof.compute_proof_for_lock(secret, lock)
+    lock = back_channel.partner_state.balance_proof.get_lock_by_hashlock(hashlock)
+    unlock_proof = back_channel.partner_state.balance_proof.compute_proof_for_lock(secret, lock)
 
     # Update the hashlock
     claim_lock(raiden_network, identifier, token, secret)
@@ -234,7 +234,7 @@ def test_settled_lock(token_addresses, raiden_network, settle_timeout, reveal_ti
 
     # The direct transfer locksroot must remove the unlocked lock and update
     # the transferred amount, the withdraw must fail.
-    balance_proof = back_channel.our_state.balance_proof.balance_proof
+    balance_proof = back_channel.partner_state.balance_proof.balance_proof
     back_channel.external_state.close(balance_proof)
     with pytest.raises(Exception):
         back_channel.external_state.netting_channel.withdraw(
@@ -335,8 +335,8 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit, reveal_timeout
     hub_contract = channel(app1, app0, token).external_state.netting_channel.address
 
     # the attacker can create a merkle proof of the locked transfer
-    lock = attack_channel.our_state.balance_proof.get_lock_by_hashlock(hashlock)
-    unlock_proof = attack_channel.our_state.balance_proof.compute_proof_for_lock(secret, lock)
+    lock = attack_channel.partner_state.balance_proof.get_lock_by_hashlock(hashlock)
+    unlock_proof = attack_channel.partner_state.balance_proof.compute_proof_for_lock(secret, lock)
 
     # start the settle counter
     attack_balance_proof = attack_transfer.to_balanceproof()
@@ -451,7 +451,7 @@ def test_automatic_dispute(raiden_network, deposit, settle_timeout):
 
     # Alice can only provide one of Bob's transfer, so she is incentivized to
     # use the one with the largest transferred_amount.
-    channel0.external_state.close(channel0.our_state.balance_proof.balance_proof)
+    channel0.external_state.close(channel0.partner_state.balance_proof.balance_proof)
     chain0 = app0.raiden.chain
     wait_until_block(chain0, chain0.block_number() + 1)
 

--- a/raiden/tests/smart_contracts/netting_channel/test_settle.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_settle.py
@@ -625,11 +625,13 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_state, tester_
     initial_balance0 = tester_token.balanceOf(address0, sender=pkey0)
     initial_balance1 = tester_token.balanceOf(address1, sender=pkey1)
 
-    transferred_amount0 = deposit * 3 + 30
-    increase_transferred_amount(channel0, channel1, transferred_amount0)
+    # increase the transferred amount by three times the deposits
+    for _ in range(3):
+        increase_transferred_amount(channel0, channel1, deposit)
+        increase_transferred_amount(channel1, channel0, deposit)
 
-    transferred_amount1 = deposit * 3 + 70
-    increase_transferred_amount(channel1, channel0, transferred_amount1)
+    transferred_amount0 = deposit * 3
+    transferred_amount1 = deposit * 3
 
     amount0 = 10
     transferred_amount0 += amount0

--- a/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
@@ -52,7 +52,8 @@ def test_withdraw(
         secret,
     )
 
-    proof = channel1.our_state.balance_proof.compute_proof_for_lock(
+    # withdraw the pending transfer sent to us by our partner
+    proof = channel1.partner_state.balance_proof.compute_proof_for_lock(
         secret,
         mediated0.lock,
     )
@@ -207,7 +208,7 @@ def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_state):
     # expire the lock
     tester_state.mine(number_of_blocks=lock_timeout + 1)
 
-    unlock_proofs = list(channel0.our_state.balance_proof.get_known_unlocks())
+    unlock_proofs = list(channel0.partner_state.balance_proof.get_known_unlocks())
     proof = unlock_proofs[0]
 
     with pytest.raises(TransactionFailed):
@@ -296,7 +297,7 @@ def test_withdraw_both_participants(
     )
     tester_state.mine(number_of_blocks=1)
 
-    proof01 = channel1.our_state.balance_proof.compute_proof_for_lock(
+    proof01 = channel1.partner_state.balance_proof.compute_proof_for_lock(
         secret,
         mediated01.lock,
     )
@@ -307,7 +308,7 @@ def test_withdraw_both_participants(
         sender=pkey1,
     )
 
-    proof10 = channel0.our_state.balance_proof.compute_proof_for_lock(
+    proof10 = channel0.partner_state.balance_proof.compute_proof_for_lock(
         secret,
         mediated10.lock,
     )
@@ -360,7 +361,7 @@ def test_withdraw_twice(reveal_timeout, tester_channels, tester_state):
         sender=pkey0,
     )
 
-    unlock_proofs = list(channel0.our_state.balance_proof.get_known_unlocks())
+    unlock_proofs = list(channel0.partner_state.balance_proof.get_known_unlocks())
     proof = unlock_proofs[0]
 
     nettingchannel.withdraw(
@@ -629,7 +630,7 @@ def test_withdraw_lock_with_a_large_expiration(
         sender=pkey1,
     )
 
-    unlock_proofs = list(channel1.our_state.balance_proof.get_known_unlocks())
+    unlock_proofs = list(channel1.partner_state.balance_proof.get_known_unlocks())
     proof = unlock_proofs[0]
 
     nettingchannel.withdraw(

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -226,7 +226,7 @@ def test_end_state():
     assert state2.nonce is None
 
 
-def test_sender_cannot_overspent():
+def test_sender_cannot_overspend():
     token_address = make_address()
     privkey1, address1 = make_privkey_address()
     address2 = make_address()

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -279,7 +279,7 @@ def assert_balance(from_channel, balance, outstanding, distributable):
 def increase_transferred_amount(from_channel, to_channel, amount):
     # increasing the transferred amount by a value larger than distributable
     # would put one end of the channel in a negative balance, which is
-    # forbindden
+    # forbidden
     assert from_channel.distributable >= amount, 'operation would end up in a incosistent state'
 
     identifier = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ rlp>=0.4.3,<0.6.0
 coincurve==4.5.1
 pycryptodome>=3.4.3
 miniupnpc
-networkx
+networkx>=2.0.0
 ethereum-serpent
 repoze.lru
 gevent-websocket==0.9.4


### PR DESCRIPTION
Review with care. This PR will make a new release incompatible with the dev preview.

The python code was storing the balance proof structure in the
participant state of the receiving end, this is switched in respect to
the smart contract code and makes it a bit harder to access the
transferred amount of a node since both state objects are required. This
commit switches around the balance proof property to fix these issues.

Progress towards #932.