### PR TITLE
Dont use all of gas limit in a transaction

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -301,9 +301,7 @@ class JSONRPCClient:
     def _gaslimit(self, location='pending') -> int:
         last_block = self.call('eth_getBlockByNumber', location, True)
         gas_limit = quantity_decoder(last_block['gasLimit'])
-        # The gas limit can fluctuate from the actual pending limit by a maximum
-        # of up to a 1/1024th of the previous gas limit
-        return gas_limit - int(gas_limit / 1024)
+        return gas_limit * 8 // 10
 
     def _gasprice(self) -> int:
         if self.given_gas_price:


### PR DESCRIPTION
Using the entire gas limit in a transaction some times results in it not getting
mined irrespective of the gas price since miners prefer smaller
transactions. Using 80% of the gas limit is working reliably from my tests.

Note: The proper gas limit solution here would be to set it from estimate gas
since estimate gas is now fixed.

This is just a step towards that to fix a problem being seen when using raiden
in ropsten at the moment.