### PR TITLE
Fix usage of set, sets are mutable.

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -241,8 +241,8 @@ class ConnectionManager:
             self.token_address,
         )
         known = set(channel_state.partner_address for channel_state in open_channels)
-        known = known.add(self.BOOTSTRAP_ADDR)
-        known = known.add(self.raiden.address)
+        known.add(self.BOOTSTRAP_ADDR)
+        known.add(self.raiden.address)
 
         participants_addresses = views.get_participants_addresses(
             views.state_from_raiden(self.raiden),


### PR DESCRIPTION
Fixes #1359 


I looked at mypy output yesterday and it complained about the same thing:
```
raiden/connection_manager.py:244: error: "add" of "set" does not return a value
raiden/connection_manager.py:245: error: "add" of "set" does not return a value
```