### PR TITLE
Add locked_amount to signature

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -278,8 +278,7 @@ class EnvelopeMessage(SignedMessage):
         data_to_sign = pack_signing_data(
             klass.get_bytes_from(data, 'nonce'),
             klass.get_bytes_from(data, 'transferred_amount'),
-            # Locked amount should get signed when smart contracts change to include it
-            # klass.get_bytes_from(data, 'locked_amount'),
+            klass.get_bytes_from(data, 'locked_amount'),
             klass.get_bytes_from(data, 'channel'),
             klass.get_bytes_from(data, 'locksroot'),
             self.message_hash,
@@ -330,8 +329,7 @@ class EnvelopeMessage(SignedMessage):
         data_that_was_signed = pack_signing_data(
             message_type.get_bytes_from(data, 'nonce'),
             message_type.get_bytes_from(data, 'transferred_amount'),
-            # Locked amount should get signed when smart contracts change to include it
-            # message_type.get_bytes_from(data, 'locked_amount'),
+            message_type.get_bytes_from(data, 'locked_amount'),
             message_type.get_bytes_from(data, 'channel'),
             message_type.get_bytes_from(data, 'locksroot'),
             message_hash,

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -252,7 +252,7 @@ class NettingChannel:
                 amount=amount,
             )
 
-    def close(self, nonce, transferred_amount, locksroot, extra_hash, signature):
+    def close(self, nonce, transferred_amount, locked_amount, locksroot, extra_hash, signature):
         """ Close the channel using the provided balance proof.
 
         Raises:
@@ -266,6 +266,7 @@ class NettingChannel:
             contract=pex(self.address),
             nonce=nonce,
             transferred_amount=transferred_amount,
+            locked_amount=locked_amount,
             locksroot=encode_hex(locksroot),
             extra_hash=encode_hex(extra_hash),
             signature=encode_hex(signature),
@@ -282,6 +283,7 @@ class NettingChannel:
                 'close',
                 nonce,
                 transferred_amount,
+                locked_amount,
                 locksroot,
                 extra_hash,
                 signature,
@@ -296,6 +298,7 @@ class NettingChannel:
                     contract=pex(self.address),
                     nonce=nonce,
                     transferred_amount=transferred_amount,
+                    locked_amount=locked_amount,
                     locksroot=encode_hex(locksroot),
                     extra_hash=encode_hex(extra_hash),
                     signature=encode_hex(signature),
@@ -309,12 +312,21 @@ class NettingChannel:
                 contract=pex(self.address),
                 nonce=nonce,
                 transferred_amount=transferred_amount,
+                locked_amount=locked_amount,
                 locksroot=encode_hex(locksroot),
                 extra_hash=encode_hex(extra_hash),
                 signature=encode_hex(signature),
             )
 
-    def update_transfer(self, nonce, transferred_amount, locksroot, extra_hash, signature):
+    def update_transfer(
+        self,
+        nonce,
+        transferred_amount,
+        locked_amount,
+        locksroot,
+        extra_hash,
+        signature,
+    ):
         if signature:
             log.info(
                 'updateTransfer called',
@@ -322,6 +334,7 @@ class NettingChannel:
                 contract=pex(self.address),
                 nonce=nonce,
                 transferred_amount=transferred_amount,
+                locked_amount=locked_amount,
                 locksroot=encode_hex(locksroot),
                 extra_hash=encode_hex(extra_hash),
                 signature=encode_hex(signature),
@@ -331,6 +344,7 @@ class NettingChannel:
                 'updateTransfer',
                 nonce,
                 transferred_amount,
+                locked_amount,
                 locksroot,
                 extra_hash,
                 signature,
@@ -349,6 +363,7 @@ class NettingChannel:
                     contract=pex(self.address),
                     nonce=nonce,
                     transferred_amount=transferred_amount,
+                    locked_amount=locked_amount,
                     locksroot=encode_hex(locksroot),
                     extra_hash=encode_hex(extra_hash),
                     signature=encode_hex(signature),
@@ -362,6 +377,7 @@ class NettingChannel:
                 contract=pex(self.address),
                 nonce=nonce,
                 transferred_amount=transferred_amount,
+                locked_amount=locked_amount,
                 locksroot=encode_hex(locksroot),
                 extra_hash=encode_hex(extra_hash),
                 signature=encode_hex(signature),

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -172,6 +172,7 @@ def handle_contract_channelclose(
     if balance_proof:
         nonce = balance_proof.nonce
         transferred_amount = balance_proof.transferred_amount
+        locked_amount = balance_proof.locked_amount
         locksroot = balance_proof.locksroot
         signature = balance_proof.signature
         message_hash = balance_proof.message_hash
@@ -179,6 +180,7 @@ def handle_contract_channelclose(
     else:
         nonce = 0
         transferred_amount = 0
+        locked_amount = 0
         locksroot = b''
         signature = b''
         message_hash = b''
@@ -188,6 +190,7 @@ def handle_contract_channelclose(
     channel.close(
         nonce,
         transferred_amount,
+        locked_amount,
         locksroot,
         message_hash,
         signature,
@@ -205,6 +208,7 @@ def handle_contract_channelupdate(
         channel.update_transfer(
             balance_proof.nonce,
             balance_proof.transferred_amount,
+            balance_proof.locked_amount,
             balance_proof.locksroot,
             balance_proof.message_hash,
             balance_proof.signature,

--- a/raiden/smart_contracts/NettingChannelContract.sol
+++ b/raiden/smart_contracts/NettingChannelContract.sol
@@ -92,6 +92,7 @@ contract NettingChannelContract {
     function close(
         uint64 nonce,
         uint256 transferred_amount,
+        uint256 locked_amount,
         bytes32 locksroot,
         bytes32 extra_hash,
         bytes signature
@@ -101,6 +102,7 @@ contract NettingChannelContract {
         data.close(
             nonce,
             transferred_amount,
+            locked_amount,
             locksroot,
             extra_hash,
             signature
@@ -113,6 +115,7 @@ contract NettingChannelContract {
     function updateTransfer(
         uint64 nonce,
         uint256 transferred_amount,
+        uint256 locked_amount,
         bytes32 locksroot,
         bytes32 extra_hash,
         bytes signature
@@ -122,6 +125,7 @@ contract NettingChannelContract {
         data.updateTransfer(
             nonce,
             transferred_amount,
+            locked_amount,
             locksroot,
             extra_hash,
             signature

--- a/raiden/smart_contracts/NettingChannelLibrary.sol
+++ b/raiden/smart_contracts/NettingChannelLibrary.sol
@@ -95,6 +95,7 @@ library NettingChannelLibrary {
         Data storage self,
         uint64 nonce,
         uint256 transferred_amount,
+        uint256 locked_amount,
         bytes32 locksroot,
         bytes32 extra_hash,
         bytes signature
@@ -125,6 +126,7 @@ library NettingChannelLibrary {
             transfer_address = recoverAddressFromSignature(
                 nonce,
                 transferred_amount,
+                locked_amount,
                 locksroot,
                 extra_hash,
                 signature 
@@ -147,6 +149,7 @@ library NettingChannelLibrary {
         Data storage self,
         uint64 nonce,
         uint256 transferred_amount,
+        uint256 locked_amount,
         bytes32 locksroot,
         bytes32 extra_hash,
         bytes signature
@@ -173,6 +176,7 @@ library NettingChannelLibrary {
         transfer_address = recoverAddressFromSignature(
             nonce,
             transferred_amount,
+            locked_amount,
             locksroot,
             extra_hash,
             signature 
@@ -191,6 +195,7 @@ library NettingChannelLibrary {
     function recoverAddressFromSignature(
         uint64 nonce,
         uint256 transferred_amount,
+        uint256 locked_amount,
         bytes32 locksroot,
         bytes32 extra_hash,
         bytes signature
@@ -209,6 +214,7 @@ library NettingChannelLibrary {
         signed_hash = keccak256(
             nonce,
             transferred_amount,
+            locked_amount,
             locksroot,
             this,
             extra_hash

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -270,6 +270,7 @@ def make_signed_balance_proof(
     data_to_sign = balance_proof.signing_data(
         nonce,
         transferred_amount,
+        locked_amount,
         channel_address,
         locksroot,
         extra_hash,

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -2,12 +2,14 @@
 from raiden.encoding.messages import (
     nonce as nonce_field,
     transferred_amount as transferred_amount_field,
+    locked_amount as locked_amount_field,
 )
 
 
 def signing_data(
         nonce: int,
         transferred_amount: int,
+        locked_amount: int,
         channel_address: bytes,
         locksroot: bytes,
         extra_hash: bytes,
@@ -23,9 +25,16 @@ def signing_data(
     )
     transferred_amount_bytes_padded = transferred_amount_bytes.rjust(pad_size, b'\x00')
 
+    locked_amount_bytes = locked_amount_field.encoder.encode(
+        locked_amount,
+        locked_amount_field.size_bytes,
+    )
+    locked_amount_bytes_padded = locked_amount_bytes.rjust(pad_size, b'\x00')
+
     data_that_was_signed = (
         nonce_bytes_padded +
         transferred_amount_bytes_padded +
+        locked_amount_bytes_padded +
         locksroot +
         channel_address +
         extra_hash
@@ -37,6 +46,7 @@ def signing_data(
 def pack_signing_data(
         nonce: bytes,
         transferred_amount: bytes,
+        locked_amount: bytes,
         channel_address: bytes,
         locksroot: bytes,
         extra_hash: bytes,
@@ -45,6 +55,7 @@ def pack_signing_data(
     data_that_was_signed = (
         nonce +
         transferred_amount +
+        locked_amount +
         locksroot +
         channel_address +
         extra_hash

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -144,6 +144,7 @@ def is_valid_signature(
     data_that_was_signed = signing_data(
         balance_proof.nonce,
         balance_proof.transferred_amount,
+        balance_proof.locked_amount,
         balance_proof.channel_address,
         balance_proof.locksroot,
         balance_proof.message_hash,


### PR DESCRIPTION
Adding the locked_amount to the signature. This also means that we add it to the old contracts.

Part of #1538