### PR TITLE
Convert RPCClient to web3 client and remove pyethereum dependency

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -165,7 +165,7 @@ class BlockChainService:
         return self.address_to_registry[registry_address]
 
     def uninstall_filter(self, filter_id_raw):
-        self.client.rpccall_with_retry('eth_uninstallFilter', filter_id_raw)
+        self.client.web3.eth.uninstallFilter(filter_id_raw)
 
     def deploy_contract(self, contract_name, contract_path, constructor_parameters=None):
         contracts = compile_files_cwd([contract_path])

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -206,4 +206,4 @@ class BlockChainService:
     @property
     @ttl_cache(ttl=10)
     def network_id(self) -> int:
-        return int(self.client.rpccall_with_retry('net_version'))
+        return int(self.client.web3.version.network)

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -15,7 +15,6 @@ from raiden.network.proxies import (
 )
 from raiden.settings import DEFAULT_POLL_TIMEOUT
 from raiden.utils import (
-    block_tag_encoder,
     isaddress,
     privatekey_to_address,
     quantity_decoder,
@@ -50,7 +49,7 @@ class BlockChainService:
         return self.client.block_number()
 
     def is_synced(self) -> bool:
-        result = self.client.rpccall_with_retry('eth_syncing')
+        result = self.client.web3.eth.syncing
 
         # the node is synchronized
         if result is False:
@@ -87,8 +86,7 @@ class BlockChainService:
         return delta / interval
 
     def get_block_header(self, block_number: int):
-        block_number = block_tag_encoder(block_number)
-        return self.client.rpccall_with_retry('eth_getBlockByNumber', block_number, False)
+        return self.client.web3.getBlock(block_number, False)
 
     def next_block(self) -> int:
         target_block_number = self.block_number() + 1

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -427,51 +427,6 @@ class JSONRPCClient:
             contract_address,
         )
 
-    def new_filter(self, fromBlock=None, toBlock=None, address=None, topics=None):
-        """ Creates a filter object, based on filter options, to notify when
-        the state changes (logs). To check if the state has changed, call
-        eth_getFilterChanges.
-        """
-
-        json_data = {
-            'fromBlock': block_tag_encoder(fromBlock or ''),
-            'toBlock': block_tag_encoder(toBlock or ''),
-        }
-
-        if address is not None:
-            json_data['address'] = address_encoder(address)
-
-        if topics is not None:
-            if not isinstance(topics, list):
-                raise ValueError('topics must be a list')
-
-            json_data['topics'] = [topic_encoder(topic) for topic in topics]
-
-        filter_id = self.rpccall_with_retry('eth_newFilter', json_data)
-        return quantity_decoder(filter_id)
-
-    def filter_changes(self, fid: int) -> List:
-        changes = self.rpccall_with_retry('eth_getFilterChanges', quantity_encoder(fid))
-
-        if not changes:
-            return list()
-
-        assert isinstance(changes, list)
-        decoders = {
-            'blockHash': data_decoder,
-            'transactionHash': data_decoder,
-            'data': data_decoder,
-            'address': address_decoder,
-            'topics': lambda x: [topic_decoder(t) for t in x],
-            'blockNumber': quantity_decoder,
-            'logIndex': quantity_decoder,
-            'transactionIndex': quantity_decoder
-        }
-        return [
-            {k: decoders[k](v) for k, v in c.items() if v is not None}
-            for c in changes
-        ]
-
     def rpccall_with_retry(self, method: str, *args):
         """ Do the request and return the result.
 

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -2,7 +2,7 @@
 import warnings
 import time
 from binascii import unhexlify
-from typing import Optional, Dict, Union
+from typing import Optional, Union
 
 from web3 import Web3, HTTPProvider
 from web3.middleware import geth_poa_middleware
@@ -374,7 +374,7 @@ class JSONRPCClient:
                 transaction_hash = unhexlify(transaction_hash_hex)
 
                 self.poll(transaction_hash, timeout=timeout)
-                receipt = self.eth_getTransactionReceipt(transaction_hash)
+                receipt = self.web3.eth.getTransactionReceipt(transaction_hash)
 
                 contract_address = receipt['contractAddress']
                 # remove the hexadecimal prefix 0x from the address
@@ -410,7 +410,7 @@ class JSONRPCClient:
         transaction_hash = unhexlify(transaction_hash_hex)
 
         self.poll(transaction_hash, timeout=timeout)
-        receipt = self.eth_getTransactionReceipt(transaction_hash)
+        receipt = self.web3.eth.getTransactionReceipt(transaction_hash)
         contract_address = receipt['contractAddress']
 
         deployed_code = self.eth_getCode(address_decoder(contract_address))
@@ -596,30 +596,6 @@ class JSONRPCClient:
                 raise e
 
         return quantity_decoder(res)
-
-    def eth_getTransactionReceipt(self, transaction_hash: bytes) -> Dict:
-        """ Returns the receipt of a transaction by transaction hash.
-
-        Args:
-            transaction_hash: Hash of a transaction.
-
-        Returns:
-            A dict representing the transaction receipt object, or null when no
-            receipt was found.
-        """
-        if transaction_hash.startswith(b'0x'):
-            warnings.warn(
-                'transaction_hash seems to be already encoded, this will'
-                ' result in unexpected behavior'
-            )
-
-        if len(transaction_hash) != 32:
-            raise ValueError(
-                'transaction_hash length must be 32 (it might be hex encoded)'
-            )
-
-        transaction_hash = data_encoder(transaction_hash)
-        return self.rpccall_with_retry('eth_getTransactionReceipt', transaction_hash)
 
     def eth_getCode(self, code_address: Address, block: Union[int, str] = 'latest') -> bytes:
         """ Returns code at a given address.

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -643,25 +643,6 @@ class JSONRPCClient:
         result = self.rpccall_with_retry('eth_getCode', address_encoder(code_address), block)
         return data_decoder(result)
 
-    def eth_getTransactionByHash(self, transaction_hash: bytes):
-        """ Returns the information about a transaction requested by
-        transaction hash.
-        """
-
-        if transaction_hash.startswith(b'0x'):
-            warnings.warn(
-                'transaction_hash seems to be already encoded, this will'
-                ' result in unexpected behavior'
-            )
-
-        if len(transaction_hash) != 32:
-            raise ValueError(
-                'transaction_hash length must be 32 (it might be hex encoded)'
-            )
-
-        transaction_hash = data_encoder(transaction_hash)
-        return self.rpccall_with_retry('eth_getTransactionByHash', transaction_hash)
-
     def poll(
             self,
             transaction_hash: bytes,
@@ -707,10 +688,7 @@ class JSONRPCClient:
             while True:
                 # Could return None for a short period of time, until the
                 # transaction is added to the pool
-                transaction = self.rpccall_with_retry(
-                    'eth_getTransactionByHash',
-                    transaction_hash,
-                )
+                transaction = self.web3.eth.getTransaction(transaction_hash)
 
                 # if the transaction was added to the pool and then removed
                 if transaction is None and last_result is not None:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -33,7 +33,6 @@ from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.settings import GAS_PRICE, GAS_LIMIT, RPC_CACHE_TTL
 from raiden.utils import (
     address_encoder,
-    data_decoder,
     data_encoder,
     privatekey_to_address,
     quantity_decoder,
@@ -547,9 +546,7 @@ class JSONRPCClient:
             startgas,
             self.gasprice(),
         )
-        res = self.rpccall_with_retry('eth_call', json_data, block_number)
-
-        return data_decoder(res)
+        return self.web3.eth.call(json_data, block_number)
 
     def eth_estimateGas(
             self,

--- a/raiden/network/rpc/transactions.py
+++ b/raiden/network/rpc/transactions.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from binascii import unhexlify
-
-from raiden.utils import data_encoder
 from raiden.settings import GAS_LIMIT
 
 
@@ -10,15 +7,14 @@ def check_transaction_threw(client, transaction_hash):
        Returns None in case of success and the transaction receipt if the
        transaction's status indicator is 0x0.
     """
-    encoded_transaction = data_encoder(unhexlify(transaction_hash))
-    receipt = client.rpccall_with_retry('eth_getTransactionReceipt', encoded_transaction)
+    receipt = client.web3.eth.getTransactionReceipt(transaction_hash)
 
     if 'status' not in receipt:
         raise ValueError(
             'Transaction receipt does not contain a status field. Upgrade your client'
         )
 
-    if receipt['status'] == '0x0':
+    if receipt['status'] == 0:
         return receipt
 
     return None

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -152,13 +152,9 @@ def endpoint_registry_exception_handler(greenlet):
         )
 
         if rpc_unreachable:
-            log.critical(
-                'Endpoint registry failed. '
-                'Ethereum RPC API might be unreachable.',
-                exception=repr(e),
-            )
+            log.exception('Endpoint registry failed. Ethereum RPC API might be unreachable.')
         else:
-            log.critical('Endpoint registry failed.', exception=repr(e))
+            log.exception('Endpoint registry failed.')
 
         sys.exit(1)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -152,13 +152,13 @@ def endpoint_registry_exception_handler(greenlet):
         )
 
         if rpc_unreachable:
-            log.fatal(
-                'Endpoint registry failed: %s. '
+            log.critical(
+                'Endpoint registry failed. '
                 'Ethereum RPC API might be unreachable.',
-                repr(e),
+                exception=repr(e),
             )
         else:
-            log.fatal('Endpoint registry failed: %s. ', repr(e))
+            log.critical('Endpoint registry failed.', exception=repr(e))
 
         sys.exit(1)
 

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -9,7 +9,6 @@ from gevent import monkey
 monkey.patch_all()
 
 import pytest
-from ethereum.tools.keys import PBKDF2_CONSTANTS
 
 from raiden.exceptions import RaidenShuttingDown
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
@@ -17,7 +16,6 @@ from raiden.log_config import configure_logging
 
 gevent.get_hub().SYSTEM_ERROR = BaseException
 gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
-PBKDF2_CONSTANTS['c'] = 100
 
 CATCH_LOG_HANDLER_NAME = 'catch_log_handler'
 

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -3,7 +3,7 @@ from binascii import unhexlify
 import os
 
 import pytest
-from eth_utils import decode_hex
+from eth_utils import decode_hex, to_checksum_address
 
 from raiden.exceptions import EthNodeCommunicationError
 from raiden.network.rpc.filters import new_filter, get_filter_events
@@ -47,7 +47,7 @@ def test_call_inexisting_address(deploy_client, blockchain_backend):
 
     inexisting_address = b'\x01\x02\x03\x04\x05' * 4
 
-    assert len(deploy_client.eth_getCode(inexisting_address)) == 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(inexisting_address))) == 0
     assert deploy_client.eth_call(sender=deploy_client.sender, to=inexisting_address) == b''
 
 
@@ -57,7 +57,7 @@ def test_call_invalid_selector(deploy_client, blockchain_backend):
     """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     selector = decode_hex(contract_proxy.encode_function_call('ret', args=[]))
     next_byte = chr(selector[0] + 1).encode()
@@ -75,7 +75,7 @@ def test_call_throws(deploy_client, blockchain_backend):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     assert contract_proxy.call('fail') == b''
 
@@ -85,7 +85,7 @@ def test_estimate_gas_fail(deploy_client, blockchain_backend):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     assert not contract_proxy.estimate_gas('fail')
 
@@ -95,7 +95,7 @@ def test_duplicated_transaction_raises(deploy_client, blockchain_backend):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     host = '0.0.0.0'  # hardcoded in the deploy_client fixture
     second_client = JSONRPCClient(
@@ -121,7 +121,7 @@ def test_transact_opcode(deploy_client, blockchain_backend):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     gas = contract_proxy.estimate_gas('ret') * 2
 
@@ -138,7 +138,7 @@ def test_transact_throws_opcode(deploy_client, blockchain_backend):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     gas = deploy_client.gaslimit()
 
@@ -155,7 +155,7 @@ def test_transact_opcode_oog(deploy_client, blockchain_backend):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     address = contract_proxy.contract_address
-    assert len(deploy_client.eth_getCode(address)) > 0
+    assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     gas = min(contract_proxy.estimate_gas('loop', 1000) // 2, deploy_client.gaslimit())
     transaction_hex = contract_proxy.transact('loop', 1000, startgas=gas)

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -5,7 +5,6 @@ import os
 import pytest
 from eth_utils import decode_hex, to_checksum_address
 
-from raiden.exceptions import EthNodeCommunicationError
 from raiden.network.rpc.filters import new_filter, get_filter_events
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.network.rpc.client import JSONRPCClient
@@ -111,7 +110,7 @@ def test_duplicated_transaction_raises(deploy_client, blockchain_backend):
 
     gas = contract_proxy.estimate_gas('ret') * 2
 
-    with pytest.raises(EthNodeCommunicationError):
+    with pytest.raises(ValueError):
         second_proxy.transact('ret', startgas=gas)
         contract_proxy.transact('ret', startgas=gas)
 

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -241,10 +241,9 @@ def test_blockchain(
         timeout=poll_timeout,
     )
 
-    log_list = jsonrpc_client.rpccall_with_retry(
-        'eth_getLogs',
+    log_list = jsonrpc_client.web3.eth.getLogs(
         {
-            'fromBlock': '0x0',
+            'fromBlock': 0,
             'toBlock': 'latest',
             'topics': [],
         },
@@ -261,10 +260,9 @@ def test_blockchain(
 
     assert len(registry_proxy.call('tokenAddresses')) == 1
 
-    log_list = jsonrpc_client.rpccall_with_retry(
-        'eth_getLogs',
+    log_list = jsonrpc_client.web3.eth.getLogs(
         {
-            'fromBlock': '0x0',
+            'fromBlock': 0,
             'toBlock': 'latest',
             'topics': [],
         },
@@ -296,10 +294,9 @@ def test_blockchain(
     )
     jsonrpc_client.poll(unhexlify(transaction_hash), timeout=poll_timeout)
 
-    log_list = jsonrpc_client.rpccall_with_retry(
-        'eth_getLogs',
+    log_list = jsonrpc_client.web3.eth.getLogs(
         {
-            'fromBlock': '0x0',
+            'fromBlock': 0,
             'toBlock': 'latest',
             'topics': [],
         },

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -5,14 +5,20 @@ from raiden.utils import (
 )
 
 
-class MockClient:
+class MockVersion:
+    def __init__(self, node):
+        self.node = node
 
+
+class MockWeb3:
     def __init__(self, version):
-        self.version_string = version
+        self.version = version
 
-    def call(self, func):
-        assert func == 'web3_clientVersion'
-        return self.version_string
+
+class MockClient:
+    def __init__(self, version):
+        version = MockVersion(version)
+        self.web3 = MockWeb3(version)
 
 
 def test_check_json_rpc_geth():

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -10,7 +10,7 @@ import termios
 import time
 import gevent
 
-from eth_utils import denoms
+from eth_utils import denoms, to_checksum_address
 import structlog
 from requests import ConnectionError
 
@@ -206,16 +206,16 @@ def geth_wait_and_check(deploy_client, privatekeys, random_marker):
         raise ValueError('geth didnt start the jsonrpc interface')
 
     for key in sorted(set(privatekeys)):
-        address = address_encoder(privatekey_to_address(key))
+        address = to_checksum_address(privatekey_to_address(key))
 
         tries = 10
-        balance = '0x0'
-        while balance == '0x0' and tries > 0:
-            balance = deploy_client.rpccall_with_retry('eth_getBalance', address, 'latest')
+        balance = 0
+        while balance == 0 and tries > 0:
+            balance = deploy_client.web3.eth.getBalance(address, 'latest')
             gevent.sleep(1)
             tries -= 1
 
-        if balance == '0x0':
+        if balance == 0:
             raise ValueError('account is with a balance of 0')
 
 

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -189,16 +189,19 @@ def geth_wait_and_check(deploy_client, privatekeys, random_marker):
     tries = 5
     while not jsonrpc_running and tries > 0:
         try:
-            block = deploy_client.web3.eth.getBlock(0, False)
+            # don't use web3 here as this will cause problem in the middleware
+            response = deploy_client.web3.providers[0].make_request(
+                'eth_getBlockByNumber',
+                ['0x0', False]
+            )
         except ConnectionError:
             gevent.sleep(0.5)
             tries -= 1
         else:
             jsonrpc_running = True
 
-            # the 'proofOfAuthorityData' key gets added by the web3 PoA middleware. See
-            # https://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority
-            running_marker = encode_hex(block['proofOfAuthorityData'])[:len(random_marker)]
+            block = response['result']
+            running_marker = block['extraData'][2:len(random_marker) + 2]
             if running_marker != random_marker:
                 raise RuntimeError(
                     'the test marker does not match, maybe two tests are running in '

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -732,7 +732,11 @@ def run(ctx, **kwargs):
     # not timeout.
 
     def _run_app():
-        app_ = ctx.invoke(app, **kwargs)
+        # this catches exceptions raised when waiting for the stalecheck to complete
+        try:
+            app_ = ctx.invoke(app, **kwargs)
+        except EthNodeCommunicationError as err:
+            sys.exit(1)
 
         domain_list = []
         if kwargs['rpccorsdomain']:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -112,7 +112,7 @@ def toggle_trace_profiler(raiden):
 
 def check_json_rpc(client):
     try:
-        client_version = client.rpccall_with_retry('web3_clientVersion')
+        client_version = client.web3.version.node
     except (requests.exceptions.ConnectionError, EthNodeCommunicationError):
         print(
             '\n'

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -10,7 +10,7 @@ import time
 import structlog
 from logging import StreamHandler, Formatter
 
-from eth_utils import denoms
+from eth_utils import denoms, to_checksum_address
 import gevent
 from gevent.event import Event
 from gevent import Greenlet
@@ -420,14 +420,18 @@ class ConsoleTools:
         """
         contract_address = safe_address_decode(contract_address_hex)
         start_time = time.time()
-        result = self._raiden.chain.client.eth_getCode(contract_address)
+        result = self._raiden.chain.client.web3.eth.getCode(
+            to_checksum_address(contract_address)
+        )
 
         current_time = time.time()
         while len(result) == 0:
             if timeout and start_time + timeout > current_time:
                 return False
 
-            result = self._raiden.chain.client.eth_getCode(contract_address)
+            result = self._raiden.chain.client.web3.eth.getCode(
+                to_checksum_address(contract_address)
+            )
             gevent.sleep(0.5)
 
             current_time = time.time()

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -10,8 +10,7 @@ from itertools import zip_longest
 
 import gevent
 from coincurve import PrivateKey
-from eth_utils import remove_0x_prefix
-from sha3 import keccak_256
+from eth_utils import remove_0x_prefix, keccak
 
 import raiden
 from raiden.utils import typing

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -51,15 +51,7 @@ def encode_hex(b) -> str:
 
 
 def sha3(data: bytes) -> bytes:
-    """
-    Raises:
-        RuntimeError: If Keccak lib initialization failed, or if the function
-        failed to compute the hash.
-
-        TypeError: This function does not accept unicode objects, they must be
-        encoded prior to usage.
-    """
-    return keccak_256(data).digest()
+    return keccak(data)
 
 
 def eth_sign_sha3(data: bytes) -> bytes:

--- a/raiden/utils/events.py
+++ b/raiden/utils/events.py
@@ -2,13 +2,13 @@
 """
 from typing import List, Dict, Union
 
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
     CONTRACT_NETTING_CHANNEL,
 )
-from raiden.utils import address_encoder
+from raiden.utils import address_encoder, data_decoder, topic_decoder
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.proxies.netting_channel import NettingChannel
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
@@ -29,10 +29,10 @@ def all_contract_events_raw(
     Returns:
         events
     """
-    return rpc.rpccall_with_retry('eth_getLogs', {
-        'fromBlock': str(start_block),
-        'toBlock': str(end_block),
-        'address': address_encoder(to_canonical_address(contract_address)),
+    return rpc.web3.eth.getLogs({
+        'fromBlock': start_block,
+        'toBlock': end_block,
+        'address': to_checksum_address(contract_address),
         'topics': [],
     })
 

--- a/raiden/utils/events.py
+++ b/raiden/utils/events.py
@@ -2,13 +2,12 @@
 """
 from typing import List, Dict, Union
 
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_checksum_address
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
     CONTRACT_NETTING_CHANNEL,
 )
-from raiden.utils import address_encoder, data_decoder, topic_decoder
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.proxies.netting_channel import NettingChannel
 from raiden.network.rpc.smartcontract_proxy import ContractProxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ netifaces==0.10.6
 networkx==2.0.0
 psutil==5.4.3
 pycryptodome==3.6.1
-pysha3==1.0.2
 # raiden-libs==???
 # FIXME: replace with released version before merge
 git+https://github.com/raiden-network/raiden-libs.git@47c01904ca9b05b107e40071adbcd1c126bcbc66#egg=raiden-libs

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ eth_utils==1.0.3
 structlog
 colorama
 py-solc
+web3==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ git+https://github.com/LefterisJP/pystun@develop#egg=pystun
 
 cachetools==2.0.1
 coincurve==7.1.0
-ethereum==2.3.1
 filelock==3.0
 Flask-Cors==3.0.3
 Flask-Restful==0.3.6
@@ -18,9 +17,8 @@ psutil==5.4.3
 pycryptodome==3.6.1
 # raiden-libs==???
 # FIXME: replace with released version before merge
-git+https://github.com/raiden-network/raiden-libs.git@47c01904ca9b05b107e40071adbcd1c126bcbc66#egg=raiden-libs
+git+https://github.com/raiden-network/raiden-libs.git@dd3f15a6159d68a0f5496e8e5985256b18d00f6a#egg=raiden-libs
 rlp==0.6
-tinyrpc[gevent,httpclient]==0.8
 webargs==1.8.1
 eth-keyfile==0.5.1
 eth_utils==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ install_requires_replacements = {
     'git+https://github.com/LefterisJP/pystun@develop#egg=pystun': 'pystun',
     (
         'git+https://github.com/raiden-network/raiden-libs.git'
-        '@47c01904ca9b05b107e40071adbcd1c126bcbc66#egg=raiden-libs'
+        '@dd3f15a6159d68a0f5496e8e5985256b18d00f6a#egg=raiden-libs'
     ): 'raiden-libs',
 }
 


### PR DESCRIPTION
This converts the RPCClient to use the web3 client internally. 

This also removes the last usage of the `pyethereum` dependency.