### PR TITLE
 Update pytest, remove it from requirements.txt 

### DIFF
--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -69,10 +69,10 @@ def test_get_privkey(test_keystore):
     # failures
     with pytest.raises(ValueError) as exc:
         account_manager.get_privkey('0x3593403033d18b82f7b4a0f18e1ed24623d23b20', '456')
-    assert 'MAC mismatch. Password incorrect?' in exc.value
+    assert 'MAC mismatch. Password incorrect?' in str(exc.value)
     with pytest.raises(ValueError) as exc:
         account_manager.get_privkey('a05934d3033d18b82f7b4adf18e1ed24e3d23b19', '123')
-    assert 'Keystore file not found for a05934d3033d18b82f7b4adf18e1ed24e3d23b19' in exc.value
+    assert 'Keystore file not found for a05934d3033d18b82f7b4adf18e1ed24e3d23b19' in str(exc.value)
 
 
 def test_account_manager_invalid_files(test_keystore, caplog):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
 -r requirements.txt
 
 # Testing
-pytest>=3.0.4
+pytest>=3.3.0
 pytest-timeout>=1.2.0
 pytest-random>=0.02
 pytest-cov
-pytest-catchlog
 flaky
 hypothesis
 grequests

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ flask-restful
 webargs
 marshmallow_polyfield==3.0
 Flask-Cors==3.0.2
-pytest>=3.0.4
 psutil
 filelock>=2.0.13,<3.0.0
 netifaces


### PR DESCRIPTION
- Update to a newer pytest version which includes pytest-catchlog.
- Remove pytest from non-dev requirements (was there a good reason for it to be there?)
- Convert some exception infos to `str` before comparing.