### PR TITLE
Add small timeout on web3 test request

### DIFF
--- a/raiden/ui/web/src/app/services/raiden.config.ts
+++ b/raiden/ui/web/src/app/services/raiden.config.ts
@@ -34,13 +34,17 @@ export class RaidenConfig {
                 .subscribe((config) => {
                     this.config = Object.assign({}, default_config, config);
                     this.api = this.config.raiden;
-                    this.web3 = new Web3(new Web3.providers.HttpProvider(this.config.web3));
+                    this.web3 = new Web3(new Web3.providers.HttpProvider(this.config.web3, 2000));
                     // make a simple test call to web3
                     this.web3.version.getNetwork((err, res) => {
                         if (err) {
                             console.error('Invalid web3 endpoint', err);
                             console.info('Switching to fallback: ' + this.config.web3_fallback);
                             this.config.web3 = this.config.web3_fallback;
+                            this.web3 = new Web3(new Web3.providers.HttpProvider(this.config.web3));
+                        } else {
+                            // on success, reconstruct without timeout,
+                            // because of long (events) running requests
                             this.web3 = new Web3(new Web3.providers.HttpProvider(this.config.web3));
                         }
                         resolve();


### PR DESCRIPTION
This should fix eternally hanging web3 test requests when web3 RPC endpoint passed by Raiden isn't acessible nor answering (DROP) from the client's perspective. On timeout, it'll fallback to `config.web3_fallback`, which defaults to `http://localhost:8545`, and make **testnet** webUI working again.