### PR TITLE
a new design of refund transfer

### DIFF
--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -115,7 +115,13 @@ contract NettingChannelContract {
         );
         TransferUpdated(msg.sender);
     }
-
+    /// @notice unwithdraw a locked transfer, when refunding.
+    /// @param locked_encoded The locked transfer which should be discarded.
+    /// @param signature  receiver's sign of this transfer to prove that it should be discarded.
+    function unwithdraw(bytes locked_encoded, bytes signature) public {
+        // throws if sender is not a participant
+        data.unwithdraw(locked_encoded, signature);
+    }
     /// @notice Unlock a locked transfer.
     /// @param locked_encoded The locked transfer to be unlocked.
     /// @param merkle_proof The merke_proof for the locked transfer.

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -29,6 +29,8 @@ library NettingChannelLibrary {
 
         // A mapping to keep track of locks that have been withdrawn.
         mapping(bytes32 => bool) withdrawn_locks;
+        // A mapping to keep track of locks that have been unwithdrawn.
+        mapping(bytes32=>bool) unwithdrawn_locks;
     }
 
     struct Data {
@@ -213,7 +215,57 @@ library NettingChannelLibrary {
         var (r, s, v) = signatureSplit(signature);
         return ecrecover(signed_hash, v, r, s);
     }
+    function recoverAddressFromRawData(bytes rawdata,bytes signature)  constant
+        internal
+        returns (address) 
+    {
+        bytes32 signed_hash;
 
+        require(signature.length == 65);
+
+        signed_hash = keccak256(rawdata);
+
+        var (r, s, v) = signatureSplit(signature);
+        return ecrecover(signed_hash, v, r, s);
+    }
+    /// @notice unwithdraw a locked transfer
+    /// @dev unwithdraw a locked transfer
+    /// @param locked_encoded The lock
+    /// @param signature of the lock
+    function unwithdraw(
+        Data storage self,
+        bytes locked_encoded,
+        bytes signature
+    )
+        isClosed(self)
+        public
+    {
+        uint amount;
+        uint8 index;
+        uint64 expiration;
+        bytes32 hashlock;
+        address partner_address;
+
+        // Check if msg.sender is a participant and select the partner (for
+        // third party unlock see #541)
+        index = 1 - index_or_throw(self, msg.sender);
+        Participant storage counterparty = self.participants[index];
+
+        (expiration, amount, hashlock) = decodeLock(locked_encoded);
+        //negative amount is not allowed.
+        require(amount>0);
+
+        // this hashlock must have been withdrawed by 
+        require(counterparty.withdrawn_locks[hashlock] == true);
+        //this hashlock must have not been unwithdrawed.
+        require(counterparty.unwithdrawn_locks[hashlock] == false);
+        counterparty.unwithdrawn_locks[hashlock] = true;
+
+        partner_address = recoverAddressFromRawData(locked_encoded,signature);
+        require(partner_address==counterparty.node_address);
+        //get the tokens back, what about punishment? set mine transferred_amount to 0?
+        counterparty.transferred_amount += amount;
+    }
     /// @notice Unlock a locked transfer
     /// @dev Unlock a locked transfer
     /// @param locked_encoded The lock


### PR DESCRIPTION
## the faults of current refund transfer
1.  refund transfer will lock tokens that is no necessary. maybe only lock these tokens several seconds.
2. In a particular case, refund transfer  will result in a failure of the transfer. This will be my focus.

 channel A-B,  A deposits 100 tokens to Channel A-B and B deposits 50 tokens to Channel A-B. 
we can simplify this to Channel  A(100)-B(50).  we can use A(100)-B(50）to represent the channel above. 

for example. there are such channels below:
A(100)-B(50)  B(50)-C(0)  A(100)-D(100) D(100)-E(100) E(100)-C(0)
now A wants to transfer 60 tokens to C, as the shortest path first, raiden will choose path A-B-C.
but B doesn't have 60 tokens to C,so B have to send a refund transfer to A.  but B doesn't have  60 tokens send back to A,so this transfer have to fail. and A will lock 60 tokens and wait for the expiration of this transfer.
## Even though there is a valid path A-D-E-C .

# my design of refund 

Let's continue to use the example above. 
when B wants to refund,B sends    B's signature of that hashlock to A  and annouces that B will remove this transfer from memory and  will  not withdraw this hashlock on contract even B knows the secret of this  hashlock. if B withdraw this hashlock on contract, A can punish B with B's signature of that hashlock.

After receiving of B's signature of that hashlock, A can remove this transfer safely and try other paths. A will also monitor the raiden contract,once B withdraw that hashlock, A can punish B with B's signature.

this is the core idea of my refund design.

the faults:
1. add new code to contract which means more gas.

the advantages : 
1. if there is a valid path , we can make sure that that Transfer will be success.
2. Reducing the locked token can make other transfers more likely to succeed
3. reducing the difficulty of the mediated node. most code of mediator.py is proccesing refund and avoid potential errors and attacks.

