### PR TITLE
Reduce unwanted transfer logging level

### DIFF
--- a/raiden/network/protocol.py
+++ b/raiden/network/protocol.py
@@ -844,7 +844,8 @@ class RaidenProtocol(object):
                 log.debug("Couldn't send the ACK", e=e)
 
         except (UnknownAddress, InvalidNonce, TransferWhenClosed, TransferUnwanted) as e:
-            log.DEV('maybe unwanted transfer', e=e)
+            if log.isEnabledFor(logging.WARN):
+                log.warn('maybe unwanted transfer', e=e)
 
         except (UnknownTokenAddress, InvalidLocksRoot) as e:
             if log.isEnabledFor(logging.WARN):


### PR DESCRIPTION
Some users [report](https://gitter.im/raiden-network/raiden?at=5a1ca4e48b3a9e2c0c25a786)
about the unwanted transfers and seem to worry about them. Reducing the
log message from `log.DEV`(CRITICAL) to `log.warn` will help with users
seeing this only if they got verbose logging output