### PR TITLE
Bugfix

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -95,7 +95,7 @@ def get_best_routes(
 
     available_routes = list()
 
-    token_network = views.get_token_network(
+    token_network = views.get_token_network_by_token_address(
         node_state,
         payment_network_id,
         token_address,


### PR DESCRIPTION
`get_token_network` accepts the token network id, not the corresponding token address