### PR TITLE
Unhandled greenlet exceptions should now terminate app

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -260,4 +260,4 @@ def on_blockchain_event(raiden, event):
         handle_channel_withdraw(raiden, event)
 
     else:
-        log.error('Unknown event type', event=event)
+        log.error('Unknown event type', raiden_event=event)

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -91,13 +91,9 @@ class AlarmTask(gevent.Greenlet):
             self.last_block_number = current_block
             remove = list()
             for callback in self.callbacks:
-                try:
-                    result = callback(current_block)
-                except RaidenShuttingDown:
-                    break
-                else:
-                    if result is REMOVE_CALLBACK:
-                        remove.append(callback)
+                result = callback(current_block)
+                if result is REMOVE_CALLBACK:
+                    remove.append(callback)
 
             for callback in remove:
                 self.callbacks.remove(callback)

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import time
-
 import structlog
 
 import gevent
@@ -19,7 +18,6 @@ class AlarmTask(gevent.Greenlet):
 
     def __init__(self, chain):
         super().__init__()
-
         self.callbacks = list()
         self.stop_event = AsyncResult()
         self.chain = chain
@@ -97,8 +95,6 @@ class AlarmTask(gevent.Greenlet):
                     result = callback(current_block)
                 except RaidenShuttingDown:
                     break
-                except:  # NOQA pylint: disable=bare-except
-                    log.exception('unexpected exception on alarm')
                 else:
                     if result is REMOVE_CALLBACK:
                         remove.append(callback)


### PR DESCRIPTION
Fix #1490 

In tests we reraise the exception and not terminate the app.