### PR TITLE
Close Requests.Session when done

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -188,13 +188,13 @@ class JSONRPCClient:
             nonce_offset: int = 0):
 
         endpoint = 'http://{}:{}'.format(host, port)
-        session = requests.Session()
+        self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(pool_maxsize=50)
-        session.mount(endpoint, adapter)
+        self.session.mount(endpoint, adapter)
 
         self.transport = HttpPostClientTransport(
             endpoint,
-            post_method=session.post,
+            post_method=self.session.post,
             headers={'content-type': 'application/json'},
         )
 
@@ -225,6 +225,9 @@ class JSONRPCClient:
         )
         cache_wrapper = cachetools.cached(cache=cache)
         self.gasprice = cache_wrapper(self._gasprice)
+
+    def __del__(self):
+        self.session.close()
 
     def __repr__(self):
         return '<JSONRPCClient @%d>' % self.port


### PR DESCRIPTION
When we are done with requests.Session() we should close it.

This way we can silence all the socket warnings:

```
  /home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/yaml/error.py:7: ResourceWarning: unclosed <socket object, fd=43, family=2, type=2049, proto=6>
    self.name = name
  /home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/yaml/error.py:7: ResourceWarning: unclosed <socket object, fd=35, family=2, type=2049, proto=6>
    self.name = name
  /home/lefteris/.virtualenvs/raidenpy3/lib/python3.6/site-packages/yaml/error.py:7: ResourceWarning: unclosed <socket object, fd=41, family=2, type=2049, proto=6>
    self.name = name
```