### PR TITLE
WIP: Add homebrew tap installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,8 +102,6 @@ jobs:
         - .travis/before_script.sh
         - python setup.py build
         - python setup.py compile_webui
-      after_script:
-        - .travis/update_formula.sh
       script:
         # pdbpp interferes with pyinstaller, uninstall it
         - pip uninstall -y pdbpp
@@ -115,6 +113,7 @@ jobs:
             secure: O85yltVQ1OacJQoNQWDJqOsXuSb+x7IMJTtUPuFM5iAOIGLmzhk0/qzJInixCGbAfWMYT4wTjA6OfxeiAWYzC5pCgqedZOsjp+8bXjn2Ek443Y+FBay3g38ebn3KBFBat3iMOamdrFSGTENugdG418GdK6yFVYpyCCUJXWLBcBUPOi7BlakI8TkznsaCad7OVRrPfMHWRe11WI3b4fajPnH/M7JRdDpT5GTisEchwKzYHnBttYySDZcQS3gtAEK7Srg9AkdEYCW3DOkmW4DeEgrQAQVcHHAV7eZREC1M3SrsrCotEqhEmIy29akOVKpOZtYWMxNFIsScDt39Y2hJLXRo1NjN0RBgIOg+Asl3B1cuK3Zfzc30r+Fyfkl9yFXpC35xddh2dHz5PFyssmtVZMEdxECtQT0DN08FB1JNdBbz3tfNw84IvR2ymYcQdRFWQM51rBUjUGspzDftAdITKkk3Z67jgYnaVvL0iBMbuuFjZDs8375IjIo7hxJ5UY7YWLV8Ic2r89wq5Dw7EsL5cyc4BVfj1kByZ1BJ6sZEKaqVdDdEc1Bv2/SYk6Da/muPB9gYK8Baw1gumLvrVS65EUVvwGmnq0zKrKmvTLl0aNPRNInaOVOloK63HdOwJhiLRn50YfCARrX+5kKBIQxdtNtmfPmdYJ3cm5bNhaXQ8fs=
           file: dist/raiden-${TRAVIS_TAG}-macOS.zip
           skip_cleanup: true
+          script: .travis/update_formula.sh
           on:
             tags: true
             repo: raiden-network/raiden

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,8 @@ jobs:
         - .travis/before_script.sh
         - python setup.py build
         - python setup.py compile_webui
+      after_script:
+        - .travis/update_formula.sh
       script:
         # pdbpp interferes with pyinstaller, uninstall it
         - pip uninstall -y pdbpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,11 @@ jobs:
             secure: O85yltVQ1OacJQoNQWDJqOsXuSb+x7IMJTtUPuFM5iAOIGLmzhk0/qzJInixCGbAfWMYT4wTjA6OfxeiAWYzC5pCgqedZOsjp+8bXjn2Ek443Y+FBay3g38ebn3KBFBat3iMOamdrFSGTENugdG418GdK6yFVYpyCCUJXWLBcBUPOi7BlakI8TkznsaCad7OVRrPfMHWRe11WI3b4fajPnH/M7JRdDpT5GTisEchwKzYHnBttYySDZcQS3gtAEK7Srg9AkdEYCW3DOkmW4DeEgrQAQVcHHAV7eZREC1M3SrsrCotEqhEmIy29akOVKpOZtYWMxNFIsScDt39Y2hJLXRo1NjN0RBgIOg+Asl3B1cuK3Zfzc30r+Fyfkl9yFXpC35xddh2dHz5PFyssmtVZMEdxECtQT0DN08FB1JNdBbz3tfNw84IvR2ymYcQdRFWQM51rBUjUGspzDftAdITKkk3Z67jgYnaVvL0iBMbuuFjZDs8375IjIo7hxJ5UY7YWLV8Ic2r89wq5Dw7EsL5cyc4BVfj1kByZ1BJ6sZEKaqVdDdEc1Bv2/SYk6Da/muPB9gYK8Baw1gumLvrVS65EUVvwGmnq0zKrKmvTLl0aNPRNInaOVOloK63HdOwJhiLRn50YfCARrX+5kKBIQxdtNtmfPmdYJ3cm5bNhaXQ8fs=
           file: dist/raiden-${TRAVIS_TAG}-macOS.zip
           skip_cleanup: true
+          on:
+            tags: true
+            repo: raiden-network/raiden
+            branch: master
+        - provider: script
           script: .travis/update_formula.sh
           on:
             tags: true

--- a/.travis/update_formula.sh
+++ b/.travis/update_formula.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 set -x
@@ -8,12 +8,11 @@ clone_repo() {
 }
 
 update_formula() {
-    UPDATED_SHA256=$(openssl sha -sha256 raiden-${TRAVIS_TAG}-macOS.zip)
+    UPDATED_SHA256=$(openssl sha -sha256 dist/raiden-${TRAVIS_TAG}-macOS.zip)
     FORMULA_FILE="./homebrew-raiden/raiden.rb"
 
-    sed "s/v[0-9]\.[0-9]\.[0-9]/${TRAVIS_TAG}/g" $FORMULA_FILE
-    sed "s/[0-9]\.[0-9]\.[0-9]/${TRAVIS_TAG/v/}/g" $FORMULA_FILE
-    sed "s/sha256 \"[a-z0-9]\"/sha256 \"${UPDATED_SHA256}\"/g" $FORMULA_FILE
+    sed -i "s/[0-9]\.[0-9]\.[0-9]/${TRAVIS_TAG/v/}/g" $FORMULA_FILE
+    sed -i "s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${UPDATED_SHA256}\"/g" $FORMULA_FILE
 }
 
 setup_git() {

--- a/.travis/update_formula.sh
+++ b/.travis/update_formula.sh
@@ -8,11 +8,13 @@ clone_repo() {
 }
 
 update_formula() {
-    UPDATED_SHA256=$(openssl sha -sha256 dist/raiden-${TRAVIS_TAG}-macOS.zip)
+    UPDATED_SHA256=$(openssl sha -sha256 ./dist/raiden-${TRAVIS_TAG}-macOS.zip)
     FORMULA_FILE="./homebrew-raiden/raiden.rb"
 
-    sed -i "s/[0-9]\.[0-9]\.[0-9]/${TRAVIS_TAG/v/}/g" $FORMULA_FILE
-    sed -i "s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${UPDATED_SHA256}\"/g" $FORMULA_FILE
+    sed -i .bak "s/[0-9]\.[0-9]\.[0-9]/${TRAVIS_TAG/v/}/g" $FORMULA_FILE
+    sed -i .bak "s/sha256 \"[a-f0-9]{64}\"/sha256 \"${UPDATED_SHA256: -64}\"/g" $FORMULA_FILE
+
+    rm $FORMULA_FILE.bak
 }
 
 setup_git() {
@@ -21,6 +23,7 @@ setup_git() {
 }
 
 commit_formula_file() {
+    cd ./homebrew-raiden
     git checkout -b release-${TRAVIS_TAG}
     git add raiden.rb
     git commit -m "Update formula to ${TRAVIS_TAG}"

--- a/.travis/update_formula.sh
+++ b/.travis/update_formula.sh
@@ -4,38 +4,38 @@ set -e
 set -x
 
 clone_repo() {
-    git clone https://github.com/raiden-network/homebrew-raiden
+    git clone git@github.com:raiden-network/homebrew-raiden
 }
 
 update_formula() {
-    UPDATED_SHA256=$(openssl sha -sha256 ./dist/raiden-${TRAVIS_TAG}-macOS.zip)
-    FORMULA_FILE="./homebrew-raiden/raiden.rb"
+    UPDATED_SHA256=$(openssl sha -sha256 dist/raiden-${TRAVIS_TAG}-macOS.zip)
+    FORMULA_FILE="homebrew-raiden/raiden.rb"
 
     sed -i .bak "s/[0-9]\.[0-9]\.[0-9]/${TRAVIS_TAG/v/}/g" $FORMULA_FILE
-    sed -i .bak "s/sha256 \"[a-f0-9]{64}\"/sha256 \"${UPDATED_SHA256: -64}\"/g" $FORMULA_FILE
+    sed -i .bak "s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${UPDATED_SHA256: -64}\"/g" $FORMULA_FILE
 
     rm $FORMULA_FILE.bak
 }
 
 setup_git() {
-    git config --global user.email "travis@travis-ci.org"
-    git config --global user.name "Travis CI"
+    git config user.email "contact@raiden.network"
+    git config user.name "Raiden Network"
 }
 
 commit_formula_file() {
-    cd ./homebrew-raiden
-    git checkout -b release-${TRAVIS_TAG}
     git add raiden.rb
     git commit -m "Update formula to ${TRAVIS_TAG}"
+    git tag -a "${TRAVIS_TAG}"
 }
 
 upload_file() {
-    git remote add release-${TRAVIS_TAG} https://${GH_TOKEN}@github.com/raiden-network/homebrew-raiden.git > /dev/null 2>&1
-    git push --quiet --set-upstream release-${TRAVIS_TAG} master
+    git push --tags
 }
 
 clone_repo
 update_formula
+
+cd homebrew-raiden
 setup_git
 commit_formula_file
 upload_file

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :feature:`` Update installation docs with Homebrew tap and update Homebrew formula on release
+* :feature:`1518` Update installation docs with Homebrew tap and update Homebrew formula on release
 * :feature:`1195` Improve AccountManager error handling if keyfile is invalid.
 * :bug:`1237` Inform the user if geth binary is missing during raiden smoketest.
 * :feature:`1328` Use separate database directory per network id. This is a breaking change. You will need to copy your data from the previous directory to the new network id subdirectory.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`` Update installation docs with Homebrew tap and update Homebrew formula on release
 * :feature:`1195` Improve AccountManager error handling if keyfile is invalid.
 * :bug:`1237` Inform the user if geth binary is missing during raiden smoketest.
 * :feature:`1328` Use separate database directory per network id. This is a breaking change. You will need to copy your data from the previous directory to the new network id subdirectory.

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -36,7 +36,14 @@ Download the latest :code:`raiden-<version>-macOS.zip`, and extract it::
     unzip raiden-<version>-macOS.zip
 
 The resulting binary will work on any version of macOS from 10.12 onwards without any other
-dependencies. An Ethereum client is required.
+dependencies.
+
+Or you can use Homebrew to install the most up to date binary::
+
+    brew tap raiden-network/raiden
+    brew install raiden
+
+An Ethereum client is required in both cases.
 
 Dependencies
 ************


### PR DESCRIPTION
Will resolve #1243. Currently we will need to add the homebrew-raiden repo to the raiden-network namespace. This merge provides the instructions on how to install raiden for mac using homebrew. It will also contain an update to travis CI to update the homebrew formula when a new release is created. 