### PR TITLE
Add Solidity language highlighting in Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Thanks to the [new release](https://github.com/github/linguist/releases/tag/v6.0.0) of Linguist we [can now have](https://github.com/github/linguist/pull/3973) solidity syntax highlighting in Github.