### PR TITLE
handling RaidenShuttingDown on test tear

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -12,9 +12,11 @@ import pytest
 from ethereum import slogging
 from ethereum.tools.keys import PBKDF2_CONSTANTS
 
+from raiden.exceptions import RaidenShuttingDown
 from raiden.tests.fixtures import *  # noqa: F401,F403
 
 gevent.get_hub().SYSTEM_ERROR = BaseException
+gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
 PBKDF2_CONSTANTS['c'] = 100
 
 CATCH_LOG_HANDLER_NAME = 'catch_log_handler'

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -3,6 +3,7 @@ import gevent
 import pytest
 from ethereum import slogging
 
+from raiden.exceptions import RaidenShuttingDown
 from raiden.network.protocol import NODE_NETWORK_REACHABLE
 from raiden.tests.utils.tests import cleanup_tasks
 from raiden.tests.utils.network import (
@@ -19,7 +20,10 @@ def _raiden_cleanup(request, raiden_apps):
     """ Helper to do cleanup a Raiden App. """
     def _cleanup():
         for app in raiden_apps:
-            app.stop(leave_channels=False)
+            try:
+                app.stop(leave_channels=False)
+            except RaidenShuttingDown:
+                pass
 
         # Two tests in sequence could run a UDP server on the same port, a hanging
         # greenlet from the previous tests could send packet to the new server and


### PR DESCRIPTION
I'm using these changes on my development branch, and it seems to reduce the number of flaky tests due to the `RaidenShuttingDown` exception