### PR TITLE
Fail CI on errors in 'before_script.sh'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ raiden/raidenwebui/node_modules/
 # never check in the smoketest_config.json
 smoketest_config.json
 /raiden/ui/web/node_modules/*
+
+# editors
+.idea
+.vscode

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
+
+set -e
+set -x
+
 flake8 raiden/ tools/
 python setup.py check --restructuredtext --strict
 raiden smoketest

--- a/raiden/network/proxies/channel_manager.py
+++ b/raiden/network/proxies/channel_manager.py
@@ -27,8 +27,6 @@ from raiden.exceptions import (
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
-    GAS_LIMIT,
-    GAS_PRICE,
 )
 from raiden.utils import (
     address_decoder,

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -17,8 +17,6 @@ from raiden.network.rpc.transactions import (
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
-    GAS_LIMIT,
-    GAS_PRICE,
 )
 from raiden.utils import (
     address_encoder,

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -24,8 +24,6 @@ from raiden.network.rpc.filters import (
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
-    GAS_LIMIT,
-    GAS_PRICE,
 )
 from raiden.utils import (
     address_decoder,

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -21,8 +21,6 @@ from raiden.utils import (
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
-    GAS_LIMIT,
-    GAS_PRICE,
 )
 from raiden.network.proxies.channel_manager import ChannelManager
 from raiden.network.rpc.client import check_address_has_code

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -13,8 +13,6 @@ from raiden.network.rpc.transactions import (
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
-    GAS_LIMIT,
-    GAS_PRICE,
 )
 from raiden.utils import (
     address_encoder,

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -105,7 +105,7 @@ class AlarmTask(Task):
             for callback in self.callbacks:
                 try:
                     result = callback(current_block)
-                except:  # pylint: disable=bare-except
+                except:  # pylint: disable=bare-except # noqa
                     log.exception('unexpected exception on alarm')
                 else:
                     if result is REMOVE_CALLBACK:

--- a/raiden/tests/benchmark/profile_transfer.py
+++ b/raiden/tests/benchmark/profile_transfer.py
@@ -285,7 +285,7 @@ if __name__ == '__main__':
                 num_nodes=args.nodes,
                 channels_per_node=args.channels_per_node,
             )
-        except:
+        except: # noqa
             import pdb
             pdb.xpm()
     else:

--- a/raiden/tests/benchmark/speed.py
+++ b/raiden/tests/benchmark/speed.py
@@ -220,7 +220,7 @@ def main():
                 test_throughput(apps, tokens, args.transfers, amount)
             else:
                 test_latency(apps, tokens, args.transfers, amount)
-        except:
+        except: # noqa
             import pdb
             pdb.xpm()
     else:

--- a/raiden/tests/unit/test_channel.py
+++ b/raiden/tests/unit/test_channel.py
@@ -82,7 +82,6 @@ def test_end_state():
     assert state1.balance(state2) == balance1
     assert state2.balance(state1) == balance2
 
-
     assert state1.is_locked(lock_hashlock) is False
     assert state2.is_locked(lock_hashlock) is False
 
@@ -177,7 +176,6 @@ def test_end_state():
     assert state2.contract_balance == balance2
     assert state1.balance(state2) == balance1 + 10
     assert state2.balance(state1) == balance2
-
 
     assert state1.is_locked(lock_hashlock) is False
     assert state2.is_locked(lock_hashlock) is False

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from raiden.transfer.architecture import State
 from raiden.utils import pex
-from raiden.exceptions import HashLengthNot32
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 
 CHANNEL_STATE_CLOSED = 'closed'

--- a/raiden/utils/profiling/profiler.py
+++ b/raiden/utils/profiling/profiler.py
@@ -44,7 +44,7 @@ _state = None
 #        perf_counter = It does include time elapsed during sleep and is system-wide.
 try:
     clock = time.perf_counter  # pylint: disable=no-member
-except:
+except AttributeError:
     clock = time.clock
 
 # info is used to store the function name/module/lineno

--- a/raiden/utils/profiling/stack.py
+++ b/raiden/utils/profiling/stack.py
@@ -154,7 +154,7 @@ def get_trace_info(frame):
     try:
         base_filename = sys.modules[module_name.split('.', 1)[0]].__file__
         filename = abs_path.split(base_filename.rsplit('/', 2)[0], 1)[-1].lstrip('/')
-    except:
+    except: # noqa
         filename = abs_path
 
     if not filename:


### PR DESCRIPTION
Errors in the [`before_script`](https://github.com/raiden-network/raiden/blob/3f8758c8/.travis/before_script.sh) currently don't block the CI. This fixes that and all accumulated problems.