### PR TITLE
Fix error response when settling inside settlement period

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -488,7 +488,8 @@ Possible Responses
 |                  | some way malformed        |
 +------------------+---------------------------+
 | 409 Conflict     | Provided channel does not |
-|                  | exist                     |
+|                  | exist, or is inside       |
+|                  | settlement period         |
 +------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -515,7 +515,7 @@ class RestAPI(object):
             return jsonify(result.data)
 
         if state == CHANNEL_STATE_SETTLED:
-            if current_state == CHANNEL_STATE_SETTLED or current_state == CHANNEL_STATE_OPENED:
+            if current_state != CHANNEL_STATE_CLOSED:
                 return make_response(
                     'Attempted to settle a channel at its {} state'.format(current_state),
                     httplib.CONFLICT,
@@ -526,13 +526,13 @@ class RestAPI(object):
                     channel.partner_address
                 )
             except InvalidState:
-                result = make_response(
+                return make_response(
                     'Settlement period is not yet over',
                     httplib.CONFLICT,
                 )
             else:
                 result = self.channel_schema.dump(channel_to_api_dict(raiden_service_result))
-            return jsonify(result.data)
+                return jsonify(result.data)
 
         # should never happen, channel_state is validated in the schema
         return make_response(


### PR DESCRIPTION
If you tried to settle inside settlement period, it'd give a `200 OK` response with the text `Settlement period is not yet over` (no JSON encoded). This PR makes it answer with `409 CONFLICT` HTTP response, which is better handled inside webUI, for example, and is consistent with other error responses in the API.