### PR TITLE
throttle don't sleep with 0 seconds

### DIFF
--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -95,7 +95,13 @@ class UDPTransport(object):
             host_port (Tuple[(str, int)]): Tuple with the host name and port number.
             bytes_ (bytes): The bytes that are going to be sent through the wire.
         """
-        gevent.sleep(self.throttle_policy.consume(1))
+        sleep_timeout = self.throttle_policy.consume(1)
+
+        # Don't sleep if timeout is zero, otherwise a context-switch is done
+        # and the message is delayed, increasing it's latency
+        if sleep_timeout:
+            gevent.sleep(sleep_timeout)
+
         self.server.sendto(bytes_, host_port)
 
         # enable debugging using the DummyNetwork callbacks


### PR DESCRIPTION
This just avoids calling `gevent.sleep` when the throttle policy returns 0 seconds.

The greenlet will context-switch anyways just a few lines further down, when the packet is actually sent, so this doesn't have a negative impact on cooperation, the zero seconds context-switch was only adding unnecessary latency.