### PR TITLE
Ignore git-tag version on non tagged commits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ def read_version_from_git():
             spec, _, commit = git_version.split('-')
             if commit.startswith('g'):
                 commit = commit[1:]
-            return '{}+git.r{}'.format(spec, commit)
+            return '{}+git.r{}'.format(version, commit)
         elif git_version.count('.') == 2:
             return git_version
         else:


### PR DESCRIPTION
Our version reporting is a little brittle for non-released installs from
git: If there is no tag (yet), but the intended version maintained in
`setup.py::version` is higher than the latest available tag, the version
description will be incorrect.

With this commit, we ignore the tag part on un-tagged git commits, which
allows for a better version resolution, especially during CI (i.e. PRs
for a version bump).