### PR TITLE
Blockchain events

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -249,6 +249,34 @@ def event_to_state_change(event):  # pylint: disable=too-many-return-statements
     return result
 
 
+def decode_event(event):
+    """ Enforce the binary encoding of address for internal usage. """
+    data = event.event_data
+    assert isinstance(data['_event_type'], bytes)
+
+    # Note: All addresses inside the event_data must be decoded.
+    if data['_event_type'] == b'TokenAdded':
+        data['channel_manager_address'] = address_decoder(data['channel_manager_address'])
+        data['token_address'] = address_decoder(data['token_address'])
+
+    elif data['_event_type'] == b'ChannelNew':
+        data['participant1'] = address_decoder(data['participant1'])
+        data['participant2'] = address_decoder(data['participant2'])
+        data['netting_channel'] = address_decoder(data['netting_channel'])
+
+    elif data['_event_type'] == b'ChannelNewBalance':
+        data['token_address'] = address_decoder(data['token_address'])
+        data['participant'] = address_decoder(data['participant'])
+
+    elif data['_event_type'] == b'ChannelClosed':
+        data['closing_address'] = address_decoder(data['closing_address'])
+
+    elif data['_event_type'] == b'ChannelSecretRevealed':
+        data['receiver_address'] = address_decoder(data['receiver_address'])
+
+    return event
+
+
 class Event:
     def __init__(self, originating_contract, event_data):
         self.originating_contract = originating_contract

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -30,10 +30,6 @@ EventListener = namedtuple(
     'EventListener',
     ('event_name', 'filter', 'translator', 'filter_creation_function'),
 )
-Event = namedtuple(
-    'BlockchainEvent',
-    ('originating_contract', 'event_data'),
-)
 Proxies = namedtuple(
     'Proxies',
     ('registry', 'channel_managers', 'channelmanager_nettingchannels'),
@@ -251,6 +247,18 @@ def event_to_state_change(event):  # pylint: disable=too-many-return-statements
         result = None
 
     return result
+
+
+class Event:
+    def __init__(self, originating_contract, event_data):
+        self.originating_contract = originating_contract
+        self.event_data = event_data
+
+    def __repr__(self):
+        return '<Event contract: {} event: {}>'.format(
+            pex(self.originating_contract),
+            self.event_data,
+        )
 
 
 class BlockchainEvents:

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -336,6 +336,10 @@ class BlockchainEvents:
         for event in self.poll_all_event_listeners(from_block):
             yield event_to_state_change(event)
 
+    def poll_blockchain_events(self, from_block=None):
+        for event in self.poll_all_event_listeners(from_block):
+            yield decode_event(event)
+
     def uninstall_all_event_listeners(self):
         for listener in self.event_listeners:
             listener.filter.uninstall()

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from raiden.routing import make_graph
+from raiden.transfer.state import (
+    NettingChannelEndState,
+    NettingChannelState,
+    TokenNetworkGraphState,
+    TokenNetworkState,
+    TransactionExecutionStatus,
+)
+
+
+def get_channel_state(token_address, reveal_timeout, netting_channel_proxy):
+    channel_details = netting_channel_proxy.detail()
+
+    our_state = NettingChannelEndState(
+        channel_details['our_address'],
+        channel_details['our_balance'],
+    )
+    partner_state = NettingChannelEndState(
+        channel_details['partner_address'],
+        channel_details['partner_balance'],
+    )
+
+    identifier = netting_channel_proxy.address
+    reveal_timeout = reveal_timeout
+    settle_timeout = channel_details['settle_timeout']
+
+    opened_block_number = netting_channel_proxy.opened()
+    closed_block_number = netting_channel_proxy.closed()
+
+    # ignore bad open block numbers
+    if opened_block_number <= 0:
+        return None
+
+    # ignore negative closed block numbers
+    if closed_block_number < 0:
+        return None
+
+    open_transaction = TransactionExecutionStatus(
+        None,
+        opened_block_number,
+        TransactionExecutionStatus.SUCCESS,
+    )
+
+    if closed_block_number:
+        close_transaction = TransactionExecutionStatus(
+            None,
+            closed_block_number,
+            TransactionExecutionStatus.SUCCESS,
+        )
+    else:
+        close_transaction = None
+
+    # For the current implementation the channel is a smart contract that
+    # will be killed on settle.
+    settle_transaction = None
+
+    channel = NettingChannelState(
+        identifier,
+        token_address,
+        reveal_timeout,
+        settle_timeout,
+        our_state,
+        partner_state,
+        open_transaction,
+        close_transaction,
+        settle_transaction,
+    )
+
+    return channel
+
+
+def get_token_network_state_from_proxies(raiden, manager_proxy, netting_channel_proxies):
+    manager_address = manager_proxy.address
+    token_address = manager_proxy.token_address()
+
+    edge_list = manager_proxy.channels_addresses()
+    graph = make_graph(edge_list)
+    network_graph = TokenNetworkGraphState(graph)
+
+    partner_channels = list()
+    for channel_proxy in netting_channel_proxies:
+        channel_state = get_channel_state(
+            token_address,
+            raiden.config['reveal_timeout'],
+            channel_proxy,
+        )
+        partner_channels.append(channel_state)
+
+    network = TokenNetworkState(
+        manager_address,
+        token_address,
+        network_graph,
+        partner_channels,
+    )
+
+    return network


### PR DESCRIPTION
This is decoupling the `BlockchainEvents` class from our internal architecture, eventually the method `poll_blockchain_events` will be dropped and the module won't need to know about the raiden architecture.

`get_channel_proxies` is being added because it will be used on a new token network event.