### PR TITLE
Prevent pytest from searching node modules dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 ignore = E731, E402
 max-line-length = 99
+exclude = raiden/ui/web/node_modules/
 
 [pep8]
 ignore = E731, E402


### PR DESCRIPTION
Just a small adition to setup.cfg to prevent pytest from descending into `node_modules` rabbithole.