### PR TITLE
Fix module and logging errors

### DIFF
--- a/raiden/network/stunsock.py
+++ b/raiden/network/stunsock.py
@@ -17,7 +17,7 @@ def stun_socket(
 ):
     timeout = socket.gettimeout()
     socket.settimeout(2)
-    log.debug('Initiating STUN for %s:%s', source_ip, source_port)
+    log.debug('Initiating STUN', source_ip=source_ip, source_port=source_port)
     nat_type, nat = stun.get_nat_type(
         socket,
         source_ip,

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -7,9 +7,9 @@ import select
 import signal
 import sys
 import time
-
 import structlog
-from structlog import StreamHandler, Formatter
+from logging import StreamHandler, Formatter
+
 from ethereum.tools._solidity import compile_file
 from eth_utils import denoms
 import gevent


### PR DESCRIPTION
When starting raiden I got the following error. Not sure if the fix work as intended with the new logging, please have a look @pcppcp 
```
  File "/Users/paul/Work/raiden/raiden/ui/console.py", line 12, in <module>
    from structlog import StreamHandler, Formatter
ImportError: cannot import name 'StreamHandler'
```

When this was fixed the following appeared:
```
  File "/Users/paul/Work/raiden/raiden/network/stunsock.py", line 20, in stun_socket
    log.debug('Initiating STUN for %s:%s', source_ip, source_port)
TypeError: _proxy_to_logger() takes from 2 to 3 positional arguments but 5 were given
```