### PR TITLE
Rename lock withdraw to unlock/claimed

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -18,7 +18,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelNew,
     ContractReceiveChannelNewBalance,
     ContractReceiveChannelSettled,
-    ContractReceiveChannelWithdraw,
+    ContractReceiveChannelUnlock,
     ContractReceiveNewTokenNetwork,
     ContractReceiveRouteNew,
 )
@@ -227,7 +227,7 @@ def handle_channel_settled(raiden, event):
         raiden.handle_state_change(channel_settled)
 
 
-def handle_channel_withdraw(raiden, event):
+def handle_channel_unlock(raiden, event):
     channel_identifier = event.originating_contract
     data = event.event_data
     registry_address = data['registry_address']
@@ -239,7 +239,7 @@ def handle_channel_withdraw(raiden, event):
     )
 
     if channel_state:
-        withdrawn_state_change = ContractReceiveChannelWithdraw(
+        unlock_state_change = ContractReceiveChannelUnlock(
             registry_address,
             channel_state.token_address,
             channel_identifier,
@@ -247,7 +247,7 @@ def handle_channel_withdraw(raiden, event):
             data['receiver_address'],
         )
 
-        raiden.handle_state_change(withdrawn_state_change)
+        raiden.handle_state_change(unlock_state_change)
 
 
 def on_blockchain_event(raiden, event):
@@ -288,7 +288,7 @@ def on_blockchain_event(raiden, event):
         data['registry_address'] = to_canonical_address(data['args']['registry_address'])
         data['receiver_address'] = to_canonical_address(data['args']['receiver_address'])
         data['secret'] = data['args']['secret']
-        handle_channel_withdraw(raiden, event)
+        handle_channel_unlock(raiden, event)
 
     # fix for https://github.com/raiden-network/raiden/issues/1508
     # balance proof updates are handled in the linked code, so no action is needed here

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -563,7 +563,7 @@ class Secret(EnvelopeMessage):
 
     Locksroot changes need to be synchronized among both participants, the
     protocol is for only the side unlocking to send the Secret message allowing
-    the other party to withdraw.
+    the other party to claim the unlocked lock.
     """
     cmdid = messages.SECRET
 

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -367,9 +367,9 @@ class NettingChannel:
                 signature=encode_hex(signature),
             )
 
-    def withdraw(self, unlock_proof):
+    def unlock(self, unlock_proof):
         log.info(
-            'withdraw called',
+            'unlock called',
             node=pex(self.node_address),
             contract=pex(self.address),
         )
@@ -380,7 +380,7 @@ class NettingChannel:
         merkleproof_encoded = b''.join(unlock_proof.merkle_proof)
 
         transaction_hash = self.proxy.transact(
-            'withdraw',
+            'unlock',
             unlock_proof.lock_encoded,
             merkleproof_encoded,
             unlock_proof.secret,
@@ -391,16 +391,16 @@ class NettingChannel:
 
         if receipt_or_none:
             log.critical(
-                'withdraw failed',
+                'unlock failed',
                 node=pex(self.node_address),
                 contract=pex(self.address),
                 lock=unlock_proof,
             )
             self._check_exists()
-            raise TransactionThrew('Withdraw', receipt_or_none)
+            raise TransactionThrew('unlock', receipt_or_none)
 
         log.info(
-            'withdraw successful',
+            'unlock successful',
             node=pex(self.node_address),
             contract=pex(self.address),
             lock=unlock_proof,

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -133,9 +133,9 @@ contract NettingChannelContract {
     /// @param locked_encoded The locked transfer to be unlocked.
     /// @param merkle_proof The merke_proof for the locked transfer.
     /// @param secret The secret to unlock the locked transfer.
-    function withdraw(bytes locked_encoded, bytes merkle_proof, bytes32 secret) public {
+    function unlock(bytes locked_encoded, bytes merkle_proof, bytes32 secret) public {
         // throws if sender is not a participant
-        data.withdraw(locked_encoded, merkle_proof, secret);
+        data.unlock(locked_encoded, merkle_proof, secret);
         emit ChannelSecretRevealed(data.registry_address, secret, msg.sender);
     }
 

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -223,7 +223,7 @@ library NettingChannelLibrary {
     /// @param locked_encoded The lock
     /// @param merkle_proof The merkle proof
     /// @param secret The secret
-    function withdraw(
+    function unlock(
         Data storage self,
         bytes locked_encoded,
         bytes merkle_proof,

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -378,7 +378,7 @@ def test_secret_revealed(raiden_chain, deposit, settle_timeout, token_addresses)
     # Reveal the secret through the blockchain (this needs to emit the
     # SecretRevealed event)
     for unlock_proof in channel.get_known_unlocks(channel_state2_1.partner_state):
-        netting_channel_proxy.withdraw(unlock_proof)
+        netting_channel_proxy.unlock(unlock_proof)
 
     settle_expiration = app0.raiden.chain.block_number() + settle_timeout
     wait_until_block(app0.raiden.chain, settle_expiration)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -7,7 +7,7 @@ from raiden.tests.utils.events import must_contain_entry
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockSuccess,
-    EventWithdrawSuccess,
+    EventUnlockClaimSuccess,
     SendRevealSecret,
     SendSecretRequest,
 )
@@ -49,7 +49,7 @@ def test_mediated_transfer_events(raiden_network, token_addresses, network_wait)
     )
     mediator_events = [blocknumber_event[1] for blocknumber_event in mediator_blockevents]
     assert must_contain_entry(mediator_events, EventUnlockSuccess, {})
-    assert must_contain_entry(mediator_events, EventWithdrawSuccess, {})
+    assert must_contain_entry(mediator_events, EventUnlockClaimSuccess, {})
 
     target_blockevents = app2.raiden.wal.storage.get_events_by_identifier(
         from_identifier=0,
@@ -58,4 +58,4 @@ def test_mediated_transfer_events(raiden_network, token_addresses, network_wait)
     target_events = [blocknumber_event[1] for blocknumber_event in target_blockevents]
     assert must_contain_entry(target_events, SendSecretRequest, {})
     assert must_contain_entry(target_events, SendRevealSecret, {})
-    assert must_contain_entry(target_events, EventWithdrawSuccess, {})
+    assert must_contain_entry(target_events, EventUnlockClaimSuccess, {})

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -15,7 +15,7 @@ from raiden.transfer.architecture import TransitionResult
 from raiden.transfer.events import EventTransferSentFailed
 from raiden.transfer.state_change import (
     Block,
-    ContractReceiveChannelWithdraw,
+    ContractReceiveChannelUnlock,
 )
 
 
@@ -49,7 +49,7 @@ def test_write_read_log():
 
     block_number = 1337
     block = Block(block_number)
-    contract_receive_withdraw = ContractReceiveChannelWithdraw(
+    contract_receive_unlock = ContractReceiveChannelUnlock(
         factories.make_address(),
         factories.make_address(),
         factories.ADDR,
@@ -72,7 +72,7 @@ def test_write_read_log():
     count2 = len(state_changes2)
     assert count1 + 1 == count2
 
-    wal.log_and_dispatch(contract_receive_withdraw, block_number)
+    wal.log_and_dispatch(contract_receive_unlock, block_number)
 
     state_changes3 = wal.storage.get_statechanges_by_identifier(
         from_identifier=0,
@@ -84,7 +84,7 @@ def test_write_read_log():
     result1, result2 = state_changes3[-2:]
     assert isinstance(result1, Block)
     assert result1.block_number == block_number
-    assert isinstance(result2, ContractReceiveChannelWithdraw)
+    assert isinstance(result2, ContractReceiveChannelUnlock)
     assert result2.channel_identifier == factories.ADDR
     assert result2.secret == factories.UNIT_SECRET
     assert result2.receiver == factories.HOP1

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -24,7 +24,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     the previous hop (payer).
 
     When this happens, an assertion must not be hit, because it means the
-    transfer must be withdrawn on-chain.
+    transfer must be unlocked on-chain.
 
     Issue: https://github.com/raiden-network/raiden/issues/1013
     """

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -14,7 +14,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretReveal,
 )
 from raiden.transfer.mediated_transfer.events import (
-    EventWithdrawFailed,
+    EventUnlockClaimFailed,
     SendRevealSecret,
     SendSecretRequest,
 )
@@ -225,7 +225,7 @@ def test_handle_inittarget_bad_expiration():
         pseudo_random_generator,
         block_number,
     )
-    assert must_contain_entry(iteration.events, EventWithdrawFailed, {})
+    assert must_contain_entry(iteration.events, EventUnlockClaimFailed, {})
 
 
 def test_handle_secretreveal():

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -10,7 +10,7 @@ from raiden.utils import pex
 
 class ContractSendChannelClose(Event):
     """ Event emitted to close the netting channel.
-    This event is used when a node needs to prepare the channel to withdraw
+    This event is used when a node needs to prepare the channel to unlock
     on-chain.
     """
 
@@ -83,22 +83,22 @@ class ContractSendChannelUpdateTransfer(Event):
         return not self.__eq__(other)
 
 
-class ContractSendChannelWithdraw(Event):
-    """ Event emitted when the lock must be withdrawn on-chain. """
+class ContractSendChannelUnlock(Event):
+    """ Event emitted when the lock must be claimed on-chain. """
 
     def __init__(self, channel_identifier, unlock_proofs):
         self.channel_identifier = channel_identifier
         self.unlock_proofs = unlock_proofs
 
     def __repr__(self):
-        return '<ContractSendChannelWithdraw channel:{} unlock_proofs:{}>'.format(
+        return '<ContractSendChannelUnlock channel:{} unlock_proofs:{}>'.format(
             pex(self.channel_identifier),
             self.unlock_proofs,
         )
 
     def __eq__(self, other):
         return (
-            isinstance(other, ContractSendChannelWithdraw) and
+            isinstance(other, ContractSendChannelUnlock) and
             self.channel_identifier == other.channel_identifier and
             self.unlock_proofs == other.unlock_proofs
         )
@@ -112,7 +112,7 @@ class EventTransferSentSuccess(Event):
 
     A transfer is considered sucessful when the initiator's payee hop sends the
     reveal secret message, assuming that each hop in the mediator chain has
-    also learned the secret and unlock/withdraw its token.
+    also learned the secret and unlocked its token off-chain or on-chain.
 
     This definition of sucessful is used to avoid the following corner case:
 
@@ -126,7 +126,7 @@ class EventTransferSentSuccess(Event):
       EventTransferSentSuccess.
 
     Note:
-        Mediators cannot use this event, since an unlock may be locally
+        Mediators cannot use this event, since an off-chain unlock may be locally
         sucessful but there is no knowledge about the global transfer.
     """
 
@@ -187,7 +187,7 @@ class EventTransferReceivedSuccess(Event):
     """ Event emitted when a payee has received a payment.
 
     Note:
-        A payee knows if a lock withdraw has failed, but this is not sufficient
+        A payee knows if a lock claim has failed, but this is not sufficient
         information to deduce when a transfer has failed, because the initiator may
         try again at a different time and/or with different routes, for this reason
         there is no correspoding `EventTransferReceivedFailed`.

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -60,10 +60,10 @@ class SendRevealSecret(SendMessageEvent):
     performed on the recipient:
 
         - For receivers in the payee role, it informs the node that the lock has
-            been released and the token can be withdrawn, either on-chain or
+            been released and the token can be claimed, either on-chain or
             off-chain.
         - For receivers in the payer role, it tells the payer that the payee
-            knows the secret and wants to withdraw the lock off-chain, so the payer
+            knows the secret and wants to claim the lock off-chain, so the payer
             may unlock the lock and send an up-to-date balance proof to the payee,
             avoiding on-chain payments which would require the channel to be
             closed.
@@ -118,7 +118,7 @@ class SendRevealSecret(SendMessageEvent):
 
 class SendBalanceProof(SendMessageEvent):
     """ Event to send a balance-proof to the counter-party, used after a lock
-    is unlocked locally allowing the counter-party to withdraw.
+    is unlocked locally allowing the counter-party to claim it.
 
     Used by payers: The initiator and mediator nodes.
 
@@ -337,21 +337,21 @@ class EventUnlockFailed(Event):
         return not self.__eq__(other)
 
 
-class EventWithdrawSuccess(Event):
-    """ Event emitted when a lock withdraw succeded. """
+class EventUnlockClaimSuccess(Event):
+    """ Event emitted when a lock claim succeded. """
     def __init__(self, identifier, secrethash):
         self.identifier = identifier
         self.secrethash = secrethash
 
     def __repr__(self):
-        return '<EventWithdrawSuccess id:{} secrethash:{}>'.format(
+        return '<EventUnlockClaimSuccess id:{} secrethash:{}>'.format(
             self.identifier,
             pex(self.secrethash),
         )
 
     def __eq__(self, other):
         return (
-            isinstance(other, EventWithdrawSuccess) and
+            isinstance(other, EventUnlockClaimSuccess) and
             self.identifier == other.identifier and
             self.secrethash == other.secrethash
         )
@@ -360,15 +360,15 @@ class EventWithdrawSuccess(Event):
         return not self.__eq__(other)
 
 
-class EventWithdrawFailed(Event):
-    """ Event emitted when a lock withdraw failed. """
+class EventUnlockClaimFailed(Event):
+    """ Event emitted when a lock claim failed. """
     def __init__(self, identifier, secrethash, reason):
         self.identifier = identifier
         self.secrethash = secrethash
         self.reason = reason
 
     def __repr__(self):
-        return '<EventWithdrawFailed id:{} secrethash:{} reason:{}>'.format(
+        return '<EventUnlockClaimFailed id:{} secrethash:{} reason:{}>'.format(
             self.identifier,
             pex(self.secrethash),
             self.reason,
@@ -376,7 +376,7 @@ class EventWithdrawFailed(Event):
 
     def __eq__(self, other):
         return (
-            isinstance(other, EventWithdrawFailed) and
+            isinstance(other, EventUnlockClaimFailed) and
             self.identifier == other.identifier and
             self.secrethash == other.secrethash
         )

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -245,7 +245,7 @@ def handle_secretreveal(
 
     if is_valid_secret_reveal and is_channel_open:
         # next hop learned the secret, unlock the token locally and send the
-        # withdraw message to next hop
+        # lock claim message to next hop
         transfer_description = initiator_state.transfer_description
 
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
@@ -257,7 +257,7 @@ def handle_secretreveal(
             state_change.secrethash,
         )
 
-        # TODO: Emit these events after on-chain withdraw
+        # TODO: Emit these events after on-chain unlock
         transfer_success = EventTransferSentSuccess(
             transfer_description.payment_identifier,
             transfer_description.amount,

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -424,15 +424,15 @@ class MediationPairState(State):
     # payee_secret_revealed:
     #   The payee is following the raiden protocol and has sent a SecretReveal.
     #
-    # payee_refund_withdraw:
-    #   The corresponding refund transfer was withdrawn on-chain, the payee has
-    #   /not/ withdrawn the lock yet, it only learned the secret through the
+    # payee_refund_unlock:
+    #   The corresponding refund transfer was claimed on-chain, the payee has
+    #   /not/ claimed the lock yet, it only learned the secret through the
     #   blockchain.
     #   Note: This state is reachable only if there is a refund transfer, that
     #   is represented by a different MediationPairState, and the refund
-    #   transfer is at 'payer_contract_withdraw'.
+    #   transfer is at 'payer_contract_unlock'.
     #
-    # payee_contract_withdraw:
+    # payee_contract_unlock:
     #   The payee received the token on-chain. A transition to this state is
     #   valid from all but the `payee_expired` state.
     #
@@ -445,8 +445,8 @@ class MediationPairState(State):
     valid_payee_states = (
         'payee_pending',
         'payee_secret_revealed',
-        'payee_refund_withdraw',
-        'payee_contract_withdraw',
+        'payee_refund_unlock',
+        'payee_contract_unlock',
         'payee_balance_proof',
         'payee_expired',
     )
@@ -455,8 +455,8 @@ class MediationPairState(State):
         'payer_pending',
         'payer_secret_revealed',    # SendRevealSecret was sent
         'payer_waiting_close',      # ContractSendChannelClose was sent
-        'payer_waiting_withdraw',   # ContractSendWithdraw was sent
-        'payer_contract_withdraw',  # ContractChannelReceiveWithdraw for the above send received
+        'payer_waiting_unlock',   # ContractSendChannelUnlock was sent
+        'payer_contract_unlock',  # ContractReceiveChannelUnlock for the above send received
         'payer_balance_proof',      # ReceiveUnlock was received
         'payer_expired',            # None of the above happened and the lock expired
     )

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -278,10 +278,10 @@ class ReceiveTransferRefund(StateChange):
         return not self.__eq__(other)
 
 
-class ContractReceiveWithdraw(StateChange):
-    """ A lock was withdrawn via the blockchain.
+class ContractReceiveUnlock(StateChange):
+    """ A lock was claimed via the blockchain.
 
-    Used when a hash time lock was withdrawn and a log ChannelSecretRevealed is
+    Used when a hash time lock was claimed and a log ChannelSecretRevealed is
     emited by the netting channel.
 
     Note:
@@ -301,7 +301,7 @@ class ContractReceiveWithdraw(StateChange):
         self.secret = secret
 
     def __repr__(self):
-        return '<ContractReceiveWithdraw channel:{} secrethash:{} receiver:{}>'.format(
+        return '<ContractReceiveUnlock channel:{} secrethash:{} receiver:{}>'.format(
             pex(self.channel_address),
             pex(self.secrethash),
             pex(self.receiver),
@@ -309,7 +309,7 @@ class ContractReceiveWithdraw(StateChange):
 
     def __eq__(self, other):
         return (
-            isinstance(other, ContractReceiveWithdraw) and
+            isinstance(other, ContractReceiveUnlock) and
             self.channel_address == other.channel_address and
             self.secrethash == other.secrethash and
             self.receiver == other.receiver and

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -30,7 +30,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelNew,
     ContractReceiveChannelNewBalance,
     ContractReceiveChannelSettled,
-    ContractReceiveChannelWithdraw,
+    ContractReceiveChannelUnlock,
     ContractReceiveNewPaymentNetwork,
     ContractReceiveNewTokenNetwork,
     ContractReceiveRouteNew,
@@ -503,7 +503,7 @@ def handle_tokenadded(node_state, state_change):
     return TransitionResult(node_state, events)
 
 
-def handle_channel_withdraw(node_state, state_change):
+def handle_channel_unlock(node_state, state_change):
     token_address = state_change.token_address
     payment_network_state, token_network_state = get_networks(
         node_state,
@@ -511,7 +511,7 @@ def handle_channel_withdraw(node_state, state_change):
         state_change.token_address,
     )
 
-    # first dispatch the withdraw to update the channel
+    # first dispatch the unlock claim to update the channel
     events = []
     if token_network_state:
         pseudo_random_generator = node_state.pseudo_random_generator
@@ -696,8 +696,8 @@ def state_transition(node_state, state_change):
             node_state,
             state_change,
         )
-    elif type(state_change) == ContractReceiveChannelWithdraw:
-        iteration = handle_channel_withdraw(
+    elif type(state_change) == ContractReceiveChannelUnlock:
+        iteration = handle_channel_unlock(
             node_state,
             state_change,
         )

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -459,9 +459,9 @@ class ContractReceiveNewTokenNetwork(StateChange):
         return not self.__eq__(other)
 
 
-class ContractReceiveChannelWithdraw(StateChange):
-    """ A lock was withdrawn via the blockchain.
-    Used when a hash time lock was withdrawn and a log ChannelSecretRevealed is
+class ContractReceiveChannelUnlock(StateChange):
+    """ A lock was claimed via the blockchain.
+    Used when a hash time lock was unlocked and a log ChannelSecretRevealed is
     emitted by the netting channel.
     Note:
         For this state change the contract caller is not important but only the
@@ -493,7 +493,7 @@ class ContractReceiveChannelWithdraw(StateChange):
         self.receiver = receiver
 
     def __repr__(self):
-        return '<ContractReceiveChannelWithdraw channel:{} receive:{} secrethash:{}>'.format(
+        return '<ContractReceiveChannelUnlock channel:{} receive:{} secrethash:{}>'.format(
             pex(self.channel_identifier),
             pex(self.receiver),
             pex(self.secrethash),
@@ -501,7 +501,7 @@ class ContractReceiveChannelWithdraw(StateChange):
 
     def __eq__(self, other):
         return (
-            isinstance(other, ContractReceiveChannelWithdraw) and
+            isinstance(other, ContractReceiveChannelUnlock) and
             self.payment_network_identifier == other.payment_network_identifier and
             self.token_address == other.token_address and
             self.channel_identifier == other.channel_identifier and


### PR DESCRIPTION
In preparation for adding the tokens `withdraw` functionality, we are renaming the lock withdraw related variables and functions to use `unlock` / `claimed`

Related issue: https://github.com/raiden-network/raiden/issues/1498
