### PR TITLE
Expire mediated transfer pair

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -380,26 +380,28 @@ def set_expired_pairs(transfers_pair, block_number):
         if block_number > pair.payer_transfer.expiration:
             assert pair.payee_state == 'payee_expired'
             assert pair.payee_transfer.expiration < pair.payer_transfer.expiration
-            pair.payer_state = 'payer_expired'
 
-            withdraw_failed = EventWithdrawFailed(
-                pair.payer_transfer.identifier,
-                pair.payer_transfer.hashlock,
-                'lock expired',
-            )
-            events.append(withdraw_failed)
+            if pair.payer_state != 'payer_expired':
+                pair.payer_state = 'payer_expired'
+                withdraw_failed = EventWithdrawFailed(
+                    pair.payer_transfer.identifier,
+                    pair.payer_transfer.hashlock,
+                    'lock expired',
+                )
+                events.append(withdraw_failed)
 
         elif block_number > pair.payee_transfer.expiration:
             assert pair.payee_state not in STATE_TRANSFER_PAID
             assert pair.payee_transfer.expiration < pair.payer_transfer.expiration
-            pair.payee_state = 'payee_expired'
 
-            unlock_failed = EventUnlockFailed(
-                pair.payee_transfer.identifier,
-                pair.payee_transfer.hashlock,
-                'lock expired',
-            )
-            events.append(unlock_failed)
+            if pair.payee_state != 'payee_expired':
+                pair.payee_state = 'payee_expired'
+                unlock_failed = EventUnlockFailed(
+                    pair.payee_transfer.identifier,
+                    pair.payee_transfer.hashlock,
+                    'lock expired',
+                )
+                events.append(unlock_failed)
 
     return events
 


### PR DESCRIPTION
Expire mediated transfer pair when either unlock or withdraw failed to stop the error message from repeating.

If a channel is closed while we have a pending lock we correctly [detect](https://github.com/raiden-network/raiden/blob/a025b2f5b56888ce327bf1cb4d2ee5e16d7fc657/raiden/transfer/mediated_transfer/mediator.py#L393) it in the state machine [generate](https://github.com/raiden-network/raiden/blob/a025b2f5b56888ce327bf1cb4d2ee5e16d7fc657/raiden/transfer/mediated_transfer/mediator.py#L402) an event and then at the event handler we log an [error](https://github.com/raiden-network/raiden/blob/a025b2f5b56888ce327bf1cb4d2ee5e16d7fc657/raiden/event_handler.py#L190).

The problem is that this happens for every block between the channel `closing` and the channel `settling` when the state machine for that channel is purged like it can be seen below:

```
DEBUG:raiden.tasks      new block timestamp=1504005813.2 number=1573221                                                                 
ERROR:raiden.event_handler      UnlockFailed! reason=lock expired hashlock=d1f674bf                                                     
DEBUG:raiden.tasks      new block timestamp=1504005818.85 number=1573222                                                                
ERROR:raiden.event_handler      UnlockFailed! reason=lock expired hashlock=d1f674bf                                                     
DEBUG:raiden.tasks      new block timestamp=1504005824.96 number=1573223                                                                
ERROR:raiden.event_handler      UnlockFailed! reason=lock expired hashlock=d1f674bf                                                     
DEBUG:raiden.tasks      new block timestamp=1504005832.17 number=1573224                                                                
ERROR:raiden.event_handler      UnlockFailed! reason=lock expired hashlock=d1f674bf                                                     
DEBUG:raiden.tasks      new block timestamp=1504005832.76 number=1573225                                                                
ERROR:raiden.event_handler      UnlockFailed! reason=lock expired hashlock=d1f674bf                                                     
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=a11f4d23]> echohash=d8d73a8f                      
INFO:raiden.message_handler     message received message=<Ping [msghash=a11f4d23]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=a2b33745 from_=9bed7fd1 message=<Ack [echohash:d8d73a8f]>                  
DEBUG:raiden.tasks      new block timestamp=1504005844.49 number=1573226                                                                
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=25511699 echohash=05659d60                                          
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=00831178 echohash=14596389                                          
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=4286cfa7]> echohash=26812324                      
INFO:raiden.message_handler     message received message=<Ping [msghash=4286cfa7]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=069e3337 from_=9bed7fd1 message=<Ack [echohash:26812324]>                  
DEBUG:raiden.tasks      new block timestamp=1504005884.94 number=1573227                                                                
DEBUG:raiden.tasks      new block timestamp=1504005892.55 number=1573228                                                                
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=87d8cdfa]> echohash=813ed98b                      
INFO:raiden.message_handler     message received message=<Ping [msghash=87d8cdfa]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=a2b33745 from_=9bed7fd1 message=<Ack [echohash:813ed98b]>                  
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=25511699 echohash=734b4d76                                          
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=00831178 echohash=8afe0628                                          
DEBUG:raiden.tasks      new block timestamp=1504005916.81 number=1573229                                                                
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=659d79d2]> echohash=4d7db1ca                      
INFO:raiden.message_handler     message received message=<Ping [msghash=659d79d2]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=069e3337 from_=9bed7fd1 message=<Ack [echohash:4d7db1ca]>                  
DEBUG:raiden.tasks      new block timestamp=1504005944.09 number=1573230                                                                
DEBUG:raiden.tasks      new block timestamp=1504005950.7 number=1573231                                                                 
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=4639a242]> echohash=1c805924                      
INFO:raiden.message_handler     message received message=<Ping [msghash=4639a242]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=a2b33745 from_=9bed7fd1 message=<Ack [echohash:1c805924]>                  
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=25511699 echohash=ddc6b210                                          
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=00831178 echohash=3aababcf                                          
DEBUG:raiden.tasks      new block timestamp=1504005977.98 number=1573232                                                                
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=814f7157]> echohash=af8925f7                      
INFO:raiden.message_handler     message received message=<Ping [msghash=814f7157]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=069e3337 from_=9bed7fd1 message=<Ack [echohash:af8925f7]>                  
DEBUG:raiden.tasks      new block timestamp=1504006000.22 number=1573233                                                                
DEBUG:raiden.tasks      new block timestamp=1504006009.36 number=1573234                                                                
DEBUG:eth.chain.tx      deserialized tx tx=12af938c                                                                                     
INFO:raiden.network.protocol    MESSAGE RECEIVED node=9bed7fd1 message=<Ping [msghash=f35ad30d]> echohash=889b9e1f                      
INFO:raiden.message_handler     message received message=<Ping [msghash=f35ad30d]>                                                      
INFO:raiden.network.protocol    SENDING ACK node=9bed7fd1 to=a2b33745 from_=9bed7fd1 message=<Ack [echohash:889b9e1f]>                  
INFO:raiden.network.protocol    ACK RECEIVED node=9bed7fd1 receiver=25511699 echohash=9813cbe4                                          
INFO:raiden.network.rpc.client  settle called contract=04b61420               
```

That is because in each round the transfer appears as pending because only one of the two parts of the pair is set to a [final state](https://github.com/raiden-network/raiden/blob/a025b2f5b56888ce327bf1cb4d2ee5e16d7fc657/raiden/transfer/mediated_transfer/mediator.py#L145).

This PR does not emit the event if it has already been emitted once.