### PR TITLE
Fix estimate gas for throwing txs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ python:
 - '3.6'
 env:
   global:
-  - GETH_URL_LINUX='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.2-1db4ecdc.tar.gz'
-  - GETH_URL_MACOS='https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.7.2-1db4ecdc.tar.gz'
-  - GETH_VERSION='1.7.2'
+  - GETH_URL_LINUX='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.3-4bb3c89d.tar.gz'
+  - GETH_URL_MACOS='https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.7.3-4bb3c89d.tar.gz'
+  - GETH_VERSION='1.7.3'
   - SOLC_URL_LINUX='https://github.com/ethereum/solidity/releases/download/v0.4.18/solc-static-linux'
   - SOLC_URL_MACOS='https://www.dropbox.com/s/21xuco6djjpdwd4/solc_0.4.18?dl=0'
   - SOLC_VERSION='v0.4.18'

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -152,7 +152,9 @@ class RaidenShuttingDown(RaidenError):
 class EthNodeCommunicationError(RaidenError):
     """ Raised when something unexpected has happened during
     communication with the underlying ethereum node"""
-    pass
+    def __init__(self, error_msg, error_code=None):
+        super(EthNodeCommunicationError, self).__init__(error_msg)
+        self.error_code = error_code
 
 
 class AddressWithoutCode(RaidenError):

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -686,7 +686,17 @@ class JSONRPCClient:
             startgas,
             gasprice,
         )
-        res = self.call('eth_estimateGas', json_data)
+        try:
+            res = self.call('eth_estimateGas', json_data)
+        except EthNodeCommunicationError as e:
+            tx_would_fail = str(e) in [
+                'gas required exceeds allowance or always failing transaction',  # geth
+                'Transaction execution error.'  # parity
+            ]
+            if tx_would_fail:
+                return -1
+            else:
+                raise e
 
         return quantity_decoder(res)
 

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -77,6 +77,12 @@ class ContractProxy:
         return res
 
     def estimate_gas(self, function_name: str, *args, **kargs):
+        """ Returns the estimated gas for the function or -1 if the function
+        will throw.
+
+        Raises:
+            EthNodeCommunicationError: If the ethereum node's reply can't be parsed.
+        """
         if not self.estimate_function:
             raise RuntimeError('estimate_function was not supplied.')
 

--- a/raiden/network/rpc/transactions.py
+++ b/raiden/network/rpc/transactions.py
@@ -32,7 +32,7 @@ def estimate_and_transact(proxy, function_name, startgas, gasprice, *args):
 
     # XXX: From Byzantium and on estimate gas is not giving an accurate estimation
     #      and as such we not longer utilize its result but use the GAS_LIMIT in
-    #      all transactions. With the revert() call not consumin all given gas that
+    #      all transactions. With the revert() call not consuming all given gas that
     #      is not that bad
     #
     # estimated_gas = callobj.estimate_gas(

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -84,7 +84,7 @@ def test_estimate_gas_fail(deploy_client, blockchain_backend):
     address = contract_proxy.contract_address
     assert len(deploy_client.eth_getCode(address)) > 0
 
-    assert contract_proxy.estimate_gas('fail') == -1
+    assert not contract_proxy.estimate_gas('fail')
 
 
 def test_transact_opcode(deploy_client, blockchain_backend):

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -77,6 +77,16 @@ def test_call_throws(deploy_client, blockchain_backend):
     assert contract_proxy.call('fail') == b''
 
 
+def test_estimate_gas_fail(deploy_client, blockchain_backend):
+    """ A JSON RPC estimate gas call for a throwing transaction returns -1"""
+    contract_proxy = deploy_rpc_test_contract(deploy_client)
+
+    address = contract_proxy.contract_address
+    assert len(deploy_client.eth_getCode(address)) > 0
+
+    assert contract_proxy.estimate_gas('fail') == -1
+
+
 def test_transact_opcode(deploy_client, blockchain_backend):
     """ The receipt status field of a transaction that did not throw is 0x1 """
     contract_proxy = deploy_rpc_test_contract(deploy_client)

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -101,10 +101,7 @@ def test_transact_throws_opcode(deploy_client, blockchain_backend):
     address = contract_proxy.contract_address
     assert len(deploy_client.eth_getCode(address)) > 0
 
-    gas = min(
-        contract_proxy.estimate_gas('fail'),
-        deploy_client.gaslimit(),
-    )
+    gas = deploy_client.gaslimit()
 
     transaction_hex = contract_proxy.transact('fail', startgas=gas)
     transaction = unhexlify(transaction_hex)

--- a/tools/testnet/files/dockerfiles/geth-testnet/Dockerfile
+++ b/tools/testnet/files/dockerfiles/geth-testnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.7.2
+FROM ethereum/client-go:v1.7.3
 MAINTAINER Ulrich Petri <ulrich@brainbot.com>
 
 RUN \


### PR DESCRIPTION
- Fixes #1146 
- Bumps travis geth version to 1.7.3

Estimate gas no longer returns max gas for throwing calls but instead throws an
error.

The error in geth looks like:
`{"jsonrpc":"2.0","id":17,"error":{"code":-32000,"message":"gas required exceeds
allowance or always failing transaction"}}`

The error in parity looks like:
`{"jsonrpc":"2.0","error":{"code":-32015,"message":"Transaction execution
error.","data":"Internal(\"Requires higher than upper limit of
80000290\")"},"id":1}`

The raiden estimate gas function now returns `None` if the transaction we are
estimating would throw