### PR TITLE
Test assumption about inclusive toBlock filter parameter

### DIFF
--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -205,7 +205,8 @@ def test_filter_start_block_inclusive(deploy_client, blockchain_backend):
 
 
 def test_filter_end_block_inclusive(deploy_client, blockchain_backend):
-    """ A filter includes events from the block given in from_block """
+    """ A filter includes events from the block given in from_block
+    until and including end_block. """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     # call the create event function twice and wait for confirmation each time


### PR DESCRIPTION
While testing the `BlockchainListener` in raiden-libs I found out that `toBlock` parameter in `eth-tester` is not inclusive while it is in geth. 

The Blockchain listener in microraiden relies on the geth behaviour, so I add a test for that so it's not forgotten when the test infrastructure changes.