### PR TITLE
Style guide: Multiline docstring should go on its own line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ def a(
 
     body comes
     here
-	"""
+    """
     pass
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,12 +228,13 @@ def a(
 ) -> D:
     """ Function Title
 
-        body comes
-        here"""
+    body comes
+    here
+	"""
     pass
 ```
 
-If in doubt consult the PEP.
+The closing quotes should be on their own line. If in doubt consult the PEP.
 
 **Breaking function calls when line is above 99 characters**
 


### PR DESCRIPTION
[skip ci]