### PR TITLE
Proper error at missing channel

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -444,6 +444,9 @@ Possible Responses
 | 400 Bad Request  | If the provided json is in|
 |                  | some way malformed        |
 +------------------+---------------------------+
+| 409 Conflict     | Provided channel does not |
+|                  | exist                     |
++------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+
 
@@ -487,6 +490,9 @@ Possible Responses
 +------------------+---------------------------+
 | 400 Bad Request  | If the provided json is in|
 |                  | some way malformed        |
++------------------+---------------------------+
+| 409 Conflict     | Provided channel does not |
+|                  | exist                     |
 +------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+
@@ -539,6 +545,9 @@ Possible Responses
 +------------------+---------------------------+
 | 402 Payment      | Insufficient balance to   |
 |     required     | do a deposit              |
++------------------+---------------------------+
+| 409 Conflict     | Provided channel does not |
+|                  | exist                     |
 +------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -30,6 +30,7 @@ from raiden.exceptions import (
     InvalidState,
     InsufficientFunds,
     NoTokenManager,
+    ChannelNotFound,
 )
 from raiden.utils import (
     isaddress,
@@ -68,7 +69,7 @@ class RaidenAPI(object):
             if channel.channel_address == channel_address:
                 return channel
 
-        raise ValueError("Channel not found")
+        raise ChannelNotFound()
 
     def manager_address_if_token_registered(self, token_address):
         """

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -24,7 +24,8 @@ from raiden.exceptions import (
     SamePeerAddress,
     NoTokenManager,
     AddressWithoutCode,
-    DuplicatedChannelError
+    DuplicatedChannelError,
+    ChannelNotFound,
 )
 from raiden.api.v1.encoding import (
     ChannelSchema,
@@ -435,7 +436,15 @@ class RestAPI(object):
             )
 
         # find the channel
-        channel = self.raiden_api.get_channel(channel_address)
+        try:
+            channel = self.raiden_api.get_channel(channel_address)
+        except ChannelNotFound:
+            return make_response(
+                "Requested channel {} not found".format(
+                    address_encoder(channel_address)),
+                httplib.CONFLICT
+            )
+
         current_state = channel.state
 
         # if we patch with `balance` it's a deposit

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -18,6 +18,11 @@ class HashLengthNot32(RaidenError):
 
 # Exceptions raised due to user interaction (the user may be another software)
 
+class ChannelNotFound(RaidenError):
+    """ Raised when a provided channel via the REST api is not found in the
+    internal data structures"""
+    pass
+
 
 class InsufficientFunds(RaidenError):
     """ Raised when provided account doesn't have token funds to complete the


### PR DESCRIPTION
If a channel that does not exist was requested via the REST Api we were getting a `500 Internal Server Errror`. This PR fixes that.