### PR TITLE
Replace read version from git with setup scm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Heiko Hees
+Copyright (c) 2015-2018 Brainbot Labs Est.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -120,40 +120,8 @@ test_requirements = []
 
 version = '0.3.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
 
-
-def read_version_from_git():
-    try:
-        import shlex
-        git_version, _ = subprocess.Popen(
-            shlex.split('git describe --tags --abbrev=8'),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        ).communicate()
-        # Popen returns bytes
-        git_version = git_version.decode()
-
-        if git_version.startswith('v'):
-            git_version = git_version[1:]
-
-        git_version = git_version.strip()
-        # if this is has commits after the tag, it's a prerelease:
-        if git_version.count('-') == 2:
-            _, _, commit = git_version.split('-')
-            if commit.startswith('g'):
-                commit = commit[1:]
-            return '{}+git.r{}'.format(version, commit)
-        elif git_version.count('.') == 2:
-            return git_version
-        else:
-            return version
-    except BaseException as e:
-        print('could not read version from git: {}'.format(e))
-        return version
-
-
 setup(
     name='raiden',
-    version=read_version_from_git(),
     description='',
     long_description=readme + '\n\n' + history,
     author='Brainbot Labs Est.',
@@ -178,6 +146,8 @@ setup(
         'compile_webui': CompileWebUI,
         'build_py': BuildPyCommand,
     },
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     install_requires=install_requires,
     tests_require=test_requirements,
     python_requires='>=3.6',


### PR DESCRIPTION
Fix #1397

We are now using setuptools_scm to read the version for setup.py. The rules are a bit different than the ones we had before but should still be fine. From the [Readme](https://github.com/pypa/setuptools_scm/blob/master/README.rst):
```
In the standard configuration setuptools_scm takes a look at 3 things:

1. latest tag (with a version number)
2. the distance to this tag (e.g. number of revisions since latest tag)
3. workdir state (e.g. uncommitted changes since latest tag)

and uses roughly the following logic to render the version:

- no distance and clean:
    `{tag}`
- `distance and clean`:
    `{next_version}.dev{distance}+{scm letter}{revision hash}`
- `no distance and not clean`:
    `{tag}+dYYYMMMDD`
- `distance and not clean`:
    `{next_version}.dev{distance}+{scm letter}{revision hash}.dYYYMMMDD`

The next version is calculated by adding ``1`` to the last numeric component
of the tag.

For git projects, the version relies on `git describe <https://git-scm.com/docs/git-describe>`_,
so you will see an additional ``g`` prepended to the ``{revision hash}``.

```

So the biggest change with the current behaviour would be that a dirty commit version would appear like this:
0.3.1.dev312+g590fcb58 

Notice the bumped patch version, instead of having a just the commit hash prepended to the previous tag as it was before.

But as I said above this should be fine.