### PR TITLE
smoketest: check if geth binary is missing and inform user accordingly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1237` Inform the user if geth binary is missing during raiden smoketest.
 * :feature:`1328` Use separate database directory per network id. This is a breaking change. You will need to copy your data from the previous directory to the new network id subdirectory.
 
 * :release:`0.3.0 <2018-02-22>`

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -73,8 +73,10 @@ $RST_GETH_BINARY
 """
 RST_GETH_BINARY = distutils.spawn.find_executable('geth')
 if not RST_GETH_BINARY:
-    print('Error: unable to locate geth binary.\n'
-          'Make sure it is installed and added to the PATH variable.')
+    print(
+        'Error: unable to locate geth binary.\n'
+        'Make sure it is installed and added to the PATH variable.'
+    )
     sys.exit(1)
 
 if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -6,6 +6,7 @@ from string import Template
 import distutils.spawn  # pylint: disable=import-error,no-name-in-module
 import json
 import os
+import sys
 import pdb
 import requests
 import shlex
@@ -71,6 +72,11 @@ $RST_GETH_BINARY
     --datadir $RST_DATADIR
 """
 RST_GETH_BINARY = distutils.spawn.find_executable('geth')
+if not RST_GETH_BINARY:
+    print('Error: unable to locate geth binary.\n'
+          'Make sure it is installed and added to the PATH variable.')
+    sys.exit(1)
+
 if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:
     os.environ['RST_GETH_BINARY'] = RST_GETH_BINARY
 


### PR DESCRIPTION
Should fix issue #1237.

If geth binary is missing `$ raiden smoketest` will fail and inform the user what went wrong.

```
$ raiden smoketest
Error: unable to locate geth binary.
Make sure it is installed and added to the PATH variable.

$ sudo pacman -S go-ethereum

$ raiden smoketest
[1/5] getting smoketest configuration
[2/5] starting ethereum
[3/5] starting raiden
[4/5] running smoketests...
[5/5] smoketest successful, report was written to /tmp/tmpsnpvtye2.log
```