### PR TITLE
Add the changelog - v2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,6 @@
+=========
+Changelog
+=========
+
+* :release:`0.1.0 <2017-09-12>`
+* :feature:`-`  This is the `Raiden Developer Preview <https://github.com/raiden-network/raiden/releases/tag/v0.1.0>`_ release. Introduces a raiden test network on ropsten, the API and all the basic functionality required to use Raiden in Dapps. For more information read the `blog post <https://medium.com/@raiden_network/raiden-network-developer-preview-dad83ec3fc23>`_ or the `documentation of v0.1.0 <http://raiden-network.readthedocs.io/en/v0.1.0/>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath('../raiden/')))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'releases',
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
@@ -43,6 +44,10 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinxcontrib.images',
 ]
+
+# 'releases' (changelog) settings
+releases_issue_uri = "https://github.com/raiden-network/raiden/issues/%s"
+releases_release_uri = "https://github.com/raiden-network/raiden/releases/tags/%s"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,5 +21,6 @@ Contents
   what_is_the_dev_preview
   webui_tutorial
   spec
+  changelog
   glossary
   Raiden Codebase Documentation <./_build/generated/modules>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,6 +21,10 @@ coverage>=4.0<4.4
 
 # Documentation
 sphinx>=1.5.1<2.0.0
+sphinx_rtd_theme
+sphinxcontrib-images
+# Pinning to latest master commit because it works with sphinx version >= 1.5.0
+git+https://github.com/bitprophet/releases.git@8261431dc8b40f6e4f587503e8a50f9d3290af74
 
 # Release
 bumpversion>=0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ psutil
 filelock
 sphinx_rtd_theme
 sphinxcontrib-images
+releases

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,3 @@ Flask-Cors==3.0.2
 pytest>=3.0.4
 psutil
 filelock
-sphinx_rtd_theme
-sphinxcontrib-images
-releases


### PR DESCRIPTION
If #1008 is not merged then this PR should be. DO NOT merge both.

---

Proposing to use a changelog from here and on since we got our first
official release. We should integrate this into our release process

This PR uses `releases` for the changelog. It's kind of cumbersome and
not flexible in the way it interprets changelog entries. Each bullet
point must adhere to a specific format as seen in the [usage
docs](http://releases.readthedocs.io/en/latest/usage.html) or else the
sphinx generation of readthedocs will throw an exception.

The proposal also is for every PR that makes a notable change to also have a changelog entry added from here and on.