### PR TITLE
Ensure always up to date repo checkouts in `make bundle`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ docs:
 	$(MAKE) -C docs html
 
 bundle:
-	# pass RAIDEN_VERSION=<git version tag> to build a specific version
-	docker build -t raidenbundler --build-arg RAIDEN_VERSION=$(RAIDEN_VERSION) -f docker/build.Dockerfile docker
+	# pass RAIDENVERSION=<git version tag> to build a specific version
+	docker build -t raidenbundler --build-arg RAIDENVERSION=$(RAIDENVERSION) -f docker/build.Dockerfile docker
 	-(docker rm bundler)
 	docker run --name bundler --privileged -e ARCH=x86_64 -e APP=raiden -e LOWERAPP=raiden --workdir / --entrypoint /bin/bash raidenbundler -c 'source functions.sh && generate_appimage'
 	mkdir -p dist

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -34,17 +34,16 @@ RUN curl -L -o /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-
     mkdir /tmp/node_modules && \
     chmod -R a+rwX /tmp/node_modules
 
+# install solc
+RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.13/solc-static-linux && \
+    chmod +x /usr/bin/solc
+
 # use --build-arg RAIDENVERSION=v0.0.3 to build a specific (tagged) version
 ARG REPO=raiden-network/raiden
 ARG RAIDENVERSION=master
 
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 ADD https://api.github.com/repos/${REPO}/commits/${RAIDENVERSION} /dev/null
-
-# install solc
-RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.13/solc-static-linux && \
-    chmod +x /usr/bin/solc
-
 
 # clone raiden
 RUN mkdir -p /apps && \

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -34,11 +34,12 @@ RUN curl -L -o /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-
     mkdir /tmp/node_modules && \
     chmod -R a+rwX /tmp/node_modules
 
-# use --build-arg RAIDEN_VERSION=v0.0.3 to build a specific (tagged) version
-ARG RAIDEN_VERSION=master
+# use --build-arg RAIDENVERSION=v0.0.3 to build a specific (tagged) version
+ARG REPO=raiden-network/raiden
+ARG RAIDENVERSION=master
 
 # This is a "hack" to automatically invalidate the cache in case there are new commits
-ADD https://api.github.com/repos/raiden-network/raiden/commits/${RAIDEN_VERSION} /dev/null
+ADD https://api.github.com/repos/${REPO}/commits/${RAIDENVERSION} /dev/null
 
 # install solc
 RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.13/solc-static-linux && \
@@ -47,12 +48,12 @@ RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/downl
 
 # clone raiden
 RUN mkdir -p /apps && \
-    git clone https://github.com/raiden-network/raiden.git /apps/raiden
+    git clone https://github.com/${REPO}.git /apps/raiden
 
 WORKDIR /apps/raiden
 
 # install requirements (replacing all --editable requirements)
-RUN git checkout $RAIDEN_VERSION && \
+RUN git checkout $RAIDENVERSION && \
     sed -s 's/^-e //' requirements.txt > _requirements.txt && \
     /raiden.AppDir/usr/bin/pip install -r _requirements.txt
 
@@ -71,7 +72,7 @@ WORKDIR /
 # add .desktop file
 ADD raiden.desktop /raiden.AppDir/raiden.desktop
 RUN cd /apps/raiden && \
-    VERSIONSTRING=${RAIDEN_VERSION:-"git-"$(git rev-parse HEAD)} && \
+    VERSIONSTRING=${RAIDENVERSION:-"git-"$(git rev-parse HEAD)} && \
     sed -s -i "s/XXVERSIONXX/$VERSIONSTRING/" /raiden.AppDir/raiden.desktop
 # add icon
 ADD raiden.svg /raiden.AppDir/raiden.svg

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -27,18 +27,23 @@ RUN curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py && \
     usr/bin/python get-pip.py && \
     rm get-pip.py
 
-RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.13/solc-static-linux && \
-    chmod +x /usr/bin/solc
-
-# use --build-arg RAIDEN_VERSION=v0.0.3 to build a specific (tagged) version
-ARG RAIDEN_VERSION
-
 # install node for webui
 RUN curl -L -o /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-x64.tar.gz && \
     cd /tmp && \
     tar xzvf node.tar.gz &&\
     mkdir /tmp/node_modules && \
     chmod -R a+rwX /tmp/node_modules
+
+# use --build-arg RAIDEN_VERSION=v0.0.3 to build a specific (tagged) version
+ARG RAIDEN_VERSION=master
+
+# This is a "hack" to automatically invalidate the cache in case there are new commits
+ADD https://api.github.com/repos/raiden-network/raiden/commits/${RAIDEN_VERSION} /dev/null
+
+# install solc
+RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.13/solc-static-linux && \
+    chmod +x /usr/bin/solc
+
 
 # clone raiden
 RUN mkdir -p /apps && \

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -64,7 +64,7 @@ Calling::
 will build ``raiden`` with all dependencies (including the webUI) inside a docker container and copy the build
 artifact to ``dist/raiden--x86_64.AppImage``. If you want to build a specific (git-tagged or branched) version, you can provide the git checkout target e.g. like this::
 
-    RAIDEN_VERSION=v1.0.0 make bundle
+    RAIDENVERSION=v1.0.0 make bundle
 
 Using it
 --------


### PR DESCRIPTION
This allows to build the application without `--no-cache` docker build
option and still avoid missing updates in the repository. The dependencies for the bundle build can stay cached.