### PR TITLE
Style guide fix for W503 W504

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,34 @@ Thus we setup the following rules:
 
 ### Coding Style
 
+#### General Style
+
+In this section we are going to see style rules that should be followed across all languages.
+
+**Line breaks after operators**
+
+For long expressions where we break the expression at the operators the line break should come **after** the operator and not before.
+
+The following should be avoided:
+
+```python
+        participant1_amount = (
+            participant1_state.deposit
+            + participant2_state.transferred_amount
+            - participant1_state.transferred_amount
+        );
+```
+
+instead it should be:
+
+```python
+        participant1_amount = (
+            participant1_state.deposit +
+            participant2_state.transferred_amount -
+            participant1_state.transferred_amount
+        );
+```
+
 #### Python
 
 Raiden is written in Python and we follow the official Python style guide

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -63,7 +63,7 @@ class BlockChainService:
 
         return True
 
-    def estimate_blocktime(self, oldest: int=256) -> float:
+    def estimate_blocktime(self, oldest: int = 256) -> float:
         """Calculate a blocktime estimate based on some past blocks.
         Args:
             oldest: delta in block numbers to go back.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [flake8]
-ignore = E731, E402
+ignore = E731, E402, W504
 max-line-length = 99
 exclude = raiden/ui/web/node_modules/
 
 [pep8]
-ignore = E731, E402
+ignore = E731, E402, W504
 max-line-length = 99
 
 [coverage:run]


### PR DESCRIPTION
All of a sudden flake8 started reporting a `W504` violation for our code due to us putting the line break after the operator in long expressions with operators that were broken in multiple lines.

This was introduced in the latest version of flake8 and made our code non flake8 compatible right under our noses.
I tried to change it to have the line break before the operator and then flake8 reported a `W503` violation. Damned if you do, damned if you don't.

That looked fishy so I did some digging:
https://github.com/PyCQA/pycodestyle/issues/498
https://github.com/PyCQA/pycodestyle/issues/502

> The W503 bug is already fixed as it’s added to the default ignore list but you have a ignore option configured in setup.cfg and if that’s the case the default ignores aren’t respected anymore. This is in my opinion pretty stupid behavior but a flake8 thing I can’t do anything about. That means though that if you specify a ignore list you have to list all default ignores as well. So I updated the list in setup.cfg and now the tests pass without problems.

Apparently this flake8 violation was considered opinionated and put in the default ignores. But there is a bug that if you have any ignores specified (which we do) then you lose all the default ignores.

## Solution

Put `W504`to the ignores, so that flake8 reports correctly when we ever make a `W503` violation. Add the rule that line breaks should come after the operator to the style guide.

Note: This rule also applies to solidity code.