### PR TITLE
Fix 500 internal error during connect API method

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -95,7 +95,7 @@ URLS_V1 = [
 
 def api_response(result, status_code=HTTPStatus.OK):
     response = make_response((
-        json.dumps(result),
+        json.dumps(result) if result else '',
         status_code,
         {'mimetype': 'application/json', 'Content-Type': 'application/json'}
     ))

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -94,8 +94,14 @@ URLS_V1 = [
 
 
 def api_response(result, status_code=HTTPStatus.OK):
+    if status_code == HTTPStatus.NO_CONTENT:
+        assert not result, 'Provided 204 response with non-zero length response'
+        data = ''
+    else:
+        data = json.dumps(result)
+
     response = make_response((
-        json.dumps(result) if result else '',
+        data,
         status_code,
         {'mimetype': 'application/json', 'Content-Type': 'application/json'}
     ))


### PR DESCRIPTION
As reported in gitter users were getting an internal server error after
attempting to use the connect endpoint.

```
Traceback (most recent call last):
  File "/home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/gevent/pywsgi.py", line 935, in handle_one_response
    self.run_application()
  File "/home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/gevent/pywsgi.py", line 908, in run_application
    self.result = self.application(self.environ, self.start_response)
  File "/home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/flask/app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/flask/app.py", line 1989, in wsgi_app
    return response(environ, start_response)
  File "/home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/werkzeug/wrappers.py", line 1326, in __call__
    start_response(status, headers)
  File "/home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/gevent/pywsgi.py", line 866, in start_response
    raise AssertionError(msg)
AssertionError: b"Invalid Content-Length for 204 response: '2' (must be absent or zero)"
Tue Jan 23 17:31:37 2018 {'REMOTE_ADDR': '127.0.0.1', 'REMOTE_PORT': '38694', 'HTTP_HOST': 'localhost:5001', (hidden keys: 23)} failed with AssertionError
```

Seems that pywsgi is enforcing the 0 length of the 204 responses.