### PR TITLE
Fix `tool.deploy` compilation

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -276,7 +276,7 @@ class JSONRPCClient:
         """ Return the balance of the account of given address. """
         return self.web3.eth.getBalance(to_checksum_address(account), 'pending')
 
-    def _gaslimit(self, location='pending') -> int:
+    def _gaslimit(self, location='latest') -> int:
         gas_limit = self.web3.eth.getBlock(location)['gasLimit']
         return gas_limit * 8 // 10
 

--- a/raiden/utils/solc.py
+++ b/raiden/utils/solc.py
@@ -77,10 +77,14 @@ def compile_files_cwd(*args, **kwargs):
     name conflicts"""
     # get root directory of the contracts
     compile_wd = os.path.commonprefix(args[0])
+    # edge case - compiling a single file
     if os.path.isfile(compile_wd):
         compile_wd = os.path.dirname(compile_wd)
+    # remove prefix from the files
+    if compile_wd[-1] is not '/':
+        compile_wd += '/'
     file_list = [
-        x.replace(compile_wd + '/', '')
+        x.replace(compile_wd, '')
         for x in args[0]
     ]
     cwd = os.getcwd()

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -81,17 +81,6 @@ def name_from_file(filename):
     return os.path.split(filename)[-1].partition('.')[0]
 
 
-def allcontracts(contract_files):
-    return {
-        "{}:{}".format(c, name_from_file(c)): compile_files_cwd(
-            get_contract_path(c),
-            name_from_file(c),
-            optimize=False
-        )
-        for c in contract_files
-    }
-
-
 def deploy_file(contract, compiled_contracts, client):
     libraries = dict()
     filename, _, name = contract.partition(":")
@@ -109,7 +98,11 @@ def deploy_file(contract, compiled_contracts, client):
 
 
 def deploy_all(client):
-    compiled_contracts = allcontracts(RAIDEN_CONTRACT_FILES)
+    contracts_expanded = [
+        get_contract_path(x)
+        for x in RAIDEN_CONTRACT_FILES
+    ]
+    compiled_contracts = compile_files_cwd(contracts_expanded)
     deployed = {}
     for contract in CONTRACTS_TO_DEPLOY:
         deployed.update(deploy_file(contract, compiled_contracts, client))


### PR DESCRIPTION
- fixes compilation for deploy script
- also changes 'pending' to 'latest' when obtaining block number in `gasLimit()` method
  (Parity "bug". See: https://github.com/paritytech/parity/issues/8703)