### PR TITLE
webUI: Implement http timeout

### DIFF
--- a/raiden/ui/web/src/app/components/event-list/event-list.component.ts
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.ts
@@ -2,11 +2,10 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
+import { RaidenConfig } from '../../services/raiden.config';
 import { RaidenService } from '../../services/raiden.service';
 import { Event, EventsParam } from '../../models/event';
 
-const INTERVAL = 5000;
-const BLOCK_START = 1509634; // block where the registry contract was deployed
 
 @Component({
     selector: 'app-event-list',
@@ -21,10 +20,13 @@ export class EventListComponent implements OnInit {
     public events$: Observable<Event[]>;
     public loading = true;
 
-    constructor(private raidenService: RaidenService) { }
+    constructor(
+        private raidenConfig: RaidenConfig,
+        private raidenService: RaidenService
+    ) { }
 
     ngOnInit() {
-        let fromBlock: number = BLOCK_START;
+        let fromBlock: number = this.raidenConfig.config.block_start;
         let first = true;
         const data_excl = ['event_type', 'block_number', 'timestamp'];
         const firerSub: BehaviorSubject<void> = new BehaviorSubject(null);
@@ -72,7 +74,7 @@ export class EventListComponent implements OnInit {
                 }
                 return events;
             }, [])
-            .do(() => setTimeout(() => firerSub.next(null), INTERVAL))
+            .do(() => setTimeout(() => firerSub.next(null), this.raidenConfig.config.poll_interval))
             .do(() => this.loading = false);
     }
 }

--- a/raiden/ui/web/src/app/services/raiden.config.ts
+++ b/raiden/ui/web/src/app/services/raiden.config.ts
@@ -5,13 +5,24 @@ declare var Web3;
 interface RDNConfig {
     raiden: string;
     web3: string;
+    web3_fallback?: string;
+    poll_interval?: number;
+    block_start?: number;
+    http_timeout?: number;
 };
 
-const WEB3_FALLBACK = 'http://localhost:8545';
+const default_config: RDNConfig = {
+    raiden: '/api/1',
+    web3: '/web3',
+    web3_fallback: 'http://localhost:8545',
+    poll_interval: 5000,
+    block_start: 1509634,
+    http_timeout: 120000,
+};
 
 @Injectable()
 export class RaidenConfig {
-    public config: RDNConfig;
+    public config: RDNConfig = default_config;
     public api: string;
     public web3: any;
 
@@ -21,15 +32,15 @@ export class RaidenConfig {
         return new Promise((resolve) => {
             this.http.get<RDNConfig>(url)
                 .subscribe((config) => {
-                    this.config = config;
+                    this.config = Object.assign({}, default_config, config);
                     this.api = this.config.raiden;
                     this.web3 = new Web3(new Web3.providers.HttpProvider(this.config.web3));
                     // make a simple test call to web3
                     this.web3.version.getNetwork((err, res) => {
                         if (err) {
                             console.error('Invalid web3 endpoint', err);
-                            console.info('Switching to fallback: ' + WEB3_FALLBACK);
-                            this.config.web3 = WEB3_FALLBACK;
+                            console.info('Switching to fallback: ' + this.config.web3_fallback);
+                            this.config.web3 = this.config.web3_fallback;
                             this.web3 = new Web3(new Web3.providers.HttpProvider(this.config.web3));
                         }
                         resolve();

--- a/raiden/ui/web/src/polyfills.ts
+++ b/raiden/ui/web/src/polyfills.ts
@@ -76,6 +76,7 @@ import 'rxjs/add/observable/zip';
 import 'rxjs/add/observable/bindNodeCallback';
 
 import 'rxjs/add/operator/first';
+import 'rxjs/add/operator/timeout';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';


### PR DESCRIPTION
webUI-only changes.
Complementing #935, and implementing the initial aim of #910 on client side, add requests timeout to webUI, with proper error message.
Requests that takes longer than **60 seconds** will be cancelled. This value is configurable in the UI configuration, including `/ui/assets/config/config.*.json` dynamic endpoint for Raiden-provided configuration parameters, through the `http_timeout` config object attribute.
Together with #935 , should fix #900.