### PR TITLE
updated cli.py to reflect the correct etherscan endpoint for usage wi…

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -27,7 +27,7 @@ NETTINGCHANNEL_SETTLE_TIMEOUT_MAX = 2700000
 # TODO: add this as an attribute of the transport class
 UDP_MAX_MESSAGE_SIZE = 1200
 
-MAINNET = 'mainnet'
+MAINNET = 'api'
 ROPSTEN = 'ropsten'
 RINKEBY = 'rinkeby'
 KOVAN = 'kovan'


### PR DESCRIPTION
Working on a deployment to the mainnet, and noticed legacy API endpoint in cli.py for checking the latest block via ethersan. mainnet.etherscan.io does not work as an API endpoint for contacting etherscan. In future pull requests, will also work to add redundancy calls as Etherscan sometimes goes down, as it did earlier today. Raiden on! @palango @schmir @ulope 