### PR TITLE
Remove usage of raiden.utils.address_encoder function

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -3,6 +3,7 @@ import filelock
 import sys
 import structlog
 from binascii import unhexlify
+from eth_utils import to_normalized_address
 
 import gevent
 
@@ -23,7 +24,7 @@ from raiden.settings import (
 from raiden.utils import (
     pex,
     privatekey_to_address,
-    address_encoder)
+)
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -84,7 +85,7 @@ class App:  # pylint: disable=too-few-public-methods
                 discovery,
             )
         except filelock.Timeout:
-            pubkey = address_encoder(
+            pubkey = to_normalized_address(
                 privatekey_to_address(unhexlify(self.config['privatekey_hex']))
             )
             print(

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from eth_utils import big_endian_to_int, encode_hex
+from eth_utils import (
+    big_endian_to_int,
+    encode_hex,
+    to_normalized_address,
+)
 import structlog
 
 import raiden_libs.messages
@@ -16,7 +20,6 @@ from raiden.transfer.balance_proof import pack_signing_data
 from raiden.transfer.state import EMPTY_MERKLE_ROOT
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     data_decoder,
     data_encoder,
     ishash,
@@ -385,7 +388,7 @@ class Processed(SignedMessage):
     def to_dict(self):
         return {
             'type': self.__class__.__name__,
-            'sender': address_encoder(self.sender),
+            'sender': to_normalized_address(self.sender),
             'message_identifier': self.message_identifier,
             'signature': data_encoder(self.signature)
         }
@@ -682,8 +685,8 @@ class Secret(EnvelopeMessage):
             'payment_identifier': self.payment_identifier,
             'secret': data_encoder(self.secret),
             'nonce': self.nonce,
-            'token_network_address': address_encoder(self.token_network_address),
-            'channel': address_encoder(self.channel),
+            'token_network_address': to_normalized_address(self.token_network_address),
+            'channel': to_normalized_address(self.channel),
             'transferred_amount': self.transferred_amount,
             'locked_amount': self.locked_amount,
             'locksroot': data_encoder(self.locksroot),
@@ -913,12 +916,12 @@ class DirectTransfer(EnvelopeMessage):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'nonce': self.nonce,
-            'token_network_address': address_encoder(self.token_network_address),
-            'token': address_encoder(self.token),
-            'channel': address_encoder(self.channel),
+            'token_network_address': to_normalized_address(self.token_network_address),
+            'token': to_normalized_address(self.token),
+            'channel': to_normalized_address(self.channel),
             'transferred_amount': self.transferred_amount,
             'locked_amount': self.locked_amount,
-            'recipient': address_encoder(self.recipient),
+            'recipient': to_normalized_address(self.recipient),
             'locksroot': data_encoder(self.locksroot),
             'signature': data_encoder(self.signature),
         }
@@ -1309,16 +1312,16 @@ class LockedTransfer(LockedTransferBase):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'nonce': self.nonce,
-            'token_network_address': address_encoder(self.token_network_address),
-            'token': address_encoder(self.token),
-            'channel': address_encoder(self.channel),
+            'token_network_address': to_normalized_address(self.token_network_address),
+            'token': to_normalized_address(self.token),
+            'channel': to_normalized_address(self.channel),
             'transferred_amount': self.transferred_amount,
             'locked_amount': self.locked_amount,
-            'recipient': address_encoder(self.recipient),
+            'recipient': to_normalized_address(self.recipient),
             'locksroot': data_encoder(self.locksroot),
             'lock': self.lock.to_dict(),
-            'target': address_encoder(self.target),
-            'initiator': address_encoder(self.initiator),
+            'target': to_normalized_address(self.target),
+            'initiator': to_normalized_address(self.initiator),
             'fee': self.fee,
             'signature': data_encoder(self.signature),
         }
@@ -1412,16 +1415,16 @@ class RefundTransfer(LockedTransfer):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'nonce': self.nonce,
-            'token_network_address': address_encoder(self.token_network_address),
-            'token': address_encoder(self.token),
-            'channel': address_encoder(self.channel),
+            'token_network_address': to_normalized_address(self.token_network_address),
+            'token': to_normalized_address(self.token),
+            'channel': to_normalized_address(self.channel),
             'transferred_amount': self.transferred_amount,
             'locked_amount': self.locked_amount,
-            'recipient': address_encoder(self.recipient),
+            'recipient': to_normalized_address(self.recipient),
             'locksroot': data_encoder(self.locksroot),
             'lock': self.lock.to_dict(),
-            'target': address_encoder(self.target),
-            'initiator': address_encoder(self.initiator),
+            'target': to_normalized_address(self.target),
+            'initiator': to_normalized_address(self.initiator),
             'fee': self.fee,
             'signature': data_encoder(self.signature),
         }

--- a/raiden/network/proxies/channel_manager.py
+++ b/raiden/network/proxies/channel_manager.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from binascii import unhexlify
 from typing import List, Tuple
-from eth_utils import is_binary_address, to_checksum_address
+from eth_utils import (
+    is_binary_address,
+    to_checksum_address,
+    to_normalized_address,
+)
 
 import structlog
 from gevent.event import AsyncResult
@@ -31,7 +35,6 @@ from raiden.settings import (
 )
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     pex,
     privatekey_to_address,
 )
@@ -51,7 +54,7 @@ class ChannelManager:
         # pylint: disable=too-many-arguments
         contract = jsonrpc_client.new_contract(
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER),
-            address_encoder(manager_address),
+            to_normalized_address(manager_address),
         )
 
         self.proxy = ContractProxy(jsonrpc_client, contract)

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -5,6 +5,7 @@ from eth_utils import (
     to_canonical_address,
     to_checksum_address,
     is_binary_address,
+    to_normalized_address,
 )
 
 from raiden.blockchain.abi import (
@@ -20,10 +21,7 @@ from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import DEFAULT_POLL_TIMEOUT
 from raiden.constants import NULL_ADDRESS
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
-from raiden.utils import (
-    address_encoder,
-    pex,
-)
+from raiden.utils import pex
 
 
 class Discovery:
@@ -40,7 +38,7 @@ class Discovery:
     ):
         contract = jsonrpc_client.new_contract(
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_ENDPOINT_REGISTRY),
-            address_encoder(discovery_address),
+            to_normalized_address(discovery_address),
         )
         self.proxy = ContractProxy(jsonrpc_client, contract)
 

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -2,6 +2,7 @@
 from binascii import unhexlify
 from gevent.lock import RLock
 from typing import List
+from eth_utils import to_normalized_address
 
 import structlog
 from web3.exceptions import BadFunctionCallOutput
@@ -28,7 +29,6 @@ from raiden.settings import (
 )
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     pex,
     privatekey_to_address,
     releasing,
@@ -48,7 +48,7 @@ class NettingChannel:
     ):
         contract = jsonrpc_client.new_contract(
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_NETTING_CHANNEL),
-            address_encoder(channel_address),
+            to_normalized_address(channel_address),
         )
         self.proxy = ContractProxy(jsonrpc_client, contract)
 

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -2,7 +2,11 @@
 from binascii import hexlify, unhexlify
 
 import structlog
-from eth_utils import is_binary_address, to_checksum_address
+from eth_utils import (
+    is_binary_address,
+    to_checksum_address,
+    to_normalized_address,
+)
 from web3.utils.filters import Filter
 
 from raiden.blockchain.abi import (
@@ -17,7 +21,6 @@ from raiden.exceptions import (
 )
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     pex,
     privatekey_to_address,
 )
@@ -44,7 +47,7 @@ class Registry:
         # pylint: disable=too-many-arguments
         contract = jsonrpc_client.new_contract(
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_REGISTRY),
-            address_encoder(registry_address),
+            to_normalized_address(registry_address),
         )
         self.proxy = ContractProxy(jsonrpc_client, contract)
 

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -1,8 +1,8 @@
 import structlog
 from binascii import unhexlify
 
-from eth_utils import is_binary_address
 from web3.utils.filters import Filter
+from eth_utils import is_binary_address, to_normalized_address
 
 from raiden.utils import typing
 from raiden.blockchain.abi import (
@@ -19,7 +19,6 @@ from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
 )
 from raiden.utils import (
-    address_encoder,
     pex,
     privatekey_to_address,
 )
@@ -43,7 +42,7 @@ class SecretRegistry:
 
         proxy = jsonrpc_client.new_contract_proxy(
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_SECRET_REGISTRY),
-            address_encoder(secret_registry_address),
+            to_normalized_address(secret_registry_address),
         )
         CONTRACT_MANAGER.check_contract_version(
             proxy.functions.contract_version().call(),

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -15,8 +15,7 @@ from raiden.network.rpc.transactions import (
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
 )
-from raiden.utils import address_encoder
-from eth_utils import to_checksum_address
+from eth_utils import to_checksum_address, to_normalized_address
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 
 
@@ -29,7 +28,7 @@ class Token:
     ):
         contract = jsonrpc_client.new_contract(
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
-            address_encoder(token_address),
+            to_normalized_address(token_address),
         )
         self.proxy = ContractProxy(jsonrpc_client, contract)
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -6,8 +6,8 @@ from typing import List
 from raiden.utils import typing
 
 import structlog
-from eth_utils import is_binary_address
 from web3.utils.filters import Filter
+from eth_utils import is_binary_address, to_normalized_address
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -41,7 +41,6 @@ from raiden.settings import (
 )
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     encode_hex,
     pex,
     privatekey_to_address,
@@ -67,7 +66,7 @@ class TokenNetwork:
 
         proxy = jsonrpc_client.new_contract_proxy(
             CONTRACT_MANAGER.get_abi(CONTRACT_TOKEN_NETWORK),
-            address_encoder(manager_address),
+            to_normalized_address(manager_address),
         )
 
         CONTRACT_MANAGER.check_contract_version(

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -2,8 +2,8 @@
 from binascii import hexlify, unhexlify
 
 import structlog
-from eth_utils import is_binary_address
 from web3.utils.filters import Filter
+from eth_utils import is_binary_address, to_normalized_address
 
 from raiden.utils import typing
 from raiden.blockchain.abi import (
@@ -18,7 +18,6 @@ from raiden.exceptions import (
 )
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     pex,
     privatekey_to_address,
 )
@@ -50,7 +49,7 @@ class TokenNetworkRegistry:
 
         proxy = jsonrpc_client.new_contract_proxy(
             CONTRACT_MANAGER.get_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
-            address_encoder(registry_address),
+            to_normalized_address(registry_address),
         )
         CONTRACT_MANAGER.check_contract_version(
             proxy.functions.contract_version().call(),

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -28,7 +28,6 @@ from raiden.exceptions import (
 )
 from raiden.settings import GAS_PRICE, GAS_LIMIT, RPC_CACHE_TTL
 from raiden.utils import (
-    address_encoder,
     data_encoder,
     privatekey_to_address,
     quantity_decoder,
@@ -87,7 +86,7 @@ def check_address_has_code(
 
         raise AddressWithoutCode('{}Address {} does not contain code'.format(
             formated_contract_name,
-            address_encoder(address),
+            to_normalized_address(address),
         ))
 
 

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -4,9 +4,10 @@ import os
 import random
 
 import pytest
+from eth_utils import to_normalized_address
 from raiden.network.utils import get_free_port
 
-from raiden.utils import address_encoder, privatekey_to_address
+from raiden.utils import privatekey_to_address
 from raiden.settings import (
     DEFAULT_EVENTS_POLL_TIMEOUT,
     DEFAULT_POLL_TIMEOUT,
@@ -285,7 +286,10 @@ def database_paths(tmpdir, private_keys, in_memory_database):
 
     database_paths = list()
     for idx, pkey in enumerate(private_keys):
-        app_dir = os.path.join(tmpdir.strpath, address_encoder(privatekey_to_address(pkey))[2:8])
+        app_dir = os.path.join(
+            tmpdir.strpath,
+            to_normalized_address(privatekey_to_address(pkey))[2:8]
+        )
         if not os.path.exists(app_dir):
             os.makedirs(app_dir)
         database_paths.append(os.path.join(app_dir, 'log.db'))

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -17,8 +17,7 @@ from raiden.blockchain.abi import (
     EVENT_CHANNEL_NEW_BALANCE,
     EVENT_CHANNEL_CLOSED
 )
-from raiden.utils import address_encoder
-from eth_utils import is_same_address
+from eth_utils import is_same_address, to_normalized_address
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])
@@ -100,11 +99,11 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit):
             event['event'] == EVENT_CHANNEL_NEW_BALANCE and
             is_same_address(
                 event['args']['registry_address'],
-                address_encoder(registry_address)
+                to_normalized_address(registry_address)
             ) and
             is_same_address(
                 event['args']['participant'],
-                address_encoder(api1.address)
+                to_normalized_address(api1.address)
             )
         )
         for event in event_list2
@@ -126,11 +125,11 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit):
             event['event'] == EVENT_CHANNEL_CLOSED and
             is_same_address(
                 event['args']['registry_address'],
-                address_encoder(registry_address)
+                to_normalized_address(registry_address)
             ) and
             is_same_address(
                 event['args']['closing_address'],
-                address_encoder(api1.address)
+                to_normalized_address(api1.address)
             )
         )
         for event in event_list3

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -2,6 +2,8 @@
 import gevent
 import pytest
 
+from eth_utils import to_normalized_address
+
 from raiden.api.python import RaidenAPI
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -25,7 +27,7 @@ from raiden.tests.utils.transfer import (
 from raiden.tests.utils.blockchain import wait_until_block
 from raiden.tests.utils.network import CHAIN
 from raiden.transfer import views, channel
-from raiden.utils import address_encoder, sha3
+from raiden.utils import sha3
 
 
 def event_dicts_are_equal(dict1, dict2):
@@ -166,9 +168,9 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     assert len(events) == 1
     assert events[0]['event'] == EVENT_TOKEN_ADDED
     assert event_dicts_are_equal(events[0]['args'], {
-        'registry_address': address_encoder(registry_address),
-        'channel_manager_address': address_encoder(manager0.address),
-        'token_address': address_encoder(token_address),
+        'registry_address': to_normalized_address(registry_address),
+        'channel_manager_address': to_normalized_address(manager0.address),
+        'token_address': to_normalized_address(token_address),
         'block_number': 'ignore',
     })
 
@@ -200,11 +202,11 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
     assert len(events) == 1
     assert events[0]['event'] == EVENT_CHANNEL_NEW
     assert event_dicts_are_equal(events[0]['args'], {
-        'registry_address': address_encoder(registry_address),
+        'registry_address': to_normalized_address(registry_address),
         'settle_timeout': settle_timeout,
-        'netting_channel': address_encoder(channel_address),
-        'participant1': address_encoder(app0.raiden.address),
-        'participant2': address_encoder(app1.raiden.address),
+        'netting_channel': to_normalized_address(channel_address),
+        'participant1': to_normalized_address(app0.raiden.address),
+        'participant2': to_normalized_address(app1.raiden.address),
         'block_number': 'ignore',
     })
 
@@ -258,9 +260,9 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
 
     assert events[0]['event'] == EVENT_CHANNEL_NEW_BALANCE
     new_balance_event = {
-        'registry_address': address_encoder(registry_address),
-        'token_address': address_encoder(token_address),
-        'participant': address_encoder(app0.raiden.address),
+        'registry_address': to_normalized_address(registry_address),
+        'token_address': to_normalized_address(token_address),
+        'participant': to_normalized_address(app0.raiden.address),
         'balance': deposit,
         'block_number': 'ignore',
     }
@@ -294,8 +296,8 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
 
     assert events[0]['event'] == EVENT_CHANNEL_CLOSED
     closed_event = {
-        'registry_address': address_encoder(registry_address),
-        'closing_address': address_encoder(app0.raiden.address),
+        'registry_address': to_normalized_address(registry_address),
+        'closing_address': to_normalized_address(app0.raiden.address),
         'block_number': 'ignore',
     }
 
@@ -323,7 +325,7 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, ev
 
     assert events[0]['event'] == EVENT_CHANNEL_SETTLED
     settled_event = {
-        'registry_address': address_encoder(registry_address),
+        'registry_address': to_normalized_address(registry_address),
         'block_number': 'ignore',
     }
 

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -10,12 +10,15 @@ import termios
 import time
 import gevent
 
-from eth_utils import denoms, to_checksum_address
+from eth_utils import (
+    denoms,
+    to_checksum_address,
+    to_normalized_address,
+)
 import structlog
 from requests import ConnectionError
 
 from raiden.utils import (
-    address_encoder,
     privatekey_to_address,
     privtopub,
     encode_hex,
@@ -140,7 +143,7 @@ def geth_bare_genesis(genesis_path, private_keys, random_marker):
     ]
 
     alloc = {
-        address_encoder(address): {
+        to_normalized_address(address): {
             'balance': DEFAULT_BALANCE_BIN,
         }
         for address in account_addresses
@@ -152,7 +155,7 @@ def geth_bare_genesis(genesis_path, private_keys, random_marker):
 
     genesis['extraData'] = clique_extradata(
         random_marker,
-        address_encoder(account_addresses[0])[2:],
+        to_normalized_address(account_addresses[0])[2:],
     )
 
     with open(genesis_path, 'w') as handler:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -16,7 +16,11 @@ import gevent
 import gevent.monkey
 gevent.monkey.patch_all()
 import requests
-from eth_utils import denoms, to_checksum_address
+from eth_utils import (
+    denoms,
+    to_checksum_address,
+    to_normalized_address,
+)
 import structlog
 from requests.exceptions import RequestException
 
@@ -43,7 +47,6 @@ from raiden.settings import (
 )
 from raiden.utils import (
     address_decoder,
-    address_encoder,
     get_system_spec,
     is_minified_address,
     is_supported_client,
@@ -535,7 +538,7 @@ def app(
     if transport == 'udp' and not mapped_socket:
         raise RuntimeError('Missing socket')
 
-    address_hex = address_encoder(address) if address else None
+    address_hex = to_normalized_address(address) if address else None
     address_hex, privatekey_bin = prompt_account(address_hex, keystore_path, password_file)
     address = address_decoder(address_hex)
 
@@ -1023,7 +1026,7 @@ def removedb(ctx):
 
     datadir = ctx.obj['datadir']
     address = ctx.obj['address']
-    address_hex = address_encoder(address) if address else None
+    address_hex = to_normalized_address(address) if address else None
 
     result = False
     for f in os.listdir(datadir):

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -115,11 +115,6 @@ def address_checksum_and_decode(addr: str) -> typing.Address:
     return addr
 
 
-def address_encoder(address: typing.Address) -> str:
-    assert len(address) in (20, 0)
-    return '0x' + hexlify(address).decode()
-
-
 def block_tag_encoder(val):
     if isinstance(val, int):
         return hex(val).rstrip('L')

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -2,13 +2,14 @@
 import json
 import os
 from binascii import hexlify
+from eth_utils import is_normalized_address
 
 import click
 import structlog
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.ui.cli import prompt_account
-from raiden.utils import address_encoder, get_contract_path, decode_hex
+from raiden.utils import get_contract_path, decode_hex
 from raiden.log_config import configure_logging
 from raiden.utils.solc import compile_files_cwd
 
@@ -92,8 +93,8 @@ def deploy_file(contract, compiled_contracts, client):
         '',
         contract_path=filename,
     )
-    log.info(f"Deployed {name} @ {address_encoder(proxy.contract_address)}")
-    libraries[contract] = address_encoder(proxy.contract_address)[2:]
+    log.info(f"Deployed {name} @ {is_normalized_address(proxy.contract_address)}")
+    libraries[contract] = is_normalized_address(proxy.contract_address)[2:]
     return libraries
 
 


### PR DESCRIPTION
Get rid of all usages of `raiden.utils.address_encoder` function.
Also get rid of few occurrences of `raiden.utils.isaddress` function that were added by PRs parallel to #1513.

Related to #1422