### PR TITLE
removed direct transfer optimization

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -535,11 +535,11 @@ class RaidenAPI(object):
             identifier=identifier
         )
 
-        async_result = self.raiden.transfer_async(
+        async_result = self.raiden.mediated_transfer_async(
             token_address,
             amount,
             target,
-            identifier=identifier,
+            identifier,
         )
         return async_result
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -873,18 +873,18 @@ class RaidenService(object):
         incremented.
 
         Because the transfer is non cancellable, there is a level of trust with
-        the target, after the message is sent the target is effectively paid
-        and there it is not possible to revert.
+        the target. After the message is sent the target is effectively paid
+        and then it is not possible to revert.
 
-        The async result will be set to False iif there is no direct channel
+        The async result will be set to False iff there is no direct channel
         with the target or the payer does not have balance to complete the
         transfer, otherwise because the transfer is non expirable the async
         result *will never be set to False* and if the message is sent it will
         hang until the target node acknowledge the message.
 
         This transfer should be used as an optimization, since only two packets
-        are required to complete the transfer (form the payer perspective),
-        where as the mediated transfer requires 6 messages.
+        are required to complete the transfer (from the payer's perspective),
+        whereas the mediated transfer requires 6 messages.
         """
         graph = self.token_to_channelgraph[token_address]
         direct_channel = graph.partneraddress_to_channel.get(target)

--- a/raiden/tests/benchmark/profile_transfer.py
+++ b/raiden/tests/benchmark/profile_transfer.py
@@ -247,24 +247,23 @@ def profile_transfer(num_nodes=10, channels_per_node=2):
     paths = main_graph.get_paths_of_length(source, num_hops)
 
     # sanity check
-    assert len(paths)
+    assert paths
 
     path = paths[0]
     target = path[-1]
 
     # addresses
-    a, b, c = path
     token_address = main_graph.token_address
 
     amount = 10
 
     # measure the hot path
     with profiling.profile():
-        result = main_app.raiden.transfer_async(
+        result = main_app.raiden.mediated_transfer_async(
             token_address,
             amount,
             target,
-            1  # TODO: fill in identifier
+            1,
         )
         result.wait()
 

--- a/raiden/tests/integration/test_e2e.py
+++ b/raiden/tests/integration/test_e2e.py
@@ -63,13 +63,7 @@ def assert_path_mediated_transfer(*transfers):
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('settle_timeout', [50])
-def test_mediation(
-        raiden_network,
-        token_addresses,
-        deposit,
-        settle_timeout,
-        reveal_timeout):
-
+def test_mediation(raiden_network, token_addresses, settle_timeout):
     # The network has the following topology:
     #
     # App1 <--> App0 <--> App2
@@ -79,11 +73,11 @@ def test_mediation(
 
     identifier = 1
     amount = 1
-    async_result = app1.raiden.transfer_async(
+    async_result = app1.raiden.mediated_transfer_async(
         token_address,
         amount,
         app2.raiden.address,
-        identifier
+        identifier,
     )
     assert async_result.wait()
 
@@ -111,6 +105,7 @@ def test_fullnetwork(
         deposit,
         settle_timeout,
         reveal_timeout):
+    # pylint: disable=too-many-locals,too-many-statements
 
     # The network has the following topology:
     #
@@ -129,7 +124,7 @@ def test_fullnetwork(
 
     # Exhaust the channel deposit (to force the mediated transfer to go backwards)
     amount = deposit
-    direct_transfer(app0, app1, token_address, amount)
+    direct_transfer(app0, app1, token_address, amount, identifier=1)
     assert get_sent_transfer(channel_0_1, 0).transferred_amount == amount
 
     amount = int(deposit / 2.)

--- a/raiden/tests/integration/test_refund.py
+++ b/raiden/tests/integration/test_refund.py
@@ -26,12 +26,12 @@ def test_refund_messages(raiden_chain, token_addresses, deposit):
 
     # Exhaust the channel App1 <-> App2 (to force the refund transfer)
     amount = deposit
-    direct_transfer(app1, app2, token_address, amount)
+    direct_transfer(app1, app2, token_address, amount, identifier=1)
     assert get_sent_transfer(channel_1_2, 0).transferred_amount == amount
 
     amount = int(deposit / 2.)
     identifier = 1
-    async_result = app0.raiden.transfer_async(
+    async_result = app0.raiden.mediated_transfer_async(
         token_address,
         amount,
         app2.raiden.address,

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -35,9 +35,10 @@ def test_regression_unfiltered_routes(raiden_network, token_addresses, settle_ti
     for app in raiden_network:
         app.raiden.poll_blockchain_events()
 
-    transfer = app0.raiden.transfer_async(
+    transfer = app0.raiden.mediated_transfer_async(
         token,
         1,
-        app4.raiden.address
+        app4.raiden.address,
+        1,
     )
     assert transfer.wait()

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -230,7 +230,7 @@ def test_settled_lock(token_addresses, raiden_network, settle_timeout, reveal_ti
 
     # Update the hashlock
     claim_lock(raiden_network, identifier, token, secret)
-    direct_transfer(app0, app1, token, amount)
+    direct_transfer(app0, app1, token, amount, identifier=1)
 
     # The direct transfer locksroot must remove the unlocked lock and update
     # the transferred amount, the withdraw must fail.

--- a/raiden/tests/integration/test_transfer.py
+++ b/raiden/tests/integration/test_transfer.py
@@ -16,10 +16,11 @@ def test_direct_transfer_to_offline_node(raiden_network, token_addresses):
 
     amount = 10
     target = app1.raiden.address
-    async_result = app0.raiden.transfer_async(
+    async_result = app0.raiden.direct_transfer_async(
         token_address,
         amount,
         target,
+        identifier=1,
     )
 
     assert async_result.wait(5) is None

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -207,7 +207,8 @@ def test_api_channel_events(raiden_chain):
         app0,
         app1,
         token_address,
-        amount
+        amount,
+        identifier=1,
     )
 
     results = RaidenAPI(app0.raiden).get_channel_events(channel_0_1.channel_address, 0)

--- a/raiden/tests/unit/test_service.py
+++ b/raiden/tests/unit/test_service.py
@@ -159,10 +159,11 @@ def test_receive_mediated_before_deposit(raiden_network, token_addresses):
     assert bob_charlie.distributable == deposit_amount
 
     transfer_amount = 1
-    async_result = app_alice.raiden.transfer_async(
+    async_result = app_alice.raiden.mediated_transfer_async(
         token_address,
         transfer_amount,
         app_charlie.raiden.address,
+        1,
     )
     assert async_result.wait(10)
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -49,7 +49,7 @@ def transfer(initiator_app, target_app, token, amount, identifier):
     will be revealed.
     """
 
-    async_result = initiator_app.raiden.transfer_async(
+    async_result = initiator_app.raiden.mediated_transfer_async(
         token,
         amount,
         target_app.raiden.address,
@@ -58,13 +58,13 @@ def transfer(initiator_app, target_app, token, amount, identifier):
     assert async_result.wait()
 
 
-def direct_transfer(initiator_app, target_app, token, amount, identifier=None):
+def direct_transfer(initiator_app, target_app, token, amount, identifier):
     """ Nice to read shortcut to make a DirectTransfer. """
     graph = initiator_app.raiden.token_to_channelgraph[token]
     has_channel = target_app.raiden.address in graph.partneraddress_to_channel
     assert has_channel, 'there is not a direct channel'
 
-    async_result = initiator_app.raiden.transfer_async(
+    async_result = initiator_app.raiden.direct_transfer_async(
         token,
         amount,
         target_app.raiden.address,
@@ -89,11 +89,11 @@ def mediated_transfer(initiator_app, target_app, token, amount, identifier=None)
         )
 
     else:
-        async_result = initiator_app.raiden.transfer_async(
+        async_result = initiator_app.raiden.mediated_transfer_async(
             token,
             amount,
             target_app.raiden.address,
-            identifier
+            identifier,
         )
         assert async_result.wait()
 


### PR DESCRIPTION
the direct transfer has a surprising property that is not expirable,
meaning that a transfer call that uses a direct transfer underneath may
hang forever, since this can be quite surprising for a user this removes
the optimization where a direct transfer is used by default, relying
solely on the mediated transfer that are cancellable and expirable as
the default transfer type.