### PR TITLE
Update linux deployment to pyinstaller package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
       - provider: releases
         api_key:
           secure: O85yltVQ1OacJQoNQWDJqOsXuSb+x7IMJTtUPuFM5iAOIGLmzhk0/qzJInixCGbAfWMYT4wTjA6OfxeiAWYzC5pCgqedZOsjp+8bXjn2Ek443Y+FBay3g38ebn3KBFBat3iMOamdrFSGTENugdG418GdK6yFVYpyCCUJXWLBcBUPOi7BlakI8TkznsaCad7OVRrPfMHWRe11WI3b4fajPnH/M7JRdDpT5GTisEchwKzYHnBttYySDZcQS3gtAEK7Srg9AkdEYCW3DOkmW4DeEgrQAQVcHHAV7eZREC1M3SrsrCotEqhEmIy29akOVKpOZtYWMxNFIsScDt39Y2hJLXRo1NjN0RBgIOg+Asl3B1cuK3Zfzc30r+Fyfkl9yFXpC35xddh2dHz5PFyssmtVZMEdxECtQT0DN08FB1JNdBbz3tfNw84IvR2ymYcQdRFWQM51rBUjUGspzDftAdITKkk3Z67jgYnaVvL0iBMbuuFjZDs8375IjIo7hxJ5UY7YWLV8Ic2r89wq5Dw7EsL5cyc4BVfj1kByZ1BJ6sZEKaqVdDdEc1Bv2/SYk6Da/muPB9gYK8Baw1gumLvrVS65EUVvwGmnq0zKrKmvTLl0aNPRNInaOVOloK63HdOwJhiLRn50YfCARrX+5kKBIQxdtNtmfPmdYJ3cm5bNhaXQ8fs=
-        file: dist/raiden--x86_64.AppImage
+        file: dist/raiden-$(TRAVIS_TAG).tar.gz
         skip_cleanup: true
         on:
           tags: true
@@ -86,7 +86,7 @@ jobs:
         - .travis/install.sh
       before_script:
         - .travis/before_script.sh
-        - python setup.py compile_contracts
+        - python setup.py build
         - python setup.py compile_webui
       script:
         # pdbpp interferes with pyinstaller, uninstall it

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,13 @@ jobs:
       before_install: mkdir -p $HOME/.bin; export PATH=$PATH:$HOME/.bin; ./.travis/before_install.sh
       install: ./.travis/install.sh
       before_script: ./.travis/before_script.sh
-      script: RAIDENVERSION=$TRAVIS_TAG make bundle
+      script: RAIDENVERSION=$TRAVIS_TAG make bundle-docker
       env: TEST_TYPE=""
       deploy:
       - provider: releases
         api_key:
           secure: O85yltVQ1OacJQoNQWDJqOsXuSb+x7IMJTtUPuFM5iAOIGLmzhk0/qzJInixCGbAfWMYT4wTjA6OfxeiAWYzC5pCgqedZOsjp+8bXjn2Ek443Y+FBay3g38ebn3KBFBat3iMOamdrFSGTENugdG418GdK6yFVYpyCCUJXWLBcBUPOi7BlakI8TkznsaCad7OVRrPfMHWRe11WI3b4fajPnH/M7JRdDpT5GTisEchwKzYHnBttYySDZcQS3gtAEK7Srg9AkdEYCW3DOkmW4DeEgrQAQVcHHAV7eZREC1M3SrsrCotEqhEmIy29akOVKpOZtYWMxNFIsScDt39Y2hJLXRo1NjN0RBgIOg+Asl3B1cuK3Zfzc30r+Fyfkl9yFXpC35xddh2dHz5PFyssmtVZMEdxECtQT0DN08FB1JNdBbz3tfNw84IvR2ymYcQdRFWQM51rBUjUGspzDftAdITKkk3Z67jgYnaVvL0iBMbuuFjZDs8375IjIo7hxJ5UY7YWLV8Ic2r89wq5Dw7EsL5cyc4BVfj1kByZ1BJ6sZEKaqVdDdEc1Bv2/SYk6Da/muPB9gYK8Baw1gumLvrVS65EUVvwGmnq0zKrKmvTLl0aNPRNInaOVOloK63HdOwJhiLRn50YfCARrX+5kKBIQxdtNtmfPmdYJ3cm5bNhaXQ8fs=
-        file: dist/raiden-$(TRAVIS_TAG).tar.gz
+        file: dist/raiden-$(TRAVIS_TAG)-linux.tar.gz
         skip_cleanup: true
         on:
           tags: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md
+include README.rst
 include requirements.txt
 include raiden/smart_contracts/*
 include raiden/smoketest_config.json

--- a/Makefile
+++ b/Makefile
@@ -59,21 +59,15 @@ docs:
 	$(MAKE) -C docs html
 
 RAIDENVERSION?=master
-GETH_URL_LINUX?='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.3-4bb3c89d.tar.gz'
-SOLC_URL_LINUX?='https://github.com/ethereum/solidity/releases/download/v0.4.18/solc-static-linux'
 
-bundle:
+bundle-docker:
 	docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) --build-arg RAIDENVERSION=$(RAIDENVERSION) -f docker/build.Dockerfile docker
 	-(docker rm builder)
 	docker create --name builder pyinstallerbuilder
-	docker cp builder:/raiden/raiden-$(RAIDENVERSION).tar.gz dist/raiden-$(RAIDENVERSION).tar.gz
+	docker cp builder:/raiden/raiden-$(RAIDENVERSION)-linux.tar.gz dist/raiden-$(RAIDENVERSION)-linux.tar.gz
 	docker rm builder
 
-test_bundle_docker := docker run --privileged --rm -v $(shell pwd)/dist:/data
-test_bundle_exe := /data/raiden--x86_64.AppImage --help
-test_bundle_test := grep -q "Usage: raiden"
-
-pyibundle:
+bundle:
 	python setup.py compile_contracts
 	python setup.py compile_webui
 	pyinstaller --noconfirm --clean raiden.spec

--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,16 @@ docs:
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 
-RAIDENVERSION ?= 'master'
+RAIDENVERSION?=master
+GETH_URL_LINUX?='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.7.3-4bb3c89d.tar.gz'
+SOLC_URL_LINUX?='https://github.com/ethereum/solidity/releases/download/v0.4.18/solc-static-linux'
+
 bundle:
-	# pass RAIDENVERSION=<git version tag> to build a specific version
-	docker build -t raidenbundler --build-arg RAIDENVERSION=$(RAIDENVERSION) -f docker/build.Dockerfile docker
-	-(docker rm bundler)
-	docker run --name bundler --privileged -e ARCH=x86_64 -e APP=raiden -e LOWERAPP=raiden --workdir / --entrypoint /bin/bash raidenbundler -c 'source functions.sh && generate_appimage'
-	mkdir -p dist
-	docker cp bundler:/out/raiden-.glibcPRIVATE-x86_64.AppImage dist/raiden--x86_64.AppImage
-	docker rm bundler
+	docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) --build-arg RAIDENVERSION=$(RAIDENVERSION) -f docker/build.Dockerfile docker
+	-(docker rm builder)
+	docker create --name builder pyinstallerbuilder
+	docker cp builder:/raiden/raiden-$(RAIDENVERSION).tar.gz dist/raiden-$(RAIDENVERSION).tar.gz
+	docker rm builder
 
 test_bundle_docker := docker run --privileged --rm -v $(shell pwd)/dist:/data
 test_bundle_exe := /data/raiden--x86_64.AppImage --help
@@ -76,68 +77,6 @@ pyibundle:
 	python setup.py compile_contracts
 	python setup.py compile_webui
 	pyinstaller --noconfirm --clean raiden.spec
-
-# test_bundle_distro <distro_name> <pre execution commands>
-define test_bundle_distro
-	################
-	# Testing "$(1)"
-	docker pull $(1)
-	${test_bundle_docker} $(1) sh -c \
-		'$(2) && \
-		${test_bundle_exe}' | ${test_bundle_test}
-	# Success "$(1)"
-	# ##############
-endef
-
-test-bundle:
-	$(call test_bundle_distro,ubuntu:17.04,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 && dpkg -i --force-all *.deb)
-	$(call test_bundle_distro,ubuntu:16.10,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 && dpkg -i --force-all *.deb)
-	$(call test_bundle_distro,ubuntu:16.04,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 && dpkg -i --force-all *.deb)
-	$(call test_bundle_distro,ubuntu:14.04,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 && dpkg -i --force-all *.deb)
-	$(call test_bundle_distro,debian:8,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 && dpkg -i --force-all *.deb)
-	$(call test_bundle_distro,debian:9,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 && dpkg -i --force-all *.deb)
-	$(call test_bundle_distro,base/archlinux,\
-		pacman -Syy && pacman --noconfirm -S fuse grep )
-	$(call test_bundle_distro,centos:7,yum install -y fuse-libs)
-	$(call test_bundle_distro,fedora:20,yum install -y fuse-libs)
-	$(call test_bundle_distro,fedora:21,yum install -y fuse-libs)
-	$(call test_bundle_distro,fedora:22,dnf install -y fuse-libs)
-	$(call test_bundle_distro,fedora:23,dnf install -y fuse-libs)
-	$(call test_bundle_distro,fedora:24,dnf install -y fuse-libs)
-	$(call test_bundle_distro,fedora:25,dnf install -y fuse-libs)
-	$(call test_bundle_distro,fedora:rawhide,dnf install -y fuse-libs)
-
-# test_bundle_distro <distro_name> <pre execution commands>
-define test_bundle_distro_fail
-	################
-	# Testing "$(1)"
-	docker pull $(1)
-	! ${test_bundle_docker} $(1) sh -c \
-		'$(2) && \
-		${test_bundle_exe}' | ${test_bundle_test}
-	# Not working: "$(1)"
-	################
-endef
-
-test-bundle-unsupported:
-	# not yet supported (version `GLIBC_2.14' not found):
-	$(call test_bundle_distro_fail,centos:5,yum install -y fuse-libs)
-	$(call test_bundle_distro_fail,centos:6,yum install -y fuse-libs)
-	$(call test_bundle_distro_fail,debian:7,\
-		apt-get update && apt-get install -y fuse && cd /tmp/ && \
-		apt-get download libglib2.0 libpcre3 && dpkg -i --force-all *.deb)
 
 release: clean
 	python setup.py sdist upload

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,42 +1,17 @@
-# backward compatibility:
-FROM ubuntu:12.04.5
+FROM python:3.6
 
-# install build dependencies
-RUN apt-get update && \
- apt-get install -y curl wget automake build-essential git-core libffi-dev \
- libgmp-dev libssl-dev libtool pkg-config fuse libsqlite3-dev
+# these are defined in .travis.yml and passed here in the makefile
+ARG SOLC_URL_LINUX
+ARG GETH_URL_LINUX
 
-# prepare AppDir
-RUN bash -c 'mkdir -p /raiden.AppDir/usr/{local,bin,share,lib}/'
+# install dependencies
+RUN apt-get update
+RUN apt-get install -y git-core wget
 
-WORKDIR /raiden.AppDir/
+RUN wget -O /usr/bin/solc ${SOLC_URL_LINUX} && chmod +x /usr/bin/solc
+RUN wget -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && cd /tmp && tar xzvf geth.tar.gz && mv geth-linux-amd64-1.7.3-4bb3c89d/geth /usr/bin/geth && rm geth.tar.gz
+RUN wget -O /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-x64.tar.gz && cd /tmp && tar xzvf node.tar.gz && mkdir /tmp/node_modules && chmod -R a+rwX /tmp/node_modules && rm node.tar.gz
 
-# build+install python
-# TODO: check http://www.egenix.com/products/python/PyRun/ as an alternative!
-RUN curl -o Python-2.7.12.tar.xz https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz && \
-    tar xf Python-2.7.12.tar.xz && \
-    cd Python-2.7.12 &&\
-    ./configure --prefix=/raiden.AppDir/usr && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -r Python-2.7.12*
-
-# install 'pip'
-RUN curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    usr/bin/python get-pip.py && \
-    rm get-pip.py
-
-# install node for webui
-RUN curl -L -o /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-x64.tar.gz && \
-    cd /tmp && \
-    tar xzvf node.tar.gz &&\
-    mkdir /tmp/node_modules && \
-    chmod -R a+rwX /tmp/node_modules
-
-# install solc
-RUN curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.18/solc-static-linux && \
-    chmod +x /usr/bin/solc
 
 # use --build-arg RAIDENVERSION=v0.0.3 to build a specific (tagged) version
 ARG REPO=raiden-network/raiden
@@ -45,54 +20,21 @@ ARG RAIDENVERSION=master
 # This is a "hack" to automatically invalidate the cache in case there are new commits
 ADD https://api.github.com/repos/${REPO}/commits/${RAIDENVERSION} /dev/null
 
-# clone raiden
-RUN mkdir -p /apps && \
-    git clone https://github.com/${REPO}.git /apps/raiden
+# clone raiden repo + install dependencies
+RUN git clone https://github.com/raiden-network/raiden
+WORKDIR /raiden
+RUN pip install -r requirements.txt
 
-WORKDIR /apps/raiden
+# build contracts and web_ui
+RUN python setup.py build
+RUN USER=root NPM_CONFIG_PREFIX=/tmp/node_modules NODE_PATH=/tmp/node_modules PATH=/tmp/node-v8.2.1-linux-x64/bin:$PATH python setup.py compile_webui
 
-# install requirements (replacing all --editable requirements)
-RUN git checkout $RAIDENVERSION && \
-    sed -s 's/^-e //' requirements.txt > _requirements.txt && \
-    /raiden.AppDir/usr/bin/pip install -r _requirements.txt
+# install raiden and pyinstaller
+RUN pip install .
+RUN pip install pyinstaller
 
-# build & install raiden with contracts, webui and smoketest
-RUN echo "recursive-include raiden/ui/web/dist *" >> MANIFEST.in && \
-    USER=root \
-    NPM_CONFIG_PREFIX=/tmp/node_modules \
-    NODE_PATH=/tmp/node_modules \
-    PATH=/tmp/node-v8.2.1-linux-x64/bin:/raiden.AppDir/usr/bin:$PATH \
-    /usr/bin/env python setup.py compile_contracts compile_webui build install && \
-    find /raiden.AppDir/ -iname '*.pyo' -exec rm {} \; && \
-    rm /raiden.AppDir/usr/lib/libpython*.a
+# build pyinstaller package
+RUN pyinstaller --noconfirm --clean raiden.spec
 
-WORKDIR /
-
-# add .desktop file
-ADD raiden.desktop /raiden.AppDir/raiden.desktop
-RUN cd /apps/raiden && \
-    VERSIONSTRING=$(/raiden.AppDir/usr/bin/raiden version --short) && \
-    sed -s -i "s/XXVERSIONXX/$VERSIONSTRING/" /raiden.AppDir/raiden.desktop
-# add icon
-ADD raiden.svg /raiden.AppDir/raiden.svg
-
-RUN curl -L -o functions.sh "https://github.com/probonopd/AppImages/raw/master/functions.sh"
-
-# use AppImageKit 'functions.sh' to setup lib
-RUN bash -c 'APP=Raiden LOWERAPP=raiden ARCH=x86_64 \
-    PATH=/raiden.AppDir/usr/bin:$PATH PYTHONHOME=/raiden.AppDir/usr \
-    source functions.sh && \
-    cd /raiden.AppDir && \
-    get_apprun && \
-    ( copy_deps ; copy_deps ; copy_deps ) && \
-    delete_blacklisted && \
-    move_lib'
-
-# fix python shebangs to point to '#!/usr/bin/env python'
-RUN sed -i -s '1 s/^\#\!.*python\(.*\)/#!\/usr\/bin\/env python\1/' /raiden.AppDir/usr/bin/*
-
-# we need python for functions.sh to work properly :o
-RUN apt-get -y install python
-
-# how to build AppImage
-RUN echo "\n\nRun these commands to generate the AppImage:\n\tdocker run --name bundler --privileged -e ARCH=x86_64 -e APP=raiden -e LOWERAPP=raiden --workdir / --entrypoint /bin/bash raidenbundler -c 'source functions.sh && generate_appimage'\ndocker cp bundler:/out/raiden-.glibcPRIVATE-x86_64.AppImage dist/raiden--x86_64.AppImage\n\tdocker rm bundler\n\n"
+# pack result to have a unique name to get it out of the container later
+RUN tar -cvzf raiden-${RAIDENVERSION}.tar.gz dist/raiden*

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get install -y git-core wget
 
 RUN wget -O /usr/bin/solc ${SOLC_URL_LINUX} && chmod +x /usr/bin/solc
-RUN wget -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && cd /tmp && tar xzvf geth.tar.gz && mv geth-linux-amd64-1.7.3-4bb3c89d/geth /usr/bin/geth && rm geth.tar.gz
+RUN wget -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && cd /tmp && tar xzvf geth.tar.gz && mv geth-linux-amd64-1.8.0-5f540757/geth /usr/bin/geth && rm geth.tar.gz
 RUN wget -O /tmp/node.tar.gz https://nodejs.org/download/release/v8.2.1/node-v8.2.1-linux-x64.tar.gz && cd /tmp && tar xzvf node.tar.gz && mkdir /tmp/node_modules && chmod -R a+rwX /tmp/node_modules && rm node.tar.gz
 
 
@@ -21,7 +21,7 @@ ARG RAIDENVERSION=master
 ADD https://api.github.com/repos/${REPO}/commits/${RAIDENVERSION} /dev/null
 
 # clone raiden repo + install dependencies
-RUN git clone https://github.com/raiden-network/raiden
+RUN git clone -b ${RAIDENVERSION} https://github.com/${REPO}
 WORKDIR /raiden
 RUN pip install -r requirements.txt
 
@@ -37,4 +37,4 @@ RUN pip install pyinstaller
 RUN pyinstaller --noconfirm --clean raiden.spec
 
 # pack result to have a unique name to get it out of the container later
-RUN tar -cvzf raiden-${RAIDENVERSION}.tar.gz dist/raiden*
+RUN cd dist && tar -cvzf raiden-${RAIDENVERSION}-linux.tar.gz raiden* && mv raiden-${RAIDENVERSION}-linux.tar.gz ..


### PR DESCRIPTION
This commit removes the old AppImage bundling from the makefile. As a replacement the bundle target in the makefile now creates a pyinstaller image.

I'm far from being an expert with makefiles and docker, so please give this a careful look. One ugly thing is the redefinition of `GETH_URL_LINUX` in the makefile. I'd like to avoid that but don't have a good idea how. Recommendations welcome!
