### PR TITLE
Use gevent default exception handler instead of registering a custom one

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -31,7 +31,7 @@ log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def greenlet_error_handler(context, exc_info):
-    log.fatal("Unhandled greenlet exception. Raiden is terminating ...")
+    log.critical('Unhandled greenlet exception. Raiden is terminating ...')
     etype = exc_info[0]
     evalue = exc_info[1]
     etb = exc_info[2]

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -14,9 +14,6 @@ from raiden.exceptions import RaidenShuttingDown
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.log_config import configure_logging
 
-gevent.get_hub().SYSTEM_ERROR = BaseException
-gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
-
 CATCH_LOG_HANDLER_NAME = 'catch_log_handler'
 
 
@@ -111,6 +108,16 @@ def validate_solidity_compiler():
     """ Check the solc prior to running any test. """
     from raiden.blockchain.abi import validate_solc
     validate_solc()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def dont_exit_pytest():
+    """ Raiden will quit on any unhandled exception.
+
+    This allows the test suite to finish in case an exception is unhandled.
+    """
+    gevent.get_hub().SYSTEM_ERROR = BaseException
+    gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
 
 
 if sys.platform == 'darwin':


### PR DESCRIPTION

```
--- Logging error ---
Traceback (most recent call last):
  File "/home/hack/work/brainbot/raiden/raiden/network/transport/udp/healthcheck.py", line 64, in healthcheck
    protocol.get_host_port(recipient)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/cachetools/__init__.py", line 46, in wrapper
    v = func(*args, **kwargs)
  File "/home/hack/work/brainbot/raiden/raiden/network/discovery.py", line 107, in get
    endpoint = self.discovery_proxy.endpoint_by_address(node_address)
  File "/home/hack/work/brainbot/raiden/raiden/network/proxies/discovery.py", line 87, in endpoint_by_address
    raise UnknownAddress('Unknown address {}'.format(pex(node_address_bin)))
raiden.exceptions.UnknownAddress: Unknown address 61c808d8

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/hack/work/brainbot/raiden/raiden/network/transport/udp/healthcheck.py", line 84, in healthcheck
    protocol.get_host_port(recipient)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/cachetools/__init__.py", line 46, in wrapper
    v = func(*args, **kwargs)
  File "/home/hack/work/brainbot/raiden/raiden/network/discovery.py", line 107, in get
    endpoint = self.discovery_proxy.endpoint_by_address(node_address)
  File "/home/hack/work/brainbot/raiden/raiden/network/proxies/discovery.py", line 83, in endpoint_by_address
    node_address_hex
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/contract.py", line 1106, in call
    **self.kwargs
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/contract.py", line 1355, in call_contract_function
    return_data = web3.eth.call(call_transaction, block_identifier=block_id)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/eth_utils/functional.py", line 22, in inner
    return callback(fn(*args, **kwargs))
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/eth.py", line 293, in call
    [transaction, block_identifier],
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/manager.py", line 107, in request_blocking
    response = self._make_request(method, params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/manager.py", line 90, in _make_request
    return request_func(method, params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/gas_price_strategy.py", line 18, in middleware
    return make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/attrdict.py", line 18, in middleware
    response = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/normalize_errors.py", line 9, in middleware
    result = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 50, in apply_formatters
    response = make_request(method, params)
  File "/home/hack/work/brainbot/raiden/raiden/network/rpc/client.py", line 57, in middleware
    raise RaidenShuttingDown()
raiden.exceptions.RaidenShuttingDown

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.6/logging/__init__.py", line 992, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.6/logging/__init__.py", line 838, in format
    return fmt.format(record)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/structlog/stdlib.py", line 459, in format
    record.msg = self.processor(logger, meth_name, ed)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/structlog/dev.py", line 184, in __call__
    self._styles.reset + "] "
KeyError: 'fatal'
Call stack:
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 13, in custom_handle_error
    error_handler(context, (type, value, tb))
  File "/home/hack/work/brainbot/raiden/raiden/app.py", line 34, in greenlet_error_handler
    log.fatal("Unhandled greenlet exception. Raiden is terminating ...")
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/structlog/_base.py", line 177, in _proxy_to_logger
    return getattr(self._logger, method_name)(*args, **kw)
Message: {'event': 'Unhandled greenlet exception. Raiden is terminating ...', 'logger': 'raiden.app', 'level': 'fatal', 'timestamp': '2018-06-07 14:51:56'}
Arguments: ()
Traceback (most recent call last):
  File "/home/hack/work/brainbot/raiden/raiden/network/transport/udp/healthcheck.py", line 64, in healthcheck
    protocol.get_host_port(recipient)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/cachetools/__init__.py", line 46, in wrapper
    v = func(*args, **kwargs)
  File "/home/hack/work/brainbot/raiden/raiden/network/discovery.py", line 107, in get
    endpoint = self.discovery_proxy.endpoint_by_address(node_address)
  File "/home/hack/work/brainbot/raiden/raiden/network/proxies/discovery.py", line 87, in endpoint_by_address
    raise UnknownAddress('Unknown address {}'.format(pex(node_address_bin)))
raiden.exceptions.UnknownAddress: Unknown address 61c808d8

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/hack/work/brainbot/raiden/raiden/network/transport/udp/healthcheck.py", line 84, in healthcheck
    protocol.get_host_port(recipient)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/cachetools/__init__.py", line 46, in wrapper
    v = func(*args, **kwargs)
  File "/home/hack/work/brainbot/raiden/raiden/network/discovery.py", line 107, in get
    endpoint = self.discovery_proxy.endpoint_by_address(node_address)
  File "/home/hack/work/brainbot/raiden/raiden/network/proxies/discovery.py", line 83, in endpoint_by_address
    node_address_hex
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/contract.py", line 1106, in call
    **self.kwargs
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/contract.py", line 1355, in call_contract_function
    return_data = web3.eth.call(call_transaction, block_identifier=block_id)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/eth_utils/functional.py", line 22, in inner
    return callback(fn(*args, **kwargs))
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/eth.py", line 293, in call
    [transaction, block_identifier],
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/manager.py", line 107, in request_blocking
    response = self._make_request(method, params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/manager.py", line 90, in _make_request
    return request_func(method, params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/gas_price_strategy.py", line 18, in middleware
    return make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/attrdict.py", line 18, in middleware
    response = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/normalize_errors.py", line 9, in middleware
    result = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 50, in apply_formatters
    response = make_request(method, params)
  File "/home/hack/work/brainbot/raiden/raiden/network/rpc/client.py", line 57, in middleware
    raise RaidenShuttingDown()
raiden.exceptions.RaidenShuttingDown
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib64/python3.6/logging/__init__.py", line 992, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.6/logging/__init__.py", line 838, in format
    return fmt.format(record)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/structlog/stdlib.py", line 459, in format
    record.msg = self.processor(logger, meth_name, ed)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/structlog/dev.py", line 184, in __call__
    self._styles.reset + "] "
KeyError: 'fatal'
Call stack:
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/gevent/hub.py", line 561, in run
    loop.run()
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 13, in custom_handle_error
    error_handler(context, (type, value, tb))
  File "/home/hack/work/brainbot/raiden/raiden/app.py", line 34, in greenlet_error_handler
    log.fatal("Unhandled greenlet exception. Raiden is terminating ...")
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/structlog/_base.py", line 177, in _proxy_to_logger
    return getattr(self._logger, method_name)(*args, **kw)
Message: {'event': 'Unhandled greenlet exception. Raiden is terminating ...', 'logger': 'raiden.app', 'level': 'fatal', 'timestamp': '2018-06-07 14:51:56'}
Arguments: ()
Traceback (most recent call last):
  File "/home/hack/work/brainbot/raiden/raiden/network/transport/udp/healthcheck.py", line 64, in healthcheck
    protocol.get_host_port(recipient)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/cachetools/__init__.py", line 46, in wrapper
    v = func(*args, **kwargs)
  File "/home/hack/work/brainbot/raiden/raiden/network/discovery.py", line 107, in get
    endpoint = self.discovery_proxy.endpoint_by_address(node_address)
  File "/home/hack/work/brainbot/raiden/raiden/network/proxies/discovery.py", line 87, in endpoint_by_address
    raise UnknownAddress('Unknown address {}'.format(pex(node_address_bin)))
raiden.exceptions.UnknownAddress: Unknown address 61c808d8

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/hack/work/brainbot/raiden/raiden/network/transport/udp/healthcheck.py", line 84, in healthcheck
    protocol.get_host_port(recipient)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/cachetools/__init__.py", line 46, in wrapper
    v = func(*args, **kwargs)
  File "/home/hack/work/brainbot/raiden/raiden/network/discovery.py", line 107, in get
    endpoint = self.discovery_proxy.endpoint_by_address(node_address)
  File "/home/hack/work/brainbot/raiden/raiden/network/proxies/discovery.py", line 83, in endpoint_by_address
    node_address_hex
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/contract.py", line 1106, in call
    **self.kwargs
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/contract.py", line 1355, in call_contract_function
    return_data = web3.eth.call(call_transaction, block_identifier=block_id)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/eth_utils/functional.py", line 22, in inner
    return callback(fn(*args, **kwargs))
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/eth.py", line 293, in call
    [transaction, block_identifier],
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/manager.py", line 107, in request_blocking
    response = self._make_request(method, params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/manager.py", line 90, in _make_request
    return request_func(method, params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/gas_price_strategy.py", line 18, in middleware
    return make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/attrdict.py", line 18, in middleware
    response = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/normalize_errors.py", line 9, in middleware
    result = make_request(method, params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 48, in apply_formatters
    response = make_request(method, formatted_params)
  File "cytoolz/functoolz.pyx", line 232, in cytoolz.functoolz.curry.__call__
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/web3/middleware/formatting.py", line 50, in apply_formatters
    response = make_request(method, params)
  File "/home/hack/work/brainbot/raiden/raiden/network/rpc/client.py", line 57, in middleware
    raise RaidenShuttingDown()
raiden.exceptions.RaidenShuttingDown

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/gevent/_waiter.py", line 119, in gevent.__waiter.Waiter.switch
  File "src/gevent/greenlet.py", line 718, in gevent._greenlet.Greenlet.run
  File "src/gevent/greenlet.py", line 706, in gevent._greenlet.Greenlet._report_error
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 13, in custom_handle_error
    error_handler(context, (type, value, tb))
  File "/home/hack/work/brainbot/raiden/raiden/app.py", line 48, in greenlet_error_handler
    sys.exit(1)
SystemExit: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/gevent/_waiter.py", line 121, in gevent.__waiter.Waiter.switch
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 15, in custom_handle_error
    self._origin_handle_error(context, type, value, tb)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 15, in custom_handle_error
    self._origin_handle_error(context, type, value, tb)
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 15, in custom_handle_error
    self._origin_handle_error(context, type, value, tb)
  [Previous line repeated 884 more times]
  File "/home/hack/work/brainbot/venvpy3/lib/python3.6/site-packages/raiden_libs/gevent_error_handler.py", line 12, in custom_handle_error
    if not issubclass(type, IGNORE_ERROR):
RecursionError: maximum recursion depth exceeded in __subclasscheck__
```