### PR TITLE
Remove bitcoin dependency as it is deprecated

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -5,9 +5,10 @@ import os
 import sys
 from binascii import hexlify, unhexlify
 
-from bitcoin import privtopub
 from ethereum.tools import keys
 from ethereum.slogging import get_logger
+
+from raiden.utils.crypto import privtopub
 
 log = get_logger(__name__)
 

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -1,0 +1,10 @@
+import hashlib
+import pytest
+
+from raiden.utils import crypto
+
+def test_privtopub():
+    privkey = hashlib.sha256(b'secret').hexdigest()
+    pubkey = 'a02b9d5fdd1307c2ee4652ba54d492d1fd11a7d1bb3f3a44c4a05e79f19de933924aa2580069952b0140d88de21c367ee4af7c4a906e1498f20ab8f62e4c2921'
+
+    assert pubkey == crypto.privtopub(privkey).hex()

--- a/raiden/utils/crypto.py
+++ b/raiden/utils/crypto.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import bitcoin
-
+from coincurve import PrivateKey
 
 def privtopub(raw_privkey):
-    pubkey = bitcoin.privtopub(raw_privkey)
-    raw_pubkey = bitcoin.encode_pubkey(pubkey, 'bin_electrum')
-    assert len(raw_pubkey) == 64
-    return raw_pubkey
+    pub = PrivateKey.from_hex(raw_privkey).public_key.format(compressed=False)
+    return pub[1:]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # temporary until pystun creates a new release
 git+https://github.com/LefterisJP/pystun@develop#egg=pystun
 
-bitcoin==1.1.42
 cachetools==2.0.1
 coincurve==6.0.0
 ethereum==2.3.0


### PR DESCRIPTION
Addresses #1200.

Let me know if the test file should live somewhere else or the test case should be in another file.

As far as I am able to tell, Raiden handles private keys in hex encoding, so we do not need to do any decoding of the input or extra encoding of the output. If I'm wrong about the hex encoding, then we'll need to add either the decode or encode step. 