### PR TITLE
Use prompt_account instead of directly getting privatekey_hex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,5 @@ blockchain-geth:
 	rm -f blockchain.log
 	./tools/startcluster.py
 
-deploy: compile
-	./tools/deploy.py
+deploy:
+	./tools/deploy.py --keystore-path=${KEYSTORE}


### PR DESCRIPTION
Hello,

I found it a bit confusing to have to specify the `privatekey_hex` to be able to deploy the contracts, so i updated the code base to make the user able to specify the keystore-path as the main raiden command instead. This will use the same `prompt_account` and retrieve the `privatekey_hex` from the selected account. 
As for the `Makefile` change, i removed the `compile` target dependency from `deploy` and you can pass the `keystore-path` to the deploy script using an env var, such that:
```
KEYSTORE=/path/to/keystore/ make deploy
```

This makes things a bit easier. 