### PR TITLE
streamline detection of concurrent operations

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -35,6 +35,7 @@ from raiden.settings import (
 from raiden.utils import (
     isaddress,
     pex,
+    releasing,
 )
 
 log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -253,7 +254,8 @@ class RaidenAPI:
                 f'Channel with id {channel_state.identifier} is '
                 f'busy with another ongoing operation'
             )
-        else:
+
+        with releasing(channel_proxy.channel_operations_lock):
             token.approve(netcontract_address, amount)
             channel_proxy.deposit(amount)
 
@@ -274,8 +276,6 @@ class RaidenAPI:
                     target_balance,
                     self.raiden.alarm.wait_time,
                 )
-
-            channel_proxy.channel_operations_lock.release()
 
     def channel_close(self, token_address, partner_address, poll_timeout=DEFAULT_POLL_TIMEOUT):
         """Close a channel opened with `partner_address` for the given

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -209,15 +209,13 @@ class NettingChannel:
                 amount=amount,
             )
 
-        if not self.channel_operations_lock.acquire(0):
+        if not self.channel_operations_lock.acquire(blocking=False):
             raise ChannelBusyError(
                 f'Channel with address {self.address} is '
                 f'busy with another ongoing operation.'
             )
 
-        self.channel_operations_lock.release()
-
-        with self.channel_operations_lock:
+        else:
             transaction_hash = estimate_and_transact(
                 self.proxy,
                 'deposit',
@@ -248,6 +246,8 @@ class NettingChannel:
                     amount=amount,
                 )
 
+            self.channel_operations_lock.release()
+
     def close(self, nonce, transferred_amount, locksroot, extra_hash, signature):
         """ Close the channel using the provided balance proof.
 
@@ -268,15 +268,13 @@ class NettingChannel:
                 signature=encode_hex(signature),
             )
 
-        if not self.channel_operations_lock.acquire(0):
+        if not self.channel_operations_lock.acquire(blocking=False):
             raise ChannelBusyError(
                 f'Channel with address {self.address} is '
                 f'busy with another ongoing operation.'
             )
 
-        self.channel_operations_lock.release()
-
-        with self.channel_operations_lock:
+        else:
             transaction_hash = estimate_and_transact(
                 self.proxy,
                 'close',
@@ -314,6 +312,8 @@ class NettingChannel:
                     extra_hash=encode_hex(extra_hash),
                     signature=encode_hex(signature),
                 )
+
+            self.channel_operations_lock.release()
 
     def update_transfer(self, nonce, transferred_amount, locksroot, extra_hash, signature):
         if signature:
@@ -425,15 +425,13 @@ class NettingChannel:
                 node=pex(self.node_address),
             )
 
-        if not self.channel_operations_lock.acquire(0):
+        if not self.channel_operations_lock.acquire(blocking=False):
             raise ChannelBusyError(
                 f'Channel with address {self.address} is '
                 f'busy with another ongoing operation'
             )
 
-        self.channel_operations_lock.release()
-
-        with self.channel_operations_lock:
+        else:
             transaction_hash = estimate_and_transact(
                 self.proxy,
                 'settle',
@@ -456,6 +454,8 @@ class NettingChannel:
                     node=pex(self.node_address),
                     contract=pex(self.address),
                 )
+
+            self.channel_operations_lock.release()
 
     def events_filter(
             self,

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -34,6 +34,7 @@ from raiden.utils import (
     address_encoder,
     pex,
     privatekey_to_address,
+    releasing,
 )
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -215,7 +216,7 @@ class NettingChannel:
                 f'busy with another ongoing operation.'
             )
 
-        else:
+        with releasing(self.channel_operations_lock):
             transaction_hash = estimate_and_transact(
                 self.proxy,
                 'deposit',
@@ -246,8 +247,6 @@ class NettingChannel:
                     amount=amount,
                 )
 
-            self.channel_operations_lock.release()
-
     def close(self, nonce, transferred_amount, locksroot, extra_hash, signature):
         """ Close the channel using the provided balance proof.
 
@@ -274,7 +273,7 @@ class NettingChannel:
                 f'busy with another ongoing operation.'
             )
 
-        else:
+        with releasing(self.channel_operations_lock):
             transaction_hash = estimate_and_transact(
                 self.proxy,
                 'close',
@@ -312,8 +311,6 @@ class NettingChannel:
                     extra_hash=encode_hex(extra_hash),
                     signature=encode_hex(signature),
                 )
-
-            self.channel_operations_lock.release()
 
     def update_transfer(self, nonce, transferred_amount, locksroot, extra_hash, signature):
         if signature:
@@ -431,7 +428,7 @@ class NettingChannel:
                 f'busy with another ongoing operation'
             )
 
-        else:
+        with releasing(self.channel_operations_lock):
             transaction_hash = estimate_and_transact(
                 self.proxy,
                 'settle',
@@ -454,8 +451,6 @@ class NettingChannel:
                     node=pex(self.node_address),
                     contract=pex(self.address),
                 )
-
-            self.channel_operations_lock.release()
 
     def events_filter(
             self,

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -341,3 +341,18 @@ def split_in_pairs(arg: Iterable) -> Iterable[Tuple]:
     # from the iterator each time and produces the desired result.
     iterator = iter(arg)
     return zip_longest(iterator, iterator)
+
+
+class releasing:
+    """context manager inspired by closing that will call release on __exit__
+    blocks, useful to release acquired locks.
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __enter__(self):
+        return self.obj
+
+    def __exit__(self, *exc_info):  # pylint: disable=unused-argument
+        self.obj.release()


### PR DESCRIPTION
The following pattern is not reliable:

```python
if lock.acquire(): raise Exception()
lock.release()
with lock: pass
```

The call to `lock.acquire` could succeed for the current greenlet, while
there are other greenlets waiting for the same lock with
`acquire(blocking=True)`. Under this circunstance the `release` call
would context-switch to the waiting greenlet, and the previous check
would be "invalidated".

Although the current code doesn't use `acquire(blocking=True)`, and the
problem mentioned above wouldn't occur, the code base is left in a
fragile state that is easy to break. This changes the code to only call
acquire once, and to release the lock only after the action is executed.

Since the change to introduce the `locked` method for `RLock` was rejected,
we need to use the pattern:

```python
if not lock.acquire(blocking=False):
  raise Exception()
else:
  ...
  lock.release()
```