### PR TITLE
Improve (contract) versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,23 +4,31 @@ commit = True
 tag = False
 
 [bumpversion:file:setup.py]
+serialize = {major}.{minor}.{patch}
 
 [bumpversion:file:docs/conf.py]
+serialize = {major}.{minor}.{patch}
 
 [bumpversion:file:raiden/smart_contracts/ChannelManagerLibrary.sol]
-search = "contract_version = \"{current_version}\";"
+parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
+serialize = contract_version = "{major}.{minor}._";
 
 [bumpversion:file:raiden/smart_contracts/EndpointRegistry.sol]
-search = "contract_version = \"{current_version}\";"
+parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
+serialize = contract_version = "{major}.{minor}._";
 
 [bumpversion:file:raiden/smart_contracts/NettingChannelContract.sol]
-search = "contract_version = \"{current_version}\";"
+parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
+serialize = contract_version = "{major}.{minor}._";
 
 [bumpversion:file:raiden/smart_contracts/NettingChannelLibrary.sol]
-search = "contract_version = \"{current_version}\";"
+parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
+serialize = contract_version = "{major}.{minor}._";
 
 [bumpversion:file:raiden/smart_contracts/Registry.sol]
-search = "contract_version = \"{current_version}\";"
+parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
+serialize = contract_version = "{major}.{minor}._";
 
 [bumpversion:file:raiden/smart_contracts/Utils.sol]
-search = "contract_version = \"{current_version}\";"
+parse = contract_version = "(?P<major>\d+)\.(?P<minor>\d+)\._";
+serialize = contract_version = "{major}.{minor}._";

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,3 +7,20 @@ tag = False
 
 [bumpversion:file:docs/conf.py]
 
+[bumpversion:file:raiden/smart_contracts/ChannelManagerLibrary.sol]
+search = "contract_version = \"{current_version}\";"
+
+[bumpversion:file:raiden/smart_contracts/EndpointRegistry.sol]
+search = "contract_version = \"{current_version}\";"
+
+[bumpversion:file:raiden/smart_contracts/NettingChannelContract.sol]
+search = "contract_version = \"{current_version}\";"
+
+[bumpversion:file:raiden/smart_contracts/NettingChannelLibrary.sol]
+search = "contract_version = \"{current_version}\";"
+
+[bumpversion:file:raiden/smart_contracts/Registry.sol]
+search = "contract_version = \"{current_version}\";"
+
+[bumpversion:file:raiden/smart_contracts/Utils.sol]
+search = "contract_version = \"{current_version}\";"

--- a/docs/what_is_the_dev_preview.rst
+++ b/docs/what_is_the_dev_preview.rst
@@ -53,11 +53,12 @@ Raiden follows `semver <http://semver.org/>`_ versioning (format ``{major}.{mino
 
 The Raiden `smart contracts <https://github.com/raiden-network/raiden/tree/master/raiden/smart_contracts>`_ also have a version identifier, ``contract_version``, that corresponds to the Raiden software version. During the ``0.x.y`` series they will follow the Raiden release versions only on the ``{major}.{minor}`` parts; the patch part is replaced by ``_``, e.g. ``contract_version = "0.1._";``.
 
-This allows you to be sure, that the version of the smart contract ABI matches those that are deployed on the testnet. In other words, if the smart contract code changes, the Raiden version will minimally increase the ``{minor}`` part, and, if a Raiden release introduces a breaking change, the smart contract versions will also be increased.
+This allows you to be sure, that the version of the smart contract ABI matches those that are deployed on the testnet. In other words, if the smart contract code changes, the Raiden version will at least increase the ``{minor}`` part, and, if a Raiden release introduces a breaking change, the smart contract versions will also be increased.
 
 **Note for Developers:**
-The version reported by ``raiden.utils.get_system_spec()`` depends on the ``pkg_resources`` version. If you are working
-on an editable source install from git, i.e. ``pip install -e .``, you should make sure to
+The version reported by ``raiden.utils.get_system_spec()`` depends on the ``pkg_resources`` version, which is configured
+during ``install`` based on git tags. If you are working on an editable source install from git, i.e. ``pip install -e .``, you should make sure to
 
-- add ``fetch = +refs/tags/*:refs/tags/*`` to your ``.git/config`` file
+- add ``fetch = +refs/tags/*:refs/tags/*`` to the ``[remote "origin"]`` entry of your ``.git/config`` file (`see here
+  <https://stackoverflow.com/a/16678319>`_ for details).
 - call ``pip install -e .`` again after every new (tagged) release.

--- a/docs/what_is_the_dev_preview.rst
+++ b/docs/what_is_the_dev_preview.rst
@@ -46,3 +46,18 @@ Other restrictions
 Currently all nodes participating in a transfer need to be online in order for a transfer to be carried out. This means that users must run a full Raiden node to receive transfers too. The Developer Preview does not offer a Raiden light client, it is however a goal to `implement a light client <https://github.com/raiden-network/raiden/issues/114>`_ in the future.
 
 The transport layer used in the Developer Preview is not very sophisticated and thus it is storing the IP addresses of all nodes participating in the `Endpoint Registry <https://github.com/raiden-network/raiden/blob/master/raiden/smart_contracts/EndpointRegistry.sol>`_ smart contract. In the future it is planned to use something like Whisper for the transportation layer.
+
+Versions
+--------
+Raiden follows `semver <http://semver.org/>`_ versioning (format ``{major}.{minor}.{patch}``). During the current alpha phase, the ``0.x.y`` series, we use the ``{minor}`` part to signify breaking changes.
+
+The Raiden `smart contracts <https://github.com/raiden-network/raiden/tree/master/raiden/smart_contracts>`_ also have a version identifier, ``contract_version``, that corresponds to the Raiden software version. During the ``0.x.y`` series they will follow the Raiden release versions only on the ``{major}.{minor}`` parts; the patch part is replaced by ``_``, e.g. ``contract_version = "0.1._";``.
+
+This allows you to be sure, that the version of the smart contract ABI matches those that are deployed on the testnet. In other words, if the smart contract code changes, the Raiden version will minimally increase the ``{minor}`` part, and, if a Raiden release introduces a breaking change, the smart contract versions will also be increased.
+
+**Note for Developers:**
+The version reported by ``raiden.utils.get_system_spec()`` depends on the ``pkg_resources`` version. If you are working
+on an editable source install from git, i.e. ``pip install -e .``, you should make sure to
+
+- add ``fetch = +refs/tags/*:refs/tags/*`` to your ``.git/config`` file
+- call ``pip install -e .`` again after every new (tagged) release.

--- a/raiden/smart_contracts/ChannelManagerLibrary.sol
+++ b/raiden/smart_contracts/ChannelManagerLibrary.sol
@@ -4,7 +4,7 @@ import "./Token.sol";
 import "./NettingChannelContract.sol";
 
 library ChannelManagerLibrary {
-    string constant public contract_version = "0.0.6";
+    string constant public contract_version = "0.0._";
 
     struct Data {
         Token token;

--- a/raiden/smart_contracts/EndpointRegistry.sol
+++ b/raiden/smart_contracts/EndpointRegistry.sol
@@ -7,7 +7,7 @@
 pragma solidity ^0.4.11;
 
 contract EndpointRegistry{
-    string constant public contract_version = "0.0.6";
+    string constant public contract_version = "0.0._";
 
     event AddressRegistered(address indexed eth_address, string socket);
 

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.11;
 import "./NettingChannelLibrary.sol";
 
 contract NettingChannelContract {
-    string constant public contract_version = "0.0.6";
+    string constant public contract_version = "0.0._";
 
     using NettingChannelLibrary for NettingChannelLibrary.Data;
     NettingChannelLibrary.Data public data;

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.11;
 import "./Token.sol";
 
 library NettingChannelLibrary {
-    string constant public contract_version = "0.0.6";
+    string constant public contract_version = "0.0._";
 
     struct Participant
     {

--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.11;
 import "./ChannelManagerContract.sol";
 
 contract Registry {
-    string constant public contract_version = "0.0.6";
+    string constant public contract_version = "0.0._";
 
     mapping(address => address) public registry;
     address[] public tokens;

--- a/raiden/smart_contracts/Utils.sol
+++ b/raiden/smart_contracts/Utils.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.11;
 
 contract Utils {
-    string constant public contract_version = "0.0.6";
+    string constant public contract_version = "0.0._";
     /// @notice Check if a contract exists
     /// @param channel The address to check whether a contract is deployed or not
     /// @return True if a contract exists, false otherwise

--- a/raiden/tests/smart_contracts/test_registry.py
+++ b/raiden/tests/smart_contracts/test_registry.py
@@ -66,6 +66,13 @@ def test_registry_nonexistent_token(tester_registry, tester_events):
         tester_registry.addToken(fake_token_address, sender=privatekey0)
 
 
+def assert_on_major_minor_version(raidenversion, versionstring):
+    """ Compare only the {major}.{minor} part of the versionstring with raidenversion. """
+    RAIDEN_VERSION = raidenversion.split('+')[0]
+    MAJOR, MINOR, PATCH = RAIDEN_VERSION.split('.')
+    assert tuple(versionstring.split('.')[:2]) == (MAJOR, MINOR)
+
+
 def test_all_contracts_same_version(
         tester_registry,
         tester_channelmanager,
@@ -74,7 +81,6 @@ def test_all_contracts_same_version(
     """ Test that all contracts in the repository have the same version"""
     privatekey0 = tester.DEFAULT_KEY
     RAIDEN_VERSION = get_system_spec()['raiden']
-    RAIDEN_VERSION = RAIDEN_VERSION.split('+')[0]
 
     registry_version = tester_registry.contract_version(sender=privatekey0)
     channelmanager_version = tester_channelmanager.contract_version(sender=privatekey0)
@@ -83,4 +89,5 @@ def test_all_contracts_same_version(
     endpointregistry_version = endpoint_discovery_services[0].version()
 
     assert registry_version == channelmanager_version == channel_version
-    assert channel_version == endpointregistry_version == RAIDEN_VERSION
+    assert channel_version == endpointregistry_version
+    assert_on_major_minor_version(RAIDEN_VERSION, channel_version)

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ install_requires = list(set(
 
 test_requirements = []
 
-version = '0.0.7'  # Keep in sync with RAIDEN_VERSION in raiden/settings.py
+version = '0.0.7'  # Do not edit: this is maintained by bumpversion (see .bumpversion.cfg)
 
 
 def read_version_from_git():

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,10 @@ def read_version_from_git():
             if commit.startswith('g'):
                 commit = commit[1:]
             return '{}+git.r{}'.format(spec, commit)
-        else:
+        elif git_version.count('.') == 2:
             return git_version
+        else:
+            return version
     except BaseException as e:
         print('could not read version from git: {}'.format(e))
         return version


### PR DESCRIPTION
- `test_all_contracts_same_version` failed on travis `master`. This was due to `setup.py::read_version_from_git` incorrectly returned the empty string when no tags where available.

- the way the contract versions where set up, meant that we had to raise contract versions with every bugfix/patch release. I propose to use `{major}.{minor}._` as `contract_version` (i.e. replace the patch part with an underscore)

- the contract versions are now handled by bumpversion

- I added documentation about the versions
