### PR TITLE
Fix script location [skip ci]

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -71,7 +71,7 @@ WORKDIR /
 # add .desktop file
 ADD raiden.desktop /raiden.AppDir/raiden.desktop
 RUN cd /apps/raiden && \
-    VERSIONSTRING=$(raiden version --short) && \
+    VERSIONSTRING=$(/raiden.AppDir/usr/bin/raiden version --short) && \
     sed -s -i "s/XXVERSIONXX/$VERSIONSTRING/" /raiden.AppDir/raiden.desktop
 # add icon
 ADD raiden.svg /raiden.AppDir/raiden.svg


### PR DESCRIPTION
`raiden version --short` needs to be called with the full path to the
script when creating the appimage