### PR TITLE
Make multiple transfers with same identifier idempotent

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -26,6 +26,7 @@ from raiden.exceptions import (
     AddressWithoutCode,
     DuplicatedChannelError,
     ChannelNotFound,
+    IdentifierCollision,
 )
 from raiden.api.v1.encoding import (
     ChannelSchema,
@@ -439,9 +440,23 @@ class RestAPI(object):
                 amount=amount,
                 identifier=identifier
             )
-        except (InvalidAmount, InvalidAddress, NoPathError) as e:
+        except (InvalidAmount, InvalidAddress, NoPathError, IdentifierCollision) as e:
+            log.exception(
+                'Transfer exception',
+                identifier=identifier,
+                amount=amount,
+                token=token_address,
+                target=target_address,
+            )
             return make_response(str(e), httplib.CONFLICT)
         except (InsufficientFunds) as e:
+            log.exception(
+                'Insuficient funds for transfer',
+                identifier=identifier,
+                amount=amount,
+                token=token_address,
+                target=target_address,
+            )
             return make_response(str(e), httplib.PAYMENT_REQUIRED)
 
         if transfer_result is False:

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -595,7 +595,7 @@ class Channel(object):
                 from_=pex(from_state.address),
                 to=pex(to_state.address),
                 transfer=repr(transfer),
-                transferred_amount=from_state.transferred_amount,
+                transferred_amount=from_state.transferred_amount(to_state),
                 nonce=from_state.nonce,
                 current_locksroot=pex(to_state.balance_proof.merkleroot_for_unclaimed()),
             )

--- a/raiden/event_handler.py
+++ b/raiden/event_handler.py
@@ -171,14 +171,28 @@ class StateMachineEventHandler(object):
             self.raiden.send_async(receiver, refund_transfer)
 
         elif isinstance(event, EventTransferSentSuccess):
-            for result in self.raiden.identifier_to_results[event.identifier]:
-                result.set(True)
+            result = self.raiden.identifier_to_result.get(event.identifier)
+            if result:
+                result.async_result.set(True)
+            else:
+                log.warning(
+                    'EventTransferSentSuccess of unknown transfer',
+                    event=event,
+                )
 
         elif isinstance(event, EventTransferSentFailed):
-            for result in self.raiden.identifier_to_results[event.identifier]:
-                result.set(False)
+            result = self.raiden.identifier_to_result.get(event.identifier)
+            if result:
+                result.async_result.set(False)
+            else:
+                log.warning(
+                    'EventTransferSentFailed of unknown transfer',
+                    event=event,
+                )
+
         elif isinstance(event, UNEVENTEFUL_EVENTS):
             pass
+
         elif isinstance(event, EventUnlockFailed):
             log.error(
                 'UnlockFailed!',

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -159,3 +159,8 @@ class NoTokenManager(RaidenError):
 
 class DuplicatedChannelError(RaidenError):
     """Raised if someone tries to create a channel that already exists."""
+
+
+class IdentifierCollision(RaidenError):
+    """Raide when an API call which requires unique identifier for a
+    given set of parameters, receives another call with different parameters"""


### PR DESCRIPTION
First split PR as part of solution of issue #900 
Make Direct Transfers idempotent. i.e.: when calling the API to make a new transfer with the same `identifier` and `amount` on the same channel of a previous transfer call, it is interpreted as being the same call, and instead of duplicating the transfer (making a new state change/balance proof), it only re-send the previous message (e.g. useful when the previous transfer timed out waiting for an ACK).