### PR TITLE
Increase tests reveal timeout

### DIFF
--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -37,7 +37,7 @@ def reveal_timeout():
     If using geth we set it considerably lower since waiting for
     too many blocks to be mined is very costly time-wise.
     """
-    return 4
+    return 8
 
 
 @pytest.fixture

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -14,6 +14,7 @@ from raiden.settings import (
     DEFAULT_PROTOCOL_THROTTLE_FILL_RATE,
 )
 from raiden.network.transport import UDPTransport
+from raiden.transfer.mediated_transfer.mediator import TRANSIT_BLOCKS
 from raiden.utils import sha3
 
 # we need to use fixture for the default values otherwise
@@ -21,13 +22,13 @@ from raiden.utils import sha3
 
 
 @pytest.fixture
-def settle_timeout():
+def settle_timeout(number_of_nodes, reveal_timeout):
     """
     NettingChannel default settle timeout for tests.
     If using geth we set it considerably lower since waiting for
     too many blocks to be mined is very costly time-wise.
     """
-    return 16
+    return number_of_nodes * (reveal_timeout + TRANSIT_BLOCKS)
 
 
 @pytest.fixture

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -21,7 +21,7 @@ from raiden.utils import sha3
 
 
 @pytest.fixture
-def settle_timeout(blockchain_type):
+def settle_timeout():
     """
     NettingChannel default settle timeout for tests.
     If using geth we set it considerably lower since waiting for
@@ -31,7 +31,7 @@ def settle_timeout(blockchain_type):
 
 
 @pytest.fixture
-def reveal_timeout(blockchain_type):
+def reveal_timeout():
     """
     NettingChannel default reveal timeout for tests.
     If using geth we set it considerably lower since waiting for

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -315,8 +315,8 @@ def test_secret_revealed(raiden_chain, deposit, settle_timeout, token_addresses)
 
     # Reveal the secret through the blockchain (this needs to emit the
     # SecretRevealed event)
-    unlock_proofs = channel.get_known_unlocks(channel_state2_1.partner_state)
-    netting_channel_proxy.withdraw(app2.raiden.address, unlock_proofs)
+    for unlock_proof in channel.get_known_unlocks(channel_state2_1.partner_state):
+        netting_channel_proxy.withdraw(unlock_proof)
 
     settle_expiration = app0.raiden.chain.block_number() + settle_timeout
     wait_until_block(app0.raiden.chain, settle_expiration)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -254,21 +254,13 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
 
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
-def test_close_channel_lack_of_balance_proof(
-        raiden_chain,
-        reveal_timeout,
-        deposit,
-        token_addresses
-):
-
+def test_close_channel_lack_of_balance_proof(raiden_chain, deposit, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
 
     token_proxy = app0.raiden.chain.token(token_address)
     initial_balance0 = token_proxy.balance_of(app0.raiden.address)
     initial_balance1 = token_proxy.balance_of(app1.raiden.address)
-
-    expiration = app0.raiden.get_block_number() + reveal_timeout * 2
 
     amount = 100
     identifier = 1
@@ -285,8 +277,6 @@ def test_close_channel_lack_of_balance_proof(
     reveal_secret = RevealSecret(secret)
     app0.raiden.sign(reveal_secret)
     udp_message_handler.on_udp_message(app1.raiden, reveal_secret)
-
-    assert app0.raiden.get_block_number() < expiration, 'increase the expiration'
 
     channel_state = get_channelstate(app0, app1, token_address)
     waiting.wait_for_settle(

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -16,6 +16,7 @@ from raiden.tests.utils.transfer import (
 )
 from raiden.transfer import channel
 from raiden.transfer.merkle_tree import validate_proof, merkleroot
+from raiden.transfer.state import UnlockProofState
 from raiden.transfer.state_change import (
     ActionForTokenNetwork,
     ContractReceiveChannelWithdraw,
@@ -148,7 +149,7 @@ def test_withdraw(raiden_network, token_addresses, deposit):
     nettingchannel_proxy = bob_app.raiden.chain.netting_channel(
         bob_alice_channel.identifier,
     )
-    nettingchannel_proxy.withdraw([unlock_proof])
+    nettingchannel_proxy.withdraw(unlock_proof)
 
     waiting.wait_for_settle(
         alice_app.raiden,
@@ -234,7 +235,7 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
     # withdraw must fail.
     netting_channel = app1.raiden.chain.netting_channel(channelstate_0_1.identifier)
     with pytest.raises(Exception):
-        netting_channel.withdraw([(unlock_proof, lock.encoded, secret)])
+        netting_channel.withdraw(UnlockProofState(unlock_proof, lock.encoded, secret))
 
     waiting.wait_for_settle(
         app1.raiden,
@@ -350,7 +351,7 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit):
 
     # since the attacker knows the secret he can net the lock
     attack_channel.netting_channel.withdraw(
-        [(unlock_proof, attack_transfer.lock, secret)],
+        UnlockProofState(unlock_proof, attack_transfer.lock, secret)
     )
     # XXX: verify that the secret was publicized
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -10,7 +10,13 @@ from raiden.tests.utils.transfer import (
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
-def test_mediated_transfer(raiden_network, deposit, token_addresses, network_wait):
+def test_mediated_transfer(
+        raiden_network,
+        number_of_nodes,
+        deposit,
+        token_addresses,
+        network_wait,
+):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
 
@@ -20,7 +26,7 @@ def test_mediated_transfer(raiden_network, deposit, token_addresses, network_wai
         app2,
         token_address,
         amount,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     assert_synched_channel_state(

--- a/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
@@ -119,8 +119,7 @@ def test_max(tester_chain, tester_nettingchannel_library_address):
 
 def test_merkle_proof_one_lock(tester_chain, tester_nettingchannel_library_address):
     """ computeMerkleRoot and the python implementation must compute the same
-    value for a merkle tree with a single lock.
-    """
+    value for a merkle tree with a single lock."""
 
     auxiliary = deploy_auxiliary_tester(tester_chain, tester_nettingchannel_library_address)
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -11,6 +11,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretReveal,
 )
 from raiden.transfer.mediated_transfer.events import (
+    EventWithdrawFailed,
     SendRevealSecret,
     SendSecretRequest,
 )
@@ -19,6 +20,7 @@ from raiden.transfer.state_change import (
     ReceiveUnlock,
 )
 from raiden.tests.utils import factories
+from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.factories import (
     HOP1,
     UNIT_HASHLOCK,
@@ -211,7 +213,7 @@ def test_handle_inittarget_bad_expiration():
 
     state_change = ActionInitTarget(payment_network_identifier, from_route, from_transfer)
     iteration = target.handle_inittarget(state_change, from_channel, block_number)
-    assert not iteration.events
+    assert must_contain_entry(iteration.events, EventWithdrawFailed, {})
 
 
 def test_handle_secretreveal():

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
+from binascii import hexlify
 from collections import namedtuple
 
 from raiden.constants import UINT256_MAX, UINT64_MAX
@@ -630,7 +631,8 @@ class UnlockProofState(State):
         self.secret = secret
 
     def __repr__(self):
-        return '<UnlockProofState>'
+        full_proof = [hexlify(entry) for entry in self.merkle_proof]
+        return f'<UnlockProofState proof:{full_proof} lock:{hexlify(self.lock_encoded)}>'
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
These builds failed because the lock ~expired too early~ reveal timeout was too short:

https://travis-ci.org/raiden-network/raiden/jobs/360941960#L1981
https://travis-ci.org/raiden-network/raiden/jobs/360932493#L2608

test_close_channel_lack_of_balance_proof was flaky, failling regularly
because the withdraw function was called too close to the lock
expiration.

In a sample failed test (events for the same node):
- [the secret was learned at block 10](https://travis-ci.org/raiden-network/raiden/jobs/361137080#L1904)
- [close was called on block 31](https://travis-ci.org/raiden-network/raiden/jobs/361137080#L1993)
- [close was confirmed by the event polling on block 34](https://travis-ci.org/raiden-network/raiden/jobs/361137080#L2008) (closed at block
  33) and withdraw was sent
- [The withdraw was mined on block 36 (0x24)](https://travis-ci.org/raiden-network/raiden/jobs/361137080#L2035), the [lock expired on block 35 (0000000000000023)](https://travis-ci.org/raiden-network/raiden/jobs/361137080#L2016), thus
the withdraw failed