### PR TITLE
Use tinyrpc from mbr/tinyrpc @0.7 release commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ pycryptodome==3.4.7
 pysha3==1.0.2
 repoze.lru==0.7.0
 rlp==0.6
-tinyrpc[gevent,httpclient,jsonext,websocket,wsgi]==0.7
+-e git://github.com/mbr/tinyrpc.git@0fb6eae9a8c0bc5eecad26c067d2d57787512452#egg=tinyrpc
 webargs==1.8.1

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ history = ''
 
 install_requires_replacements = {
     'git+https://github.com/LefterisJP/pystun@develop#egg=pystun': 'pystun',
+    '-e git://github.com/mbr/tinyrpc.git@0fb6eae9a8c0bc5eecad26c067d2d57787512452#egg=tinyrpc': 'tinyrpc',
 }
 
 install_requires = list(set(


### PR DESCRIPTION
Since PyPi package 0.7 was removed and no newer release is available, we
switch to the github source install for now. Using the commit hash
instead of the tag ensures that we're installing the expected source.