### PR TITLE
Use numerical value of unicode codepoint for 雷 as default port value

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,6 @@ RUN git clone https://github.com/raiden-network/raiden.git /apps/raiden \
 
 WORKDIR /apps/raiden
 
-EXPOSE 40001/udp
+EXPOSE 38647/udp
 
 ENTRYPOINT ["raiden"]

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -2,7 +2,7 @@
 from binascii import hexlify
 from ethereum.utils import denoms, int_to_big_endian
 
-INITIAL_PORT = 40001
+INITIAL_PORT = 38647
 
 RPC_CACHE_TTL = 600
 CACHE_TTL = 60

--- a/raiden/smart_contracts/EndpointRegistry.sol
+++ b/raiden/smart_contracts/EndpointRegistry.sol
@@ -27,7 +27,7 @@ contract EndpointRegistry{
     /*
      * @notice Registers the Ethereum Address to the Endpoint socket.
      * @dev Registers the Ethereum Address to the Endpoint socket.
-     * @param string of socket in this format "127.0.0.1:40001"
+     * @param string of socket in this format "127.0.0.1:38647"
      */
     function registerEndpoint(string socket)
         public
@@ -61,7 +61,7 @@ contract EndpointRegistry{
     /*
      * @notice Finds Ethreum Address if given an existing socket address
      * @dev Finds Ethreum Address if given an existing socket address
-     * @param string of socket in this format "127.0.0.1:40001"
+     * @param string of socket in this format "127.0.0.1:38647"
      * @return An ethereum address
      */
     function findAddressByEndpoint(string socket) public constant returns (address eth_address)

--- a/raiden/tests/smart_contracts/test_endpointregistry.py
+++ b/raiden/tests/smart_contracts/test_endpointregistry.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from ethereum.tools import tester, _solidity
 from raiden.utils import get_contract_path, address_encoder, event_decoder
+from raiden.settings import INITIAL_PORT
 
 
 def test_endpointregistry(tester_chain, tester_events):
@@ -24,9 +25,9 @@ def test_endpointregistry(tester_chain, tester_events):
         endpointregistry_address
     )
 
-    endpoint_registry.registerEndpoint('127.0.0.1:4001')
-    assert endpoint_registry.findAddressByEndpoint('127.0.0.1:4001') == sender
-    assert endpoint_registry.findEndpointByAddress(sender) == b'127.0.0.1:4001'
+    endpoint_registry.registerEndpoint('127.0.0.1:{}'.format(INITIAL_PORT))
+    assert endpoint_registry.findAddressByEndpoint('127.0.0.1:{}'.format(INITIAL_PORT)) == sender
+    assert endpoint_registry.findEndpointByAddress(sender) == f'127.0.0.1:{INITIAL_PORT}'.encode()
 
     endpoint_registry.registerEndpoint('192.168.0.1:4002')
     assert endpoint_registry.findAddressByEndpoint('192.168.0.1:4002') == sender

--- a/tools/startcluster.py
+++ b/tools/startcluster.py
@@ -15,12 +15,13 @@ from raiden.utils import (
     privatekey_to_address,
     sha3
 )
+from raiden.settings import INITIAL_PORT
 
 # DEFAULTS
 NUM_GETH_NODES = 3
 NUM_RAIDEN_ACCOUNTS = 10
 CLUSTER_NAME = 'raiden'
-RAIDEN_PORT = 40001
+RAIDEN_PORT = INITIAL_PORT
 DEFAULT_PW = 'notsosecret'
 
 

--- a/tools/testnet/main.tf
+++ b/tools/testnet/main.tf
@@ -79,8 +79,8 @@ resource "aws_security_group" "raiden" {
 
     // Allow Raiden P2P in
     ingress {
-        from_port = 40001
-        to_port = 40001
+        from_port = 38647
+        to_port = 38647
         protocol = "udp"
         cidr_blocks = ["0.0.0.0/0"]
     }

--- a/tools/testnet/roles/raiden/tasks/main.yml
+++ b/tools/testnet/roles/raiden/tasks/main.yml
@@ -9,7 +9,7 @@
       logstash: "{{ hostvars[groups['role_infrastructure'][0]]['private_ip'] }}"
     hostname: "{{ hostname }}"
     ports:
-      - 40001:40001/udp
+      - 38647:38647/udp
       - 5001:5001
     volumes:
       - "{{ raiden_root }}:/root/.raiden"

--- a/tools/tmuxtest.sh
+++ b/tools/tmuxtest.sh
@@ -201,9 +201,9 @@ am2=raiden.default_registry.get_manager_by_token_address('${TOKEN2}'.decode('hex
     tmux send-keys -t raiden:2 "geth --datadir ${TEMP} --password ${TEMP}/password account new" C-m
     tmux send-keys -t raiden:2 "geth --minerthreads 1 --nodiscover --rpc --rpcport ${GETHPORT} --mine --etherbase 0 --datadir ${TEMP}" C-m
 
-    tmux send-keys -t raiden:3 "$(printf "$RAIDEN_TEMPLATE" 40001 "${KEYSTORE1}" "${ADDRESS1}" "${LOG1}") || exit" C-m
-    tmux send-keys -t raiden:4 "$(printf "$RAIDEN_TEMPLATE" 40002 "${KEYSTORE2}" "${ADDRESS2}" "${LOG2}") || exit" C-m
-    tmux send-keys -t raiden:5 "$(printf "$RAIDEN_TEMPLATE" 40003 "${KEYSTORE3}" "${ADDRESS3}" "${LOG3}") || exit" C-m
+    tmux send-keys -t raiden:3 "$(printf "$RAIDEN_TEMPLATE" 38647 "${KEYSTORE1}" "${ADDRESS1}" "${LOG1}") || exit" C-m
+    tmux send-keys -t raiden:4 "$(printf "$RAIDEN_TEMPLATE" 38648 "${KEYSTORE2}" "${ADDRESS2}" "${LOG2}") || exit" C-m
+    tmux send-keys -t raiden:5 "$(printf "$RAIDEN_TEMPLATE" 38649 "${KEYSTORE3}" "${ADDRESS3}" "${LOG3}") || exit" C-m
     # wait for all password prompts to appear:
     sleep 20
     tmux send-keys -t raiden:3 "$(printf "nopassword")" C-m


### PR DESCRIPTION
In Japanese Raiden is written as 雷電. Numerical value of the Unicode codepoint for 雷 (Rai) is 38647. It's in general unassigned according to [this](https://www.speedguide.net/port.php?port=38647) source while 40001 has [been used by some apps](https://www.speedguide.net/port.php?port=40001). In general it's a meaningful value to have as the default port. Also kind of cool.

@ulope Can you have a look? Are these changes sufficient? Also is there any way to make this into a variable used in our yaml files instead of having it hard coded in all of them?