### PR TITLE
fixture setup using only the deploy service

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -236,7 +236,7 @@ class ConnectionManager(object):
             )
         # this can fail because of a race condition, where the channel partner opens first
         except DuplicatedChannelError:
-            log.error('partner opened channel first')
+            log.info('partner opened channel first')
 
         channelgraph = self.raiden.token_to_channelgraph[self.token_address]
         if partner not in channelgraph.partneraddress_to_channel:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -16,7 +16,7 @@ from pyethapp.jsonrpc import (
     data_encoder,
     default_gasprice,
 )
-from pyethapp.rpc_client import topic_encoder, JSONRPCClient, block_tag_encoder
+from pyethapp.rpc_client import topic_encoder, block_tag_encoder
 import requests
 
 from raiden import messages
@@ -288,10 +288,8 @@ class BlockChainService(object):
             self,
             privatekey_bin,
             registry_address,
-            host,
-            port,
-            poll_timeout=DEFAULT_POLL_TIMEOUT,
-            **kwargs):
+            jsonrpc_client,
+            poll_timeout=DEFAULT_POLL_TIMEOUT):
 
         self.address_to_token = dict()
         self.address_to_discovery = dict()
@@ -300,24 +298,11 @@ class BlockChainService(object):
         self.address_to_registry = dict()
         self.token_to_channelmanager = dict()
 
-        jsonrpc_client = JSONRPCClient(
-            privkey=privatekey_bin,
-            host=host,
-            port=port,
-            print_communication=kwargs.get('print_communication', False),
-        )
-        patch_send_transaction(jsonrpc_client)
-        patch_send_message(jsonrpc_client)
-
         self.client = jsonrpc_client
         self.private_key = privatekey_bin
         self.node_address = privatekey_to_address(privatekey_bin)
         self.poll_timeout = poll_timeout
         self.default_registry = self.registry(registry_address)
-
-    def set_verbosity(self, level):
-        if level:
-            self.client.print_communication = True
 
     def block_number(self):
         return self.client.blocknumber()

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -145,8 +145,8 @@ def patch_send_transaction(client, nonce_offset=0):
         nonce = get_nonce()
 
         tx = Transaction(nonce, gasprice, startgas, to, value, data)
-        assert hasattr(client, 'privkey') and client.privkey
         tx.sign(client.privkey)
+
         result = client.call(
             'eth_sendRawTransaction',
             data_encoder(rlp.encode(tx)),
@@ -541,6 +541,9 @@ class Discovery(object):
             gasprice=GAS_PRICE,
             poll_timeout=DEFAULT_POLL_TIMEOUT):
 
+        if not isaddress(discovery_address):
+            raise ValueError('discovery_address must be a valid address')
+
         result = jsonrpc_client.call(
             'eth_getCode',
             address_encoder(discovery_address),
@@ -609,6 +612,9 @@ class Token(object):
             gasprice=GAS_PRICE,
             poll_timeout=DEFAULT_POLL_TIMEOUT):
 
+        if not isaddress(token_address):
+            raise ValueError('token_address must be a valid address')
+
         result = jsonrpc_client.call(
             'eth_getCode',
             address_encoder(token_address),
@@ -671,9 +677,17 @@ class Token(object):
 
 
 class Registry(object):
-    def __init__(self, jsonrpc_client, registry_address, startgas=GAS_LIMIT,
-                 gasprice=GAS_PRICE, poll_timeout=DEFAULT_POLL_TIMEOUT):
+    def __init__(
+            self,
+            jsonrpc_client,
+            registry_address,
+            startgas=GAS_LIMIT,
+            gasprice=GAS_PRICE,
+            poll_timeout=DEFAULT_POLL_TIMEOUT):
         # pylint: disable=too-many-arguments
+
+        if not isaddress(registry_address):
+            raise ValueError('registry_address must be a valid address')
 
         result = jsonrpc_client.call(
             'eth_getCode',
@@ -772,6 +786,9 @@ class ChannelManager(object):
             gasprice=GAS_PRICE,
             poll_timeout=DEFAULT_POLL_TIMEOUT):
         # pylint: disable=too-many-arguments
+
+        if not isaddress(manager_address):
+            raise ValueError('manager_address must be a valid address')
 
         result = jsonrpc_client.call(
             'eth_getCode',

--- a/raiden/tests/benchmark/profile_transfer.py
+++ b/raiden/tests/benchmark/profile_transfer.py
@@ -224,7 +224,6 @@ def profile_transfer(num_nodes=10, channels_per_node=2):
     discovery_mock = Discovery()
     endpoint_discovery_services = [discovery_mock for _ in private_keys]
 
-    verbosity = 3
     apps = create_apps(
         blockchain_services,
         endpoint_discovery_services,
@@ -233,7 +232,6 @@ def profile_transfer(num_nodes=10, channels_per_node=2):
         deposit,
         DEFAULT_SETTLE_TIMEOUT,
         UDPTransport,
-        verbosity,
     )
 
     main_app = apps[0]

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -57,13 +57,11 @@ def raiden_chain(
         'with 0, 1 or 2 channels'
     )
 
-    verbosity = request.config.option.verbose
     raiden_apps = create_apps(
         blockchain_services.blockchain_services,
         endpoint_discovery_services,
         raiden_udp_ports,
         transport_class,
-        verbosity,
         reveal_timeout,
         settle_timeout,
         database_paths,
@@ -115,14 +113,11 @@ def raiden_network(
         nat_keepalive_retries,
         nat_keepalive_timeout):
 
-    verbosity = request.config.option.verbose
-
     raiden_apps = create_apps(
         blockchain_services.blockchain_services,
         endpoint_discovery_services,
         raiden_udp_ports,
         transport_class,
-        verbosity,
         reveal_timeout,
         settle_timeout,
         database_paths,

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -229,7 +229,6 @@ def create_apps(
         endpoint_discovery_services,
         raiden_udp_ports,
         transport_class,
-        verbosity,
         reveal_timeout,
         settle_timeout,
         database_paths,
@@ -267,9 +266,6 @@ def create_apps(
         port = raiden_udp_ports[idx]
         private_key = blockchain.private_key
         nodeid = privatekey_to_address(private_key)
-
-        if verbosity > 7:
-            blockchain.set_verbosity(1)
 
         # split the nodes into two different networks
         if idx > half_of_nodes:

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -217,7 +217,7 @@ class FilterTesterMock(object):
 
 
 class BlockChainServiceTesterMock(object):
-    def __init__(self, private_key, tester_state, registry_address, **kwargs):
+    def __init__(self, private_key, tester_state, registry_address):
         self.tester_state = tester_state
         default_registry = RegistryTesterMock(tester_state, private_key, registry_address)
 
@@ -232,9 +232,6 @@ class BlockChainServiceTesterMock(object):
         self.address_to_nettingchannel = dict()
         self.address_to_registry = dict()
         self.token_to_channelmanager = dict()
-
-    def set_verbosity(self, level):
-        pass
 
     def block_number(self):
         return self.tester_state.block.number

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -4,20 +4,21 @@ from __future__ import print_function
 
 import signal
 import json
+import time
+import random
 
 import click
 import gevent
 from gevent import monkey
-import time
-import random
 from ethereum import slogging
-
 from ethereum.utils import decode_hex
-from raiden.console import ConsoleTools
+from pyethapp.rpc_client import JSONRPCClient
+
 from raiden.app import App
 from raiden.network.rpc.client import BlockChainService
 from raiden.network.discovery import ContractDiscovery
 from raiden.utils import split_endpoint
+from raiden.ui.console import ConsoleTools
 
 
 monkey.patch_all()
@@ -83,11 +84,18 @@ def run(privatekey,
     config['port'] = listen_port
     config['privatekey_hex'] = privatekey
 
+    privatekey_bin = decode_hex(privatekey)
+
+    rpc_client = JSONRPCClient(
+        privkey=privatekey_bin,
+        host='127.0.0.1',
+        port='8545',
+    )
+
     blockchain_service = BlockChainService(
-        decode_hex(privatekey),
+        privatekey_bin,
         decode_hex(registry_contract_address),
-        host="127.0.0.1",
-        port="8545",
+        rpc_client,
     )
 
     discovery = ContractDiscovery(


### PR DESCRIPTION
The blockchain fixture/utils was testing the balance of each address
with an unique rpc client, since the rpc client objects store the nonce
as local state, the nonces were not synchronized for the actual test
run. This may be a reason for tests with underpriced transactions
errors.