### PR TITLE
Catch exception on invalid protocol data

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -177,3 +177,7 @@ class TransactionThrew(RaidenError):
         super(TransactionThrew, self).__init__(
             '{} transaction threw. Receipt={}'.format(txname, receipt)
         )
+
+
+class InvalidProtocolMessage(RaidenError):
+    """Raised on an invalid or an unknown Raiden protocol message"""

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -7,6 +7,7 @@ from raiden.encoding.format import buffer_for
 from raiden.encoding.signing import recover_publickey
 from raiden.utils import publickey_to_address, sha3, ishash, pex
 from raiden.transfer.state import BalanceProofState
+from raiden.exceptions import InvalidProtocolMessage
 
 __all__ = (
     'Ack',
@@ -59,7 +60,10 @@ def assert_transfer_values(identifier, token, recipient):
 
 
 def decode(data):
-    klass = CMDID_TO_CLASS[data[0]]
+    try:
+        klass = CMDID_TO_CLASS[data[0]]
+    except KeyError:
+        raise InvalidProtocolMessage('Invalid message type (data[0] = {})'.format(hex(data[0])))
     return klass.decode(data)
 
 

--- a/raiden/network/transport.py
+++ b/raiden/network/transport.py
@@ -9,7 +9,13 @@ import socket
 import gevent
 from gevent.server import DatagramServer
 
-from raiden.exceptions import RaidenShuttingDown
+from raiden.exceptions import (
+    RaidenShuttingDown,
+    InvalidProtocolMessage,
+)
+from ethereum import slogging
+
+log = slogging.getLogger(__name__)
 
 
 class DummyPolicy:
@@ -81,6 +87,9 @@ class UDPTransport:
     def receive(self, data, host_port):  # pylint: disable=unused-argument
         try:
             self.protocol.receive(data)
+        except InvalidProtocolMessage as e:
+            log.warning("Can't decode: {} (data={}, len={})".format(str(e), data, len(data)))
+            return
         except RaidenShuttingDown:  # For a clean shutdown
             return
 


### PR DESCRIPTION
Instead of a traceback, a log message is printed out.

Fixes #1137 