### PR TITLE
Enable ipc for geth tests

### DIFF
--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -82,7 +82,6 @@ def geth_to_cmd(node, datadir, verbosity):
     # dont use the '--dev' flag
     cmd.extend([
         '--nodiscover',
-        '--ipcdisable',
         '--rpc',
         '--rpcapi', 'eth,net,web3',
         '--rpcaddr', '0.0.0.0',


### PR DESCRIPTION
It's convenient to be able to attach to the running testing geth. No idea why ipc was disabled for tests in the first place. With ipc enabled again we can put a breakpoint in a test and then attach to the running geth and query it easily like so:

```
$ ps aux | grep geth                                                                                                                                                                                    
lefteris 26383  6.6  1.8 2130888 309100 pts/8  Sl+  15:04   0:00 geth --nodekeyhex f68952f08b60b79a5dbd3ec754ee33e6e52101fcf1d8055fc89979c253b14832 --port 29871 --rpcport 29870 --bootnodes enode://4fd93e573bf5949fadaf092a1e49341267902e76d886bd02360a550df77672b6d1a1c78c9d31
f542d1fc6633d8cc85a0535da432c221560e6e1f32dc8b25b9c9@127.0.0.1:29871 --unlock 0 --nodiscover --ipcdisable --rpc --rpcapi eth,net,web3 --rpcaddr 0.0.0.0 --networkid 627 --verbosity 0 --datadir /tmp/lefteris/pytest-of-lefteris/pytest-0/test_event_transfer_received_s0/f68952f
0 --password /tmp/lefteris/pytest-of-lefteris/pytest-0/test_event_transfer_received_s0/f68952f0/pw --mine

$ geth attach --datadir /tmp/lefteris/pytest-of-lefteris/pytest-0/test_event_transfer_received_s0/f68952f0/
```

