### PR TITLE
Disable routes to nodes at the unknown state

### DIFF
--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -133,7 +133,7 @@ def get_best_routes(
     # distributable amount, but to sort them based on available balance and
     # let the task use as many as required to finish the transfer.
 
-    online_nodes = []
+    online_nodes = list()
 
     neighbors_heap = ordered_neighbors(
         channel_graph.graph,

--- a/raiden/network/channelgraph.py
+++ b/raiden/network/channelgraph.py
@@ -165,15 +165,6 @@ def get_best_routes(
                 )
             continue
 
-        if not channel.can_transfer:
-            if log.isEnabledFor(logging.INFO):
-                log.info(
-                    'channel %s - %s is closed or has zero funding, ignoring',
-                    pex(our_address),
-                    pex(partner_address),
-                )
-            continue
-
         if amount > channel.distributable:
             if log.isEnabledFor(logging.INFO):
                 log.info(

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -492,6 +492,11 @@ class RaidenProtocol(object):
                 {'nonce': 0},  # HACK: Allows the task to mutate the object
             )
 
+            # set the value right away to create the key in the dictionary,
+            # this is /not/ necessary for normal execution, but for fixture
+            # setup
+            self.nodeaddresses_networkstatuses[receiver_address] = NODE_NETWORK_UNREACHABLE
+
             events = HealthEvents(
                 event_healthy=Event(),
                 event_unhealthy=Event(),

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -41,7 +41,7 @@ def wait_for_partners(app_list, sleep=0.5, timeout=10):
             for status in waiting[0].raiden.protocol.nodeaddresses_networkstatuses.values()
         )
 
-        if sleep <= 0:
+        if timeout <= 0:
             raise RuntimeError('fixture setup failed, nodes are unreachable')
 
         if all_healthy:

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -7,7 +7,10 @@ from raiden.messages import (
     RevealSecret,
     Secret,
 )
-from raiden.tests.fixtures.raiden_network import CHAIN
+from raiden.tests.fixtures.raiden_network import (
+    CHAIN,
+    wait_for_partners,
+)
 from raiden.tests.utils.network import setup_channels
 from raiden.tests.utils.transfer import channel
 from raiden.transfer.mediated_transfer.events import (
@@ -46,8 +49,7 @@ def test_regression_unfiltered_routes(raiden_network, token_addresses, settle_ti
     )
 
     # poll the channel manager events
-    for app in raiden_network:
-        app.raiden.poll_blockchain_events()
+    wait_for_partners(raiden_network)
 
     transfer = app0.raiden.mediated_transfer_async(
         token_address=token,

--- a/raiden/tests/unit/test_service.py
+++ b/raiden/tests/unit/test_service.py
@@ -9,7 +9,7 @@ from raiden.messages import (
     Ack,
     Ping,
 )
-from raiden.network.transport import UnreliableTransport
+from raiden.tests.utils.transport import UnreliableTransport
 from raiden.tests.utils.messages import setup_messages_cb
 from raiden.tests.utils.transfer import channel
 from raiden.tests.fixtures.raiden_network import CHAIN
@@ -52,11 +52,13 @@ def test_ping(raiden_network):
 def test_ping_unreachable(raiden_network):
     app0, app1 = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
-    UnreliableTransport.droprate = 1  # drop everything to force disabling of re-sends
+    # drop everything to force disabling of re-sends
+    app0.raiden.protocol.transport.droprate = 1
+    app1.raiden.protocol.transport.droprate = 1
+
     app0.raiden.protocol.retry_interval = 0.1  # for fast tests
 
     messages = setup_messages_cb()
-    UnreliableTransport.network.counter = 0
 
     ping_message = Ping(nonce=0)
     app0.raiden.sign(ping_message)

--- a/raiden/tests/unit/test_transfer.py
+++ b/raiden/tests/unit/test_transfer.py
@@ -394,7 +394,7 @@ def test_cancel_transfer(raiden_chain, token_addresses, deposit):
         app2.raiden.address,
         identifier_refund,
     )
-    assert async_result.wait() is False, 'there is not path with capacity, the transfer must fail'
+    assert async_result.wait() is False, 'there is no path with capacity, the transfer must fail'
 
     gevent.sleep(0.2)
 

--- a/raiden/tests/utils/messages.py
+++ b/raiden/tests/utils/messages.py
@@ -4,9 +4,8 @@ from __future__ import print_function
 
 import string
 
-from raiden.messages import decode
 from raiden.network.transport import DummyTransport
-from raiden.utils import pex, sha3
+from raiden.utils import sha3
 from raiden.tests.utils.tests import fixture_all_combinations
 from raiden.tests.utils.factories import make_privkey_address
 from raiden.messages import (
@@ -182,82 +181,3 @@ def dump_messages(message_list):
 
     for message in message_list:
         print(message)
-
-
-class MessageLog(object):
-    """ Wraps a packet. """
-    SENT = '>'
-    RECV = '<'
-
-    def __init__(self, address, msg_bytes, direction):
-        self.address = address
-        self.msg_bytes = msg_bytes
-        self.direction = direction
-        self.msg = None
-
-    def is_recv(self):
-        return self.direction == self.RECV
-
-    def is_sent(self):
-        return self.direction == self.SENT
-
-    @property
-    def decoded(self):
-        if self.msg is None:
-            self.msg = decode(self.msg_bytes)
-        return self.msg
-
-
-class MessageLogger(object):
-    """Register callbacks to collect all messages. Messages can be queried"""
-
-    def __init__(self):
-        self.messages_by_node = {}
-
-        # register the tracing callbacks
-        DummyTransport.network.on_send_cbs.append(self.sent_msg_cb)
-        DummyTransport.on_recv_cbs.append(self.recv_msg_cb)
-
-    def sent_msg_cb(self, sender_raiden, host_port, bytes_):
-        self.collect_message(sender_raiden.address, bytes_, MessageLog.SENT)
-
-    def recv_msg_cb(self, receiver_raiden, host_port, msg):
-        self.collect_message(receiver_raiden.address, msg, MessageLog.RECV)
-
-    def collect_message(self, address, msg, direction):
-        msglog = MessageLog(address, msg, direction)
-        key = pex(address)
-        self.messages_by_node.setdefault(key, [])
-        self.messages_by_node[key].append(msglog)
-
-    def get_node_messages(self, node_address, only=None):
-        """ Return list of node's messages.
-
-        Args:
-            node_messages: The hex representation of the data
-            only: Flag to filter messages, valid values are sent and recv.
-
-        Returns:
-            List[message]: The relevante messages that involved the node.
-        """
-        node_messages = self.messages_by_node.get(node_address, [])
-
-        if only == 'sent':
-            result = [
-                message
-                for message in node_messages
-                if message.is_sent()
-            ]
-        elif only == 'recv':
-            result = [
-                message
-                for message in node_messages
-                if message.is_recv()
-            ]
-        else:
-            result = node_messages
-
-        return [
-            message.decoded
-            for message in result
-        ]

--- a/raiden/tests/utils/tests.py
+++ b/raiden/tests/utils/tests.py
@@ -7,10 +7,6 @@ import gevent
 
 from raiden.utils import get_project_root
 
-__all__ = (
-    'cleanup_tasks',
-)
-
 
 def get_test_contract_path(contract_name):
     contract_path = os.path.join(
@@ -84,11 +80,11 @@ def fixture_all_combinations(invalid_values):
     # - {a: 1, b:4}
     # - {a: 2, b:3}
     # - {a: 2, b:4}
-    for invalid_values in all_invalid_values:
+    for invalid_combinations in all_invalid_values:
         # expand the value list `(key, [v1,v2])` to `((key, v1), (key, v2))`
         keys_values = (
             product((key,), values)
-            for key, values in invalid_values
+            for key, values in invalid_combinations
         )
 
         # now make the cartesian product of all possible invalid keys and values

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -22,7 +22,7 @@ class MessageLoggerTransport(DummyTransport):
             throttle_policy=DummyPolicy()):
 
         super(MessageLoggerTransport, self).__init__(host, port, protocol, throttle_policy)
-        self.addresses_to_messages = {}
+        self.addresses_to_messages = dict()
 
     def send(self, sender, host_port, bytes_):
         self.addresses_to_messages.setdefault(sender.address, []).append(decode(bytes_))

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import logging
+
+import gevent
+
+from raiden.messages import decode
+from raiden.network.transport import (
+    DummyPolicy,
+    DummyTransport,
+)
+from raiden.utils import pex, sha3
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+class MessageLoggerTransport(DummyTransport):
+    def __init__(
+            self,
+            host,
+            port,
+            protocol=None,
+            throttle_policy=DummyPolicy()):
+
+        super(MessageLoggerTransport, self).__init__(host, port, protocol, throttle_policy)
+        self.addresses_to_messages = {}
+
+    def send(self, sender, host_port, bytes_):
+        self.addresses_to_messages.setdefault(sender.address, []).append(decode(bytes_))
+        super(MessageLoggerTransport, self).network.send(sender, host_port, bytes_)
+
+    def get_sent_messages(self, node_address):
+        return self.addresses_to_messages.get(node_address, [])
+
+
+class UnreliableTransport(DummyTransport):
+    """ A transport that simulates random losses of UDP messages.
+
+    Note:
+        The transport is not shared among the instances.
+    """
+
+    def __init__(
+            self,
+            host,
+            port,
+            protocol=None,
+            throttle_policy=DummyPolicy()):
+
+        super(UnreliableTransport, self).__init__(host, port, protocol, throttle_policy)
+        self.droprate = 0
+
+    def send(self, sender, host_port, bytes_):
+        # even dropped packages have to go through throttle_policy
+        gevent.sleep(self.throttle_policy.consume(1))
+
+        if self.droprate:
+            drop = self.network.counter % self.droprate == 0
+        else:
+            drop = False
+
+        if not drop:
+            self.network.send(sender, host_port, bytes_)
+        else:
+            # since this path wont go to super.send we need to call track
+            # ourselves
+            self.network.track_send(sender, host_port, bytes_)
+
+            log.debug(
+                'dropped packet',
+                sender=pex(sender),
+                counter=self.network.counter,
+                msghash=pex(sha3(bytes_))
+            )


### PR DESCRIPTION
Users are experiencing problems with transfer because unknown nodes are actually unreachable. Issues #1086 and #1020