### PR TITLE
Integrate `raiden-contracts` contract manager

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -100,7 +100,7 @@ def get_all_channel_manager_events(
 
     return get_contract_events(
         chain,
-        CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
+        CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER),
         channel_manager_address,
         events,
         from_block,
@@ -119,7 +119,7 @@ def get_all_registry_events(
     """
     return get_contract_events(
         chain,
-        CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY),
+        CONTRACT_MANAGER.get_contract_abi(CONTRACT_REGISTRY),
         registry_address,
         events,
         from_block,
@@ -139,7 +139,7 @@ def get_all_netting_channel_events(
 
     return get_contract_events(
         chain,
-        CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL),
+        CONTRACT_MANAGER.get_contract_abi(CONTRACT_NETTING_CHANNEL),
         netting_channel_address,
         events,
         from_block,
@@ -304,7 +304,7 @@ class BlockchainEvents:
         self.add_event_listener(
             'Registry {}'.format(pex(registry_address)),
             tokenadded,
-            CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_REGISTRY),
             registry_proxy.tokenadded_filter,
         )
 
@@ -315,7 +315,7 @@ class BlockchainEvents:
         self.add_event_listener(
             'ChannelManager {}'.format(pex(manager_address)),
             channelnew,
-            CONTRACT_MANAGER.get_abi('channel_manager'),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER),
             channel_manager_proxy.channelnew_filter,
         )
 
@@ -326,7 +326,7 @@ class BlockchainEvents:
         self.add_event_listener(
             'NettingChannel Event {}'.format(pex(channel_address)),
             netting_channel_events,
-            CONTRACT_MANAGER.get_abi('netting_channel'),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_NETTING_CHANNEL),
             netting_channel_proxy.all_events_filter,
         )
 

--- a/raiden/network/proxies/channel_manager.py
+++ b/raiden/network/proxies/channel_manager.py
@@ -58,7 +58,7 @@ class ChannelManager:
         check_address_has_code(jsonrpc_client, manager_address, 'Channel Manager')
 
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER),
             address_encoder(manager_address),
         )
 

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -40,7 +40,7 @@ class Discovery:
         check_address_has_code(jsonrpc_client, discovery_address, 'Discovery')
 
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_abi(CONTRACT_ENDPOINT_REGISTRY),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_ENDPOINT_REGISTRY),
             address_encoder(discovery_address),
         )
         CONTRACT_MANAGER.check_contract_version(

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -54,7 +54,7 @@ class NettingChannel:
         self.client = jsonrpc_client
         self.node_address = privatekey_to_address(self.client.privkey)
         self.proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_abi(CONTRACT_NETTING_CHANNEL),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_NETTING_CHANNEL),
             address_encoder(channel_address),
         )
         CONTRACT_MANAGER.check_contract_version(

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -51,7 +51,7 @@ class Registry:
         check_address_has_code(jsonrpc_client, registry_address, 'Registry')
 
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_abi(CONTRACT_REGISTRY),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_REGISTRY),
             address_encoder(registry_address),
         )
         CONTRACT_MANAGER.check_contract_version(

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -33,7 +33,7 @@ class Token:
         check_address_has_code(jsonrpc_client, token_address, 'Token')
 
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
             address_encoder(token_address),
         )
 

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -283,7 +283,7 @@ def test_blockchain(
     assert token_proxy.contract_address == to_canonical_address(event_args['token_address'])
 
     channel_manager_proxy = jsonrpc_client.new_contract_proxy(
-        CONTRACT_MANAGER.get_abi(CONTRACT_CHANNEL_MANAGER),
+        CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER),
         channel_manager_address,
     )
 

--- a/raiden/tests/integration/test_version.py
+++ b/raiden/tests/integration/test_version.py
@@ -9,7 +9,7 @@ from raiden.utils import get_contract_path
 from raiden.utils.solc import compile_files_cwd
 from raiden.exceptions import ContractVersionMismatch
 
-from raiden.blockchain.abi import CONTRACT_VERSION_RE, CONTRACT_MANAGER
+from raiden.blockchain.abi import CONTRACT_VERSION_RE, CONTRACT_MANAGER, CONTRACT_CHANNEL_MANAGER
 
 
 def replace_contract_version(file_path, new_version):
@@ -49,7 +49,7 @@ def test_deploy_contract(raiden_network, deploy_client, tmpdir):
     temp_dir = TempSolidityDir(os.path.dirname(contract_path), tmpdir)
     replaced_registry_path = os.path.join(temp_dir.name, 'Registry.sol')
 
-    CONTRACT_MANAGER.get_abi('channel_manager')
+    CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER)
 
     replace_contract_version(replaced_registry_path, '0.0.31415')
     contracts = compile_files_cwd([replaced_registry_path])

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pycryptodome==3.6.1
 # raiden-libs==???
 # FIXME: replace with released version before merge
 git+https://github.com/raiden-network/raiden-libs.git@dd3f15a6159d68a0f5496e8e5985256b18d00f6a#egg=raiden-libs
+git+https://github.com/raiden-network/raiden-contracts.git#egg=raiden-contracts
 webargs==1.8.1
 eth-keyfile==0.5.1
 eth_utils==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,10 @@ install_requires_replacements = {
         'git+https://github.com/raiden-network/raiden-libs.git'
         '@dd3f15a6159d68a0f5496e8e5985256b18d00f6a#egg=raiden-libs'
     ): 'raiden-libs',
+    (
+        'git+https://github.com/raiden-network/raiden-contracts.git'
+        '#egg=raiden-contracts'
+    ): 'raiden-contracts',
 }
 
 install_requires = list(set(


### PR DESCRIPTION
This integrates manager from the other repo with raiden. Since it works well, I'd merge this PR now and continue on integrating new contracts.

~~- [ ] remove all solc-related code~~
~~- [ ] move solc checks to `raiden-contracts`~~
~~- [ ] merge `raiden-contracts` changes~~
~~- [ ] update `requirements.txt` and `setup.py`~~