### PR TITLE
Remove `slogging` module

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -7,12 +7,12 @@ from binascii import hexlify, unhexlify
 from json import JSONDecodeError
 from typing import Dict
 
-from ethereum.slogging import get_logger
 from eth_keyfile import decode_keyfile_json
+import structlog
 
 from raiden.utils import privtopub, privatekey_to_address
 
-log = get_logger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def find_datadir():
@@ -89,7 +89,7 @@ class AccountManager:
                 files = os.listdir(self.keystore_path)
             except OSError as ex:
                 msg = 'Unable to list the specified directory'
-                log.error('%s %s: %s', msg, self.keystore_path, ex)
+                log.error('OsError', msg=msg, path=self.keystore_path, ex=ex)
                 return
 
             for f in files:
@@ -114,7 +114,7 @@ class AccountManager:
                                 msg = 'Can not read account file (errno=%s)' % ex.errno
                             if isinstance(ex, json.decoder.JSONDecodeError):
                                 msg = 'The account file is not valid JSON format'
-                            log.warning('%s %s: %s', msg, fullpath, ex)
+                            log.warning('OsError', msg=msg, path=fullpath, ex=ex)
 
     def address_in_keystore(self, address):
         if address is None:

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -3,7 +3,7 @@ from binascii import hexlify
 
 import gevent
 from contextlib import ExitStack
-from ethereum import slogging
+import structlog
 
 from raiden import waiting
 from raiden.blockchain.events import (
@@ -38,7 +38,7 @@ from raiden.utils import (
     releasing,
 )
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 EVENTS_EXTERNALLY_VISIBLE = (
     EventTransferSentSuccess,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -12,7 +12,7 @@ from webargs.flaskparser import parser
 from werkzeug.exceptions import NotFound
 from gevent.pywsgi import WSGIServer
 
-from ethereum import slogging
+import structlog
 
 from raiden.exceptions import (
     AddressWithoutCode,
@@ -63,7 +63,7 @@ from raiden.raiden_service import (
 from raiden.api.objects import ChannelList, PartnersPerTokenList, AddressList
 from raiden.utils import address_encoder, channelstate_to_api_dict, split_endpoint, is_frozen
 
-log = slogging.get_logger(__name__)
+log = structlog.get_logger(__name__)
 
 ERROR_STATUS_CODES = [
     HTTPStatus.CONFLICT,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -11,9 +11,9 @@ from raiden.api.v1.encoding import (
     ConnectionsLeaveSchema,
 )
 
-from ethereum import slogging
+import structlog
 
-log = slogging.get_logger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def create_blueprint():

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -2,7 +2,7 @@
 import itertools
 from collections import namedtuple, defaultdict
 
-from ethereum import slogging
+import structlog
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -28,7 +28,7 @@ Proxies = namedtuple(
 
 # `new_filter` uses None to signal the absence of topics filters
 ALL_EVENTS = None
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def poll_event_listener(eth_filter, translator):
@@ -255,8 +255,7 @@ class BlockchainEvents:
                 # filters will no longer exist there. In that case we will need
                 # to recreate all the filters.
                 if not reinstalled_filters and str(e) == 'filter not found':
-                    if log.isEnabledFor('DEBUG'):
-                        log.debug('reinstalling eth filters')
+                    log.debug('reinstalling eth filters')
 
                     result = list()
                     reinstalled_filters = True

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-import logging
-
 import gevent
-from ethereum import slogging
+import structlog
 
 from raiden.blockchain.events import get_channel_proxies
 from raiden.blockchain.state import (
@@ -23,7 +21,7 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils import pex
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def handle_tokennetwork_new(raiden, event):
@@ -224,8 +222,7 @@ def handle_channel_withdraw(raiden, event):
 
 
 def on_blockchain_event(raiden, event):
-    if log.isEnabledFor(logging.DEBUG):
-        log.debug('EVENT', node=pex(raiden.address), event=event)
+    log.debug('EVENT', node=pex(raiden.address), chain_event=event)
 
     data = event.event_data
     assert isinstance(data['_event_type'], bytes)
@@ -248,5 +245,5 @@ def on_blockchain_event(raiden, event):
     elif data['_event_type'] == b'ChannelSecretRevealed':
         handle_channel_withdraw(raiden, event)
 
-    elif log.isEnabledFor(logging.ERROR):
+    else:
         log.error('Unknown event type', event=event)

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -5,7 +5,7 @@ import gevent
 from gevent.lock import Semaphore
 from gevent.event import AsyncResult
 
-from ethereum import slogging
+import structlog
 
 from raiden import waiting
 from raiden.exceptions import DuplicatedChannelError
@@ -17,7 +17,7 @@ from raiden.exceptions import (
 )
 from raiden.transfer import views
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def log_open_channels(raiden, registry_address, token_address, funds):

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from ethereum import slogging
+import structlog
 
 from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.encoding.encoders import integer, optional_bytes
@@ -38,7 +38,7 @@ DELIVERED = 12
 
 
 # pylint: disable=invalid-name
-log = slogging.get_logger(__name__)
+log = structlog.get_logger(__name__)
 
 
 nonce = make_field('nonce', 8, '8s', integer(0, UINT64_MAX))

--- a/raiden/encoding/signing.py
+++ b/raiden/encoding/signing.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from coincurve import PublicKey
-from ethereum.slogging import getLogger
+import structlog
 
 from raiden.utils import sha3, publickey_to_address
 
 
-log = getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def recover_publickey(messagedata, signature, hasher=sha3):

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -1,0 +1,77 @@
+import logging.config
+import structlog
+
+
+def get_log_handler(formatter, log_file, level):
+    if log_file:
+        return {
+            'file': {
+                'level': level,
+                'class': 'logging.handlers.WatchedFileHandler',
+                'filename': log_file,
+                'formatter': formatter,
+            },
+        }
+    else:
+        return {
+            'default': {
+                'level': level,
+                'class': 'logging.StreamHandler',
+                'formatter': formatter,
+            }
+        }
+
+
+def configure_logging(
+    level='WARN',
+    colorize=True,
+    log_json=None,
+    log_file=None
+):
+    timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
+    pre_chain = [structlog.stdlib.add_log_level, timestamper]
+    formatter = 'colorized' if colorize and log_file is '' else 'plain'
+    if log_json:
+        formatter = 'json'
+    log_handler = get_log_handler(formatter, log_file, level)
+    logging.config.dictConfig(
+        {
+            'version': 1,
+            'formatters': {
+                'plain': {
+                    '()': structlog.stdlib.ProcessorFormatter,
+                    'processor': structlog.dev.ConsoleRenderer(colors=False),
+                    'foreign_pre_chain': pre_chain,
+                },
+                'json': {
+                    '()': structlog.stdlib.ProcessorFormatter,
+                    'processor': structlog.processors.JSONRenderer(),
+                    'foreign_pre_chain': pre_chain,
+                },
+                'colorized': {
+                    '()': structlog.stdlib.ProcessorFormatter,
+                    'processor': structlog.dev.ConsoleRenderer(colors=True),
+                    'foreign_pre_chain': pre_chain,
+                },
+            },
+            'handlers': log_handler,
+            'loggers': {
+                '': {
+                    'handlers': list(log_handler.keys()),
+                    'level': level,
+                    'propagate': True,
+                },
+            }
+        }
+    )
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            timestamper,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory()
+    )

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1,5 +1,6 @@
-from ethereum.slogging import getLogger
+# -*- coding: utf-8 -*-
 from eth_utils import big_endian_to_int
+import structlog
 
 from raiden.constants import (
     UINT256_MAX,
@@ -37,7 +38,7 @@ __all__ = (
     'from_dict',
 )
 
-log = getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def assert_envelope_values(nonce, channel, transferred_amount, locked_amount, locksroot):

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -3,7 +3,7 @@ import os
 
 import gevent
 from cachetools.func import ttl_cache
-from ethereum import slogging
+import structlog
 from ethereum.tools import _solidity
 
 from raiden.network.rpc.client import JSONRPCClient
@@ -22,7 +22,7 @@ from raiden.utils import (
     quantity_decoder,
 )
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class BlockChainService:
@@ -173,8 +173,8 @@ class BlockChainService:
         contracts = _solidity.compile_file(contract_path, libraries=dict())
 
         log.info(
-            'Deploying "%s" contract',
-            os.path.basename(contract_path),
+            'Deploying contract: ',
+            path=os.path.basename(contract_path)
         )
 
         proxy = self.client.deploy_solidity_contract(

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -2,7 +2,7 @@
 import socket
 from typing import Tuple
 
-from ethereum import slogging
+import structlog
 
 from raiden.exceptions import UnknownAddress
 from raiden.network import proxies
@@ -14,7 +14,7 @@ from raiden.utils import (
 )
 from raiden.exceptions import InvalidAddress
 
-log = slogging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Discovery:

--- a/raiden/network/proxies/channel_manager.py
+++ b/raiden/network/proxies/channel_manager.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import logging
 from binascii import unhexlify
 from gevent.event import AsyncResult
 from typing import List, Union, Tuple
 
-from ethereum import slogging
+import structlog
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -42,7 +41,7 @@ from raiden.utils import (
 from raiden.utils.typing import Address
 from raiden.constants import NULL_ADDRESS
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class ChannelManager:
@@ -136,13 +135,12 @@ class ChannelManager:
 
         netting_channel_address_bin = address_decoder(netting_channel_address_encoded)
 
-        if log.isEnabledFor(logging.INFO):
-            log.info(
-                'new_netting_channel called',
-                peer1=pex(local_address),
-                peer2=pex(other_peer),
-                netting_channel=pex(netting_channel_address_bin),
-            )
+        log.info(
+            'new_netting_channel called',
+            peer1=pex(local_address),
+            peer2=pex(other_peer),
+            netting_channel=pex(netting_channel_address_bin),
+        )
 
         return netting_channel_address_bin
 

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import logging
 from binascii import unhexlify
 from gevent.lock import RLock
 from typing import Optional, List
 
-from ethereum import slogging
+import structlog
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -37,7 +36,7 @@ from raiden.utils import (
     encode_hex,
 )
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class NettingChannel:
@@ -202,13 +201,12 @@ class NettingChannel:
                 current_balance,
             ))
 
-        if log.isEnabledFor(logging.INFO):
-            log.info(
-                'deposit called',
-                node=pex(self.node_address),
-                contract=pex(self.address),
-                amount=amount,
-            )
+        log.info(
+            'deposit called',
+            node=pex(self.node_address),
+            contract=pex(self.address),
+            amount=amount,
+        )
 
         if not self.channel_operations_lock.acquire(blocking=False):
             raise ChannelBusyError(
@@ -239,13 +237,12 @@ class NettingChannel:
                 self._check_exists()
                 raise TransactionThrew('Deposit', receipt_or_none)
 
-            if log.isEnabledFor(logging.INFO):
-                log.info(
-                    'deposit successful',
-                    node=pex(self.node_address),
-                    contract=pex(self.address),
-                    amount=amount,
-                )
+            log.info(
+                'deposit successful',
+                node=pex(self.node_address),
+                contract=pex(self.address),
+                amount=amount,
+            )
 
     def close(self, nonce, transferred_amount, locksroot, extra_hash, signature):
         """ Close the channel using the provided balance proof.
@@ -255,17 +252,16 @@ class NettingChannel:
             ChannelBusyError: If the channel is busy with another operation.
         """
 
-        if log.isEnabledFor(logging.INFO):
-            log.info(
-                'close called',
-                node=pex(self.node_address),
-                contract=pex(self.address),
-                nonce=nonce,
-                transferred_amount=transferred_amount,
-                locksroot=encode_hex(locksroot),
-                extra_hash=encode_hex(extra_hash),
-                signature=encode_hex(signature),
-            )
+        log.info(
+            'close called',
+            node=pex(self.node_address),
+            contract=pex(self.address),
+            nonce=nonce,
+            transferred_amount=transferred_amount,
+            locksroot=encode_hex(locksroot),
+            extra_hash=encode_hex(extra_hash),
+            signature=encode_hex(signature),
+        )
 
         if not self.channel_operations_lock.acquire(blocking=False):
             raise ChannelBusyError(
@@ -300,31 +296,29 @@ class NettingChannel:
                 self._check_exists()
                 raise TransactionThrew('Close', receipt_or_none)
 
-            if log.isEnabledFor(logging.INFO):
-                log.info(
-                    'close successful',
-                    node=pex(self.node_address),
-                    contract=pex(self.address),
-                    nonce=nonce,
-                    transferred_amount=transferred_amount,
-                    locksroot=encode_hex(locksroot),
-                    extra_hash=encode_hex(extra_hash),
-                    signature=encode_hex(signature),
-                )
+            log.info(
+                'close successful',
+                node=pex(self.node_address),
+                contract=pex(self.address),
+                nonce=nonce,
+                transferred_amount=transferred_amount,
+                locksroot=encode_hex(locksroot),
+                extra_hash=encode_hex(extra_hash),
+                signature=encode_hex(signature),
+            )
 
     def update_transfer(self, nonce, transferred_amount, locksroot, extra_hash, signature):
         if signature:
-            if log.isEnabledFor(logging.INFO):
-                log.info(
-                    'updateTransfer called',
-                    node=pex(self.node_address),
-                    contract=pex(self.address),
-                    nonce=nonce,
-                    transferred_amount=transferred_amount,
-                    locksroot=encode_hex(locksroot),
-                    extra_hash=encode_hex(extra_hash),
-                    signature=encode_hex(signature),
-                )
+            log.info(
+                'updateTransfer called',
+                node=pex(self.node_address),
+                contract=pex(self.address),
+                nonce=nonce,
+                transferred_amount=transferred_amount,
+                locksroot=encode_hex(locksroot),
+                extra_hash=encode_hex(extra_hash),
+                signature=encode_hex(signature),
+            )
 
             transaction_hash = estimate_and_transact(
                 self.proxy,
@@ -356,25 +350,23 @@ class NettingChannel:
                 self._check_exists()
                 raise TransactionThrew('Update Transfer', receipt_or_none)
 
-            if log.isEnabledFor(logging.INFO):
-                log.info(
-                    'updateTransfer successful',
-                    node=pex(self.node_address),
-                    contract=pex(self.address),
-                    nonce=nonce,
-                    transferred_amount=transferred_amount,
-                    locksroot=encode_hex(locksroot),
-                    extra_hash=encode_hex(extra_hash),
-                    signature=encode_hex(signature),
-                )
-
-    def withdraw(self, unlock_proof):
-        if log.isEnabledFor(logging.INFO):
             log.info(
-                'withdraw called',
+                'updateTransfer successful',
                 node=pex(self.node_address),
                 contract=pex(self.address),
+                nonce=nonce,
+                transferred_amount=transferred_amount,
+                locksroot=encode_hex(locksroot),
+                extra_hash=encode_hex(extra_hash),
+                signature=encode_hex(signature),
             )
+
+    def withdraw(self, unlock_proof):
+        log.info(
+            'withdraw called',
+            node=pex(self.node_address),
+            contract=pex(self.address),
+        )
 
         if isinstance(unlock_proof.lock_encoded, messages.Lock):
             raise ValueError('unlock must be called with a lock encoded `.as_bytes`')
@@ -402,13 +394,12 @@ class NettingChannel:
             self._check_exists()
             raise TransactionThrew('Withdraw', receipt_or_none)
 
-        elif log.isEnabledFor(logging.INFO):
-            log.info(
-                'withdraw successful',
-                node=pex(self.node_address),
-                contract=pex(self.address),
-                lock=unlock_proof,
-            )
+        log.info(
+            'withdraw successful',
+            node=pex(self.node_address),
+            contract=pex(self.address),
+            lock=unlock_proof,
+        )
 
     def settle(self):
         """ Settle the channel.
@@ -416,11 +407,10 @@ class NettingChannel:
         Raises:
             ChannelBusyError: If the channel is busy with another operation
         """
-        if log.isEnabledFor(logging.INFO):
-            log.info(
-                'settle called',
-                node=pex(self.node_address),
-            )
+        log.info(
+            'settle called',
+            node=pex(self.node_address),
+        )
 
         if not self.channel_operations_lock.acquire(blocking=False):
             raise ChannelBusyError(
@@ -445,12 +435,11 @@ class NettingChannel:
                 self._check_exists()
                 raise TransactionThrew('Settle', receipt_or_none)
 
-            if log.isEnabledFor(logging.INFO):
-                log.info(
-                    'settle successful',
-                    node=pex(self.node_address),
-                    contract=pex(self.address),
-                )
+            log.info(
+                'settle successful',
+                node=pex(self.node_address),
+                contract=pex(self.address),
+            )
 
     def events_filter(
             self,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -9,7 +9,7 @@ import rlp
 import gevent
 import cachetools
 from gevent.lock import Semaphore
-from ethereum import slogging
+import structlog
 from ethereum.tools import _solidity
 from ethereum.abi import ContractTranslator
 from ethereum.transactions import Transaction
@@ -49,7 +49,7 @@ from raiden.utils import (
 )
 from raiden.utils.typing import Address
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 solidity = _solidity.get_solidity()  # pylint: disable=invalid-name
 
 

--- a/raiden/network/sockfactory.py
+++ b/raiden/network/sockfactory.py
@@ -1,12 +1,12 @@
 import socket
 
-from ethereum import slogging
+import structlog
 import netifaces
 
 from raiden.exceptions import STUNUnavailableException
 from raiden.network import upnpsock, stunsock
 
-log = slogging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class PortMappedSocket:

--- a/raiden/network/stunsock.py
+++ b/raiden/network/stunsock.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import stun
-from ethereum import slogging as logging
+import structlog as structlog
 
 from raiden.exceptions import STUNUnavailableException
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def stun_socket(

--- a/raiden/network/upnpsock.py
+++ b/raiden/network/upnpsock.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import miniupnpc
 import ipaddress
-from ethereum import slogging
+import structlog
 
 MAX_PORT = 65535
 RAIDEN_IDENTIFICATOR = 'raiden-network udp service'
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 NON_MAPPABLE = [
     '127.0.0.1',

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
-
-from ethereum import slogging
+import structlog
 
 from raiden.messages import (
     DirectTransfer,
@@ -37,7 +35,7 @@ from raiden.transfer.mediated_transfer.events import (
 )
 from raiden.utils import pex
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 UNEVENTFUL_EVENTS = (
     EventTransferReceivedSuccess,
     EventUnlockSuccess,
@@ -273,5 +271,5 @@ def on_raiden_event(raiden: 'RaidenService', event: 'Event'):
         handle_contract_channelsettle(raiden, event)
     elif isinstance(event, UNEVENTFUL_EVENTS):
         pass
-    elif log.isEnabledFor(logging.ERROR):
+    else:
         log.error('Unknown event {}'.format(type(event)))

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
-import logging
 import os
 import random
 import sys
@@ -10,7 +9,7 @@ import filelock
 import gevent
 from gevent.event import AsyncResult, Event
 from coincurve import PrivateKey
-from ethereum import slogging
+import structlog
 
 from raiden import routing, waiting
 from raiden.blockchain_events_handler import on_blockchain_event
@@ -59,7 +58,7 @@ from raiden.utils import (
 )
 from raiden.storage import wal, serialize, sqlite
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def initiator_init(
@@ -360,10 +359,7 @@ class RaidenService:
         self._block_number = block_number
 
     def handle_state_change(self, state_change, block_number=None):
-        is_logging = log.isEnabledFor(logging.DEBUG)
-
-        if is_logging:
-            log.debug('STATE CHANGE', node=pex(self.address), state_change=state_change)
+        log.debug('STATE CHANGE', node=pex(self.address), state_change=state_change)
 
         if block_number is None:
             block_number = self.get_block_number()
@@ -371,8 +367,7 @@ class RaidenService:
         event_list = self.wal.log_and_dispatch(state_change, block_number)
 
         for event in event_list:
-            if is_logging:
-                log.debug('EVENT', node=pex(self.address), event=event)
+            log.debug('EVENT', node=pex(self.address), chain_event=event)
 
             on_raiden_event(self, event)
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import time
 
-from ethereum import slogging
+import structlog
 
 import gevent
 from gevent.event import AsyncResult
@@ -11,7 +11,7 @@ from gevent.queue import (
 from raiden.exceptions import RaidenShuttingDown
 
 REMOVE_CALLBACK = object()
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class AlarmTask(gevent.Greenlet):
@@ -81,10 +81,7 @@ class AlarmTask(gevent.Greenlet):
 
         if current_block > self.last_block_number + 1:
             difference = current_block - self.last_block_number - 1
-            log.error(
-                'alarm missed %s blocks',
-                difference,
-            )
+            log.error('alarm missed %s blocks' % (difference))
 
         if current_block != self.last_block_number:
             log.debug(

--- a/raiden/tests/benchmark/speed.py
+++ b/raiden/tests/benchmark/speed.py
@@ -2,7 +2,7 @@
 import time
 
 import gevent
-from ethereum import slogging
+import structlog
 
 from raiden.settings import DEFAULT_SETTLE_TIMEOUT
 from raiden.tests.utils.tester_client import (
@@ -24,7 +24,7 @@ from raiden.tests.benchmark.utils import (
 )
 from raiden.utils import sha3
 
-log = slogging.getLogger('test.speed')  # pylint: disable=invalid-name
+log = structlog.get_logger('test.speed')  # pylint: disable=invalid-name
 
 
 def setup_apps(amount, tokens, num_transfers, num_nodes, channels_per_node):
@@ -190,7 +190,7 @@ def main():
     args = parser.parse_args()
 
     if args.log:
-        slogging.configure(':DEBUG')
+        structlog.configure(':DEBUG')
 
     if args.profile:
         import GreenletProfiler

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -121,19 +121,6 @@ def validate_solidity_compiler():
     validate_solc()
 
 
-# Connect catchlog's handler to structlog's root logger
-# @pytest.hookimpl(hookwrapper=True, trylast=True)
-# def pytest_runtest_call(item):
-#    catchlog_handler = getattr(item, CATCH_LOG_HANDLER_NAME, None)
-#    if catchlog_handler and catchlog_handler not in structlog.rootLogger.handlers:
-#        structlog.rootLogger.addHandler(catchlog_handler)
-
-#    yield
-
-#    if catchlog_handler and catchlog_handler in structlog.rootLogger.handlers:
-#        structlog.rootLogger.removeHandler(catchlog_handler)
-
-
 if sys.platform == 'darwin':
     # On macOS the temp directory base path is already very long.
     # To avoid failures on ipc tests (ipc path length is limited to 104/108 chars on macOS/linux)

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 import gevent
 import pytest
-from ethereum import slogging
+import structlog
 from ethereum.tools._solidity import compile_file
 
 from raiden.utils import (
@@ -43,7 +43,7 @@ BlockchainServices = namedtuple(
         'blockchain_services',
     )
 )
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 # pylint: disable=redefined-outer-name,too-many-arguments,unused-argument,too-many-locals
 

--- a/raiden/tests/fixtures/raiden_network.py
+++ b/raiden/tests/fixtures/raiden_network.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import gevent
 import pytest
-from ethereum import slogging
+import structlog
 
 from raiden import waiting
 from raiden.exceptions import RaidenShuttingDown
@@ -14,7 +14,7 @@ from raiden.tests.utils.network import (
     netting_channel_open_and_deposit,
 )
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def _raiden_cleanup(request, raiden_apps):

--- a/raiden/tests/long_running/flaky/test_token_networks.py
+++ b/raiden/tests/long_running/flaky/test_token_networks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
+import structlog
 
 import pytest
 import gevent
@@ -8,7 +8,7 @@ from raiden.api.python import RaidenAPI
 from raiden.tests.utils.blockchain import wait_until_block
 from raiden.transfer.state import CHANNEL_STATE_SETTLED
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # TODO: add test scenarios for

--- a/raiden/tests/smart_contracts/test_registry.py
+++ b/raiden/tests/smart_contracts/test_registry.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from ethereum import slogging
+import structlog
 from ethereum.tools import tester
 
 from raiden.tests.fixtures.tester import tester_token_address
 from raiden.utils import sha3, address_encoder, event_decoder
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def test_registry(tester_registry, tester_events, private_keys, tester_chain):

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -11,6 +11,9 @@ from raiden.utils import get_project_root, encode_hex
 KEYFILE_INACCESSIBLE = 'UTC--2017-06-20T16-33-00.000000000Z--inaccessible'
 KEYFILE_INVALID = 'UTC--2017-06-20T16-06-00.000000000Z--invalid'
 
+import structlog
+log = structlog.get_logger()
+
 
 @pytest.yield_fixture(scope='module')
 def test_keystore():

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from itertools import cycle
 
 import pytest
-from ethereum import slogging
+import structlog
 
 from raiden.constants import UINT64_MAX
 from raiden.messages import (
@@ -57,7 +57,7 @@ from raiden.utils import (
     privatekey_to_address,
 )
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 PartnerStateModel = namedtuple(

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -10,8 +10,8 @@ import termios
 import time
 import gevent
 
-from ethereum import slogging
 from eth_utils import denoms
+import structlog
 from requests import ConnectionError
 
 from raiden.utils import (
@@ -22,7 +22,7 @@ from raiden.utils import (
 )
 from raiden.tests.utils.genesis import GENESIS_STUB
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 DEFAULT_BALANCE = denoms.ether * 10000000
 DEFAULT_BALANCE_BIN = str(denoms.ether * 10000000)
@@ -58,7 +58,7 @@ def geth_to_cmd(node, datadir, verbosity):
     Args:
         node (dict): a node configuration
         datadir (str): the node's datadir
-        verbosity (int): geth logging verbosity, 0 - nothing, 5 - max
+        verbosity (int): geth structlog verbosity, 0 - nothing, 5 - max
 
     Return:
         List[str]: cmd-args list

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -4,7 +4,7 @@
 from binascii import hexlify
 
 from gevent import server
-from ethereum import slogging
+import structlog
 
 from raiden.app import App
 from raiden.network.matrixtransport import MatrixTransport
@@ -13,7 +13,7 @@ from raiden.network.transport import TokenBucket
 from raiden.tests.utils.matrix import MockMatrixClient
 from raiden.utils import privatekey_to_address
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 CHAIN = object()  # Flag used by create a network does make a loop with the channels
 

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from itertools import count
 from typing import Union
 
-from ethereum import slogging
+import structlog
 from ethereum.tools import tester, _solidity
 from ethereum.tools.tester import TransactionFailed
 from ethereum.abi import ContractTranslator
@@ -46,7 +46,7 @@ from raiden.network.rpc.client import (
 )
 from raiden.exceptions import SamePeerAddress
 
-log = slogging.getLogger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 FILTER_ID_GENERATOR = count()
 
 # NOTE: mine after each transaction to reset block.gas_used

--- a/raiden/udp_message_handler.py
+++ b/raiden/udp_message_handler.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
-
-from ethereum import slogging
+import structlog
 
 from raiden.utils import random_secret
 from raiden.routing import get_best_routes
@@ -30,7 +28,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveTransferRefundCancelRoute,
 )
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def handle_message_secretrequest(raiden: 'RaidenService', message: SecretRequest):
@@ -145,7 +143,7 @@ def on_udp_message(raiden: 'RaidenService', message: Message):
         handle_message_lockedtransfer(raiden, message)
     elif type(message) == Processed:
         handle_message_processed(raiden, message)
-    elif log.isEnabledFor(logging.ERROR):
+    else:
         log.error('Unknown message cmdid {}'.format(message.cmdid))
         return False
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -7,9 +7,9 @@ import select
 import signal
 import sys
 import time
-from logging import StreamHandler, Formatter
+from structlog import StreamHandler, Formatter
 
-from ethereum.slogging import getLogger
+from ethereum.structlog import get_logger
 from ethereum.tools._solidity import compile_file
 from eth_utils import denoms
 import gevent
@@ -235,7 +235,7 @@ class Console(BaseService):
         print_usage()
 
         # Remove handlers that log to stderr
-        root = getLogger()
+        root = get_logger()
         for handler in root.handlers[:]:
             if isinstance(handler, StreamHandler) and handler.stream == sys.stderr:
                 root.removeHandler(handler)

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -7,7 +7,7 @@ from gevent.queue import Queue
 from gevent.lock import BoundedSemaphore
 from gevent.event import Event
 from gevent.timeout import Timeout
-from ethereum import slogging
+import structlog
 import click
 
 from raiden.api.python import RaidenAPI
@@ -20,7 +20,7 @@ from raiden.utils import pex, get_system_spec
 from raiden.utils.cli import ADDRESS_TYPE
 
 
-log = slogging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 # number of transfers we will check for duplicates
 TRANSFER_MEMORY = 4096
@@ -270,16 +270,16 @@ def runner(ctx, **kwargs):
     # This is largely a copy&paste job from `raiden.ui.cli::run`, with the difference that
     # an `EchoNode` is instantiated from the App's `RaidenAPI`.
     print('Welcome to Raiden, version {} [Echo Node]'.format(get_system_spec()['raiden']))
-    slogging.configure(
-        kwargs['logging'],
+    structlog.configure(
+        kwargs['structlog'],
         log_json=kwargs['log_json'],
         log_file=kwargs['logfile']
     )
     if kwargs['logfile']:
-        # Disable stream logging
-        root = slogging.getLogger()
+        # Disable stream structlog
+        root = structlog.get_logger()
         for handler in root.handlers:
-            if isinstance(handler, slogging.logging.StreamHandler):
+            if isinstance(handler, structlog.structlog.StreamHandler):
                 root.handlers.remove(handler)
                 break
 

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import gevent
-from ethereum import slogging
+import structlog
 
 from raiden.network.protocol import NODE_NETWORK_REACHABLE
 from raiden.transfer.state import (
@@ -9,7 +9,7 @@ from raiden.transfer.state import (
 )
 from raiden.transfer import channel, views
 
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def wait_for_newchannel(

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ tinyrpc[gevent,httpclient]==0.8
 webargs==1.8.1
 eth-keyfile==0.5.1
 eth_utils==1.0.3
+structlog
+colorama

--- a/tools/create_compilation_dump.py
+++ b/tools/create_compilation_dump.py
@@ -5,11 +5,11 @@ from binascii import hexlify
 import json
 
 from ethereum.tools import tester
-from ethereum import slogging
+import structlog
+from raiden.log_config import configure_logging
 from raiden.utils import privatekey_to_address, get_contract_path
 
-slogging.configure(":INFO")
-log = slogging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 TARGETS = dict(
     registry='Registry.sol',
@@ -215,4 +215,5 @@ def main():
 
 
 if __name__ == '__main__':
+    configure_logging('DEBUG')
     main()

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -4,14 +4,15 @@ import os
 from binascii import hexlify
 
 import click
-from ethereum import slogging
+import structlog
 from ethereum.tools._solidity import compile_contract
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.ui.cli import prompt_account
 from raiden.utils import address_encoder, get_contract_path, decode_hex
+from raiden.log_config import configure_logging
 
-log = slogging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # Source files for all to be deployed solidity contracts
@@ -128,7 +129,7 @@ def get_privatekey_hex(keystore_path):
 @click.option("--port", type=int, default=8545, show_default=True)
 @click.option("--keystore-path", type=click.Path(exists=True))
 def main(keystore_path, pretty, gas_price, port):
-    slogging.configure(':debug')
+    configure_logging('DEBUG', colorize=True)
 
     privatekey_hex = get_privatekey_hex(keystore_path)
 

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -10,7 +10,7 @@ import random
 import click
 import gevent
 from gevent import monkey, server
-from ethereum import slogging
+import structlog
 
 from raiden.app import App
 from raiden.api.python import RaidenAPI
@@ -25,7 +25,7 @@ from raiden.utils import split_endpoint, decode_hex
 from raiden.settings import GAS_PRICE
 
 monkey.patch_all()
-log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 @click.option(  # noqa
@@ -45,7 +45,7 @@ log = slogging.get_logger(__name__)  # pylint: disable=invalid-name
     type=str,
 )
 @click.option(  # noqa
-    '--logging',
+    '--structlog',
     default=':INFO',
     type=str,
 )
@@ -72,14 +72,14 @@ def run(
         registry_contract_address,
         discovery_contract_address,
         listen_address,
-        logging,
+        structlog,
         logfile,
         scenario,
         stage_prefix
 ):  # pylint: disable=unused-argument
 
-    # TODO: only enabled logging on "initiators"
-    slogging.configure(logging, log_file=logfile)
+    # TODO: only enabled structlog on "initiators"
+    structlog.configure(structlog, log_file=logfile)
 
     (listen_host, listen_port) = split_endpoint(listen_address)
 

--- a/tools/testnet/files/dockerfiles/geth-testnet/run.py
+++ b/tools/testnet/files/dockerfiles/geth-testnet/run.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
-import logging
+import structlog
 import os
 import time
 import subprocess
 import sys
-from logging import getLogger
+import logging
 
 import click
 from datetime import datetime, timedelta
@@ -15,7 +15,7 @@ import requests
 from web3 import Web3, IPCProvider
 from web3.utils.compat.compat_stdlib import Timeout
 
-log = getLogger(__name__)
+log = struct.get_logger(__name__)
 
 # Since this will run inside a docker container and is written for Python 3 we
 # have to disable flake8 since it will run with Python 2 and break on Travis-CI

--- a/tools/testnet/files/dockerfiles/mkkeystore/mkkey.py
+++ b/tools/testnet/files/dockerfiles/mkkeystore/mkkey.py
@@ -4,9 +4,9 @@ import os
 from json import JSONEncoder
 
 import click
+import logging
 from coincurve import PrivateKey
 from datetime import datetime
-from ethereum import slogging
 
 
 from ethereum.tools.keys import make_keystore_json, sha3, encode_hex
@@ -63,5 +63,5 @@ def make_keystore_json_patched(private_key, password):
 
 
 if __name__ == "__main__":
-    slogging.configure(":ERROR")
+    logging.basicConfig(level=logging.ERROR)
     main()

--- a/tools/testnet/files/dockerfiles/raiden/raiden
+++ b/tools/testnet/files/dockerfiles/raiden/raiden
@@ -4,7 +4,8 @@ import os
 import sys
 from json import JSONEncoder
 
-from ethereum import slogging
+import logging
+from raiden.log_config import configure_logging
 from logstash import LogstashFormatterVersion1, UDPLogstashHandler
 from pkg_resources import load_entry_point
 
@@ -45,8 +46,8 @@ class NotCrashingUDPLogstashHandler(UDPLogstashHandler):
 
 if __name__ == "__main__":
     if 'RAIDEN_LOGSTASH_HOST' in os.environ:
-        slogging.configure()
-        slogging.rootLogger.addHandler(
+        configure_logging('WARN', colorize=False)
+        logging.root.addHandler(
             NotCrashingUDPLogstashHandler(
                 os.environ.get('RAIDEN_LOGSTASH_HOST'),
                 int(os.environ.get('RAIDEN_LOGSTASH_PORT', 9595)),

--- a/tools/testnet/files/dockerfiles/raiden/raiden_echo_node
+++ b/tools/testnet/files/dockerfiles/raiden/raiden_echo_node
@@ -4,7 +4,8 @@ import os
 import sys
 from json import JSONEncoder
 
-from ethereum import slogging
+import logging
+from raiden.log_config import configure_logging
 from logstash import LogstashFormatterVersion1, UDPLogstashHandler
 
 from raiden.utils import echo_node
@@ -46,8 +47,8 @@ class NotCrashingUDPLogstashHandler(UDPLogstashHandler):
 
 if __name__ == "__main__":
     if 'RAIDEN_LOGSTASH_HOST' in os.environ:
-        slogging.configure()
-        slogging.rootLogger.addHandler(
+        configure_logging('WARN', colorize=False)
+        logging.root.addHandler(
             NotCrashingUDPLogstashHandler(
                 os.environ.get('RAIDEN_LOGSTASH_HOST'),
                 int(os.environ.get('RAIDEN_LOGSTASH_PORT', 9595)),


### PR DESCRIPTION
- replaces `ethereum.slogging` with `structlog`
- removes `log.isEnabledFor()` conditionals
- adds colorized logs
- adds `configure_logging()` for a quick log setup

to do:
- [x] adapt log setup to honor `pytest` commandline options
- [x] update docker scripts
- [ ] add per-module configuration
- [x] update all `structlog.configure()` calls and initialize logging system properly