### PR TITLE
Enable parity plus Byzantium client version check

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -119,6 +119,15 @@ def check_json_rpc(client):
             if minor < 7 or (minor == 7 and patch < 6):
                 print('You need Byzantium enabled parity. >= 1.7.6 / 1.8.0')
                 sys.exit(1)
+        elif client_version.startswith('Geth'):
+            major, minor, patch = [
+                int(x) for x in re.search('/v(\d)\.(\d)\.(\d)', client_version).groups()
+            ]
+            if minor < 7 or (minor == 7 and patch == 0):
+                print('You need Byzantium enabled geth. >= 1.7.1')
+                sys.exit(1)
+        else:
+            print('Unsupported client {} detected.'.format(client_version))
 
 
 def check_synced(blockchain_service):

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 import os
+import re
 import tempfile
 import json
 import socket
@@ -112,12 +113,12 @@ def check_json_rpc(client):
         sys.exit(1)
     else:
         if client_version.startswith('Parity'):
-            print(
-                "Parity is not currently supported.\n"
-                "Waiting for the clients to expose the transaction's status code in the receipt.\n"
-                "https://github.com/ethereum/EIPs/pull/658"
-            )
-            sys.exit(1)
+            major, minor, patch = [
+                int(x) for x in re.search('//v(\d)\.(\d)\.(\d)', client_version).groups()
+            ]
+            if minor < 7 or (minor == 7 and patch < 6):
+                print('You need Byzantium enabled parity. >= 1.7.6 / 1.8.0')
+                sys.exit(1)
 
 
 def check_synced(blockchain_service):


### PR DESCRIPTION
Fix #1078 

With the release of [parity 1.7.6](https://github.com/paritytech/parity/releases/tag/v1.7.6), we  have a byzantium enabled parity client and raiden should now be able to work with it!

This PR also adds a version check for geth too.