### PR TITLE
More py3 fixes

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -3,6 +3,7 @@ import getpass
 import json
 import os
 import sys
+from binascii import unhexlify
 
 from bitcoin import privtopub
 from ethereum import keys
@@ -128,7 +129,7 @@ class Account(object):
         self._address = None
 
         try:
-            self._address = self.keystore['address'].decode('hex')
+            self._address = unhexlify(self.keystore['address'])
         except KeyError:
             pass
 
@@ -218,7 +219,7 @@ class Account(object):
         if self._address:
             pass
         elif 'address' in self.keystore:
-            self._address = self.keystore['address'].decode('hex')
+            self._address = unhexlify(self.keystore['address'])
         elif not self.locked:
             self._address = keys.privtoaddr(self.privkey)
         else:

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -3,7 +3,7 @@ import getpass
 import json
 import os
 import sys
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 from bitcoin import privtopub
 from ethereum import keys
@@ -167,7 +167,7 @@ class Account(object):
         d['crypto'] = self.keystore['crypto']
         d['version'] = self.keystore['version']
         if include_address and self.address is not None:
-            d['address'] = self.address.encode('hex')
+            d['address'] = hexlify(self.address)
         if include_id and self.uuid is not None:
             d['id'] = self.uuid
         return json.dumps(d)
@@ -263,7 +263,7 @@ class Account(object):
 
     def __repr__(self):
         if self.address is not None:
-            address = self.address.encode('hex')
+            address = hexlify(self.address)
         else:
             address = '?'
         return '<Account(address={address}, id={id})>'.format(address=address, id=self.uuid)

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
+
 import gevent
 from gevent.event import AsyncResult
 from ethereum import slogging
@@ -254,7 +256,7 @@ class RaidenAPI(object):
         # Checking the balance is not helpful since this requires multiple
         # transactions that can race, e.g. the deposit check succeed but the
         # user spent his balance before deposit.
-        balance = token.balance_of(self.raiden.address.encode('hex'))
+        balance = token.balance_of(hexlify(self.raiden.address))
         if not balance >= amount:
             msg = 'Not enough balance to deposit. {} Available={} Tried={}'.format(
                 pex(token_address),

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
 
 from marshmallow import (
     fields,
@@ -46,7 +47,7 @@ class HexAddressConverter(BaseConverter):
             raise ValidationError()
 
         try:
-            value = value[2:].decode('hex')
+            value = unhexlify(value[2:])
         except TypeError:
             raise ValidationError()
 
@@ -74,7 +75,7 @@ class AddressField(fields.Field):
             self.fail('missing_prefix')
 
         try:
-            value = value[2:].decode('hex')
+            value = unhexlify(value[2:])
         except TypeError:
             self.fail('invalid_data')
 

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import filelock
 import sys
-
-from ethereum.utils import decode_hex
+from binascii import unhexlify
 
 from raiden.raiden_service import RaidenService
 from raiden.settings import (
@@ -74,13 +73,13 @@ class App(object):  # pylint: disable=too-few-public-methods
             self.raiden = RaidenService(
                 chain,
                 default_registry,
-                decode_hex(config['privatekey_hex']),
+                unhexlify(config['privatekey_hex']),
                 transport,
                 discovery,
                 config,
             )
         except filelock.Timeout:
-            pubkey = privatekey_to_address(decode_hex(self.config['privatekey_hex']))
+            pubkey = privatekey_to_address(unhexlify(self.config['privatekey_hex']))
             print ('FATAL: Another Raiden instance already running for account 0x%s' %
                    str(pubkey).encode('hex'))
             sys.exit(1)

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 import filelock
 import sys
 from binascii import unhexlify

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import filelock
 import sys
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 from raiden.raiden_service import RaidenService
 from raiden.settings import (
@@ -82,7 +82,7 @@ class App(object):  # pylint: disable=too-few-public-methods
         except filelock.Timeout:
             pubkey = privatekey_to_address(unhexlify(self.config['privatekey_hex']))
             print ('FATAL: Another Raiden instance already running for account 0x%s' %
-                   str(pubkey).encode('hex'))
+                   hexlify(str(pubkey)))
             sys.exit(1)
         self.start_console = self.config['console']
 

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
+
 import gevent
 from gevent.lock import Semaphore
 from gevent.event import AsyncResult
@@ -32,7 +34,7 @@ class ConnectionManager(object):
     # XXX Hack: for bootstrapping, the first node on a network opens a channel
     # with this address to become visible.
     BOOTSTRAP_ADDR_HEX = '2' * 40
-    BOOTSTRAP_ADDR = BOOTSTRAP_ADDR_HEX.decode('hex')
+    BOOTSTRAP_ADDR = unhexlify(BOOTSTRAP_ADDR_HEX)
 
     def __init__(
             self,

--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
 import logging
 import random
 from collections import (
@@ -760,7 +761,7 @@ class RaidenProtocol(object):
         elif log.isEnabledFor(logging.ERROR):
             log.error(
                 'Invalid message',
-                message=data.encode('hex'),
+                message=hexlify(data),
             )
 
     def receive_ack(self, ack):

--- a/raiden/network/proxies/channel_manager.py
+++ b/raiden/network/proxies/channel_manager.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from binascii import unhexlify
 
 from ethereum import slogging
 
@@ -111,7 +112,7 @@ class ChannelManager(object):
             settle_timeout,
         )
 
-        self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+        self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)
 
         if check_transaction_threw(self.client, transaction_hash):
             raise DuplicatedChannelError('Duplicated channel')

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -76,7 +77,7 @@ class Discovery(object):
         )
 
         self.client.poll(
-            transaction_hash.decode('hex'),
+            unhexlify(transaction_hash),
             timeout=self.poll_timeout,
         )
 
@@ -99,7 +100,7 @@ class Discovery(object):
         if set(address) == {'0'}:  # the 0 address means nothing found
             return None
 
-        return address.decode('hex')
+        return unhexlify(address)
 
     def version(self):
         return self.proxy.contract_version.call()

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -86,7 +86,7 @@ class Discovery(object):
             raise TransactionThrew('Register Endpoint', receipt_or_none)
 
     def endpoint_by_address(self, node_address_bin):
-        node_address_hex = node_address_bin.encode('hex')
+        node_address_hex = hexlify(node_address_bin)
         endpoint = self.proxy.findEndpointByAddress.call(node_address_hex)
 
         if endpoint == '':

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from binascii import unhexlify
 
 from ethereum import slogging
 from ethereum.utils import encode_hex
@@ -238,7 +239,7 @@ class NettingChannel(object):
         )
 
         self.client.poll(
-            transaction_hash.decode('hex'),
+            unhexlify(transaction_hash),
             timeout=self.poll_timeout,
         )
 
@@ -278,7 +279,7 @@ class NettingChannel(object):
             extra_hash,
             signature,
         )
-        self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+        self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)
 
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
         if receipt_or_none:
@@ -330,7 +331,7 @@ class NettingChannel(object):
             )
 
             self.client.poll(
-                transaction_hash.decode('hex'),
+                unhexlify(transaction_hash),
                 timeout=self.poll_timeout,
             )
 
@@ -382,7 +383,7 @@ class NettingChannel(object):
                 secret,
             )
 
-            self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+            self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)
             receipt_or_none = check_transaction_threw(self.client, transaction_hash)
             lock = messages.Lock.from_bytes(locked_encoded)
             if receipt_or_none:
@@ -415,7 +416,7 @@ class NettingChannel(object):
             self.gasprice,
         )
 
-        self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+        self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
         if receipt_or_none:
             log.info('settle failed', contract=pex(self.address))

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from binascii import unhexlify
 
 from ethereum import slogging
 
@@ -92,7 +93,7 @@ class Registry(object):
             token_address,
         )
 
-        self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+        self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
         if receipt_or_none:
             raise TransactionThrew('AddToken', receipt_or_none)

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 from ethereum import slogging
 
@@ -180,7 +180,7 @@ class Registry(object):
 
             if manager_address is None:
                 raise NoTokenManager(
-                    'Manager for token 0x{} does not exist'.format(token_address.encode('hex'))
+                    'Manager for token 0x{} does not exist'.format(hexlify(token_address))
                 )
 
             manager = ChannelManager(

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
+
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
     CONTRACT_HUMAN_STANDARD_TOKEN,
@@ -69,7 +71,7 @@ class Token(object):
             allowance,
         )
 
-        self.client.poll(transaction_hash.decode('hex'), timeout=self.poll_timeout)
+        self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
 
         if receipt_or_none:
@@ -122,7 +124,7 @@ class Token(object):
             amount,
         )
 
-        self.client.poll(transaction_hash.decode('hex'))
+        self.client.poll(unhexlify(transaction_hash))
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
         if receipt_or_none:
             raise TransactionThrew('Transfer', receipt_or_none)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -2,6 +2,7 @@
 import os
 import warnings
 from time import time as now
+from binascii import unhexlify
 
 import rlp
 import gevent
@@ -215,7 +216,7 @@ class JSONRPCClient(object):
 
     def nonce(self, address):
         if len(address) == 40:
-            address = address.decode('hex')
+            address = unhexlify(address)
 
         with self.nonce_lock:
             initialized = self.nonce_current_value is not None
@@ -358,7 +359,7 @@ class JSONRPCClient(object):
                 dependency_contract = all_contracts[deploy_contract]
 
                 hex_bytecode = solidity_resolve_symbols(dependency_contract['bin_hex'], libraries)
-                bytecode = hex_bytecode.decode('hex')
+                bytecode = unhexlify(hex_bytecode)
 
                 dependency_contract['bin_hex'] = hex_bytecode
                 dependency_contract['bin'] = bytecode
@@ -369,7 +370,7 @@ class JSONRPCClient(object):
                     data=bytecode,
                     gasprice=gasprice,
                 )
-                transaction_hash = transaction_hash_hex.decode('hex')
+                transaction_hash = unhexlify(transaction_hash_hex)
 
                 self.poll(transaction_hash, timeout=timeout)
                 receipt = self.eth_getTransactionReceipt(transaction_hash)
@@ -380,13 +381,13 @@ class JSONRPCClient(object):
 
                 libraries[deploy_contract] = contract_address
 
-                deployed_code = self.eth_getCode(contract_address.decode('hex'))
+                deployed_code = self.eth_getCode(unhexlify(contract_address))
 
                 if deployed_code == '0x':
                     raise RuntimeError('Contract address has no code, check gas usage.')
 
             hex_bytecode = solidity_resolve_symbols(contract['bin_hex'], libraries)
-            bytecode = hex_bytecode.decode('hex')
+            bytecode = unhexlify(hex_bytecode)
 
             contract['bin_hex'] = hex_bytecode
             contract['bin'] = bytecode
@@ -404,13 +405,13 @@ class JSONRPCClient(object):
             data=bytecode,
             gasprice=gasprice,
         )
-        transaction_hash = transaction_hash_hex.decode('hex')
+        transaction_hash = unhexlify(transaction_hash_hex)
 
         self.poll(transaction_hash, timeout=timeout)
         receipt = self.eth_getTransactionReceipt(transaction_hash)
         contract_address = receipt['contractAddress']
 
-        deployed_code = self.eth_getCode(contract_address[2:].decode('hex'))
+        deployed_code = self.eth_getCode(unhexlify(contract_address[2:]))
 
         if deployed_code == '0x':
             raise RuntimeError(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -2,7 +2,7 @@
 import os
 import warnings
 from time import time as now
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 import rlp
 import gevent
@@ -552,7 +552,7 @@ class JSONRPCClient(object):
             res = self.eth_sendTransaction(**tx_dict)
 
         assert len(res) in (20, 32)
-        return res.encode('hex')
+        return hexlify(res)
 
     def eth_sendTransaction(
             self,

--- a/raiden/network/rpc/transactions.py
+++ b/raiden/network/rpc/transactions.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
+
 from raiden.utils import data_encoder
 from raiden.settings import GAS_LIMIT
 
@@ -8,7 +10,7 @@ def check_transaction_threw(client, transaction_hash):
        Returns None in case of success and the transaction receipt if the
        transaction's status indicator is 0x0.
     """
-    encoded_transaction = data_encoder(transaction_hash.decode('hex'))
+    encoded_transaction = data_encoder(unhexlify(transaction_hash))
     receipt = client.call('eth_getTransactionReceipt', encoded_transaction)
 
     if 'status' not in receipt:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
+from future import standard_library
+standard_library.install_aliases()
 import os
 import sys
 import itertools
-import cPickle as pickle
+import pickle as pickle
 import random
 from collections import defaultdict
 

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
 from ethereum.utils import denoms, int_to_big_endian
 
 INITIAL_PORT = 40001
@@ -6,7 +7,7 @@ INITIAL_PORT = 40001
 CACHE_TTL = 60
 ESTIMATED_BLOCK_TIME = 7
 GAS_LIMIT = 3141592  # Morden's gasLimit.
-GAS_LIMIT_HEX = '0x' + int_to_big_endian(GAS_LIMIT).encode('hex')
+GAS_LIMIT_HEX = '0x' + hexlify(int_to_big_endian(GAS_LIMIT))
 GAS_PRICE = denoms.shannon * 20
 
 DEFAULT_PROTOCOL_RETRIES_BEFORE_BACKOFF = 5

--- a/raiden/tests/api/test_pythonapi.py
+++ b/raiden/tests/api/test_pythonapi.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
+
 import pytest
 
 from raiden.api.python import RaidenAPI
@@ -123,7 +125,7 @@ def test_channel_lifecycle(blockchain_type, raiden_network, token_addresses, dep
     assert any(
         (
             event['_event_type'] == 'ChannelNewBalance' and
-            event['participant'] == api1.address.encode('hex')
+            event['participant'] == hexlify(api1.address)
         )
         for event in event_list2
     )
@@ -142,7 +144,7 @@ def test_channel_lifecycle(blockchain_type, raiden_network, token_addresses, dep
     assert any(
         (
             event['_event_type'] == 'ChannelClosed' and
-            event['closing_address'] == api1.address.encode('hex')
+            event['closing_address'] == hexlify(api1.address)
         )
         for event in event_list3
     )

--- a/raiden/tests/api/test_restapi.py
+++ b/raiden/tests/api/test_restapi.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-import httplib
+from future import standard_library
+standard_library.install_aliases()
+import http.client
 import json
 
 import pytest
@@ -35,7 +37,7 @@ def assert_no_content_response(response):
     assert(
         response is not None and
         response.text == '' and
-        response.status_code == httplib.NO_CONTENT
+        response.status_code == http.client.NO_CONTENT
     )
 
 
@@ -55,7 +57,7 @@ def assert_response_with_error(response, status_code):
     )
 
 
-def assert_proper_response(response, status_code=httplib.OK):
+def assert_proper_response(response, status_code=http.client.OK):
     assert (
         response is not None and
         response.status_code == status_code and
@@ -186,7 +188,7 @@ def test_url_with_invalid_address(rest_api_port_number, api_backend):
     )
     response = request.send().response
 
-    assert_response_with_code(response, httplib.NOT_FOUND)
+    assert_response_with_code(response, http.client.NOT_FOUND)
 
 
 def test_payload_with_address_without_prefix(api_backend):
@@ -202,7 +204,7 @@ def test_payload_with_address_without_prefix(api_backend):
         json=channel_data_obj
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.BAD_REQUEST)
+    assert_response_with_error(response, http.client.BAD_REQUEST)
 
 
 def test_payload_with_address_invalid_chars(api_backend):
@@ -218,7 +220,7 @@ def test_payload_with_address_invalid_chars(api_backend):
         json=channel_data_obj
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.BAD_REQUEST)
+    assert_response_with_error(response, http.client.BAD_REQUEST)
 
 
 def test_payload_with_address_invalid_length(api_backend):
@@ -234,7 +236,7 @@ def test_payload_with_address_invalid_length(api_backend):
         json=channel_data_obj
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.BAD_REQUEST)
+    assert_response_with_error(response, http.client.BAD_REQUEST)
 
 
 def test_api_query_our_address(
@@ -291,7 +293,7 @@ def test_api_open_and_deposit_channel(
     )
     response = request.send().response
 
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
     response = response.json()
     expected_response = channel_data_obj
     expected_response['balance'] = 0
@@ -318,7 +320,7 @@ def test_api_open_and_deposit_channel(
     )
     response = request.send().response
 
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
     response = response.json()
     expected_response = channel_data_obj
     expected_response['balance'] = balance
@@ -397,7 +399,7 @@ def test_api_open_close_and_settle_channel(
     response = request.send().response
 
     balance = 0
-    assert_proper_response(response, status_code=httplib.CREATED)
+    assert_proper_response(response, status_code=http.client.CREATED)
     response = response.json()
     expected_response = channel_data_obj
     expected_response['balance'] = balance
@@ -476,7 +478,7 @@ def test_api_open_channel_invalid_input(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_response_with_error(response, status_code=httplib.CONFLICT)
+    assert_response_with_error(response, status_code=http.client.CONFLICT)
 
     channel_data_obj['settle_timeout'] = NETTINGCHANNEL_SETTLE_TIMEOUT_MAX + 1
     request = grequests.put(
@@ -484,7 +486,7 @@ def test_api_open_channel_invalid_input(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_response_with_error(response, status_code=httplib.CONFLICT)
+    assert_response_with_error(response, status_code=http.client.CONFLICT)
 
 
 def test_api_channel_state_change_errors(
@@ -507,7 +509,7 @@ def test_api_channel_state_change_errors(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
     response = response.json()
     channel_address = response['channel_address']
 
@@ -521,7 +523,7 @@ def test_api_channel_state_change_errors(
         json=dict(state=CHANNEL_STATE_SETTLED)
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.CONFLICT)
+    assert_response_with_error(response, http.client.CONFLICT)
     # let's try to set a random state
     request = grequests.patch(
         api_url_for(
@@ -532,7 +534,7 @@ def test_api_channel_state_change_errors(
         json=dict(state='inlimbo')
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.BAD_REQUEST)
+    assert_response_with_error(response, http.client.BAD_REQUEST)
     # let's try to set both new state and balance
     request = grequests.patch(
         api_url_for(
@@ -543,7 +545,7 @@ def test_api_channel_state_change_errors(
         json=dict(state=CHANNEL_STATE_CLOSED, balance=200)
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.CONFLICT)
+    assert_response_with_error(response, http.client.CONFLICT)
     # let's try to path with no arguments
     request = grequests.patch(
         api_url_for(
@@ -553,7 +555,7 @@ def test_api_channel_state_change_errors(
         ),
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.BAD_REQUEST)
+    assert_response_with_error(response, http.client.BAD_REQUEST)
 
     # ok now let's close and settle for real
     request = grequests.patch(
@@ -587,7 +589,7 @@ def test_api_channel_state_change_errors(
         json=dict(balance=500)
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.CONFLICT)
+    assert_response_with_error(response, http.client.CONFLICT)
 
     # and now let's try to settle again
     request = grequests.patch(
@@ -599,7 +601,7 @@ def test_api_channel_state_change_errors(
         json=dict(state=CHANNEL_STATE_SETTLED)
     )
     response = request.send().response
-    assert_response_with_error(response, httplib.CONFLICT)
+    assert_response_with_error(response, http.client.CONFLICT)
 
 
 def test_api_tokens(
@@ -620,7 +622,7 @@ def test_api_tokens(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
 
     partner_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     token_address = '0x61c808d82a3ac53231750dadc13c777b59310bd9'
@@ -635,7 +637,7 @@ def test_api_tokens(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
 
     # and now let's get the token list
     request = grequests.get(
@@ -670,7 +672,7 @@ def test_query_partners_by_token(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
     response = response.json()
     first_channel_address = response['channel_address']
 
@@ -680,7 +682,7 @@ def test_query_partners_by_token(
         json=channel_data_obj,
     )
     response = request.send().response
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
     response = response.json()
     second_channel_address = response['channel_address']
 
@@ -692,7 +694,7 @@ def test_query_partners_by_token(
         json=channel_data_obj
     )
     response = request.send().response
-    assert_proper_response(response, httplib.CREATED)
+    assert_proper_response(response, http.client.CREATED)
 
     # and now let's query our partners per token for the first token
     request = grequests.get(
@@ -932,7 +934,7 @@ def test_api_token_swaps(
         json=tokenswap_obj
     )
     response = request.send().response
-    assert_proper_response(response, status_code=httplib.CREATED)
+    assert_proper_response(response, status_code=http.client.CREATED)
 
     tokenswap_obj = {
         'role': 'taker',
@@ -957,7 +959,7 @@ def test_api_token_swaps(
         json=tokenswap_obj
     )
     response = request.send().response
-    assert_proper_response(response, status_code=httplib.CREATED)
+    assert_proper_response(response, status_code=http.client.CREATED)
 
 
 def test_api_transfers(
@@ -1081,7 +1083,7 @@ def test_register_token(api_backend, api_test_context, api_raiden_service):
         token_address=token_address,
     ))
     response = request.send().response
-    assert_proper_response(response, status_code=httplib.CREATED)
+    assert_proper_response(response, status_code=http.client.CREATED)
     assert 'channel_manager_address' in response.json()
 
     # now try to reregister it and get the error
@@ -1091,7 +1093,7 @@ def test_register_token(api_backend, api_test_context, api_raiden_service):
         token_address=token_address,
     ))
     response = request.send().response
-    assert_response_with_error(response, httplib.CONFLICT)
+    assert_response_with_error(response, http.client.CONFLICT)
 
 
 def test_get_connection_managers_info(

--- a/raiden/tests/benchmark/speed_simulation.py
+++ b/raiden/tests/benchmark/speed_simulation.py
@@ -5,6 +5,7 @@ transactions.
 """
 from __future__ import print_function
 
+from binascii import unhexlify
 import codecs
 import random
 import signal
@@ -259,7 +260,7 @@ def main():
             args.host,
             args.port,
             args.config,
-            args.privatekey.decode('hex'),
+            unhexlify(args.privatekey),
             args.rpc_server,
             args.registry_address,
             TOKEN_ADDRESS,
@@ -271,7 +272,7 @@ def main():
         setup_tps(
             args.rpc_server,
             args.config,
-            args.privatekey.decode('hex'),
+            unhexlify(args.privatekey),
             args.registry_address,
             TOKEN_ADDRESS,
             deposit,

--- a/raiden/tests/fixtures/api.py
+++ b/raiden/tests/fixtures/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-arguments,redefined-outer-name
 import copy
-
+from binascii import hexlify
 import os
 import pytest
 import psutil
@@ -80,7 +80,7 @@ def api_raiden_service(
     config['host'] = '127.0.0.1'
     config['external_ip'] = '127.0.0.1'
     config['external_port'] = raiden_udp_ports[0]
-    config['privatekey_hex'] = deploy_service.private_key.encode('hex')
+    config['privatekey_hex'] = hexlify(deploy_service.private_key)
     config['reveal_timeout'] = reveal_timeout
     config['database_path'] = os.path.join(tmpdir.strpath, 'database.db')
     raiden_service = RaidenService(

--- a/raiden/tests/fixtures/tester.py
+++ b/raiden/tests/fixtures/tester.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
+
 import pytest
 import ethereum.db
 import ethereum.blocks
@@ -254,7 +256,7 @@ def tester_channels(tester_state, tester_nettingcontracts, reveal_timeout):
         first_externalstate = ChannelExternalStateTester(
             tester_state,
             first_key,
-            nettingcontract.address.decode('hex'),
+            unhexlify(nettingcontract.address),
         )
         first_channel = channel_from_nettingcontract(
             first_key,
@@ -266,7 +268,7 @@ def tester_channels(tester_state, tester_nettingcontracts, reveal_timeout):
         second_externalstate = ChannelExternalStateTester(
             tester_state,
             second_key,
-            nettingcontract.address.decode('hex'),
+            unhexlify(nettingcontract.address),
         )
         second_channel = channel_from_nettingcontract(
             second_key,

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
+from binascii import unhexlify
 import os
 
 import pytest
@@ -81,7 +82,7 @@ def test_transact_opcode(deploy_client, blockchain_backend):
     gas = contract_proxy.ret.estimate_gas() * 2
 
     transaction_hex = contract_proxy.ret.transact(startgas=gas)
-    transaction = transaction_hex.decode('hex')
+    transaction = unhexlify(transaction_hex)
 
     deploy_client.poll(transaction)
 
@@ -98,7 +99,7 @@ def test_transact_throws_opcode(deploy_client, blockchain_backend):
 
     gas = min(contract_proxy.fail.estimate_gas(), deploy_client.gaslimit())
     transaction_hex = contract_proxy.fail.transact(startgas=gas)
-    transaction = transaction_hex.decode('hex')
+    transaction = unhexlify(transaction_hex)
 
     deploy_client.poll(transaction)
 
@@ -115,7 +116,7 @@ def test_transact_opcode_oog(deploy_client, blockchain_backend):
 
     gas = min(contract_proxy.loop.estimate_gas(1000) // 2, deploy_client.gaslimit)
     transaction_hex = contract_proxy.loop.transact(1000, startgas=gas)
-    transaction = transaction_hex.decode('hex')
+    transaction = unhexlify(transaction_hex)
 
     deploy_client.poll(transaction)
 
@@ -141,9 +142,9 @@ def test_filter_start_block_inclusive(deploy_client, blockchain_backend):
     # call the create event function twice and wait for confirmation each time
     gas = contract_proxy.createEvent.estimate_gas() * 2
     transaction_hex_1 = contract_proxy.createEvent.transact(1, startgas=gas)
-    deploy_client.poll(transaction_hex_1.decode('hex'))
+    deploy_client.poll(unhexlify(transaction_hex_1))
     transaction_hex_2 = contract_proxy.createEvent.transact(2, startgas=gas)
-    deploy_client.poll(transaction_hex_2.decode('hex'))
+    deploy_client.poll(unhexlify(transaction_hex_2))
 
     # create a new filter in the node
     new_filter(deploy_client, contract_proxy.address, None)

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
+from binascii import unhexlify
 import os
 import itertools
 
@@ -280,7 +281,7 @@ def test_blockchain(
         token_proxy.address,
         gasprice=denoms.wei,
     )
-    jsonrpc_client.poll(transaction_hash.decode('hex'), timeout=poll_timeout)
+    jsonrpc_client.poll(unhexlify(transaction_hash), timeout=poll_timeout)
 
     assert len(registry_proxy.tokenAddresses.call()) == 1
 
@@ -297,7 +298,7 @@ def test_blockchain(
     channel_manager_address_encoded = registry_proxy.channelManagerByToken.call(
         token_proxy.address,
     )
-    channel_manager_address = channel_manager_address_encoded.decode('hex')
+    channel_manager_address = unhexlify(channel_manager_address_encoded)
 
     log = log_list[0]
     log_topics = [
@@ -307,11 +308,11 @@ def test_blockchain(
     log_data = log['data']
     event = registry_proxy.translator.decode_event(
         log_topics,
-        log_data[2:].decode('hex'),
+        unhexlify(log_data[2:]),
     )
 
-    assert channel_manager_address == event['channel_manager_address'].decode('hex')
-    assert token_proxy.address == event['token_address'].decode('hex')
+    assert channel_manager_address == unhexlify(event['channel_manager_address'])
+    assert token_proxy.address == unhexlify(event['token_address'])
 
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
         CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
@@ -323,7 +324,7 @@ def test_blockchain(
         10,
         gasprice=denoms.wei,
     )
-    jsonrpc_client.poll(transaction_hash.decode('hex'), timeout=poll_timeout)
+    jsonrpc_client.poll(unhexlify(transaction_hash), timeout=poll_timeout)
 
     log_list = jsonrpc_client.call(
         'eth_getLogs',

--- a/raiden/tests/property/smart_contracts/test_nettingchannel.py
+++ b/raiden/tests/property/smart_contracts/test_nettingchannel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
 import contextlib
 
 from coincurve import PrivateKey
@@ -136,12 +137,12 @@ class NettingChannelStateMachine(GenericStateMachine):
         self.closing_address = None
         self.update_transfer_called = False
         self.participant_addresses = {
-            address_and_balance[0].decode('hex'),
-            address_and_balance[2].decode('hex'),
+            unhexlify(address_and_balance[0]),
+            unhexlify(address_and_balance[2]),
         }
 
         self.channel_addresses = [
-            self.netting_channel.address.decode('hex'),
+            unhexlify(self.netting_channel.address),
             make_address(),  # used to test invalid transfers
         ]
 
@@ -309,7 +310,7 @@ class NettingChannelStateMachine(GenericStateMachine):
                     sender=sender_pkey,
                 )
 
-        elif transfer.channel != self.netting_channel.address.decode('hex'):
+        elif transfer.channel != unhexlify(self.netting_channel.address):
             msg = 'close called with a transfer for a different channe didnt fail'
             with transaction_must_fail(msg):
                 self.netting_channel.close(  # pylint: disable=no-member
@@ -395,7 +396,7 @@ class NettingChannelStateMachine(GenericStateMachine):
                     sender=sender_pkey,
                 )
 
-        elif transfer.channel != self.netting_channel.address.decode('hex'):
+        elif transfer.channel != unhexlify(self.netting_channel.address):
             msg = 'updateTransfer called with a transfer for a different channel didnt fail'
             with transaction_must_fail(msg):
                 self.netting_channel.updateTransfer(  # pylint: disable=no-member

--- a/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 import os
 import string
 from itertools import chain, product
@@ -44,7 +44,7 @@ def deploy_auxiliary_tester(tester_state, tester_nettingchannel_library_address)
         None,
         path=get_relative_contract(__file__, 'AuxiliaryTester.sol'),
         language='solidity',
-        libraries={'NettingChannelLibrary': tester_nettingchannel_library_address.encode('hex')},
+        libraries={'NettingChannelLibrary': hexlify(tester_nettingchannel_library_address)},
         extra_args=raiden_remap,
     )
     tester_state.mine(number_of_blocks=1)

--- a/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
 import os
 import string
 from itertools import chain, product
@@ -221,4 +222,4 @@ def test_recoverAddressFromSignature(tester_state, tester_nettingchannel_library
         signature
     )
 
-    assert computed_address.decode('hex') == msg.sender
+    assert unhexlify(computed_address) == msg.sender

--- a/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
+
 import pytest
 from ethereum.tester import TransactionFailed
 from coincurve import PrivateKey
@@ -45,7 +47,7 @@ def test_transfer_update_event(tester_state, tester_channels, tester_events):
 
     assert tester_events[-1] == {
         '_event_type': 'TransferUpdated',
-        'node_address': address1.encode('hex'),
+        'node_address': hexlify(address1),
     }
 
 

--- a/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
+
 import pytest
 from ethereum.tester import TransactionFailed
 from coincurve import PrivateKey
@@ -133,7 +135,7 @@ def test_withdraw_at_settlement_block(
         identifier=1,
         nonce=nonce,
         token=tester_token.address,
-        channel=nettingchannel.address.decode('hex'),
+        channel=unhexlify(nettingchannel.address),
         transferred_amount=0,
         recipient=address1,
         locksroot=lock0_hash,

--- a/raiden/tests/smart_contracts/test_channel_manager.py
+++ b/raiden/tests/smart_contracts/test_channel_manager.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
 import itertools
 
 import pytest
@@ -81,8 +82,8 @@ def test_channeldeleted_event(
     channeldelete_event = tester_events[-2]
     assert channeldelete_event == {
         '_event_type': 'ChannelDeleted',
-        'caller_address': address0.encode('hex'),
-        'partner': address1.encode('hex')
+        'caller_address': hexlify(address0),
+        'partner': hexlify(address1)
     }
 
 
@@ -270,8 +271,8 @@ def test_for_issue_892(
         else:
             # this is brittle, relying on an implicit ordering of addresses
             participant_pairs.extend((
-                address0.encode('hex'),
-                address1.encode('hex'),
+                hexlify(address0),
+                hexlify(address1),
             ))
 
         assert participant_pairs == tester_channelmanager.getChannelsParticipants(sender=pkey0)

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
 from ethereum import tester
 from raiden.utils import get_contract_path
 
 
 def test_endpointregistry(tester_state, tester_events):
     account0 = tester.DEFAULT_ACCOUNT
-    sender = account0.encode('hex')
+    sender = hexlify(account0)
 
     endpointregistry_path = get_contract_path('EndpointRegistry.sol')
     registry_contract = tester_state.abi_contract(

--- a/raiden/tests/smart_contracts/test_registry.py
+++ b/raiden/tests/smart_contracts/test_registry.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
+
 import pytest
 
 from ethereum import slogging
@@ -44,17 +46,17 @@ def test_registry(tester_registry, tester_events, private_keys, tester_state):
     addresses = tester_registry.tokenAddresses(sender=privatekey0)
 
     assert len(addresses) == 2
-    assert addresses[0] == token_address1.encode('hex')
-    assert addresses[1] == token_address2.encode('hex')
+    assert addresses[0] == hexlify(token_address1)
+    assert addresses[1] == hexlify(token_address2)
 
     assert len(tester_events) == 2
 
     assert tester_events[0]['_event_type'] == 'TokenAdded'
-    assert tester_events[0]['token_address'] == token_address1.encode('hex')
+    assert tester_events[0]['token_address'] == hexlify(token_address1)
     assert tester_events[0]['channel_manager_address'] == contract_address1
 
     assert tester_events[1]['_event_type'] == 'TokenAdded'
-    assert tester_events[1]['token_address'] == token_address2.encode('hex')
+    assert tester_events[1]['token_address'] == hexlify(token_address2)
     assert tester_events[1]['channel_manager_address'] == contract_address2
 
 

--- a/raiden/tests/smart_contracts/test_token.py
+++ b/raiden/tests/smart_contracts/test_token.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
 import os
 
 from ethereum import tester
@@ -23,7 +24,7 @@ def test_token():
     )
 
     contract_libraries = {
-        'StandardToken': standard_token.address.encode('hex'),
+        'StandardToken': hexlify(standard_token.address),
     }
     human_token = state.abi_contract(
         None,
@@ -60,7 +61,7 @@ def test_token_approve():
     )
 
     contract_libraries = {
-        'StandardToken': standard_token.address.encode('hex'),
+        'StandardToken': hexlify(standard_token.address),
     }
     human_token = state.abi_contract(
         None,

--- a/raiden/tests/unit/test_namedbuffer.py
+++ b/raiden/tests/unit/test_namedbuffer.py
@@ -37,10 +37,10 @@ def test_decoder_long():
     packed_data = HugeInt(data)
     assert packed_data.huge == 0
 
-    packed_data.huge = 1L
+    packed_data.huge = 1
     assert packed_data.huge == 1
 
-    packed_data.huge = 2L ** 32
+    packed_data.huge = 2 ** 32
     assert packed_data.huge == 2 ** 32
 
     huge = 2 ** (8 * 100) - 1

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division
 
+from binascii import hexlify
 import json
 import os
 import shutil
@@ -104,7 +105,7 @@ def geth_create_account(datadir, privkey):
     """
     keyfile_path = os.path.join(datadir, 'keyfile')
     with open(keyfile_path, 'w') as handler:
-        handler.write(privkey.encode('hex'))
+        handler.write(hexlify(privkey))
 
     create = subprocess.Popen(
         ['geth', '--datadir', datadir, 'account', 'import', keyfile_path],

--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8
+from binascii import hexlify
+
 from raiden.settings import GAS_LIMIT_HEX
+
 GENESIS_STUB = {
     'config': {
         'homesteadBlock': 0,
@@ -15,7 +18,7 @@ GENESIS_STUB = {
     'coinbase': '0x0000000000000000000000000000000000000000',
     'timestamp': '0x00',
     'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
-    'extraData': '0x' + 'raiden'.encode('hex'),
+    'extraData': '0x' + hexlify('raiden'),
     'gasLimit': GAS_LIMIT_HEX,
     # add precompiled addresses with minimal balance to avoid deletion
     'alloc': {'%040x' % precompiled: {'balance': '0x1'} for precompiled in range(256)}

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -2,6 +2,7 @@
 """ Utilities to set-up a Raiden network. """
 from __future__ import print_function, division
 
+from binascii import hexlify
 
 from ethereum import slogging
 
@@ -251,7 +252,7 @@ def create_apps(
             'port': port,
             'external_ip': host,
             'external_port': port,
-            'privatekey_hex': private_key.encode('hex'),
+            'privatekey_hex': hexlify(private_key),
             'reveal_timeout': reveal_timeout,
             'settle_timeout': settle_timeout,
             'database_path': database_paths[idx],

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from future import standard_library
 standard_library.install_aliases()
+from binascii import hexlify
 import os
 import time
 import json
@@ -103,7 +104,7 @@ def run_restapi_smoketests(raiden_service, test_config):
 
     response_json = response.json()
     assert (response_json[0]['partner_address'] ==
-            '0x' + str(ConnectionManager.BOOTSTRAP_ADDR).encode('hex'))
+            '0x' + hexlify(str(ConnectionManager.BOOTSTRAP_ADDR)))
     assert response_json[0]['state'] == 'opened'
     assert response_json[0]['balance'] > 0
 
@@ -260,12 +261,12 @@ def deploy_and_open_channel_alloc(deployment_key):
         channel_address=channel_address,
     )
     for k, v in contracts.iteritems():
-        contracts[k] = v.encode('hex')
+        contracts[k] = hexlify(v)
 
     alloc = dict()
     # preserve all accounts and contracts
     for address in state.block.state.to_dict().keys():
-        address = address.encode('hex')
+        address = hexlify(address)
         alloc[address] = state.block.account_to_dict(address)
 
     for account, content in alloc.iteritems():
@@ -281,7 +282,7 @@ def complete_genesis():
     smoketest_genesis = GENESIS_STUB.copy()
     smoketest_genesis['config']['clique'] = {'period': 1, 'epoch': 30000}
     smoketest_genesis['extraData'] = '0x{:0<64}{:0<170}'.format(
-        'raiden'.encode('hex'),
+        hexlify('raiden'),
         TEST_ACCOUNT['address'],
     )
     smoketest_genesis['alloc'][TEST_ACCOUNT['address']] = dict(balance=hex(10 ** 18))

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from future import standard_library
+standard_library.install_aliases()
 import os
 import time
 import json
@@ -9,7 +11,7 @@ import distutils.spawn
 import pdb
 import traceback
 import requests
-import httplib
+import http.client
 from string import Template
 
 from ethereum._solidity import get_solidity
@@ -97,7 +99,7 @@ def run_restapi_smoketests(raiden_service, test_config):
     ).format(port=5001)
     response = requests.get(url)
 
-    assert response.status_code == httplib.OK
+    assert response.status_code == http.client.OK
 
     response_json = response.json()
     assert (response_json[0]['partner_address'] ==

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -310,7 +310,7 @@ def init_with_genesis(smoketest_genesis):
 
 
 def start_ethereum(smoketest_genesis):
-    RST_RPC_PORT = get_free_port('127.0.0.1', 27854).next()
+    RST_RPC_PORT = next(get_free_port('127.0.0.1', 27854))
     os.environ['RST_RPC_PORT'] = str(RST_RPC_PORT)
     cmd = os.environ.get('RST_ETH_COMMAND', DEFAULT_ETH_COMMAND)
     args = shlex.split(

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 
 from ethereum import tester
 
@@ -59,7 +59,7 @@ def deploy_standard_token(deploy_key, tester_state, token_amount):
     tester_state.mine(number_of_blocks=1)
 
     human_token_libraries = {
-        'StandardToken': standard_token_address.encode('hex'),
+        'StandardToken': hexlify(standard_token_address),
     }
     # using abi_contract because of the constructor_parameters
     human_token_proxy = tester_state.abi_contract(
@@ -97,7 +97,7 @@ def deploy_channelmanager_library(deploy_key, tester_state, tester_nettingchanne
         language='solidity',
         contract_name='ChannelManagerLibrary',
         libraries={
-            'NettingChannelLibrary': tester_nettingchannel_library_address.encode('hex'),
+            'NettingChannelLibrary': hexlify(tester_nettingchannel_library_address),
         },
         sender=deploy_key,
     )
@@ -113,7 +113,7 @@ def deploy_registry(deploy_key, tester_state, channel_manager_library_address):
         language='solidity',
         contract_name='Registry',
         libraries={
-            'ChannelManagerLibrary': channel_manager_library_address.encode('hex')
+            'ChannelManagerLibrary': hexlify(channel_manager_library_address)
         },
         sender=deploy_key,
     )

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
+
 from ethereum import tester
-from ethereum.utils import decode_hex
 
 from raiden.constants import (
     NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
@@ -192,9 +193,9 @@ def channel_from_nettingcontract(
     address_balance = netting_contract.addressAndBalance(sender=our_key)
     address1_hex, balance1, address2_hex, balance2 = address_balance
 
-    token_address = decode_hex(token_address_hex)
-    address1 = decode_hex(address1_hex)
-    address2 = decode_hex(address2_hex)
+    token_address = unhexlify(token_address_hex)
+    address1 = unhexlify(address1_hex)
+    address2 = unhexlify(address2_hex)
 
     if our_address == address1:
         our_balance = balance1

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 import os
 from collections import defaultdict
 from itertools import count
@@ -349,7 +349,7 @@ class DiscoveryTesterMock(object):
         self.tester_state.mine(number_of_blocks=1)
 
     def endpoint_by_address(self, node_address_bin):
-        node_address_hex = node_address_bin.encode('hex')
+        node_address_hex = hexlify(node_address_bin)
         endpoint = self.proxy.findEndpointByAddress(node_address_hex)
 
         if endpoint is '':

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
 import os
 from collections import defaultdict
 from itertools import count
@@ -6,7 +7,7 @@ from itertools import count
 from ethereum import tester, slogging, _solidity
 from ethereum.tester import TransactionFailed
 from ethereum.abi import ContractTranslator
-from ethereum.utils import decode_hex, encode_hex
+from ethereum.utils import encode_hex
 from ethereum._solidity import solidity_get_contract_key
 
 from raiden import messages
@@ -80,7 +81,7 @@ def tester_deploy_contract(
             dependency_contract['bin_hex'],
             libraries,
         )
-        bytecode = decode_hex(hex_bytecode)
+        bytecode = unhexlify(hex_bytecode)
 
         dependency_contract['bin_hex'] = hex_bytecode
         dependency_contract['bin'] = bytecode
@@ -556,7 +557,7 @@ class ChannelManagerTesterMock(object):
             netting_channel_address_hex,
         )
 
-        return decode_hex(channel.address)
+        return unhexlify(channel.address)
 
     def channels_addresses(self):
         channel_flat_encoded = self.proxy.getChannelsParticipants()

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-few-public-methods
-import types
 from collections import namedtuple
 from copy import deepcopy
 

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -134,7 +134,7 @@ class StateManager(object):
 
         self.current_state, events = iteration
 
-        assert isinstance(self.current_state, (State, types.NoneType))
+        assert isinstance(self.current_state, (State, type(None)))
         assert all(isinstance(e, Event) for e in events)
 
         return events

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -128,7 +128,7 @@ def try_new_route(state):
     else:
         state.route = try_route
 
-        secret = state.random_generator.next()
+        secret = next(state.random_generator)
         hashlock = sha3(secret)
 
         # The initiator doesn't need to learn the secret, so there is no need

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -845,7 +845,7 @@ def smoketest(ctx, debug, **kwargs):
     args['mapped_socket'] = None
     args['password_file'] = click.File()(password_file)
     args['datadir'] = args['keystore_path']
-    args['api_address'] = 'localhost:' + str(get_free_port('127.0.0.1', 5001).next())
+    args['api_address'] = 'localhost:' + str(next(get_free_port('127.0.0.1', 5001)))
     args['sync_check'] = False
 
     # invoke the raiden app

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+from binascii import hexlify
 import sys
 import os
 import re
@@ -506,7 +507,7 @@ def app(address,
     address_hex, privatekey_bin = prompt_account(address_hex, keystore_path, password_file)
     address = address_decoder(address_hex)
 
-    privatekey_hex = privatekey_bin.encode('hex')
+    privatekey_hex = hexlify(privatekey_bin)
     config['privatekey_hex'] = privatekey_hex
 
     endpoint = eth_rpc_endpoint

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-
 from future import standard_library
 standard_library.install_aliases()
+from binascii import hexlify
 import io
 import errno
 import json
@@ -336,7 +336,7 @@ class ConsoleTools(object):
             contract_path=contract_path,
             gasprice=gasprice,
             timeout=timeout)
-        token_address_hex = token_proxy.address.encode('hex')
+        token_address_hex = hexlify(token_proxy.address)
         if auto_register:
             self.register_token(token_address_hex)
         print("Successfully created {}the token '{}'.".format(
@@ -437,7 +437,7 @@ class ConsoleTools(object):
             ),
             channel=(channel
                      if not pretty
-                     else channel.external_state.netting_channel.address.encode('hex')),
+                     else hexlify(channel.external_state.netting_channel.address)),
             lifecycle=dict(
                 opened_at=channel.external_state.opened_block or 'not yet',
                 can_transfer=channel.can_transfer,
@@ -452,8 +452,8 @@ class ConsoleTools(object):
                 symbol=token.proxy.symbol(),
             ),
         )
-        stats['funding']['our_address'] = stats['funding']['our_address'].encode('hex')
-        stats['funding']['partner_address'] = stats['funding']['partner_address'].encode('hex')
+        stats['funding']['our_address'] = hexlify(stats['funding']['our_address'])
+        stats['funding']['partner_address'] = hexlify(stats['funding']['partner_address'])
         if not pretty:
             return stats
         else:

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-import cStringIO
+from future import standard_library
+standard_library.install_aliases()
+import io
 import errno
 import json
 import os
@@ -243,7 +245,7 @@ class Console(BaseService):
             if isinstance(handler, StreamHandler) and handler.stream == sys.stderr:
                 root.removeHandler(handler)
 
-        stream = cStringIO.StringIO()
+        stream = io.StringIO()
         handler = StreamHandler(stream=stream)
         handler.formatter = Formatter('%(levelname)s:%(name)s %(message)s')
         root.addHandler(handler)
@@ -272,7 +274,7 @@ class Console(BaseService):
 
         self.console_locals['lastlog'] = lastlog
 
-        err = cStringIO.StringIO()
+        err = io.StringIO()
         sys.stderr = err
 
         def lasterr(n=1):

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from binascii import unhexlify
 import os
 import re
 import string
@@ -19,7 +20,7 @@ LETTERS = string.printable
 def safe_address_decode(address):
     try:
         address = safe_lstrip_hex(address)
-        address = address.decode('hex')
+        address = unhexlify(address)
     except TypeError:
         pass
 
@@ -50,7 +51,7 @@ def address_decoder(addr):
     if addr[:2] == '0x':
         addr = addr[2:]
 
-    addr = addr.decode('hex')
+    addr = unhexlify(addr)
     assert len(addr) in (20, 0)
     return addr
 
@@ -77,7 +78,7 @@ def data_encoder(data, length=None):
 def data_decoder(data):
     assert data[:2] == '0x'
     data = data[2:]  # remove 0x
-    data = data.decode('hex')
+    data = unhexlify(data)
     return data
 
 
@@ -132,7 +133,7 @@ def split_endpoint(endpoint):
     host, port = match.groups()
     if port:
         port = int(port)
-    return (host, port)
+    return host, port
 
 
 def publickey_to_address(publickey):

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 import os
 import re
 import string
@@ -58,7 +58,7 @@ def address_decoder(addr):
 
 def address_encoder(address):
     assert len(address) in (20, 0)
-    return '0x' + address.encode('hex')
+    return '0x' + hexlify(address)
 
 
 def block_tag_encoder(val):
@@ -66,11 +66,11 @@ def block_tag_encoder(val):
         return hex(val).rstrip('L')
 
     assert val in ('latest', 'pending')
-    return '0x' + val.encode('hex')
+    return '0x' + hexlify(val)
 
 
 def data_encoder(data, length=None):
-    data = data.encode('hex')
+    data = hexlify(data)
     length = length or 0
     return '0x' + data.rjust(length * 2, '0')
 
@@ -110,7 +110,7 @@ def topic_encoder(topic):
 
 
 def pex(data):
-    return str(data).encode('hex')[:8]
+    return hexlify(str(data))[:8]
 
 
 def lpex(lst):

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 from collections import deque
 import random
 

--- a/raiden/utils/profiling/__init__.py
+++ b/raiden/utils/profiling/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
-from profiler import *  # noqa
+from __future__ import absolute_import
+from .profiler import *  # noqa

--- a/raiden/utils/profiling/graph.py
+++ b/raiden/utils/profiling/graph.py
@@ -26,6 +26,7 @@ using ImageMagick:
     convert -append memory_timeline.png latency_scatter.png memory_objcount.png collage.png
 """
 from __future__ import absolute_import
+from __future__ import print_function
 
 # Improvements:
 # - Draw the composite graphs with matplotlib instead of using convert and make
@@ -140,7 +141,7 @@ def memory_objcount(output, data_list, topn=10):
     values = [alltime_data[label] for label in labels]
 
     if not values:
-        print 'file is empty'
+        print('file is empty')
         return
 
     # plot only once to share the labels and colors

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ psutil
 filelock>=2.0.13,<3.0.0
 netifaces
 ipaddress
+future==0.16.0

--- a/tools/create_compilation_dump.py
+++ b/tools/create_compilation_dump.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8
 from __future__ import print_function
 
+from binascii import hexlify
 import json
 
 from ethereum import tester
@@ -28,12 +29,12 @@ def deploy_all(token_groups=None):
     log.DEV(  # pylint: disable=no-member
         'default key',
         raw=tester.DEFAULT_KEY,
-        enc=tester.DEFAULT_KEY.encode('hex'),
+        enc=hexlify(tester.DEFAULT_KEY),
     )
     log.DEV(  # pylint: disable=no-member
         'default account',
         raw=tester.DEFAULT_ACCOUNT,
-        enc=tester.DEFAULT_ACCOUNT.encode('hex'),
+        enc=hexlify(tester.DEFAULT_ACCOUNT),
     )
 
     tester.DEFAULT_KEY = DEFAULT_KEY
@@ -44,19 +45,19 @@ def deploy_all(token_groups=None):
     log.DEV(  # pylint: disable=no-member
         'default key',
         raw=tester.DEFAULT_KEY,
-        enc=tester.DEFAULT_KEY.encode('hex'),
+        enc=hexlify(tester.DEFAULT_KEY),
     )
     log.DEV(  # pylint: disable=no-member
         'default account',
         raw=tester.DEFAULT_ACCOUNT,
-        enc=tester.DEFAULT_ACCOUNT.encode('hex'),
+        enc=hexlify(tester.DEFAULT_ACCOUNT),
     )
 
     state = tester.state(num_accounts=1)
 
     log.DEV(  # pylint: disable=no-member
         'state',
-        coinbase=state.block.coinbase.encode('hex'),
+        coinbase=hexlify(state.block.coinbase),
         balance=state.block.get_balance(DEFAULT_ACCOUNT),
     )
     tester.gas_limit = 10 * 10 ** 6
@@ -123,7 +124,7 @@ def create_and_distribute_token(state,
     for receiver in receivers:
         proxy.transfer(receiver, amount_per_receiver)
     state.mine(number_of_blocks=1)
-    return (name, proxy.address.encode('hex'))
+    return (name, hexlify(proxy.address))
 
 
 def deploy_with_dependencies(contract_name, state, libraries=None):
@@ -159,7 +160,7 @@ def deploy_with_dependencies(contract_name, state, libraries=None):
             sender=DEFAULT_KEY,
         )
 
-        libraries[dependency.split('.')[0]] = deployed.address.encode('hex')
+        libraries[dependency.split('.')[0]] = hexlify(deployed.address)
         state.mine()
 
     log.DEV('deploying target', name=contract_name)  # pylint: disable=no-member
@@ -173,7 +174,7 @@ def deploy_with_dependencies(contract_name, state, libraries=None):
         sender=DEFAULT_KEY,
     )
 
-    libraries[contract_name.split('.')[0]] = contract.address.encode('hex')
+    libraries[contract_name.split('.')[0]] = hexlify(contract.address)
     state.mine()
     return libraries
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+from binascii import hexlify
 import json
 import os
 
@@ -107,8 +108,8 @@ def deploy_file(contract, compiled_contracts, client, gas_price=GAS_PRICE):
         contract_path=filename,
         gasprice=gas_price
     )
-    log.info("Deployed %s @ 0x%s", name, proxy.address.encode('hex'))
-    libraries[contract] = proxy.address.encode('hex')
+    log.info("Deployed %s @ 0x%s", name, hexlify(proxy.address))
+    libraries[contract] = hexlify(proxy.address)
     return libraries
 
 

--- a/tools/genesis_builder.py
+++ b/tools/genesis_builder.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
+
 from ethereum.utils import encode_hex, denoms
 
 from raiden.utils import privatekey_to_address, sha3
@@ -26,7 +28,7 @@ def mk_genesis(accounts, initial_alloc=denoms.ether * 100000000):
     :return: genesis dict
     """
     genesis = GENESIS_STUB.copy()
-    genesis['extraData'] = '0x' + CLUSTER_NAME.encode('hex')
+    genesis['extraData'] = '0x' + hexlify(CLUSTER_NAME)
     genesis['alloc'].update({
         account: {
             'balance': str(initial_alloc)

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from binascii import hexlify
+
 from ethereum._solidity import compile_file
 
 from raiden.network.rpc.client import JSONRPCClient
@@ -26,7 +28,7 @@ def create_and_distribute_token(
     """Create a new ERC-20 token and distribute it among `receivers`.
     If `name` is None, the name will be derived from hashing all receivers.
     """
-    name = name or sha3(''.join(receivers)).encode('hex')
+    name = name or hexlify(sha3(''.join(receivers)))
     contract_path = get_contract_path('HumanStandardToken.sol')
     token_proxy = client.deploy_solidity_contract(
         client.sender,
@@ -45,4 +47,4 @@ def create_and_distribute_token(
     )
     for receiver in receivers:
         token_proxy.transfer(receiver, amount_per_receiver)
-    return token_proxy.address.encode('hex')
+    return hexlify(token_proxy.address)

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+from binascii import hexlify
 import signal
 import json
 import time
@@ -144,7 +145,7 @@ def run(privatekey,
         tokens = script['tokens']
         token_address = None
         peer = None
-        our_node = app.raiden.address.encode('hex')
+        our_node = hexlify(app.raiden.address)
         log.warning("our address is {}".format(our_node))
         for token in tokens:
             # skip tokens that we're not part of


### PR DESCRIPTION
Merge after #1153 

This includes some pure py2 fixes as suggested by the `futurize` tool and uses the `future` library to handle imports in python 2 and 3. This makes the final diff smaller and can be removed once we're on py3.