### PR TITLE
gevent.wsgi -> gevent.pywsgi

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -10,7 +10,7 @@ from flask_restful import Api, abort
 from flask_cors import CORS
 from webargs.flaskparser import parser
 from werkzeug.exceptions import NotFound
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 
 from ethereum import slogging
 


### PR DESCRIPTION
Gevent 1.3.0 was released today (2018-05-11), and it removed the deprecated module `gevent.wsgi`. This fixes the import