### PR TITLE
Use the local address implicitly for NettingChannel creation

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -202,7 +202,6 @@ class RaidenAPI:
         assert token_address in self.raiden.token_to_channelgraph
 
         netcontract_address = channel_manager.new_netting_channel(
-            self.raiden.address,
             partner_address,
             settle_timeout,
         )

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -60,7 +60,6 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
 
     # create one channel
     netting_address_01 = manager0.new_netting_channel(
-        peer0_address,
         peer1_address,
         settle_timeout,
     )
@@ -80,13 +79,11 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
     #  is still open should throw an exception
     with pytest.raises(Exception):
         manager0.new_netting_channel(
-            peer0_address,
             peer1_address,
             settle_timeout,
         )
     # create other channel
     netting_address_02 = manager0.new_netting_channel(
-        peer0_address,
         peer2_address,
         settle_timeout,
     )
@@ -163,7 +160,6 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
 
     # open channel with same peer again
     netting_address_01_reopened = manager0.new_netting_channel(
-        peer0_address,
         peer1_address,
         settle_timeout,
     )
@@ -192,7 +188,6 @@ def test_channelmanager_graph_building(
     for app0, app1 in pairs:
         manager = app0.raiden.default_registry.manager_by_token(token_address)
         manager.new_netting_channel(
-            app0.raiden.address,
             app1.raiden.address,
             settle_timeout,
         )
@@ -343,11 +338,10 @@ def test_channel_with_self(raiden_network, settle_timeout):
     with pytest.raises(SamePeerAddress) as excinfo:
         graph0.new_netting_channel(
             app0.raiden.address,
-            app0.raiden.address,
             settle_timeout,
         )
 
-    assert 'Peer1 and peer2 must not be equal' in str(excinfo.value)
+    assert 'The other peer must not have the same address as the client.' in str(excinfo.value)
 
     transaction_hash = graph0.proxy.transact(
         'newChannel',

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -59,7 +59,6 @@ def test_event_new_channel(raiden_chain, deposit, settle_timeout, events_poll_ti
     token1 = app1.raiden.chain.token(token_address)
 
     netcontract_address = graph0.new_netting_channel(
-        app0.raiden.address,
         app1.raiden.address,
         settle_timeout,
     )
@@ -157,7 +156,6 @@ def test_query_events(raiden_chain, deposit, settle_timeout, events_poll_timeout
     assert not events
 
     netcontract_address = manager0.new_netting_channel(
-        app0.raiden.address,
         app1.raiden.address,
         settle_timeout,
     )

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -39,7 +39,6 @@ def setup_channels(token_address, app_pairs, deposit, settle_timeout):
         manager = first.raiden.default_registry.manager_by_token(token_address)
 
         netcontract_address = manager.new_netting_channel(
-            first.raiden.address,
             second.raiden.address,
             settle_timeout,
         )

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -235,10 +235,8 @@ def deploy_and_open_channel_alloc(deployment_key):
 
     manager = registry.manager_by_token(token_address)
     assert manager.private_key == deployment_key_bin
-    our_address = TEST_ACCOUNT['address']
 
     channel_address = manager.new_netting_channel(
-        unhexlify(our_address),
         unhexlify(TEST_PARTNER_ADDRESS),
         50
     )

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -507,20 +507,18 @@ class ChannelManagerTesterMock:
         token_address = address_decoder(token_address_hex)
         return token_address
 
-    def new_netting_channel(self, peer1, peer2, settle_timeout):
+    def new_netting_channel(self, other_peer, settle_timeout):
         """ Creates a new netting contract between peer1 and peer2.
 
         Raises:
-            ValueError: If peer1 or peer2 is not a valid address.
+            ValueError: If other_peer is not a valid address.
         """
-        if not isaddress(peer1):
-            raise ValueError('The peer1 must be a valid address')
+        if not isaddress(other_peer):
+            raise ValueError('The other_peer must be a valid address')
 
-        if not isaddress(peer2):
-            raise ValueError('The peer2 must be a valid address')
-
-        if peer1 == peer2:
-            raise SamePeerAddress('peer1 and peer2 must not be equal')
+        local_address = privatekey_to_address(self.private_key)
+        if local_address == other_peer:
+            raise SamePeerAddress('The other peer must not have the same address as the client.')
 
         invalid_timeout = (
             settle_timeout < NETTINGCHANNEL_SETTLE_TIMEOUT_MIN or
@@ -531,14 +529,9 @@ class ChannelManagerTesterMock:
                 NETTINGCHANNEL_SETTLE_TIMEOUT_MIN, NETTINGCHANNEL_SETTLE_TIMEOUT_MAX
             ))
 
-        if privatekey_to_address(self.private_key) == peer1:
-            other = peer2
-        else:
-            other = peer1
-
         try:
             netting_channel_address_hex = self.proxy.newChannel(
-                other,
+                other_peer,
                 settle_timeout,
                 sender=self.private_key
             )


### PR DESCRIPTION
The is a small flaw in the code for creating a new `NettingChannel` in the `ChannelManager`.
https://github.com/raiden-network/raiden/blob/212d2c23dd1f6484a5f1a02db8b9ce71b81c0917/raiden/network/proxies/channel_manager.py#L93-L96

If `privatekey_to_address(self.client.privkey) == peer1` is true, then the other peer is set correctly. However, it is then assumed that `privatekey_to_address(self.client.privkey) == peer2`is true, which might be wrong.

I solved this by removing one address from the function signature and take the local clients address as the other channel participant.