### PR TITLE
Message queue

### DIFF
--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -40,7 +40,14 @@ log = slogging.get_logger(__name__)
 
 
 nonce = make_field('nonce', 8, '8s', integer(0, UINT64_MAX))
-identifier = make_field('identifier', 8, '8s', integer(0, UINT64_MAX))
+payment_identifier = make_field('payment_identifier', 8, '8s', integer(0, UINT64_MAX))
+message_identifier = make_field('message_identifier', 8, '8s', integer(0, UINT64_MAX))
+processed_message_identifier = make_field(
+    'processed_message_identifier',
+    8,
+    '8s',
+    integer(0, UINT64_MAX),
+)
 expiration = make_field('expiration', 8, '8s', integer(0, UINT64_MAX))
 
 token = make_field('token', 20, '20s')
@@ -53,7 +60,6 @@ channel = make_field('channel', 20, '20s')
 locksroot = make_field('locksroot', 32, '32s')
 secrethash = make_field('secrethash', 32, '32s')
 secret = make_field('secret', 32, '32s')
-echo = make_field('echo', 32, '32s')
 transferred_amount = make_field('transferred_amount', 32, '32s', integer(0, UINT256_MAX))
 amount = make_field('amount', 32, '32s', integer(0, UINT256_MAX))
 fee = make_field('fee', 32, '32s', integer(0, UINT256_MAX))
@@ -65,30 +71,31 @@ signature = make_field('signature', 65, '65s')
 Processed = namedbuffer(
     'processed',
     [
-        cmdid(PROCESSED),  # [0:1]
-        pad(3),      # [1:4]
+        cmdid(PROCESSED),
+        pad(3),
         sender,
-        echo,
+        processed_message_identifier,
     ]
 )
 
 Ping = namedbuffer(
     'ping',
     [
-        cmdid(PING),  # [0:1]
-        pad(3),       # [1:4]
-        nonce,        # [4:12]
-        signature,    # [12:77]
+        cmdid(PING),
+        pad(3),
+        nonce,
+        signature,
     ]
 )
 
 SecretRequest = namedbuffer(
     'secret_request',
     [
-        cmdid(SECRETREQUEST),  # [0:1]
-        pad(3),                # [1:4]
-        identifier,            # [4:12]
-        secrethash,              # [12:46]
+        cmdid(SECRETREQUEST),
+        pad(3),
+        message_identifier,
+        payment_identifier,
+        secrethash,
         amount,
         signature,
     ]
@@ -99,7 +106,8 @@ Secret = namedbuffer(
     [
         cmdid(SECRET),
         pad(3),
-        identifier,
+        message_identifier,
+        payment_identifier,
         secret,
         nonce,
         channel,
@@ -112,9 +120,10 @@ Secret = namedbuffer(
 RevealSecret = namedbuffer(
     'reveal_secret',
     [
-        cmdid(REVEALSECRET),  # [0:1]
-        pad(3),               # [1:4]
-        secret,               # [4:36]
+        cmdid(REVEALSECRET),
+        pad(3),
+        message_identifier,
+        secret,
         signature,
     ]
 )
@@ -125,7 +134,8 @@ DirectTransfer = namedbuffer(
         cmdid(DIRECTTRANSFER),
         pad(3),
         nonce,
-        identifier,
+        message_identifier,
+        payment_identifier,
         token,
         channel,
         recipient,
@@ -141,7 +151,8 @@ LockedTransfer = namedbuffer(
         cmdid(LOCKEDTRANSFER),
         pad(3),
         nonce,
-        identifier,
+        message_identifier,
+        payment_identifier,
         expiration,
         token,
         channel,
@@ -163,7 +174,8 @@ RefundTransfer = namedbuffer(
         cmdid(REFUNDTRANSFER),
         pad(3),
         nonce,
-        identifier,
+        message_identifier,
+        payment_identifier,
         expiration,
         token,
         channel,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -387,7 +387,7 @@ class Secret(EnvelopeMessage):
         if payment_identifier < 0:
             raise ValueError('payment_identifier cannot be negative')
 
-        if payment_identifier >= 2 ** 64:
+        if payment_identifier > UINT64_MAX:
             raise ValueError('payment_identifier is too large')
 
         if len(secret) != 32:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -75,7 +75,7 @@ def handle_send_revealsecret(
     reveal_secret_message = RevealSecret.from_event(reveal_secret_event)
     raiden.sign(reveal_secret_message)
     raiden.send_async(
-        reveal_secret_event.receiver,
+        reveal_secret_event.recipient,
         reveal_secret_message,
     )
 
@@ -87,7 +87,7 @@ def handle_send_balanceproof(
     secret_message = Secret.from_event(balance_proof_event)
     raiden.sign(secret_message)
     raiden.send_async(
-        balance_proof_event.receiver,
+        balance_proof_event.recipient,
         secret_message,
     )
 
@@ -99,7 +99,7 @@ def handle_send_secretrequest(
     secret_request_message = SecretRequest.from_event(secret_request_event)
     raiden.sign(secret_request_message)
     raiden.send_async(
-        secret_request_event.receiver,
+        secret_request_event.recipient,
         secret_request_message,
     )
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -278,7 +278,10 @@ class RaidenService:
         if self.wal.state_manager.current_state is None:
             block_number = self.chain.block_number()
 
-            state_change = ActionInitNode(block_number)
+            state_change = ActionInitNode(
+                random.Random(),
+                block_number,
+            )
             self.wal.log_and_dispatch(state_change, block_number)
         else:
             # Get the last known block number after reapplying all the state changes from the log
@@ -514,8 +517,8 @@ class RaidenService:
         async_result = self.start_mediated_transfer(
             token_address,
             amount,
-            identifier,
             target,
+            identifier,
         )
 
         return async_result
@@ -558,7 +561,7 @@ class RaidenService:
 
         self.handle_state_change(direct_transfer)
 
-    def start_mediated_transfer(self, token_address, amount, identifier, target):
+    def start_mediated_transfer(self, token_address, amount, target, identifier):
         self.protocol.start_health_check(target)
 
         if identifier is None:

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 
 from raiden import waiting, udp_message_handler
 from raiden.api.python import RaidenAPI
+from raiden.constants import UINT64_MAX
 from raiden.messages import RevealSecret
 from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.blockchain import wait_until_block
@@ -269,7 +272,10 @@ def test_close_channel_lack_of_balance_proof(raiden_chain, deposit, token_addres
     # Stop app0 to avoid sending the unlock
     app0.raiden.protocol.stop_and_wait()
 
-    reveal_secret = RevealSecret(secret)
+    reveal_secret = RevealSecret(
+        random.randint(0, UINT64_MAX),
+        secret,
+    )
     app0.raiden.sign(reveal_secret)
     udp_message_handler.on_udp_message(app1.raiden, reveal_secret)
 

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -193,7 +193,6 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     amount = 30
-    queueids_to_queues = dict()
 
     address0 = app0.raiden.address
     address1 = app1.raiden.address
@@ -224,13 +223,7 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
         secret,
         lock,
     )
-    claim_lock(
-        raiden_network,
-        queueids_to_queues,
-        identifier,
-        token_address,
-        secret,
-    )
+    claim_lock(raiden_network, identifier, token_address, secret)
 
     # Make a new transfer
     direct_transfer(app0, app1, token_address, amount, identifier=1)

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -193,6 +193,7 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     amount = 30
+    queueids_to_queues = dict()
 
     address0 = app0.raiden.address
     address1 = app1.raiden.address
@@ -223,7 +224,13 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
         secret,
         lock,
     )
-    claim_lock(raiden_network, identifier, token_address, secret)
+    claim_lock(
+        raiden_network,
+        queueids_to_queues,
+        identifier,
+        token_address,
+        secret,
+    )
 
     # Make a new transfer
     direct_transfer(app0, app1, token_address, amount, identifier=1)

--- a/raiden/tests/integration/transfer/test_directransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_directransfer_invalid.py
@@ -158,10 +158,10 @@ def test_receive_directtransfer_invalidsender(raiden_network, deposit, token_add
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_receive_directtransfer_invalidnonce(raiden_network, deposit, token_addresses):
+
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     channel0 = get_channelstate(app0, app1, token_address)
-    message_queue = list()
 
     transferred_amount = 10
     same_payment_identifier = 1
@@ -169,7 +169,6 @@ def test_receive_directtransfer_invalidnonce(raiden_network, deposit, token_addr
 
     event = channel.send_directtransfer(
         channel0,
-        message_queue,
         transferred_amount,
         message_identifier,
         same_payment_identifier,

--- a/raiden/tests/integration/transfer/test_directransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_directransfer_invalid.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 
 from raiden.api.python import RaidenAPI
+from raiden.constants import UINT64_MAX
 from raiden.messages import DirectTransfer
 from raiden.transfer import channel
 from raiden.transfer.state import EMPTY_MERKLE_ROOT
@@ -46,12 +49,14 @@ def test_receive_directtransfer_invalidtoken(raiden_network, deposit, token_addr
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     channel0 = get_channelstate(app0, app1, token_address)
+    message_identifier = random.randint(0, UINT64_MAX)
 
-    identifier = 1
+    payment_identifier = 1
     invalid_token_address = make_address()
     channel_identifier = channel0.identifier
     direct_transfer_message = DirectTransfer(
-        identifier=identifier,
+        message_identifier=message_identifier,
+        payment_identifier=payment_identifier,
         nonce=1,
         token=invalid_token_address,
         channel=channel_identifier,
@@ -84,11 +89,14 @@ def test_receive_directtransfer_invalidlocksroot(raiden_network, token_addresses
     balance0 = channel.get_balance(channel0.our_state, channel0.partner_state)
     balance1 = channel.get_balance(channel0.partner_state, channel0.our_state)
 
-    identifier = 1
+    payment_identifier = 1
     invalid_locksroot = UNIT_SECRETHASH
     channel_identifier = channel0.identifier
+    message_identifier = random.randint(0, UINT64_MAX)
+
     direct_transfer_message = DirectTransfer(
-        identifier=identifier,
+        message_identifier=message_identifier,
+        payment_identifier=payment_identifier,
         nonce=1,
         token=token_address,
         channel=channel_identifier,
@@ -120,8 +128,11 @@ def test_receive_directtransfer_invalidsender(raiden_network, deposit, token_add
 
     channel0 = get_channelstate(app0, app1, token_address)
     channel_identifier = channel0.identifier
+    message_identifier = random.randint(0, UINT64_MAX)
+
     direct_transfer_message = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1,
         token=token_address,
         channel=channel_identifier,
@@ -153,11 +164,14 @@ def test_receive_directtransfer_invalidnonce(raiden_network, deposit, token_addr
     channel0 = get_channelstate(app0, app1, token_address)
 
     transferred_amount = 10
-    same_identifier = 1
+    same_payment_identifier = 1
+    message_identifier = random.randint(0, UINT64_MAX)
+
     event = channel.send_directtransfer(
         channel0,
         transferred_amount,
-        same_identifier,
+        message_identifier,
+        same_payment_identifier,
     )
 
     direct_transfer_message = DirectTransfer.from_event(event)
@@ -170,8 +184,11 @@ def test_receive_directtransfer_invalidnonce(raiden_network, deposit, token_addr
 
     # Send a *different* direct transfer with the *same nonce*
     invalid_transferred_amount = transferred_amount // 2
+    message_identifier = random.randint(0, UINT64_MAX)
+
     invalid_direct_transfer_message = DirectTransfer(
-        identifier=same_identifier,
+        message_identifier=message_identifier,
+        payment_identifier=same_payment_identifier,
         nonce=1,
         token=token_address,
         channel=channel0.identifier,
@@ -213,8 +230,10 @@ def test_received_directtransfer_closedchannel(raiden_network, token_addresses, 
     )
 
     # Now receive one direct transfer for the closed channel
+    message_identifier = random.randint(0, UINT64_MAX)
     direct_transfer_message = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1,
         token=token_address,
         channel=channel0.identifier,

--- a/raiden/tests/integration/transfer/test_directransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_directransfer_invalid.py
@@ -158,10 +158,10 @@ def test_receive_directtransfer_invalidsender(raiden_network, deposit, token_add
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_receive_directtransfer_invalidnonce(raiden_network, deposit, token_addresses):
-
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     channel0 = get_channelstate(app0, app1, token_address)
+    message_queue = list()
 
     transferred_amount = 10
     same_payment_identifier = 1
@@ -169,6 +169,7 @@ def test_receive_directtransfer_invalidnonce(raiden_network, deposit, token_addr
 
     event = channel.send_directtransfer(
         channel0,
+        message_queue,
         transferred_amount,
         message_identifier,
         same_payment_identifier,

--- a/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
+++ b/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
@@ -34,7 +34,7 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
 
     assert must_contain_entry(app0_state_changes, ActionTransferDirect, {
         'token_address': token_address,
-        'identifier': identifier,
+        'payment_identifier': identifier,
         'amount': amount,
         'receiver_address': app1.raiden.address,
     })
@@ -45,7 +45,7 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
     )
     assert must_contain_entry(app1_state_changes, ReceiveTransferDirect, {
         'token_address': token_address,
-        'transfer_identifier': identifier,
+        'payment_identifier': identifier,
         'balance_proof': {
             'transferred_amount': amount,
             'sender': app0.raiden.address,

--- a/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
+++ b/raiden/tests/integration/transfer/test_directtransfer_statechanges.py
@@ -17,14 +17,14 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
     token_address = token_addresses[0]
 
     amount = int(deposit / 2.)
-    identifier = 13
+    payment_identifier = 13
 
     direct_transfer(
         app0,
         app1,
         token_address,
         amount,
-        identifier,
+        payment_identifier,
     )
 
     app0_state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
@@ -34,7 +34,7 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
 
     assert must_contain_entry(app0_state_changes, ActionTransferDirect, {
         'token_address': token_address,
-        'payment_identifier': identifier,
+        'payment_identifier': payment_identifier,
         'amount': amount,
         'receiver_address': app1.raiden.address,
     })
@@ -45,7 +45,7 @@ def test_log_directransfer(raiden_chain, token_addresses, deposit):
     )
     assert must_contain_entry(app1_state_changes, ReceiveTransferDirect, {
         'token_address': token_address,
-        'payment_identifier': identifier,
+        'payment_identifier': payment_identifier,
         'balance_proof': {
             'transferred_amount': amount,
             'sender': app0.raiden.address,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 
 from raiden.api.python import RaidenAPI
+from raiden.constants import UINT64_MAX
 from raiden.messages import (
     Lock,
     LockedTransfer,
@@ -90,11 +93,12 @@ def test_receive_lockedtransfer_invalidnonce(
     )
 
     amount = 10
-    identifier = 1
+    payment_identifier = 1
     repeated_nonce = 1
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
-        identifier=identifier,
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=payment_identifier,
         nonce=repeated_nonce,
         token=token_address,
         channel=channel0.identifier,
@@ -138,7 +142,8 @@ def test_receive_lockedtransfer_invalidsender(
     amount = 10
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
-        identifier=1,
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=1,
         nonce=1,
         token=token_address,
         channel=channel0.identifier,
@@ -178,12 +183,13 @@ def test_receive_lockedtransfer_invalidrecipient(
     token_address = token_addresses[0]
     channel0 = get_channelstate(app0, app1, token_address)
 
-    identifier = 1
+    payment_identifier = 1
     invalid_recipient = make_address()
     amount = 10
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
-        identifier=identifier,
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=payment_identifier,
         nonce=1,
         token=token_address,
         channel=channel0.identifier,
@@ -236,10 +242,11 @@ def test_received_lockedtransfer_closedchannel(
 
     # Now receive one mediated transfer for the closed channel
     amount = 10
-    identifier = 1
+    payment_identifier = 1
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
-        identifier=identifier,
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=payment_identifier,
         nonce=1,
         token=token_address,
         channel=channel0.identifier,

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 
+from raiden.constants import UINT64_MAX
 from raiden.messages import (
     RevealSecret,
     Secret,
@@ -27,7 +30,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     other_address = HOP1
     amount = 10
     refund_transfer_message = make_refund_transfer(
-        identifier=1,
+        payment_identifier=1,
         nonce=1,
         token=token_address,
         channel=other_address,
@@ -40,7 +43,8 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     sign_and_inject(refund_transfer_message, other_key, other_address, app0)
 
     secret = Secret(
-        identifier=1,
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=1,
         nonce=1,
         channel=make_address(),
         transferred_amount=amount,
@@ -49,8 +53,16 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     )
     sign_and_inject(secret, other_key, other_address, app0)
 
-    secret_request_message = SecretRequest(1, UNIT_SECRETHASH, 1)
+    secret_request_message = SecretRequest(
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=1,
+        secrethash=UNIT_SECRETHASH,
+        amount=1,
+    )
     sign_and_inject(secret_request_message, other_key, other_address, app0)
 
-    reveal_secret_message = RevealSecret(UNIT_SECRET)
+    reveal_secret_message = RevealSecret(
+        message_identifier=random.randint(0, UINT64_MAX),
+        secret=UNIT_SECRET,
+    )
     sign_and_inject(reveal_secret_message, other_key, other_address, app0)

--- a/raiden/tests/property/smart_contracts/strategies.py
+++ b/raiden/tests/property/smart_contracts/strategies.py
@@ -19,6 +19,7 @@ transferred_amount = integers(min_value=0, max_value=UINT256_MAX)
 def direct_transfer(draw, token, channel, recipient, locksroot):
     return DirectTransfer(
         draw(identifier),
+        draw(identifier),
         draw(nonce),
         draw(token),
         draw(channel),

--- a/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from binascii import hexlify
 import os
+import random
 import string
+from binascii import hexlify
 from itertools import chain, product
 
 import pytest
@@ -208,8 +209,10 @@ def test_signature_split(tester_chain, tester_nettingchannel_library_address):
     auxiliary = deploy_auxiliary_tester(tester_chain, tester_nettingchannel_library_address)
 
     privkey, address = make_privkey_address()
+    message_identifier = random.randint(0, UINT64_MAX)
     msg = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1,
         token='x' * 20,
         channel=auxiliary.address,
@@ -241,8 +244,10 @@ def test_recoverAddressFromSignature(tester_chain, tester_nettingchannel_library
     auxiliary = deploy_auxiliary_tester(tester_chain, tester_nettingchannel_library_address)
     privkey, address = make_privkey_address()
 
+    message_identifier = random.randint(0, UINT64_MAX)
     msg = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1,
         token='x' * 20,
         channel=auxiliary.address,

--- a/raiden/tests/smart_contracts/netting_channel/test_close.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_close.py
@@ -69,13 +69,11 @@ def test_close_first_argument_is_for_partner_transfer(tester_channels):
     """ Close must not accept a transfer from the closing address. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )
@@ -231,13 +229,11 @@ def test_close_tampered_identifier(tester_channels):
     """ Messages with a tampered identifier must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )
@@ -262,13 +258,11 @@ def test_close_tampered_nonce(tester_channels):
     """ Messages with a tampered nonce must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )

--- a/raiden/tests/smart_contracts/netting_channel/test_close.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_close.py
@@ -69,11 +69,13 @@ def test_close_first_argument_is_for_partner_transfer(tester_channels):
     """ Close must not accept a transfer from the closing address. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )
@@ -229,11 +231,13 @@ def test_close_tampered_identifier(tester_channels):
     """ Messages with a tampered identifier must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )
@@ -258,11 +262,13 @@ def test_close_tampered_nonce(tester_channels):
     """ Messages with a tampered nonce must be rejected. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )

--- a/raiden/tests/smart_contracts/netting_channel/test_close.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_close.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 from ethereum.tools import tester
 from ethereum.tools.tester import TransactionFailed
 from coincurve import PrivateKey
 
+from raiden.constants import UINT64_MAX
 from raiden.messages import DirectTransfer
 from raiden.tests.utils import factories
 from raiden.tests.utils.messages import make_direct_transfer
@@ -95,8 +98,10 @@ def test_close_accepts_only_transfer_from_participants(tester_channels, private_
     opened_block = nettingchannel.opened(sender=pkey0)
 
     # make a transfer where pkey0 is the target
+    message_identifier = random.randint(0, UINT64_MAX)
     transfer_nonparticipant = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1 + (opened_block * (2 ** 32)),
         token=channel0.token_address,
         channel=channel0.identifier,
@@ -130,8 +135,10 @@ def test_close_wrong_channel(tester_channels):
     wrong_address = factories.make_address()
 
     # make a transfer where the recipient is totally wrong
+    message_identifier = random.randint(0, UINT64_MAX)
     transfer_wrong_channel = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1 + (opened_block * (2 ** 32)),
         token=channel0.token_address,
         channel=wrong_address,
@@ -233,7 +240,7 @@ def test_close_tampered_identifier(tester_channels):
     transfer0_data = transfer0.encode()
 
     tampered_transfer = DirectTransfer.decode(transfer0_data)
-    tampered_transfer.identifier += 1
+    tampered_transfer.payment_identifier += 1
 
     tampered_transfer_hash = sha3(tampered_transfer.encode()[:-65])
     with pytest.raises(TransactionFailed):

--- a/raiden/tests/smart_contracts/netting_channel/test_settle.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_settle.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 
 from raiden.messages import Lock
@@ -235,6 +237,7 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -253,8 +256,18 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
 
     expiration0 = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
-    channel.state_transition(channel0, new_block, new_block.block_number)
-    channel.state_transition(channel1, new_block, new_block.block_number)
+    channel.state_transition(
+        channel0,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
+    channel.state_transition(
+        channel1,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
     lock0 = Lock(amount=29, expiration=expiration0, secrethash=sha3(b'lock1'))
     mediated0 = make_mediated_transfer(
         channel0,
@@ -303,6 +316,7 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -321,8 +335,18 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
 
     expiration0 = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
-    channel.state_transition(channel0, new_block, new_block.block_number)
-    channel.state_transition(channel1, new_block, new_block.block_number)
+    channel.state_transition(
+        channel0,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
+    channel.state_transition(
+        channel1,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
     lock0 = Lock(amount=29, expiration=expiration0, secrethash=sha3(b'lock1'))
     mediated0 = make_mediated_transfer(
         channel0,
@@ -365,6 +389,7 @@ def test_settle_two_locked_mediated_transfer_messages(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -392,8 +417,18 @@ def test_settle_two_locked_mediated_transfer_messages(
 
     expiration0 = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
-    channel.state_transition(channel0, new_block, new_block.block_number)
-    channel.state_transition(channel1, new_block, new_block.block_number)
+    channel.state_transition(
+        channel0,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
+    channel.state_transition(
+        channel1,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
     lock0 = Lock(amount=29, expiration=expiration0, secrethash=sha3(b'lock1'))
     mediated0 = make_mediated_transfer(
         channel0,
@@ -517,6 +552,7 @@ def test_mediated_after_direct_transfer(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -535,8 +571,18 @@ def test_mediated_after_direct_transfer(
 
     lock_expiration = tester_chain.block.number + reveal_timeout + 5
     new_block = Block(tester_chain.block.number)
-    channel.state_transition(channel0, new_block, new_block.block_number)
-    channel.state_transition(channel1, new_block, new_block.block_number)
+    channel.state_transition(
+        channel0,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
+    channel.state_transition(
+        channel1,
+        new_block,
+        pseudo_random_generator,
+        new_block.block_number,
+    )
     lock1 = Lock(amount=31, expiration=lock_expiration, secrethash=sha3(b'lock2'))
     second_mediated0 = make_mediated_transfer(
         channel0,

--- a/raiden/tests/smart_contracts/netting_channel/test_settle.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_settle.py
@@ -75,7 +75,6 @@ def test_settle_single_direct_transfer_for_closing_party(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -88,7 +87,6 @@ def test_settle_single_direct_transfer_for_closing_party(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount,
         pkey0,
     )
@@ -124,7 +122,6 @@ def test_settle_single_direct_transfer_for_counterparty(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -137,7 +134,6 @@ def test_settle_single_direct_transfer_for_counterparty(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount,
         pkey0,
     )
@@ -172,7 +168,6 @@ def test_settle_two_direct_transfers(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -185,7 +180,6 @@ def test_settle_two_direct_transfers(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount0,
         pkey0,
     )
@@ -195,7 +189,6 @@ def test_settle_two_direct_transfers(
         payment_network_identifier,
         channel1,
         channel0,
-        channel0to1_message_queue,
         amount1,
         pkey1,
     )
@@ -244,8 +237,6 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -259,7 +250,6 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         transferred_amount0,
         pkey0,
     )
@@ -268,14 +258,12 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -284,7 +272,6 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -329,8 +316,6 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -344,7 +329,6 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         transferred_amount0,
         pkey0,
     )
@@ -353,14 +337,12 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -369,7 +351,6 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -408,8 +389,6 @@ def test_settle_two_locked_mediated_transfer_messages(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -423,7 +402,6 @@ def test_settle_two_locked_mediated_transfer_messages(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         transferred_amount0,
         pkey0,
     )
@@ -433,7 +411,6 @@ def test_settle_two_locked_mediated_transfer_messages(
         payment_network_identifier,
         channel1,
         channel0,
-        channel1to0_message_queue,
         transferred_amount1,
         pkey1,
     )
@@ -442,14 +419,12 @@ def test_settle_two_locked_mediated_transfer_messages(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -458,7 +433,6 @@ def test_settle_two_locked_mediated_transfer_messages(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -470,7 +444,6 @@ def test_settle_two_locked_mediated_transfer_messages(
     mediated1 = make_mediated_transfer(
         channel1,
         channel0,
-        channel1to0_message_queue,
         address1,
         address0,
         lock1,
@@ -520,7 +493,6 @@ def test_two_direct_transfers(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -533,7 +505,6 @@ def test_two_direct_transfers(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         first_amount0,
         pkey0,
     )
@@ -543,7 +514,6 @@ def test_two_direct_transfers(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         second_amount0,
         pkey0,
     )
@@ -582,8 +552,6 @@ def test_mediated_after_direct_transfer(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel1to0_message_queue = list()
-    channel0to1_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -597,7 +565,6 @@ def test_mediated_after_direct_transfer(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         first_amount0,
         pkey0,
     )
@@ -606,14 +573,12 @@ def test_mediated_after_direct_transfer(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -622,7 +587,6 @@ def test_mediated_after_direct_transfer(
     second_mediated0 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock1,
@@ -662,7 +626,6 @@ def test_settlement_with_unauthorized_token_transfer(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -675,7 +638,6 @@ def test_settlement_with_unauthorized_token_transfer(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount0,
         pkey0,
     )
@@ -685,7 +647,6 @@ def test_settlement_with_unauthorized_token_transfer(
         payment_network_identifier,
         channel1,
         channel0,
-        channel0to1_message_queue,
         amount1,
         pkey1,
     )
@@ -730,8 +691,6 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -745,7 +704,6 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
             payment_network_identifier,
             channel0,
             channel1,
-            channel0to1_message_queue,
             deposit,
             pkey0,
         )
@@ -753,7 +711,6 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
             payment_network_identifier,
             channel1,
             channel0,
-            channel1to0_message_queue,
             deposit,
             pkey1,
         )
@@ -767,7 +724,6 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount0,
         pkey0,
     )
@@ -778,7 +734,6 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
         payment_network_identifier,
         channel1,
         channel0,
-        channel0to1_message_queue,
         amount1,
         pkey1,
     )

--- a/raiden/tests/smart_contracts/netting_channel/test_settle.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_settle.py
@@ -75,6 +75,7 @@ def test_settle_single_direct_transfer_for_closing_party(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -87,6 +88,7 @@ def test_settle_single_direct_transfer_for_closing_party(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount,
         pkey0,
     )
@@ -122,6 +124,7 @@ def test_settle_single_direct_transfer_for_counterparty(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -134,6 +137,7 @@ def test_settle_single_direct_transfer_for_counterparty(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount,
         pkey0,
     )
@@ -168,6 +172,7 @@ def test_settle_two_direct_transfers(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -180,6 +185,7 @@ def test_settle_two_direct_transfers(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount0,
         pkey0,
     )
@@ -189,6 +195,7 @@ def test_settle_two_direct_transfers(
         payment_network_identifier,
         channel1,
         channel0,
+        channel0to1_message_queue,
         amount1,
         pkey1,
     )
@@ -237,6 +244,8 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -250,6 +259,7 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         transferred_amount0,
         pkey0,
     )
@@ -258,12 +268,14 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -272,6 +284,7 @@ def test_settle_with_locked_mediated_transfer_for_counterparty(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -316,6 +329,8 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -329,6 +344,7 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         transferred_amount0,
         pkey0,
     )
@@ -337,12 +353,14 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -351,6 +369,7 @@ def test_settle_with_locked_mediated_transfer_for_closing_party(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -389,6 +408,8 @@ def test_settle_two_locked_mediated_transfer_messages(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -402,6 +423,7 @@ def test_settle_two_locked_mediated_transfer_messages(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         transferred_amount0,
         pkey0,
     )
@@ -411,6 +433,7 @@ def test_settle_two_locked_mediated_transfer_messages(
         payment_network_identifier,
         channel1,
         channel0,
+        channel1to0_message_queue,
         transferred_amount1,
         pkey1,
     )
@@ -419,12 +442,14 @@ def test_settle_two_locked_mediated_transfer_messages(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -433,6 +458,7 @@ def test_settle_two_locked_mediated_transfer_messages(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -444,6 +470,7 @@ def test_settle_two_locked_mediated_transfer_messages(
     mediated1 = make_mediated_transfer(
         channel1,
         channel0,
+        channel1to0_message_queue,
         address1,
         address0,
         lock1,
@@ -493,6 +520,7 @@ def test_two_direct_transfers(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -505,6 +533,7 @@ def test_two_direct_transfers(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         first_amount0,
         pkey0,
     )
@@ -514,6 +543,7 @@ def test_two_direct_transfers(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         second_amount0,
         pkey0,
     )
@@ -552,6 +582,8 @@ def test_mediated_after_direct_transfer(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel1to0_message_queue = list()
+    channel0to1_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -565,6 +597,7 @@ def test_mediated_after_direct_transfer(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         first_amount0,
         pkey0,
     )
@@ -573,12 +606,14 @@ def test_mediated_after_direct_transfer(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -587,6 +622,7 @@ def test_mediated_after_direct_transfer(
     second_mediated0 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock1,
@@ -626,6 +662,7 @@ def test_settlement_with_unauthorized_token_transfer(
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -638,6 +675,7 @@ def test_settlement_with_unauthorized_token_transfer(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount0,
         pkey0,
     )
@@ -647,6 +685,7 @@ def test_settlement_with_unauthorized_token_transfer(
         payment_network_identifier,
         channel1,
         channel0,
+        channel0to1_message_queue,
         amount1,
         pkey1,
     )
@@ -691,6 +730,8 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
 
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
@@ -704,6 +745,7 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
             payment_network_identifier,
             channel0,
             channel1,
+            channel0to1_message_queue,
             deposit,
             pkey0,
         )
@@ -711,6 +753,7 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
             payment_network_identifier,
             channel1,
             channel0,
+            channel1to0_message_queue,
             deposit,
             pkey1,
         )
@@ -724,6 +767,7 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount0,
         pkey0,
     )
@@ -734,6 +778,7 @@ def test_netting(deposit, settle_timeout, tester_channels, tester_chain, tester_
         payment_network_identifier,
         channel1,
         channel0,
+        channel0to1_message_queue,
         amount1,
         pkey1,
     )

--- a/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
@@ -21,11 +21,13 @@ def test_transfer_update_event(tester_channels, tester_events):
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     address1 = privatekey_to_address(pkey1)
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     direct0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )
@@ -55,11 +57,13 @@ def test_update_fails_on_open_channel(tester_channels):
     """ Cannot call updateTransfer on a open channel. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -80,11 +84,13 @@ def test_update_not_allowed_after_settlement_period(settle_timeout, tester_chann
     """ updateTransfer cannot be called after the settlement period. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     direct0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=70,
         pkey=pkey0,
     )
@@ -108,11 +114,14 @@ def test_update_not_allowed_for_the_closing_address(tester_channels):
     """ Closing address cannot call updateTransfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -121,6 +130,7 @@ def test_update_not_allowed_for_the_closing_address(tester_channels):
         payment_network_identifier,
         channel1,
         channel0,
+        channel1to0_message_queue,
         amount=10,
         pkey=pkey1,
     )
@@ -234,11 +244,13 @@ def test_update_called_multiple_times_same_transfer(tester_channels):
     """ updateTransfer can be called only once. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -270,11 +282,13 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
     """ updateTransfer second call must fail even if there is a new transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -283,6 +297,7 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -315,11 +330,13 @@ def test_update_called_multiple_times_older_transfer(tester_channels):
     """ updateTransfer second call must fail even if called with an older transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
+    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -328,6 +345,7 @@ def test_update_called_multiple_times_older_transfer(tester_channels):
         payment_network_identifier,
         channel0,
         channel1,
+        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )

--- a/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 from ethereum.tools.tester import TransactionFailed
 from coincurve import PrivateKey
 
+from raiden.constants import UINT64_MAX
 from raiden.messages import DirectTransfer
 from raiden.tests.utils import factories
 from raiden.tests.utils.transfer import make_direct_transfer_from_channel
@@ -157,8 +160,10 @@ def test_update_must_fail_with_a_nonparticipant_transfer(tester_channels, privat
     opened_block = nettingchannel.opened(sender=pkey0)
 
     # make a transfer where pkey1 is the target
+    message_identifier = random.randint(0, UINT64_MAX)
     transfer_nonparticipant = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1 + (opened_block * (2 ** 32)),
         token=channel0.token_address,
         channel=channel0.identifier,
@@ -194,8 +199,10 @@ def test_update_must_fail_with_a_channel_address(tester_channels):
     wrong_channel = factories.make_address()
 
     # make a transfer where pkey1 is the target
+    message_identifier = random.randint(0, UINT64_MAX)
     transfer_wrong_recipient = DirectTransfer(
-        identifier=1,
+        message_identifier=message_identifier,
+        payment_identifier=1,
         nonce=1 + (opened_block * (2 ** 32)),
         token=channel0.token_address,
         channel=wrong_channel,

--- a/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_updatetransfer.py
@@ -21,13 +21,11 @@ def test_transfer_update_event(tester_channels, tester_events):
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     address1 = privatekey_to_address(pkey1)
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     direct0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=90,
         pkey=pkey0,
     )
@@ -57,13 +55,11 @@ def test_update_fails_on_open_channel(tester_channels):
     """ Cannot call updateTransfer on a open channel. """
     pkey0, _, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -84,13 +80,11 @@ def test_update_not_allowed_after_settlement_period(settle_timeout, tester_chann
     """ updateTransfer cannot be called after the settlement period. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     direct0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=70,
         pkey=pkey0,
     )
@@ -114,14 +108,11 @@ def test_update_not_allowed_for_the_closing_address(tester_channels):
     """ Closing address cannot call updateTransfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -130,7 +121,6 @@ def test_update_not_allowed_for_the_closing_address(tester_channels):
         payment_network_identifier,
         channel1,
         channel0,
-        channel1to0_message_queue,
         amount=10,
         pkey=pkey1,
     )
@@ -244,13 +234,11 @@ def test_update_called_multiple_times_same_transfer(tester_channels):
     """ updateTransfer can be called only once. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -282,13 +270,11 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
     """ updateTransfer second call must fail even if there is a new transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -297,7 +283,6 @@ def test_update_called_multiple_times_new_transfer(tester_channels):
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -330,13 +315,11 @@ def test_update_called_multiple_times_older_transfer(tester_channels):
     """ updateTransfer second call must fail even if called with an older transfer. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     payment_network_identifier = factories.make_address()
-    channel0to1_message_queue = list()
 
     transfer0 = make_direct_transfer_from_channel(
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )
@@ -345,7 +328,6 @@ def test_update_called_multiple_times_older_transfer(tester_channels):
         payment_network_identifier,
         channel0,
         channel1,
-        channel0to1_message_queue,
         amount=10,
         pkey=pkey0,
     )

--- a/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
@@ -38,6 +38,8 @@ def test_withdraw(
         tester_token):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -53,12 +55,14 @@ def test_withdraw(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -68,6 +72,7 @@ def test_withdraw(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -201,6 +206,8 @@ def test_withdraw_at_settlement_block(
 
 def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_chain):
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     lock_timeout = reveal_timeout + 5
@@ -210,12 +217,14 @@ def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_chain):
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -225,6 +234,7 @@ def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_chain):
     mediated0 = make_mediated_transfer(
         channel1,
         channel0,
+        channel0to1_message_queue,
         privatekey_to_address(pkey0),
         privatekey_to_address(pkey1),
         lock1,
@@ -268,6 +278,8 @@ def test_withdraw_both_participants(
         tester_token):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -286,12 +298,14 @@ def test_withdraw_both_participants(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -304,6 +318,7 @@ def test_withdraw_both_participants(
     mediated01 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock01,
@@ -314,6 +329,7 @@ def test_withdraw_both_participants(
     mediated10 = make_mediated_transfer(
         channel1,
         channel0,
+        channel1to0_message_queue,
         address1,
         address0,
         lock10,
@@ -382,6 +398,8 @@ def test_withdraw_both_participants(
 def test_withdraw_twice(reveal_timeout, tester_channels, tester_chain):
     """ A lock can be withdrawn only once, the second try must fail. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
+    channel0to1_message_queue = list()
+    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     lock_expiration = tester_chain.block.number + reveal_timeout + 5
@@ -389,12 +407,14 @@ def test_withdraw_twice(reveal_timeout, tester_channels, tester_chain):
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
+        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -404,6 +424,7 @@ def test_withdraw_twice(reveal_timeout, tester_channels, tester_chain):
     mediated0 = make_mediated_transfer(
         channel1,
         channel0,
+        channel1to0_message_queue,
         privatekey_to_address(pkey1),
         privatekey_to_address(pkey0),
         lock,
@@ -655,6 +676,7 @@ def test_withdraw_lock_with_a_large_expiration(
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
+    channel0to1_message_queue = list()
     pseudo_random_generator = random.Random()
 
     initial_balance0 = tester_token.balanceOf(address0, sender=pkey0)
@@ -667,6 +689,7 @@ def test_withdraw_lock_with_a_large_expiration(
     bad_block_number = lock_expiration - 10
     channel.state_transition(
         channel0,
+        channel0to1_message_queue,
         Block(bad_block_number),
         pseudo_random_generator,
         bad_block_number,
@@ -683,6 +706,7 @@ def test_withdraw_lock_with_a_large_expiration(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
+        channel0to1_message_queue,
         address0,
         address1,
         lock,

--- a/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
@@ -38,8 +38,6 @@ def test_withdraw(
         tester_token):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -55,14 +53,12 @@ def test_withdraw(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -72,7 +68,6 @@ def test_withdraw(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock0,
@@ -206,8 +201,6 @@ def test_withdraw_at_settlement_block(
 
 def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_chain):
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     lock_timeout = reveal_timeout + 5
@@ -217,14 +210,12 @@ def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_chain):
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -234,7 +225,6 @@ def test_withdraw_expired_lock(reveal_timeout, tester_channels, tester_chain):
     mediated0 = make_mediated_transfer(
         channel1,
         channel0,
-        channel0to1_message_queue,
         privatekey_to_address(pkey0),
         privatekey_to_address(pkey1),
         lock1,
@@ -278,8 +268,6 @@ def test_withdraw_both_participants(
         tester_token):
 
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     address0 = privatekey_to_address(pkey0)
@@ -298,14 +286,12 @@ def test_withdraw_both_participants(
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -318,7 +304,6 @@ def test_withdraw_both_participants(
     mediated01 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock01,
@@ -329,7 +314,6 @@ def test_withdraw_both_participants(
     mediated10 = make_mediated_transfer(
         channel1,
         channel0,
-        channel1to0_message_queue,
         address1,
         address0,
         lock10,
@@ -398,8 +382,6 @@ def test_withdraw_both_participants(
 def test_withdraw_twice(reveal_timeout, tester_channels, tester_chain):
     """ A lock can be withdrawn only once, the second try must fail. """
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
-    channel0to1_message_queue = list()
-    channel1to0_message_queue = list()
     pseudo_random_generator = random.Random()
 
     lock_expiration = tester_chain.block.number + reveal_timeout + 5
@@ -407,14 +389,12 @@ def test_withdraw_twice(reveal_timeout, tester_channels, tester_chain):
     new_block = Block(tester_chain.block.number)
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
     )
     channel.state_transition(
         channel1,
-        channel1to0_message_queue,
         new_block,
         pseudo_random_generator,
         new_block.block_number,
@@ -424,7 +404,6 @@ def test_withdraw_twice(reveal_timeout, tester_channels, tester_chain):
     mediated0 = make_mediated_transfer(
         channel1,
         channel0,
-        channel1to0_message_queue,
         privatekey_to_address(pkey1),
         privatekey_to_address(pkey0),
         lock,
@@ -676,7 +655,6 @@ def test_withdraw_lock_with_a_large_expiration(
     pkey0, pkey1, nettingchannel, channel0, channel1 = tester_channels[0]
     address0 = privatekey_to_address(pkey0)
     address1 = privatekey_to_address(pkey1)
-    channel0to1_message_queue = list()
     pseudo_random_generator = random.Random()
 
     initial_balance0 = tester_token.balanceOf(address0, sender=pkey0)
@@ -689,7 +667,6 @@ def test_withdraw_lock_with_a_large_expiration(
     bad_block_number = lock_expiration - 10
     channel.state_transition(
         channel0,
-        channel0to1_message_queue,
         Block(bad_block_number),
         pseudo_random_generator,
         bad_block_number,
@@ -706,7 +683,6 @@ def test_withdraw_lock_with_a_large_expiration(
     mediated0 = make_mediated_transfer(
         channel0,
         channel1,
-        channel0to1_message_queue,
         address0,
         address1,
         lock,

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import random
+
 import pytest
 
 from raiden.messages import (
@@ -46,23 +48,26 @@ def test_hash():
 
 
 def test_processed():
-    echo = sha3(b'random')
-    processed_message = Processed(ADDRESS, echo)
-    assert processed_message.echo == echo
+    processed_message_identifier = random.randint(0, UINT64_MAX)
+    processed_message = Processed(ADDRESS, processed_message_identifier)
+
+    assert processed_message.processed_message_identifier == processed_message_identifier
+
     data = processed_message.encode()
-    msghash = sha3(data)
     decoded_processed_message = decode(data)
-    assert decoded_processed_message.echo == processed_message.echo
+
+    assert decoded_processed_message.processed_message_identifier == processed_message_identifier
+    assert processed_message.processed_message_identifier == processed_message_identifier
     assert decoded_processed_message.sender == processed_message.sender
-    assert sha3(decoded_processed_message.encode()) == msghash
+    assert sha3(decoded_processed_message.encode()) == sha3(data)
 
 
-@pytest.mark.parametrize('identifier', [0, UINT64_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
 @pytest.mark.parametrize('nonce', [1, UINT64_MAX])
 @pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
-def test_direct_transfer_min_max(identifier, nonce, transferred_amount):
+def test_direct_transfer_min_max(payment_identifier, nonce, transferred_amount):
     direct_transfer = make_direct_transfer(
-        identifier=identifier,
+        payment_identifier=payment_identifier,
         nonce=nonce,
         transferred_amount=transferred_amount,
     )
@@ -72,14 +77,14 @@ def test_direct_transfer_min_max(identifier, nonce, transferred_amount):
 
 
 @pytest.mark.parametrize('amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('identifier', [0, UINT64_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
 @pytest.mark.parametrize('nonce', [1, UINT64_MAX])
 @pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
 @pytest.mark.parametrize('fee', [0, UINT256_MAX])
-def test_mediated_transfer_min_max(amount, identifier, fee, nonce, transferred_amount):
+def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, transferred_amount):
     mediated_transfer = make_mediated_transfer(
         amount=amount,
-        identifier=identifier,
+        payment_identifier=payment_identifier,
         nonce=nonce,
         fee=fee,
         transferred_amount=transferred_amount,
@@ -90,13 +95,13 @@ def test_mediated_transfer_min_max(amount, identifier, fee, nonce, transferred_a
 
 
 @pytest.mark.parametrize('amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('identifier', [0, UINT64_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
 @pytest.mark.parametrize('nonce', [1, UINT64_MAX])
 @pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
-def test_refund_transfer_min_max(amount, identifier, nonce, transferred_amount):
+def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_amount):
     refund_transfer = make_refund_transfer(
         amount=amount,
-        identifier=identifier,
+        payment_identifier=payment_identifier,
         nonce=nonce,
         transferred_amount=transferred_amount,
     )

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -290,7 +290,6 @@ def test_channelstate_update_contract_balance():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     token_address = factories.make_address()
     payment_network_identifier = factories.make_address()
-    partner_channel_message_queue = list()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
@@ -310,7 +309,6 @@ def test_channelstate_update_contract_balance():
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         deepcopy(channel_state),
-        partner_channel_message_queue,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -340,7 +338,6 @@ def test_channelstate_decreasing_contract_balance():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     payment_network_identifier = factories.make_address()
     token_address = factories.make_address()
-    partner_channel_message_queue = list()
 
     amount = 10
     balance1_new = our_model1.balance - amount
@@ -360,7 +357,6 @@ def test_channelstate_decreasing_contract_balance():
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         deepcopy(channel_state),
-        partner_channel_message_queue,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -383,7 +379,6 @@ def test_channelstate_repeated_contract_balance():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     payment_network_identifier = factories.make_address()
     token_address = factories.make_address()
-    partner_channel_message_queue = list()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
@@ -411,7 +406,6 @@ def test_channelstate_repeated_contract_balance():
     for _ in range(10):
         iteration = channel.state_transition(
             deepcopy(channel_state),
-            partner_channel_message_queue,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -431,7 +425,6 @@ def test_deposit_must_wait_for_confirmation():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     payment_network_identifier = factories.make_address()
     token_address = factories.make_address()
-    partner_channel_message_queue = list()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
@@ -459,7 +452,6 @@ def test_deposit_must_wait_for_confirmation():
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         deepcopy(channel_state),
-        partner_channel_message_queue,
         new_balance,
         pseudo_random_generator,
         block_number,
@@ -470,7 +462,6 @@ def test_deposit_must_wait_for_confirmation():
         unconfirmed_block = Block(block_number)
         iteration = channel.state_transition(
             deepcopy(unconfirmed_state),
-            partner_channel_message_queue,
             unconfirmed_block,
             pseudo_random_generator,
             block_number,
@@ -491,7 +482,6 @@ def test_deposit_must_wait_for_confirmation():
     confirmed_block = Block(confirmed_deposit_block_number)
     iteration = channel.state_transition(
         deepcopy(unconfirmed_state),
-        partner_channel_message_queue,
         confirmed_block,
         pseudo_random_generator,
         confirmed_deposit_block_number,
@@ -510,7 +500,6 @@ def test_channelstate_send_lockedtransfer():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
-    partner_channel_message_queue = list()
 
     lock_amount = 30
     lock_expiration = 10
@@ -530,7 +519,6 @@ def test_channelstate_send_lockedtransfer():
 
     channel.send_lockedtransfer(
         channel_state,
-        partner_channel_message_queue,
         transfer_initiator,
         transfer_target,
         lock_amount,
@@ -560,14 +548,12 @@ def test_channelstate_send_direct_transfer():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
-    partner_channel_message_queue = list()
 
     amount = 30
     payment_identifier = 1
     message_identifier = random.randint(0, UINT64_MAX)
     channel.send_directtransfer(
         channel_state,
-        partner_channel_message_queue,
         amount,
         message_identifier,
         payment_identifier,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -290,6 +290,7 @@ def test_channelstate_update_contract_balance():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     token_address = factories.make_address()
     payment_network_identifier = factories.make_address()
+    partner_channel_message_queue = list()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
@@ -309,6 +310,7 @@ def test_channelstate_update_contract_balance():
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         deepcopy(channel_state),
+        partner_channel_message_queue,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -338,6 +340,7 @@ def test_channelstate_decreasing_contract_balance():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     payment_network_identifier = factories.make_address()
     token_address = factories.make_address()
+    partner_channel_message_queue = list()
 
     amount = 10
     balance1_new = our_model1.balance - amount
@@ -357,6 +360,7 @@ def test_channelstate_decreasing_contract_balance():
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         deepcopy(channel_state),
+        partner_channel_message_queue,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -379,6 +383,7 @@ def test_channelstate_repeated_contract_balance():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     payment_network_identifier = factories.make_address()
     token_address = factories.make_address()
+    partner_channel_message_queue = list()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
@@ -406,6 +411,7 @@ def test_channelstate_repeated_contract_balance():
     for _ in range(10):
         iteration = channel.state_transition(
             deepcopy(channel_state),
+            partner_channel_message_queue,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -425,6 +431,7 @@ def test_deposit_must_wait_for_confirmation():
     channel_state = create_channel_from_models(our_model1, partner_model1)
     payment_network_identifier = factories.make_address()
     token_address = factories.make_address()
+    partner_channel_message_queue = list()
 
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
@@ -452,6 +459,7 @@ def test_deposit_must_wait_for_confirmation():
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         deepcopy(channel_state),
+        partner_channel_message_queue,
         new_balance,
         pseudo_random_generator,
         block_number,
@@ -462,6 +470,7 @@ def test_deposit_must_wait_for_confirmation():
         unconfirmed_block = Block(block_number)
         iteration = channel.state_transition(
             deepcopy(unconfirmed_state),
+            partner_channel_message_queue,
             unconfirmed_block,
             pseudo_random_generator,
             block_number,
@@ -482,6 +491,7 @@ def test_deposit_must_wait_for_confirmation():
     confirmed_block = Block(confirmed_deposit_block_number)
     iteration = channel.state_transition(
         deepcopy(unconfirmed_state),
+        partner_channel_message_queue,
         confirmed_block,
         pseudo_random_generator,
         confirmed_deposit_block_number,
@@ -500,6 +510,7 @@ def test_channelstate_send_lockedtransfer():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    partner_channel_message_queue = list()
 
     lock_amount = 30
     lock_expiration = 10
@@ -519,6 +530,7 @@ def test_channelstate_send_lockedtransfer():
 
     channel.send_lockedtransfer(
         channel_state,
+        partner_channel_message_queue,
         transfer_initiator,
         transfer_target,
         lock_amount,
@@ -548,12 +560,14 @@ def test_channelstate_send_direct_transfer():
     our_model1, _ = create_model(70)
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
+    partner_channel_message_queue = list()
 
     amount = 30
     payment_identifier = 1
     message_identifier = random.randint(0, UINT64_MAX)
     channel.send_directtransfer(
         channel_state,
+        partner_channel_message_queue,
         amount,
         message_identifier,
         payment_identifier,

--- a/raiden/tests/unit/test_dict_encoding.py
+++ b/raiden/tests/unit/test_dict_encoding.py
@@ -17,12 +17,12 @@ from raiden.tests.utils.factories import make_privkey_address
 PRIVKEY, ADDRESS = make_privkey_address()
 
 
-@pytest.mark.parametrize('identifier', [0, UINT64_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
 @pytest.mark.parametrize('nonce', [1, UINT64_MAX])
 @pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
-def test_direct_transfer_min_max(identifier, nonce, transferred_amount):
+def test_direct_transfer_min_max(payment_identifier, nonce, transferred_amount):
     direct_transfer = make_direct_transfer(
-        identifier=identifier,
+        payment_identifier=payment_identifier,
         nonce=nonce,
         transferred_amount=transferred_amount,
     )
@@ -32,14 +32,14 @@ def test_direct_transfer_min_max(identifier, nonce, transferred_amount):
 
 
 @pytest.mark.parametrize('amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('identifier', [0, UINT64_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
 @pytest.mark.parametrize('nonce', [1, UINT64_MAX])
 @pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
 @pytest.mark.parametrize('fee', [0, UINT256_MAX])
-def test_mediated_transfer_min_max(amount, identifier, fee, nonce, transferred_amount):
+def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, transferred_amount):
     mediated_transfer = make_mediated_transfer(
         amount=amount,
-        identifier=identifier,
+        payment_identifier=payment_identifier,
         nonce=nonce,
         fee=fee,
         transferred_amount=transferred_amount,
@@ -50,13 +50,13 @@ def test_mediated_transfer_min_max(amount, identifier, fee, nonce, transferred_a
 
 
 @pytest.mark.parametrize('amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('identifier', [0, UINT64_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
 @pytest.mark.parametrize('nonce', [1, UINT64_MAX])
 @pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
-def test_refund_transfer_min_max(amount, identifier, nonce, transferred_amount):
+def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_amount):
     refund_transfer = make_refund_transfer(
         amount=amount,
-        identifier=identifier,
+        payment_identifier=payment_identifier,
         nonce=nonce,
         transferred_amount=transferred_amount,
     )

--- a/raiden/tests/unit/test_operators.py
+++ b/raiden/tests/unit/test_operators.py
@@ -49,21 +49,21 @@ def test_transfer_statechange_operators():
         payment_network_identifier,
         token_address,
         receiver_address=ADDRESS,
-        identifier=2,
+        payment_identifier=2,
         amount=2,
     )
     b = ActionTransferDirect(
         payment_network_identifier,
         token_address,
         receiver_address=ADDRESS,
-        identifier=2,
+        payment_identifier=2,
         amount=2,
     )
     c = ActionTransferDirect(
         payment_network_identifier,
         token_address,
         receiver_address=ADDRESS2,  # different recipient
-        identifier=2,
+        payment_identifier=2,
         amount=2,
     )
 
@@ -109,9 +109,12 @@ def test_event_operators():
 
 
 def test_message_operators():
-    a = Processed(ADDRESS, HASH)
-    b = Processed(ADDRESS, HASH)
-    c = Processed(ADDRESS2, HASH2)
+    message_identifier = 10
+    message_identifier2 = 11
+
+    a = Processed(ADDRESS, message_identifier)
+    b = Processed(ADDRESS, message_identifier)
+    c = Processed(ADDRESS2, message_identifier2)
 
     # pylint: disable=unneeded-not
     assert a == b

--- a/raiden/tests/unit/test_service.py
+++ b/raiden/tests/unit/test_service.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from raiden.constants import UINT64_MAX
-from raiden.utils import sha3
 from raiden.messages import (
     decode,
     Processed,
@@ -10,6 +8,7 @@ from raiden.messages import (
 )
 from raiden.tests.utils.transport import UnreliableTransport
 from raiden.tests.utils.messages import setup_messages_cb
+from raiden.network.protocol import messageid_from_data
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])
@@ -28,9 +27,7 @@ def test_ping(raiden_network):
     )
     assert async_result.wait(2), 'The message was not processed'
 
-    expected_echohash = sha3(ping_encoded + app1.raiden.address)
-    expected_messageid = int.from_bytes(expected_echohash, 'big') % UINT64_MAX
-
+    expected_messageid = messageid_from_data(ping_encoded, app1.raiden.address)
     messages_decoded = [decode(m) for m in messages]
     processed_message = next(
         decoded

--- a/raiden/tests/unit/test_service.py
+++ b/raiden/tests/unit/test_service.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from raiden.constants import UINT64_MAX
 from raiden.utils import sha3
 from raiden.messages import (
     decode,
@@ -28,12 +29,14 @@ def test_ping(raiden_network):
     assert async_result.wait(2), 'The message was not processed'
 
     expected_echohash = sha3(ping_encoded + app1.raiden.address)
+    expected_messageid = int.from_bytes(expected_echohash, 'big') % UINT64_MAX
 
     messages_decoded = [decode(m) for m in messages]
     processed_message = next(
         decoded
         for decoded in messages_decoded
-        if isinstance(decoded, Processed) and decoded.echo == expected_echohash
+        if isinstance(decoded, Processed) and
+        decoded.processed_message_identifier == expected_messageid
     )
 
     # the ping message was sent and processed

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -42,7 +42,7 @@ def make_initiator_state(
         routes,
         transfer_description,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
         payment_network_identifier=None,
@@ -62,7 +62,7 @@ def make_initiator_state(
         inital_state,
         init_state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -75,7 +75,7 @@ def test_next_route():
     channel1 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
     channel2 = factories.make_channel(our_balance=0, token_address=UNIT_TOKEN_ADDRESS)
     channel3 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channelmap = {
@@ -95,7 +95,7 @@ def test_next_route():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -112,7 +112,7 @@ def test_next_route():
         state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -128,7 +128,7 @@ def test_init_with_usable_routes():
     )
     channelmap = {channel1.identifier: channel1}
     available_routes = [factories.route_from_channel(channel1)]
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     payment_network_identifier = factories.make_address()
@@ -143,7 +143,7 @@ def test_init_with_usable_routes():
         None,
         init_state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -172,7 +172,7 @@ def test_init_without_routes():
     block_number = 1
     routes = []
     payment_network_identifier = factories.make_address()
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     init_state_change = ActionInitInitiator(
@@ -186,7 +186,7 @@ def test_init_without_routes():
         None,
         init_state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -201,7 +201,7 @@ def test_init_without_routes():
 def test_state_wait_secretrequest_valid():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
@@ -211,7 +211,7 @@ def test_state_wait_secretrequest_valid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -227,7 +227,7 @@ def test_state_wait_secretrequest_valid():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -238,7 +238,7 @@ def test_state_wait_secretrequest_valid():
 
 def test_state_wait_unlock_valid():
     block_number = 1
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -252,7 +252,7 @@ def test_state_wait_unlock_valid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -273,7 +273,7 @@ def test_state_wait_unlock_valid():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -296,7 +296,7 @@ def test_state_wait_unlock_invalid():
     block_number = 1
     target_address = factories.HOP2
     token = factories.UNIT_TOKEN_ADDRESS
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -309,7 +309,7 @@ def test_state_wait_unlock_invalid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -332,7 +332,7 @@ def test_state_wait_unlock_invalid():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -345,7 +345,7 @@ def test_refund_transfer_next_route():
     amount = UNIT_TRANSFER_AMOUNT
     our_address = factories.ADDR
     refund_pkey, refund_address = factories.make_privkey_address()
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -383,7 +383,7 @@ def test_refund_transfer_next_route():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -417,7 +417,7 @@ def test_refund_transfer_next_route():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -439,7 +439,7 @@ def test_refund_transfer_no_more_routes():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
     refund_pkey, refund_address = factories.make_privkey_address()
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -456,7 +456,7 @@ def test_refund_transfer_no_more_routes():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -489,7 +489,7 @@ def test_refund_transfer_no_more_routes():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -506,7 +506,7 @@ def test_refund_transfer_no_more_routes():
 def test_refund_transfer_invalid_sender():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -521,7 +521,7 @@ def test_refund_transfer_invalid_sender():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -552,7 +552,7 @@ def test_refund_transfer_invalid_sender():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -564,7 +564,7 @@ def test_refund_transfer_invalid_sender():
 def test_cancel_transfer():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -579,7 +579,7 @@ def test_cancel_transfer():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -592,7 +592,7 @@ def test_cancel_transfer():
         current_state,
         state_change,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1,5 +1,6 @@
 # -*- coding: utf8 -*-
 # pylint: disable=invalid-name,too-few-public-methods,too-many-arguments,too-many-locals
+import random
 from copy import deepcopy
 
 from raiden.utils import random_secret
@@ -41,8 +42,11 @@ def make_initiator_state(
         routes,
         transfer_description,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
-        payment_network_identifier=None):
+        payment_network_identifier=None,
+):
 
     if payment_network_identifier is None:
         payment_network_identifier = factories.make_address()
@@ -58,6 +62,8 @@ def make_initiator_state(
         inital_state,
         init_state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -69,6 +75,8 @@ def test_next_route():
     channel1 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
     channel2 = factories.make_channel(our_balance=0, token_address=UNIT_TOKEN_ADDRESS)
     channel3 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channelmap = {
         channel1.identifier: channel1,
@@ -87,6 +95,8 @@ def test_next_route():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -102,6 +112,8 @@ def test_next_route():
         state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -116,6 +128,8 @@ def test_init_with_usable_routes():
     )
     channelmap = {channel1.identifier: channel1}
     available_routes = [factories.route_from_channel(channel1)]
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     payment_network_identifier = factories.make_address()
     init_state_change = ActionInitInitiator(
@@ -129,6 +143,8 @@ def test_init_with_usable_routes():
         None,
         init_state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -156,6 +172,9 @@ def test_init_without_routes():
     block_number = 1
     routes = []
     payment_network_identifier = factories.make_address()
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
+
     init_state_change = ActionInitInitiator(
         payment_network_identifier,
         factories.UNIT_TRANSFER_DESCRIPTION,
@@ -167,6 +186,8 @@ def test_init_without_routes():
         None,
         init_state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -180,6 +201,8 @@ def test_init_without_routes():
 def test_state_wait_secretrequest_valid():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
     channelmap = {channel1.identifier: channel1}
@@ -188,6 +211,8 @@ def test_state_wait_secretrequest_valid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -202,6 +227,8 @@ def test_state_wait_secretrequest_valid():
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -211,6 +238,8 @@ def test_state_wait_secretrequest_valid():
 
 def test_state_wait_unlock_valid():
     block_number = 1
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
         our_balance=UNIT_TRANSFER_AMOUNT,
@@ -223,6 +252,8 @@ def test_state_wait_unlock_valid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -242,6 +273,8 @@ def test_state_wait_unlock_valid():
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -259,10 +292,12 @@ def test_state_wait_unlock_valid():
 
 
 def test_state_wait_unlock_invalid():
-    identifier = identifier = 1
+    identifier = 1
     block_number = 1
     target_address = factories.HOP2
     token = factories.UNIT_TOKEN_ADDRESS
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
         our_balance=UNIT_TRANSFER_AMOUNT,
@@ -274,6 +309,8 @@ def test_state_wait_unlock_invalid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -295,6 +332,8 @@ def test_state_wait_unlock_invalid():
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -306,6 +345,8 @@ def test_refund_transfer_next_route():
     amount = UNIT_TRANSFER_AMOUNT
     our_address = factories.ADDR
     refund_pkey, refund_address = factories.make_privkey_address()
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
         our_balance=amount,
@@ -342,6 +383,8 @@ def test_refund_transfer_next_route():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -356,7 +399,7 @@ def test_refund_transfer_next_route():
         original_transfer.target,
         expiration,
         UNIT_SECRET,
-        identifier=original_transfer.identifier,
+        payment_identifier=original_transfer.payment_identifier,
         channel_identifier=channel1.identifier,
         pkey=refund_pkey,
         sender=refund_address,
@@ -374,6 +417,8 @@ def test_refund_transfer_next_route():
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
     assert iteration.new_state is not None
@@ -394,6 +439,8 @@ def test_refund_transfer_no_more_routes():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
     refund_pkey, refund_address = factories.make_privkey_address()
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
         our_balance=amount,
@@ -409,6 +456,8 @@ def test_refund_transfer_no_more_routes():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -423,7 +472,7 @@ def test_refund_transfer_no_more_routes():
         original_transfer.target,
         expiration,
         UNIT_SECRET,
-        identifier=original_transfer.identifier,
+        payment_identifier=original_transfer.payment_identifier,
         channel_identifier=channel1.identifier,
         pkey=refund_pkey,
         sender=refund_address,
@@ -440,6 +489,8 @@ def test_refund_transfer_no_more_routes():
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
     assert iteration.new_state is None
@@ -455,6 +506,8 @@ def test_refund_transfer_no_more_routes():
 def test_refund_transfer_invalid_sender():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
         our_balance=amount,
@@ -468,6 +521,8 @@ def test_refund_transfer_invalid_sender():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
@@ -497,6 +552,8 @@ def test_refund_transfer_invalid_sender():
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
     assert iteration.new_state is not None
@@ -507,6 +564,8 @@ def test_refund_transfer_invalid_sender():
 def test_cancel_transfer():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
+    addresses_to_queues = dict()
+    pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
         our_balance=amount,
@@ -520,17 +579,21 @@ def test_cancel_transfer():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
 
     state_change = ActionCancelPayment(
-        identifier=UNIT_TRANSFER_IDENTIFIER,
+        payment_identifier=UNIT_TRANSFER_IDENTIFIER,
     )
 
     iteration = initiator_manager.state_transition(
         current_state,
         state_change,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
     assert iteration.new_state is None

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -42,7 +42,6 @@ def make_initiator_state(
         routes,
         transfer_description,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
         payment_network_identifier=None,
@@ -62,7 +61,6 @@ def make_initiator_state(
         inital_state,
         init_state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -75,7 +73,6 @@ def test_next_route():
     channel1 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
     channel2 = factories.make_channel(our_balance=0, token_address=UNIT_TOKEN_ADDRESS)
     channel3 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channelmap = {
@@ -95,7 +92,6 @@ def test_next_route():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -112,7 +108,6 @@ def test_next_route():
         state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -128,7 +123,6 @@ def test_init_with_usable_routes():
     )
     channelmap = {channel1.identifier: channel1}
     available_routes = [factories.route_from_channel(channel1)]
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     payment_network_identifier = factories.make_address()
@@ -143,7 +137,6 @@ def test_init_with_usable_routes():
         None,
         init_state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -172,7 +165,6 @@ def test_init_without_routes():
     block_number = 1
     routes = []
     payment_network_identifier = factories.make_address()
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     init_state_change = ActionInitInitiator(
@@ -186,7 +178,6 @@ def test_init_without_routes():
         None,
         init_state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -201,7 +192,6 @@ def test_init_without_routes():
 def test_state_wait_secretrequest_valid():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(our_balance=amount, token_address=UNIT_TOKEN_ADDRESS)
@@ -211,7 +201,6 @@ def test_state_wait_secretrequest_valid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -227,7 +216,6 @@ def test_state_wait_secretrequest_valid():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -238,7 +226,6 @@ def test_state_wait_secretrequest_valid():
 
 def test_state_wait_unlock_valid():
     block_number = 1
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -252,17 +239,17 @@ def test_state_wait_unlock_valid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
 
     # setup the state for the wait unlock
     current_state.initiator.revealsecret = SendRevealSecret(
+        UNIT_TRANSFER_TARGET,
+        'global',
         UNIT_TRANSFER_IDENTIFIER,
         UNIT_SECRET,
         UNIT_TOKEN_ADDRESS,
-        UNIT_TRANSFER_TARGET,
     )
 
     state_change = ReceiveSecretReveal(
@@ -273,7 +260,6 @@ def test_state_wait_unlock_valid():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -286,7 +272,7 @@ def test_state_wait_unlock_valid():
     balance_proof = next(e for e in iteration.events if isinstance(e, SendBalanceProof))
     complete = next(e for e in iteration.events if isinstance(e, EventTransferSentSuccess))
 
-    assert balance_proof.receiver == channel1.partner_state.address
+    assert balance_proof.recipient == channel1.partner_state.address
     assert complete.identifier == UNIT_TRANSFER_IDENTIFIER
     assert iteration.new_state is None, 'state must be cleaned'
 
@@ -296,7 +282,6 @@ def test_state_wait_unlock_invalid():
     block_number = 1
     target_address = factories.HOP2
     token = factories.UNIT_TOKEN_ADDRESS
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -309,17 +294,17 @@ def test_state_wait_unlock_invalid():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
 
     # setup the state for the wait unlock
     current_state.initiator.revealsecret = SendRevealSecret(
+        target_address,
+        'global',
         identifier,
         UNIT_SECRET,
         token,
-        target_address,
     )
 
     before_state = deepcopy(current_state)
@@ -332,7 +317,6 @@ def test_state_wait_unlock_invalid():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -345,7 +329,6 @@ def test_refund_transfer_next_route():
     amount = UNIT_TRANSFER_AMOUNT
     our_address = factories.ADDR
     refund_pkey, refund_address = factories.make_privkey_address()
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -383,7 +366,6 @@ def test_refund_transfer_next_route():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -417,7 +399,6 @@ def test_refund_transfer_next_route():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -439,7 +420,6 @@ def test_refund_transfer_no_more_routes():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
     refund_pkey, refund_address = factories.make_privkey_address()
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -456,7 +436,6 @@ def test_refund_transfer_no_more_routes():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -489,7 +468,6 @@ def test_refund_transfer_no_more_routes():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -506,7 +484,6 @@ def test_refund_transfer_no_more_routes():
 def test_refund_transfer_invalid_sender():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -521,7 +498,6 @@ def test_refund_transfer_invalid_sender():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -552,7 +528,6 @@ def test_refund_transfer_invalid_sender():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -564,7 +539,6 @@ def test_refund_transfer_invalid_sender():
 def test_cancel_transfer():
     amount = UNIT_TRANSFER_AMOUNT
     block_number = 1
-    queueids_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel1 = factories.make_channel(
@@ -579,7 +553,6 @@ def test_cancel_transfer():
         available_routes,
         factories.UNIT_TRANSFER_DESCRIPTION,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -592,7 +565,6 @@ def test_cancel_transfer():
         current_state,
         state_change,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -33,7 +33,6 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     target = HOP2
     expiration = 30
     pseudo_random_generator = random.Random()
-    queueids_to_queues = dict()
 
     payer_channel = factories.make_channel(
         partner_balance=amount,
@@ -66,7 +65,6 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         possible_routes,
         payer_channel,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         payer_transfer,
         block_number,
@@ -99,7 +97,6 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         new_state,
         receive_secret,
         channelmap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -33,7 +33,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     target = HOP2
     expiration = 30
     pseudo_random_generator = random.Random()
-    addresses_to_queues = dict()
+    queueids_to_queues = dict()
 
     payer_channel = factories.make_channel(
         partner_balance=amount,
@@ -66,6 +66,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         possible_routes,
         payer_channel,
         channelmap,
+        queueids_to_queues,
         pseudo_random_generator,
         payer_transfer,
         block_number,
@@ -98,7 +99,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         new_state,
         receive_secret,
         channelmap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
+import random
+
 from raiden.transfer.mediated_transfer import mediator
 from raiden.transfer.mediated_transfer.state import MediatorTransferState
 from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
@@ -30,6 +32,8 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     block_number = 5
     target = HOP2
     expiration = 30
+    pseudo_random_generator = random.Random()
+    addresses_to_queues = dict()
 
     payer_channel = factories.make_channel(
         partner_balance=amount,
@@ -62,6 +66,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         possible_routes,
         payer_channel,
         channelmap,
+        pseudo_random_generator,
         payer_transfer,
         block_number,
     )
@@ -93,6 +98,8 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         new_state,
         receive_secret,
         channelmap,
+        addresses_to_queues,
+        pseudo_random_generator,
         block_number,
     )
     paid_state = paid_iteration.new_state

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -147,7 +147,6 @@ def test_handle_inittarget():
     initiator = factories.HOP1
     target_address = UNIT_TRANSFER_TARGET
     payment_network_identifier = factories.make_address()
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     from_channel = factories.make_channel(
@@ -176,7 +175,6 @@ def test_handle_inittarget():
     iteration = target.handle_inittarget(
         state_change,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -188,7 +186,7 @@ def test_handle_inittarget():
     assert events[0].payment_identifier == from_transfer.payment_identifier
     assert events[0].amount == from_transfer.lock.amount
     assert events[0].secrethash == from_transfer.lock.secrethash
-    assert events[0].receiver == initiator
+    assert events[0].recipient == initiator
 
 
 def test_handle_inittarget_bad_expiration():
@@ -198,7 +196,6 @@ def test_handle_inittarget_bad_expiration():
     initiator = factories.HOP1
     target_address = UNIT_TRANSFER_TARGET
     payment_network_identifier = factories.make_address()
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     from_channel = factories.make_channel(
@@ -227,7 +224,6 @@ def test_handle_inittarget_bad_expiration():
     iteration = target.handle_inittarget(
         state_change,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -244,7 +240,6 @@ def test_handle_secretreveal():
     initiator = factories.HOP1
     our_address = factories.ADDR
     secret = factories.UNIT_SECRET
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     channel_state, state = make_target_state(
@@ -260,7 +255,6 @@ def test_handle_secretreveal():
         state,
         state_change,
         channel_state,
-        addresses_to_queues,
         pseudo_random_generator,
     )
     assert len(iteration.events) == 1
@@ -270,7 +264,7 @@ def test_handle_secretreveal():
 
     assert iteration.new_state.state == 'reveal_secret'
     assert reveal.secret == secret
-    assert reveal.receiver == state.route.node_address
+    assert reveal.recipient == state.route.node_address
 
 
 def test_handle_block():
@@ -279,7 +273,6 @@ def test_handle_block():
     our_address = factories.ADDR
     amount = 3
     block_number = 1
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     from_channel, state = make_target_state(
@@ -294,7 +287,6 @@ def test_handle_block():
         state,
         new_block,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         new_block.block_number,
     )
@@ -308,7 +300,6 @@ def test_handle_block_equal_block_number():
     our_address = factories.ADDR
     amount = 3
     block_number = 1
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     from_channel, state = make_target_state(
@@ -323,7 +314,6 @@ def test_handle_block_equal_block_number():
         state,
         new_block,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         new_block.block_number,
     )
@@ -337,7 +327,6 @@ def test_handle_block_lower_block_number():
     our_address = factories.ADDR
     amount = 3
     block_number = 10
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     from_channel, state = make_target_state(
@@ -352,7 +341,6 @@ def test_handle_block_lower_block_number():
         state,
         new_block,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         new_block.block_number,
     )
@@ -366,7 +354,6 @@ def test_state_transition():
     block_number = 1
     initiator = factories.HOP6
     payment_network_identifier = factories.make_address()
-    addresses_to_queues = dict()
     pseudo_random_generator = random.Random()
 
     our_balance = 100
@@ -401,7 +388,6 @@ def test_state_transition():
         None,
         init,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         block_number,
     )
@@ -414,7 +400,6 @@ def test_state_transition():
         init_transition.new_state,
         first_new_block,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         first_new_block.block_number,
     )
@@ -424,7 +409,6 @@ def test_state_transition():
         first_block_iteration.new_state,
         secret_reveal,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         first_new_block,
     )
@@ -435,7 +419,6 @@ def test_state_transition():
         init_transition.new_state,
         second_new_block,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         second_new_block.block_number,
     )
@@ -466,7 +449,6 @@ def test_state_transition():
         init_transition.new_state,
         balance_proof_state_change,
         from_channel,
-        addresses_to_queues,
         pseudo_random_generator,
         block_number + 2,
     )

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -6,6 +6,7 @@ import string
 
 from coincurve import PrivateKey
 
+from raiden.constants import UINT64_MAX
 from raiden.messages import (
     Lock,
     LockedTransfer,
@@ -211,7 +212,8 @@ def make_signed_transfer(
         target,
         expiration,
         secret,
-        identifier=1,
+        payment_identifier=1,
+        message_identifier=None,
         nonce=1,
         transferred_amount=0,
         recipient=UNIT_TRANSFER_TARGET,
@@ -221,6 +223,9 @@ def make_signed_transfer(
         sender=UNIT_TRANSFER_SENDER
 ):
 
+    if message_identifier is None:
+        message_identifier = random.randint(0, UINT64_MAX)
+
     secrethash = sha3(secret)
     lock = Lock(
         amount,
@@ -229,7 +234,8 @@ def make_signed_transfer(
     )
 
     transfer = LockedTransfer(
-        identifier,
+        message_identifier,
+        payment_identifier,
         nonce,
         token,
         channel_identifier,
@@ -308,14 +314,14 @@ def make_signed_transfer_for(
         target,
         expiration,
         secret,
-        identifier,
-        nonce,
-        transferred_amount,
-        recipient,
-        channel_address,
-        token_address,
-        pkey,
-        sender,
+        payment_identifier=identifier,
+        nonce=nonce,
+        transferred_amount=transferred_amount,
+        recipient=recipient,
+        channel_identifier=channel_address,
+        token=token_address,
+        pkey=pkey,
+        sender=sender,
     )
 
     # Do *not* register the transfer here

--- a/raiden/tests/utils/messages.py
+++ b/raiden/tests/utils/messages.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """ Utilities to track and assert transferred messages. """
-
 import string
+import random
 
+from raiden.constants import UINT64_MAX
 from raiden.network.transport import DummyTransport
 from raiden.utils import sha3
 from raiden.tests.utils.tests import fixture_all_combinations
@@ -43,7 +44,7 @@ SECRETHASHES_FOR_MERKLETREE = [
 # nonce value
 DIRECT_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
     'nonce': [-1, 0, 2 ** 64],
-    'identifier': [-1, 2 ** 64],
+    'payment_identifier': [-1, 2 ** 64],
     'token': INVALID_ADDRESSES,
     'recipient': INVALID_ADDRESSES,
     'transferred_amount': [-1, 2 ** 256],
@@ -51,7 +52,7 @@ DIRECT_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
 
 REFUND_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
     'nonce': [-1, 0, 2 ** 64],
-    'identifier': [-1, 2 ** 64],
+    'payment_identifier': [-1, 2 ** 64],
     'token': INVALID_ADDRESSES,
     'recipient': INVALID_ADDRESSES,
     'transferred_amount': [-1, 2 ** 256],
@@ -59,7 +60,7 @@ REFUND_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
 
 MEDIATED_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
     'nonce': [-1, 0, 2 ** 64],
-    'identifier': [-1, 2 ** 64],
+    'payment_identifier': [-1, 2 ** 64],
     'token': INVALID_ADDRESSES,
     'recipient': INVALID_ADDRESSES,
     'target': INVALID_ADDRESSES,
@@ -78,7 +79,8 @@ def make_lock(amount=7, expiration=1, secrethash=VALID_SECRETHASHES[0]):
 
 
 def make_refund_transfer(
-        identifier=0,
+        message_identifier=None,
+        payment_identifier=0,
         nonce=1,
         token=ADDRESS,
         channel=ADDRESS,
@@ -91,8 +93,12 @@ def make_refund_transfer(
         fee=0,
         secrethash=VALID_SECRETHASHES[0]):
 
+    if message_identifier is None:
+        message_identifier = random.randint(0, UINT64_MAX)
+
     return RefundTransfer(
-        identifier,
+        message_identifier,
+        payment_identifier,
         nonce,
         token,
         channel,
@@ -107,7 +113,8 @@ def make_refund_transfer(
 
 
 def make_mediated_transfer(
-        identifier=0,
+        message_identifier=None,
+        payment_identifier=0,
         nonce=1,
         token=ADDRESS,
         channel=ADDRESS,
@@ -120,6 +127,9 @@ def make_mediated_transfer(
         initiator=ADDRESS,
         fee=0):
 
+    if message_identifier is None:
+        message_identifier = random.randint(0, UINT64_MAX)
+
     lock = make_lock(
         amount=amount,
         expiration=expiration,
@@ -129,7 +139,8 @@ def make_mediated_transfer(
         locksroot = sha3(lock.as_bytes)
 
     return LockedTransfer(
-        identifier,
+        message_identifier,
+        payment_identifier,
         nonce,
         token,
         channel,
@@ -139,12 +150,13 @@ def make_mediated_transfer(
         lock,
         target,
         initiator,
-        fee
+        fee,
     )
 
 
 def make_direct_transfer(
-        identifier=0,
+        message_identifier=None,
+        payment_identifier=0,
         nonce=1,
         token=ADDRESS,
         channel=ADDRESS,
@@ -152,8 +164,12 @@ def make_direct_transfer(
         recipient=ADDRESS,
         locksroot=EMPTY_MERKLE_ROOT):
 
+    if message_identifier is None:
+        message_identifier = random.randint(0, UINT64_MAX)
+
     return DirectTransfer(
-        identifier,
+        message_identifier,
+        payment_identifier,
         nonce,
         token,
         channel,

--- a/raiden/tests/utils/messages.py
+++ b/raiden/tests/utils/messages.py
@@ -3,7 +3,10 @@
 import string
 import random
 
-from raiden.constants import UINT64_MAX
+from raiden.constants import (
+    UINT64_MAX,
+    UINT256_MAX,
+)
 from raiden.network.transport import DummyTransport
 from raiden.utils import sha3
 from raiden.tests.utils.tests import fixture_all_combinations
@@ -43,30 +46,30 @@ SECRETHASHES_FOR_MERKLETREE = [
 # zero is used to indicate novalue in solidity, that is why it's an invalid
 # nonce value
 DIRECT_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
-    'nonce': [-1, 0, 2 ** 64],
-    'payment_identifier': [-1, 2 ** 64],
+    'nonce': [-1, 0, UINT64_MAX + 1],
+    'payment_identifier': [-1, UINT64_MAX + 1],
     'token': INVALID_ADDRESSES,
     'recipient': INVALID_ADDRESSES,
-    'transferred_amount': [-1, 2 ** 256],
+    'transferred_amount': [-1, UINT256_MAX + 1],
 }))
 
 REFUND_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
-    'nonce': [-1, 0, 2 ** 64],
-    'payment_identifier': [-1, 2 ** 64],
+    'nonce': [-1, 0, UINT64_MAX + 1],
+    'payment_identifier': [-1, UINT64_MAX + 1],
     'token': INVALID_ADDRESSES,
     'recipient': INVALID_ADDRESSES,
-    'transferred_amount': [-1, 2 ** 256],
+    'transferred_amount': [-1, UINT256_MAX + 1],
 }))
 
 MEDIATED_TRANSFER_INVALID_VALUES = list(fixture_all_combinations({
-    'nonce': [-1, 0, 2 ** 64],
-    'payment_identifier': [-1, 2 ** 64],
+    'nonce': [-1, 0, UINT64_MAX + 1],
+    'payment_identifier': [-1, UINT64_MAX + 1],
     'token': INVALID_ADDRESSES,
     'recipient': INVALID_ADDRESSES,
     'target': INVALID_ADDRESSES,
     'initiator': INVALID_ADDRESSES,
-    'transferred_amount': [-1, 2 ** 256],
-    'fee': [2 ** 256],
+    'transferred_amount': [-1, UINT256_MAX + 1],
+    'fee': [UINT256_MAX + 1],
 }))
 
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -163,7 +163,7 @@ def pending_mediated_transfer(app_chain, token, amount, identifier):
     return secret
 
 
-def claim_lock(app_chain, queueids_to_queues, payment_identifier, token, secret):
+def claim_lock(app_chain, payment_identifier, token, secret):
     """ Unlock a pending transfer. """
     secrethash = sha3(secret)
     for from_, to_ in zip(app_chain[:-1], app_chain[1:]):
@@ -171,11 +171,8 @@ def claim_lock(app_chain, queueids_to_queues, payment_identifier, token, secret)
         partner_channel = get_channelstate(to_, from_, token)
 
         message_identifier = random.randint(0, UINT64_MAX)
-        queueid = (from_channel.partner_state.address, from_channel.identifier)
-        partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
         unlock_lock = channel.send_unlock(
             from_channel,
-            partner_channel_message_queue,
             message_identifier,
             payment_identifier,
             secret,
@@ -312,7 +309,6 @@ def increase_transferred_amount(
         payment_network_identifier,
         from_channel,
         partner_channel,
-        partner_channel_message_queue,
         amount,
         pkey,
 ):
@@ -328,10 +324,9 @@ def increase_transferred_amount(
     payment_identifier = 1
     event = channel.send_directtransfer(
         from_channel,
-        partner_channel_message_queue,
         amount,
-        message_identifier,
         payment_identifier,
+        message_identifier,
     )
 
     direct_transfer_message = DirectTransfer.from_event(event)
@@ -362,7 +357,6 @@ def make_direct_transfer_from_channel(
         payment_network_identifier,
         from_channel,
         partner_channel,
-        partner_channel_message_queue,
         amount,
         pkey,
 ):
@@ -380,7 +374,6 @@ def make_direct_transfer_from_channel(
     )
     iteration = channel.handle_send_directtransfer(
         from_channel,
-        partner_channel_message_queue,
         state_change,
         pseudo_random_generator,
     )
@@ -413,7 +406,6 @@ def make_direct_transfer_from_channel(
 def make_mediated_transfer(
         from_channel,
         partner_channel,
-        partner_channel_message_queue,
         initiator,
         target,
         lock,
@@ -427,7 +419,6 @@ def make_mediated_transfer(
 
     lockedtransfer = channel.send_lockedtransfer(
         from_channel,
-        partner_channel_message_queue,
         initiator,
         target,
         lock.amount,

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -163,7 +163,7 @@ def pending_mediated_transfer(app_chain, token, amount, identifier):
     return secret
 
 
-def claim_lock(app_chain, payment_identifier, token, secret):
+def claim_lock(app_chain, queueids_to_queues, payment_identifier, token, secret):
     """ Unlock a pending transfer. """
     secrethash = sha3(secret)
     for from_, to_ in zip(app_chain[:-1], app_chain[1:]):
@@ -171,8 +171,11 @@ def claim_lock(app_chain, payment_identifier, token, secret):
         partner_channel = get_channelstate(to_, from_, token)
 
         message_identifier = random.randint(0, UINT64_MAX)
+        queueid = (from_channel.partner_state.address, from_channel.identifier)
+        partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
         unlock_lock = channel.send_unlock(
             from_channel,
+            partner_channel_message_queue,
             message_identifier,
             payment_identifier,
             secret,
@@ -309,6 +312,7 @@ def increase_transferred_amount(
         payment_network_identifier,
         from_channel,
         partner_channel,
+        partner_channel_message_queue,
         amount,
         pkey,
 ):
@@ -324,9 +328,10 @@ def increase_transferred_amount(
     payment_identifier = 1
     event = channel.send_directtransfer(
         from_channel,
+        partner_channel_message_queue,
         amount,
-        payment_identifier,
         message_identifier,
+        payment_identifier,
     )
 
     direct_transfer_message = DirectTransfer.from_event(event)
@@ -357,6 +362,7 @@ def make_direct_transfer_from_channel(
         payment_network_identifier,
         from_channel,
         partner_channel,
+        partner_channel_message_queue,
         amount,
         pkey,
 ):
@@ -374,6 +380,7 @@ def make_direct_transfer_from_channel(
     )
     iteration = channel.handle_send_directtransfer(
         from_channel,
+        partner_channel_message_queue,
         state_change,
         pseudo_random_generator,
     )
@@ -406,6 +413,7 @@ def make_direct_transfer_from_channel(
 def make_mediated_transfer(
         from_channel,
         partner_channel,
+        partner_channel_message_queue,
         initiator,
         target,
         lock,
@@ -419,6 +427,7 @@ def make_mediated_transfer(
 
     lockedtransfer = channel.send_lockedtransfer(
         from_channel,
+        partner_channel_message_queue,
         initiator,
         target,
         lock.amount,

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -80,6 +80,13 @@ class Event:
     __slots__ = ()
 
 
+class SendMessageEvent(Event):
+    def __init__(self, recipient, queue_name, message_identifier):
+        self.recipient = recipient
+        self.queue_name = queue_name
+        self.message_identifier = message_identifier
+
+
 class StateManager:
     """ The mutable storage for the application state, this storage can do
     state transitions by applying the StateChanges to the current State.

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from raiden.constants import UINT256_MAX
-from raiden.transfer.architecture import Event
+from raiden.transfer.architecture import (
+    Event,
+    SendMessageEvent,
+)
 from raiden.utils import pex
 # pylint: disable=too-many-arguments,too-few-public-methods
 
@@ -244,22 +247,24 @@ class EventTransferReceivedInvalidDirectTransfer(Event):
         return not self.__eq__(other)
 
 
-class SendDirectTransfer(Event):
+class SendDirectTransfer(SendMessageEvent):
     """ Event emitted when a direct transfer message must be sent. """
 
     def __init__(
             self,
+            recipient,
+            queue_name,
             message_identifier,
             payment_identifier,
             balance_proof,
             token,
-            recipient):
+    ):
 
-        self.message_identifier = message_identifier
+        super().__init__(recipient, queue_name, message_identifier)
+
         self.payment_identifier = payment_identifier
         self.balance_proof = balance_proof
         self.token = token
-        self.recipient = recipient
 
     def __repr__(self):
         return (

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -249,21 +249,24 @@ class SendDirectTransfer(Event):
 
     def __init__(
             self,
-            identifier,
+            message_identifier,
+            payment_identifier,
             balance_proof,
             token,
             recipient):
 
-        self.identifier = identifier
+        self.message_identifier = message_identifier
+        self.payment_identifier = payment_identifier
         self.balance_proof = balance_proof
         self.token = token
         self.recipient = recipient
 
     def __repr__(self):
         return (
-            '<SendDirectTransfer identifier:{} balance_proof:{} token:{} recipient:{}>'
+            '<SendDirectTransfer msgid:{} paymentid:{} balance_proof:{} token:{} recipient:{}>'
         ).format(
-            self.identifier,
+            self.message_identifier,
+            self.payment_identifier,
             self.balance_proof,
             pex(self.token),
             pex(self.recipient),
@@ -272,7 +275,8 @@ class SendDirectTransfer(Event):
     def __eq__(self, other):
         return (
             isinstance(other, SendDirectTransfer) and
-            self.identifier == other.identifier and
+            self.message_identifier == other.message_identifier and
+            self.payment_identifier == other.payment_identifier and
             self.balance_proof == other.balance_proof and
             self.token == other.token and
             self.recipient == other.recipient

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -8,7 +8,8 @@ from raiden.utils import pex, sha3
 def refund_from_sendmediated(send_lockedtransfer_event):
     transfer = send_lockedtransfer_event.transfer
     return SendRefundTransfer(
-        transfer.identifier,
+        send_lockedtransfer_event.message_identifier,
+        transfer.payment_identifier,
         transfer.token,
         transfer.balance_proof,
         transfer.lock,
@@ -21,15 +22,17 @@ def refund_from_sendmediated(send_lockedtransfer_event):
 class SendLockedTransfer(Event):
     """ A locked transfer that must be sent to `recipient`. """
 
-    def __init__(self, transfer, recipient):
+    def __init__(self, message_identifier, transfer, recipient):
         if not isinstance(transfer, LockedTransferUnsignedState):
             raise ValueError('transfer must be a LockedTransferUnsignedState instance')
 
+        self.message_identifier = message_identifier
         self.transfer = transfer
         self.recipient = recipient
 
     def __repr__(self):
-        return '<SendLockedTransfer transfer:{} recipient:{}>'.format(
+        return '<SendLockedTransfer msgid:{} transfer:{} recipient:{}>'.format(
+            self.message_identifier,
             self.transfer,
             pex(self.recipient),
         )
@@ -37,6 +40,7 @@ class SendLockedTransfer(Event):
     def __eq__(self, other):
         return (
             isinstance(other, SendLockedTransfer) and
+            self.message_identifier == other.message_identifier and
             self.transfer == other.transfer and
             self.recipient == other.recipient
         )
@@ -47,8 +51,10 @@ class SendLockedTransfer(Event):
 
 class SendRevealSecret(Event):
     """ Sends a RevealSecret to another node.
+
     This event is used once the secret is known locally and an action must be
     performed on the receiver:
+
         - For receivers in the payee role, it informs the node that the lock has
             been released and the token can be withdrawn, either on-chain or
             off-chain.
@@ -57,11 +63,13 @@ class SendRevealSecret(Event):
             may unlock the lock and send an up-to-date balance proof to the payee,
             avoiding on-chain payments which would require the channel to be
             closed.
+
     For any mediated transfer:
         - The initiator will only perform the payer role.
         - The target will only perform the payee role.
         - The mediators will have `n` channels at the payee role and `n` at the
           payer role, where `n` is equal to `1 + number_of_refunds`.
+
     Note:
         The payee must only update its local balance once the payer sends an
         up-to-date balance-proof message. This is a requirement for keeping the
@@ -69,18 +77,18 @@ class SendRevealSecret(Event):
         to the sender, so when the secret is learned it is not yet time to
         update the balance.
     """
-    def __init__(self, identifier, secret, token, receiver):
+    def __init__(self, message_identifier, secret, token, receiver):
         secrethash = sha3(secret)
 
-        self.identifier = identifier
+        self.message_identifier = message_identifier
         self.secret = secret
         self.secrethash = secrethash
         self.token = token
         self.receiver = receiver
 
     def __repr__(self):
-        return '<SendRevealSecret id:{} secrethash:{} token:{} receiver:{}>'.format(
-            self.identifier,
+        return '<SendRevealSecret msgid:{} secrethash:{} token:{} receiver:{}>'.format(
+            self.message_identifier,
             pex(self.secrethash),
             pex(self.token),
             pex(self.receiver),
@@ -89,7 +97,7 @@ class SendRevealSecret(Event):
     def __eq__(self, other):
         return (
             isinstance(other, SendRevealSecret) and
-            self.identifier == other.identifier and
+            self.message_identifier == other.message_identifier and
             self.secret == other.secret and
             self.secrethash == other.secrethash and
             self.token == other.token and
@@ -103,10 +111,13 @@ class SendRevealSecret(Event):
 class SendBalanceProof(Event):
     """ Event to send a balance-proof to the counter-party, used after a lock
     is unlocked locally allowing the counter-party to withdraw.
+
     Used by payers: The initiator and mediator nodes.
+
     Note:
         This event has a dual role, it serves as a synchronization and as
         balance-proof for the netting channel smart contract.
+
         Nodes need to keep the last known merkle root synchronized. This is
         required by the receiving end of a transfer in order to properly
         validate. The rule is "only the party that owns the current payment
@@ -114,16 +125,28 @@ class SendBalanceProof(Event):
         two uni-directional channels), as a consequence the merkle root is only
         updated by the receiver once a balance proof message is received.
     """
-    def __init__(self, identifier, token, receiver, secret, balance_proof):
-        self.identifier = identifier
+    def __init__(
+            self,
+            message_identifier,
+            payment_identifier,
+            token,
+            receiver,
+            secret,
+            balance_proof,
+    ):
+        self.message_identifier = message_identifier
+        self.payment_identifier = payment_identifier
         self.token = token
         self.receiver = receiver
         self.secret = secret
         self.balance_proof = balance_proof
 
     def __repr__(self):
-        return '<SendBalanceProof id:{} token:{} receiver:{} balance_proof:{}>'.format(
-            self.identifier,
+        return (
+            '<SendBalanceProof msgid:{} paymentid:{} token:{} receiver:{} balance_proof:{}>'
+        ).format(
+            self.message_identifier,
+            self.payment_identifier,
             pex(self.token),
             pex(self.receiver),
             self.balance_proof,
@@ -132,7 +155,8 @@ class SendBalanceProof(Event):
     def __eq__(self, other):
         return (
             isinstance(other, SendBalanceProof) and
-            self.identifier == other.identifier and
+            self.message_identifier == other.message_identifier and
+            self.payment_identifier == other.payment_identifier and
             self.token == other.token and
             self.receiver == other.receiver and
             self.secret == other.secret and
@@ -147,15 +171,19 @@ class SendSecretRequest(Event):
     """ Event used by a target node to request the secret from the initiator
     (`receiver`).
     """
-    def __init__(self, identifier, amount, secrethash, receiver):
-        self.identifier = identifier
+    def __init__(self, message_identifier, payment_identifier, amount, secrethash, receiver):
+        self.message_identifier = message_identifier
+        self.payment_identifier = payment_identifier
         self.amount = amount
         self.secrethash = secrethash
         self.receiver = receiver
 
     def __repr__(self):
-        return '<SendSecretRequest id:{} amount:{} secrethash:{} receiver:{}>'.format(
-            self.identifier,
+        return (
+            '<SendSecretRequest msgid:{} paymentid:{} amount:{} secrethash:{} receiver:{}>'
+        ).format(
+            self.message_identifier,
+            self.payment_identifier,
             self.amount,
             pex(self.secrethash),
             pex(self.receiver),
@@ -164,7 +192,8 @@ class SendSecretRequest(Event):
     def __eq__(self, other):
         return (
             isinstance(other, SendSecretRequest) and
-            self.identifier == other.identifier and
+            self.message_identifier == other.message_identifier and
+            self.payment_identifier == other.payment_identifier and
             self.amount == other.amount and
             self.secrethash == other.secrethash and
             self.receiver == other.receiver
@@ -182,7 +211,8 @@ class SendRefundTransfer(Event):
     """
     def __init__(
             self,
-            identifier,
+            message_identifier,
+            payment_identifier,
             token,
             balance_proof,
             lock,
@@ -190,7 +220,8 @@ class SendRefundTransfer(Event):
             target,
             recipient):
 
-        self.identifier = identifier
+        self.message_identifier = message_identifier
+        self.payment_identifier = payment_identifier
         self.token = token
         self.balance_proof = balance_proof
         self.lock = lock
@@ -201,11 +232,12 @@ class SendRefundTransfer(Event):
     def __repr__(self):
         return (
             '<'
-            'SendRefundTransfer id:{} token:{} balance_proof:{} lock:{} '
+            'SendRefundTransfer msgid:{} paymentid:{} token:{} balance_proof:{} lock:{} '
             'initiator:{} target:{} recipient:{}'
             '>'
         ).format(
-            self.identifier,
+            self.message_identifier,
+            self.payment_identifier,
             pex(self.token),
             self.balance_proof,
             self.lock,
@@ -217,7 +249,8 @@ class SendRefundTransfer(Event):
     def __eq__(self, other):
         return (
             isinstance(other, SendRefundTransfer) and
-            self.identifier == other.identifier and
+            self.message_identifier == other.message_identifier and
+            self.payment_identifier == other.payment_identifier and
             self.token == other.token and
             self.balance_proof == other.balance_proof and
             self.lock == other.lock and

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import random
+
 from raiden.utils import typing
 from raiden.transfer import channel
 from raiden.transfer.architecture import TransitionResult
@@ -82,7 +84,7 @@ def try_new_route(
         channelidentifiers_to_channels: ChannelMap,
         available_routes: typing.List[RouteState],
         transfer_description: TransferDescriptionWithSecretState,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
 
@@ -166,7 +168,7 @@ def send_lockedtransfer(
 def handle_secretrequest(
         initiator_state: InitiatorTransferState,
         state_change: ReceiveSecretRequest,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
 ) -> TransitionResult:
 
     request_from_target = (
@@ -228,7 +230,7 @@ def handle_secretreveal(
         initiator_state: InitiatorTransferState,
         state_change: ReceiveSecretReveal,
         channel_state: NettingChannelState,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
 ) -> TransitionResult:
     """ Send a balance proof to the next hop with the current mediated transfer
     lock removed and the balance updated.

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -159,6 +159,7 @@ def send_lockedtransfer(
 def handle_secretrequest(
         initiator_state: InitiatorTransferState,
         state_change: ReceiveSecretRequest,
+        partner_message_queue: typing.UnorderedMessageQueue,
 ) -> TransitionResult:
 
     request_from_target = (
@@ -185,15 +186,16 @@ def handle_secretrequest(
         # Note: The target might be the first hop
         #
         transfer_description = initiator_state.transfer_description
-        reveal_secret = SendRevealSecret(
+        revealsecret = SendRevealSecret(
             transfer_description.identifier,
             transfer_description.secret,
             transfer_description.token,
             transfer_description.target,
         )
 
-        initiator_state.revealsecret = reveal_secret
-        iteration = TransitionResult(initiator_state, [reveal_secret])
+        initiator_state.revealsecret = revealsecret
+        partner_message_queue.append(revealsecret)
+        iteration = TransitionResult(initiator_state, [revealsecret])
 
     elif invalid_secretrequest:
         cancel = EventTransferSentFailed(

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -252,6 +252,7 @@ def state_transition(
         payment_state: InitiatorPaymentState,
         state_change: StateChange,
         channelidentifiers_to_channels: initiator.ChannelMap,
+        addresses_to_queues: typing.UnorderedMessageQueue,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
 
@@ -264,9 +265,16 @@ def state_transition(
             block_number,
         )
     elif type(state_change) == ReceiveSecretRequest:
+        channel_state = channelidentifiers_to_channels[payment_state.initiator.channel_identifier]
+        partner_message_queue = addresses_to_queues.setdefault(
+            channel_state.partner_state.address,
+            [],
+        )
+
         sub_iteration = initiator.handle_secretrequest(
             payment_state.initiator,
             state_change,
+            partner_message_queue,
         )
         iteration = iteration_from_sub(payment_state, sub_iteration)
     elif type(state_change) == ActionCancelRoute:

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -84,12 +84,14 @@ def handle_init(
         payment_state: InitiatorPaymentState,
         state_change: ActionInitInitiator,
         channelidentifiers_to_channels: initiator.ChannelMap,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
     if payment_state is None:
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels,
+            queueids_to_queues,
             state_change.routes,
             state_change.transfer,
             pseudo_random_generator,
@@ -110,6 +112,7 @@ def handle_cancelroute(
         payment_state: InitiatorPaymentState,
         state_change: ActionCancelRoute,
         channelidentifiers_to_channels: initiator.ChannelMap,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
@@ -122,6 +125,7 @@ def handle_cancelroute(
         assert payment_state.initiator is None, msg
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels,
+            queueids_to_queues,
             state_change.routes,
             transfer_description,
             pseudo_random_generator,
@@ -161,6 +165,7 @@ def handle_transferrefund(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveTransferRefundCancelRoute,
         channelidentifiers_to_channels: initiator.ChannelMap,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
@@ -222,6 +227,7 @@ def handle_transferrefund(
                 payment_state,
                 state_change,
                 channelidentifiers_to_channels,
+                queueids_to_queues,
                 pseudo_random_generator,
                 block_number,
             )
@@ -239,14 +245,18 @@ def handle_secretreveal(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveSecretReveal,
         channelidentifiers_to_channels: initiator.ChannelMap,
+        queueids_to_queues,
         pseudo_random_generator,
 ) -> TransitionResult:
     channel_identifier = payment_state.initiator.channel_identifier
     channel_state = channelidentifiers_to_channels[channel_identifier]
+    queueid = (channel_state.partner_state.address, channel_state.identifier)
+    partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
     sub_iteration = initiator.handle_secretreveal(
         payment_state.initiator,
         state_change,
         channel_state,
+        partner_channel_message_queue,
         pseudo_random_generator,
     )
     iteration = iteration_from_sub(payment_state, sub_iteration)
@@ -257,7 +267,7 @@ def state_transition(
         payment_state: InitiatorPaymentState,
         state_change: StateChange,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
@@ -267,20 +277,19 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ReceiveSecretRequest:
         channel_state = channelidentifiers_to_channels[payment_state.initiator.channel_identifier]
-        partner_message_queue = addresses_to_queues.setdefault(
-            channel_state.partner_state.address,
-            [],
-        )
+        queueid = (channel_state.partner_state.address, 'global')
+        partner_default_message_queue = queueids_to_queues.setdefault(queueid, [])
 
         sub_iteration = initiator.handle_secretrequest(
             payment_state.initiator,
             state_change,
-            partner_message_queue,
+            partner_default_message_queue,
             pseudo_random_generator,
         )
         iteration = iteration_from_sub(payment_state, sub_iteration)
@@ -289,6 +298,7 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -297,6 +307,7 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -309,6 +320,7 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
+            queueids_to_queues,
             pseudo_random_generator,
         )
     else:

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -84,14 +84,12 @@ def handle_init(
         payment_state: InitiatorPaymentState,
         state_change: ActionInitInitiator,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
     if payment_state is None:
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels,
-            queueids_to_queues,
             state_change.routes,
             state_change.transfer,
             pseudo_random_generator,
@@ -112,7 +110,6 @@ def handle_cancelroute(
         payment_state: InitiatorPaymentState,
         state_change: ActionCancelRoute,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
@@ -125,7 +122,6 @@ def handle_cancelroute(
         assert payment_state.initiator is None, msg
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels,
-            queueids_to_queues,
             state_change.routes,
             transfer_description,
             pseudo_random_generator,
@@ -165,7 +161,6 @@ def handle_transferrefund(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveTransferRefundCancelRoute,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
@@ -227,7 +222,6 @@ def handle_transferrefund(
                 payment_state,
                 state_change,
                 channelidentifiers_to_channels,
-                queueids_to_queues,
                 pseudo_random_generator,
                 block_number,
             )
@@ -245,18 +239,14 @@ def handle_secretreveal(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveSecretReveal,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        queueids_to_queues,
         pseudo_random_generator,
 ) -> TransitionResult:
     channel_identifier = payment_state.initiator.channel_identifier
     channel_state = channelidentifiers_to_channels[channel_identifier]
-    queueid = (channel_state.partner_state.address, channel_state.identifier)
-    partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
     sub_iteration = initiator.handle_secretreveal(
         payment_state.initiator,
         state_change,
         channel_state,
-        partner_channel_message_queue,
         pseudo_random_generator,
     )
     iteration = iteration_from_sub(payment_state, sub_iteration)
@@ -267,7 +257,6 @@ def state_transition(
         payment_state: InitiatorPaymentState,
         state_change: StateChange,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        queueids_to_queues,
         pseudo_random_generator,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
@@ -277,19 +266,13 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
-            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ReceiveSecretRequest:
-        channel_state = channelidentifiers_to_channels[payment_state.initiator.channel_identifier]
-        queueid = (channel_state.partner_state.address, 'global')
-        partner_default_message_queue = queueids_to_queues.setdefault(queueid, [])
-
         sub_iteration = initiator.handle_secretrequest(
             payment_state.initiator,
             state_change,
-            partner_default_message_queue,
             pseudo_random_generator,
         )
         iteration = iteration_from_sub(payment_state, sub_iteration)
@@ -298,7 +281,6 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
-            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -307,7 +289,6 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
-            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -320,7 +301,6 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
-            queueids_to_queues,
             pseudo_random_generator,
         )
     else:

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import random
+
 from raiden.utils import typing
 from raiden.transfer import channel
 from raiden.transfer.architecture import (
@@ -84,7 +86,7 @@ def handle_init(
         payment_state: InitiatorPaymentState,
         state_change: ActionInitInitiator,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
     if payment_state is None:
@@ -110,7 +112,7 @@ def handle_cancelroute(
         payment_state: InitiatorPaymentState,
         state_change: ActionCancelRoute,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
     events = list()
@@ -161,7 +163,7 @@ def handle_transferrefund(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveTransferRefundCancelRoute,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
 
@@ -239,7 +241,7 @@ def handle_secretreveal(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveSecretReveal,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
 ) -> TransitionResult:
     channel_identifier = payment_state.initiator.channel_identifier
     channel_state = channelidentifiers_to_channels[channel_identifier]
@@ -257,7 +259,7 @@ def state_transition(
         payment_state: InitiatorPaymentState,
         state_change: StateChange,
         channelidentifiers_to_channels: initiator.ChannelMap,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
     # pylint: disable=unidiomatic-typecheck

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import itertools
+import random
 from typing import List, Dict
 
 from raiden.transfer import channel
@@ -349,7 +350,7 @@ def next_transfer_pair(
         payer_transfer: LockedTransferSignedState,
         available_routes: List['RouteState'],
         channelidentifiers_to_channels: Dict,
-        pseudo_random_generator,
+        pseudo_random_generator: random.Random,
         timeout_blocks: int,
         block_number: int
 ):

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -53,7 +53,7 @@ class InitiatorPaymentState(State):
         'cancelled_channels',
     )
 
-    def __init__(self, initiator: typing.Address):
+    def __init__(self, initiator: 'InitiatorTransferState'):
         # TODO: Allow multiple concurrent transfers and unlock refunds (issue #1091).
         self.initiator = initiator
         self.cancelled_channels = list()

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -31,7 +31,7 @@ def lockedtransfersigned_from_message(message):
     )
 
     transfer_state = LockedTransferSignedState(
-        message.identifier,
+        message.payment_identifier,
         message.token,
         balance_proof,
         lock,
@@ -213,7 +213,7 @@ class LockedTransferUnsignedState(State):
     """
 
     __slots__ = (
-        'identifier',
+        'payment_identifier',
         'token',
         'balance_proof',
         'lock',
@@ -223,7 +223,7 @@ class LockedTransferUnsignedState(State):
 
     def __init__(
             self,
-            identifier,
+            payment_identifier,
             token: typing.Address,
             balance_proof: BalanceProofUnsignedState,
             lock: HashTimeLockState,
@@ -241,7 +241,7 @@ class LockedTransferUnsignedState(State):
         if balance_proof.locksroot is EMPTY_MERKLE_ROOT:
             raise ValueError('balance_proof must not be empty')
 
-        self.identifier = identifier
+        self.payment_identifier = payment_identifier
         self.token = token
         self.balance_proof = balance_proof
         self.lock = lock
@@ -252,7 +252,7 @@ class LockedTransferUnsignedState(State):
         return (
             '<LockedTransferUnsignedState id:{} token:{} lock:{} target:{}>'
         ).format(
-            self.identifier,
+            self.payment_identifier,
             encode_hex(self.token),
             self.lock,
             encode_hex(self.target),
@@ -261,7 +261,7 @@ class LockedTransferUnsignedState(State):
     def __eq__(self, other):
         return (
             isinstance(other, LockedTransferUnsignedState) and
-            self.identifier == other.identifier and
+            self.payment_identifier == other.payment_identifier and
             self.token == other.token and
             self.balance_proof == other.balance_proof and
             self.lock == other.lock and
@@ -279,7 +279,7 @@ class LockedTransferSignedState(State):
     """
 
     __slots__ = (
-        'identifier',
+        'payment_identifier',
         'token',
         'balance_proof',
         'lock',
@@ -289,7 +289,7 @@ class LockedTransferSignedState(State):
 
     def __init__(
             self,
-            identifier,
+            payment_identifier,
             token: typing.Address,
             balance_proof: BalanceProofSignedState,
             lock: HashTimeLockState,
@@ -307,7 +307,7 @@ class LockedTransferSignedState(State):
         if balance_proof.locksroot is EMPTY_MERKLE_ROOT:
             raise ValueError('balance_proof must not be empty')
 
-        self.identifier = identifier
+        self.payment_identifier = payment_identifier
         self.token = token
         self.balance_proof = balance_proof
         self.lock = lock
@@ -318,7 +318,7 @@ class LockedTransferSignedState(State):
         return (
             '<LockedTransferSignedState id:{} token:{} lock:{} target:{}>'
         ).format(
-            self.identifier,
+            self.payment_identifier,
             encode_hex(self.token),
             self.lock,
             encode_hex(self.target),
@@ -327,7 +327,7 @@ class LockedTransferSignedState(State):
     def __eq__(self, other):
         return (
             isinstance(other, LockedTransferSignedState) and
-            self.identifier == other.identifier and
+            self.payment_identifier == other.payment_identifier and
             self.token == other.token and
             self.balance_proof == other.balance_proof and
             self.lock == other.lock and
@@ -345,7 +345,7 @@ class TransferDescriptionWithSecretState(State):
     """
 
     __slots__ = (
-        'identifier',
+        'payment_identifier',
         'amount',
         'registry',
         'token',
@@ -357,7 +357,7 @@ class TransferDescriptionWithSecretState(State):
 
     def __init__(
             self,
-            identifier,
+            payment_identifier,
             amount: typing.TokenAmount,
             registry: typing.Address,
             token: typing.Address,
@@ -367,7 +367,7 @@ class TransferDescriptionWithSecretState(State):
 
         secrethash = sha3(secret)
 
-        self.identifier = identifier
+        self.payment_identifier = payment_identifier
         self.amount = amount
         self.registry = registry
         self.token = token
@@ -389,7 +389,7 @@ class TransferDescriptionWithSecretState(State):
     def __eq__(self, other):
         return (
             isinstance(other, TransferDescriptionWithSecretState) and
-            self.identifier == other.identifier and
+            self.payment_identifier == other.payment_identifier and
             self.amount == other.amount and
             self.registry == other.registry and
             self.token == other.token and

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -164,16 +164,16 @@ class ActionCancelRoute(StateChange):
 class ReceiveSecretRequest(StateChange):
     """ A SecretRequest message received. """
 
-    def __init__(self, identifier, amount, secrethash, sender):
-        self.identifier = identifier
+    def __init__(self, payment_identifier, amount, secrethash, sender):
+        self.payment_identifier = payment_identifier
         self.amount = amount
         self.secrethash = secrethash
         self.sender = sender
         self.revealsecret = None
 
     def __repr__(self):
-        return '<ReceiveSecretRequest id:{} amount:{} secrethash:{} sender:{}>'.format(
-            self.identifier,
+        return '<ReceiveSecretRequest paymentid:{} amount:{} secrethash:{} sender:{}>'.format(
+            self.payment_identifier,
             self.amount,
             pex(self.secrethash),
             pex(self.sender),
@@ -182,7 +182,7 @@ class ReceiveSecretRequest(StateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ReceiveSecretRequest) and
-            self.identifier == other.identifier and
+            self.payment_identifier == other.payment_identifier and
             self.amount == other.amount and
             self.secrethash == other.secrethash and
             self.sender == other.sender and

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -47,7 +47,7 @@ def events_for_close(target_state, channel_state, block_number):
 def handle_inittarget(
         state_change,
         channel_state,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
 ):
@@ -84,8 +84,9 @@ def handle_inittarget(
             transfer.initiator,
         )
 
-        partner_message_queue = addresses_to_queues.setdefault(route.node_address, [])
-        partner_message_queue.append(secret_request)
+        queueid = (route.node_address, 'global')
+        partner_default_message_queue = queueids_to_queues.setdefault(queueid, [])
+        partner_default_message_queue.append(secret_request)
         iteration = TransitionResult(target_state, [secret_request])
     else:
         if not is_valid:
@@ -107,7 +108,7 @@ def handle_secretreveal(
         target_state,
         state_change,
         channel_state,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
 ):
     """ Validates and handles a ReceiveSecretReveal state change. """
@@ -134,8 +135,9 @@ def handle_secretreveal(
             receiver_address,
         )
 
-        partner_message_queue = addresses_to_queues.setdefault(receiver_address, [])
-        partner_message_queue.append(reveal)
+        queueid = (receiver_address, 'global')
+        partner_default_message_queue = queueids_to_queues.setdefault(queueid, [])
+        partner_default_message_queue.append(reveal)
 
         iteration = TransitionResult(target_state, [reveal])
 
@@ -207,7 +209,7 @@ def state_transition(
         target_state,
         state_change,
         channel_state,
-        addresses_to_queues,
+        queueids_to_queues,
         pseudo_random_generator,
         block_number,
 ):
@@ -220,7 +222,7 @@ def state_transition(
         iteration = handle_inittarget(
             state_change,
             channel_state,
-            addresses_to_queues,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -237,7 +239,7 @@ def state_transition(
             target_state,
             state_change,
             channel_state,
-            addresses_to_queues,
+            queueids_to_queues,
             pseudo_random_generator,
         )
     elif type(state_change) == ReceiveUnlock:

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -71,12 +71,17 @@ def get_token_network(node_state, payment_network_identifier, token_address):
 
 def subdispatch_to_all_channels(node_state, state_change, block_number):
     events = list()
+    queueids_to_queues = node_state.queueids_to_queues
 
     for payment_network in node_state.identifiers_to_paymentnetworks.values():
         for token_network_state in payment_network.tokenaddresses_to_tokennetworks.values():
             for channel_state in token_network_state.channelidentifiers_to_channels.values():
+                queueid = (channel_state.partner_state.address, channel_state.identifier)
+                partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
+
                 result = channel.state_transition(
                     channel_state,
+                    partner_channel_message_queue,
                     state_change,
                     node_state.pseudo_random_generator,
                     block_number,
@@ -102,7 +107,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
     events = list()
 
     if sub_task:
-        addresses_to_queues = node_state.addresses_to_queues
+        queueids_to_queues = node_state.queueids_to_queues
         pseudo_random_generator = node_state.pseudo_random_generator
 
         if isinstance(sub_task, PaymentMappingState.InitiatorTask):
@@ -120,7 +125,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
                     sub_task.manager_state,
                     state_change,
                     token_network_state.channelidentifiers_to_channels,
-                    addresses_to_queues,
+                    queueids_to_queues,
                     pseudo_random_generator,
                     block_number,
                 )
@@ -141,7 +146,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
                     sub_task.mediator_state,
                     state_change,
                     token_network_state.channelidentifiers_to_channels,
-                    addresses_to_queues,
+                    queueids_to_queues,
                     pseudo_random_generator,
                     block_number,
                 )
@@ -164,7 +169,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
                     sub_task.target_state,
                     state_change,
                     channel_state,
-                    addresses_to_queues,
+                    queueids_to_queues,
                     pseudo_random_generator,
                     block_number,
                 )
@@ -198,7 +203,7 @@ def subdispatch_initiatortask(
 
     events = list()
     if is_valid_subtask:
-        addresses_to_queues = node_state.addresses_to_queues
+        queueids_to_queues = node_state.queueids_to_queues
         pseudo_random_generator = node_state.pseudo_random_generator
 
         token_network_state = get_token_network(
@@ -210,7 +215,7 @@ def subdispatch_initiatortask(
             manager_state,
             state_change,
             token_network_state.channelidentifiers_to_channels,
-            addresses_to_queues,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -252,7 +257,7 @@ def subdispatch_mediatortask(
 
     events = list()
     if is_valid_subtask:
-        addresses_to_queues = node_state.addresses_to_queues
+        queueids_to_queues = node_state.queueids_to_queues
 
         token_network_state = get_token_network(
             node_state,
@@ -265,7 +270,7 @@ def subdispatch_mediatortask(
             mediator_state,
             state_change,
             token_network_state.channelidentifiers_to_channels,
-            addresses_to_queues,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -317,14 +322,14 @@ def subdispatch_targettask(
         )
 
     if channel_state:
-        addresses_to_queues = node_state.addresses_to_queues
+        queueids_to_queues = node_state.queueids_to_queues
         pseudo_random_generator = node_state.pseudo_random_generator
 
         iteration = target.state_transition(
             target_state,
             state_change,
             channel_state,
-            addresses_to_queues,
+            queueids_to_queues,
             pseudo_random_generator,
             block_number,
         )
@@ -411,8 +416,10 @@ def handle_token_network_action(node_state, state_change):
     events = list()
     if token_network_state:
         pseudo_random_generator = node_state.pseudo_random_generator
+        queueids_to_queues = node_state.queueids_to_queues
         iteration = token_network.state_transition(
             token_network_state,
+            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             node_state.block_number,
@@ -499,8 +506,10 @@ def handle_channel_withdraw(node_state, state_change):
     events = []
     if token_network_state:
         pseudo_random_generator = node_state.pseudo_random_generator
+        queueids_to_queues = node_state.queueids_to_queues
         sub_iteration = token_network.subdispatch_to_channel_by_id(
             token_network_state,
+            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             node_state.block_number,

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -97,6 +97,8 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
     events = list()
 
     if sub_task:
+        addresses_to_queues = node_state.addresses_to_queues
+
         if isinstance(sub_task, PaymentMappingState.InitiatorTask):
             payment_network_identifier = sub_task.payment_network_identifier
             token_address = sub_task.token_address
@@ -112,6 +114,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
                     sub_task.manager_state,
                     state_change,
                     token_network_state.channelidentifiers_to_channels,
+                    addresses_to_queues,
                     block_number,
                 )
                 events = sub_iteration.events
@@ -131,6 +134,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
                     sub_task.mediator_state,
                     state_change,
                     token_network_state.channelidentifiers_to_channels,
+                    addresses_to_queues,
                     block_number,
                 )
                 events = sub_iteration.events
@@ -152,6 +156,7 @@ def subdispatch_to_paymenttask(node_state, state_change, secrethash):
                     sub_task.target_state,
                     state_change,
                     channel_state,
+                    addresses_to_queues,
                     block_number,
                 )
                 events = sub_iteration.events
@@ -184,6 +189,8 @@ def subdispatch_initiatortask(
 
     events = list()
     if is_valid_subtask:
+        addresses_to_queues = node_state.addresses_to_queues
+
         token_network_state = get_token_network(
             node_state,
             payment_network_identifier,
@@ -193,6 +200,7 @@ def subdispatch_initiatortask(
             manager_state,
             state_change,
             token_network_state.channelidentifiers_to_channels,
+            addresses_to_queues,
             block_number,
         )
         events = iteration.events
@@ -233,6 +241,8 @@ def subdispatch_mediatortask(
 
     events = list()
     if is_valid_subtask:
+        addresses_to_queues = node_state.addresses_to_queues
+
         token_network_state = get_token_network(
             node_state,
             payment_network_identifier,
@@ -242,6 +252,7 @@ def subdispatch_mediatortask(
             mediator_state,
             state_change,
             token_network_state.channelidentifiers_to_channels,
+            addresses_to_queues,
             block_number,
         )
         events = iteration.events
@@ -292,10 +303,13 @@ def subdispatch_targettask(
         )
 
     if channel_state:
+        addresses_to_queues = node_state.addresses_to_queues
+
         iteration = target.state_transition(
             target_state,
             state_change,
             channel_state,
+            addresses_to_queues,
             block_number,
         )
         events = iteration.events

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
+import random
 from binascii import hexlify
 from collections import namedtuple
 
@@ -76,13 +77,12 @@ class NodeState(State):
         'queueids_to_queues',
         'pseudo_random_generator',
         'block_number',
-        'pseudo_random_generator',
         'identifiers_to_paymentnetworks',
         'nodeaddresses_to_networkstates',
         'payment_mapping',
     )
 
-    def __init__(self, pseudo_random_generator, block_number: typing.BlockNumber):
+    def __init__(self, pseudo_random_generator: random.Random, block_number: typing.BlockNumber):
         if not isinstance(block_number, typing.T_BlockNumber):
             raise ValueError('block_number must be a block_number')
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -69,6 +69,7 @@ class NodeState(State):
     """
 
     __slots__ = (
+        'addresses_to_queues',
         'block_number',
         'identifiers_to_paymentnetworks',
         'nodeaddresses_to_networkstates',
@@ -80,6 +81,7 @@ class NodeState(State):
             raise ValueError('block_number must be a block_number')
 
         self.block_number = block_number
+        self.addresses_to_queues = list()
         self.identifiers_to_paymentnetworks = dict()
         self.nodeaddresses_to_networkstates = dict()
         self.payment_mapping = PaymentMappingState()
@@ -95,6 +97,7 @@ class NodeState(State):
         return (
             isinstance(other, NodeState) and
             self.block_number == other.block_number and
+            self.addresses_to_queues == other.addresses_to_queues and
             self.identifiers_to_paymentnetworks == other.identifiers_to_paymentnetworks and
             self.nodeaddresses_to_networkstates == other.nodeaddresses_to_networkstates and
             self.payment_mapping == other.payment_mapping
@@ -781,6 +784,7 @@ class NettingChannelState(State):
         'open_transaction',
         'close_transaction',
         'settle_transaction',
+        'ordered_message_queue',
     )
 
     def __init__(
@@ -793,7 +797,8 @@ class NettingChannelState(State):
             partner_state: NettingChannelEndState,
             open_transaction: TransactionExecutionStatus,
             close_transaction: typing.Optional[TransactionExecutionStatus],
-            settle_transaction: typing.Optional[TransactionExecutionStatus]):
+            settle_transaction: typing.Optional[TransactionExecutionStatus],
+    ):
 
         if reveal_timeout >= settle_timeout:
             raise ValueError('reveal_timeout must be smaller than settle_timeout')
@@ -838,6 +843,7 @@ class NettingChannelState(State):
         self.open_transaction = open_transaction
         self.close_transaction = close_transaction
         self.settle_transaction = settle_transaction
+        self.ordered_message_queue: typing.OrderedMessageQueue = list()
 
     def __repr__(self):
         return '<NettingChannelState id:{} opened:{} closed:{} settled:{}>'.format(
@@ -859,7 +865,8 @@ class NettingChannelState(State):
             self.deposit_transaction_queue == other.deposit_transaction_queue and
             self.open_transaction == other.open_transaction and
             self.close_transaction == other.close_transaction and
-            self.settle_transaction == other.settle_transaction
+            self.settle_transaction == other.settle_transaction and
+            self.ordered_message_queue == other.ordered_message_queue
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -62,6 +62,10 @@ def lockstate_from_lock(lock):
     )
 
 
+def message_identifier_from_prng(prng):
+    return prng.randint(0, UINT64_MAX)
+
+
 class NodeState(State):
     """ Umbrella object that stores all the node state.
     For each registry smart contract there must be a payment network. Within the
@@ -70,16 +74,19 @@ class NodeState(State):
 
     __slots__ = (
         'addresses_to_queues',
+        'pseudo_random_generator',
         'block_number',
+        'pseudo_random_generator',
         'identifiers_to_paymentnetworks',
         'nodeaddresses_to_networkstates',
         'payment_mapping',
     )
 
-    def __init__(self, block_number: typing.BlockNumber):
+    def __init__(self, pseudo_random_generator, block_number: typing.BlockNumber):
         if not isinstance(block_number, typing.T_BlockNumber):
             raise ValueError('block_number must be a block_number')
 
+        self.pseudo_random_generator = pseudo_random_generator
         self.block_number = block_number
         self.addresses_to_queues = list()
         self.identifiers_to_paymentnetworks = dict()
@@ -96,6 +103,7 @@ class NodeState(State):
     def __eq__(self, other):
         return (
             isinstance(other, NodeState) and
+            self.pseudo_random_generator == other.pseudo_random_generator and
             self.block_number == other.block_number and
             self.addresses_to_queues == other.addresses_to_queues and
             self.identifiers_to_paymentnetworks == other.identifiers_to_paymentnetworks and
@@ -843,7 +851,7 @@ class NettingChannelState(State):
         self.open_transaction = open_transaction
         self.close_transaction = close_transaction
         self.settle_transaction = settle_transaction
-        self.ordered_message_queue: typing.OrderedMessageQueue = list()
+        self.ordered_message_queue = list()
 
     def __repr__(self):
         return '<NettingChannelState id:{} opened:{} closed:{} settled:{}>'.format(

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -73,7 +73,7 @@ class NodeState(State):
     """
 
     __slots__ = (
-        'addresses_to_queues',
+        'queueids_to_queues',
         'pseudo_random_generator',
         'block_number',
         'pseudo_random_generator',
@@ -88,7 +88,7 @@ class NodeState(State):
 
         self.pseudo_random_generator = pseudo_random_generator
         self.block_number = block_number
-        self.addresses_to_queues = list()
+        self.queueids_to_queues = dict()
         self.identifiers_to_paymentnetworks = dict()
         self.nodeaddresses_to_networkstates = dict()
         self.payment_mapping = PaymentMappingState()
@@ -105,7 +105,7 @@ class NodeState(State):
             isinstance(other, NodeState) and
             self.pseudo_random_generator == other.pseudo_random_generator and
             self.block_number == other.block_number and
-            self.addresses_to_queues == other.addresses_to_queues and
+            self.queueids_to_queues == other.queueids_to_queues and
             self.identifiers_to_paymentnetworks == other.identifiers_to_paymentnetworks and
             self.nodeaddresses_to_networkstates == other.nodeaddresses_to_networkstates and
             self.payment_mapping == other.payment_mapping
@@ -792,7 +792,6 @@ class NettingChannelState(State):
         'open_transaction',
         'close_transaction',
         'settle_transaction',
-        'ordered_message_queue',
     )
 
     def __init__(
@@ -851,7 +850,6 @@ class NettingChannelState(State):
         self.open_transaction = open_transaction
         self.close_transaction = close_transaction
         self.settle_transaction = settle_transaction
-        self.ordered_message_queue = list()
 
     def __repr__(self):
         return '<NettingChannelState id:{} opened:{} closed:{} settled:{}>'.format(
@@ -873,8 +871,7 @@ class NettingChannelState(State):
             self.deposit_transaction_queue == other.deposit_transaction_queue and
             self.open_transaction == other.open_transaction and
             self.close_transaction == other.close_transaction and
-            self.settle_transaction == other.settle_transaction and
-            self.ordered_message_queue == other.ordered_message_queue
+            self.settle_transaction == other.settle_transaction
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -41,18 +41,18 @@ class ActionCancelPayment(StateChange):
     state of the transfer.
     """
 
-    def __init__(self, identifier):
-        self.identifier = identifier
+    def __init__(self, payment_identifier):
+        self.payment_identifier = payment_identifier
 
     def __repr__(self):
         return '<ActionCancelPayment identifier:{}>'.format(
-            self.identifier,
+            self.payment_identifier,
         )
 
     def __eq__(self, other):
         return (
             isinstance(other, ActionCancelPayment) and
-            self.identifier == other.identifier
+            self.payment_identifier == other.payment_identifier
         )
 
     def __ne__(self, other):
@@ -115,8 +115,8 @@ class ActionTransferDirect(StateChange):
             payment_network_identifier,
             token_address,
             receiver_address: typing.T_Address,
-            identifier,
             amount: int,
+            payment_identifier,
     ):
         if not isinstance(receiver_address, typing.T_Address):
             raise ValueError('receiver_address must be address')
@@ -126,14 +126,14 @@ class ActionTransferDirect(StateChange):
 
         self.payment_network_identifier = payment_network_identifier
         self.token_address = token_address
-        self.identifier = identifier
         self.amount = amount
         self.receiver_address = receiver_address
+        self.payment_identifier = payment_identifier
 
     def __repr__(self):
         return '<ActionTransferDirect receiver_address:{} identifier:{} amount:{}>'.format(
             pex(self.receiver_address),
-            self.identifier,
+            self.payment_identifier,
             self.amount,
         )
 
@@ -143,7 +143,7 @@ class ActionTransferDirect(StateChange):
             self.payment_network_identifier == other.payment_network_identifier and
             self.token_address == other.token_address and
             self.receiver_address == other.receiver_address and
-            self.identifier == other.identifier and
+            self.payment_identifier == other.payment_identifier and
             self.amount == other.amount
         )
 
@@ -229,10 +229,11 @@ class ContractReceiveChannelClosed(StateChange):
 
 
 class ActionInitNode(StateChange):
-    def __init__(self, block_number: int):
+    def __init__(self, pseudo_random_generator, block_number: int):
         if not isinstance(block_number, int):
             raise ValueError('block_number must be int')
 
+        self.pseudo_random_generator = pseudo_random_generator
         self.block_number = block_number
 
     def __repr__(self):
@@ -241,6 +242,7 @@ class ActionInitNode(StateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ActionInitNode) and
+            self.pseudo_random_generator == other.pseudo_random_generator and
             self.block_number == other.block_number
         )
 
@@ -494,7 +496,7 @@ class ContractReceiveChannelWithdraw(StateChange):
         return (
             isinstance(other, ContractReceiveChannelWithdraw) and
             self.payment_network_identifier == other.payment_network_identifier and
-            self.token_network_identifier == other.token_network_identifier and
+            self.token_address == other.token_address and
             self.channel_identifier == other.channel_identifier and
             self.secret == other.secret and
             self.secrethash == other.secrethash and
@@ -583,7 +585,7 @@ class ReceiveTransferDirect(StateChange):
             self,
             payment_network_identifier,
             token_address,
-            transfer_identifier,
+            payment_identifier,
             balance_proof,
     ):
         if not isinstance(balance_proof, BalanceProofSignedState):
@@ -591,7 +593,7 @@ class ReceiveTransferDirect(StateChange):
 
         self.payment_network_identifier = payment_network_identifier
         self.token_address = token_address
-        self.transfer_identifier = transfer_identifier
+        self.payment_identifier = payment_identifier
         self.balance_proof = balance_proof
 
     def __repr__(self):
@@ -602,7 +604,7 @@ class ReceiveTransferDirect(StateChange):
         ).format(
             pex(self.payment_network_identifier),
             pex(self.token_address),
-            self.transfer_identifier,
+            self.payment_identifier,
             self.balance_proof,
         )
 
@@ -611,7 +613,7 @@ class ReceiveTransferDirect(StateChange):
             isinstance(other, ReceiveTransferDirect) and
             self.payment_network_identifier == other.payment_network_identifier and
             self.token_address == other.token_address and
-            self.transfer_identifier == other.transfer_identifier and
+            self.payment_identifier == other.payment_identifier and
             self.balance_proof == other.balance_proof
         )
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -115,8 +115,8 @@ class ActionTransferDirect(StateChange):
             payment_network_identifier,
             token_address,
             receiver_address: typing.T_Address,
-            amount: int,
             payment_identifier,
+            amount: int,
     ):
         if not isinstance(receiver_address, typing.T_Address):
             raise ValueError('receiver_address must be address')

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -23,7 +23,6 @@ def maybe_update_subtask(new_state, secrethash, secrethashes_to_states):
 
 def subdispatch_to_channel_by_id(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -34,11 +33,8 @@ def subdispatch_to_channel_by_id(
     channel_state = ids_to_channels.get(state_change.channel_identifier)
 
     if channel_state:
-        queueid = (channel_state.partner_state.address, channel_state.identifier)
-        partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
         result = channel.state_transition(
             channel_state,
-            partner_channel_message_queue,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -50,14 +46,12 @@ def subdispatch_to_channel_by_id(
 
 def handle_channel_close(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
 ):
     return subdispatch_to_channel_by_id(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -85,14 +79,12 @@ def handle_channelnew(token_network_state, state_change):
 
 def handle_balance(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
 ):
     return subdispatch_to_channel_by_id(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -101,14 +93,12 @@ def handle_balance(
 
 def handle_closed(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
 ):
     return subdispatch_to_channel_by_id(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -117,14 +107,12 @@ def handle_closed(
 
 def handle_settled(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
 ):
     return subdispatch_to_channel_by_id(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -144,7 +132,6 @@ def handle_newroute(token_network_state, state_change):
 
 def handle_action_transfer_direct(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -153,11 +140,8 @@ def handle_action_transfer_direct(
     channel_state = token_network_state.partneraddresses_to_channels.get(receiver_address)
 
     if channel_state:
-        queueid = (channel_state.partner_state.address, channel_state.identifier)
-        partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
         iteration = channel.state_transition(
             channel_state,
-            partner_channel_message_queue,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -175,7 +159,6 @@ def handle_action_transfer_direct(
 
 def handle_receive_transfer_direct(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -186,11 +169,8 @@ def handle_receive_transfer_direct(
     channel_state = token_network_state.channelidentifiers_to_channels.get(channel_id)
 
     if channel_state:
-        queueid = (channel_state.partner_state.address, channel_state.identifier)
-        partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
         result = channel.state_transition(
             channel_state,
-            partner_channel_message_queue,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -202,7 +182,6 @@ def handle_receive_transfer_direct(
 
 def handle_receive_transfer_refund(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -213,11 +192,8 @@ def handle_receive_transfer_refund(
     channel_state = token_network_state.channelidentifiers_to_channels.get(channel_id)
 
     if channel_state:
-        queueid = (channel_state.partner_state.address, channel_state.identifier)
-        partner_channel_message_queue = queueids_to_queues.setdefault(queueid, [])
         result = channel.state_transition(
             channel_state,
-            partner_channel_message_queue,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -229,7 +205,6 @@ def handle_receive_transfer_refund(
 
 def state_transition(
         token_network_state,
-        queueids_to_queues,
         state_change,
         pseudo_random_generator,
         block_number,
@@ -239,7 +214,6 @@ def state_transition(
     if type(state_change) == ActionChannelClose:
         iteration = handle_channel_close(
             token_network_state,
-            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -252,7 +226,6 @@ def state_transition(
     elif type(state_change) == ContractReceiveChannelNewBalance:
         iteration = handle_balance(
             token_network_state,
-            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -260,7 +233,6 @@ def state_transition(
     elif type(state_change) == ContractReceiveChannelClosed:
         iteration = handle_closed(
             token_network_state,
-            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -268,7 +240,6 @@ def state_transition(
     elif type(state_change) == ContractReceiveChannelSettled:
         iteration = handle_settled(
             token_network_state,
-            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -281,7 +252,6 @@ def state_transition(
     elif type(state_change) == ActionTransferDirect:
         iteration = handle_action_transfer_direct(
             token_network_state,
-            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             block_number,
@@ -289,7 +259,6 @@ def state_transition(
     elif type(state_change) == ReceiveTransferDirect:
         iteration = handle_receive_transfer_direct(
             token_network_state,
-            queueids_to_queues,
             state_change,
             pseudo_random_generator,
             block_number,

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -21,21 +21,36 @@ def maybe_update_subtask(new_state, secrethash, secrethashes_to_states):
         del secrethashes_to_states[secrethash]
 
 
-def subdispatch_to_channel_by_id(token_network_state, state_change, block_number):
+def subdispatch_to_channel_by_id(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+):
     events = list()
 
     ids_to_channels = token_network_state.channelidentifiers_to_channels
     channel_state = ids_to_channels.get(state_change.channel_identifier)
 
     if channel_state:
-        result = channel.state_transition(channel_state, state_change, block_number)
+        result = channel.state_transition(
+            channel_state,
+            state_change,
+            pseudo_random_generator,
+            block_number,
+        )
         events.extend(result.events)
 
     return TransitionResult(token_network_state, events)
 
 
-def handle_channel_close(token_network_state, state_change, block_number):
-    return subdispatch_to_channel_by_id(token_network_state, state_change, block_number)
+def handle_channel_close(token_network_state, state_change, pseudo_random_generator, block_number):
+    return subdispatch_to_channel_by_id(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+    )
 
 
 def handle_channelnew(token_network_state, state_change):
@@ -57,16 +72,31 @@ def handle_channelnew(token_network_state, state_change):
     return TransitionResult(token_network_state, events)
 
 
-def handle_balance(token_network_state, state_change, block_number):
-    return subdispatch_to_channel_by_id(token_network_state, state_change, block_number)
+def handle_balance(token_network_state, state_change, pseudo_random_generator, block_number):
+    return subdispatch_to_channel_by_id(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+    )
 
 
-def handle_closed(token_network_state, state_change, block_number):
-    return subdispatch_to_channel_by_id(token_network_state, state_change, block_number)
+def handle_closed(token_network_state, state_change, pseudo_random_generator, block_number):
+    return subdispatch_to_channel_by_id(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+    )
 
 
-def handle_settled(token_network_state, state_change, block_number):
-    return subdispatch_to_channel_by_id(token_network_state, state_change, block_number)
+def handle_settled(token_network_state, state_change, pseudo_random_generator, block_number):
+    return subdispatch_to_channel_by_id(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+    )
 
 
 def handle_newroute(token_network_state, state_change):
@@ -80,12 +110,22 @@ def handle_newroute(token_network_state, state_change):
     return TransitionResult(token_network_state, events)
 
 
-def handle_action_transfer_direct(token_network_state, state_change, block_number):
+def handle_action_transfer_direct(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+):
     receiver_address = state_change.receiver_address
     channel_state = token_network_state.partneraddresses_to_channels.get(receiver_address)
 
     if channel_state:
-        iteration = channel.state_transition(channel_state, state_change, block_number)
+        iteration = channel.state_transition(
+            channel_state,
+            state_change,
+            pseudo_random_generator,
+            block_number,
+        )
         events = iteration.events
     else:
         failure = EventTransferSentFailed(
@@ -97,39 +137,60 @@ def handle_action_transfer_direct(token_network_state, state_change, block_numbe
     return TransitionResult(token_network_state, events)
 
 
-def handle_receive_transfer_direct(token_network_state, state_change, block_number):
+def handle_receive_transfer_direct(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+):
     events = list()
 
     channel_id = state_change.balance_proof.channel_address
     channel_state = token_network_state.channelidentifiers_to_channels.get(channel_id)
 
     if channel_state:
-        result = channel.state_transition(channel_state, state_change, block_number)
+        result = channel.state_transition(
+            channel_state,
+            state_change,
+            pseudo_random_generator,
+            block_number,
+        )
         events.extend(result.events)
 
     return TransitionResult(token_network_state, events)
 
 
-def handle_receive_transfer_refund(token_network_state, state_change, block_number):
+def handle_receive_transfer_refund(
+        token_network_state,
+        state_change,
+        pseudo_random_generator,
+        block_number,
+):
     events = list()
 
     channel_id = state_change.balance_proof.channel_address
     channel_state = token_network_state.channelidentifiers_to_channels.get(channel_id)
 
     if channel_state:
-        result = channel.state_transition(channel_state, state_change, block_number)
+        result = channel.state_transition(
+            channel_state,
+            state_change,
+            pseudo_random_generator,
+            block_number,
+        )
         events.extend(result.events)
 
     return TransitionResult(token_network_state, events)
 
 
-def state_transition(token_network_state, state_change, block_number):
+def state_transition(token_network_state, state_change, pseudo_random_generator, block_number):
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 
     if type(state_change) == ActionChannelClose:
         iteration = handle_channel_close(
             token_network_state,
             state_change,
+            pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ContractReceiveChannelNew:
@@ -141,18 +202,21 @@ def state_transition(token_network_state, state_change, block_number):
         iteration = handle_balance(
             token_network_state,
             state_change,
+            pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ContractReceiveChannelClosed:
         iteration = handle_closed(
             token_network_state,
             state_change,
+            pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ContractReceiveChannelSettled:
         iteration = handle_settled(
             token_network_state,
             state_change,
+            pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ContractReceiveRouteNew:
@@ -164,12 +228,14 @@ def state_transition(token_network_state, state_change, block_number):
         iteration = handle_action_transfer_direct(
             token_network_state,
             state_change,
+            pseudo_random_generator,
             block_number,
         )
     elif type(state_change) == ReceiveTransferDirect:
         iteration = handle_receive_transfer_direct(
             token_network_state,
             state_change,
+            pseudo_random_generator,
             block_number,
         )
     else:

--- a/raiden/udp_message_handler.py
+++ b/raiden/udp_message_handler.py
@@ -33,7 +33,7 @@ log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
 
 def handle_message_secretrequest(raiden: 'RaidenService', message: SecretRequest):
     secret_request = ReceiveSecretRequest(
-        message.identifier,
+        message.payment_identifier,
         message.amount,
         message.secrethash,
         message.sender,
@@ -103,7 +103,7 @@ def handle_message_directtransfer(raiden: 'RaidenService', message: DirectTransf
     direct_transfer = ReceiveTransferDirect(
         payment_network_identifier,
         token_address,
-        message.identifier,
+        message.payment_identifier,
         balance_proof,
     )
 


### PR DESCRIPTION
- Renamed identifier to payment_identifier where it was required to make things clearer
- The `Processed` message needs a way to identify the processed message, currently this relies on the hash of the encoded message, which is only available at an upper layer (at the transport). With the process of moving the queue from the transport to the core logic, an explicit identifier was required.