### PR TITLE
Fix comparison in 'test_participant_selection' and mark as xfail

### DIFF
--- a/raiden/tests/long_running/flaky/test_token_networks.py
+++ b/raiden/tests/long_running/flaky/test_token_networks.py
@@ -3,7 +3,6 @@ import logging
 
 import pytest
 import gevent
-from flaky import flaky
 
 from raiden.api.python import RaidenAPI
 from raiden.tests.utils.blockchain import wait_until_block
@@ -16,7 +15,7 @@ log = logging.getLogger(__name__)
 # - subsequent `connect()` calls with different `funds` arguments
 # - `connect()` calls with preexisting channels
 
-@flaky
+@pytest.mark.xfail(reason='Some issues in this test, see raiden #691')
 @pytest.mark.parametrize('number_of_nodes', [6])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('cached_genesis', [False])
@@ -60,7 +59,7 @@ def test_participant_selection(raiden_network, token_addresses):
     def not_saturated(connection_managers):
         return [
             1 for connection_manager in connection_managers
-            if connection_manager.open_channels < connection_manager.initial_channel_target
+            if len(connection_manager.open_channels) < connection_manager.initial_channel_target
         ]
 
     chain = raiden_network[-1].raiden.chain


### PR DESCRIPTION
There was a comarison between `list` and `int` that was always true. After fixing the test fails, so mark it as `xfail` for now. The issue is tracked under  https://github.com/raiden-network/raiden/issues/691 