### PR TITLE
Require ipaddress module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pytest>=3.0.4
 psutil
 filelock
 netifaces
+ipaddress


### PR DESCRIPTION
The `ipaddress` module is necessary to run raiden and was probably required implicitly earlier.