### PR TITLE
Handle non-hex params, fix #230

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -19,7 +19,6 @@ from requests.exceptions import RequestException
 from ethereum import slogging
 from ethereum.utils import denoms
 from ipaddress import IPv4Address, AddressValueError
-from tinyrpc import BadRequestError
 
 from raiden.accounts import AccountManager
 from raiden.api.rest import APIServer, RestAPI
@@ -237,7 +236,7 @@ class AddressType(click.ParamType):
     def convert(self, value, param, ctx):
         try:
             return address_decoder(value)
-        except BadRequestError:
+        except TypeError:
             self.fail('Please specify a valid hex-encoded address.')
 
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -592,6 +592,12 @@ def prompt_account(address_hex, keystore_path, password_file):
         raise RuntimeError('No Ethereum accounts found in the user\'s system')
 
     if not accmgr.address_in_keystore(address_hex):
+        # check if an address has been passed
+        if address_hex is not None:
+            print("Account '{}' could not be found on the system. Aborting ...".format(
+                address_hex))
+            sys.exit(1)
+
         addresses = list(accmgr.accounts.keys())
         formatted_addresses = [
             '[{:3d}] - 0x{}'.format(idx, addr)


### PR DESCRIPTION
The first commit handles address parameters that aren't hexadecimal gracefully. 
The second commit fixes #230 