### PR TITLE
Improve logging configuration

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -92,6 +92,8 @@ from raiden.utils import (
 )
 
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+# register filelock logger
+filelock.logger = slogging.get_logger('filelock')
 
 
 def create_default_identifier():

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -432,6 +432,13 @@ def run(ctx, **kwargs):
             log_json=kwargs['log_json'],
             log_file=kwargs['logfile']
         )
+        if kwargs['logfile']:
+            # Disable stream logging
+            root = slogging.getLogger()
+            for handler in root.handlers:
+                if isinstance(handler, slogging.logging.StreamHandler):
+                    root.handlers.remove(handler)
+                    break
 
         # TODO:
         # - Ask for confirmation to quit if there are any locked transfers that did


### PR DESCRIPTION
There were two annoyances with logging:
- the `filelock` logger was not properly configured
- `--logfile <path to logfile>` would not disable the streamhandler logger, hence still spamming into the console