### PR TITLE
Add the Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
+
+## Unreleased
+---
+
+### New
+
+### Changes
+
+### Fixes
+
+### Breaks
+
+
+## 0.1.0 - (2017-09-12)
+---
+
+This is the [Raiden Developer Preview](https://github.com/raiden-network/raiden/releases/tag/v0.1.0) release.
+Introduces a raiden test network on ropsten, the API and all the basic functionality required to use Raiden in Dapps.
+For more information read the [blog post](https://medium.com/@raiden_network/raiden-network-developer-preview-dad83ec3fc23)
+or the [documentation of v0.1.0](http://raiden-network.readthedocs.io/en/v0.1.0/).


### PR DESCRIPTION
Proposing to use a changelog from here and on since we got our first official release. We can easily use
[changelog-cli](https://pypi.python.org/pypi/changelog-cli/0.3.3) to add stuff to the log and integrate it into our release process.

This also adheres to the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.

The proposal also is for every PR that makes a notable change to also have a changelog entry added from here and on.