### PR TITLE
Remove usage of ethereum.utils module

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -2,7 +2,7 @@
 from binascii import unhexlify
 
 from ethereum.slogging import getLogger
-from ethereum.utils import big_endian_to_int
+from eth_utils import big_endian_to_int
 
 from raiden.constants import (
     UINT256_MAX,

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from binascii import hexlify, unhexlify
 
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -83,7 +83,7 @@ class Discovery:
         if address == self.not_found_address:  # the 0 address means nothing found
             return None
 
-        return normalize_address(address)
+        return to_canonical_address(address)
 
     def version(self):
         return self.proxy.call('contract_version')

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -5,7 +5,6 @@ from gevent.lock import RLock
 from typing import Optional, List
 
 from ethereum import slogging
-from ethereum.utils import encode_hex
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -35,6 +34,7 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
     releasing,
+    encode_hex,
 )
 
 log = slogging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/raiden/network/rpc/filters.py
+++ b/raiden/network/rpc/filters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import List, Dict, Union, Optional
 
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import (
@@ -30,7 +30,7 @@ def new_filter(
     json_data = {
         'fromBlock': from_block,
         'toBlock': to_block,
-        'address': address_encoder(normalize_address(contract_address)),
+        'address': address_encoder(to_canonical_address(contract_address)),
     }
 
     if topics is not None:
@@ -61,7 +61,7 @@ def get_filter_events(
     json_data = {
         'fromBlock': from_block,
         'toBlock': to_block,
-        'address': address_encoder(normalize_address(contract_address)),
+        'address': address_encoder(to_canonical_address(contract_address)),
     }
 
     if topics is not None:

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -2,7 +2,7 @@
 from typing import Callable, Optional, Dict
 
 from ethereum.abi import ContractTranslator
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 
 from raiden.exceptions import InvalidFunctionName
 from raiden.utils.typing import Address
@@ -20,8 +20,8 @@ class ContractProxy:
             transact_function: Callable,
             estimate_function: Optional[Callable] = None):
 
-        sender = normalize_address(sender)
-        contract_address = normalize_address(contract_address)
+        sender = to_canonical_address(sender)
+        contract_address = to_canonical_address(contract_address)
         translator = ContractTranslator(abi)
 
         self.abi = abi

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from binascii import hexlify
-from ethereum.utils import denoms, int_to_big_endian
+from eth_utils import denoms, int_to_big_endian
 
 INITIAL_PORT = 38647
 

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -6,7 +6,7 @@ import itertools
 import pytest
 from ethereum.tools import _solidity
 from ethereum.tools._solidity import compile_file
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
@@ -279,7 +279,7 @@ def test_blockchain(
         'channelManagerByToken',
         token_proxy.contract_address,
     )
-    channel_manager_address = normalize_address(channel_manager_address_encoded)
+    channel_manager_address = to_canonical_address(channel_manager_address_encoded)
 
     log = log_list[0]
     log_topics = [
@@ -292,8 +292,8 @@ def test_blockchain(
         unhexlify(log_data[2:]),
     )
 
-    assert channel_manager_address == normalize_address(event['channel_manager_address'])
-    assert token_proxy.contract_address == normalize_address(event['token_address'])
+    assert channel_manager_address == to_canonical_address(event['channel_manager_address'])
+    assert token_proxy.contract_address == to_canonical_address(event['token_address'])
 
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
         CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),

--- a/raiden/tests/property/smart_contracts/test_nettingchannel.py
+++ b/raiden/tests/property/smart_contracts/test_nettingchannel.py
@@ -2,7 +2,7 @@
 import contextlib
 
 from coincurve import PrivateKey
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 from ethereum.tools.tester import TransactionFailed
 from ethereum.exceptions import BlockGasLimitReached
 from hypothesis import assume
@@ -312,7 +312,7 @@ class NettingChannelStateMachine(GenericStateMachine):
                     sender=sender_pkey,
                 )
 
-        elif transfer.channel != normalize_address(self.netting_channel.address):
+        elif transfer.channel != to_canonical_address(self.netting_channel.address):
             msg = 'close called with a transfer for a different channe didnt fail'
             with transaction_must_fail(msg):
                 self.netting_channel.close(  # pylint: disable=no-member
@@ -398,7 +398,7 @@ class NettingChannelStateMachine(GenericStateMachine):
                     sender=sender_pkey,
                 )
 
-        elif transfer.channel != normalize_address(self.netting_channel.address):
+        elif transfer.channel != to_canonical_address(self.netting_channel.address):
             msg = 'updateTransfer called with a transfer for a different channel didnt fail'
             with transaction_must_fail(msg):
                 self.netting_channel.updateTransfer(  # pylint: disable=no-member

--- a/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_auxiliary_netting_channel.py
@@ -9,7 +9,8 @@ import pytest
 from ethereum.abi import ValueOutOfBounds
 from ethereum.tools import _solidity, tester
 from ethereum.tools.tester import TransactionFailed
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
+
 
 from raiden.constants import INT64_MIN, INT64_MAX, UINT64_MIN, UINT64_MAX
 from raiden.messages import DirectTransfer, Lock
@@ -272,4 +273,4 @@ def test_recoverAddressFromSignature(tester_chain, tester_nettingchannel_library
         signature
     )
 
-    assert normalize_address(computed_address) == msg.sender
+    assert to_canonical_address(computed_address) == msg.sender

--- a/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
+++ b/raiden/tests/smart_contracts/netting_channel/test_withdraw.py
@@ -2,7 +2,7 @@
 import random
 
 import pytest
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 from ethereum.tools.tester import TransactionFailed
 from coincurve import PrivateKey
 
@@ -161,7 +161,7 @@ def test_withdraw_at_settlement_block(
         nonce=nonce,
         registry_address=tester_registry_address,
         token=tester_token.address,
-        channel=normalize_address(nettingchannel.address),
+        channel=to_canonical_address(nettingchannel.address),
         transferred_amount=0,
         locked_amount=lock_amount,
         recipient=address1,

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -4,10 +4,9 @@ import os
 from unittest.mock import patch
 
 import pytest
-from ethereum.utils import encode_hex
 
 from raiden.accounts import AccountManager
-from raiden.utils import get_project_root
+from raiden.utils import get_project_root, encode_hex
 
 KEYFILE_INACCESSIBLE = 'UTC--2017-06-20T16-33-00.000000000Z--inaccessible'
 KEYFILE_INVALID = 'UTC--2017-06-20T16-06-00.000000000Z--invalid'

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -11,13 +11,14 @@ import time
 import gevent
 
 from ethereum import slogging
-from ethereum.utils import denoms, encode_hex
+from eth_utils import denoms
 from requests import ConnectionError
 
 from raiden.utils import (
     address_encoder,
     privatekey_to_address,
-    privtopub
+    privtopub,
+    encode_hex,
 )
 from raiden.tests.utils.genesis import GENESIS_STUB
 

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -2,7 +2,7 @@
 from binascii import hexlify
 
 from ethereum.tools import tester, _solidity
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 
 from raiden.tests.utils.blockchain import DEFAULT_BALANCE
 from raiden.constants import (
@@ -238,9 +238,9 @@ def channel_from_nettingcontract(our_key, netting_contract, reveal_timeout):
     settled_block_number = None
 
     identifier = address_decoder(netting_contract.address)
-    token_address = normalize_address(token_address_hex)
-    address1 = normalize_address(address1_hex)
-    address2 = normalize_address(address2_hex)
+    token_address = to_canonical_address(token_address_hex)
+    address1 = to_canonical_address(address1_hex)
+    address2 = to_canonical_address(address2_hex)
 
     if our_address == address1:
         our_balance = balance1

--- a/raiden/tests/utils/tester_client.py
+++ b/raiden/tests/utils/tester_client.py
@@ -9,7 +9,6 @@ from ethereum import slogging
 from ethereum.tools import tester, _solidity
 from ethereum.tools.tester import TransactionFailed
 from ethereum.abi import ContractTranslator
-from ethereum.utils import encode_hex
 from ethereum.tools._solidity import solidity_get_contract_key
 
 from raiden import messages
@@ -28,6 +27,7 @@ from raiden.utils import (
     isaddress,
     pex,
     privatekey_to_address,
+    encode_hex,
 )
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
-from ethereum.utils import encode_hex
-
 from raiden.transfer.architecture import State
-from raiden.utils import pex, sha3, typing
+from raiden.utils import pex, sha3, typing, encode_hex
 from raiden.transfer.state import (
     EMPTY_MERKLE_ROOT,
     balanceproof_from_envelope,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -16,7 +16,7 @@ import gevent
 import gevent.monkey
 import requests
 from ethereum import slogging
-from ethereum.utils import denoms
+from eth_utils import denoms
 from requests.exceptions import RequestException
 
 from raiden.accounts import AccountManager

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -11,7 +11,7 @@ from logging import StreamHandler, Formatter
 
 from ethereum.slogging import getLogger
 from ethereum.tools._solidity import compile_file
-from ethereum.utils import denoms
+from eth_utils import denoms
 import gevent
 from gevent.event import Event
 from gevent import Greenlet

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -10,7 +10,7 @@ from itertools import zip_longest
 
 import gevent
 from coincurve import PrivateKey
-from ethereum.utils import remove_0x_head
+from eth_utils import remove_0x_prefix
 from ethereum.abi import ContractTranslator
 from ethereum.messages import Log
 from sha3 import keccak_256
@@ -34,6 +34,22 @@ def safe_address_decode(address):
 
 def random_secret():
     return os.urandom(32)
+
+
+def decode_hex(s) -> bytes:
+    if isinstance(s, str):
+        return bytes.fromhex(s)
+    if isinstance(s, (bytes, bytearray)):
+        return unhexlify(s)
+    raise TypeError('Value must be an instance of str or bytes')
+
+
+def encode_hex(b) -> str:
+    if isinstance(b, str):
+        b = bytes(b, 'utf-8')
+    if isinstance(b, (bytes, bytearray)):
+        return str(hexlify(b), 'utf-8')
+    raise TypeError('Value must be an instance of str or bytes')
 
 
 def sha3(data: bytes) -> bytes:
@@ -203,7 +219,7 @@ def get_contract_path(contract_name: str) -> str:
 
 def safe_lstrip_hex(val):
     if isinstance(val, str):
-        return remove_0x_head(val)
+        return remove_0x_prefix(val)
     return val
 
 

--- a/raiden/utils/events.py
+++ b/raiden/utils/events.py
@@ -3,7 +3,7 @@
 from typing import List, Dict, Union
 
 from ethereum.abi import ContractTranslator
-from ethereum.utils import normalize_address
+from eth_utils import to_canonical_address
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -32,7 +32,7 @@ def all_contract_events_raw(
     return rpc.rpccall_with_retry('eth_getLogs', {
         'fromBlock': str(start_block),
         'toBlock': str(end_block),
-        'address': address_encoder(normalize_address(contract_address)),
+        'address': address_encoder(to_canonical_address(contract_address)),
         'topics': [],
     })
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ rlp==0.6
 tinyrpc[gevent,httpclient]==0.8
 webargs==1.8.1
 eth-keyfile==0.5.1
+eth_utils==1.0.3

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -6,11 +6,10 @@ from binascii import hexlify
 import click
 from ethereum import slogging
 from ethereum.tools._solidity import compile_contract
-from ethereum.utils import decode_hex
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.ui.cli import prompt_account
-from raiden.utils import address_encoder, get_contract_path
+from raiden.utils import address_encoder, get_contract_path, decode_hex
 
 log = slogging.getLogger(__name__)
 

--- a/tools/genesis_builder.py
+++ b/tools/genesis_builder.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from binascii import hexlify
 
-from ethereum.utils import encode_hex, denoms
+from eth_utils import denoms
 
-from raiden.utils import privatekey_to_address, sha3
+from raiden.utils import privatekey_to_address, sha3, encode_hex
 from raiden.tests.utils.blockchain import GENESIS_STUB
 
 CLUSTER_NAME = 'raiden'

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -11,7 +11,6 @@ import click
 import gevent
 from gevent import monkey, server
 from ethereum import slogging
-from ethereum.utils import decode_hex
 
 from raiden.app import App
 from raiden.api.python import RaidenAPI
@@ -22,7 +21,7 @@ from raiden.network.protocol import UDPTransport
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.transport import TokenBucket
 from raiden.ui.console import ConsoleTools
-from raiden.utils import split_endpoint
+from raiden.utils import split_endpoint, decode_hex
 from raiden.settings import GAS_PRICE
 
 monkey.patch_all()

--- a/tools/startcluster.py
+++ b/tools/startcluster.py
@@ -7,13 +7,12 @@ import tempfile
 import signal
 from subprocess import Popen, PIPE
 
-from ethereum.utils import encode_hex
-
 from genesis_builder import mk_genesis, generate_accounts
 from raiden.utils import (
     privtopub as privtopub_enode,
     privatekey_to_address,
-    sha3
+    sha3,
+    encode_hex,
 )
 from raiden.settings import INITIAL_PORT
 


### PR DESCRIPTION
Get rid of all usages of `ethereum.utils`.

Related to #1293 