### PR TITLE
Skip the flaky test_api_tokens test on travis

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 from http import HTTPStatus
 
 import pytest
@@ -500,6 +501,10 @@ def test_api_channel_state_change_errors(
     assert_response_with_error(response, HTTPStatus.CONFLICT)
 
 
+@pytest.mark.skipif(
+    'TRAVIS' in os.environ,
+    reason='Flaky test on Travis. See issue #1552'
+)
 @pytest.mark.parametrize('number_of_tokens', [2])
 def test_api_tokens(api_backend, blockchain_services, token_addresses):
     partner_address = '0x61C808D82A3Ac53231750daDc13c777b59310bD9'


### PR DESCRIPTION
Related to #1552 

Disable this test for now on travis.