### PR TITLE
Update macOS packaging for py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: true
 
 language: python
 python:
-- '3.5'
 - '3.6'
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,17 +77,12 @@ jobs:
       os: osx
       language: generic
       osx_image: xcode8.3
+      env: TEST_TYPE=""
       before_install:
         - sysctl -n machdep.cpu.brand_string
         - mkdir -p $HOME/.bin
-        - export PATH=$PATH:$HOME/.bin:$HOME/Library/Python/2.7/bin
+        - export PATH=$HOME/.bin:$HOME/Library/Python/3.6/bin:$PATH
         - .travis/before_install.sh
-        - ls -la $HOME/.bin
-        - uname -a
-        - sw_vers
-        - xcodebuild -version
-        - solc --version
-        - geth --help
       install:
         - .travis/install.sh
       before_script:

--- a/.travis/prepare_os_osx.sh
+++ b/.travis/prepare_os_osx.sh
@@ -3,22 +3,17 @@
 set -e
 set -x
 
-for tool in automake libtool pkg-config libffi gmp openssl ; do
+for tool in automake libtool pkg-config libffi gmp openssl node python3; do
     brew install ${tool} || brew upgrade ${tool} || true
 done
 
-if [ ! -x $HOME/.bin/geth-${GETH_VERSION}-${TRAVIS_OS_NAME} ]; then
-    mkdir -p $HOME/.bin
-
-    TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'nodetmp')
-    cd $TEMP
-    curl -L https://nodejs.org/dist/v6.11.3/node-v6.11.3-darwin-x64.tar.gz > node.tgz
-    tar xzf node.tgz
-
-    cd node*
-    install -m 755 bin/npm $HOME/.bin/npm
-    install -m 755 bin/node $HOME/.bin/node
-fi
-
-curl -O https://bootstrap.pypa.io/get-pip.py
-python get-pip.py --user
+# some debug info
+ls -la $HOME/.bin
+uname -a
+sw_vers
+xcodebuild -version
+solc --version
+geth --help
+python --version
+node --version
+npm --version

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -332,6 +332,7 @@ def start_ethereum(smoketest_genesis):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        encoding='UTF-8',
     )
     ethereum_node.stdin.write(TEST_ACCOUNT_PASSWORD + os.linesep)
     time.sleep(.1)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -812,7 +812,7 @@ def smoketest(ctx, debug, **kwargs):
     open(report_file, 'w+')
 
     def append_report(subject, data):
-        with open(report_file, 'a') as handler:
+        with open(report_file, 'a', encoding='UTF-8') as handler:
             handler.write('{:=^80}'.format(' %s ' % subject.upper()) + os.linesep)
             if data is not None:
                 if isinstance(data, bytes):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ pytest-cov==2.5.1
 flaky==3.4.0
 hypothesis==3.44.14
 grequests==0.3.0
-detox==0.11
 flake8==3.5.0
 
 # Debugging

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
     cmdclass={
@@ -181,7 +180,7 @@ setup(
     },
     install_requires=install_requires,
     tests_require=test_requirements,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     entry_points={
         'console_scripts': [
             'raiden = raiden.__main__:main'


### PR DESCRIPTION
Don't use detox as it pulls enum34.
Simplify some of the macOS setup with homebrew.

This is a part of #1205 