### PR TITLE
Shorten travis `deploy` stage on non-tagged commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ notifications:
 jobs:
   include:
     stage: deploy
-    script: make bundle
+    script: if [ -n "$TRAVIS_TAG" ]; then make bundle; fi
+    env: TEST_TYPE=""
     deploy:
     - provider: releases
       api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,13 @@ cache:
   - "$HOME/.ethash"
   - "$HOME/.bin"
 before_install:
-- mkdir -p $HOME/.bin
-- export PATH=$PATH:$HOME/.bin
-- "./.travis/download_geth.sh"
-- "./.travis/download_solc.sh"
+  - mkdir -p $HOME/.bin
+  - export PATH=$PATH:$HOME/.bin
+  - ./.travis/before_install.sh
 install:
-- pip install -U pip wheel coveralls "coverage<4.4"
-- pip install pytest-travis-fold
-- pip install flake8
-- pip install -r requirements-dev.txt
-- pip install .
+  ./.travis/install.sh
 before_script:
-- flake8 raiden/ tools/
-- raiden smoketest
+  ./.travis/before_script.sh
 script:
 - coverage run -m py.test --travis-fold=always -vvvvvv --log-config='raiden:DEBUG' --random $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE
 after_success:
@@ -52,6 +46,9 @@ notifications:
 jobs:
   include:
     stage: deploy
+    before_install: if [ -n "$TRAVIS_TAG" ]; then mkdir -p $HOME/.bin; export PATH=$PATH:$HOME/.bin; ./.travis/before_install.sh; fi
+    install: if [ -n "$TRAVIS_TAG" ]; then . .travis/install.sh; fi
+    before_script: if [ -n "$TRAVIS_TAG" ]; then . .travis/before_script; fi
     script: if [ -n "$TRAVIS_TAG" ]; then make bundle; fi
     env: TEST_TYPE=""
     deploy:

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+"./.travis/download_geth.sh"
+"./.travis/download_solc.sh"

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+flake8 raiden/ tools/
+raiden smoketest

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+pip install -U pip wheel coveralls "coverage<4.4"
+pip install pytest-travis-fold
+pip install flake8
+pip install -r requirements-dev.txt
+pip install .


### PR DESCRIPTION
https://github.com/raiden-network/raiden/pull/951 added 15min to every build. 
- Until we have added caching to the docker build of the bundler (see https://github.com/travis-ci/travis-ci/issues/5358) we should not be calling `make bundle` in the deploy stage at all, when we don't plan to actually deploy it. With caching, we could have the `make bundle` step on every build on `master`, to test it.
- `before_install`, `install`, `before_script` should also only be run on tagged commits.

This also empties the `TEST_TYPE` env variable in the deploy stage to avoid confusion.