### PR TITLE
Fix token event API for non-registered tokens.

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -642,15 +642,18 @@ class RaidenAPI:
                 'Expected binary address format for token in get_token_network_events'
             )
 
-        graph = self.raiden.token_to_channelgraph[token_address]
+        try:
+            graph = self.raiden.token_to_channelgraph[token_address]
 
-        return get_all_channel_manager_events(
-            self.raiden.chain,
-            graph.channelmanager_address,
-            events=ALL_EVENTS,
-            from_block=from_block,
-            to_block=to_block,
-        )
+            return get_all_channel_manager_events(
+                self.raiden.chain,
+                graph.channelmanager_address,
+                events=ALL_EVENTS,
+                from_block=from_block,
+                to_block=to_block,
+            )
+        except KeyError:
+            raise KeyError('The token address is not registered.')
 
     def get_network_events(self, from_block, to_block):
         registry_address = self.raiden.default_registry.address

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -32,6 +32,7 @@ from raiden.exceptions import (
     InvalidState,
     NoPathError,
     NoTokenManager,
+    UnknownTokenAddress,
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
@@ -653,7 +654,7 @@ class RaidenAPI:
                 to_block=to_block,
             )
         except KeyError:
-            raise KeyError('The token address is not registered.')
+            raise UnknownTokenAddress('The token address is not registered.')
 
     def get_network_events(self, from_block, to_block):
         registry_address = self.raiden.default_registry.address

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -27,6 +27,7 @@ from raiden.exceptions import (
     AddressWithoutCode,
     DuplicatedChannelError,
     ChannelNotFound,
+    UnknownTokenAddress,
 )
 from raiden.api.v1.encoding import (
     ChannelSchema,
@@ -444,7 +445,7 @@ class RestAPI:
                 token_address, from_block, to_block
             )
             return api_response(result=normalize_events_list(raiden_service_result))
-        except KeyError as e:
+        except UnknownTokenAddress as e:
             return api_error(str(e), status_code=HTTPStatus.NOT_FOUND)
 
     def get_channel_events(self, channel_address, from_block, to_block):

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -439,10 +439,13 @@ class RestAPI:
         return api_response(result=normalize_events_list(raiden_service_result))
 
     def get_token_network_events(self, token_address, from_block, to_block):
-        raiden_service_result = self.raiden_api.get_token_network_events(
-            token_address, from_block, to_block
-        )
-        return api_response(result=normalize_events_list(raiden_service_result))
+        try:
+            raiden_service_result = self.raiden_api.get_token_network_events(
+                token_address, from_block, to_block
+            )
+            return api_response(result=normalize_events_list(raiden_service_result))
+        except KeyError as e:
+            return api_error(str(e), status_code=HTTPStatus.NOT_FOUND)
 
     def get_channel_events(self, channel_address, from_block, to_block):
         raiden_service_result = self.raiden_api.get_channel_events(

--- a/raiden/tests/api/test_restapi.py
+++ b/raiden/tests/api/test_restapi.py
@@ -1094,6 +1094,24 @@ def test_register_token(api_backend, api_test_context, api_raiden_service):
     assert_response_with_error(response, HTTPStatus.CONFLICT)
 
 
+def test_token_events_errors_for_unregistered_token(
+        api_backend,
+        api_test_context,
+        api_raiden_service):
+
+    request = grequests.get(
+        api_url_for(
+            api_backend,
+            'tokeneventsresource',
+            token_address='0x61c808d82a3ac53231750dadc13c777b59310bd9',
+            from_block=5,
+            to_block=20
+        )
+    )
+    response = request.send().response
+    assert_response_with_error(response, status_code=HTTPStatus.NOT_FOUND)
+
+
 def test_get_connection_managers_info(
         api_backend,
         api_test_context,

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -104,8 +104,10 @@ class ApiTestContext:
 
     def get_token_network_events(self, token_address, from_block, to_block):
         return_list = list()
-        if token_address != self.token_for_channelnew:
-            raise ValueError(
+        # if this happens the token hasn't been registered yet
+        # in the API the lookup would fail with a KeyError, return the same here
+        if not hasattr(self, 'token_for_channelnew') or token_address != self.token_for_channelnew:
+            raise KeyError(
                 'Unexpected token address: "{}"  during channelnew '
                 'query'.format(pex(token_address))
             )

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -12,7 +12,11 @@ from raiden.channel import (
     ChannelExternalState,
 )
 from raiden.constants import NETTINGCHANNEL_SETTLE_TIMEOUT_MIN, NETTINGCHANNEL_SETTLE_TIMEOUT_MAX
-from raiden.exceptions import InvalidAddress, InvalidSettleTimeout
+from raiden.exceptions import (
+    InvalidAddress,
+    InvalidSettleTimeout,
+    UnknownTokenAddress,
+)
 from raiden.tests.utils.factories import make_address
 from raiden.transfer.merkle_tree import EMPTY_MERKLE_TREE
 from raiden.transfer.state import (
@@ -105,9 +109,9 @@ class ApiTestContext:
     def get_token_network_events(self, token_address, from_block, to_block):
         return_list = list()
         # if this happens the token hasn't been registered yet
-        # in the API the lookup would fail with a KeyError, return the same here
+        # in the API the lookup would fail with a UnknownTokenAddress, return the same here
         if not hasattr(self, 'token_for_channelnew') or token_address != self.token_for_channelnew:
-            raise KeyError(
+            raise UnknownTokenAddress(
                 'Unexpected token address: "{}"  during channelnew '
                 'query'.format(pex(token_address))
             )


### PR DESCRIPTION
Fixes #1224 

I'm not sure about the test as it just tests the APITestContext, not the real implementation.