### PR TITLE
Don't crash when using the '--nat=ext:IP' command line option.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :release:`0.3.0 <2018-02-21>`
+* :bug:`1273` Don't crash when using the ``--nat=ext:IP`` command line option.
 * :bug:`1217` Correctly decode network events in the REST API.
 * :bug:`1224` Fix internal server error on REST endpoint ``/events/tokens/`` for non-existing tokens.
 * :bug:`1261` REST API now returns json error for invalid endpoints.

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -257,7 +257,7 @@ class NATChoiceType(click.Choice):
         if value.startswith('ext:'):
             ip, _, port = value[4:].partition(':')
             try:
-                IPv4Address(ip.decode('UTF-8', 'ignore'))
+                IPv4Address(ip)
             except AddressValueError:
                 self.fail('invalid IP address: {}'.format(ip), param, ctx)
             if port:


### PR DESCRIPTION
Fixes #1273