### PR TITLE
Documentation: Fix status code for token-leave (API)

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -654,7 +654,7 @@ Possible Responses
 +------------------+---------------------------+
 | HTTP Code        | Condition                 |
 +==================+===========================+
-| 204 NO CONTENT   | For successfully leaving  |
+| 200 OK           | For successfully leaving  |
 |                  | a token network           |
 +------------------+---------------------------+
 | 500 Server Error | Internal Raiden node error|


### PR DESCRIPTION
The status code `204 NO CONTENT` did not reflect the response from the API in the code.
Instead, a `200 OK` is returned for normal operation:

https://github.com/raiden-network/raiden/blob/master/raiden/api/rest.py#L404
https://github.com/raiden-network/raiden/blob/master/raiden/api/rest.py#L98