### PR TITLE
Fix skipped restapi tests

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -589,6 +589,9 @@ class RaidenAPI:
         channel_manager_address = self.raiden.default_registry.manager_address_by_token(
             token_address
         )
+        if channel_manager_address is None:
+            raise UnknownTokenAddress('Token address is not known.')
+
         returned_events = get_all_channel_manager_events(
             self.raiden.chain,
             channel_manager_address,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -191,3 +191,11 @@ class ConnectionsResource(BaseResource):
             token_address=token_address,
             only_receiving=only_receiving_channels
         )
+
+
+class ConnectionsInfoResource(BaseResource):
+
+    def get(self):
+        return self.rest_api.get_connection_managers_info(
+            self.rest_api.raiden_api.raiden.default_registry.address
+        )

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -8,6 +8,7 @@ from eth_utils import (
     to_normalized_address,
 )
 from web3.utils.filters import Filter
+from web3.exceptions import BadFunctionCallOutput
 
 from raiden.blockchain.abi import (
     CONTRACT_MANAGER,
@@ -73,11 +74,11 @@ class Registry:
         """ Return the channel manager address for the given token or None if
         there is no correspoding address.
         """
-        address = self.proxy.contract.functions.channelManagerByToken(
-            to_checksum_address(token_address),
-        ).call()
-
-        if address == b'':
+        try:
+            address = self.proxy.contract.functions.channelManagerByToken(
+                to_checksum_address(token_address),
+            ).call()
+        except BadFunctionCallOutput as e:
             check_address_has_code(self.client, self.address)
             return None
 

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -762,7 +762,6 @@ def test_get_connection_managers_info(api_backend, blockchain_services):
     assert set(token_addresses[token_address2].keys()) == {'funds', 'sum_deposits', 'channels'}
 
 
-@pytest.mark.skip
 def test_token_events_errors_for_unregistered_token(api_backend):
     request = grequests.get(
         api_url_for(

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -696,19 +696,19 @@ def test_register_token(api_backend, token_amount, token_addresses, raiden_netwo
     assert_response_with_error(conflict_response, HTTPStatus.CONFLICT)
 
 
-@pytest.mark.skip
-def test_get_connection_managers_info(api_backend, blockchain_services):
-    # check that no connection managers exists yet
-
+@pytest.mark.parametrize('channels_per_node', [0])
+@pytest.mark.parametrize('number_of_tokens', [2])
+def test_get_connection_managers_info(raiden_network, api_backend, token_addresses):
+    # check that there are no registered tokens
     request = grequests.get(
-        api_url_for(api_backend, 'connectionmanagersresource'),
+        api_url_for(api_backend, 'connectionsinforesource')
     )
     response = request.send().response
-    token_addresses = response.json()
-    assert token_addresses == dict()
+    result = response.json()
+    assert len(result) == 0
 
     funds = 100
-    token_address1 = '0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8'
+    token_address1 = to_checksum_address(token_addresses[0])
     connect_data_obj = {
         'funds': funds,
     }
@@ -725,17 +725,17 @@ def test_get_connection_managers_info(api_backend, blockchain_services):
 
     # check that there now is one registered channel manager
     request = grequests.get(
-        api_url_for(api_backend, 'connectionmanagersresource')
+        api_url_for(api_backend, 'connectionsinforesource')
     )
     response = request.send().response
-    token_addresses = response.json()
-    assert isinstance(token_addresses, dict) and len(token_addresses.keys()) == 1
-    assert token_address1 in token_addresses
-    assert isinstance(token_addresses[token_address1], dict)
-    assert set(token_addresses[token_address1].keys()) == {'funds', 'sum_deposits', 'channels'}
+    result = response.json()
+    assert isinstance(result, dict) and len(result.keys()) == 1
+    assert token_address1 in result
+    assert isinstance(result[token_address1], dict)
+    assert set(result[token_address1].keys()) == {'funds', 'sum_deposits', 'channels'}
 
     funds = 100
-    token_address2 = '0x3EdF0f56AA9716B898ec8eA674fDdE714fD979dE'
+    token_address2 = to_checksum_address(token_addresses[1])
     connect_data_obj = {
         'funds': funds,
     }
@@ -752,14 +752,14 @@ def test_get_connection_managers_info(api_backend, blockchain_services):
 
     # check that there now are two registered channel managers
     request = grequests.get(
-        api_url_for(api_backend, 'connectionmanagersresource')
+        api_url_for(api_backend, 'connectionsinforesource')
     )
     response = request.send().response
-    token_addresses = response.json()
-    assert isinstance(token_addresses, dict) and len(token_addresses.keys()) == 2
-    assert token_address2 in token_addresses
-    assert isinstance(token_addresses[token_address2], dict)
-    assert set(token_addresses[token_address2].keys()) == {'funds', 'sum_deposits', 'channels'}
+    result = response.json()
+    assert isinstance(result, dict) and len(result.keys()) == 2
+    assert token_address2 in result
+    assert isinstance(result[token_address2], dict)
+    assert set(result[token_address2].keys()) == {'funds', 'sum_deposits', 'channels'}
 
 
 def test_token_events_errors_for_unregistered_token(api_backend):


### PR DESCRIPTION
- Fix token_events_errors_for_unregistered_token and unskip it
- Reintroduce the connection_managers_info resource endpoint, fix the corresponding test and unskip it


Fixes #1533  