### PR TITLE
Remove unused block_tag_encoder

### DIFF
--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -19,7 +19,7 @@ from raiden.utils.solc import compile_files_cwd
 
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
 from raiden_contracts.constants import (
-    CONTRACT_SECRET_REGISTRY_NAME,
+    CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
 )
 
@@ -303,7 +303,7 @@ def _jsonrpc_services(
     if deploy_new_contracts:
         # secret registry
         secret_registry_address = deploy_contract_web3(
-            CONTRACT_SECRET_REGISTRY_NAME,
+            CONTRACT_SECRET_REGISTRY,
             poll_timeout,
             deploy_client,
         )

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -106,14 +106,6 @@ def address_checksum_and_decode(addr: str) -> typing.Address:
     return addr
 
 
-def block_tag_encoder(val):
-    if isinstance(val, int):
-        return hex(val).rstrip('L')
-
-    assert val in ('latest', 'pending')
-    return '0x' + hexlify(val).decode()
-
-
 def data_encoder(data: bytes, length: int = 0) -> str:
     data = hexlify(data)
     return '0x' + data.rjust(length * 2, b'0').decode()


### PR DESCRIPTION
Simple cleanup.

Also updates the name of the `SecretRegistry` contract name constant to fix the tests.