### PR TITLE
improvement: handling OSError when running solc

### DIFF
--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -151,6 +151,21 @@ def validate_solc():
 
         raise RuntimeError(msg)
 
+    except OSError as e:
+        msg = (
+            'The solidity compiler failed to execute. Please make sure the\n'
+            'binary is compatible with your architecture and you can execute it.'
+        )
+
+        child_traceback = getattr(e, 'child_traceback', None)
+        if child_traceback:
+            msg += (
+                '\n'
+                'Traceback: ' + child_traceback
+            )
+
+        raise RuntimeError(msg)
+
 
 class ContractManager(object):
     def __init__(self):


### PR DESCRIPTION
If the solc binary doesn't have the executable flag set, or if the
executable is compiled to a different architecture, the OSError
exception will be raised. This handles the exception and suggests a
solution for the problem.