### PR TITLE
Pass a valid address to balance request.

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -487,6 +487,7 @@ def app(address,
 
     address_hex = address_encoder(address) if address else None
     address_hex, privatekey_bin = prompt_account(address_hex, keystore_path, password_file)
+    address = address_decoder(address_hex)
 
     privatekey_hex = privatekey_bin.encode('hex')
     config['privatekey_hex'] = privatekey_hex


### PR DESCRIPTION
Fixes #1070

The address variable wasn't updated correctly, use address_hex instead
and convert when necessary.

@konradkonrad @LefterisJP 