### PR TITLE
Global TokenNetwork (channel manager) contract per token

### DIFF
--- a/raiden/smart_contracts/SecretRegistry.sol
+++ b/raiden/smart_contracts/SecretRegistry.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.17;
+
+contract SecretRegistry {
+
+    /*
+     *  Data structures
+     */
+
+    string constant public contract_version = "0.3._";
+
+    // Token address => TokenNetwork address
+    mapping(bytes32 => uint64) public secret_to_block;
+
+    /*
+     *  Events
+     */
+
+    event ChannelSecretRevealed(bytes32 secret, address receiver_address);
+
+    function registerSecret(bytes32 secret, address receiver_address) public {
+        require(secret_to_block[secret] == 0);
+        secret_to_block[secret] = uint64(block.number);
+        ChannelSecretRevealed(secret, receiver_address);
+    }
+
+    function getSecretBlockHeight(bytes32 secret) public constant returns (uint64) {
+        return secret_to_block[secret];
+    }
+}

--- a/raiden/smart_contracts/SecretRegistry.sol
+++ b/raiden/smart_contracts/SecretRegistry.sol
@@ -15,12 +15,12 @@ contract SecretRegistry {
      *  Events
      */
 
-    event ChannelSecretRevealed(bytes32 secret, address receiver_address);
+    event SecretRevealed(bytes32 secret);
 
-    function registerSecret(bytes32 secret, address receiver_address) public {
+    function registerSecret(bytes32 secret) public {
         require(secret_to_block[secret] == 0);
         secret_to_block[secret] = uint64(block.number);
-        ChannelSecretRevealed(secret, receiver_address);
+        SecretRevealed(secret);
     }
 
     function getSecretBlockHeight(bytes32 secret) public constant returns (uint64) {

--- a/raiden/smart_contracts/SecretRegistry.sol
+++ b/raiden/smart_contracts/SecretRegistry.sol
@@ -17,10 +17,13 @@ contract SecretRegistry {
 
     event SecretRevealed(bytes32 secret);
 
-    function registerSecret(bytes32 secret) public {
-        require(secret_to_block[secret] == 0);
+    function registerSecret(bytes32 secret) public returns (bool) {
+        if (secret_to_block[secret] > 0) {
+            return false;
+        }
         secret_to_block[secret] = uint64(block.number);
         SecretRevealed(secret);
+        return true;
     }
 
     function getSecretBlockHeight(bytes32 secret) public constant returns (uint64) {

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.17;
 
 import "./Token.sol";
 import "./Utils.sol";

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -329,7 +329,7 @@ contract TokenNetwork is Utils {
 
         // The lock must not have expired, it does not matter how far in the
         // future it would have expired
-        require(expiration_block >= block.number);
+        require(expiration_block > block.number);
         require(hashlock == keccak256(secret));
 
         locked_encoded = encodeLock(expiration_block, locked_amount, hashlock);

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -429,7 +429,7 @@ contract TokenNetwork is Utils {
 
     /// @notice Registers the lock secret in the SecretRegistry contract.
     function registerSecret(bytes32 secret) public {
-        secret_registry.registerSecret(secret);
+        require(secret_registry.registerSecret(secret));
     }
 
     /// @notice Unlocks a pending transfer and increases the partner's transferred amount

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -1,0 +1,563 @@
+pragma solidity ^0.4.19;
+
+import "./Token.sol";
+import "./Utils.sol";
+
+contract TokenNetwork is Utils {
+    string constant public contract_version = "0.3._";
+
+    // Instance of the token used as digital currency by the channels.
+    Token public token;
+
+    // Each channel identifier is a uint
+    mapping (uint => Channel) public channels;
+    uint public last_channel_index;
+
+    // The ClosingRequest identfier must be THE SAME as the channel identifier from `channels`
+    mapping (uint => ClosingRequest) public closing_requests;
+
+    /*
+     *  Data Structures
+     */
+
+    struct Participant
+    {
+        // Total amount of token transferred to this smart contract through the
+        // `deposit` function, note that direct token transfer cannot be
+        // tracked and will be burned.
+        uint256 balance;
+
+        // The latest known merkle root of the pending hash-time locks, used to
+        // validate the withdrawn proofs.
+        bytes32 locksroot;
+
+        // The latest known transferred_amount from this node to the other
+        // participant, used to compute the net balance on settlement.
+        uint256 transferred_amount;
+
+        // Value used to order transfers and only accept the latest on calls to
+        // update, this will only be relevant after either #182 or #293 is
+        // implemented.
+        uint64 nonce;
+
+        // This value is set to True after the channel has been opened.
+        // This is an efficient way to mark the channel participants without doing a deposit.
+        // This is uint8 and it gets packed with the nonce.
+        bool initialized;
+
+        // A mapping to keep track of locks that have been withdrawn.
+        mapping(bytes32 => bool) withdrawn_locks;
+    }
+
+    struct Channel {
+        // We also use the settle_timeout to verify that
+        // the channel is open
+        uint settle_timeout;
+        mapping(address => Participant) participants;
+    }
+
+    struct ClosingRequest {
+        address closing_address;
+
+        // Block number at which the settlement window ends.
+        uint settle_block_number;
+    }
+
+    /*
+     *  Events
+     */
+
+    event ChannelOpened(
+        uint channel_identifier,
+        address participant1,
+        address participant2,
+        uint settle_timeout
+    );
+
+    event ChannelNewBalance(uint channel_identifier, address participant, uint balance);
+
+    event ChannelClosed(uint channel_identifier, address closing_address);
+
+    event ChannelUnlocked(uint channel_identifier, address participant, uint transferred_amount);
+
+    event TransferUpdated(uint channel_identifier, address participant);
+
+    event ChannelSettled(uint channel_identifier);
+
+    /*
+     * Modifiers
+     */
+
+    modifier isClosed(uint channel_identifier) {
+        require(closing_requests[channel_identifier].settle_block_number > 0);
+        _;
+    }
+
+    modifier stillTimeout(uint channel_identifier) {
+        require(closing_requests[channel_identifier].settle_block_number > block.number);
+        _;
+    }
+
+    modifier timeoutOver(uint channel_identifier) {
+        require(closing_requests[channel_identifier].settle_block_number <= block.number);
+        _;
+    }
+
+    // Note: we use the settleTimeout to check if the channel is open. It must always be > 0.
+    modifier settleTimeoutValid(uint timeout) {
+        require(timeout >= 6 && timeout <= 2700000);
+        _;
+    }
+
+    /*
+     *  Constructor
+     */
+
+    function TokenNetwork(address _token_address) public {
+        require(_token_address != 0x0);
+        require(contractExists(_token_address));
+
+        token = Token(_token_address);
+
+        // Check if the contract is indeed a token contract
+        require(token.totalSupply() > 0);
+    }
+
+    /*
+     *  Public functions
+     */
+
+    /// @notice Opens a new channel between `participant1` and `participant2`.
+    /// Can be called by anyone.
+    function openChannel(
+        address participant1,
+        address participant2,
+        uint settle_timeout)
+        settleTimeoutValid(settle_timeout)
+        public
+        returns (uint)
+    {
+        require(participant1 != 0x0);
+        require(participant2 != 0x0);
+        require(participant1 != participant2);
+
+        // Increase channel index counter
+        last_channel_index += 1;
+
+        require(channels[last_channel_index].settle_timeout == 0);
+        require(!channels[last_channel_index].participants[participant1].initialized);
+        require(!channels[last_channel_index].participants[participant2].initialized);
+
+        // Store channel information
+        channels[last_channel_index] = Channel({settle_timeout: settle_timeout});
+
+        // Mark the channel participants
+        // We use this in deposit to ensure the beneficiary is a channel participant
+        channels[last_channel_index].participants[participant1].initialized = true;
+        channels[last_channel_index].participants[participant2].initialized = true;
+
+        ChannelOpened(last_channel_index, participant1, participant2, settle_timeout);
+
+        return last_channel_index;
+    }
+
+    /// @notice Deposit tokens to an already existent channel.
+    /// Can be called by anyone.
+    function deposit(
+        uint channel_identifier,
+        address beneficiary,
+        uint256 added_amount)
+        public
+        returns (bool)
+    {
+        Channel storage channel = channels[channel_identifier];
+
+        // Channel must be open and beneficiary must be one of the participants
+        require(channel.participants[beneficiary].initialized);
+
+        // Channel cannot be closed
+        require(closing_requests[channel_identifier].settle_block_number == 0);
+
+        // Sender should have enough balance
+        // TODO: is this necessary? token.transfer should fail anyway if implemented correctly
+        require(token.balanceOf(msg.sender) >= added_amount);
+
+        // Change the state
+        channel.participants[beneficiary].balance += added_amount;
+
+        // Do the transfer
+        require(token.transferFrom(msg.sender, address(this), added_amount));
+
+        ChannelNewBalance(channel_identifier, beneficiary, channel.participants[beneficiary].balance);
+
+        return true;
+    }
+
+    /// @notice Close a channel between two parties that was used bidirectionally.
+    /// Only a participant may close the channel, providing a balance proof signed by its partner. Callable only once.
+    /// @param channel_identifier The channel identifier.
+    /// @param nonce Strictly monotonic value used to order transfers.
+    /// @param transferred_amount Total amount of tokens transferred by the channel partner
+    /// to the channel participant who calls the function.
+    /// @param locksroot Root of the partner's merkle tree of all pending lock lockhashes.
+    /// @param additional_hash Computed from the message. Used for message authentication.
+    /// @param signature Partner's signature of the balance proof data.
+    function closeChannel(
+        uint channel_identifier,
+        uint64 nonce,
+        uint256 transferred_amount,
+        bytes32 locksroot,
+        bytes32 additional_hash,
+        bytes signature)
+        public
+    {
+        address partner_address;
+
+        // Close can be called only once
+        require(closing_requests[channel_identifier].settle_block_number == 0);
+
+        Channel storage channel = channels[channel_identifier];
+
+        // Only a participant may close the channel.
+        require(channel.participants[msg.sender].initialized);
+
+        // Store the closing request data
+        closing_requests[channel_identifier].closing_address = msg.sender;
+        closing_requests[channel_identifier].settle_block_number = channel.settle_timeout + block.number;
+
+        // An empty value means that the closer never received a transfer, or
+        // he is intentionally not providing the latest transfer, in which case
+        // the closing party is going to lose the tokens that were transferred
+        // to him.
+        partner_address = recoverAddressFromSignature(
+            channel_identifier,
+            nonce,
+            transferred_amount,
+            locksroot,
+            additional_hash,
+            signature
+        );
+
+        // Signature must be from the channel partner
+        require(msg.sender != partner_address);
+
+        updateParticipantStruct(
+            channel_identifier,
+            partner_address,
+            nonce,
+            locksroot,
+            transferred_amount
+        );
+
+        ChannelClosed(channel_identifier, msg.sender);
+    }
+
+    /// @notice Called on a closed channel, the function allows the non-closing participant
+    /// to provide the last balance proof, which modifies the closing participant's state.
+    /// Can be called multiple times, by anyone.
+    function updateTransfer(
+        uint channel_identifier,
+        uint64 nonce,
+        uint256 transferred_amount,
+        bytes32 locksroot,
+        bytes32 additional_hash,
+        bytes signature)
+        isClosed(channel_identifier)
+        stillTimeout(channel_identifier)
+        public
+    {
+        address partner_address;
+
+        partner_address = recoverAddressFromSignature(
+            channel_identifier,
+            nonce,
+            transferred_amount,
+            locksroot,
+            additional_hash,
+            signature
+        );
+
+        uint64 old_nonce = channels[channel_identifier].participants[partner_address].nonce;
+        bytes32 old_locksroot = channels[channel_identifier].participants[partner_address].locksroot;
+
+        // This will reset the transferred amount, invalidating any unlocked locks that were
+        // unlocked but not included in the new locksroot
+        updateParticipantStruct(
+            channel_identifier,
+            partner_address,
+            nonce,
+            locksroot,
+            transferred_amount
+        );
+
+        // Clean up storage for the old (nonce, locksroot)
+        // after the locksroot has been replaced.
+        // This cannot be used anymore to unlock locks anyway.
+        bytes32 old_key = keccak256(old_nonce, old_locksroot);
+        delete channels[channel_identifier].participants[partner_address].withdrawn_locks[old_key];
+
+        TransferUpdated(channel_identifier, msg.sender);
+    }
+
+    /// @notice Unlocks a pending transfer and increases the partner's transferred amount
+    /// with the transfer value. A lock can be unlocked only once per participant.
+    // Anyone can call unlock a transfer on behalf of a channel participant.
+    function unlock(
+        uint channel_identifier,
+        address partner,
+        uint64 expiration_block,
+        uint amount,
+        bytes32 hashlock,
+        bytes merkle_proof,
+        bytes32 secret)
+        isClosed(channel_identifier)
+        public
+    {
+        bytes32 key;
+        bytes32 computed_locksroot;
+        bytes memory locked_encoded;
+
+        // Check that the partner is a channel participant.
+        require(channels[channel_identifier].participants[partner].initialized);
+
+        Participant storage partner_state = channels[channel_identifier].participants[partner];
+
+        // An empty locksroot means there are no pending locks
+        require(partner_state.locksroot != 0);
+
+        // The lock must not have expired, it does not matter how far in the
+        // future it would have expired
+        require(expiration_block >= block.number);
+        require(hashlock == keccak256(secret));
+
+        locked_encoded = encodeLock(expiration_block, amount, hashlock);
+        computed_locksroot = computeMerkleRoot(locked_encoded, merkle_proof);
+
+        // Note that unlocked locks have to be re-unlocked after a `transferUpdate` with a
+        // locksroot that does not contain this lock.
+        require(partner_state.locksroot == computed_locksroot);
+
+        // A lock can be withdrawn only once per participant
+        key = keccak256(partner_state.nonce, partner_state.locksroot);
+        require(!partner_state.withdrawn_locks[key]);
+        partner_state.withdrawn_locks[key] = true;
+
+        // Finally change the amount of owed tokens
+        // This implementation allows for each transfer to be set only once, so
+        // it's safe to update the transferred_amount in place.
+        //
+        partner_state.transferred_amount += amount;
+
+        ChannelUnlocked(channel_identifier, partner, partner_state.transferred_amount);
+    }
+
+    /// @notice Settles the balance between the two parties
+    function settleChannel(
+        uint channel_identifier,
+        address participant1,
+        address participant2)
+        isClosed(channel_identifier)
+        timeoutOver(channel_identifier)
+        public
+    {
+        uint participant1_amount;
+        uint participant2_amount;
+        uint total_deposit;
+
+        Participant memory participant1_state = channels[channel_identifier].participants[participant1];
+        Participant memory participant2_state = channels[channel_identifier].participants[participant2];
+
+        // Make sure the addresses are channel participant addresses
+        require(participant1_state.initialized);
+        require(participant2_state.initialized);
+
+        // Direct token transfers done through the token `transfer` function
+        // cannot be accounted for, these superfluous tokens will be burned,
+        // this is because there is no way to tell which participant (if any)
+        // had ownership over the token.
+        total_deposit = participant1_state.balance + participant2_state.balance;
+
+        participant1_amount = (
+            participant1_state.balance
+            + participant2_state.transferred_amount
+            - participant1_state.transferred_amount
+        );
+
+        // To account for cases when participant2 does not provide participant1's balance proof
+        // Therefore, participant1's transferred_amount will be lower than in reality
+        participant1_amount = min(participant1_amount, total_deposit);
+
+        // To account for cases when participant1 does not provide participant2's balance proof
+        // Therefore, participant2's transferred_amount will be lower than in reality
+        participant1_amount = max(participant1_amount, 0);
+
+        // At this point `participant1_amount` is between [0,total_deposit], so this is safe.
+        participant2_amount = total_deposit - participant1_amount;
+
+        // Remove the channel data from storage
+        delete channels[channel_identifier];
+        delete closing_requests[channel_identifier];
+
+        // Do the actual token transfers
+        require(token.transfer(participant1, participant1_amount));
+        require(token.transfer(participant2, participant2_amount));
+
+        ChannelSettled(channel_identifier);
+    }
+
+    // TODO
+    /*function cooperativeSettle(
+        uint channel_identifier,
+        uint256 balance1,
+        uint256 balance2,
+        bytes signature1,
+        bytes signature2)
+        public
+    {
+
+    }*/
+
+    /*
+     * Internal Functions
+     */
+
+    function updateParticipantStruct(
+        uint channel_identifier,
+        address participant,
+        uint64 nonce,
+        bytes32 locksroot,
+        uint256 transferred_amount)
+        internal
+    {
+        Channel storage channel = channels[channel_identifier];
+
+        require(channel.participants[participant].initialized);
+        require(nonce > channel.participants[participant].nonce);
+        // Transfers can have 0 value
+        require(transferred_amount >= channel.participants[participant].transferred_amount);
+        require(locksroot != channel.participants[participant].locksroot);
+
+        // Update the partner's structure with the data provided
+        // by the closing participant.
+        channel.participants[participant].nonce = nonce;
+        channel.participants[participant].locksroot = locksroot;
+        channel.participants[participant].transferred_amount = transferred_amount;
+    }
+
+    function recoverAddressFromSignature(
+        uint channel_identifier,
+        uint64 nonce,
+        uint256 transferred_amount,
+        bytes32 locksroot,
+        bytes32 additional_hash,
+        bytes signature
+    )
+        view
+        internal
+        returns (address)
+    {
+        require(signature.length == 65);
+
+        bytes32 signed_hash = keccak256(
+            nonce,
+            transferred_amount,
+            locksroot,
+            channel_identifier,
+            address(this),
+            additional_hash
+        );
+
+        var (r, s, v) = signatureSplit(signature);
+        return ecrecover(signed_hash, v, r, s);
+    }
+
+    function signatureSplit(bytes signature)
+        pure
+        internal
+        returns (bytes32 r, bytes32 s, uint8 v)
+    {
+        // The signature format is a compact form of:
+        //   {bytes32 r}{bytes32 s}{uint8 v}
+        // Compact means, uint8 is not padded to 32 bytes.
+        assembly {
+            r := mload(add(signature, 32))
+            s := mload(add(signature, 64))
+            // Here we are loading the last 32 bytes, including 31 bytes
+            // of 's'. There is no 'mload8' to do this.
+            //
+            // 'byte' is not working due to the Solidity parser, so lets
+            // use the second best option, 'and'
+            v := and(mload(add(signature, 65)), 0xff)
+        }
+
+        require(v == 27 || v == 28);
+    }
+
+    // TODO - implement this
+    function encodeLock(
+        uint64 expiration_block,
+        uint amount,
+        bytes32 hashlock)
+        pure
+        internal
+        returns (bytes lock)
+    {
+
+    }
+
+    // TODO - not used anymore now
+    function decodeLock(bytes lock)
+        pure
+        internal
+        returns (uint64 expiration, uint amount, bytes32 hashlock)
+    {
+        require(lock.length == 72);
+
+        // Lock format:
+        // [0:8] expiration
+        // [8:40] amount
+        // [40:72] hashlock
+        assembly {
+            expiration := mload(add(lock, 8))
+            amount := mload(add(lock, 40))
+            hashlock := mload(add(lock, 72))
+        }
+    }
+
+    function computeMerkleRoot(bytes lock, bytes merkle_proof)
+        pure
+        internal
+        returns (bytes32)
+    {
+        require(merkle_proof.length % 32 == 0);
+
+        uint i;
+        bytes32 h;
+        bytes32 el;
+
+        h = keccak256(lock);
+        for (i = 32; i <= merkle_proof.length; i += 32) {
+            assembly {
+                el := mload(add(merkle_proof, i))
+            }
+
+            if (h < el) {
+                h = keccak256(h, el);
+            } else {
+                h = keccak256(el, h);
+            }
+        }
+
+        return h;
+    }
+
+    function min(uint a, uint b) pure internal returns (uint)
+    {
+        return a > b ? b : a;
+    }
+
+    function max(uint a, uint b) pure internal returns (uint)
+    {
+        return a > b ? a : b;
+    }
+}

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -99,12 +99,12 @@ contract TokenNetwork is Utils {
     }
 
     modifier stillTimeout(uint256 channel_identifier) {
-        require(closing_requests[channel_identifier].settle_block_number > block.number);
+        require(closing_requests[channel_identifier].settle_block_number >= block.number);
         _;
     }
 
     modifier timeoutOver(uint256 channel_identifier) {
-        require(closing_requests[channel_identifier].settle_block_number <= block.number);
+        require(closing_requests[channel_identifier].settle_block_number < block.number);
         _;
     }
 

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -4,21 +4,26 @@ import "./Token.sol";
 import "./Utils.sol";
 
 contract TokenNetwork is Utils {
+
+    /*
+     *  Data structures
+     */
+
     string constant public contract_version = "0.3._";
 
-    // Instance of the token used as digital currency by the channels.
+    // Instance of the token used as digital currency by the channels
     Token public token;
 
-    // Each channel identifier is a uint
+    // Channel identifier is a uint, incremented after each new channel
     mapping (uint => Channel) public channels;
-    uint public last_channel_index;
+
+    // Used for determining the next channel identifier
+    // Start from 1 instead of 0, otherwise the first channel will have an additional
+    // 15000 gas cost than the rest
+    uint public last_channel_index = 1;
 
     // The ClosingRequest identfier must be THE SAME as the channel identifier from `channels`
     mapping (uint => ClosingRequest) public closing_requests;
-
-    /*
-     *  Data Structures
-     */
 
     struct Participant
     {
@@ -80,7 +85,7 @@ contract TokenNetwork is Utils {
 
     event ChannelUnlocked(uint channel_identifier, address participant, uint transferred_amount);
 
-    event TransferUpdated(uint channel_identifier, address participant);
+    event TransferUpdated(uint channel_identifier, address caller);
 
     event ChannelSettled(uint channel_identifier);
 

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -183,7 +183,6 @@ contract TokenNetwork is Utils {
         require(closing_requests[channel_identifier].settle_block_number == 0);
 
         // Sender should have enough balance
-        // TODO: is this necessary? token.transfer should fail anyway if implemented correctly
         require(token.balanceOf(msg.sender) >= added_amount);
 
         // Change the state

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -346,7 +346,6 @@ contract TokenNetwork is Utils {
         // Finally change the amount of owed tokens
         // This implementation allows for each transfer to be set only once, so
         // it's safe to update the transferred_amount in place.
-        //
         partner_state.transferred_amount += locked_amount;
 
         ChannelUnlocked(channel_identifier, partner, partner_state.transferred_amount);
@@ -396,6 +395,8 @@ contract TokenNetwork is Utils {
         participant2_amount = total_deposit - participant1_amount;
 
         // Remove the channel data from storage
+        delete channels[channel_identifier].participants[participant1];
+        delete channels[channel_identifier].participants[participant2];
         delete channels[channel_identifier];
         delete closing_requests[channel_identifier];
 

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -22,7 +22,7 @@ contract TokenNetwork is Utils {
     // 15000 gas cost than the rest
     uint256 public last_channel_index = 1;
 
-    // The ClosingRequest identfier must be THE SAME as the channel identifier from `channels`
+    // The ClosingRequest identfier must be THE SAME as the channel identifier (mapping key) from `channels`
     mapping (uint256 => ClosingRequest) public closing_requests;
 
     struct Participant

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -437,7 +437,8 @@ contract TokenNetwork is Utils {
         require(nonce > channel.participants[participant].nonce);
         // Transfers can have 0 value
         require(transferred_amount >= channel.participants[participant].transferred_amount);
-        require(locksroot != channel.participants[participant].locksroot);
+
+        // Note, locksroot may be 0x0 and it may not change between two balance proofs.
 
         // Update the partner's structure with the data provided
         // by the closing participant.

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -315,7 +315,7 @@ contract TokenNetwork is Utils {
         bytes32 hashlock,
         bytes merkle_proof,
         bytes32 secret)
-        isClosed(channel_identifier)
+        stillTimeout(channel_identifier)
         public
     {
         bytes32 key;

--- a/raiden/smart_contracts/TokenNetwork.sol
+++ b/raiden/smart_contracts/TokenNetwork.sol
@@ -173,7 +173,6 @@ contract TokenNetwork is Utils {
         address beneficiary,
         uint256 added_amount)
         public
-        returns (bool)
     {
         Channel storage channel = channels[channel_identifier];
 
@@ -194,8 +193,6 @@ contract TokenNetwork is Utils {
         require(token.transferFrom(msg.sender, address(this), added_amount));
 
         ChannelNewBalance(channel_identifier, beneficiary, channel.participants[beneficiary].balance);
-
-        return true;
     }
 
     /// @notice Close a channel between two parties that was used bidirectionally.

--- a/raiden/smart_contracts/TokenNetworksRegistry.sol
+++ b/raiden/smart_contracts/TokenNetworksRegistry.sol
@@ -5,16 +5,29 @@ import "./TokenNetwork.sol";
 import "./Utils.sol";
 
 contract TokenNetworkRegistry is Utils {
+
+    /*
+     *  Data structures
+     */
+
     string constant public contract_version = "0.3._";
 
     // Token address => TokenNetwork address
     mapping(address => address) public token_to_token_networks;
 
+    /*
+     *  Events
+     */
+
     event TokenNetworkCreated(address token_address, address token_network_address);
+
+    /*
+     *  External Functions
+     */
 
     function createERC20TokenNetwork(
         address _token_address)
-        public
+        external
         returns (address token_network_address)
     {
         require(_token_address != 0x0);
@@ -22,7 +35,6 @@ contract TokenNetworkRegistry is Utils {
         require(token_to_token_networks[_token_address] == 0x0);
 
         // Check if the contract is indeed a token contract
-        // TODO we might want to also check for the transfer function/ERC that we support
         require(Token(_token_address).totalSupply() > 0);
 
         token_network_address = new TokenNetwork(_token_address);

--- a/raiden/smart_contracts/TokenNetworksRegistry.sol
+++ b/raiden/smart_contracts/TokenNetworksRegistry.sol
@@ -2,9 +2,8 @@ pragma solidity ^0.4.17;
 
 import "./Token.sol";
 import "./TokenNetwork.sol";
-import "./Utils.sol";
 
-contract TokenNetworkRegistry is Utils {
+contract TokenNetworkRegistry {
 
     /*
      *  Data structures

--- a/raiden/smart_contracts/TokenNetworksRegistry.sol
+++ b/raiden/smart_contracts/TokenNetworksRegistry.sol
@@ -30,15 +30,11 @@ contract TokenNetworkRegistry is Utils {
         external
         returns (address token_network_address)
     {
-        require(_token_address != 0x0);
-        require(contractExists(_token_address));
         require(token_to_token_networks[_token_address] == 0x0);
 
-        // Check if the contract is indeed a token contract
-        require(Token(_token_address).totalSupply() > 0);
+        // Token contract checks are in the corresponding TokenNetwork contract
 
         token_network_address = new TokenNetwork(_token_address);
-
         TokenNetworkCreated(_token_address, token_network_address);
 
         return token_network_address;

--- a/raiden/smart_contracts/TokenNetworksRegistry.sol
+++ b/raiden/smart_contracts/TokenNetworksRegistry.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.4.19;
+
+import "./Token.sol";
+import "./TokenNetwork.sol";
+import "./Utils.sol";
+
+contract TokenNetworkRegistry is Utils {
+    string constant public contract_version = "0.3._";
+
+    // Token address => TokenNetwork address
+    mapping(address => address) public token_to_token_networks;
+
+    event TokenNetworkCreated(address token_address, address token_network_address);
+
+    function createERC20TokenNetwork(
+        address _token_address)
+        public
+        returns (address token_network_address)
+    {
+        require(_token_address != 0x0);
+        require(contractExists(_token_address));
+        require(token_to_token_networks[_token_address] == 0x0);
+
+        // Check if the contract is indeed a token contract
+        // TODO we might want to also check for the transfer function/ERC that we support
+        require(Token(_token_address).totalSupply() > 0);
+
+        token_network_address = new TokenNetwork(_token_address);
+
+        TokenNetworkCreated(_token_address, token_network_address);
+
+        return token_network_address;
+    }
+}

--- a/raiden/smart_contracts/TokenNetworksRegistry.sol
+++ b/raiden/smart_contracts/TokenNetworksRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.17;
 
 import "./Token.sol";
 import "./TokenNetwork.sol";

--- a/raiden/smart_contracts/TokenNetworksRegistry.sol
+++ b/raiden/smart_contracts/TokenNetworksRegistry.sol
@@ -1,15 +1,17 @@
 pragma solidity ^0.4.17;
 
+import "./Utils.sol";
 import "./Token.sol";
 import "./TokenNetwork.sol";
 
-contract TokenNetworkRegistry {
+contract TokenNetworkRegistry is Utils {
 
     /*
      *  Data structures
      */
 
     string constant public contract_version = "0.3._";
+    address public secret_registry_address;
 
     // Token address => TokenNetwork address
     mapping(address => address) public token_to_token_networks;
@@ -19,6 +21,16 @@ contract TokenNetworkRegistry {
      */
 
     event TokenNetworkCreated(address token_address, address token_network_address);
+
+    /*
+     *  Constructor
+     */
+
+    function TokenNetworkRegistry(address _secret_registry_address) public {
+        require(_secret_registry_address != 0x0);
+        require(contractExists(_secret_registry_address));
+        secret_registry_address = _secret_registry_address;
+    }
 
     /*
      *  External Functions
@@ -33,7 +45,7 @@ contract TokenNetworkRegistry {
 
         // Token contract checks are in the corresponding TokenNetwork contract
 
-        token_network_address = new TokenNetwork(_token_address);
+        token_network_address = new TokenNetwork(_token_address, secret_registry_address);
         TokenNetworkCreated(_token_address, token_network_address);
 
         return token_network_address;

--- a/raiden/smart_contracts/Utils.sol
+++ b/raiden/smart_contracts/Utils.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.17;
 
 contract Utils {
     string constant public contract_version = "0.3._";

--- a/raiden/smart_contracts/Utils.sol
+++ b/raiden/smart_contracts/Utils.sol
@@ -1,15 +1,16 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.19;
 
 contract Utils {
-    string constant public contract_version = "0.2._";
+    string constant public contract_version = "0.3._";
+
     /// @notice Check if a contract exists
-    /// @param channel The address to check whether a contract is deployed or not
+    /// @param contract_address The address to check whether a contract is deployed or not
     /// @return True if a contract exists, false otherwise
-    function contractExists(address channel) public constant returns (bool) {
+    function contractExists(address contract_address) public constant returns (bool) {
         uint size;
 
         assembly {
-            size := extcodesize(channel)
+            size := extcodesize(contract_address)
         }
 
         return size > 0;


### PR DESCRIPTION
WIP (discussion points are being added)
Contract restructuring
fixes https://github.com/raiden-network/raiden/issues/1171

! Implementation might change. !
I started integrating most of the changes from the start, to determine what data structures I would need. If necessary, after I have something ok, I can make smaller PRs with the changes.

Open discussion points:
- `settleTimeoutValid`: is 6 blocks enough? uRaiden has a min of 500
- `event TokenNetworkCreated(address token_address, address token_network_address, string token_interface_identifier);` -> e.g. `token_interface_identifier = "ERC20"` -  easier to get all of the erc20-compatible token networks.
- `updateTransfer` callable by anyone - allows `Monitoring Service` to monitor it’s own channels if needed (is this bad?; the participant can use other monitoring services any time)
- `event TransferUpdated(uint channel_identifier, address caller);` - now logs the `msg.sender` (3rd party for ex.) - is there a reason to log the participant on behalf of which the update was made? In the current state, I can only (additionally) log the `partner_address` that provided the signature.
- (note to self) see if a separate `ClosingRequest` structure + mapping makes sense.

Notes on Upgradability & libraries (will come later)
- `TokenNetwork` will contain the core code (library). We will have contracts for each token interface: e.g. `TokenNetworkERC20` 



Notes:
- `ChannelUnlocked` - event argument is `transferred_amount` - the entire amount, not the transfer value.

Settled:
- `closeChannel` - only called by a participant.
- `openChannel`: it is ok to be callable by anyone. Put this info in the specs.
- `deposit` - it won't return anything
- `updateTransfer` & `updateTransferDelegate` with 2 signatures (more details in the future commit)