### PR TITLE
Fix race condition for event handling 

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -247,6 +247,9 @@ class BlockchainEvents:
                 # filters will no longer exist there. In that case we will need
                 # to recreate all the filters.
                 if not reinstalled_filters and str(e) == 'filter not found':
+                    if log.isEnabledFor('DEBUG'):
+                        log.debug('reinstalling eth filters')
+
                     result = list()
                     reinstalled_filters = True
                     updated_event_listerners = list()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -246,6 +246,10 @@ class RaidenService:
         # finish before starting the protocol
         endpoint_registration_event.join()
 
+        # Lock used to serialize calls to `poll_blockchain_events`, this is
+        # important to give a consistent view of the node state.
+        self.event_poll_lock = gevent.lock.Semaphore()
+
         self.start()
 
     def start(self):
@@ -368,10 +372,10 @@ class RaidenService:
     def get_block_number(self):
         return views.block_number(self.wal.state_manager.current_state)
 
-    def poll_blockchain_events(self, current_block=None):
-        # pylint: disable=unused-argument
-        for event in self.blockchain_events.poll_blockchain_events():
-            on_blockchain_event(self, event)
+    def poll_blockchain_events(self, current_block=None):  # pylint: disable=unused-argument
+        with self.event_poll_lock:
+            for event in self.blockchain_events.poll_blockchain_events():
+                on_blockchain_event(self, event)
 
     def sign(self, message):
         """ Sign message inplace. """

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -25,7 +25,8 @@ TEST_TOKEN_SWAP_SETTLE_TIMEOUT = (
 
 
 @pytest.mark.parametrize('privatekey_seed', ['test_token_registration:{}'])
-@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('number_of_nodes', [1])
+@pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('number_of_tokens', [1])
 def test_register_token(raiden_network, token_amount):
     app1 = raiden_network[0]

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -187,7 +187,10 @@ class TokenNetworkState(State):
         }
 
     def __repr__(self):
-        return '<TokenNetworkState id:{}>'.format(pex(self.address))
+        return '<TokenNetworkState id:{} token:{}>'.format(
+            pex(self.address),
+            pex(self.token_address),
+        )
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
The `RaidenAPI` calls `RaidenService.poll_blockchain_events` explicitely to
ensure that a transaction recently mined has all the events processed.
This is to update the node state and ensure the user of `RaidenAPI` will
see the expected effects applied.

The problem is that the `AlarmTask` can race with the transaction polling,
and *if* the event handler context-switches the effects may not be
applied once the `RaidenAPI` call returns. The introduced lock will
serialize all calls to `poll_blockchain_events`, forcing the `RaidenAPI`
to wait until the `AlarmTask` finish processing the events.

Note: This change will break if the events are *not* processed in the
`AlarmTask` greenlet.