### PR TITLE
Fix the file argument name for serve_webui

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -215,7 +215,7 @@ class APIServer(object):
             self.flask_app.config['WEBUI_PATH'] = '{}/raiden/ui/web/dist/'.format(sys.prefix)
 
         if web_ui:
-            for route in ('/ui/<path:file>', '/ui', '/ui/', '/index.html', '/'):
+            for route in ('/ui/<path:file_name>', '/ui', '/ui/', '/index.html', '/'):
                 self.flask_app.add_url_rule(
                     route,
                     route,


### PR DESCRIPTION
At some point it used to be `file` but was renamed to `file_name` to not
overshadow the built-in python `file`.

But whoever made the change forgot to change the name of the variable in the
way `serve_webui()` determines the name of the files to serve.

Without this change webui does not start and can't load any pages. When trying
to load them we got this error:

```
INFO:raiden.api.rest    127.0.0.1 - - [2018-01-10 15:32:56] "GET /ui/vendor.636d457f414f2bb1f76f.bundle.js HTTP/1.1" 500 412 0.000945
ERROR:raiden.api.rest   [2018-01-10 15:32:56,321] ERROR in app: Exception on /ui/main.bb2c35b48259b3cf3d8f.bundle.js [GET]
Traceback (most recent call last):
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask_restful/__init__.py", line 273, in error_router
    return original_handler(e)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/lefteris/.virtualenvs/raiden/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
TypeError: _serve_webui() got an unexpected keyword argument 'file'
```