### PR TITLE
Add handling of TokenNetworkCreated events from the new contracts

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -10,6 +10,7 @@ from raiden.blockchain.abi import (
     CONTRACT_CHANNEL_MANAGER,
     CONTRACT_NETTING_CHANNEL,
     CONTRACT_REGISTRY,
+    CONTRACT_TOKEN_NETWORK,
     EVENT_TOKEN_ADDED,
     EVENT_TOKEN_ADDED2,
     EVENT_CHANNEL_NEW,
@@ -308,6 +309,17 @@ class BlockchainEvents:
             channelnew,
             CONTRACT_MANAGER.get_contract_abi(CONTRACT_CHANNEL_MANAGER),
             channel_manager_proxy.channelnew_filter,
+        )
+
+    def add_token_network_listener(self, token_network_proxy, from_block=None):
+        channel_new_filter = token_network_proxy.channelnew_filter(from_block=from_block)
+        token_network_address = token_network_proxy.address
+
+        self.add_event_listener(
+            'TokenNetwork {}'.format(pex(token_network_address)),
+            channel_new_filter,
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+            token_network_proxy.channelnew_filter,
         )
 
     def add_netting_channel_listener(self, netting_channel_proxy, from_block=None):

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import networkx
+
 from raiden.routing import make_graph
 from raiden.transfer.state import (
     NettingChannelEndState,
@@ -102,3 +104,22 @@ def get_token_network_state_from_proxies(raiden, manager_proxy, netting_channel_
     )
 
     return network
+
+
+def create_new_token_network_state(raiden, token_network_proxy):
+    token_network_address = token_network_proxy.address
+    token_address = token_network_proxy.token_address()
+
+    # initialze with an empty graph, will be filled from events later
+    graph = networkx.Graph()
+    network_graph = TokenNetworkGraphState(graph)
+    partner_channels = list()
+
+    network_state = TokenNetworkState(
+        token_network_address,
+        token_address,
+        network_graph,
+        partner_channels,
+    )
+
+    return network_state

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -4,6 +4,8 @@ import random
 from binascii import hexlify
 from collections import namedtuple
 
+import networkx
+
 from raiden.constants import UINT256_MAX, UINT64_MAX
 from raiden.encoding.format import buffer_for
 from raiden.encoding import messages
@@ -233,7 +235,7 @@ class TokenNetworkGraphState(State):
         'network',
     )
 
-    def __init__(self, network):
+    def __init__(self, network: networkx.Graph):
         self.network = network
 
     def __repr__(self):


### PR DESCRIPTION
Handle `TokenNetworkCreated` events in the state machine.


Fixes #1542 