### PR TITLE
Replace `ethereum._solidity` with `py-solc`

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -4,7 +4,6 @@ import os
 import gevent
 from cachetools.func import ttl_cache
 import structlog
-from ethereum.tools import _solidity
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.proxies import (
@@ -21,6 +20,7 @@ from raiden.utils import (
     privatekey_to_address,
     quantity_decoder,
 )
+from raiden.utils.solc import compile_files_cwd
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -170,7 +170,7 @@ class BlockChainService:
         self.client.rpccall_with_retry('eth_uninstallFilter', filter_id_raw)
 
     def deploy_contract(self, contract_name, contract_path, constructor_parameters=None):
-        contracts = _solidity.compile_file(contract_path, libraries=dict())
+        contracts = compile_files_cwd([contract_path])
 
         log.info(
             'Deploying contract: ',

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import pytest
 import structlog
-from ethereum.tools._solidity import compile_file
 
 from raiden.utils import (
     get_contract_path,
@@ -15,6 +14,7 @@ from raiden.network.discovery import ContractDiscovery
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.blockchain import geth_create_blockchain
 from raiden.settings import GAS_PRICE
+from raiden.utils.solc import compile_files_cwd
 
 BlockchainServices = namedtuple(
     'BlockchainServices',
@@ -257,7 +257,7 @@ def _jsonrpc_services(
     # deploy it directly with a JSONRPCClient
     if registry_address is None:
         registry_path = get_contract_path('Registry.sol')
-        registry_contracts = compile_file(registry_path, libraries=dict())
+        registry_contracts = compile_files_cwd([registry_path])
 
         log.info('Deploying registry contract')
         registry_proxy = deploy_client.deploy_solidity_contract(

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -3,13 +3,13 @@ from binascii import unhexlify
 import os
 
 import pytest
-from ethereum.tools import _solidity
 from eth_utils import decode_hex
 
 from raiden.exceptions import EthNodeCommunicationError
 from raiden.network.rpc.filters import new_filter, get_filter_events
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.utils.solc import compile_files_cwd
 
 # pylint: disable=unused-argument,protected-access
 
@@ -17,7 +17,7 @@ from raiden.network.rpc.client import JSONRPCClient
 def deploy_rpc_test_contract(deploy_client):
     here = os.path.dirname(os.path.relpath(__file__))
     contract_path = os.path.join(here, 'RpcTest.sol')
-    contracts = _solidity.compile_file(contract_path, libraries=dict())
+    contracts = compile_files_cwd([contract_path])
 
     contract_proxy = deploy_client.deploy_solidity_contract(
         'RpcTest',

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -4,8 +4,6 @@ import os
 import itertools
 
 import pytest
-from ethereum.tools import _solidity
-from ethereum.tools._solidity import compile_file
 from eth_utils import to_canonical_address
 
 from raiden import waiting
@@ -17,9 +15,7 @@ from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.tests.utils.blockchain import wait_until_block
 from raiden.transfer import views
 from raiden.utils import privatekey_to_address, get_contract_path
-
-
-solidity = _solidity.get_solidity()   # pylint: disable=invalid-name
+from raiden.utils.solc import compile_files_cwd
 
 
 @pytest.mark.parametrize('number_of_nodes', [3])
@@ -224,7 +220,7 @@ def test_blockchain(
     )
 
     humantoken_path = get_contract_path('HumanStandardToken.sol')
-    humantoken_contracts = compile_file(humantoken_path, libraries=dict())
+    humantoken_contracts = compile_files_cwd([humantoken_path])
     token_proxy = jsonrpc_client.deploy_solidity_contract(
         'HumanStandardToken',
         humantoken_contracts,
@@ -235,7 +231,7 @@ def test_blockchain(
     )
 
     registry_path = get_contract_path('Registry.sol')
-    registry_contracts = compile_file(registry_path)
+    registry_contracts = compile_files_cwd([registry_path])
     registry_proxy = jsonrpc_client.deploy_solidity_contract(
         'Registry',
         registry_contracts,

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -10,7 +10,6 @@ import time
 import structlog
 from logging import StreamHandler, Formatter
 
-from ethereum.tools._solidity import compile_file
 from eth_utils import denoms
 import gevent
 from gevent.event import Event
@@ -20,6 +19,7 @@ from IPython.lib.inputhook import inputhook_manager, stdin_ready
 
 from raiden.api.python import RaidenAPI
 from raiden.utils import get_contract_path, safe_address_decode
+from raiden.utils.solc import compile_files_cwd
 
 ENTER_CONSOLE_TIMEOUT = 3
 GUI_GEVENT = 'gevent'
@@ -323,7 +323,7 @@ class ConsoleTools:
         # Deploy a new ERC20 token
         token_proxy = self._chain.client.deploy_solidity_contract(
             'HumanStandardToken',
-            compile_file(contract_path),
+            compile_files_cwd([contract_path]),
             dict(),
             (initial_alloc, name, decimals, symbol),
             contract_path=contract_path,

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -216,13 +216,21 @@ def get_project_root() -> str:
     return os.path.dirname(raiden.__file__)
 
 
+def get_relative_path(file_name) -> str:
+    prefix = os.path.commonprefix([
+        os.path.realpath('.'),
+        os.path.realpath(file_name)
+    ])
+    return file_name.replace(prefix + '/', '')
+
+
 def get_contract_path(contract_name: str) -> str:
     contract_path = os.path.join(
         get_project_root(),
         'smart_contracts',
         contract_name
     )
-    return os.path.realpath(contract_path)
+    return get_relative_path(contract_path)
 
 
 def safe_lstrip_hex(val):

--- a/raiden/utils/solc.py
+++ b/raiden/utils/solc.py
@@ -1,0 +1,92 @@
+from solc import compile_files
+import os
+import re
+from eth_utils import decode_hex
+
+
+def solidity_resolve_address(hex_code, library_symbol, library_address):
+    """ Change the bytecode to use the given library address.
+
+    Args:
+        hex_code (bin): The bytecode encoded in hexadecimal.
+        library_name (str): The library that will be resolved.
+        library_address (str): The address of the library.
+
+    Returns:
+        bin: The bytecode encoded in hexadecimal with the library references
+            resolved.
+    """
+    if library_address.startswith('0x'):
+        raise ValueError('Address should not contain the 0x prefix')
+
+    try:
+        decode_hex(library_address)
+    except TypeError:
+        raise ValueError(
+            'library_address contains invalid characters, it must be hex encoded.')
+
+    if len(library_symbol) != 40 or len(library_address) != 40:
+        raise ValueError('Address with wrong length')
+
+    return hex_code.replace(library_symbol, library_address)
+
+
+def solidity_resolve_symbols(hex_code, libraries):
+    symbol_address = {
+        solidity_library_symbol(library_name): address
+        for library_name, address in libraries.items()
+    }
+
+    for unresolved in solidity_unresolved_symbols(hex_code):
+        address = symbol_address[unresolved]
+        hex_code = solidity_resolve_address(hex_code, unresolved, address)
+
+    return hex_code
+
+
+def solidity_library_symbol(library_name):
+    """ Return the symbol used in the bytecode to represent the `library_name`. """
+    # the symbol is always 40 characters in length with the minimum of two
+    # leading and trailing underscores
+    length = min(len(library_name), 36)
+
+    library_piece = library_name[:length]
+    hold_piece = '_' * (36 - length)
+
+    return '__{library}{hold}__'.format(
+        library=library_piece,
+        hold=hold_piece,
+    )
+
+
+def solidity_unresolved_symbols(hex_code):
+    """ Return the unresolved symbols contained in the `hex_code`.
+
+    Note:
+        The binary representation should not be provided since this function
+        relies on the fact that the '_' is invalid in hex encoding.
+
+    Args:
+        hex_code (str): The bytecode encoded as hexadecimal.
+    """
+    return set(re.findall(r"_.{39}", hex_code))
+
+
+def compile_files_cwd(*args, **kwargs):
+    """change working directory to contract's dir in order to avoid symbol
+    name conflicts"""
+    # get root directory of the contracts
+    compile_wd = os.path.commonprefix(args[0])
+    if os.path.isfile(compile_wd):
+        compile_wd = os.path.dirname(compile_wd)
+    file_list = [
+        x.replace(compile_wd + '/', '')
+        for x in args[0]
+    ]
+    cwd = os.getcwd()
+    try:
+        os.chdir(compile_wd)
+        compiled_contracts = compile_files(file_list, **kwargs)
+    finally:
+        os.chdir(cwd)
+    return compiled_contracts

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ eth-keyfile==0.5.1
 eth_utils==1.0.3
 structlog
 colorama
+py-solc

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -5,12 +5,12 @@ from binascii import hexlify
 
 import click
 import structlog
-from ethereum.tools._solidity import compile_contract
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.ui.cli import prompt_account
 from raiden.utils import address_encoder, get_contract_path, decode_hex
 from raiden.log_config import configure_logging
+from raiden.utils.solc import compile_files_cwd
 
 log = structlog.get_logger(__name__)
 
@@ -83,7 +83,7 @@ def name_from_file(filename):
 
 def allcontracts(contract_files):
     return {
-        "{}:{}".format(c, name_from_file(c)): compile_contract(
+        "{}:{}".format(c, name_from_file(c)): compile_files_cwd(
             get_contract_path(c),
             name_from_file(c),
             optimize=False

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from binascii import hexlify
 
-from ethereum.tools._solidity import compile_file
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import get_contract_path, sha3
+from raiden.utils.solc import compile_files_cwd
 
 
 def connect(host='127.0.0.1', port=8545):
@@ -30,7 +30,7 @@ def create_and_distribute_token(
     contract_path = get_contract_path('HumanStandardToken.sol')
     token_proxy = client.deploy_solidity_contract(
         'HumanStandardToken',
-        compile_file(contract_path),
+        compile_files_cwd([contract_path]),
         dict(),
         (
             len(receivers) * amount_per_receiver,


### PR DESCRIPTION
- replaces `pyethereum` `solc` helper methods and replaces them with calls from `py-solc` library