### PR TITLE
fixed TransactionThrew format

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -166,5 +166,5 @@ class TransactionThrew(RaidenError):
     the gasUsed in receipt is the same as the provided transaction gas limit"""
     def __init__(self, txname, receipt):
         super(TransactionThrew, self).__init__(
-            '{} transaction threw. Receipt={}'.format(receipt)
+            '{} transaction threw. Receipt={}'.format(txname, receipt)
         )


### PR DESCRIPTION
The format expected two arguments but only one was provided.

This fixes: travis-ci.org/raiden-network/raiden/jobs/272216632#L1050