### PR TITLE
Add ability to leave all channels of token network

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -598,10 +598,20 @@ You can leave a token network by making a ``DELETE`` request to the following en
 
 The request will only return once all blockchain calls for closing/settling a channel have completed.
 
+Important note. If no arguments are given then raiden will only close and settle channels where your node has received transfers. This is safe from an accounting point of view since deposits can't be lost and provides for the fastest and cheapest way to leave a token network when you want to shut down your node.
+
+If the default behaviour is not desired and the goal is to leave all channels irrespective of having received transfers or not then you should provide as payload to the request ``leave_all_channels=true``
+
 Example Request
 ^^^^^^^^^^^^^^^
 
 ``DELETE /api/1/connection/0x2a65aca4d5fc5b5c859090a6c34d164135398226``
+
+with payload::
+
+  {
+      "leave_all_channels": true
+  }
 
 
 Example Response

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -592,7 +592,7 @@ Possible Responses
 Leaving a token network
 -----------------------
 
-You can leave a token network by making a ``DELETE`` request to the following endpoint along with a json payload containing details about the way you want to leave the network. For instance if you want to wait for settlement and the timeout period.
+You can leave a token network by making a ``DELETE`` request to the following endpoint along with a json payload containing details about the way you want to leave the network.
 
 ``DELETE /api/<version>/connection/<token_address>``
 
@@ -600,7 +600,7 @@ The request will only return once all blockchain calls for closing/settling a ch
 
 Important note. If no arguments are given then raiden will only close and settle channels where your node has received transfers. This is safe from an accounting point of view since deposits can't be lost and provides for the fastest and cheapest way to leave a token network when you want to shut down your node.
 
-If the default behaviour is not desired and the goal is to leave all channels irrespective of having received transfers or not then you should provide as payload to the request ``leave_all_channels=true``
+If the default behaviour is not desired and the goal is to leave all channels irrespective of having received transfers or not then you should provide as payload to the request ``only_receiving_channels=false``
 
 A list with the addresses of all the closed channels will be returned.
 
@@ -612,7 +612,7 @@ Example Request
 with payload::
 
   {
-      "leave_all_channels": true
+      "only_receiving_channels": false
   }
 
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -209,8 +209,8 @@ Example Response
 ::
 
     [
-        {"address": "0xea674fdde714fd979de3edf0f56aa9716b898ec8"},
-        {"address": "0x61bb630d3b2e8eda0fc1d50f9f958ec02e3969f6"}
+        "0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+        "0x61bb630d3b2e8eda0fc1d50f9f958ec02e3969f6"
     ]
 
 Possible Responses
@@ -602,6 +602,8 @@ Important note. If no arguments are given then raiden will only close and settle
 
 If the default behaviour is not desired and the goal is to leave all channels irrespective of having received transfers or not then you should provide as payload to the request ``leave_all_channels=true``
 
+A list with the addresses of all the closed channels will be returned.
+
 Example Request
 ^^^^^^^^^^^^^^^
 
@@ -616,7 +618,14 @@ with payload::
 
 Example Response
 ^^^^^^^^^^^^^^^^
-``204 NO CONTENT``
+``200 OKAY`` with
+::
+
+    [
+        "0x41bcbc2fd72a731bcc136cf6f7442e9c19e9f313",
+        "0x5a5f458f6c1a034930e45dc9a64b99d7def06d7e",
+        "0x8942c06faa74cebff7d55b79f9989adfc85c6b85"
+    ]
 
 Possible Responses
 ^^^^^^^^^^^^^^^^^^

--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -34,13 +34,6 @@ class EventsList(FlatList):
     pass
 
 
-class Token(object):
-    """If we don't end up adding anything to the token schema just delete it
-    and use Address"""
-    def __init__(self, token_address):
-        self.address = token_address
-
-
 class Address(object):
     def __init__(self, token_address):
         self.address = token_address

--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -22,6 +22,10 @@ class TokensList(FlatList):
     pass
 
 
+class AddressList(FlatList):
+    pass
+
+
 class PartnersPerTokenList(FlatList):
     pass
 
@@ -31,6 +35,13 @@ class EventsList(FlatList):
 
 
 class Token(object):
+    """If we don't end up adding anything to the token schema just delete it
+    and use Address"""
+    def __init__(self, token_address):
+        self.address = token_address
+
+
+class Address(object):
     def __init__(self, token_address):
         self.address = token_address
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -139,12 +139,12 @@ class RaidenAPI(object):
             joinable_funds_target=joinable_funds_target
         )
 
-    def leave_token_network(self, token_address):
+    def leave_token_network(self, token_address, leave_all=False):
         """Instruct the ConnectionManager to close all channels and wait for
         settlement.
         """
         connection_manager = self.raiden.connection_manager_for_token(token_address)
-        connection_manager.leave()
+        connection_manager.leave(leave_all)
 
     def get_connection_manager_funds(self, token_address):
         """Get the connection manager for a specific token"""

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -139,12 +139,12 @@ class RaidenAPI(object):
             joinable_funds_target=joinable_funds_target
         )
 
-    def leave_token_network(self, token_address, leave_all=False):
+    def leave_token_network(self, token_address, only_receiving=True):
         """Instruct the ConnectionManager to close all channels and wait for
         settlement.
         """
         connection_manager = self.raiden.connection_manager_for_token(token_address)
-        return connection_manager.leave(leave_all)
+        return connection_manager.leave(only_receiving)
 
     def get_connection_manager_funds(self, token_address):
         """Get the connection manager for a specific token"""

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -144,7 +144,7 @@ class RaidenAPI(object):
         settlement.
         """
         connection_manager = self.raiden.connection_manager_for_token(token_address)
-        connection_manager.leave(leave_all)
+        return connection_manager.leave(leave_all)
 
     def get_connection_manager_funds(self, token_address):
         """Get the connection manager for a specific token"""

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -30,7 +30,6 @@ from raiden.exceptions import (
 from raiden.api.v1.encoding import (
     ChannelSchema,
     ChannelListSchema,
-    TokensListSchema,
     AddressListSchema,
     PartnersPerTokenListSchema,
     HexAddressConverter,
@@ -60,7 +59,7 @@ from raiden.transfer.state import (
 from raiden.raiden_service import (
     create_default_identifier,
 )
-from raiden.api.objects import ChannelList, TokensList, PartnersPerTokenList, AddressList
+from raiden.api.objects import ChannelList, PartnersPerTokenList, AddressList
 from raiden.utils import channel_to_api_dict, split_endpoint
 
 log = slogging.get_logger(__name__)
@@ -250,7 +249,6 @@ class RestAPI(object):
         self.raiden_api = raiden_api
         self.channel_schema = ChannelSchema()
         self.channel_list_schema = ChannelListSchema()
-        self.tokens_list_schema = TokensListSchema()
         self.address_list_schema = AddressListSchema()
         self.partner_per_token_list_schema = PartnersPerTokenListSchema()
         self.transfer_schema = TransferSchema()
@@ -383,13 +381,8 @@ class RestAPI(object):
     def get_tokens_list(self):
         raiden_service_result = self.raiden_api.get_tokens_list()
         assert isinstance(raiden_service_result, list)
-
-        new_list = []
-        for result in raiden_service_result:
-            new_list.append({'address': result})
-
-        tokens_list = TokensList(new_list)
-        result = self.tokens_list_schema.dump(tokens_list)
+        tokens_list = AddressList(raiden_service_result)
+        result = self.address_list_schema.dump(tokens_list)
         return jsonify(result.data)
 
     def get_network_events(self, from_block, to_block):

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -348,7 +348,7 @@ class RestAPI(object):
 
     def leave(self, token_address, leave_all=False):
         closed_channels = self.raiden_api.leave_token_network(token_address, leave_all)
-        closed_channels = [{'address': channel.channel_address} for channel in closed_channels]
+        closed_channels = [channel.channel_address for channel in closed_channels]
         channel_addresses_list = AddressList(closed_channels)
         result = self.address_list_schema.dump(channel_addresses_list)
         return jsonify(result.data)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -344,8 +344,8 @@ class RestAPI(object):
         )
         return make_response('', httplib.NO_CONTENT)
 
-    def leave(self, token_address, leave_all=False):
-        closed_channels = self.raiden_api.leave_token_network(token_address, leave_all)
+    def leave(self, token_address, only_receiving):
+        closed_channels = self.raiden_api.leave_token_network(token_address, only_receiving)
         closed_channels = [channel.channel_address for channel in closed_channels]
         channel_addresses_list = AddressList(closed_channels)
         result = self.address_list_schema.dump(channel_addresses_list)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -344,8 +344,8 @@ class RestAPI(object):
         )
         return make_response('', httplib.NO_CONTENT)
 
-    def leave(self, token_address):
-        self.raiden_api.leave_token_network(token_address)
+    def leave(self, token_address, leave_all=False):
+        self.raiden_api.leave_token_network(token_address, leave_all)
         return make_response('', httplib.NO_CONTENT)
 
     def get_connection_manager_funds(self, token_address):

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -273,3 +273,16 @@ class ConnectionsConnectSchema(BaseSchema):
     class Meta:
         strict = True
         decoding_class = dict
+
+
+class ConnectionsLeaveSchema(BaseSchema):
+    leave_all_channels = fields.Boolean(
+        required=False,
+        default=False,
+        missing=False,
+        location='json'
+    )
+
+    class Meta:
+        strict = True
+        decoding_class = dict

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -236,12 +236,11 @@ class TokenSwapsSchema(BaseSchema):
     role = fields.String(
         required=True,
         validate=validate.OneOf(['maker', 'taker']),
-        location='json',
     )
-    sending_amount = fields.Integer(required=True, location='json')
-    sending_token = AddressField(required=True, location='json')
-    receiving_amount = fields.Integer(required=True, location='json')
-    receiving_token = AddressField(required=True, location='json')
+    sending_amount = fields.Integer(required=True)
+    sending_token = AddressField(required=True)
+    receiving_amount = fields.Integer(required=True)
+    receiving_token = AddressField(required=True)
 
     class Meta:
         strict = True
@@ -261,12 +260,11 @@ class TransferSchema(BaseSchema):
 
 
 class ConnectionsConnectSchema(BaseSchema):
-    funds = fields.Integer(required=True, location='json')
+    funds = fields.Integer(required=True)
     initial_channel_target = fields.Integer(
         missing=DEFAULT_INITIAL_CHANNEL_TARGET,
-        location='json'
     )
-    joinable_funds_target = fields.Decimal(missing=DEFAULT_JOINABLE_FUNDS_TARGET, location='json')
+    joinable_funds_target = fields.Decimal(missing=DEFAULT_JOINABLE_FUNDS_TARGET)
 
     class Meta:
         strict = True
@@ -278,7 +276,6 @@ class ConnectionsLeaveSchema(BaseSchema):
         required=False,
         default=True,
         missing=True,
-        location='json'
     )
 
     class Meta:

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -174,7 +174,7 @@ class AddressSchema(BaseSchema):
 
 
 class AddressListSchema(BaseListSchema):
-    data = fields.Nested(AddressSchema, many=True)
+    data = fields.List(AddressField())
 
     class Meta:
         strict = True

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -274,10 +274,10 @@ class ConnectionsConnectSchema(BaseSchema):
 
 
 class ConnectionsLeaveSchema(BaseSchema):
-    leave_all_channels = fields.Boolean(
+    only_receiving_channels = fields.Boolean(
         required=False,
-        default=False,
-        missing=False,
+        default=True,
+        missing=True,
         location='json'
     )
 

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -20,6 +20,8 @@ from pyethapp.jsonrpc import (
 )
 
 from raiden.api.objects import (
+    Address,
+    AddressList,
     Channel,
     ChannelList,
     Token,
@@ -147,7 +149,7 @@ class EventRequestSchema(BaseSchema):
 
 class TokenSchema(BaseSchema):
     """Simple token schema only with an address field. In the future we could
-    add other attributes like 'name'"""
+    add other attributes like 'name. If not replace it with the AddressSchema'"""
     address = AddressField()
 
     class Meta:
@@ -161,6 +163,22 @@ class TokensListSchema(BaseListSchema):
     class Meta:
         strict = True
         decoding_class = TokensList
+
+
+class AddressSchema(BaseSchema):
+    address = AddressField()
+
+    class Meta:
+        strict = True
+        decoding_class = Address
+
+
+class AddressListSchema(BaseListSchema):
+    data = fields.Nested(AddressSchema, many=True)
+
+    class Meta:
+        strict = True
+        decoding_class = AddressList
 
 
 class PartnersPerTokenSchema(BaseSchema):

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -24,8 +24,6 @@ from raiden.api.objects import (
     AddressList,
     Channel,
     ChannelList,
-    Token,
-    TokensList,
     PartnersPerToken,
     PartnersPerTokenList
 )
@@ -145,24 +143,6 @@ class EventRequestSchema(BaseSchema):
         strict = True
         # decoding to a dict is required by the @use_kwargs decorator from webargs
         decoding_class = dict
-
-
-class TokenSchema(BaseSchema):
-    """Simple token schema only with an address field. In the future we could
-    add other attributes like 'name. If not replace it with the AddressSchema'"""
-    address = AddressField()
-
-    class Meta:
-        strict = True
-        decoding_class = Token
-
-
-class TokensListSchema(BaseListSchema):
-    data = fields.Nested(TokenSchema, many=True)
-
-    class Meta:
-        strict = True
-        decoding_class = TokensList
 
 
 class AddressSchema(BaseSchema):

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -178,10 +178,10 @@ class ConnectionsResource(BaseResource):
         )
 
     @use_kwargs(delete_schema, locations=('json',))
-    def delete(self, token_address, leave_all_channels):
+    def delete(self, token_address, only_receiving_channels):
         return self.rest_api.leave(
             token_address=token_address,
-            leave_all=leave_all_channels
+            only_receiving=only_receiving_channels
         )
 
     def get(self, token_address):

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -9,6 +9,7 @@ from raiden.api.v1.encoding import (
     TokenSwapsSchema,
     TransferSchema,
     ConnectionsConnectSchema,
+    ConnectionsLeaveSchema,
 )
 
 
@@ -165,6 +166,7 @@ class TransferToTargetResource(BaseResource):
 class ConnectionsResource(BaseResource):
 
     put_schema = ConnectionsConnectSchema()
+    delete_schema = ConnectionsLeaveSchema()
 
     @use_kwargs(put_schema)
     def put(self, token_address, funds, initial_channel_target, joinable_funds_target):
@@ -175,8 +177,12 @@ class ConnectionsResource(BaseResource):
             joinable_funds_target=joinable_funds_target,
         )
 
-    def delete(self, token_address):
-        return self.rest_api.leave(token_address=token_address)
+    @use_kwargs(delete_schema, locations=('json',))
+    def delete(self, token_address, leave_all_channels):
+        return self.rest_api.leave(
+            token_address=token_address,
+            leave_all=leave_all_channels
+        )
 
     def get(self, token_address):
         return self.rest_api.get_connection_manager_funds(token_address=token_address)

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -150,7 +150,7 @@ class ConnectionManager(object):
         Note, that this does not time out.
         """
         not_settled_channels = [
-            channel for channel in self.closed_channels
+            channel for channel in closed_channels
             if not channel.state != CHANNEL_STATE_SETTLED
         ]
         while any(c.state != CHANNEL_STATE_SETTLED for c in not_settled_channels):

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -112,7 +112,7 @@ class ConnectionManager(object):
         gevent.spawn(self.leave).link(leave_result)
         return leave_result
 
-    def leave(self, leave_all=False):
+    def leave(self, only_receiving=True):
         """ Leave the token network.
         This implies closing all channels and waiting for all channels to be settled.
         """
@@ -122,11 +122,11 @@ class ConnectionManager(object):
         if self.initial_channel_target > 0:
             self.initial_channel_target = 0
 
-        closed_channels = self.close_all(leave_all)
+        closed_channels = self.close_all(only_receiving)
         self.wait_for_settle(closed_channels)
         return closed_channels
 
-    def close_all(self, leave_all=False):
+    def close_all(self, only_receiving=True):
         """ Close all channels in the token network.
         Note: By default we're just discarding all channels we haven't received anything.
         This potentially leaves deposits locked in channels after `closing`. This is "safe"
@@ -134,12 +134,14 @@ class ConnectionManager(object):
         undesirable from a liquidity point of view (deposits will only be freed after
         manually closing or after the partner closed the channel).
 
-        If leave_all is True then we close and settle all channels irrespective of them
+        If only_receiving is False then we close and settle all channels irrespective of them
         having received transfers or not.
         """
         with self.lock:
             self.initial_channel_target = 0
-            channels_to_close = self.open_channels[:] if leave_all else self.receiving_channels[:]
+            channels_to_close = (
+                self.receiving_channels[:] if only_receiving else self.open_channels[:]
+            )
             for channel in channels_to_close:
                 # FIXME: race condition, this can fail if channel was closed externally
                 self.api.close(self.token_address, channel.partner_address)

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -112,7 +112,7 @@ class ConnectionManager(object):
         gevent.spawn(self.leave).link(leave_result)
         return leave_result
 
-    def leave(self):
+    def leave(self, leave_all=False):
         """ Leave the token network.
         This implies closing all channels and waiting for all channels to be settled.
         """
@@ -122,20 +122,23 @@ class ConnectionManager(object):
         if self.initial_channel_target > 0:
             self.initial_channel_target = 0
 
-        self.close_all()
+        self.close_all(leave_all)
         return self.wait_for_settle()
 
-    def close_all(self):
-        """ Close all receiving channels in the token network.
-        Note: we're just discarding all channels we haven't received anything. This potentially
-        leaves deposits locked in channels after `closing`. This is "safe" from an accounting
-        point of view (deposits can not be lost), but may still be undesirable from a liquidity
-        point of view (deposits will only be freed after manually closing or after the partner
-        closed the channel).
+    def close_all(self, leave_all=False):
+        """ Close all channels in the token network.
+        Note: By default we're just discarding all channels we haven't received anything.
+        This potentially leaves deposits locked in channels after `closing`. This is "safe"
+        from an accounting point of view (deposits can not be lost), but may still be
+        undesirable from a liquidity point of view (deposits will only be freed after
+        manually closing or after the partner closed the channel).
+
+        If leave_all is True then we close and settle all channels irrespective of them
+        having received transfers or not.
         """
         with self.lock:
             self.initial_channel_target = 0
-            channels_to_close = self.receiving_channels[:]
+            channels_to_close = self.open_channels[:] if leave_all else self.receiving_channels[:]
             for channel in channels_to_close:
                 # FIXME: race condition, this can fail if channel was closed externally
                 self.api.close(self.token_address, channel.partner_address)

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -622,7 +622,7 @@ def test_api_tokens(
         '0x61c808d82a3ac53231750dadc13c777b59310bd9',
         '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
     ]
-    assert all(r in response for r in expected_response)
+    assert set(response) == set(expected_response)
 
 
 def test_query_partners_by_token(
@@ -1023,7 +1023,7 @@ def test_connect_and_leave_token_network(
     assert_proper_response(response)
     response = response.json()
     expected_response = [channel['channel_address'] for channel in channels]
-    assert all(r in response for r in expected_response)
+    assert set(response) == set(expected_response)
 
     # check that all channels were settled after calling `leave`
     request = grequests.get(

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -1019,7 +1019,7 @@ def test_connect_and_leave_token_network(
         api_url_for(api_backend, 'connectionsresource', token_address=token_address),
     )
     response = request.send().response
-    assert(not api_test_context.last_leave_all)
+    assert(api_test_context.last_only_receiving)
     assert_proper_response(response)
     response = response.json()
     expected_response = [channel['channel_address'] for channel in channels]
@@ -1037,14 +1037,14 @@ def test_connect_and_leave_token_network(
     assert channels[1]['state'] == CHANNEL_STATE_SETTLED
     assert channels[2]['state'] == CHANNEL_STATE_SETTLED
 
-    # Let's try to leave again but this time give the leave_all argument
+    # Let's try to leave again but this time set only_receiving to False
     request = grequests.delete(
         api_url_for(api_backend, 'connectionsresource', token_address=token_address),
-        json={'leave_all_channels': True},
+        json={'only_receiving_channels': False},
     )
     response = request.send().response
     assert_proper_response(response)
-    assert(api_test_context.last_leave_all)
+    assert(not api_test_context.last_only_receiving)
 
 
 def test_register_token(api_backend, api_test_context, api_raiden_service):

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -619,8 +619,8 @@ def test_api_tokens(
     assert_proper_response(response)
     response = response.json()
     expected_response = [
-        {'address': '0x61c808d82a3ac53231750dadc13c777b59310bd9'},
-        {'address': '0xea674fdde714fd979de3edf0f56aa9716b898ec8'},
+        '0x61c808d82a3ac53231750dadc13c777b59310bd9',
+        '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
     ]
     assert all(r in response for r in expected_response)
 
@@ -1019,7 +1019,11 @@ def test_connect_and_leave_token_network(
         api_url_for(api_backend, 'connectionsresource', token_address=token_address),
     )
     response = request.send().response
-    assert_empty_response_with_code(response, httplib.NO_CONTENT)
+    assert(not api_test_context.last_leave_all)
+    assert_proper_response(response)
+    response = response.json()
+    expected_response = [channel['channel_address'] for channel in channels]
+    assert all(r in response for r in expected_response)
 
     # check that all channels were settled after calling `leave`
     request = grequests.get(
@@ -1032,6 +1036,15 @@ def test_connect_and_leave_token_network(
     assert channels[0]['state'] == CHANNEL_STATE_SETTLED
     assert channels[1]['state'] == CHANNEL_STATE_SETTLED
     assert channels[2]['state'] == CHANNEL_STATE_SETTLED
+
+    # Let's try to leave again but this time give the leave_all argument
+    request = grequests.delete(
+        api_url_for(api_backend, 'connectionsresource', token_address=token_address),
+        json={'leave_all_channels': True},
+    )
+    response = request.send().response
+    assert_proper_response(response)
+    assert(api_test_context.last_leave_all)
 
 
 def test_register_token(api_backend, api_test_context, api_raiden_service):

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -324,13 +324,13 @@ class ApiTestContext():
         connection_manager = ConnectionManagerMock(token_address, funds)
         self.connection_managers.append(connection_manager)
 
-    def leave(self, token_address, leave_all):
+    def leave(self, token_address, only_receiving):
         if not isaddress(token_address):
             raise InvalidAddress('not an address %s' % pex(token_address))
 
-        # for the mocking purposes let's just ignore leave_all but keep its value
-        # in the mock context for checking
-        self.last_leave_all = leave_all
+        # for the mocking purposes let's just ignore only_receiving_ but keep its
+        # value in the mock context for checking
+        self.last_only_receiving = only_receiving
 
         channels = self.get_all_channels_for_token(token_address)
         for channel in channels:

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -324,15 +324,20 @@ class ApiTestContext():
         connection_manager = ConnectionManagerMock(token_address, funds)
         self.connection_managers.append(connection_manager)
 
-    def leave(self, token_address):
-
+    def leave(self, token_address, leave_all):
         if not isaddress(token_address):
             raise InvalidAddress('not an address %s' % pex(token_address))
+
+        # for the mocking purposes let's just ignore leave_all but keep its value
+        # in the mock context for checking
+        self.last_leave_all = leave_all
 
         channels = self.get_all_channels_for_token(token_address)
         for channel in channels:
             channel.external_state.netting_channel.state = CHANNEL_STATE_SETTLED
             channel.external_state._settled_block = 1
+
+        return channels
 
     def get_connection_manager_funds(self, token_address):
 

--- a/raiden/ui/web/src/app/services/raiden.service.ts
+++ b/raiden/ui/web/src/app/services/raiden.service.ts
@@ -79,19 +79,19 @@ export class RaidenService {
     }
 
     public getTokensBalances(refresh: boolean = true): Observable<Array<Usertoken>> {
-        return this.httpEncap(this.http.get<Array<{ address: string }>>(`${this.raidenConfig.api}/tokens`))
+        return this.httpEncap(this.http.get<Array<string>>(`${this.raidenConfig.api}/tokens`))
             .combineLatest(this.getChannels())
             .map(([data, channels]): Array<Observable<Usertoken>> => {
                 const tokenArray = data;
                 return tokenArray
                     .map((token) => this.getUsertoken(
-                        token.address,
+                        token,
                         refresh)
                         .map((userToken) => {
                             if (userToken) {
                                 return Object.assign(userToken,
                                     { channelCnt: channels.filter((channel) =>
-                                        channel.token_address === token.address).length });
+                                        channel.token_address === token).length });
                             }
                             return userToken;
                         })


### PR DESCRIPTION
- Adds the ability to leave all channels of a token network instead of just those that have received transfers. The default remains the current option, but with an extra argument given to the REST endpoint you can leave all channels you are part of in the token

- The `leave` endpoint now returns a response. The list of all closed/settled channels.

- Simplified the schema for returning a list of addresses. It was quite wasteful to return a list of one-key dictionaries with the same `"address"` key. We now use a simple `AddressList` schema for a list of addresses to be returned by the REST API. Used it also in the endpoint returning the list of tokens. @andrevmatos I think that the webui uses that endpoint so there is going to be a change in its consumption. Can you help point to where the change should happen?