### PR TITLE
removed ActionForTokenNetwork

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -16,10 +16,7 @@ from raiden.transfer.events import (
     EventTransferSentFailed,
     EventTransferReceivedSuccess,
 )
-from raiden.transfer.state_change import (
-    ActionForTokenNetwork,
-    ActionChannelClose,
-)
+from raiden.transfer.state_change import ActionChannelClose
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     ChannelNotFound,
@@ -314,13 +311,12 @@ class RaidenAPI:
         )
 
         for channel_state in channels_to_close:
-            channel_close = ActionChannelClose(channel_state.identifier)
-            state_change = ActionForTokenNetwork(
+            channel_close = ActionChannelClose(
                 registry_address,
                 token_address,
-                channel_close,
+                channel_state.identifier,
             )
-            self.raiden.handle_state_change(state_change)
+            self.raiden.handle_state_change(channel_close)
 
         msg = 'After {} seconds the deposit was not properly processed.'.format(
             poll_timeout

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -12,7 +12,6 @@ from raiden.blockchain.state import (
 from raiden.connection_manager import ConnectionManager
 from raiden.transfer import views
 from raiden.transfer.state_change import (
-    ActionForTokenNetwork,
     ContractReceiveChannelNew,
     ContractReceiveRouteNew,
     ContractReceiveNewTokenNetwork,
@@ -72,13 +71,12 @@ def handle_channel_new(raiden, event):
             channel_proxy,
         )
 
-        new_channel = ContractReceiveChannelNew(channel_state)
-        state_change = ActionForTokenNetwork(
+        new_channel = ContractReceiveChannelNew(
             payment_network_identifier,
             token_address,
-            new_channel,
+            channel_state,
         )
-        raiden.handle_state_change(state_change)
+        raiden.handle_state_change(new_channel)
 
         partner_address = channel_state.partner_state.address
         connection_manager = raiden.connection_manager_for_token(token_address)
@@ -100,15 +98,12 @@ def handle_channel_new(raiden, event):
         token_address = manager.token_address()
 
         new_route = ContractReceiveRouteNew(
+            payment_network_identifier,
+            token_address,
             participant1,
             participant2,
         )
-        state_change = ActionForTokenNetwork(
-            payment_network_identifier,
-            token_address,
-            new_route,
-        )
-        raiden.handle_state_change(state_change)
+        raiden.handle_state_change(new_route)
 
 
 def handle_channel_new_balance(raiden, event):
@@ -134,16 +129,13 @@ def handle_channel_new_balance(raiden, event):
         balance_was_zero = previous_balance == 0
 
         newbalance_statechange = ContractReceiveChannelNewBalance(
+            payment_network_identifier,
+            token_address,
             channel_identifier,
             participant_address,
             new_balance,
         )
-        state_change = ActionForTokenNetwork(
-            payment_network_identifier,
-            token_address,
-            newbalance_statechange,
-        )
-        raiden.handle_state_change(state_change)
+        raiden.handle_state_change(newbalance_statechange)
 
         if balance_was_zero:
             connection_manager = raiden.connection_manager_for_token(token_address)
@@ -168,16 +160,13 @@ def handle_channel_closed(raiden, event):
 
     if channel_state:
         channel_closed = ContractReceiveChannelClosed(
+            payment_network_identifier,
+            channel_state.token_address,
             channel_identifier,
             data['closing_address'],
             data['block_number'],
         )
-        state_change = ActionForTokenNetwork(
-            payment_network_identifier,
-            channel_state.token_address,
-            channel_closed,
-        )
-        raiden.handle_state_change(state_change)
+        raiden.handle_state_change(channel_closed)
 
 
 def handle_channel_settled(raiden, event):
@@ -193,15 +182,12 @@ def handle_channel_settled(raiden, event):
 
     if channel_state:
         channel_settled = ContractReceiveChannelSettled(
+            payment_network_identifier,
+            channel_state.token_address,
             channel_identifier,
             data['block_number'],
         )
-        state_change = ActionForTokenNetwork(
-            payment_network_identifier,
-            channel_state.token_address,
-            channel_settled,
-        )
-        raiden.handle_state_change(state_change)
+        raiden.handle_state_change(channel_settled)
 
 
 def handle_channel_withdraw(raiden, event):

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -37,7 +37,6 @@ from raiden.transfer.mediated_transfer.state import (
 )
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
-    ActionForTokenNetwork,
     ActionInitNode,
     ActionLeaveAllNetworks,
     ActionTransferDirect,
@@ -536,20 +535,16 @@ class RaidenService:
         if identifier is None:
             identifier = create_default_identifier()
 
+        registry_address = self.default_registry.address
         direct_transfer = ActionTransferDirect(
+            registry_address,
+            token_address,
             target,
             identifier,
             amount,
         )
 
-        registry_address = self.default_registry.address
-        state_change = ActionForTokenNetwork(
-            registry_address,
-            token_address,
-            direct_transfer,
-        )
-
-        self.handle_state_change(state_change)
+        self.handle_state_change(direct_transfer)
 
     def start_mediated_transfer(self, token_address, amount, identifier, target):
         self.protocol.start_health_check(target)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -174,7 +174,7 @@ def test_withdraw(raiden_network, token_addresses, deposit):
 
     assert must_contain_entry(state_changes, ContractReceiveChannelWithdraw, {
         'payment_network_identifier': registry_address,
-        'token_network_identifier': token_address,
+        'token_address': token_address,
         'channel_identifier': alice_bob_channel.identifier,
         'hashlock': hashlock,
         'secret': secret,

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -18,7 +18,8 @@ from raiden.transfer import channel
 from raiden.transfer.merkle_tree import validate_proof, merkleroot
 from raiden.transfer.state import UnlockProofState
 from raiden.transfer.state_change import (
-    ActionForTokenNetwork,
+    ContractReceiveChannelClosed,
+    ContractReceiveChannelSettled,
     ContractReceiveChannelWithdraw,
 )
 from raiden.utils import sha3
@@ -59,25 +60,19 @@ def test_settle_is_automatically_called(raiden_network, token_addresses, deposit
     assert channel_state.close_transaction.finished_block_number
     assert channel_state.settle_transaction.finished_block_number
 
-    # ContractReceiveChannelClosed
-    assert must_contain_entry(state_changes, ActionForTokenNetwork, {
+    assert must_contain_entry(state_changes, ContractReceiveChannelClosed, {
         'payment_network_identifier': registry_address,
-        'token_network_identifier': token_address,
-        'sub_state_change': {
-            'channel_identifier': channel_identifier,
-            'closing_address': app1.raiden.address,
-            'closed_block_number': channel_state.close_transaction.finished_block_number,
-        }
+        'token_address': token_address,
+        'channel_identifier': channel_identifier,
+        'closing_address': app1.raiden.address,
+        'closed_block_number': channel_state.close_transaction.finished_block_number,
     })
 
-    # ContractReceiveChannelSettled
-    assert must_contain_entry(state_changes, ActionForTokenNetwork, {
+    assert must_contain_entry(state_changes, ContractReceiveChannelSettled, {
         'payment_network_identifier': registry_address,
-        'token_network_identifier': token_address,
-        'sub_state_change': {
-            'channel_identifier': channel_identifier,
-            'settle_block_number': channel_state.settle_transaction.finished_block_number,
-        }
+        'token_address': token_address,
+        'channel_identifier': channel_identifier,
+        'settle_block_number': channel_state.settle_transaction.finished_block_number,
     })
 
 

--- a/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
+++ b/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from raiden.transfer.state_change import (
+    ActionTransferDirect,
+    ReceiveTransferDirect,
+)
 from raiden.tests.utils.transfer import direct_transfer
 from raiden.tests.utils.events import must_contain_entry
-from raiden.transfer.state_change import ActionForTokenNetwork
 
 
 @pytest.mark.parametrize('channels_per_node', [1])
@@ -29,28 +32,22 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
         to_identifier='latest',
     )
 
-    # ActionTransferDirect
-    assert must_contain_entry(app0_state_changes, ActionForTokenNetwork, {
+    assert must_contain_entry(app0_state_changes, ActionTransferDirect, {
         'token_network_identifier': token_address,
-        'sub_state_change': {
-            'identifier': identifier,
-            'amount': amount,
-            'receiver_address': app1.raiden.address,
-        }
+        'identifier': identifier,
+        'amount': amount,
+        'receiver_address': app1.raiden.address,
     })
 
-    # ReceiveTransferDirect
     app1_state_changes = app1.raiden.wal.storage.get_statechanges_by_identifier(
         from_identifier=0,
         to_identifier='latest',
     )
-    assert must_contain_entry(app1_state_changes, ActionForTokenNetwork, {
+    assert must_contain_entry(app1_state_changes, ReceiveTransferDirect, {
         'token_network_identifier': token_address,
-        'sub_state_change': {
-            'transfer_identifier': identifier,
-            'balance_proof': {
-                'transferred_amount': amount,
-                'sender': app0.raiden.address,
-            }
+        'transfer_identifier': identifier,
+        'balance_proof': {
+            'transferred_amount': amount,
+            'sender': app0.raiden.address,
         }
     })

--- a/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
+++ b/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
@@ -33,7 +33,7 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
     )
 
     assert must_contain_entry(app0_state_changes, ActionTransferDirect, {
-        'token_network_identifier': token_address,
+        'token_address': token_address,
         'identifier': identifier,
         'amount': amount,
         'receiver_address': app1.raiden.address,
@@ -44,7 +44,7 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
         to_identifier='latest',
     )
     assert must_contain_entry(app1_state_changes, ReceiveTransferDirect, {
-        'token_network_identifier': token_address,
+        'token_address': token_address,
         'transfer_identifier': identifier,
         'balance_proof': {
             'transferred_amount': amount,

--- a/raiden/tests/smart_contracts/netting_channel/test_close.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_close.py
@@ -5,7 +5,7 @@ from ethereum.tools.tester import TransactionFailed
 from coincurve import PrivateKey
 
 from raiden.messages import DirectTransfer
-from raiden.tests.utils.factories import make_address
+from raiden.tests.utils import factories
 from raiden.tests.utils.messages import make_direct_transfer
 from raiden.tests.utils.transfer import make_direct_transfer_from_channel
 from raiden.transfer.state import EMPTY_MERKLE_ROOT
@@ -65,8 +65,10 @@ def test_close_only_participant_can_close(tester_nettingcontracts):
 def test_close_first_argument_is_for_partner_transfer(tester_channels):
     """ Close must not accept a transfer from the closing address. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=90,
@@ -125,7 +127,7 @@ def test_close_wrong_channel(tester_channels):
     """ Close must not accept a transfer aimed at a different channel. """
     pkey0, pkey1, nettingchannel, channel0, _ = tester_channels[0]
     opened_block = nettingchannel.opened(sender=pkey0)
-    wrong_address = make_address()
+    wrong_address = factories.make_address()
 
     # make a transfer where the recipient is totally wrong
     transfer_wrong_channel = DirectTransfer(
@@ -219,8 +221,10 @@ def test_close_valid_tranfer_different_token(
 def test_close_tampered_identifier(tester_channels):
     """ Messages with a tampered identifier must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=90,
@@ -246,8 +250,10 @@ def test_close_tampered_identifier(tester_channels):
 def test_close_tampered_nonce(tester_channels):
     """ Messages with a tampered nonce must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=90,

--- a/raiden/tests/smart_contracts/netting_channel/test_settle.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_settle.py
@@ -2,6 +2,7 @@
 import pytest
 
 from raiden.messages import Lock
+from raiden.tests.utils import factories
 from raiden.tests.utils.transfer import (
     increase_transferred_amount,
     make_direct_transfer_from_channel,
@@ -71,6 +72,7 @@ def test_settle_single_direct_transfer_for_closing_party(
     """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -80,6 +82,7 @@ def test_settle_single_direct_transfer_for_closing_party(
 
     amount = 90
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount,
@@ -116,6 +119,7 @@ def test_settle_single_direct_transfer_for_counterparty(
     """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -125,6 +129,7 @@ def test_settle_single_direct_transfer_for_counterparty(
 
     amount = 90
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount,
@@ -160,6 +165,7 @@ def test_settle_two_direct_transfers(
     """ Test settle of a channel with two direct transfers. """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -169,6 +175,7 @@ def test_settle_two_direct_transfers(
 
     amount0 = 10
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount0,
@@ -177,6 +184,7 @@ def test_settle_two_direct_transfers(
 
     amount1 = 30
     transfer1 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel1,
         channel0,
         amount1,
@@ -226,6 +234,8 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
     """ Test settle with a locked mediated transfer for the counter party. """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
+
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
 
@@ -233,7 +243,13 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
     initial1 = tester_token.balanceOf(address1, sender=pkey0)
 
     transferred_amount0 = 30
-    increase_transferred_amount(channel0, channel1, transferred_amount0, pkey0)
+    increase_transferred_amount(
+        payment_network_identifier,
+        channel0,
+        channel1,
+        transferred_amount0,
+        pkey0,
+    )
 
     expiration0 = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
@@ -286,6 +302,8 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
     """ Test settle with a locked mediated transfer for the closing address. """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
+
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
 
@@ -293,7 +311,13 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
     initial1 = tester_token.balanceOf(address1, sender=pkey0)
 
     transferred_amount0 = 30
-    increase_transferred_amount(channel0, channel1, transferred_amount0, pkey0)
+    increase_transferred_amount(
+        payment_network_identifier,
+        channel0,
+        channel1,
+        transferred_amount0,
+        pkey0,
+    )
 
     expiration0 = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
@@ -340,6 +364,8 @@ def test_settle_two_locked_mediated_transfer_messages(
         tester_token):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
+
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
 
@@ -347,10 +373,22 @@ def test_settle_two_locked_mediated_transfer_messages(
     initial_balance1 = tester_token.balanceOf(address1, sender=pkey1)
 
     transferred_amount0 = 30
-    increase_transferred_amount(channel0, channel1, transferred_amount0, pkey0)
+    increase_transferred_amount(
+        payment_network_identifier,
+        channel0,
+        channel1,
+        transferred_amount0,
+        pkey0,
+    )
 
     transferred_amount1 = 70
-    increase_transferred_amount(channel1, channel0, transferred_amount1, pkey1)
+    increase_transferred_amount(
+        payment_network_identifier,
+        channel1,
+        channel0,
+        transferred_amount1,
+        pkey1,
+    )
 
     expiration0 = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
@@ -419,6 +457,7 @@ def test_two_direct_transfers(
     """ The value of both transfers must be account for. """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -428,6 +467,7 @@ def test_two_direct_transfers(
 
     first_amount0 = 90
     make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         first_amount0,
@@ -436,6 +476,7 @@ def test_two_direct_transfers(
 
     second_amount0 = 90
     second_direct0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         second_amount0,
@@ -475,6 +516,7 @@ def test_mediated_after_direct_transfer(
     """ The transfer types must not change the behavior of the dispute. """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -484,6 +526,7 @@ def test_mediated_after_direct_transfer(
 
     first_amount0 = 90
     make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         first_amount0,
@@ -536,6 +579,7 @@ def test_settlement_with_unauthorized_token_transfer(
         tester_token):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -545,6 +589,7 @@ def test_settlement_with_unauthorized_token_transfer(
 
     amount0 = 10
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount0,
@@ -553,6 +598,7 @@ def test_settlement_with_unauthorized_token_transfer(
 
     amount1 = 30
     transfer1 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel1,
         channel0,
         amount1,
@@ -598,6 +644,8 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
     """ Transferred amount can be larger than the deposit. """
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
+
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
 
@@ -606,8 +654,20 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
 
     # increase the transferred amount by three times the deposits
     for _ in range(3):
-        increase_transferred_amount(channel0, channel1, deposit, pkey0)
-        increase_transferred_amount(channel1, channel0, deposit, pkey1)
+        increase_transferred_amount(
+            payment_network_identifier,
+            channel0,
+            channel1,
+            deposit,
+            pkey0,
+        )
+        increase_transferred_amount(
+            payment_network_identifier,
+            channel1,
+            channel0,
+            deposit,
+            pkey1,
+        )
 
     transferred_amount0 = deposit * 3
     transferred_amount1 = deposit * 3
@@ -615,6 +675,7 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
     amount0 = 10
     transferred_amount0 += amount0
     direct0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount0,
@@ -624,6 +685,7 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
     amount1 = 30
     transferred_amount1 += amount1
     direct1 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel1,
         channel0,
         amount1,

--- a/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
@@ -4,7 +4,7 @@ from ethereum.tools.tester import TransactionFailed
 from coincurve import PrivateKey
 
 from raiden.messages import DirectTransfer
-from raiden.tests.utils.factories import make_address
+from raiden.tests.utils import factories
 from raiden.tests.utils.transfer import make_direct_transfer_from_channel
 from raiden.transfer.state import EMPTY_MERKLE_ROOT
 from raiden.utils import privatekey_to_address, sha3, event_decoder, address_encoder
@@ -17,8 +17,10 @@ def test_transfer_update_event(tester_channels, tester_events):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     address1 = privatekey_to_address(pkey1)
+    payment_network_identifier = factories.make_address()
 
     direct0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=90,
@@ -49,8 +51,10 @@ def test_transfer_update_event(tester_channels, tester_events):
 def test_update_fails_on_open_channel(tester_channels):
     """ Cannot call updateTransfer on a open channel. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,
@@ -72,8 +76,10 @@ def test_update_fails_on_open_channel(tester_channels):
 def test_update_not_allowed_after_settlement_period(settle_timeout, tester_channels, tester_chain):
     """ updateTransfer cannot be called after the settlement period. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     direct0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=70,
@@ -98,8 +104,10 @@ def test_update_not_allowed_after_settlement_period(settle_timeout, tester_chann
 def test_update_not_allowed_for_the_closing_address(tester_channels):
     """ Closing address cannot call updateTransfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,
@@ -107,6 +115,7 @@ def test_update_not_allowed_for_the_closing_address(tester_channels):
     )
 
     transfer1 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel1,
         channel0,
         amount=10,
@@ -182,7 +191,7 @@ def test_update_must_fail_with_a_channel_address(tester_channels):
     """ updateTransfer must not accept a transfer signed with the wrong channel address. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     opened_block = nettingchannel.opened(sender=pkey0)
-    wrong_channel = make_address()
+    wrong_channel = factories.make_address()
 
     # make a transfer where pkey1 is the target
     transfer_wrong_recipient = DirectTransfer(
@@ -217,8 +226,10 @@ def test_update_must_fail_with_a_channel_address(tester_channels):
 def test_update_called_multiple_times_same_transfer(tester_channels):
     """ updateTransfer can be called only once. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,
@@ -251,8 +262,10 @@ def test_update_called_multiple_times_same_transfer(tester_channels):
 def test_update_called_multiple_times_new_transfer(tester_channels):
     """ updateTransfer second call must fail even if there is a new transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,
@@ -260,6 +273,7 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
     )
 
     transfer1 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,
@@ -293,8 +307,10 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
 def test_update_called_multiple_times_older_transfer(tester_channels):
     """ updateTransfer second call must fail even if called with an older transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    payment_network_identifier = factories.make_address()
 
     transfer0 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,
@@ -302,6 +318,7 @@ def test_update_called_multiple_times_older_transfer(tester_channels):
     )
 
     transfer1 = make_direct_transfer_from_channel(
+        payment_network_identifier,
         channel0,
         channel1,
         amount=10,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -144,6 +144,7 @@ def create_channel_from_models(our_model, partner_model):
 
 
 def make_receive_transfer_direct(
+        payment_network_identifier,
         channel_state,
         privkey,
         nonce,
@@ -169,6 +170,8 @@ def make_receive_transfer_direct(
     balance_proof = balanceproof_from_envelope(mediated_transfer_msg)
 
     receive_directtransfer = ReceiveTransferDirect(
+        payment_network_identifier,
+        channel_state.token_address,
         identifier,
         balance_proof,
     )
@@ -274,10 +277,13 @@ def test_channelstate_update_contract_balance():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
     state_change = ContractReceiveChannelNewBalance(
+        payment_network_identifier,
+        channel_state.token_address,
         channel_state.identifier,
         our_model1.participant_address,
         balance1_new,
@@ -310,10 +316,13 @@ def test_channelstate_decreasing_contract_balance():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     amount = 10
     balance1_new = our_model1.balance - amount
     state_change = ContractReceiveChannelNewBalance(
+        payment_network_identifier,
+        channel_state.token_address,
         channel_state.identifier,
         our_model1.participant_address,
         balance1_new,
@@ -339,10 +348,13 @@ def test_channelstate_repeated_contract_balance():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
     state_change = ContractReceiveChannelNewBalance(
+        payment_network_identifier,
+        channel_state.token_address,
         channel_state.identifier,
         our_model1.participant_address,
         balance1_new,
@@ -546,12 +558,14 @@ def test_channelstate_directtransfer_overspent():
     our_model1, _ = create_model(70)
     partner_model1, privkey2 = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     distributable = channel.get_distributable(channel_state.partner_state, channel_state.our_state)
 
     nonce = 1
     transferred_amount = distributable + 1
     receive_mediatedtransfer = make_receive_transfer_direct(
+        payment_network_identifier,
         channel_state,
         privkey2,
         nonce,
@@ -999,10 +1013,12 @@ def test_receive_directdtransfer_before_deposit():
     our_model1, _ = create_model(0)  # our deposit is 0
     partner_model1, privkey2 = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     nonce = 1
     transferred_amount = 30
     receive_directtransfer = make_receive_transfer_direct(
+        payment_network_identifier,
         channel_state,
         privkey2,
         nonce,
@@ -1022,9 +1038,12 @@ def test_channelstate_withdraw_without_locks():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     closed_block_number = 77
     state_change = ContractReceiveChannelClosed(
+        payment_network_identifier,
+        channel_state.token_address,
         channel_state.identifier,
         partner_model1.participant_address,
         closed_block_number,
@@ -1038,6 +1057,7 @@ def test_channelstate_withdraw():
     our_model1, _ = create_model(70)
     partner_model1, privkey2 = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    payment_network_identifier = factories.make_address()
 
     lock_amount = 10
     lock_expiration = 100
@@ -1071,6 +1091,8 @@ def test_channelstate_withdraw():
     # at risk of expiring
     closed_block_number = lock_expiration - channel_state.reveal_timeout - 1
     state_change = ContractReceiveChannelClosed(
+        payment_network_identifier,
+        channel_state.token_address,
         channel_state.identifier,
         partner_model1.participant_address,
         closed_block_number,

--- a/raiden/tests/unit/test_operators.py
+++ b/raiden/tests/unit/test_operators.py
@@ -44,7 +44,7 @@ def test_transfer_statechange_operators():
     assert not a == c
 
     payment_network_identifier = factories.make_address()
-    token_address  = factories.make_address()
+    token_address = factories.make_address()
     a = ActionTransferDirect(
         payment_network_identifier,
         token_address,

--- a/raiden/tests/unit/test_operators.py
+++ b/raiden/tests/unit/test_operators.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from raiden.utils import sha3
+from raiden.messages import Processed
+from raiden.tests.utils import factories
 from raiden.transfer.state_change import (
     ActionCancelPayment,
     ActionTransferDirect,
@@ -10,7 +11,7 @@ from raiden.transfer.events import (
     EventTransferSentFailed,
     EventTransferReceivedSuccess,
 )
-from raiden.messages import Processed
+from raiden.utils import sha3
 
 
 ADDRESS = sha3(b'foo')[:20]
@@ -42,17 +43,25 @@ def test_transfer_statechange_operators():
     assert a != c
     assert not a == c
 
+    payment_network_identifier = factories.make_address()
+    token_address  = factories.make_address()
     a = ActionTransferDirect(
+        payment_network_identifier,
+        token_address,
         receiver_address=ADDRESS,
         identifier=2,
         amount=2,
     )
     b = ActionTransferDirect(
+        payment_network_identifier,
+        token_address,
         receiver_address=ADDRESS,
         identifier=2,
         amount=2,
     )
     c = ActionTransferDirect(
+        payment_network_identifier,
+        token_address,
         receiver_address=ADDRESS2,  # different recipient
         identifier=2,
         amount=2,

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -299,7 +299,13 @@ def assert_balance(from_channel, balance, locked):
     assert balance == amount_locked + distributable
 
 
-def increase_transferred_amount(from_channel, partner_channel, amount, pkey):
+def increase_transferred_amount(
+        payment_network_identifier,
+        from_channel,
+        partner_channel,
+        amount,
+        pkey,
+):
     # increasing the transferred amount by a value larger than distributable
     # would put one end of the channel in a negative balance, which is forbidden
     distributable_from_to = channel.get_distributable(
@@ -325,6 +331,8 @@ def increase_transferred_amount(from_channel, partner_channel, amount, pkey):
 
     balance_proof = balanceproof_from_envelope(direct_transfer_message)
     receive_direct = ReceiveTransferDirect(
+        payment_network_identifier,
+        from_channel.token_address,
         identifier,
         balance_proof,
     )
@@ -337,7 +345,13 @@ def increase_transferred_amount(from_channel, partner_channel, amount, pkey):
     return direct_transfer_message
 
 
-def make_direct_transfer_from_channel(from_channel, partner_channel, amount, pkey):
+def make_direct_transfer_from_channel(
+        payment_network_identifier,
+        from_channel,
+        partner_channel,
+        amount,
+        pkey,
+):
     """ Helper to create and register a direct transfer from `from_channel` to
     `partner_channel`."""
     identifier = channel.get_next_nonce(from_channel.our_state)
@@ -365,6 +379,8 @@ def make_direct_transfer_from_channel(from_channel, partner_channel, amount, pke
 
     balance_proof = balanceproof_from_envelope(direct_transfer_message)
     receive_direct = ReceiveTransferDirect(
+        payment_network_identifier,
+        from_channel.token_address,
         identifier,
         balance_proof,
     )

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -343,6 +343,8 @@ def make_direct_transfer_from_channel(from_channel, partner_channel, amount, pke
     identifier = channel.get_next_nonce(from_channel.our_state)
 
     state_change = ActionTransferDirect(
+        payment_network_identifier,
+        from_channel.token_address,
         from_channel.partner_state.address,
         identifier,
         amount,

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -17,14 +17,21 @@ from raiden.transfer.state import (
 )
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
-    ActionForTokenNetwork,
+    ActionChannelClose,
     ActionInitNode,
     ActionLeaveAllNetworks,
     ActionNewTokenNetwork,
+    ActionTransferDirect,
     Block,
+    ContractReceiveChannelClosed,
+    ContractReceiveChannelNew,
+    ContractReceiveChannelNewBalance,
+    ContractReceiveChannelSettled,
     ContractReceiveChannelWithdraw,
     ContractReceiveNewPaymentNetwork,
     ContractReceiveNewTokenNetwork,
+    ContractReceiveRouteNew,
+    ReceiveTransferDirect,
     ReceiveUnlock,
 )
 from raiden.transfer.mediated_transfer.state_change import (
@@ -372,7 +379,7 @@ def handle_token_network_action(node_state, state_change):
     if token_network_state:
         iteration = token_network.state_transition(
             token_network_state,
-            state_change.sub_state_change,
+            state_change,
             node_state.block_number,
         )
 
@@ -577,18 +584,23 @@ def state_transition(node_state, state_change):
             node_state,
             state_change,
         )
-    elif type(state_change) == ActionForTokenNetwork:
-        iteration = handle_token_network_action(
-            node_state,
-            state_change,
-        )
     elif type(state_change) == ActionNewTokenNetwork:
         iteration = handle_new_token_network(
             node_state,
             state_change,
         )
+    elif type(state_change) == ActionChannelClose:
+        iteration = handle_token_network_action(
+            node_state,
+            state_change,
+        )
     elif type(state_change) == ActionChangeNodeNetworkState:
         iteration = handle_node_change_network_state(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ActionTransferDirect:
+        iteration = handle_token_network_action(
             node_state,
             state_change,
         )
@@ -623,6 +635,36 @@ def state_transition(node_state, state_change):
         )
     elif type(state_change) == ContractReceiveChannelWithdraw:
         iteration = handle_channel_withdraw(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ContractReceiveChannelNew:
+        iteration = handle_token_network_action(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ContractReceiveChannelClosed:
+        iteration = handle_token_network_action(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ContractReceiveChannelNewBalance:
+        iteration = handle_token_network_action(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ContractReceiveChannelSettled:
+        iteration = handle_token_network_action(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ContractReceiveRouteNew:
+        iteration = handle_token_network_action(
+            node_state,
+            state_change,
+        )
+    elif type(state_change) == ReceiveTransferDirect:
+        iteration = handle_token_network_action(
             node_state,
             state_change,
         )

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -255,19 +255,19 @@ class PaymentMappingState(State):
 
     InitiatorTask = namedtuple('InitiatorTask', (
         'payment_network_identifier',
-        'token_network_identifier',
+        'token_address',
         'manager_state',
     ))
 
     MediatorTask = namedtuple('MediatorTask', (
         'payment_network_identifier',
-        'token_network_identifier',
+        'token_address',
         'mediator_state',
     ))
 
     TargetTask = namedtuple('TargetTask', (
         'payment_network_identifier',
-        'token_network_identifier',
+        'token_address',
         'channel_identifier',
         'target_state',
     ))

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -479,7 +479,7 @@ class ContractReceiveChannelWithdraw(StateChange):
     def __init__(
             self,
             payment_network_identifier,
-            token_network_identifier,
+            token_address,
             channel_identifier,
             secret,
             receiver: typing.Address):
@@ -490,7 +490,7 @@ class ContractReceiveChannelWithdraw(StateChange):
         hashlock = sha3(secret)
 
         self.payment_network_identifier = payment_network_identifier
-        self.token_network_identifier = token_network_identifier
+        self.token_address = token_address
         self.channel_identifier = channel_identifier
         self.secret = secret
         self.hashlock = hashlock

--- a/raiden/udp_message_handler.py
+++ b/raiden/udp_message_handler.py
@@ -8,7 +8,6 @@ from raiden.routing import get_best_routes
 from raiden.transfer import views
 from raiden.transfer.state import balanceproof_from_envelope
 from raiden.transfer.state_change import (
-    ActionForTokenNetwork,
     ReceiveTransferDirect,
     ReceiveUnlock,
 )
@@ -102,17 +101,13 @@ def handle_message_directtransfer(raiden: 'RaidenService', message: DirectTransf
     balance_proof = balanceproof_from_envelope(message)
 
     direct_transfer = ReceiveTransferDirect(
+        payment_network_identifier,
+        token_address,
         message.identifier,
         balance_proof,
     )
 
-    state_change = ActionForTokenNetwork(
-        payment_network_identifier,
-        token_address,
-        direct_transfer,
-    )
-
-    raiden.handle_state_change(state_change)
+    raiden.handle_state_change(direct_transfer)
 
 
 def handle_message_mediatedtransfer(raiden: 'RaidenService', message: MediatedTransfer):


### PR DESCRIPTION
ActionForTokenNetwork was initially added to remove duplicated code, but turns out that it made logs harder to read, tests harder to write, and dispatch a bit less explicit.

In retrospect I don't think it's worth having this class to save a few lines of boilerplate in the state change definitions.