### PR TITLE
Fix maybe send ack

### DIFF
--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -102,6 +102,9 @@ class UDPTransport(object):
         if sleep_timeout:
             gevent.sleep(sleep_timeout)
 
+        if not hasattr(self.server, 'socket'):
+            raise RuntimeError('trying to send a message on a closed server')
+
         self.server.sendto(bytes_, host_port)
 
         # enable debugging using the DummyNetwork callbacks


### PR DESCRIPTION
This fixes a regression, a context switch was introduced after the check
for the state of the datagram server, this context switch exposed a race
that allowed a call to `transport.send` on a closed transport.

merge after #972