### PR TITLE
Bump minimum required solc version to v0.4.23

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -44,5 +44,5 @@ NETWORKNAME_TO_ID = {
     for id, name in ID_TO_NETWORKNAME.items()
 }
 
-MIN_REQUIRED_SOLC = 'v0.4.21'
+MIN_REQUIRED_SOLC = 'v0.4.23'
 NULL_ADDRESS = '0x' + '0' * 40


### PR DESCRIPTION
[skip ci]

HumanStandardToken.sol uses the `constructor` keyword and I also see other
contracts using solidity v0.4.23 only features. Adjusting the minimum version accordingly