### PR TITLE
Use event name variables, add new event decoders

### DIFF
--- a/raiden/blockchain/abi.py
+++ b/raiden/blockchain/abi.py
@@ -30,10 +30,14 @@ __all__ = (
 
     'EVENT_CHANNEL_NEW',
     'EVENT_CHANNEL_NEW_BALANCE',
+    'EVENT_CHANNEL_WITHDRAW',
+    'EVENT_CHANNEL_UNLOCK',
+    'EVENT_TRANSFER_UPDATED',
     'EVENT_CHANNEL_CLOSED',
     'EVENT_CHANNEL_SECRET_REVEALED',
     'EVENT_CHANNEL_SETTLED',
     'EVENT_TOKEN_ADDED',
+    'EVENT_ADDRESS_REGISTERED',
 )
 
 CONTRACT_CHANNEL_MANAGER = 'ChannelManagerContract'
@@ -43,11 +47,19 @@ CONTRACT_NETTING_CHANNEL = 'NettingChannelContract'
 CONTRACT_REGISTRY = 'Registry'
 
 EVENT_CHANNEL_NEW = 'ChannelNew'
+EVENT_CHANNEL_NEW2 = 'ChannelOpened'
 EVENT_CHANNEL_NEW_BALANCE = 'ChannelNewBalance'
+EVENT_CHANNEL_NEW_BALANCE2 = 'ChannelNewDeposit'
+EVENT_CHANNEL_WITHDRAW = 'ChannelWithdraw'
+EVENT_CHANNEL_UNLOCK = 'ChannelUnlocked'
+EVENT_TRANSFER_UPDATED = 'NonClosingBalanceProofUpdated'
 EVENT_CHANNEL_CLOSED = 'ChannelClosed'
 EVENT_CHANNEL_SECRET_REVEALED = 'ChannelSecretRevealed'
+EVENT_CHANNEL_SECRET_REVEALED2 = 'SecretRevealed'
 EVENT_CHANNEL_SETTLED = 'ChannelSettled'
 EVENT_TOKEN_ADDED = 'TokenAdded'
+EVENT_TOKEN_ADDED2 = 'TokenNetworkCreated'
+EVENT_ADDRESS_REGISTERED = 'AddressRegistered'
 
 CONTRACT_VERSION_RE = r'^\s*string constant public contract_version = "([0-9]+\.[0-9]+\.[0-9\_])";\s*$' # noqa
 
@@ -172,12 +184,12 @@ class ContractManagerWrap(ContractManager):
         self.is_instantiated = False
         self.lock = Lock()
         self.event_to_contract = {
-            'ChannelNew': CONTRACT_CHANNEL_MANAGER,
-            'ChannelNewBalance': CONTRACT_NETTING_CHANNEL,
-            'ChannelClosed': CONTRACT_NETTING_CHANNEL,
-            'ChannelSecretRevealed': CONTRACT_NETTING_CHANNEL,
-            'ChannelSettled': CONTRACT_NETTING_CHANNEL,
-            'TokenAdded': CONTRACT_REGISTRY,
+            EVENT_CHANNEL_NEW: CONTRACT_CHANNEL_MANAGER,
+            EVENT_CHANNEL_NEW_BALANCE: CONTRACT_NETTING_CHANNEL,
+            EVENT_CHANNEL_CLOSED: CONTRACT_NETTING_CHANNEL,
+            EVENT_CHANNEL_SECRET_REVEALED: CONTRACT_NETTING_CHANNEL,
+            EVENT_CHANNEL_SETTLED: CONTRACT_NETTING_CHANNEL,
+            EVENT_TOKEN_ADDED: CONTRACT_REGISTRY,
         }
         self.contract_to_version = dict()
         self.init_contract_versions()

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -9,6 +9,18 @@ from raiden.blockchain.abi import (
     CONTRACT_CHANNEL_MANAGER,
     CONTRACT_NETTING_CHANNEL,
     CONTRACT_REGISTRY,
+    EVENT_TOKEN_ADDED,
+    EVENT_TOKEN_ADDED2,
+    EVENT_CHANNEL_NEW,
+    EVENT_CHANNEL_NEW2,
+    EVENT_CHANNEL_NEW_BALANCE,
+    EVENT_CHANNEL_NEW_BALANCE2,
+    EVENT_CHANNEL_WITHDRAW,
+    EVENT_CHANNEL_UNLOCK,
+    EVENT_TRANSFER_UPDATED,
+    EVENT_CHANNEL_CLOSED,
+    EVENT_CHANNEL_SETTLED,
+    EVENT_CHANNEL_SECRET_REVEALED,
 )
 from raiden.exceptions import (
     AddressWithoutCode,
@@ -25,6 +37,10 @@ EventListener = namedtuple(
 Proxies = namedtuple(
     'Proxies',
     ('registry', 'channel_managers', 'channelmanager_nettingchannels'),
+)
+Proxies2 = namedtuple(
+    'Proxies',
+    ('token_registry', 'token_networks'),
 )
 
 # `new_filter` uses None to signal the absence of topics filters
@@ -189,32 +205,63 @@ def decode_event_to_internal(event):
     data = event.event_data
 
     # Note: All addresses inside the event_data must be decoded.
-    if data['event'] == 'TokenAdded':
+    if data['event'] == EVENT_TOKEN_ADDED:
         data['registry_address'] = address_decoder(data['args']['registry_address'])
         data['channel_manager_address'] = address_decoder(data['args']['channel_manager_address'])
         data['token_address'] = address_decoder(data['args']['token_address'])
 
-    elif data['event'] == 'ChannelNew':
+    elif data['event'] == EVENT_CHANNEL_NEW:
         data['registry_address'] = address_decoder(data['args']['registry_address'])
         data['participant1'] = address_decoder(data['args']['participant1'])
         data['participant2'] = address_decoder(data['args']['participant2'])
         data['netting_channel'] = address_decoder(data['args']['netting_channel'])
 
-    elif data['event'] == 'ChannelNewBalance':
+    elif data['event'] == EVENT_CHANNEL_NEW_BALANCE:
         data['registry_address'] = address_decoder(data['args']['registry_address'])
         data['token_address'] = address_decoder(data['args']['token_address'])
         data['participant'] = address_decoder(data['args']['participant'])
 
-    elif data['event'] == 'ChannelClosed':
+    elif data['event'] == EVENT_CHANNEL_CLOSED:
         data['registry_address'] = address_decoder(data['args']['registry_address'])
         data['closing_address'] = address_decoder(data['args']['closing_address'])
 
-    elif data['event'] == 'ChannelSecretRevealed':
+    elif data['event'] == EVENT_CHANNEL_SECRET_REVEALED:
         data['registry_address'] = address_decoder(data['args']['registry_address'])
         data['receiver_address'] = address_decoder(data['args']['receiver_address'])
 
-    elif data['event'] == 'ChannelSettled':
+    elif data['event'] == EVENT_CHANNEL_SETTLED:
         data['registry_address'] = address_decoder(data['args']['registry_address'])
+
+    return event
+
+
+def decode_event_to_internal2(event):
+    """ Enforce the binary encoding of address for internal usage. """
+    data = event.event_data
+
+    # Note: All addresses inside the event_data must be decoded.
+    if data['event'] == EVENT_TOKEN_ADDED2:
+        data['token_network_address'] = address_decoder(data['args']['token_network_address'])
+        data['token_address'] = address_decoder(data['args']['token_address'])
+
+    elif data['event'] == EVENT_CHANNEL_NEW2:
+        data['participant1'] = address_decoder(data['args']['participant1'])
+        data['participant2'] = address_decoder(data['args']['participant2'])
+
+    elif data['event'] == EVENT_CHANNEL_NEW_BALANCE2:
+        data['participant'] = address_decoder(data['args']['participant'])
+
+    elif data['event'] == EVENT_CHANNEL_WITHDRAW:
+        data['participant'] = address_decoder(data['args']['participant'])
+
+    elif data['event'] == EVENT_CHANNEL_UNLOCK:
+        data['participant'] = address_decoder(data['args']['participant'])
+
+    elif data['event'] == EVENT_TRANSFER_UPDATED:
+        data['closing_participant'] = address_decoder(data['args']['closing_participant'])
+
+    elif data['event'] == EVENT_CHANNEL_CLOSED:
+        data['closing_participant'] = address_decoder(data['args']['closing_participant'])
 
     return event
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -12,6 +12,11 @@ from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     CHANNEL_STATE_SETTLED,
 )
+from raiden.blockchain.abi import (
+    EVENT_CHANNEL_NEW,
+    EVENT_CHANNEL_NEW_BALANCE,
+    EVENT_CHANNEL_CLOSED
+)
 from raiden.utils import address_encoder
 from eth_utils import is_same_address
 
@@ -59,7 +64,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit):
         token_address,
         channel12.open_transaction.finished_block_number,
     )
-    assert token_events[0]['event'] == 'ChannelNew'
+    assert token_events[0]['event'] == EVENT_CHANNEL_NEW
 
     registry_address = api1.raiden.default_registry.address
     # Load the new state with the deposit
@@ -87,7 +92,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit):
     )
     assert any(
         (
-            event['event'] == 'ChannelNewBalance' and
+            event['event'] == EVENT_CHANNEL_NEW_BALANCE and
             is_same_address(
                 event['args']['registry_address'],
                 address_encoder(registry_address)
@@ -113,7 +118,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit):
     assert len(event_list3) > len(event_list2)
     assert any(
         (
-            event['event'] == 'ChannelClosed' and
+            event['event'] == EVENT_CHANNEL_CLOSED and
             is_same_address(
                 event['args']['registry_address'],
                 address_encoder(registry_address)

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -5,6 +5,8 @@ import pytest
 from raiden.api.python import RaidenAPI
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
+    EVENT_TOKEN_ADDED,
+    EVENT_CHANNEL_NEW,
     EVENT_CHANNEL_CLOSED,
     EVENT_CHANNEL_NEW_BALANCE,
     EVENT_CHANNEL_SETTLED,
@@ -152,7 +154,7 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     )
 
     assert len(events) == 1
-    assert events[0]['event'] == 'TokenAdded'
+    assert events[0]['event'] == EVENT_TOKEN_ADDED
     assert event_dicts_are_equal(events[0]['args'], {
         'registry_address': address_encoder(registry_address),
         'channel_manager_address': address_encoder(manager0.address),
@@ -186,7 +188,7 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     )
 
     assert len(events) == 1
-    assert events[0]['event'] == 'ChannelNew'
+    assert events[0]['event'] == EVENT_CHANNEL_NEW
     assert event_dicts_are_equal(events[0]['args'], {
         'registry_address': address_encoder(registry_address),
         'settle_timeout': settle_timeout,
@@ -244,7 +246,7 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     assert len(all_netting_channel_events) == 1
     assert len(events) == 1
 
-    assert events[0]['event'] == 'ChannelNewBalance'
+    assert events[0]['event'] == EVENT_CHANNEL_NEW_BALANCE
     new_balance_event = {
         'registry_address': address_encoder(registry_address),
         'token_address': address_encoder(token_address),
@@ -280,7 +282,7 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     assert len(all_netting_channel_events) == 2
     assert len(events) == 1
 
-    assert events[0]['event'] == 'ChannelClosed'
+    assert events[0]['event'] == EVENT_CHANNEL_CLOSED
     closed_event = {
         'registry_address': address_encoder(registry_address),
         'closing_address': address_encoder(app0.raiden.address),
@@ -309,7 +311,7 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     assert len(all_netting_channel_events) == 3
     assert len(events) == 1
 
-    assert events[0]['event'] == 'ChannelSettled'
+    assert events[0]['event'] == EVENT_CHANNEL_SETTLED
     settled_event = {
         'registry_address': address_encoder(registry_address),
         'block_number': 'ignore',

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -8,6 +8,7 @@ from raiden.exceptions import (
     InvalidAddress,
     InsufficientFunds,
 )
+from raiden.blockchain.abi import EVENT_CHANNEL_NEW_BALANCE
 from raiden.tests.utils.events import must_have_event
 from raiden.tests.utils.transfer import (
     assert_synched_channel_state,
@@ -203,7 +204,7 @@ def test_api_channel_events(raiden_chain, token_addresses):
     channel_0_1 = get_channelstate(app0, app1, token_address)
     app0_events = RaidenAPI(app0.raiden).get_channel_events(channel_0_1.identifier, 0)
 
-    assert must_have_event(app0_events, {'event': 'ChannelNewBalance'})
+    assert must_have_event(app0_events, {'event': EVENT_CHANNEL_NEW_BALANCE})
 
     # This event was temporarily removed. Confirmation from the protocol layer
     # as a state change is necessary to properly fire this event.
@@ -219,7 +220,7 @@ def test_api_channel_events(raiden_chain, token_addresses):
     assert not results
 
     app1_events = RaidenAPI(app1.raiden).get_channel_events(channel_0_1.identifier, 0)
-    assert must_have_event(app1_events, {'event': 'ChannelNewBalance'})
+    assert must_have_event(app1_events, {'event': EVENT_CHANNEL_NEW_BALANCE})
     assert must_have_event(app1_events, {'event': 'EventTransferReceivedSuccess'})
 
 


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden/issues/1480

- use event name variables instead of the actual string name
- add new event decoder and handler