### PR TITLE
Make event names bytes and decode them in RestAPI

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -694,7 +694,7 @@ class RaidenAPI:
             if is_user_transfer_event:
                 new_event = {
                     'block_number': event.block_number,
-                    '_event_type': type(event.event_object).__name__,
+                    '_event_type': type(event.event_object).__name__.encode(),
                 }
                 new_event.update(event.event_object.__dict__)
                 returned_events.append(new_event)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -132,7 +132,7 @@ def normalize_events_list(old_list):
     new_list = []
     for _event in old_list:
         new_event = dict(_event)
-        new_event['event_type'] = new_event.pop('_event_type')
+        new_event['event_type'] = new_event.pop('_event_type').decode()
         # Some of the raiden events contain accounts and as such need to
         # be exported in hex to the outside world
         if new_event['event_type'] == 'EventTransferReceivedSuccess':

--- a/raiden/tests/api/test_restapi.py
+++ b/raiden/tests/api/test_restapi.py
@@ -726,46 +726,46 @@ def test_query_blockchain_events(
     # a block number but for the purposes of making sure block numbers propagate
     # in the API logic I am adding them here and testing for them later.
     api_test_context.add_events([{
-        '_event_type': 'TokenAdded',
+        '_event_type': b'TokenAdded',
         'block_number': 1,
         'channel_manager_address': '0x61c808d82a3ac53231750dadc13c777b59310bd9',
         'token_address': '0x61c808d82a3ac53231750dadc13c777b59310bd9'
     }, {
-        '_event_type': 'TokenAdded',
+        '_event_type': b'TokenAdded',
         'block_number': 13,
         'channel_manager_address': '0x61c808d82a3ac53231750dadc13c777b59310bd9',
         'token_address': '0xea674fdde714fd979de3edf0f56aa9716b898ec8'
     }, {
-        '_event_type': 'ChannelNew',
+        '_event_type': b'ChannelNew',
         'settle_timeout': 10,
         'netting_channel': '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
         'participant1': '0x4894a542053248e0c504e3def2048c08f73e1ca6',
         'participant2': '0x356857Cd22CBEFccDa4e96AF13b408623473237A',
         'block_number': 15,
     }, {
-        '_event_type': 'ChannelNew',
+        '_event_type': b'ChannelNew',
         'settle_timeout': 10,
         'netting_channel': '0xa193fb0032c8635d590f8f31be9f70bd12451b1e',
         'participant1': '0xcd111aa492a9c77a367c36e6d6af8e6f212e0c8e',
         'participant2': '0x88bacc4ddc8f8a5987e1b990bb7f9e8430b24f1a',
         'block_number': 100,
     }, {
-        '_event_type': 'ChannelNewBalance',
+        '_event_type': b'ChannelNewBalance',
         'token_address': '0x61c808d82a3ac53231750dadc13c777b59310bd9',
         'participant': '0xcd111aa492a9c77a367c36e6d6af8e6f212e0c8e',
         'balance': 200,
         'block_number': 20,
     }, {
-        '_event_type': 'ChannelNewBalance',
+        '_event_type': b'ChannelNewBalance',
         'token_address': '0x61c808d82a3ac53231750dadc13c777b59310bd9',
         'participant': '0x00472c1e4275230354dbe5007a5976053f12610a',
         'balance': 650,
         'block_number': 150,
     }, {
-        '_event_type': 'ChannelSettled',
+        '_event_type': b'ChannelSettled',
         'block_number': 35,
     }, {
-        '_event_type': 'ChannelSettled',
+        '_event_type': b'ChannelSettled',
         'block_number': 250,
     }])
 
@@ -850,14 +850,14 @@ def test_break_blockchain_events(
         rest_api_port_number):
 
     api_test_context.add_events([{
-        '_event_type': 'ChannelNew',
+        '_event_type': b'ChannelNew',
         'settle_timeout': 10,
         'netting_channel': '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
         'participant1': '0x4894a542053248e0c504e3def2048c08f73e1ca6',
         'participant2': '0x356857Cd22CBEFccDa4e96AF13b408623473237A',
         'block_number': 15,
     }, {
-        '_event_type': 'ChannelSettled',
+        '_event_type': b'ChannelSettled',
         'block_number': 35,
     }])
 

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -42,7 +42,7 @@ def test_event_transfer_received_success(token_addresses, raiden_chain):
     transfer_initiators = list()
     events_received = list()
     for event in events:
-        if event['_event_type'] == 'EventTransferReceivedSuccess':
+        if event['_event_type'] == b'EventTransferReceivedSuccess':
             events_received.append(event)
             transfer_initiators.append(event['initiator'])
 
@@ -98,7 +98,7 @@ def test_echo_node_response(token_addresses, raiden_chain):
         received = {}
 
         for event in events:
-            if event['_event_type'] == 'EventTransferReceivedSuccess':
+            if event['_event_type'] == b'EventTransferReceivedSuccess':
                 received[repr(event)] = event
 
         assert len(received) == 1
@@ -178,7 +178,7 @@ def test_echo_node_lottery(token_addresses, raiden_chain):
         events = get_channel_events_for_token(app, token_address, 0)
 
         for event in events:
-            if event['_event_type'] == 'EventTransferReceivedSuccess':
+            if event['_event_type'] == b'EventTransferReceivedSuccess':
                 received[repr(event)] = event
 
     assert len(received) == 2

--- a/raiden/tests/unit/api/test_python_api.py
+++ b/raiden/tests/unit/api/test_python_api.py
@@ -214,7 +214,7 @@ def test_api_channel_events(raiden_chain):
             assert max_block != 0
 
         if idx == 2:
-            assert result['_event_type'] == 'EventTransferSentSuccess'
+            assert result['_event_type'] == b'EventTransferSentSuccess'
             assert result['amount'] == amount
             assert result['target'] == app1.raiden.address
         else:

--- a/raiden/tests/utils/apitestcontext.py
+++ b/raiden/tests/utils/apitestcontext.py
@@ -96,7 +96,7 @@ class ApiTestContext:
     def get_network_events(self, from_block, to_block):
         return_list = list()
         for event in self.events:
-            expected_event_type = event['_event_type'] == 'TokenAdded'
+            expected_event_type = event['_event_type'] == b'TokenAdded'
             in_block_range = (
                 event['block_number'] >= from_block and
                 event['block_number'] <= to_block
@@ -116,7 +116,7 @@ class ApiTestContext:
                 'query'.format(pex(token_address))
             )
         for event in self.events:
-            expected_event_type = event['_event_type'] == 'ChannelNew'
+            expected_event_type = event['_event_type'] == b'ChannelNew'
             in_block_range = (
                 event['block_number'] >= from_block and
                 event['block_number'] <= to_block
@@ -136,11 +136,11 @@ class ApiTestContext:
 
         for event in self.events:
             is_channel_event = (
-                event['_event_type'] == 'ChannelNewBalance' or
-                event['_event_type'] == 'ChannelClosed' or
-                event['_event_type'] == 'TransferUpdated' or
-                event['_event_type'] == 'ChannelSettled' or
-                event['_event_type'] == 'ChannelSecretRevealed'
+                event['_event_type'] == b'ChannelNewBalance' or
+                event['_event_type'] == b'ChannelClosed' or
+                event['_event_type'] == b'TransferUpdated' or
+                event['_event_type'] == b'ChannelSettled' or
+                event['_event_type'] == b'ChannelSecretRevealed'
             )
             in_block_range = (
                 event['block_number'] >= from_block and

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -106,7 +106,7 @@ class EchoNode:
                         )
                         received_transfers.extend([
                             event for event in channel_events
-                            if event['_event_type'] == 'EventTransferReceivedSuccess'
+                            if event['_event_type'] == b'EventTransferReceivedSuccess'
                         ])
                     for event in received_transfers:
                         transfer = event.copy()


### PR DESCRIPTION
This is another solution for #1217 . In contrast to #1221 this PR consistently changes event names to `bytes` internally and decodes them into strings when requested by the API.

Fixes #1217 