### PR TITLE
Stop endless loop at shutdown after connection loss

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -40,8 +40,8 @@ class InvalidAddress(RaidenError):
 
 
 class InvalidAmount(RaidenError):
-    """ Raised when the user provided value is not a integer and cannot be used
-    to defined a transfer value.
+    """ Raised when the user provided value is not an integer and cannot be
+    used to defined a transfer value.
     """
     pass
 
@@ -78,7 +78,7 @@ class InvalidState(RaidenError):
 
 
 class TransferWhenClosed(RaidenError):
-    """ Raised when a user tries to request a transfer is a closed channel. """
+    """ Raised when a user tries to request a transfer in a closed channel. """
     pass
 
 
@@ -89,14 +89,14 @@ class UnknownAddress(RaidenError):
 
 
 # Exceptions raised due to protocol errors (this includes messages received
-# from a bizantine node)
+# from a byzantine node)
 
 
 class InsufficientBalance(RaidenError):
-    """ Raised when the netting channel doesn't enough available capacity to
-    pay for the transfer.
+    """ Raised when the netting channel doesn't have enough available capacity
+    to pay for the transfer.
 
-    Used for the validation of an *incoming* messages.
+    Used for the validation of *incoming* messages.
     """
     pass
 
@@ -105,7 +105,7 @@ class InvalidLocksRoot(RaidenError):
     """ Raised when the received message has an invalid locksroot.
 
     Used to reject a message when a pending lock is missing from the locksroot,
-    otherwise if the message is accepted there is a pontential loss of token.
+    otherwise if the message is accepted there is a potential loss of token.
     """
     def __init__(self, expected_locksroot, got_locksroot):
         msg = 'Locksroot mismatch. Expected {} but got {}'.format(

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -142,6 +142,13 @@ class STUNUnavailableException(RaidenError):
     pass
 
 
+class RaidenShuttingDown(RaidenError):
+    """ Raised when Raiden is in the process of shutting down to help with a
+    clean shutdown and not have exceptions thrown in all greenlets when there
+    is a connection timeout with the rpc client before shutting down."""
+    pass
+
+
 class EthNodeCommunicationError(RaidenError):
     """ Raised when something unexpected has happened during
     communication with the underlying ethereum node"""

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -29,6 +29,7 @@ import requests
 from raiden.exceptions import (
     AddressWithoutCode,
     EthNodeCommunicationError,
+    RaidenShuttingDown,
 )
 from raiden.network.protocol import timeout_two_stage
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
@@ -159,7 +160,7 @@ def check_node_connection(func):
         for i, timeout in enumerate(timeout_two_stage(10, 3, 10)):
 
             if self.shutting_down:
-                return None
+                raise RaidenShuttingDown()
 
             try:
                 result = func(self, *args, **kwargs)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -155,7 +155,12 @@ def format_data_for_call(
 def check_node_connection(func):
     """ A decorator to reconnect if the connection to the node is lost."""
     def retry_on_disconnect(self, *args, **kwargs):
+        """self here is always an obhect of JSONRPCClient"""
         for i, timeout in enumerate(timeout_two_stage(10, 3, 10)):
+
+            if self.shutting_down:
+                return None
+
             try:
                 result = func(self, *args, **kwargs)
                 if i > 0:
@@ -206,6 +211,7 @@ class JSONRPCClient(object):
         self.nonce_lock = Semaphore()
         self.nonce_update_interval = nonce_update_interval
         self.nonce_offset = nonce_offset
+        self.shutting_down = False
 
     def __repr__(self):
         return '<JSONRPCClient @%d>' % self.port

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -154,12 +154,12 @@ def format_data_for_call(
 
 
 def check_node_connection(func):
-    """ A decorator to reconnect if the connection to the node is lost."""
+    """ A decorator to reconnect if the connection to the node is lost.
+    Decorator should only wrap methods of the JSONRPCClient class"""
     def retry_on_disconnect(self, *args, **kwargs):
-        """self here is always an obhect of JSONRPCClient"""
         for i, timeout in enumerate(timeout_two_stage(10, 3, 10)):
 
-            if self.shutting_down_event and self.shutting_down_event.is_set():
+            if self.stop_event and self.stop_event.is_set():
                 raise RaidenShuttingDown()
 
             try:
@@ -208,7 +208,7 @@ class JSONRPCClient(object):
         self.sender = privatekey_to_address(privkey)
         # Needs to be initialized to None in the beginning since JSONRPCClient
         # gets constructed before the RaidenService Object.
-        self.shutting_down_event = None
+        self.stop_event = None
 
         self.nonce_last_update = 0
         self.nonce_current_value = None
@@ -276,8 +276,8 @@ class JSONRPCClient(object):
 
             return self.nonce_current_value
 
-    def inject_shutting_down_event(self, event):
-        self.shutting_down_event = event
+    def inject_stop_event(self, event):
+        self.stop_event = event
 
     def balance(self, account):
         """ Return the balance of the account of given address. """

--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -9,6 +9,8 @@ import socket
 import gevent
 from gevent.server import DatagramServer
 
+from raiden.exceptions import RaidenShuttingDown
+
 
 class DummyPolicy(object):
     """Dummy implementation for the throttling policy that always
@@ -77,7 +79,10 @@ class UDPTransport(object):
         self.throttle_policy = throttle_policy
 
     def receive(self, data, host_port):  # pylint: disable=unused-argument
-        self.protocol.receive(data)
+        try:
+            self.protocol.receive(data)
+        except RaidenShuttingDown:  # For a clean shutdown
+            return
 
         # enable debugging using the DummyNetwork callbacks
         DummyTransport.track_recv(self.protocol.raiden, host_port, data)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -310,6 +310,8 @@ class RaidenService(object):
         """ Stop the node. """
         self.alarm.stop_async()
         self.protocol.stop_and_wait()
+        # Needs to come before the greenlets joining
+        self.chain.client.shutting_down = True
 
         wait_for = [self.alarm]
         wait_for.extend(self.protocol.greenlets)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -241,9 +241,9 @@ class RaidenService(object):
         self.alarm = AlarmTask(chain)
         self.shutdown_timeout = config['shutdown_timeout']
         self._block_number = None
-        self.shutting_down_event = Event()
-        self.initialization_complete_event = Event()
-        self.chain.client.inject_shutting_down_event(self.shutting_down_event)
+        self.stop_event = Event()
+        self.start_event = Event()
+        self.chain.client.inject_stop_event(self.stop_event)
 
         self.transaction_log = StateChangeLog(
             storage_instance=StateChangeLogSQLiteBackend(
@@ -280,8 +280,8 @@ class RaidenService(object):
         # XXX Should this really be here? Or will start() never be called again
         # after stop() in the lifetime of Raiden apart from the tests? This is
         # at least at the moment prompted by tests/integration/test_transer.py
-        if self.shutting_down_event and self.shutting_down_event.is_set():
-            self.shutting_down_event.clear()
+        if self.stop_event and self.stop_event.is_set():
+            self.stop_event.clear()
 
         self.alarm.start()
 
@@ -309,7 +309,7 @@ class RaidenService(object):
         # Health check needs the protocol layer
         self.start_neighbours_healthcheck()
 
-        self.initialization_complete_event.set()
+        self.start_event.set()
 
     def start_neighbours_healthcheck(self):
         for graph in self.token_to_channelgraph.values():
@@ -320,7 +320,7 @@ class RaidenService(object):
     def stop(self):
         """ Stop the node. """
         # Needs to come before any greenlets joining
-        self.shutting_down_event.set()
+        self.stop_event.set()
         self.protocol.stop_and_wait()
         self.alarm.stop_async()
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -8,6 +8,7 @@ from gevent.event import AsyncResult
 from gevent.queue import (
     Queue,
 )
+from raiden.exceptions import RaidenShuttingDown
 
 REMOVE_CALLBACK = object()
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -64,7 +65,10 @@ class AlarmTask(Task):
 
         sleep_time = 0
         while self.stop_event.wait(sleep_time) is not True:
-            self.poll_for_new_block()
+            try:
+                self.poll_for_new_block()
+            except RaidenShuttingDown:
+                break
 
             # we want this task to iterate in the tick of `wait_time`, so take
             # into account how long we spent executing one tick.

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -109,6 +109,8 @@ class AlarmTask(Task):
             for callback in self.callbacks:
                 try:
                     result = callback(current_block)
+                except RaidenShuttingDown:
+                    break
                 except:  # pylint: disable=bare-except # noqa
                     log.exception('unexpected exception on alarm')
                 else:

--- a/raiden/tests/integration/test_transfer.py
+++ b/raiden/tests/integration/test_transfer.py
@@ -14,7 +14,7 @@ def test_direct_transfer_to_offline_node(raiden_network, token_addresses):
     app0, app1 = raiden_network
 
     # Wait until the initialization of the node is complete and then stop it
-    gevent.wait([app1.raiden.initialization_complete_event])
+    gevent.wait([app1.raiden.start_event])
     app1.raiden.stop()
 
     amount = 10

--- a/raiden/tests/integration/test_transfer.py
+++ b/raiden/tests/integration/test_transfer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import gevent
 
 from raiden.tests.utils.transfer import assert_mirror, channel
 
@@ -12,6 +13,8 @@ def test_direct_transfer_to_offline_node(raiden_network, token_addresses):
     token_address = token_addresses[0]
     app0, app1 = raiden_network
 
+    # Wait until the initialization of the node is complete and then stop it
+    gevent.wait([app1.raiden.initialization_complete_event])
     app1.raiden.stop()
 
     amount = 10

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -225,6 +225,14 @@ class FilterTesterMock(object):
         self.events = list()
 
 
+class ClientMock(object):
+    def __init__(self):
+        self.shutting_down_event = None
+
+    def inject_shutting_down_event(self, event):
+        self.shutting_down_event = event
+
+
 class BlockChainServiceTesterMock(object):
     def __init__(self, private_key, tester_state):
         self.tester_state = tester_state
@@ -237,6 +245,7 @@ class BlockChainServiceTesterMock(object):
         self.address_to_discovery = dict()
         self.address_to_nettingchannel = dict()
         self.address_to_registry = dict()
+        self.client = ClientMock()
 
     def block_number(self):
         return self.tester_state.block.number

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -227,10 +227,10 @@ class FilterTesterMock(object):
 
 class ClientMock(object):
     def __init__(self):
-        self.shutting_down_event = None
+        self.stop_event = None
 
-    def inject_shutting_down_event(self, event):
-        self.shutting_down_event = event
+    def inject_stop_event(self, event):
+        self.stop_event = event
 
 
 class BlockChainServiceTesterMock(object):

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -751,7 +751,7 @@ def run(ctx, **kwargs):
                 gevent.signal(signal.SIGUSR2, toggle_trace_profiler)
 
                 event.wait()
-
+                print('Signal received. Shutting down ...')
                 try:
                     api_server.stop()
                 except NameError:


### PR DESCRIPTION
The issue is simple to reproduce. Shut down the ethereum node and wait for a bit until all greenlets start reporting the error message that the ethereum client is offline.

Then try to send a signal to stop raiden. It won't be able to. It will get stuck waiting for the greenlets to close since they are in an endless loop of repeating the RPC connection attempt.

This PR tries to address this issue by doing two things:

1. Introduing a flag in the JSONRPC client that signifies we are shutting down, flipped over when the signal to shut down is received. The reconnection attempts stop one this flag is flipped.

2. Allow for a clean exit of all greenlet by throwing a special exception `RaidenShuttingDown` from there which is caught in all the top places where rpc client calls are made. This way Raiden does terminate succesfully and also does it without throwing a gazzilion exceptions in all its running greenlets.