### PR TITLE
Improvements to `/connection` API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 
+* :feature:`921` Add ``/api/1/connection`` API endpoint returning information about all connected token networks.
 * :bug:`1011` Remove ``settled`` attribute from the NettingChannel smart contract.
 * :release:`0.1.0 <2017-09-12>`
 * :feature:`-`  This is the `Raiden Developer Preview <https://github.com/raiden-network/raiden/releases/tag/v0.1.0>`_ release. Introduces a raiden test network on ropsten, the API and all the basic functionality required to use Raiden in Dapps. For more information read the `blog post <https://medium.com/@raiden_network/raiden-network-developer-preview-dad83ec3fc23>`_ or the `documentation of v0.1.0 <http://raiden-network.readthedocs.io/en/v0.1.0/>`_.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -640,6 +640,52 @@ Possible Responses
 | 500 Server Error | Internal Raiden node error|
 +------------------+---------------------------+
 
+Querying connections details
+------------------------------
+
+You can query for details of previously joined token networks by making a GET request to the connection endpoint.
+
+``GET /api/<version>/connection``
+
+The request will return a JSON object where each key is a token address for which you have open channels.
+The values are a JSON object containing numeric values for ``funds`` from last connect request, ``sum_deposits``
+of all currently open channels and number of ``channels`` currently open for that token.
+
+Example Request
+^^^^^^^^^^^^^^^
+
+``GET /api/1/connection``
+
+Example Response
+^^^^^^^^^^^^^^^^
+``200 OK``
+
+::
+
+    {
+        "0x2a65aca4d5fc5b5c859090a6c34d164135398226": {
+            "funds": 100,
+            "sum_deposits": 67,
+            "channels": 3
+        },
+        "0x0f114a1e9db192502e7856309cc899952b3db1ed": {
+            "funds": 49
+            "sum_deposits": 31,
+            "channels": 1
+        }
+    }
+
+Possible Responses
+^^^^^^^^^^^^^^^^^^
+
++------------------+---------------------------+
+| HTTP Code        | Condition                 |
++==================+===========================+
+| 200 OK           | For a successful query    |
++------------------+---------------------------+
+| 500 Server Error | Internal Raiden node error|
++------------------+---------------------------+
+
 Transfers
 =========
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -158,11 +158,15 @@ class RaidenAPI(object):
             return connection_manager.funds
 
     def get_connection_managers_list(self):
+        """Get a list of connection managers with open channels"""
         connection_managers = []
 
         for token in self.get_tokens_list():
-            connection_manager = self.raiden.connection_manager_for_token(token)
-            if connection_manager is not None:
+            try:
+                connection_manager = self.raiden.connection_manager_for_token(token)
+            except InvalidAddress:
+                connection_manager = None
+            if connection_manager is not None and connection_manager.open_channels:
                 connection_managers.append(connection_manager.token_address)
 
         return connection_managers

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -149,21 +149,10 @@ class RaidenAPI(object):
         connection_manager = self.raiden.connection_manager_for_token(token_address)
         return connection_manager.leave(only_receiving)
 
-    def get_connection_manager_funds(self, token_address):
-        """Get the sum of all connection manager's open channels deposits"""
-        try:
-            connection_manager = self.raiden.connection_manager_for_token(token_address)
-        except InvalidAmount:
-            connection_manager = None
-        if connection_manager is not None and connection_manager.open_channels:
-            return connection_manager.sum_deposits
-        else:
-            # explicitly return None, in case of invalid connection manager
-            return None
-
-    def get_connection_managers_list(self):
-        """Get a list of connection managers with open channels"""
-        connection_managers = []
+    def get_connection_managers_info(self):
+        """Get a dict whose keys are token addresses and whose values are
+        open channels, funds of last request, sum of deposits and number of channels"""
+        connection_managers = dict()
 
         for token in self.get_tokens_list():
             try:
@@ -171,7 +160,11 @@ class RaidenAPI(object):
             except InvalidAddress:
                 connection_manager = None
             if connection_manager is not None and connection_manager.open_channels:
-                connection_managers.append(connection_manager.token_address)
+                connection_managers[connection_manager.token_address] = {
+                    "funds": connection_manager.funds,
+                    "sum_deposits": connection_manager.sum_deposits,
+                    "channels": len(connection_manager.open_channels),
+                }
 
         return connection_managers
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -150,12 +150,16 @@ class RaidenAPI(object):
         return connection_manager.leave(only_receiving)
 
     def get_connection_manager_funds(self, token_address):
-        """Get the connection manager for a specific token"""
-        connection_manager = self.raiden.connection_manager_for_token(token_address)
-        if not connection_manager:
-            return None
+        """Get the sum of all connection manager's open channels deposits"""
+        try:
+            connection_manager = self.raiden.connection_manager_for_token(token_address)
+        except InvalidAmount:
+            connection_manager = None
+        if connection_manager is not None and connection_manager.open_channels:
+            return connection_manager.sum_deposits
         else:
-            return connection_manager.funds
+            # explicitly return None, in case of invalid connection manager
+            return None
 
     def get_connection_managers_list(self):
         """Get a list of connection managers with open channels"""

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -352,13 +352,10 @@ class RestAPI(object):
         return jsonify(result.data)
 
     def get_connection_manager_funds(self, token_address):
-        connection_manager = self.raiden_api.get_connection_manager_funds(token_address)
-
-        if connection_manager is None:
+        funds = self.raiden_api.get_connection_manager_funds(token_address)
+        if funds is None:
             return make_response('No connection manager exists for token', httplib.NO_CONTENT)
-
-        if connection_manager is not None:
-            return jsonify(connection_manager)
+        return jsonify(funds)
 
     def get_connection_managers_list(self):
         raiden_service_result = self.raiden_api.get_connection_managers_list()

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -363,12 +363,9 @@ class RestAPI(object):
     def get_connection_managers_list(self):
         raiden_service_result = self.raiden_api.get_connection_managers_list()
         assert isinstance(raiden_service_result, list)
-
-        new_list = []
-        for result in raiden_service_result:
-            new_list.append(address_encoder(result))
-
-        return jsonify(new_list)
+        tokens_list = AddressList(raiden_service_result)
+        result = self.address_list_schema.dump(tokens_list)
+        return jsonify(result.data)
 
     def get_channel_list(self, token_address=None, partner_address=None):
         raiden_service_result = self.raiden_api.get_channel_list(token_address, partner_address)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -351,18 +351,13 @@ class RestAPI(object):
         result = self.address_list_schema.dump(channel_addresses_list)
         return jsonify(result.data)
 
-    def get_connection_manager_funds(self, token_address):
-        funds = self.raiden_api.get_connection_manager_funds(token_address)
-        if funds is None:
-            return make_response('No connection manager exists for token', httplib.NO_CONTENT)
-        return jsonify(funds)
-
-    def get_connection_managers_list(self):
-        raiden_service_result = self.raiden_api.get_connection_managers_list()
-        assert isinstance(raiden_service_result, list)
-        tokens_list = AddressList(raiden_service_result)
-        result = self.address_list_schema.dump(tokens_list)
-        return jsonify(result.data)
+    def get_connection_managers_info(self):
+        raiden_service_result = self.raiden_api.get_connection_managers_info()
+        assert isinstance(raiden_service_result, dict)
+        # encode token addresses indexes
+        result = {address_encoder(token_address): info
+                  for token_address, info in raiden_service_result.iteritems()}
+        return jsonify(result)
 
     def get_channel_list(self, token_address=None, partner_address=None):
         raiden_service_result = self.raiden_api.get_channel_list(token_address, partner_address)

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -184,14 +184,8 @@ class ConnectionsResource(BaseResource):
             only_receiving=only_receiving_channels
         )
 
-    def get(self, token_address):
-        return self.rest_api.get_connection_manager_funds(token_address=token_address)
-
 
 class ConnectionManagersResource(BaseResource):
 
-    def __init__(self, **kwargs):
-        super(ConnectionManagersResource, self).__init__(**kwargs)
-
     def get(self):
-        return self.rest_api.get_connection_managers_list()
+        return self.rest_api.get_connection_managers_info()

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -86,9 +86,7 @@ class ConnectionManager(object):
                 'connect() called on an already joined token network',
                 token_address=pex(self.token_address),
                 open_channels=len(open_channels),
-                sum_deposits=sum(
-                    channel.contract_balance for channel in open_channels
-                ),
+                sum_deposits=self.sum_deposits,
                 funds=funds,
             )
 
@@ -320,9 +318,7 @@ class ConnectionManager(object):
         """The remaining funds after subtracting the already deposited amounts.
         """
         if self.funds > 0:
-            remaining = self.funds - sum(
-                channel.contract_balance for channel in self.open_channels
-            )
+            remaining = self.funds - self.sum_deposits
             assert isinstance(remaining, int)
             return remaining
         return 0
@@ -336,6 +332,11 @@ class ConnectionManager(object):
             self.api.get_channel_list(token_address=self.token_address)
             if channel.state == CHANNEL_STATE_OPENED
         ]
+
+    @property
+    def sum_deposits(self):
+        """Shorthand for getting sum of all open channels deposited funds"""
+        return sum(channel.contract_balance for channel in self.open_channels)
 
     @property
     def receiving_channels(self):

--- a/raiden/tests/api/test_api.py
+++ b/raiden/tests/api/test_api.py
@@ -1068,64 +1068,7 @@ def test_register_token(api_backend, api_test_context, api_raiden_service):
     assert response is not None and response.status_code == httplib.CONFLICT
 
 
-def test_get_connection_manager_for_token(
-        api_backend,
-        api_test_context,
-        api_raiden_service):
-
-    # first check we don't have any existing conection manager
-    token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
-    request = grequests.get(
-        api_url_for(api_backend, 'connectionsresource', token_address=token_address)
-    )
-    response = request.send().response
-    assert_response_with_code(response, status_code=httplib.NO_CONTENT)
-
-    funds = 100
-    initial_channel_target = DEFAULT_INITIAL_CHANNEL_TARGET
-    joinable_funds_target = DEFAULT_JOINABLE_FUNDS_TARGET
-    token_address = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
-    connect_data_obj = {
-        'funds': funds,
-    }
-    request = grequests.put(
-        api_url_for(api_backend, 'connectionsresource', token_address=token_address),
-        json=connect_data_obj,
-    )
-    response = request.send().response
-    assert_empty_response_with_code(response, httplib.NO_CONTENT)
-
-    # check that channels got created
-    request = grequests.get(
-        api_url_for(api_backend, 'channelsresource')
-    )
-    response = request.send().response
-    assert_proper_response(response)
-    channels = response.json()
-    # There should be three channels according to the default initial_channel_target
-    assert len(channels) == DEFAULT_INITIAL_CHANNEL_TARGET
-    assert response.json() == api_test_context.expect_channels()
-
-    expected_balance = int((funds * joinable_funds_target) / initial_channel_target)
-    assert channels[0]['balance'] == expected_balance
-    assert channels[1]['balance'] == expected_balance
-    assert channels[2]['balance'] == expected_balance
-    assert channels[0]['state'] == CHANNEL_STATE_OPENED
-    assert channels[1]['state'] == CHANNEL_STATE_OPENED
-    assert channels[2]['state'] == CHANNEL_STATE_OPENED
-
-    # Check that a channel manager was created and returned
-    request = grequests.get(
-        api_url_for(api_backend, 'connectionsresource', token_address=token_address)
-    )
-    response = request.send().response
-    assert response is not None and response.status_code == httplib.OK
-    assert_proper_response(response)
-    cm_funds = response.json()
-    assert cm_funds == funds
-
-
-def test_get_connection_managers_list(
+def test_get_connection_managers_info(
         api_backend,
         api_test_context,
         api_raiden_service):
@@ -1136,7 +1079,7 @@ def test_get_connection_managers_list(
     )
     response = request.send().response
     token_addresses = response.json()
-    assert token_addresses == []
+    assert token_addresses == dict()
 
     funds = 100
     token_address1 = '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
@@ -1156,7 +1099,10 @@ def test_get_connection_managers_list(
     )
     response = request.send().response
     token_addresses = response.json()
-    assert token_addresses == [token_address1]
+    assert isinstance(token_addresses, dict) and len(token_addresses.keys()) == 1
+    assert token_address1 in token_addresses
+    assert isinstance(token_addresses[token_address1], dict)
+    assert set(token_addresses[token_address1].keys()) == {"funds", "sum_deposits", "channels"}
 
     funds = 100
     token_address2 = '0x3edf0f56aa9716b898ec8ea674fdde714fd979de'
@@ -1176,4 +1122,7 @@ def test_get_connection_managers_list(
     )
     response = request.send().response
     token_addresses = response.json()
-    assert token_addresses == [token_address1, token_address2]
+    assert isinstance(token_addresses, dict) and len(token_addresses.keys()) == 2
+    assert token_address2 in token_addresses
+    assert isinstance(token_addresses[token_address2], dict)
+    assert set(token_addresses[token_address2].keys()) == {"funds", "sum_deposits", "channels"}

--- a/raiden/tests/fixtures/api.py
+++ b/raiden/tests/fixtures/api.py
@@ -103,13 +103,8 @@ def api_raiden_service(
     monkeypatch.setattr(api, 'leave_token_network', api_test_context.leave)
     monkeypatch.setattr(
         api,
-        'get_connection_manager_funds',
-        api_test_context.get_connection_manager_funds
-    )
-    monkeypatch.setattr(
-        api,
-        'get_connection_managers_list',
-        api_test_context.get_connection_managers_list
+        'get_connection_managers_info',
+        api_test_context.get_connection_managers_info
     )
     monkeypatch.setattr(api, 'register_token', api_test_context.register_token)
     monkeypatch.setattr(

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -43,6 +43,8 @@ class ConnectionManagerMock(object):
     def __init__(self, token_address, funds):
         self.token_address = token_address
         self.funds = funds
+        self.sum_deposits = funds
+        self.open_channels = []
 
 
 class ApiTestContext():
@@ -336,22 +338,15 @@ class ApiTestContext():
 
         return channels
 
-    def get_connection_manager_funds(self, token_address):
-
-        if not isaddress(token_address):
-            raise InvalidAddress('not an address %s' % pex(token_address))
+    def get_connection_managers_info(self):
+        token_addresses = {}
 
         for connection_manager in self.connection_managers:
-            if (connection_manager.token_address == token_address):
-                return connection_manager.funds
-
-        return None
-
-    def get_connection_managers_list(self):
-        token_addresses = []
-
-        for connection_manager in self.connection_managers:
-            token_addresses.append(connection_manager.token_address)
+            token_addresses[connection_manager.token_address] = {
+                "funds": connection_manager.funds,
+                "sum_deposits": connection_manager.sum_deposits,
+                "channels": len(connection_manager.open_channels)
+            }
 
         return token_addresses
 

--- a/raiden/ui/web/src/app/components/channel-table/channel-table.component.ts
+++ b/raiden/ui/web/src/app/components/channel-table/channel-table.component.ts
@@ -200,7 +200,7 @@ export class ChannelTableComponent implements OnInit {
             {
                 label: 'Transfer',
                 icon: 'fa-exchange',
-                disabled: channel.state !== 'opened',
+                disabled: !(channel.state === 'opened' && channel.balance > 0),
                 command: () => this.onTransfer(channel)
             },
             {

--- a/raiden/ui/web/src/app/components/token-network/token-network.component.ts
+++ b/raiden/ui/web/src/app/components/token-network/token-network.component.ts
@@ -66,7 +66,7 @@ export class TokenNetworkComponent implements OnInit {
             {
                 label: 'Transfer',
                 icon: 'fa-exchange',
-                disabled: !(userToken.connected && userToken.balance > 0),
+                disabled: !(userToken.connected && userToken.connected.sum_deposits > 0),
                 command: () => this.showTransferDialog(userToken),
             },
             {

--- a/raiden/ui/web/src/app/models/connection.ts
+++ b/raiden/ui/web/src/app/models/connection.ts
@@ -1,0 +1,9 @@
+export interface Connection {
+    funds: number;
+    sum_deposits: number;
+    channels: number;
+};
+
+export interface Connections {
+    [address: string]: Connection;
+};

--- a/raiden/ui/web/src/app/models/usertoken.ts
+++ b/raiden/ui/web/src/app/models/usertoken.ts
@@ -1,7 +1,9 @@
+import { Connection } from './connection';
+
 export interface Usertoken {
     address: string;
     symbol: string;
     name: string;
     balance: number;
-    connected?: boolean;
+    connected?: Connection;
 };


### PR DESCRIPTION
This PR should:
- Test for `ConnectionManager`s with open channels to return in the `/connection` endpoint
- Use sum of deposits in all open channels for a given ConnectionManager on `/connection/<token_address>` endpoint
- ~~Plus [optimization]: try to parallelize open and deposit when joining a token network.~~

Fix #921 and improves the work done in #934 .