### PR TITLE
Don't print client comms by default

### DIFF
--- a/raiden/tests/benchmark/speed_simulation.py
+++ b/raiden/tests/benchmark/speed_simulation.py
@@ -99,6 +99,7 @@ def setup_tps(
         privkey=privatekey,
         host=host,
         port=port,
+        print_communication=False,
     )
 
     blockchain_service = BlockChainService(
@@ -166,6 +167,7 @@ def tps_run(
         privkey=privatekey,
         host=host,
         port=port,
+        print_communication=False,
     )
 
     blockchain_service = BlockChainService(

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -384,14 +384,13 @@ def blockchain_backend(
 def deploy_client(blockchain_type, blockchain_rpc_ports, deploy_key, request):
     if blockchain_type == 'geth':
         host = '0.0.0.0'
-        print_communication = request.config.option.verbose > 6
         rpc_port = blockchain_rpc_ports[0]
 
         deploy_client = JSONRPCClient(
             host=host,
             port=rpc_port,
             privkey=deploy_key,
-            print_communication=print_communication,
+            print_communication=False,
         )
 
         # cant patch transaction because the blockchain may not be running yet
@@ -481,6 +480,7 @@ def _jsonrpc_services(
             privkey=privkey,
             host=host,
             port=deploy_client.port,
+            print_communication=False,
         )
         patch_send_transaction(rpc_client)
         patch_send_message(rpc_client)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -175,10 +175,7 @@ OPTIONS = [
     ),
     click.option(
         '--console',
-        help=(
-            'Start with or without the command line interface. Default is to '
-            'start with the CLI disabled'
-        ),
+        help='Start the interactive raiden console',
         is_flag=True
     ),
     click.option(
@@ -555,7 +552,7 @@ def version(short, **kwargs):
 @click.option(
     '--debug',
     is_flag=True,
-    help='Drop into pdb on errors (default: False).'
+    help='Drop into pdb on errors.'
 )
 @click.pass_context
 def smoketest(ctx, debug, **kwargs):

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -223,6 +223,11 @@ OPTIONS = [
         ),
         default=True,
     ),
+    click.option(
+        '--eth-client-communication',
+        help='Print all communication with the underlying eth client',
+        is_flag=True,
+    )
 ]
 
 
@@ -254,7 +259,8 @@ def app(address,
         console,
         password_file,
         web_ui,
-        datadir):
+        datadir,
+        eth_client_communication):
 
     from raiden.app import App
     from raiden.network.rpc.client import BlockChainService
@@ -311,6 +317,7 @@ def app(address,
         privkey=privatekey_bin,
         host=rpc_host,
         port=rpc_port,
+        print_communication=eth_client_communication,
     )
 
     # this assumes the eth node is already online

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -174,12 +174,12 @@ OPTIONS = [
         type=int,
     ),
     click.option(
-        '--console/--no-console',
+        '--console',
         help=(
             'Start with or without the command line interface. Default is to '
             'start with the CLI disabled'
         ),
-        default=False,
+        is_flag=True
     ),
     click.option(
         '--rpc/--no-rpc',
@@ -553,8 +553,8 @@ def version(short, **kwargs):
 
 @run.command()
 @click.option(
-    '--debug/--no-debug',
-    default=False,
+    '--debug',
+    is_flag=True,
     help='Drop into pdb on errors (default: False).'
 )
 @click.pass_context

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -90,6 +90,7 @@ def run(privatekey,
         privkey=privatekey_bin,
         host='127.0.0.1',
         port='8545',
+        print_communication=False,
     )
 
     blockchain_service = BlockChainService(


### PR DESCRIPTION
We were printing all client communication by default due to a change in
the rpc client ininitialization. This provides an argument for it and
makes it False by default.