### PR TITLE
Improve AccountManager error handling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`1195` Improve AccountManager error handling if keyfile is invalid.
 * :bug:`1237` Inform the user if geth binary is missing during raiden smoketest.
 * :feature:`1328` Use separate database directory per network id. This is a breaking change. You will need to copy your data from the previous directory to the new network id subdirectory.
 

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -59,13 +59,15 @@ class AccountManager:
                         with open(fullpath) as data_file:
                             data = json.load(data_file)
                             self.accounts[str(data['address']).lower()] = str(fullpath)
-                    except (ValueError, KeyError, IOError) as ex:
+                    except (KeyError, IOError, json.decoder.JSONDecodeError) as ex:
                         # Invalid file - skip
                         if f.startswith('UTC--'):
                             # Should be a valid account file - warn user
                             msg = 'Invalid account file'
                             if isinstance(ex, IOError):
                                 msg = 'Can not read account file'
+                            if isinstance(ex, json.decoder.JSONDecodeError):
+                                msg = 'The account file is not valid JSON format'
                             log.warning('%s %s: %s', msg, fullpath, ex)
 
     def address_in_keystore(self, address):

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -52,7 +52,14 @@ class AccountManager:
             self.keystore_path = find_keystoredir()
         if self.keystore_path is not None:
 
-            for f in os.listdir(self.keystore_path):
+            try:
+                files = os.listdir(self.keystore_path)
+            except OSError as ex:
+                msg = 'Unable to list the specified directory'
+                log.error('%s %s: %s', msg, self.keystore_path, ex)
+                return
+
+            for f in files:
                 fullpath = os.path.join(self.keystore_path, f)
                 if os.path.isfile(fullpath):
                     try:

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -65,7 +65,7 @@ class AccountManager:
                             # Should be a valid account file - warn user
                             msg = 'Invalid account file'
                             if isinstance(ex, IOError):
-                                msg = 'Can not read account file'
+                                msg = 'Can not read account file (errno=%s)' % ex.errno
                             if isinstance(ex, json.decoder.JSONDecodeError):
                                 msg = 'The account file is not valid JSON format'
                             log.warning('%s %s: %s', msg, fullpath, ex)

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -59,12 +59,12 @@ class AccountManager:
                         with open(fullpath) as data_file:
                             data = json.load(data_file)
                             self.accounts[str(data['address']).lower()] = str(fullpath)
-                    except (KeyError, IOError, json.decoder.JSONDecodeError) as ex:
+                    except (KeyError, OSError, IOError, json.decoder.JSONDecodeError) as ex:
                         # Invalid file - skip
                         if f.startswith('UTC--'):
                             # Should be a valid account file - warn user
                             msg = 'Invalid account file'
-                            if isinstance(ex, IOError):
+                            if isinstance(ex, IOError) or isinstance(ex, OSError):
                                 msg = 'Can not read account file (errno=%s)' % ex.errno
                             if isinstance(ex, json.decoder.JSONDecodeError):
                                 msg = 'The account file is not valid JSON format'

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -80,8 +80,8 @@ def test_account_manager_invalid_files(test_keystore, caplog):
         AccountManager(test_keystore)
 
     for msg, file_name, reason in [
-        ('Invalid account file', KEYFILE_INVALID, 'Expecting value: line 1 column 1 (char 0)'),
-        ('Can not read account file', KEYFILE_INACCESSIBLE, 'Permission denied')
+        ('The account file is not valid JSON format', KEYFILE_INVALID, 'Expecting value: line 1 column 1 (char 0)'),
+        ('Can not read account file (errno=13)', KEYFILE_INACCESSIBLE, 'Permission denied')
     ]:
         for record in caplog.records:
             message = record.getMessage()

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -80,7 +80,9 @@ def test_account_manager_invalid_files(test_keystore, caplog):
         AccountManager(test_keystore)
 
     for msg, file_name, reason in [
-        ('The account file is not valid JSON format', KEYFILE_INVALID, 'Expecting value: line 1 column 1 (char 0)'),
+        ('The account file is not valid JSON format',
+         KEYFILE_INVALID,
+         'Expecting value: line 1 column 1 (char 0)'),
         ('Can not read account file (errno=13)', KEYFILE_INACCESSIBLE, 'Permission denied')
     ]:
         for record in caplog.records:

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-import pytest
+from unittest.mock import patch
 
+import pytest
 from ethereum.utils import encode_hex
+
 from raiden.accounts import AccountManager
 from raiden.utils import get_project_root
-
 
 KEYFILE_INACCESSIBLE = 'UTC--2017-06-20T16-33-00.000000000Z--inaccessible'
 KEYFILE_INVALID = 'UTC--2017-06-20T16-06-00.000000000Z--invalid'
@@ -88,6 +89,22 @@ def test_account_manager_invalid_files(test_keystore, caplog):
         for record in caplog.records:
             message = record.getMessage()
             if msg in message and file_name in message and reason in message:
+                break
+        else:
+            assert False, "'{}' not in log messages".format(msg)
+
+
+def test_account_manager_invalid_directory(caplog):
+    with patch.object(os, 'listdir') as mock_listdir:
+        mock_listdir.side_effect = OSError
+        AccountManager('/some/path')
+
+    for msg, path, reason in [
+        ('Unable to list the specified directory', '/some/path', '')
+    ]:
+        for record in caplog.records:
+            message = record.getMessage()
+            if msg in message and path in message and reason in message:
                 break
         else:
             assert False, "'{}' not in log messages".format(msg)


### PR DESCRIPTION
Should fix issue #1195.

`json.decoder.JSONDecodeError` gets now catched explicitly and the user is informed that the account file is not valid JSON format.
I also added the error number in case an IOError occured to ease troubleshooting.

It is still possible that `os.listdir(self.keystore_path)` raises a PermissionError, but I'm not sure if this is in scope of this PR.