### PR TITLE
fixed solidity warnings

### DIFF
--- a/raiden/smart_contracts/ChannelManagerContract.sol
+++ b/raiden/smart_contracts/ChannelManagerContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.21;
 
 import "./Token.sol";
 import "./Utils.sol";
@@ -39,11 +39,11 @@ contract ChannelManagerContract is Utils {
     {
         address old_channel = getChannelWith(partner);
         if (old_channel != 0) {
-            ChannelDeleted(msg.sender, partner);
+            emit ChannelDeleted(msg.sender, partner);
         }
 
         address new_channel = data.newChannel(partner, settle_timeout);
-        ChannelNew(new_channel, msg.sender, partner, settle_timeout);
+        emit ChannelNew(new_channel, msg.sender, partner, settle_timeout);
         return new_channel;
     }
 
@@ -84,6 +84,8 @@ contract ChannelManagerContract is Utils {
         uint i;
         uint pos;
         address[] memory result;
+        address address1;
+        address address2;
         NettingChannelContract channel;
 
         uint open_channels_num = 0;
@@ -101,7 +103,7 @@ contract ChannelManagerContract is Utils {
             }
             channel = NettingChannelContract(data.all_channels[i]);
 
-            var (address1, , address2, ) = channel.addressAndBalance();
+            (address1, , address2, ) = channel.addressAndBalance();
 
             result[pos] = address1;
             pos += 1;

--- a/raiden/smart_contracts/EndpointRegistry.sol
+++ b/raiden/smart_contracts/EndpointRegistry.sol
@@ -4,7 +4,7 @@
  * The Ethereum address registers his address in this registry.
 */
 
-pragma solidity ^0.4.16;
+pragma solidity ^0.4.21;
 
 contract EndpointRegistry{
     string constant public contract_version = "0.2._";
@@ -44,7 +44,7 @@ contract EndpointRegistry{
         socket_to_address[old_socket] = address(0);
         address_to_socket[msg.sender] = socket;
         socket_to_address[socket] = msg.sender;
-        AddressRegistered(msg.sender, socket);
+        emit AddressRegistered(msg.sender, socket);
     }
 
     /*

--- a/raiden/smart_contracts/HumanStandardToken.sol
+++ b/raiden/smart_contracts/HumanStandardToken.sol
@@ -49,7 +49,7 @@ contract HumanStandardToken is StandardToken {
         //call the receiveApproval function on the contract you want to be notified. This crafts the function signature manually so one doesn't have to include a contract in here just for this.
         //receiveApproval(address _from, uint256 _value, address _tokenContract, bytes _extraData)
         require(_spender.call(bytes4(bytes32(keccak256("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData));
-        Approval(msg.sender, _spender, _value);
+        emit Approval(msg.sender, _spender, _value);
         return true;
     }
 

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.21;
 
 import "./NettingChannelLibrary.sol";
 
@@ -53,7 +53,7 @@ contract NettingChannelContract {
         (success, balance) = data.deposit(amount);
 
         if (success == true) {
-            ChannelNewBalance(data.token, msg.sender, balance);
+            emit ChannelNewBalance(data.token, msg.sender, balance);
         }
 
         return success;
@@ -92,7 +92,7 @@ contract NettingChannelContract {
             extra_hash,
             signature
         );
-        ChannelClosed(msg.sender);
+        emit ChannelClosed(msg.sender);
     }
 
     /// @notice Dispute the state after closing, called by the counterparty (the
@@ -113,7 +113,7 @@ contract NettingChannelContract {
             extra_hash,
             signature
         );
-        TransferUpdated(msg.sender);
+        emit TransferUpdated(msg.sender);
     }
 
     /// @notice Unlock a locked transfer.
@@ -123,7 +123,7 @@ contract NettingChannelContract {
     function withdraw(bytes locked_encoded, bytes merkle_proof, bytes32 secret) public {
         // throws if sender is not a participant
         data.withdraw(locked_encoded, merkle_proof, secret);
-        ChannelSecretRevealed(secret, msg.sender);
+        emit ChannelSecretRevealed(secret, msg.sender);
     }
 
     /// @notice Settle the transfers and balances of the channel and pay out to
@@ -132,7 +132,7 @@ contract NettingChannelContract {
     ///         have passed.
     function settle() public {
         data.settle();
-        ChannelSettled();
+        emit ChannelSettled();
     }
 
     /// @notice Returns the number of blocks until the settlement timeout.

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -198,6 +198,9 @@ library NettingChannelLibrary {
         internal
         returns (address)
     {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
         bytes32 signed_hash;
 
         require(signature.length == 65);
@@ -210,7 +213,7 @@ library NettingChannelLibrary {
             extra_hash
         );
 
-        var (r, s, v) = signatureSplit(signature);
+        (r, s, v) = signatureSplit(signature);
         return ecrecover(signed_hash, v, r, s);
     }
 

--- a/raiden/smart_contracts/Registry.sol
+++ b/raiden/smart_contracts/Registry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.21;
 
 import "./ChannelManagerContract.sol";
 
@@ -39,7 +39,7 @@ contract Registry {
         registry[token_address] = manager_address;
         tokens.push(token_address);
 
-        TokenAdded(token_address, manager_address);
+        emit TokenAdded(token_address, manager_address);
 
         return manager_address;
     }

--- a/raiden/smart_contracts/StandardToken.sol
+++ b/raiden/smart_contracts/StandardToken.sol
@@ -6,7 +6,7 @@ If you deploy this, you won't have anything useful.
 
 Implements ERC 20 Token standard: https://github.com/ethereum/EIPs/issues/20
 .*/
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.21;
 import "./Token.sol";
 
 contract StandardToken is Token {
@@ -22,7 +22,7 @@ contract StandardToken is Token {
         if (balances[msg.sender] >= _value && _value > 0) {
             balances[msg.sender] -= _value;
             balances[_to] += _value;
-            Transfer(msg.sender, _to, _value);
+            emit Transfer(msg.sender, _to, _value);
             return true;
         } else { return false; }
     }
@@ -34,7 +34,7 @@ contract StandardToken is Token {
             balances[_to] += _value;
             balances[_from] -= _value;
             allowed[_from][msg.sender] -= _value;
-            Transfer(_from, _to, _value);
+            emit Transfer(_from, _to, _value);
             return true;
         } else { return false; }
     }
@@ -45,7 +45,7 @@ contract StandardToken is Token {
 
     function approve(address _spender, uint256 _value) public returns (bool success) {
         allowed[msg.sender][_spender] = _value;
-        Approval(msg.sender, _spender, _value);
+        emit Approval(msg.sender, _spender, _value);
         return true;
     }
 


### PR DESCRIPTION
- explicitely declaring variables instead of using the destructuring
`var`
- using the keyword `emit` for events
- increased the version to 0.4.21 for the contracts that used events