### PR TITLE
webUI: fix config route

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -195,10 +195,10 @@ class APIServer(object):
             assert file
             web3 = self.flask_app.config.get('WEB3_ENDPOINT')
             if web3 and 'config.' in file and file.endswith('.json'):
-                if any(h in web3 for h in ('localhost', '127.0.0.1', '::1')) and\
-                        request.headers.get('Host'):
+                host = request.headers.get('Host')
+                if any(h in web3 for h in ('localhost', '127.0.0.1')) and host:
                     _, _port = split_endpoint(web3)
-                    _host, _ = split_endpoint(request.headers.get('Host'))
+                    _host, _ = split_endpoint(host)
                     web3 = "http://{}:{}".format(_host, _port)
                 response = jsonify({'raiden': self._api_prefix, 'web3': web3})
             else:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -465,6 +465,7 @@ def run(ctx, **kwargs):
                         rest_api,
                         cors_domain_list=domain_list,
                         web_ui=ctx.params['web_ui'],
+                        eth_rpc_endpoint=ctx.params['eth_rpc_endpoint'],
                     )
                     (api_host, api_port) = split_endpoint(kwargs["api_address"])
                     api_server.start(api_host, api_port)

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -62,8 +62,11 @@ def host_port_to_endpoint(host, port):
 
 
 def split_endpoint(endpoint):
-    host, port = endpoint.split(':')[:2]
-    port = int(port)
+    match = re.match(r'(?:[a-z0-9]*:?//)?([^:/]+)(?::(\d+))?', endpoint, re.I)
+    if not match:
+        raise ValueError('Invalid endpoint', endpoint)
+    host, port = match.groups()
+    port = port and int(port)
     return (host, port)
 
 

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -66,7 +66,8 @@ def split_endpoint(endpoint):
     if not match:
         raise ValueError('Invalid endpoint', endpoint)
     host, port = match.groups()
-    port = port and int(port)
+    if port:
+        port = int(port)
     return (host, port)
 
 


### PR DESCRIPTION
With this PR, reverting back some changes made in 94a5c3cf, which avoided `--eth-rpc-address` being correctly passed to the Rest API, for providing `config.production.json` webUI config file with correct web3 address.
For that, changed `split_endpoint` to support getting `host` and `port` from URLs with protocol-prefixes (`http://`, `https://`) and path sufixes.
Last, testing for web3 endpoint on webUI, and falling back to `localhost:8545` in case of failure (e.g.: testnet).