### PR TITLE
Balance proof state

### DIFF
--- a/raiden/encoding/signing.py
+++ b/raiden/encoding/signing.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from coincurve import PublicKey
+from ethereum.slogging import getLogger
+
 from raiden.utils import sha3
+
+log = getLogger(__name__)  # pylint: disable=invalid-name
 
 
 def recover_publickey(messagedata, signature):
@@ -14,6 +18,24 @@ def recover_publickey(messagedata, signature):
         hasher=sha3,
     )
     return publickey.format(compressed=False)
+
+
+def recover_publickey_safe(messagedata, signature):
+    publickey = None
+
+    try:
+        publickey = recover_publickey(messagedata, signature)
+    except ValueError:
+        # raised if the signature has the wrong length
+        log.error('invalid signature')
+    except TypeError as e:
+        # raised if the PublicKey instantiation failed
+        log.error('invalid key data: {}'.format(e.message))
+    except Exception as e:  # pylint: disable=broad-except
+        # secp256k1 is using bare Exception classes: raised if the recovery failed
+        log.error('error while recovering pubkey: {}'.format(e.message))
+
+    return publickey
 
 
 def sign(messagedata, private_key):

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from raiden.encoding.messages import (
+    nonce as nonce_field,
+    transferred_amount as transferred_amount_field,
+)
+
+
+def singing_data(
+        nonce: int,
+        transferred_amount: int,
+        channel_address: bytes,
+        locksroot: bytes,
+        extra_hash: bytes,
+) -> bytes:
+
+    nonce_bytes = nonce_field.encoder.encode(nonce, nonce_field.size_bytes)
+    pad_size = nonce_field.size_bytes - len(nonce_bytes)
+    nonce_bytes_padded = nonce_bytes.rjust(pad_size, b'\x00')
+
+    transferred_amount_bytes = transferred_amount_field.encoder.encode(
+        transferred_amount,
+        transferred_amount_field.size_bytes,
+    )
+    transferred_amount_bytes_padded = transferred_amount_bytes.rjust(pad_size, b'\x00')
+
+    data_that_was_signed = (
+        nonce_bytes_padded +
+        transferred_amount_bytes_padded +
+        locksroot +
+        channel_address +
+        extra_hash
+    )
+
+    return data_that_was_signed
+
+
+def pack_signing_data(
+        nonce: bytes,
+        transferred_amount: bytes,
+        channel_address: bytes,
+        locksroot: bytes,
+        extra_hash: bytes,
+) -> bytes:
+
+    data_that_was_signed = (
+        nonce +
+        transferred_amount +
+        locksroot +
+        channel_address +
+        extra_hash
+    )
+
+    return data_that_was_signed

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -5,7 +5,7 @@ from raiden.encoding.messages import (
 )
 
 
-def singing_data(
+def signing_data(
         nonce: int,
         transferred_amount: int,
         channel_address: bytes,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from raiden.transfer.architecture import State
 from raiden.utils import pex, typing
+from raiden.constants import UINT256_MAX, UINT64_MAX
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 
 CHANNEL_STATE_CLOSED = 'closed'
@@ -11,7 +12,7 @@ CHANNEL_STATE_SETTLING = 'waiting_for_settle'
 
 
 def balanceproof_from_envelope(envelope_message):
-    return BalanceProofState2(
+    return BalanceProofSignedState(
         envelope_message.nonce,
         envelope_message.transferred_amount,
         envelope_message.locksroot,
@@ -182,7 +183,7 @@ class BalanceProofUnsignedState(State):
             raise ValueError('transferred_amount must be a token_amount instance')
 
         if not isinstance(locksroot, typing.keccak256):
-            raise ValueError('locksroot must be an keccak256 instance')
+            raise ValueError('locksroot must be a keccak256 instance')
 
         if not isinstance(channel_address, typing.address):
             raise ValueError('channel_address must be an address instance')
@@ -190,13 +191,13 @@ class BalanceProofUnsignedState(State):
         if nonce <= 0:
             raise ValueError('nonce cannot be zero or negative')
 
-        if nonce >= 2 ** 64:
+        if nonce > UINT64_MAX:
             raise ValueError('nonce is too large')
 
         if transferred_amount < 0:
             raise ValueError('transferred_amount cannot be negative')
 
-        if transferred_amount >= 2 ** 256:
+        if transferred_amount > UINT256_MAX:
             raise ValueError('transferred_amount is too large')
 
         if len(locksroot) != 32:
@@ -210,7 +211,7 @@ class BalanceProofUnsignedState(State):
         self.locksroot = locksroot
         self.channel_address = channel_address
 
-    def __str__(self):
+    def __repr__(self):
         return (
             '<'
             'BalanceProofUnsignedState nonce:{} transferred_amount:{} '
@@ -236,7 +237,7 @@ class BalanceProofUnsignedState(State):
         return not self.__eq__(other)
 
 
-class BalanceProofState2(State):
+class BalanceProofSignedState(State):
     """ Proof of a channel balance that can be used on-chain to resolve
     disputes.
     """
@@ -277,7 +278,7 @@ class BalanceProofState2(State):
             raise ValueError('message_hash must be a keccak256 instance')
 
         if not isinstance(signature, typing.signature):
-            raise ValueError('signature must be an signature instance')
+            raise ValueError('signature must be a signature instance')
 
         if not isinstance(sender, typing.address):
             raise ValueError('sender must be an address instance')
@@ -285,13 +286,13 @@ class BalanceProofState2(State):
         if nonce <= 0:
             raise ValueError('nonce cannot be zero or negative')
 
-        if nonce >= 2 ** 64:
+        if nonce > UINT64_MAX:
             raise ValueError('nonce is too large')
 
         if transferred_amount < 0:
             raise ValueError('transferred_amount cannot be negative')
 
-        if transferred_amount >= 2 ** 256:
+        if transferred_amount > UINT256_MAX:
             raise ValueError('transferred_amount is too large')
 
         if len(locksroot) != 32:
@@ -314,10 +315,10 @@ class BalanceProofState2(State):
         self.signature = signature
         self.sender = sender
 
-    def __str__(self):
+    def __repr__(self):
         return (
             '<'
-            'BalanceProofState nonce:{} transferred_amount:{} '
+            'BalanceProofSignedState nonce:{} transferred_amount:{} '
             'locksroot:{} channel_address:{} message_hash:{}'
             'signature:{} sender:{}'
             '>'
@@ -333,7 +334,7 @@ class BalanceProofState2(State):
 
     def __eq__(self, other):
         return (
-            isinstance(other, BalanceProofState) and
+            isinstance(other, BalanceProofSignedState) and
             self.nonce == other.nonce and
             self.transferred_amount == other.transferred_amount and
             self.locksroot == other.locksroot and


### PR DESCRIPTION
Merge after: #1269

Added `BalanceProofUnsignedState` class. This class is used to increase type safety, used only by senders, since the signing is done outside of the state machinery, in contrast to the `BalanceProofState2` which is used only by receivers, since it's a complete balance proof with a signature.