### PR TITLE
Decrease deposit wait, check and raise on transaction fail

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -22,7 +22,6 @@ from raiden.transfer.events import (
     EventTransferReceivedSuccess,
 )
 from raiden.exceptions import (
-    EthNodeCommunicationError,
     NoPathError,
     InvalidAddress,
     InvalidAmount,
@@ -35,6 +34,7 @@ from raiden.exceptions import (
 from raiden.utils import (
     isaddress,
     pex,
+    wait_until,
 )
 
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -236,19 +236,20 @@ class RaidenAPI(object):
         # Obtain the netting channel and fund it by depositing the amount
         old_balance = channel.contract_balance
         netting_channel = self.raiden.chain.netting_channel(netcontract_address)
+        # actually make the deposit, and wait for it to be mined
         netting_channel.deposit(amount)
+
         # Wait until the balance has been updated via a state transition triggered
         # by processing the `ChannelNewBalance` event
-        wait_timeout_secs = 60  # FIXME: unconfigurable timeout
-        if not channel.wait_for_balance_update(
-                old_balance,
-                wait_timeout_secs,
-                self.raiden.alarm.wait_time):
-            raise EthNodeCommunicationError(
-                'After {} seconds the deposit event was not seen by the ethereum node.'.format(
-                    wait_timeout_secs
-                )
-            )
+        # Usually, it'll take a single gevent.sleep, as we already have waited
+        # for it to be mined, and only need to give the event handling greenlet
+        # the chance to process the event, but let's wait 10s to be safe
+        if not wait_until(
+            lambda: channel.contract_balance != old_balance,
+            10,
+            self.raiden.alarm.wait_time,
+        ):
+            log.debug('Wait until failed', contract_balance=channel.contract_balance)
 
         return channel
 

--- a/raiden/channel/netting_channel.py
+++ b/raiden/channel/netting_channel.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-import time
 
-import gevent
 from gevent.event import Event
 from ethereum import slogging
 from ethereum.utils import encode_hex
@@ -812,15 +810,6 @@ class Channel(object):
 
             if self.external_state.opened_block == 0:
                 self.external_state.set_opened(block_number)
-
-    def wait_for_balance_update(self, old_balance, wait_time=60, sleep_for=1):
-        """Intended to be called inside an event loop to wait for a change in
-        contract balance. This function will preemptively wait and return when
-        the balance changed."""
-        start = time.time()
-        while time.time() - start < wait_time and self.contract_balance == old_balance:
-            gevent.sleep(sleep_for)
-        return self.contract_balance != old_balance
 
     def serialize(self):
         return ChannelSerialization(self)

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -159,3 +159,8 @@ class NoTokenManager(RaidenError):
 
 class DuplicatedChannelError(RaidenError):
     """Raised if someone tries to create a channel that already exists."""
+
+
+class TransactionThrew(RaidenError):
+    """Raised when, after waiting for a transaction to be mined,
+    the gasUsed in receipt is the same as the provided transaction gas limit"""

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -164,3 +164,7 @@ class DuplicatedChannelError(RaidenError):
 class TransactionThrew(RaidenError):
     """Raised when, after waiting for a transaction to be mined,
     the gasUsed in receipt is the same as the provided transaction gas limit"""
+    def __init__(self, txname, receipt):
+        super(TransactionThrew, self).__init__(
+            '{} transaction threw. Receipt={}'.format(receipt)
+        )

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -646,9 +646,9 @@ class Token(object):
         )
 
         self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-        threw = check_transaction_threw(self.client, transaction_hash)
-        if threw:
-            raise TransactionThrew('Approve transaction threw', threw)
+        tx_receipt_or_false = check_transaction_threw(self.client, transaction_hash)
+        if tx_receipt_or_false:
+            raise TransactionThrew('Approve', tx_receipt_or_false)
 
     def balance_of(self, address):
         """ Return the balance of `address`. """
@@ -663,9 +663,9 @@ class Token(object):
         )
 
         self.client.poll(transaction_hash.decode('hex'))
-        threw = check_transaction_threw(self.client, transaction_hash)
-        if threw:
-            raise TransactionThrew('Transfer transaction threw', threw)
+        tx_receipt_or_false = check_transaction_threw(self.client, transaction_hash)
+        if tx_receipt_or_false:
+            raise TransactionThrew('Transfer', tx_receipt_or_false)
 
         # TODO: check Transfer event
 
@@ -710,9 +710,9 @@ class Registry(object):
         )
 
         self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-        threw = check_transaction_threw(self.client, transaction_hash)
-        if threw:
-            raise TransactionThrew('AddToken transaction threw', threw)
+        tx_receipt_or_false = check_transaction_threw(self.client, transaction_hash)
+        if tx_receipt_or_false:
+            raise TransactionThrew('AddToken', tx_receipt_or_false)
 
         channel_manager_address_encoded = self.proxy.channelManagerByToken.call(
             token_address,
@@ -1014,9 +1014,9 @@ class NettingChannel(object):
         transaction_hash = estimate_and_transact(self, self.proxy.deposit, amount)
 
         self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-        threw = check_transaction_threw(self.client, transaction_hash)
-        if threw:
-            raise TransactionThrew('Deposit transaction threw', threw)
+        tx_receipt_or_false = check_transaction_threw(self.client, transaction_hash)
+        if tx_receipt_or_false:
+            raise TransactionThrew('Deposit', tx_receipt_or_false)
 
         log.info('deposit called', contract=pex(self.address), amount=amount)
 
@@ -1166,9 +1166,9 @@ class NettingChannel(object):
         )
 
         self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
-        threw = check_transaction_threw(self.client, transaction_hash)
-        if threw:
-            raise TransactionThrew('Settle transaction threw', threw)
+        tx_receipt_or_false = check_transaction_threw(self.client, transaction_hash)
+        if tx_receipt_or_false:
+            raise TransactionThrew('Settle', tx_receipt_or_false)
 
         # TODO: check if the ChannelSettled event was emitted and if it wasn't raise an error
         log.info('settle called', contract=pex(self.address))

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -358,4 +358,4 @@ def test_channel_with_self(raiden_network, settle_timeout, blockchain_type):
         tx = graph0.proxy.newChannel(app0.raiden.address, settle_timeout)
         # wait to make sure we get the receipt
         wait_until_block(app0.raiden.chain, app0.raiden.chain.block_number() + 5)
-        assert check_transaction_threw(app0.raiden.chain.client, tx) is True
+        assert check_transaction_threw(app0.raiden.chain.client, tx)

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 import string
+import time
+import gevent
 
 from coincurve import PrivateKey
 from ethereum.utils import remove_0x_head
@@ -174,3 +176,22 @@ def get_system_spec():
         )
     )
     return system_spec
+
+
+def wait_until(func, wait_for=None, sleep_for=0.5):
+    """Preemptively (gevent) test for a function and wait for it to return a
+    truth value and returns it, or None if a timeout is given and the function
+    didn't return inside time timeout
+    Args:
+        func (callable): a function to be evaluated, use lambda if parameters are required
+        wait_for (float, integer, None): the maximum time to wait, or None for infinite loop
+        sleep_form (float, integer): how much to gevent.sleep between calls
+    Returns:
+        func(): result of func, if truth value, or None"""
+    start = time.time()
+    res = func()
+    while (True if wait_for is None else (time.time() - start < wait_for))\
+            and not res:
+        gevent.sleep(sleep_for)
+        res = func()
+    return res or None

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -179,13 +179,13 @@ def get_system_spec():
 
 
 def wait_until(func, wait_for=None, sleep_for=0.5):
-    """Preemptively (gevent) test for a function and wait for it to return a
-    truth value and returns it, or None if a timeout is given and the function
-    didn't return inside time timeout
+    """Test for a function and wait for it to return a truth value or to timeout.
+    Returns the value or None if a timeout is given and the function didn't return
+    inside time timeout
     Args:
         func (callable): a function to be evaluated, use lambda if parameters are required
-        wait_for (float, integer, None): the maximum time to wait, or None for infinite loop
-        sleep_form (float, integer): how much to gevent.sleep between calls
+        wait_for (float, integer, None): the maximum time to wait, or None for an infinite loop
+        sleep_for (float, integer): how much to gevent.sleep between calls
     Returns:
         func(): result of func, if truth value, or None"""
     start = time.time()


### PR DESCRIPTION
Instead of increasing the wait timeout in deposit, we remove it.

Added `wait=True` parameter to contracts methods which didn't depend on the result or exception checking, so we can call `approve` and `deposit` and only wait for the later, allowing both transactions to be mined in the same block.

As the [wait in deposit](https://github.com/raiden-network/raiden/blob/b490e2ee3fb434780733250f0c5a30879ad3a096/raiden/api/python.py#L243) doesn't need to actually wait for the whole transaction to be sent/mined, we just make a small preemptive wait to give other greenlets the opportunity to detect and process the deposit event, and update the balances.

So, it does not actually fixes #878 , as it does not need fixing, but will make deposits quicker, handling better the wide block times in Ropsten.