### PR TITLE
More py3 cleanups

### DIFF
--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -22,7 +22,7 @@ def create_blueprint():
 
 class BaseResource(Resource):
     def __init__(self, rest_api_object, **kwargs):
-        super(BaseResource, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.rest_api = rest_api_object
 
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -117,7 +117,7 @@ class InvalidLocksRoot(RaidenError):
             pex(got_locksroot),
         )
 
-        super(InvalidLocksRoot, self).__init__(msg)
+        super().__init__(msg)
 
 
 class InvalidNonce(RaidenError):
@@ -153,7 +153,7 @@ class EthNodeCommunicationError(RaidenError):
     """ Raised when something unexpected has happened during
     communication with the underlying ethereum node"""
     def __init__(self, error_msg, error_code=None):
-        super(EthNodeCommunicationError, self).__init__(error_msg)
+        super().__init__(error_msg)
         self.error_code = error_code
 
 
@@ -174,7 +174,7 @@ class TransactionThrew(RaidenError):
     """Raised when, after waiting for a transaction to be mined,
     the receipt has a 0x0 status field"""
     def __init__(self, txname, receipt):
-        super(TransactionThrew, self).__init__(
+        super().__init__(
             '{} transaction threw. Receipt={}'.format(txname, receipt)
         )
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -120,7 +120,7 @@ class SignedMessage(Message):
     # current API assumes that signing is called before, this can be improved
     # by changing the order to packing then signing
     def __init__(self):
-        super(SignedMessage, self).__init__()
+        super().__init__()
         self.signature = b''
         self.sender = b''
 
@@ -177,7 +177,7 @@ class SignedMessage(Message):
 
 class EnvelopeMessage(SignedMessage):
     def __init__(self):
-        super(EnvelopeMessage, self).__init__()
+        super().__init__()
         self.nonce = 0
         self.transferred_amount = 0
         self.locksroot = EMPTY_MERKLE_ROOT
@@ -284,7 +284,7 @@ class Ack(Message):
     cmdid = messages.ACK
 
     def __init__(self, sender, echo):
-        super(Ack, self).__init__()
+        super().__init__()
         self.sender = sender
         self.echo = echo
 
@@ -311,7 +311,7 @@ class Ping(SignedMessage):
     cmdid = messages.PING
 
     def __init__(self, nonce):
-        super(Ping, self).__init__()
+        super().__init__()
         self.nonce = nonce
 
     @staticmethod
@@ -330,7 +330,7 @@ class SecretRequest(SignedMessage):
     cmdid = messages.SECRETREQUEST
 
     def __init__(self, identifier, hashlock, amount):
-        super(SecretRequest, self).__init__()
+        super().__init__()
         self.identifier = identifier
         self.hashlock = hashlock
         self.amount = amount
@@ -373,7 +373,7 @@ class Secret(EnvelopeMessage):
             transferred_amount,
             locksroot,
             secret):
-        super(Secret, self).__init__()
+        super().__init__()
 
         assert_envelope_values(
             nonce,
@@ -453,7 +453,7 @@ class RevealSecret(SignedMessage):
     cmdid = messages.REVEALSECRET
 
     def __init__(self, secret):
-        super(RevealSecret, self).__init__()
+        super().__init__()
         self.secret = secret
         self._hashlock = None
 
@@ -526,7 +526,7 @@ class DirectTransfer(EnvelopeMessage):
         )
         assert_transfer_values(identifier, token, recipient)
 
-        super(DirectTransfer, self).__init__()
+        super().__init__()
         self.identifier = identifier
         self.nonce = nonce
         self.token = token
@@ -667,7 +667,7 @@ class LockedTransfer(EnvelopeMessage):
             recipient,
             locksroot,
             lock):
-        super(LockedTransfer, self).__init__()
+        super().__init__()
 
         assert_envelope_values(
             nonce,
@@ -801,7 +801,7 @@ class MediatedTransfer(LockedTransfer):
         if fee >= 2 ** 256:
             raise ValueError('fee is too large')
 
-        super(MediatedTransfer, self).__init__(
+        super().__init__(
             identifier,
             nonce,
             token,

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -61,7 +61,7 @@ class ContractDiscovery(Discovery):
             node_address: bytes,
             discovery_proxy: proxies.Discovery):
 
-        super(ContractDiscovery, self).__init__()
+        super().__init__()
 
         self.node_address = node_address
         self.discovery_proxy = discovery_proxy

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -183,7 +183,7 @@ class JSONRPCClient:
             host: str,
             port: int,
             privkey: bytes,
-            gasprice: Optional[int] = None,
+            gasprice: int = None,
             nonce_update_interval: float = 5.0,
             nonce_offset: int = 0):
 
@@ -535,8 +535,8 @@ class JSONRPCClient:
             to: address,
             value: int = 0,
             data: bytes = b'',
-            startgas: Optional[int] = None,
-            nonce: Optional[int] = None):
+            startgas: int = None,
+            nonce: int = None):
         """ Helper to send signed messages.
 
         This method will use the `privkey` provided in the constructor to
@@ -593,7 +593,8 @@ class JSONRPCClient:
             value: int = 0,
             data: bytes = b'',
             gas: int = GAS_LIMIT,
-            nonce: Optional[int] = None):
+            nonce: int = None
+    ) -> bytes:
         """ Creates new message call transaction or a contract creation, if the
         data field contains code.
 
@@ -646,8 +647,9 @@ class JSONRPCClient:
             to: address = b'',
             value: int = 0,
             data: bytes = b'',
-            startgas: Optional[int] = None,
-            block_number: Union[str, int] = 'latest'):
+            startgas: int = None,
+            block_number: Union[str, int] = 'latest'
+    ) -> bytes:
         """ Executes a new message call immediately without creating a
         transaction on the blockchain.
 
@@ -683,7 +685,8 @@ class JSONRPCClient:
             to: address = b'',
             value: int = 0,
             data: bytes = b'',
-            startgas: Optional[int] = None) -> int:
+            startgas: int = None
+    ) -> Optional[int]:
         """ Makes a call or transaction, which won't be added to the blockchain
         and returns the used gas, which can be used for estimating the used
         gas.
@@ -787,8 +790,8 @@ class JSONRPCClient:
     def poll(
             self,
             transaction_hash: bytes,
-            confirmations: Optional[int] = None,
-            timeout: Optional[float] = None):
+            confirmations: int = None,
+            timeout: float = None):
         """ Wait until the `transaction_hash` is applied or rejected.
         If timeout is None, this could wait indefinitely!
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -22,7 +22,7 @@ class Task(gevent.Greenlet):
     """
 
     def __init__(self):
-        super(Task, self).__init__()
+        super().__init__()
         self.response_queue = Queue()
 
 
@@ -30,7 +30,7 @@ class AlarmTask(Task):
     """ Task to notify when a block is mined. """
 
     def __init__(self, chain):
-        super(AlarmTask, self).__init__()
+        super().__init__()
 
         self.callbacks = list()
         self.stop_event = AsyncResult()
@@ -122,7 +122,7 @@ class AlarmTask(Task):
 
     def start(self):
         self.last_block_number = self.chain.block_number()
-        super(AlarmTask, self).start()
+        super().start()
 
     def stop_and_wait(self):
         self.stop_event.set(True)

--- a/raiden/tests/property/smart_contracts/test_nettingchannel.py
+++ b/raiden/tests/property/smart_contracts/test_nettingchannel.py
@@ -59,7 +59,7 @@ class NettingChannelStateMachine(GenericStateMachine):
     """
 
     def __init__(self):
-        super(NettingChannelStateMachine, self).__init__()
+        super().__init__()
 
         deploy_key = sha3(b'deploy_key')
         gas_limit = 10 ** 10

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -21,12 +21,12 @@ class MessageLoggerTransport(DummyTransport):
             protocol=None,
             throttle_policy=DummyPolicy()):
 
-        super(MessageLoggerTransport, self).__init__(host, port, protocol, throttle_policy)
+        super().__init__(host, port, protocol, throttle_policy)
         self.addresses_to_messages = dict()
 
     def send(self, sender, host_port, bytes_):
         self.addresses_to_messages.setdefault(sender.address, []).append(decode(bytes_))
-        super(MessageLoggerTransport, self).network.send(sender, host_port, bytes_)
+        super().network.send(sender, host_port, bytes_)
 
     def get_sent_messages(self, node_address):
         return self.addresses_to_messages.get(node_address, [])
@@ -46,7 +46,7 @@ class UnreliableTransport(DummyTransport):
             protocol=None,
             throttle_policy=DummyPolicy()):
 
-        super(UnreliableTransport, self).__init__(host, port, protocol, throttle_policy)
+        super().__init__(host, port, protocol, throttle_policy)
         self.droprate = 0
 
     def send(self, sender, host_port, bytes_):

--- a/raiden/token_swap.py
+++ b/raiden/token_swap.py
@@ -296,7 +296,7 @@ class MakerTokenSwapTask(BaseMediatedTransferTask):
     """
 
     def __init__(self, raiden, tokenswap, async_result):
-        super(MakerTokenSwapTask, self).__init__()
+        super().__init__()
 
         self.raiden = raiden
         self.tokenswap = tokenswap
@@ -536,7 +536,7 @@ class TakerTokenSwapTask(BaseMediatedTransferTask):
             tokenswap,
             from_mediated_transfer):
 
-        super(TakerTokenSwapTask, self).__init__()
+        super().__init__()
 
         self.raiden = raiden
         self.from_mediated_transfer = from_mediated_transfer

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -268,7 +268,7 @@ class NATChoiceType(click.Choice):
             else:
                 port = None
             return ip, port
-        return super(NATChoiceType, self).convert(value, param, ctx)
+        return super().convert(value, param, ctx)
 
 
 ADDRESS_TYPE = AddressType()

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -194,7 +194,7 @@ class Console(BaseService):
     """
 
     def __init__(self, app):
-        super(Console, self).__init__(app)
+        super().__init__(app)
         self.interrupt = Event()
         self.console_locals = {}
         if app.start_console:
@@ -205,7 +205,7 @@ class Console(BaseService):
 
     def start(self):
         # start console service
-        super(Console, self).start()
+        super().start()
 
         class Raiden:
             def __init__(self, app):

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -5,7 +5,7 @@ from gevent.event import Event
 
 class NotifyingQueue(Event):
     def __init__(self):
-        super(NotifyingQueue, self).__init__()
+        super().__init__()
         self._queue = Queue()
 
     def put(self, item):

--- a/raiden/utils/profiling/profiler.py
+++ b/raiden/utils/profiling/profiler.py
@@ -147,7 +147,7 @@ def calculate_metrics(info):
 class GlobalState(dict):
     ''' This class is responsable to store the state of a profiling session '''
     def __init__(self, *args, **kwargs):
-        super(GlobalState, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.last = None
 
 

--- a/tools/testnet/files/dockerfiles/mkkeystore/mkkey.py
+++ b/tools/testnet/files/dockerfiles/mkkeystore/mkkey.py
@@ -17,7 +17,7 @@ class BytesJSONEncoder(JSONEncoder):
     def default(self, o):
         if isinstance(o, bytes):
             return o.decode('UTF-8')
-        return super(BytesJSONEncoder, self).default(o)
+        return super().default(o)
 
 
 @click.command()

--- a/tools/testnet/files/dockerfiles/raiden/raiden
+++ b/tools/testnet/files/dockerfiles/raiden/raiden
@@ -28,7 +28,7 @@ class NotCrashingLogstashFormatter(LogstashFormatterVersion1):
             return bytes(json.dumps(message, cls=REPRJSONEncoder), 'utf-8')
 
     def get_extra_fields(self, record):
-        fields = super(NotCrashingLogstashFormatter, self).get_extra_fields(record)
+        fields = super().get_extra_fields(record)
         if 'original_msg' in fields and record.args:
             fields['original_msg'] = fields['original_msg'] % record.args
         return fields
@@ -36,8 +36,7 @@ class NotCrashingLogstashFormatter(LogstashFormatterVersion1):
 
 class NotCrashingUDPLogstashHandler(UDPLogstashHandler):
     def __init__(self, host, port=5959, message_type='logstash', tags=None, fqdn=False, version=0):
-        super(NotCrashingUDPLogstashHandler, self).__init__(host, port, message_type, tags, fqdn,
-                                                            version)
+        super().__init__(host, port, message_type, tags, fqdn, version)
         if version == 1:
             self.formatter = NotCrashingLogstashFormatter(message_type, tags, fqdn)
         else:

--- a/tools/testnet/files/dockerfiles/raiden/raiden_echo_node
+++ b/tools/testnet/files/dockerfiles/raiden/raiden_echo_node
@@ -29,7 +29,7 @@ class NotCrashingLogstashFormatter(LogstashFormatterVersion1):
             return bytes(json.dumps(message, cls=REPRJSONEncoder), 'utf-8')
 
     def get_extra_fields(self, record):
-        fields = super(NotCrashingLogstashFormatter, self).get_extra_fields(record)
+        fields = super().get_extra_fields(record)
         if 'original_msg' in fields and record.args:
             fields['original_msg'] = fields['original_msg'] % record.args
         return fields
@@ -37,8 +37,7 @@ class NotCrashingLogstashFormatter(LogstashFormatterVersion1):
 
 class NotCrashingUDPLogstashHandler(UDPLogstashHandler):
     def __init__(self, host, port=5959, message_type='logstash', tags=None, fqdn=False, version=0):
-        super(NotCrashingUDPLogstashHandler, self).__init__(host, port, message_type, tags, fqdn,
-                                                            version)
+        super().__init__(host, port, message_type, tags, fqdn, version)
         if version == 1:
             self.formatter = NotCrashingLogstashFormatter(message_type, tags, fqdn)
         else:


### PR DESCRIPTION
More small cleanups for python 3.

- Fix a type annotation in client
- use `super()` instead of `super(Type, self)`