### PR TITLE
Enable developer warning while testing and fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 before_script:
   ./.travis/before_script.sh
 script:
-  - coverage run -m py.test --travis-fold=always -vvvvvv --log-config='raiden:DEBUG' --random $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE
+  - coverage run -m py.test -Wd --travis-fold=always -vvvvvv --log-config='raiden:DEBUG' --random $BLOCKCHAIN_TYPE ./raiden/tests/$TEST_TYPE
 after_success:
   - coveralls
 notifications:

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -43,7 +43,7 @@ class ContractProxy:
     def transact(self, function_name, *args, **kargs):
         self._check_function_name_and_kargs(function_name, kargs)
 
-        data = self.translator.encode(function_name, args)
+        data = self.translator.encode_function_call(function_name, args)
         txhash = self.transaction_function(
             sender=self.sender,
             to=self.contract_address,
@@ -57,7 +57,7 @@ class ContractProxy:
     def call(self, function_name, *args, **kargs):
         self._check_function_name_and_kargs(function_name, kargs)
 
-        data = self.translator.encode(function_name, args)
+        data = self.translator.encode_function_call(function_name, args)
         res = self.call_function(
             sender=self.sender,
             to=self.contract_address,
@@ -67,7 +67,7 @@ class ContractProxy:
         )
 
         if res:
-            res = self.translator.decode(function_name, res)
+            res = self.translator.decode_function_result(function_name, res)
             if len(res) == 1:
                 res = res[0]
 
@@ -79,7 +79,7 @@ class ContractProxy:
 
         self._check_function_name_and_kargs(function_name, kargs)
 
-        data = self.translator.encode(function_name, args)
+        data = self.translator.encode_function_call(function_name, args)
 
         res = self.estimate_function(
             sender=self.sender,

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -237,12 +237,11 @@ def get_system_spec():
             platform.architecture()[0]
         )
     else:
-        system_info = '{} {} {} {} / {}'.format(
+        system_info = '{} {} {} {}'.format(
             platform.system(),
             '_'.join(platform.architecture()),
             platform.release(),
-            platform.machine(),
-            ' '.join(part for part in platform.linux_distribution() if part)
+            platform.machine()
         )
 
     system_spec = dict(


### PR DESCRIPTION
This enables developer warnings during testing. It also fixes some deprecations that get found by this.

I just removed the `linux_distribution` info for now, but could bring that back with the https://pypi.python.org/pypi/distro package if it's deemed important.