### PR TITLE
Add balance_hash property to BalanceProof[Unsigned|Signed]State

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -17,7 +17,7 @@ from raiden.constants import (
 from raiden.encoding import messages, signing
 from raiden.encoding.format import buffer_for
 from raiden.exceptions import InvalidProtocolMessage
-from raiden.transfer.balance_proof import pack_signing_data
+from raiden.transfer.balance_proof import pack_signing_data, hash_balance_data
 from raiden.transfer.state import EMPTY_MERKLE_ROOT
 from raiden.utils import (
     data_decoder,
@@ -292,10 +292,15 @@ class EnvelopeMessage(SignedMessage):
 
     def sign2(self, private_key, node_address, chain_id):
         """ Creates the signature to the balance proof. Will be used in the SC refactoring. """
+        balance_hash = hash_balance_data(
+            self.transferred_amount,
+            self.locked_amount,
+            self.locksroot,
+        )
         balance_proof = raiden_libs.messages.BalanceProof(
             channel_identifier=self.channel,
             token_network_address=self.token_network_address,
-            balance_hash=None,
+            balance_hash=balance_hash,
             nonce=self.nonce,
             additional_hash=self.message_hash.decode(),
             chain_id=chain_id,

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+from web3 import Web3
+
 from raiden.encoding.messages import (
     nonce as nonce_field,
     transferred_amount as transferred_amount_field,
     locked_amount as locked_amount_field,
 )
+from raiden.utils import typing
 
 
 def signing_data(
@@ -62,3 +65,14 @@ def pack_signing_data(
     )
 
     return data_that_was_signed
+
+
+def hash_balance_data(
+        transferred_amount: typing.TokenAmount,
+        locked_amount: typing.TokenAmount,
+        locksroot: typing.Locksroot,
+) -> str:
+    return Web3.soliditySha3(
+        ['uint256', 'uint256', 'bytes32'],
+        [transferred_amount, locked_amount, locksroot],
+    )

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -11,6 +11,7 @@ from raiden.encoding.format import buffer_for
 from raiden.encoding import messages
 from raiden.transfer.architecture import State
 from raiden.transfer.merkle_tree import merkleroot
+from raiden.transfer.balance_proof import hash_balance_data
 from raiden.utils import lpex, pex, sha3, typing
 
 SecretHashToLock = typing.Dict[typing.SecretHash, 'HashTimeLockState']
@@ -359,11 +360,10 @@ class BalanceProofUnsignedState(State):
             nonce: int,
             transferred_amount: typing.TokenAmount,
             locked_amount: typing.TokenAmount,
-            locksroot: typing.Keccak256,
+            locksroot: typing.Locksroot,
             token_network_identifier: typing.Address,
             channel_address: typing.Address,
     ):
-
         if not isinstance(nonce, int):
             raise ValueError('nonce must be int')
 
@@ -433,6 +433,14 @@ class BalanceProofUnsignedState(State):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    @property
+    def balance_hash(self):
+        return hash_balance_data(
+            transferred_amount=self.transferred_amount,
+            locked_amount=self.locked_amount,
+            locksroot=self.locksroot,
+        )
+
 
 class BalanceProofSignedState(State):
     """ Proof of a channel balance that can be used on-chain to resolve
@@ -456,14 +464,13 @@ class BalanceProofSignedState(State):
             nonce: int,
             transferred_amount: typing.TokenAmount,
             locked_amount: typing.TokenAmount,
-            locksroot: typing.Keccak256,
+            locksroot: typing.Locksroot,
             token_network_identifier: typing.Address,
             channel_address: typing.Address,
             message_hash: typing.Keccak256,
             signature: typing.Signature,
             sender: typing.Address,
     ):
-
         if not isinstance(nonce, int):
             raise ValueError('nonce must be int')
 
@@ -560,6 +567,14 @@ class BalanceProofSignedState(State):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    @property
+    def balance_hash(self):
+        return hash_balance_data(
+            transferred_amount=self.transferred_amount,
+            locked_amount=self.locked_amount,
+            locksroot=self.locksroot,
+        )
 
 
 class HashTimeLockState(State):


### PR DESCRIPTION
This way we don't have to update all state objects for the contracts transition.

Fixes  #1538