### PR TITLE
smoketest: allow geth executable to be specified via RST_GETH_BINARY

### DIFF
--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -3,13 +3,13 @@ from binascii import hexlify
 from binascii import unhexlify
 from http import HTTPStatus
 from string import Template
-import distutils.spawn  # pylint: disable=import-error,no-name-in-module
 import json
 import os
 import sys
 import pdb
 import requests
 import shlex
+import shutil
 import subprocess
 import tempfile
 import time
@@ -71,17 +71,19 @@ $RST_GETH_BINARY
     --verbosity 3
     --datadir $RST_DATADIR
 """
-RST_GETH_BINARY = distutils.spawn.find_executable('geth')
-if not RST_GETH_BINARY:
-    print(
-        'Error: unable to locate geth binary.\n'
-        'Make sure it is installed and added to the PATH variable.'
-    )
-    sys.exit(1)
 
-if RST_GETH_BINARY is not None and 'RST_GETH_BINARY' not in os.environ:
-    os.environ['RST_GETH_BINARY'] = RST_GETH_BINARY
 
+def ensure_executable(cmd):
+    """look for the given command and make sure it can be executed"""
+    if not shutil.which(cmd):
+        print(
+            'Error: unable to locate %s binary.\n'
+            'Make sure it is installed and added to the PATH variable.' % cmd
+        )
+        sys.exit(1)
+
+
+ensure_executable(os.environ.setdefault('RST_GETH_BINARY', 'geth'))
 
 TEST_ACCOUNT = {
     'version': 3,


### PR DESCRIPTION
This fixes a regression introduced in 3658169e0ebd71e9f631175146ac8399388681da.
If an invalid RST_GETH_BINARY path is now specified, smoketest also bails out
early now.

While I'm here also use 'shutil.which' instead of
'distutils.spawn.find_executable'. The latter does not really care if the file
it returns is executable.

shutil.which has the added benefit of also handling absolute and relative paths.

see https://github.com/raiden-network/raiden/pull/1353 and
https://github.com/raiden-network/raiden/issues/1237