### PR TITLE
Assure no rogue geth process if fixture fails early

### DIFF
--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -328,16 +328,24 @@ def geth_create_blockchain(
 
         processes_list.append(process)
 
-    geth_wait_and_check(deploy_client, private_keys, random_marker)
+    try:
+        geth_wait_and_check(deploy_client, private_keys, random_marker)
 
-    # reenter echo mode (disabled by geth pasphrase prompt)
-    if isinstance(sys.stdin, io.IOBase):
-        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, term_settings)
+        # reenter echo mode (disabled by geth pasphrase prompt)
+        if isinstance(sys.stdin, io.IOBase):
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, term_settings)
 
-    for process in processes_list:
-        process.poll()
+        for process in processes_list:
+            process.poll()
 
-        if process.returncode is not None:
-            raise ValueError('geth failed to start')
+            if process.returncode is not None:
+                raise ValueError('geth failed to start')
+
+    except (ValueError, RuntimeError) as e:
+        # If geth_wait_and_check or the above loop throw an exception make sure
+        # we don't end up with a rogue geth process running in the background
+        for proccess in processes_list:
+            process.terminate()
+        raise e
 
     return processes_list

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -331,10 +331,6 @@ def geth_create_blockchain(
     try:
         geth_wait_and_check(deploy_client, private_keys, random_marker)
 
-        # reenter echo mode (disabled by geth pasphrase prompt)
-        if isinstance(sys.stdin, io.IOBase):
-            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, term_settings)
-
         for process in processes_list:
             process.poll()
 
@@ -347,5 +343,10 @@ def geth_create_blockchain(
         for proccess in processes_list:
             process.terminate()
         raise e
+
+    finally:
+        # reenter echo mode (disabled by geth pasphrase prompt)
+        if isinstance(sys.stdin, io.IOBase):
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, term_settings)
 
     return processes_list


### PR DESCRIPTION
If geth's fixture building code fails early then we have to make sure that
we terminate the processes