### PR TITLE
Batch unlock

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -21,7 +21,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelSettled,
     ContractReceiveChannelUnlock,
     ContractReceiveNewTokenNetwork,
-    ContractReceiveRegisteredSecret,
+    ContractReceiveSecretReveal,
     ContractReceiveRouteNew,
 )
 from raiden.blockchain.abi import (
@@ -276,11 +276,11 @@ def handle_channel_unlock(raiden, event, current_block_number):
         raiden.handle_state_change(unlock_state_change, current_block_number)
 
 
-def handle_secret_registered(raiden, event, current_block_number):
+def handle_secret_revealed(raiden, event, current_block_number):
     secret_registry_address = event.originating_contract
     data = event.event_data
 
-    registeredsecret_state_change = ContractReceiveRegisteredSecret(
+    registeredsecret_state_change = ContractReceiveSecretReveal(
         secret_registry_address,
         data['secrethash'],
     )
@@ -389,7 +389,7 @@ def on_blockchain_event2(raiden, event, current_block_number):
 
     elif data['event'] == EVENT_CHANNEL_SECRET_REVEALED2:
         data['secrethash'] = data['args']['secrethash']
-        handle_secret_registered(raiden, event, current_block_number)
+        handle_secret_revealed(raiden, event, current_block_number)
 
     else:
         log.error('Unknown event type', event_name=data['event'], raiden_event=event)

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -21,6 +21,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelSettled,
     ContractReceiveChannelUnlock,
     ContractReceiveNewTokenNetwork,
+    ContractReceiveRegisteredSecret,
     ContractReceiveRouteNew,
 )
 from raiden.blockchain.abi import (
@@ -275,6 +276,18 @@ def handle_channel_unlock(raiden, event, current_block_number):
         raiden.handle_state_change(unlock_state_change, current_block_number)
 
 
+def handle_secret_registered(raiden, event, current_block_number):
+    secret_registry_address = event.originating_contract
+    data = event.event_data
+
+    registeredsecret_state_change = ContractReceiveRegisteredSecret(
+        secret_registry_address,
+        data['secrethash'],
+    )
+
+    raiden.handle_state_change(registeredsecret_state_change, current_block_number)
+
+
 def on_blockchain_event(raiden, event, current_block_number):
     log.debug(
         'EVENT',
@@ -376,8 +389,7 @@ def on_blockchain_event2(raiden, event, current_block_number):
 
     elif data['event'] == EVENT_CHANNEL_SECRET_REVEALED2:
         data['secrethash'] = data['args']['secrethash']
-        # handle_secret_reveal(raiden, event, current_block_number)
-        raise NotImplementedError('handle_secret_reveal not implemented yet')
+        handle_secret_registered(raiden, event, current_block_number)
 
     else:
         log.error('Unknown event type', event_name=data['event'], raiden_event=event)

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -233,6 +233,15 @@ Lock = namedbuffer(
     ],
 )
 
+UnlockedLock = namedbuffer(
+    'unlockedlock',
+    [
+        expiration,
+        amount,
+        secret,
+    ]
+)
+
 
 CMDID_MESSAGE = {
     PROCESSED: Processed,

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -233,15 +233,6 @@ Lock = namedbuffer(
     ],
 )
 
-UnlockedLock = namedbuffer(
-    'unlockedlock',
-    [
-        expiration,
-        amount,
-        secret,
-    ],
-)
-
 
 CMDID_MESSAGE = {
     PROCESSED: Processed,

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -239,7 +239,7 @@ UnlockedLock = namedbuffer(
         expiration,
         amount,
         secret,
-    ]
+    ],
 )
 
 

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -93,8 +93,11 @@ class SecretRegistry:
             secret=secret,
         )
 
-    def register_block_by_secrethash(self, secrethash: typing.Keccak256):
+    def register_block_by_secrethash(self, secrethash: typing.Keccak256) -> int:
         return self.proxy.contract.functions.getSecretRevealBlockHeight(secrethash).call()
+
+    def check_registered(self, secrethash: typing.Keccak256) -> bool:
+        return self.register_block_by_secrethash(secrethash) > 0
 
     def secret_registered_filter(self, from_block=None, to_block=None) -> Filter:
         event_abi = CONTRACT_MANAGER.get_event_abi(

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -619,7 +619,7 @@ class TokenNetwork:
                 signature=encode_hex(signature),
             )
 
-    def unlock(self, partner: typing.Address, merkle_tree_leaves: bytes):
+    def unlock(self, partner: typing.Address, unlocked_locks_packed: typing.UnlockedLocksPacked):
         log.info(
             'unlock called',
             token_network=pex(self.address),
@@ -633,7 +633,7 @@ class TokenNetwork:
             'unlock',
             self.node_address,
             partner,
-            merkle_tree_leaves,
+            unlocked_locks_packed,
         )
 
         self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -619,7 +619,7 @@ class TokenNetwork:
                 signature=encode_hex(signature),
             )
 
-    def unlock(self, partner: typing.Address, unlocked_locks_packed: typing.UnlockedLocksPacked):
+    def unlock(self, partner: typing.Address, merkle_tree_leaves: typing.MerkleTreeLeaves):
         log.info(
             'unlock called',
             token_network=pex(self.address),
@@ -633,7 +633,7 @@ class TokenNetwork:
             'unlock',
             self.node_address,
             partner,
-            unlocked_locks_packed,
+            merkle_tree_leaves,
         )
 
         self.client.poll(unhexlify(transaction_hash), timeout=self.poll_timeout)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -166,7 +166,7 @@ def handle_unlockfailed(
 
 def handle_contract_secretreveal(
         raiden: 'RaidenService',
-        channel_close_event: ContractSendSecretReveal
+        channel_close_event: ContractSendSecretReveal,
 ):
     registry = raiden.chain.secret_registry()
     secrethash = sha3(channel_close_event.secret)
@@ -246,7 +246,7 @@ def handle_contract_channelunlock(
 
 def handle_contract_channelunlock2(
         raiden: 'RaidenService',
-        channel_unlock_event: ContractSendChannelUnlock
+        channel_unlock_event: ContractSendChannelUnlock,
 ):
     channel = raiden.chain.netting_channel(channel_unlock_event.channel_identifier)
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -29,7 +29,7 @@ from raiden.transfer.mediated_transfer.events import (
     SendRevealSecret,
     SendSecretRequest,
 )
-from raiden.utils import pex
+from raiden.utils import pex, sha3
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
 
@@ -168,7 +168,12 @@ def handle_contract_secretreveal(
         raiden: 'RaidenService',
         channel_close_event: ContractSendSecretReveal
 ):
-    raise NotImplementedError('handle_contract_secretreveal not implemented')
+    registry = raiden.chain.secret_registry()
+    secrethash = sha3(channel_close_event.secret)
+
+    registered = registry.check_registered(secrethash)
+    if not registered:
+        raiden.chain.secret_registry.register_secret(channel_close_event.secret)
 
 
 def handle_contract_channelclose(

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -7,6 +7,7 @@ from raiden.messages import (
 )
 from raiden.transfer.architecture import Event
 from raiden.transfer.events import (
+    ContractSendSecretReveal,
     ContractSendChannelClose,
     ContractSendChannelSettle,
     ContractSendChannelUpdateTransfer,
@@ -163,6 +164,13 @@ def handle_unlockfailed(
     )
 
 
+def handle_contract_secretreveal(
+        raiden: 'RaidenService',
+        channel_close_event: ContractSendSecretReveal
+):
+    raise NotImplementedError('handle_contract_secretreveal not implemented')
+
+
 def handle_contract_channelclose(
         raiden: RaidenService,
         channel_close_event: ContractSendChannelClose,
@@ -231,6 +239,15 @@ def handle_contract_channelunlock(
             channel.unlock(unlock_proof)
 
 
+def handle_contract_channelunlock2(
+        raiden: 'RaidenService',
+        channel_unlock_event: ContractSendChannelUnlock
+):
+    channel = raiden.chain.netting_channel(channel_unlock_event.channel_identifier)
+
+    channel.unlock(channel_unlock_event.unlock_proofs)
+
+
 def handle_contract_channelsettle(
         raiden: RaidenService,
         channel_settle_event: ContractSendChannelSettle,
@@ -262,6 +279,8 @@ def on_raiden_event(raiden: RaidenService, event: Event):
         handle_transfersentfailed(raiden, event)
     elif type(event) == EventUnlockFailed:
         handle_unlockfailed(raiden, event)
+    elif type(event) == ContractSendSecretReveal:
+        handle_contract_secretreveal(raiden, event)
     elif type(event) == ContractSendChannelClose:
         handle_contract_channelclose(raiden, event)
     elif type(event) == ContractSendChannelUpdateTransfer:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -285,7 +285,8 @@ def on_raiden_event(raiden: RaidenService, event: Event):
     elif type(event) == EventUnlockFailed:
         handle_unlockfailed(raiden, event)
     elif type(event) == ContractSendSecretReveal:
-        handle_contract_secretreveal(raiden, event)
+        # handle_contract_secretreveal(raiden, event)
+        pass
     elif type(event) == ContractSendChannelClose:
         handle_contract_channelclose(raiden, event)
     elif type(event) == ContractSendChannelUpdateTransfer:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -29,7 +29,7 @@ from raiden.transfer.mediated_transfer.events import (
     SendRevealSecret,
     SendSecretRequest,
 )
-from raiden.utils import pex, sha3
+from raiden.utils import pex
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
 
@@ -168,12 +168,8 @@ def handle_contract_secretreveal(
         raiden: 'RaidenService',
         channel_close_event: ContractSendSecretReveal,
 ):
-    registry = raiden.chain.secret_registry()
-    secrethash = sha3(channel_close_event.secret)
-
-    registered = registry.check_registered(secrethash)
-    if not registered:
-        raiden.chain.secret_registry.register_secret(channel_close_event.secret)
+    secret_registry = raiden.chain.secret_registry()
+    secret_registry.register_secret(channel_close_event.secret)
 
 
 def handle_contract_channelclose(

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -15,8 +15,8 @@ def test_secret_registry(secret_registry_proxy):
     data = keccak(secret)
     assert decoded_event['args']['secrethash'] == data
     # check if registration block matches
-    block = secret_registry_proxy.register_block_by_secrethash(data)
+    block = secret_registry_proxy.get_register_block_for_secrehash(data)
     assert logs[0]['blockNumber'] == block
 
     #  test non-existing secret
-    assert 0 == secret_registry_proxy.register_block_by_secrethash(b'\x11' * 32)
+    assert 0 == secret_registry_proxy.get_register_block_for_secrehash(b'\x11' * 32)

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1199,7 +1199,7 @@ def test_channelstate_unlock_without_locks():
 
 
 def test_channelstate_get_unlock_proof():
-    number_of_transfers = 2
+    number_of_transfers = 100
     lock_amounts = cycle([1, 3, 5, 7, 11])
     lock_secrets = [
         make_secret(i)
@@ -1213,7 +1213,7 @@ def test_channelstate_get_unlock_proof():
     locked_locks = {}
     unlocked_locks = {}
 
-    for _i, (lock_amount, lock_secret) in enumerate(zip(lock_amounts, lock_secrets)):
+    for lock_amount, lock_secret in zip(lock_amounts, lock_secrets):
         block_number += 1
         locked_amount += lock_amount
 
@@ -1227,16 +1227,16 @@ def test_channelstate_get_unlock_proof():
 
         merkletree_leaves.append(lock.lockhash)
         if random.randint(0, 1) == 0:
-            locked_locks[lock.lockhash] = lock
+            locked_locks[lock_secrethash] = lock
         else:
-            unlocked_locks[lock.lockhash] = UnlockPartialProofState(lock, lock_secret)
+            unlocked_locks[lock_secrethash] = UnlockPartialProofState(lock, lock_secret)
 
     end_state = NettingChannelEndState(HOP1, 300)
     end_state.secrethashes_to_lockedlocks = locked_locks
     end_state.secrethashes_to_unlockedlocks = unlocked_locks
     end_state.merkletree = MerkleTreeState(compute_layers(merkletree_leaves))
 
-    unlock_proof = channel.get_known_unlocks2(end_state)
+    unlock_proof = channel.get_batch_unlock(end_state)
     packed_leaves = unlock_proof.merkle_tree_leaves
     assert len(packed_leaves) == len(end_state.merkletree.layers[LEAVES]) * 72
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1237,11 +1237,10 @@ def test_channelstate_get_unlock_proof():
     end_state.merkletree = MerkleTreeState(compute_layers(merkletree_leaves))
 
     unlock_proof = channel.get_batch_unlock(end_state)
-    packed_leaves = unlock_proof.merkle_tree_leaves
-    assert len(packed_leaves) == len(end_state.merkletree.layers[LEAVES]) * 72
+    assert len(unlock_proof) == len(end_state.merkletree.layers[LEAVES]) * 72
 
     computed_merkleroot = merkleroot(MerkleTreeState(compute_layers(
-        merkle_leaves_from_packed_data(packed_leaves),
+        merkle_leaves_from_packed_data(unlock_proof),
     )))
     assert merkleroot(end_state.merkletree) == computed_merkleroot
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -54,6 +54,7 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.factories import (
     UNIT_REGISTRY_IDENTIFIER,
     HOP1,
+    make_secret,
 )
 from raiden.tests.utils.events import must_contain_entry
 from raiden.utils import (
@@ -924,7 +925,7 @@ def test_interwoven_transfers():
 
     lock_amounts = cycle([1, 3, 5, 7, 11])
     lock_secrets = [
-        format(i, '>032').encode()
+        make_secret(i)
         for i in range(number_of_transfers)
     ]
 
@@ -1201,7 +1202,7 @@ def test_channelstate_get_unlock_proof():
     number_of_transfers = 2
     lock_amounts = cycle([1, 3, 5, 7, 11])
     lock_secrets = [
-        format(i, '>032').encode()
+        make_secret(i)
         for i in range(number_of_transfers)
     ]
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -28,12 +28,15 @@ from raiden.transfer.merkle_tree import (
     MERKLEROOT,
     compute_layers,
     merkleroot,
+    merkle_leaves_from_packed_data,
 )
 from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     EMPTY_MERKLE_ROOT,
     balanceproof_from_envelope,
+    MerkleTreeState,
     HashTimeLockState,
+    UnlockPartialProofState,
     NettingChannelEndState,
     NettingChannelState,
     TransactionChannelNewBalance,
@@ -50,6 +53,7 @@ from raiden.transfer.state_change import (
 from raiden.tests.utils import factories
 from raiden.tests.utils.factories import (
     UNIT_REGISTRY_IDENTIFIER,
+    HOP1,
 )
 from raiden.tests.utils.events import must_contain_entry
 from raiden.utils import (
@@ -1191,6 +1195,54 @@ def test_channelstate_unlock_without_locks():
     )
     iteration = channel.handle_channel_closed(channel_state, state_change)
     assert not iteration.events
+
+
+def test_channelstate_get_unlock_proof():
+    number_of_transfers = 2
+    lock_amounts = cycle([1, 3, 5, 7, 11])
+    lock_secrets = [
+        format(i, '>032').encode()
+        for i in range(number_of_transfers)
+    ]
+
+    block_number = 1000
+    locked_amount = 0
+    settle_timeout = 8
+    merkletree_leaves = []
+    locked_locks = {}
+    unlocked_locks = {}
+
+    for _i, (lock_amount, lock_secret) in enumerate(zip(lock_amounts, lock_secrets)):
+        block_number += 1
+        locked_amount += lock_amount
+
+        lock_expiration = block_number + settle_timeout
+        lock_secrethash = sha3(lock_secret)
+        lock = HashTimeLockState(
+            lock_amount,
+            lock_expiration,
+            lock_secrethash,
+        )
+
+        merkletree_leaves.append(lock.lockhash)
+        if random.randint(0, 1) == 0:
+            locked_locks[lock.lockhash] = lock
+        else:
+            unlocked_locks[lock.lockhash] = UnlockPartialProofState(lock, lock_secret)
+
+    end_state = NettingChannelEndState(HOP1, 300)
+    end_state.secrethashes_to_lockedlocks = locked_locks
+    end_state.secrethashes_to_unlockedlocks = unlocked_locks
+    end_state.merkletree = MerkleTreeState(compute_layers(merkletree_leaves))
+
+    unlock_proof = channel.get_known_unlocks2(end_state)
+    packed_leaves = unlock_proof.merkle_tree_leaves
+    assert len(packed_leaves) == len(end_state.merkletree.layers[LEAVES]) * 72
+
+    computed_merkleroot = merkleroot(MerkleTreeState(compute_layers(
+        merkle_leaves_from_packed_data(packed_leaves),
+    )))
+    assert merkleroot(end_state.merkletree) == computed_merkleroot
 
 
 def test_channelstate_unlock():

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -89,6 +89,10 @@ def make_privkey_address():
     return privkey, address
 
 
+def make_secret(i):
+    return format(i, '>032').encode()
+
+
 def route_from_channel(channel_state):
     route = RouteState(
         channel_state.partner_state.address,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -59,7 +59,6 @@ from raiden.transfer.state import (
     TransactionExecutionStatus,
     UnlockPartialProofState,
     UnlockProofState,
-    UnlockProofState2,
 )
 from raiden.transfer.state_change import (
     ActionChannelClose,
@@ -614,12 +613,17 @@ def get_known_unlocks(end_state: NettingChannelEndState) -> typing.List[UnlockPr
     ]
 
 
-def get_batch_unlock(end_state: NettingChannelEndState) -> UnlockProofState2:
+def get_batch_unlock(
+        end_state: NettingChannelEndState,
+) -> typing.Optional[typing.MerkleTreeLeaves]:
     """ Unlock proof for an entire merkle tree of pending locks
 
     The unlock proof contains all the merkle tree data, tightly packed, needed by the token
     network contract to verify the secret expiry and calculate the token amounts to transfer.
     """
+
+    if len(end_state.merkletree.layers[LEAVES]) == 0:
+        return None
 
     lockhashes_to_locks = dict()
     lockhashes_to_locks.update({
@@ -635,7 +639,7 @@ def get_batch_unlock(end_state: NettingChannelEndState) -> UnlockProofState2:
         lockhashes_to_locks[lockhash].encoded for lockhash in end_state.merkletree.layers[LEAVES]
     )
 
-    return UnlockProofState2(all_locks_packed)
+    return all_locks_packed
 
 
 def get_lock(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -620,15 +620,22 @@ def get_known_unlocks2(end_state: NettingChannelEndState) -> UnlockProofState2:
     The unlock proof contains all the merkle tree data, tightly packed, needed by the token
     network contract to verify the secret expiry and calculate the token amounts to transfer.
     """
-    unlocked_locks_packed = b''
+    all_locks_packed = b''
+    for lock in end_state.secrethashes_to_lockedlocks.values():
+        packed = messages.Lock(buffer_for(messages.Lock))
+        packed.amount = lock.amount
+        packed.expiration = lock.expiration
+        packed.secrethash = lock.secrethash
+        all_locks_packed += bytes(packed.data)
+
     for proof in end_state.secrethashes_to_unlockedlocks.values():
-        packed = messages.UnlockedLock(buffer_for(messages.UnlockedLock))
+        packed = messages.Lock(buffer_for(messages.Lock))
         packed.amount = proof.lock.amount
         packed.expiration = proof.lock.expiration
-        packed.secret = proof.secret
-        unlocked_locks_packed += bytes(packed.data)
+        packed.secrethash = proof.lock.secrethash
+        all_locks_packed += bytes(packed.data)
 
-    return UnlockProofState2(unlocked_locks_packed)
+    return UnlockProofState2(all_locks_packed)
 
 
 def get_lock(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -132,6 +132,15 @@ def is_secret_known(
     return secrethash in end_state.secrethashes_to_unlockedlocks
 
 
+def get_secret(
+        end_state: NettingChannelEndState,
+        secrethash: typing.SecretHash,
+) -> typing.Secret:
+    """Returns `secret` if the `secrethash` is for a lock with a known secret."""
+    if is_secret_known(end_state, secrethash):
+        return end_state.secrethashes_to_unlockedlocks[secrethash].secret
+
+
 def is_transaction_confirmed(
         transaction_block_number: typing.BlockNumber,
         blockchain_block_number: typing.BlockNumber,

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -4,7 +4,7 @@ from raiden.transfer.architecture import (
     Event,
     SendMessageEvent,
 )
-from raiden.utils import pex
+from raiden.utils import pex, typing, sha3
 # pylint: disable=too-many-arguments,too-few-public-methods
 
 
@@ -101,6 +101,29 @@ class ContractSendChannelUnlock(Event):
             isinstance(other, ContractSendChannelUnlock) and
             self.channel_identifier == other.channel_identifier and
             self.unlock_proofs == other.unlock_proofs
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class ContractSendSecretReveal(Event):
+    """ Event emitted when the lock must be claimed on-chain. """
+
+    def __init__(self, secret: typing.Secret):
+        if not isinstance(secret, typing.T_Secret):
+            raise ValueError('secret must be a Secret instance')
+
+        self.secret = secret
+
+    def __repr__(self):
+        secrethash: typing.SecretHash = typing.SecretHash(sha3(self.secret))
+        return '<ContractSendSecretReveal secrethash:{}>'.format(secrethash)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ContractSendSecretReveal) and
+            self.secret == other.secret
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -234,7 +234,7 @@ def handle_block(target_state, channel_state, block_number):
         # TODO: to be removed
         events = events_for_close(target_state, channel_state, block_number)
 
-        events = events_for_onchain_secretregister(target_state, channel_state, block_number)
+        events.extend(events_for_onchain_secretregister(target_state, channel_state, block_number))
     else:
         events = list()
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -71,7 +71,7 @@ def events_for_onchain_secretregister(target_state, channel_state, block_number)
         return secret_registry.events_for_onchain_secretregister(
             channel_state,
             block_number,
-            secret
+            secret,
         )
 
     return list()

--- a/raiden/transfer/merkle_tree.py
+++ b/raiden/transfer/merkle_tree.py
@@ -107,3 +107,11 @@ def merkleroot(merkletree):
     assert merkletree.layers[MERKLEROOT], 'the root layer is empty'
 
     return merkletree.layers[MERKLEROOT][0]
+
+
+def merkle_leaves_from_packed_data(packed_data):
+    number_of_bytes = len(packed_data)
+    leaves = []
+    for i in range(0, number_of_bytes, 72):
+        leaves.append(sha3(packed_data[i: i + 72]))
+    return leaves

--- a/raiden/transfer/secret_registry.py
+++ b/raiden/transfer/secret_registry.py
@@ -1,0 +1,26 @@
+from raiden.transfer.architecture import Event
+from raiden.transfer.channel import get_status
+from raiden.transfer.events import ContractSendSecretReveal
+from raiden.utils import typing
+from raiden.transfer.state import (
+    CHANNEL_STATES_PRIOR_TO_CLOSED,
+    CHANNEL_STATE_CLOSED,
+    NettingChannelState,
+)
+
+
+def events_for_onchain_secretregister(
+        channel_state: NettingChannelState,
+        block_number: typing.BlockNumber,
+        secret: typing.Secret,
+) -> typing.List[Event]:
+    events = list()
+
+    if not isinstance(secret, typing.T_Secret):
+        raise ValueError('secret must be a Secret instance')
+
+    if get_status(channel_state) in CHANNEL_STATES_PRIOR_TO_CLOSED + (CHANNEL_STATE_CLOSED, ):
+        reveal_event = ContractSendSecretReveal(secret)
+        events.append(reveal_event)
+
+    return events

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -714,26 +714,26 @@ class UnlockProofState2(State):
     """ An unlock proof for all the pending locks. """
 
     __slots__ = (
-        'unlocked_locks_packed',
+        'merkle_tree_leaves',
     )
 
     def __init__(
             self,
-            unlocked_locks_packed: typing.UnlockedLocksPacked,
+            merkle_tree_leaves: typing.MerkleTreeLeaves,
     ):
 
-        if not isinstance(unlocked_locks_packed, typing.T_UnlockedLocksPacked):
-            raise ValueError('unlocked_locks_packed must be a UnlockedLocksPacked instance')
+        if not isinstance(merkle_tree_leaves, typing.T_MerkleTreeLeaves):
+            raise ValueError('merkle_tree_leaves must be a MerkleTreeLeaves instance')
 
-        self.unlocked_locks_packed = unlocked_locks_packed
+        self.merkle_tree_leaves = merkle_tree_leaves
 
     def __repr__(self):
-        return f'<UnlockProofState2 proof:{hexlify(self.unlocked_locks_packed)}>'
+        return f'<UnlockProofState2 proof:{hexlify(self.merkle_tree_leaves)}>'
 
     def __eq__(self, other):
         return (
             isinstance(other, UnlockProofState2) and
-            self.unlocked_locks_packed == other.unlocked_locks_packed
+            self.merkle_tree_leaves == other.merkle_tree_leaves
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -710,36 +710,6 @@ class UnlockProofState(State):
         return not self.__eq__(other)
 
 
-class UnlockProofState2(State):
-    """ An unlock proof for all the pending locks. """
-
-    __slots__ = (
-        'merkle_tree_leaves',
-    )
-
-    def __init__(
-            self,
-            merkle_tree_leaves: typing.MerkleTreeLeaves,
-    ):
-
-        if not isinstance(merkle_tree_leaves, typing.T_MerkleTreeLeaves):
-            raise ValueError('merkle_tree_leaves must be a MerkleTreeLeaves instance')
-
-        self.merkle_tree_leaves = merkle_tree_leaves
-
-    def __repr__(self):
-        return f'<UnlockProofState2 proof:{hexlify(self.merkle_tree_leaves)}>'
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, UnlockProofState2) and
-            self.merkle_tree_leaves == other.merkle_tree_leaves
-        )
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-
 class TransactionExecutionStatus(State):
     """ Represents the status of a transaction. """
     SUCCESS = 'success'

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
+# pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attribute
 import random
 from binascii import hexlify
 from collections import namedtuple
@@ -684,7 +684,8 @@ class UnlockProofState(State):
             self,
             merkle_proof: typing.List[typing.Keccak256],
             lock_encoded,
-            secret: typing.Secret):
+            secret: typing.Secret
+    ):
 
         if not isinstance(secret, typing.T_Secret):
             raise ValueError('secret must be a secret instance')
@@ -703,6 +704,36 @@ class UnlockProofState(State):
             self.merkle_proof == other.merkle_proof and
             self.lock_encoded == other.lock_encoded and
             self.secret == other.secret
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class UnlockProofState2(State):
+    """ An unlock proof for all the pending locks. """
+
+    __slots__ = (
+        'unlocked_locks_packed',
+    )
+
+    def __init__(
+            self,
+            unlocked_locks_packed: typing.UnlockedLocksPacked
+    ):
+
+        if not isinstance(unlocked_locks_packed, typing.T_UnlockedLocksPacked):
+            raise ValueError('unlocked_locks_packed must be a UnlockedLocksPacked instance')
+
+        self.unlocked_locks_packed = unlocked_locks_packed
+
+    def __repr__(self):
+        return f'<UnlockProofState2 proof:{hexlify(self.unlocked_locks_packed)}>'
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, UnlockProofState2) and
+            self.unlocked_locks_packed == other.unlocked_locks_packed
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attribute
+# pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 import random
 from binascii import hexlify
 from collections import namedtuple

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -684,7 +684,7 @@ class UnlockProofState(State):
             self,
             merkle_proof: typing.List[typing.Keccak256],
             lock_encoded,
-            secret: typing.Secret
+            secret: typing.Secret,
     ):
 
         if not isinstance(secret, typing.T_Secret):
@@ -719,7 +719,7 @@ class UnlockProofState2(State):
 
     def __init__(
             self,
-            unlocked_locks_packed: typing.UnlockedLocksPacked
+            unlocked_locks_packed: typing.UnlockedLocksPacked,
     ):
 
         if not isinstance(unlocked_locks_packed, typing.T_UnlockedLocksPacked):

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -459,7 +459,7 @@ class ContractReceiveNewTokenNetwork(StateChange):
         return not self.__eq__(other)
 
 
-class ContractReceiveRegisteredSecret(StateChange):
+class ContractReceiveSecretReveal(StateChange):
     """ A new secret was registered with the SecretRegistry contract. """
 
     def __init__(
@@ -476,14 +476,14 @@ class ContractReceiveRegisteredSecret(StateChange):
         self.secrethash = secrethash
 
     def __repr__(self):
-        return '<ContractReceiveRegisteredSecret secret registry:{} secrethash:{}>'.format(
+        return '<ContractReceiveSecretReveal secret registry:{} secrethash:{}>'.format(
             pex(self.secret_registry_address),
             pex(self.secrethash),
         )
 
     def __eq__(self, other):
         return (
-            isinstance(other, ContractReceiveRegisteredSecret) and
+            isinstance(other, ContractReceiveSecretReveal) and
             self.secret_registry_address == other.secret_registry_address and
             self.secrethash == other.secrethash
         )
@@ -563,7 +563,7 @@ class ContractReceiveChannelUnlock2(StateChange):
             payment_network_identifier: typing.PaymentNetworkID,
             token_address: typing.TokenAddress,
             channel_identifier: typing.ChannelID,
-            unlocked_locks_packed: typing.UnlockedLocksPacked,
+            merkle_tree_leaves: typing.MerkleTreeLeaves,
             participant: typing.Address,
             unlocked_amount: typing.TokenAmount,
             returned_tokens: typing.TokenAmount,
@@ -578,7 +578,7 @@ class ContractReceiveChannelUnlock2(StateChange):
         self.payment_network_identifier = payment_network_identifier
         self.token_address = token_address
         self.channel_identifier = channel_identifier
-        self.unlocked_locks_packed = unlocked_locks_packed
+        self.merkle_tree_leaves = merkle_tree_leaves
         self.participant = participant
         self.unlocked_amount = unlocked_amount
         self.returned_tokens = returned_tokens

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -459,6 +459,39 @@ class ContractReceiveNewTokenNetwork(StateChange):
         return not self.__eq__(other)
 
 
+class ContractReceiveRegisteredSecret(StateChange):
+    """ A new secret was registered with the SecretRegistry contract. """
+
+    def __init__(
+        self,
+        secret_registry_address: typing.SecretRegistryAddress,
+        secrethash: typing.SecretHash,
+    ):
+        if not isinstance(secret_registry_address, typing.T_SecretRegistryAddress):
+            raise ValueError('secret_registry_address must be of type SecretRegistryAddress')
+        if not isinstance(secrethash, typing.T_SecretHash):
+            raise ValueError('secrethash must be of type SecretHash')
+
+        self.secret_registry_address = secret_registry_address
+        self.secrethash = secrethash
+
+    def __repr__(self):
+        return '<ContractReceiveRegisteredSecret secret registry:{} secrethash:{}>'.format(
+            pex(self.secret_registry_address),
+            pex(self.secrethash),
+        )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ContractReceiveRegisteredSecret) and
+            self.secret_registry_address == other.secret_registry_address and
+            self.secrethash == other.secrethash
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
 class ContractReceiveChannelUnlock(StateChange):
     """ A lock was claimed via the blockchain.
     Used when a hash time lock was unlocked and a log ChannelSecretRevealed is

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -514,6 +514,43 @@ class ContractReceiveChannelUnlock(StateChange):
         return not self.__eq__(other)
 
 
+class ContractReceiveChannelUnlock2(StateChange):
+    """ All the locks were claimed via the blockchain.
+
+    Used when all the hash time locks were unlocked and a log ChannelUnlocked is emitted
+    by the token network contract.
+    Note:
+        For this state change the contract caller is not important but only the
+        receiving address. `participant` is the address to which the `unlocked_amount`
+        was transferred. `returned_tokens` was transferred to the channel partner.
+    """
+
+    def __init__(
+            self,
+            payment_network_identifier: typing.PaymentNetworkID,
+            token_address: typing.TokenAddress,
+            channel_identifier: typing.ChannelID,
+            unlocked_locks_packed: typing.UnlockedLocksPacked,
+            participant: typing.Address,
+            unlocked_amount: typing.TokenAmount,
+            returned_tokens: typing.TokenAmount,
+    ):
+
+        if not isinstance(payment_network_identifier, typing.T_PaymentNetworkID):
+            raise ValueError('payment_network_identifier must be of type PaymentNetworkID')
+
+        if not isinstance(participant, typing.T_Address):
+            raise ValueError('participant must be of type address')
+
+        self.payment_network_identifier = payment_network_identifier
+        self.token_address = token_address
+        self.channel_identifier = channel_identifier
+        self.unlocked_locks_packed = unlocked_locks_packed
+        self.participant = participant
+        self.unlocked_amount = unlocked_amount
+        self.returned_tokens = returned_tokens
+
+
 class ContractReceiveNewRoute(StateChange):
     """ New channel was created and this node is NOT a participant. """
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -547,7 +547,7 @@ class ContractReceiveChannelUnlock(StateChange):
         return not self.__eq__(other)
 
 
-class ContractReceiveChannelUnlock2(StateChange):
+class ContractReceiveChannelBatchUnlock(StateChange):
     """ All the locks were claimed via the blockchain.
 
     Used when all the hash time locks were unlocked and a log ChannelUnlocked is emitted

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -35,6 +35,9 @@ Locksroot = NewType('Locksroot', T_Locksroot)
 T_LockHash = bytes
 LockHash = NewType('LockHash', T_LockHash)
 
+T_UnlockedLocksPacked = bytes
+UnlockedLocksPacked = NewType('UnlockedLocksPacked', T_UnlockedLocksPacked)
+
 T_MessageID = int
 MessageID = NewType('MessageID', T_MessageID)
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -35,8 +35,8 @@ Locksroot = NewType('Locksroot', T_Locksroot)
 T_LockHash = bytes
 LockHash = NewType('LockHash', T_LockHash)
 
-T_UnlockedLocksPacked = bytes
-UnlockedLocksPacked = NewType('UnlockedLocksPacked', T_UnlockedLocksPacked)
+T_MerkleTreeLeaves = bytes
+MerkleTreeLeaves = NewType('MerkleTreeLeaves', T_MerkleTreeLeaves)
 
 T_MessageID = int
 MessageID = NewType('MessageID', T_MessageID)

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -86,6 +86,9 @@ Secret = NewType('Secret', T_Secret)
 T_SecretHash = bytes
 SecretHash = NewType('SecretHash', T_SecretHash)
 
+T_SecretRegistryAddress = bytes
+SecretRegistryAddress = NewType('SecretRegistryAddress', T_SecretRegistryAddress)
+
 T_Signature = bytes
 Signature = NewType('Signature', T_Signature)
 


### PR DESCRIPTION
Fixes part of  https://github.com/raiden-network/raiden/issues/1584 (reveal secret when it is about to expire)

Part of parent `META` issue https://github.com/raiden-network/raiden/issues/1496

Reveal secret when it is about to expire

- adds `events_for_onchain_secretregister` - `transfer/mediated_transfer/target.py`
- adds `ContractSendSecretReveal`
- adds `handle_contract_secretreveal` in `raiden_event_handler.py` and register the secret
- adds unit test

- adds `ContractReceiveSecretReveal`

Batch unlock:

- adds `UnlockProofState2` for the packed merkle tree data
- adds function for packing all the locks, needed to call `unlock` on-chain 
`get_known_unlocks2`
- adds `merkle_leaves_from_packed_data` to rebuild the merkle tree from packed data
- adds unit test to check above function
- adds `handle_contract_channelunlock` in `raiden_event_handler.py`
- adds duplicate `handle_channel_closed2` without the old `unlock` logic
- adds duplicate `handle_channel_settled2`, which also triggers the batch unlock on-chain
- adds `ContractReceiveChannelUnlock2`

- adds typings `MerkleTreeLeaves` , `SecretRegistryAddress`


