### PR TITLE
Warn user to remove nosyncheck if running in a private network

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -150,6 +150,14 @@ def check_synced(blockchain_service):
             "node cannot be trusted. Giving up.\n"
         )
         sys.exit(1)
+    except KeyError:
+        print(
+            'Your ethereum client is connected to a non-recognized private \n'
+            'network with network-ID {}. Since we can not check if the client \n'
+            'is synced please restart raiden with the --no-sync-check argument.'
+            '\n'.format(net_id)
+        )
+        sys.exit(1)
 
     url = ETHERSCAN_API.format(
         network=network,


### PR DESCRIPTION
When users try to run raiden on a private network we will fail with a `KeyError` at the moment due to the sync check trying to find an oracle.

With this PR we don't throw an exception but instead we provide an error message to the user to use the appropriate argument so that the sync check does not happen.

Alternative solution. If there is a keyerror automatically disable the sync check. 