### PR TITLE
Use metropolis transaction error checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
 - '2.7'
 env:
   global:
-  - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.0-6c6c7b2a.tar.gz'
-  - GETH_VERSION='1.7.0'
+  - GETH_URL='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.1-05101641.tar.gz'
+  - GETH_VERSION='1.7.1'
   - SOLC_URL='https://github.com/ethereum/solidity/releases/download/v0.4.17/solc-static-linux'
   - SOLC_VERSION='v0.4.17'
   matrix:

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -69,7 +69,7 @@ Using geth
 
 Run the Ethereum client and let it sync with the Ropsten testnet::
 
-    geth --testnet --fast --rpc --rpcapi eth,net,web3,debug --bootnodes "enode://20c9ad97c081d63397d7b685a412227a40e23c8bdc6688c6f37e97cfbc22d2b4d1db1510d8f61e6a8866ad7f0e17c02b14182d37ea7c3c8b9c2683aeb6b733a1@52.169.14.227:30303,enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@13.84.180.240:30303"
+    geth --testnet --fast --rpc --rpcapi eth,net,web3 --bootnodes "enode://20c9ad97c081d63397d7b685a412227a40e23c8bdc6688c6f37e97cfbc22d2b4d1db1510d8f61e6a8866ad7f0e17c02b14182d37ea7c3c8b9c2683aeb6b733a1@52.169.14.227:30303,enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@13.84.180.240:30303"
 
 Unless you already have an account you can also create one in the console by invoking ``personal.newAccount()``.
 

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -177,7 +177,8 @@ class Account(object):
         If the account is already unlocked, nothing happens, even if the password is wrong.
 
         Raises:
-            ValueError: (originating in ethereum.keys) if the password is wrong (and the account is locked)
+            ValueError: (originating in ethereum.keys) if the password is wrong
+            (and the account is locked)
         """
         if self.locked:
             self._privkey = keys.decode_keystore_json(self.keystore, password)

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -163,7 +163,7 @@ class DuplicatedChannelError(RaidenError):
 
 class TransactionThrew(RaidenError):
     """Raised when, after waiting for a transaction to be mined,
-    the gasUsed in receipt is the same as the provided transaction gas limit"""
+    the receipt has a 0x0 status field"""
     def __init__(self, txname, receipt):
         super(TransactionThrew, self).__init__(
             '{} transaction threw. Receipt={}'.format(txname, receipt)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -560,9 +560,6 @@ class JSONRPCClient(object):
         gas_limit = quantity_decoder(last_block['gasLimit'])
         return gas_limit
 
-    def lastgasprice(self):
-        return quantity_decoder(self.call('eth_lastGasPrice'))
-
     def new_abi_contract(self, contract_interface, address):
         warnings.warn('deprecated, use new_contract_proxy', DeprecationWarning)
         return self.new_contract_proxy(contract_interface, address)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -552,11 +552,7 @@ class JSONRPCClient(object):
         return quantity_decoder(res)
 
     def gaslimit(self):
-        last_block = self.call(
-            'eth_getBlockByNumber',
-            quantity_encoder(self.blocknumber()),
-            True
-        )
+        last_block = self.call('eth_getBlockByNumber', 'latest', True)
         gas_limit = quantity_decoder(last_block['gasLimit'])
         return gas_limit
 

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -595,8 +595,8 @@ class JSONRPCClient(object):
             libraries (list): A list of libraries to use in deployment
             constructor_parameters (tuple): A tuple of arguments to pass to the constructor
             contract_path (str): If we are dealing with solc >= v0.4.9 then the path
-                                 to the contract is a required argument to extract the contract data
-                                 from the `all_contracts` dict.
+                                 to the contract is a required argument to extract
+                                 the contract data from the `all_contracts` dict.
             timeout (int): Amount of time to poll the chain to confirm deployment
             gasprice: The gasprice to provide for the transaction
         """

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -552,7 +552,13 @@ class JSONRPCClient(object):
         return quantity_decoder(res)
 
     def gaslimit(self):
-        return quantity_decoder(self.call('eth_gasLimit'))
+        last_block = self.call(
+            'eth_getBlockByNumber',
+            quantity_encoder(self.blocknumber()),
+            True
+        )
+        gas_limit = quantity_decoder(last_block['gasLimit'])
+        return gas_limit
 
     def lastgasprice(self):
         return quantity_decoder(self.call('eth_lastGasPrice'))

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -59,31 +59,20 @@ def test_call_invalid_selector(deploy_client, blockchain_backend):
     assert result == ''
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize('blockchain_type', ['geth'])
-def test_transact_throws(deploy_client, blockchain_backend):
-    """ A JSON RPC call to a function that throws any kind of exception has
-    a status field in its receipt of 0x0.
-    """
+def test_call_throws(deploy_client, blockchain_backend):
+    """ A JSON RPC call to a function that throws returns the empty string. """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.address
     assert deploy_client.eth_getCode(address) != '0x'
 
-    gas = contract_proxy.fail.estimate_gas()
-
-    transaction_hex = contract_proxy.fail.transact(startgas=gas)
-    transaction = transaction_hex.decode('hex')
-
-    deploy_client.poll(transaction)
-
-    receipt = deploy_client.call('eth_getTransactionReceipt', data_encoder(transaction))
-    assert 'status' in receipt and receipt['status'] == '0x0'
+    assert contract_proxy.fail.call() == ''
 
 
 @pytest.mark.parametrize('blockchain_type', ['geth'])
 def test_transact_opcode(deploy_client, blockchain_backend):
-    """ The last opcode of a transaction that did NOT throw is STOP/RETURN. """
+    """ The receipt status field of a transaction that did not throw is 0x1 """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.address
@@ -101,7 +90,7 @@ def test_transact_opcode(deploy_client, blockchain_backend):
 
 @pytest.mark.parametrize('blockchain_type', ['geth'])
 def test_transact_throws_opcode(deploy_client, blockchain_backend):
-    """ The last opcode of a transaction that threw is not STOP. """
+    """ The receipt status field of a transaction that threw is 0x0 """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.address
@@ -118,7 +107,7 @@ def test_transact_throws_opcode(deploy_client, blockchain_backend):
 
 @pytest.mark.parametrize('blockchain_type', ['geth'])
 def test_transact_opcode_oog(deploy_client, blockchain_backend):
-    """ The last opcode of a transaction that did NOT throw is STOP. """
+    """ The receipt status field of a transaction that did NOT throw is 0x0. """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.address

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -7,7 +7,6 @@ import pytest
 from ethereum import _solidity
 
 from raiden.network.rpc.client import check_transaction_threw
-from raiden.utils import data_encoder, quantity_decoder, quantity_encoder
 
 # pylint: disable=unused-argument,protected-access
 

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -83,7 +83,7 @@ def geth_to_cmd(node, datadir, verbosity):
         '--nodiscover',
         '--ipcdisable',
         '--rpc',
-        '--rpcapi', 'eth,net,web3,debug',
+        '--rpcapi', 'eth,net,web3',
         '--rpcaddr', '0.0.0.0',
         '--networkid', '627',
         '--verbosity', str(verbosity),

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -52,7 +52,7 @@ $RST_GETH_BINARY
     --ipcdisable
     --rpc
     --rpcaddr 127.0.0.1
-    --rpcapi eth,net,web3,debug
+    --rpcapi eth,net,web3
     --rpcport $RST_RPC_PORT
     --mine
     --etherbase 0

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -105,7 +105,7 @@ def check_json_rpc(client):
             "Couldn't contact the ethereum node through JSON-RPC.\n"
             "Please make sure the JSON-RPC is enabled for these interfaces:\n"
             "\n"
-            "    eth_*, net_*, web3_*, and debug_*\n"
+            "    eth_*, net_*, web3_*\n"
             "\n"
             "geth: https://github.com/ethereum/go-ethereum/wiki/Management-APIs\n"
         )

--- a/tools/testnet/files/dockerfiles/geth-testnet/Dockerfile
+++ b/tools/testnet/files/dockerfiles/geth-testnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.7.0
+FROM ethereum/client-go:v1.7.1
 MAINTAINER Ulrich Petri <ulrich@brainbot.com>
 
 RUN \


### PR DESCRIPTION
- Remove dependency to geth's debugTrace call
- Upgrade to geth 1.7.1
- Use the transaction's `status` as per https://github.com/ethereum/EIPs/pull/658 to check if a transaction errored in any way.

Fix #1023 