### PR TITLE
Fix the PaymentChannel proxy

### DIFF
--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from binascii import unhexlify
 from gevent.lock import RLock
-from typing import List
 from eth_utils import to_normalized_address, to_canonical_address
 
 import structlog
@@ -444,29 +443,6 @@ class NettingChannel:
                 contract=pex(self.address),
             )
 
-    def events_filter(
-            self,
-            topics: List[str] = None,
-            from_block: typing.BlockSpecification = None,
-            to_block: typing.BlockSpecification = None,
-    ) -> Filter:
-        """ Install a new filter for an array of topics emitted by the netting contract.
-        Args:
-            topics: A list of event ids to filter for. Can also be None,
-                    in which case all events are queried.
-            from_block: The block number at which to start looking for events.
-            to_block: The block number at which to stop looking for events.
-        Return:
-            Filter: The filter instance.
-        """
-        netting_channel_address_bin = self.proxy.contract_address
-        return self.client.new_filter(
-            netting_channel_address_bin,
-            topics=topics,
-            from_block=from_block,
-            to_block=to_block,
-        )
-
     def all_events_filter(
             self,
             from_block: typing.BlockSpecification = None,
@@ -477,4 +453,9 @@ class NettingChannel:
         Return:
             Filter: The filter instance.
         """
-        return self.events_filter(None, from_block, to_block)
+        return self.client.new_filter(
+            contract_address=self.proxy.contract_address,
+            topics=None,
+            from_block=from_block,
+            to_block=to_block,
+        )

--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -471,7 +471,7 @@ class NettingChannel:
             self,
             from_block: typing.BlockSpecification = None,
             to_block: typing.BlockSpecification = None,
-    ):
+    ) -> Filter:
         """ Install a new filter for all the events emitted by the current netting channel contract
 
         Return:

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -2,11 +2,10 @@
 from typing import Dict
 
 from web3.utils.filters import Filter
-from eth_utils import decode_hex
-
-from raiden.network.proxies import TokenNetwork
 from raiden.utils import typing
 from raiden.utils.filters import get_filter_args_for_channel_from_token_network
+
+from raiden.network.proxies import TokenNetwork
 
 
 class PaymentChannel:
@@ -45,7 +44,7 @@ class PaymentChannel:
         filter = self.token_network.proxy.contract.events.ChannelOpened.createFilter(
             fromBlock=0,
             argument_filters={
-                'channel_identifier': decode_hex(self.channel_identifier()),
+                'channel_identifier': self.channel_identifier(),
             },
         )
 
@@ -154,4 +153,9 @@ class PaymentChannel:
             to_block=to_block,
         )
 
-        return self.token_network.client.new_filter(args)
+        return self.token_network.client.new_filter(
+            contract_address=args['address'],
+            topics=args['topics'],
+            from_block=args['fromBlock'],
+            to_block=args['toBlock'],
+        )

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -29,13 +29,6 @@ class PaymentChannel:
         """ Returns the channel details. """
         return self.token_network.detail(self.partner_address)
 
-    def settle_block_number(self) -> int:
-        """ Returns the channels settle block number.
-
-        This is relative while the channel is open and becomes absolute when the channel is closed
-        """
-        return self.token_network.settle_block_number(self.partner_address)
-
     def settle_timeout(self) -> int:
         """ Returns the channels settle_timeout. """
 

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -1,4 +1,3 @@
-import gevent
 from eth_utils import (
     to_canonical_address,
     encode_hex,
@@ -8,19 +7,13 @@ from eth_utils import (
 from raiden_libs.utils.signing import sign_data
 from raiden_libs.messages import BalanceProof
 
-
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.proxies import TokenNetwork, PaymentChannel
 from raiden.constants import (
     NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
     EMPTY_HASH,
 )
-
-
-def wait_blocks(web3, blocks):
-    target_block = web3.eth.blockNumber + blocks
-    while web3.eth.blockNumber < target_block:
-        gevent.sleep(0.5)
+from raiden.tests.utils import wait_blocks
 
 
 def test_payment_channel_proxy_basics(
@@ -37,11 +30,13 @@ def test_payment_channel_proxy_basics(
         '0.0.0.0',
         blockchain_rpc_ports[0],
         private_keys[1],
+        web3=web3,
     )
     c2_client = JSONRPCClient(
         '0.0.0.0',
         blockchain_rpc_ports[0],
         private_keys[2],
+        web3=web3,
     )
     c1_token_network_proxy = TokenNetwork(
         c1_client,
@@ -81,9 +76,6 @@ def test_payment_channel_proxy_basics(
     assert channel_proxy_1.opened() is True
 
     # check the settlement timeouts
-    assert channel_proxy_1.settle_block_number() == channel_proxy_2.settle_block_number()
-    assert channel_proxy_1.settle_block_number() == NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
-
     assert channel_proxy_1.settle_timeout() == channel_proxy_2.settle_timeout()
     assert channel_proxy_1.settle_timeout() == NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
 
@@ -131,9 +123,6 @@ def test_payment_channel_proxy_basics(
     assert len(events) == 3  # ChannelOpened, ChannelNewDeposit, ChannelClosed
 
     # check the settlement timeouts again
-    assert channel_proxy_1.settle_block_number() == channel_proxy_2.settle_block_number()
-    assert channel_proxy_1.settle_block_number() != NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
-
     assert channel_proxy_1.settle_timeout() == channel_proxy_2.settle_timeout()
     assert channel_proxy_1.settle_timeout() == NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
 

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -1,0 +1,157 @@
+import gevent
+from eth_utils import (
+    to_canonical_address,
+    encode_hex,
+    decode_hex,
+    to_checksum_address,
+)
+from raiden_libs.utils.signing import sign_data
+from raiden_libs.messages import BalanceProof
+
+
+from raiden.network.rpc.client import JSONRPCClient
+from raiden.network.proxies import TokenNetwork, PaymentChannel
+from raiden.constants import (
+    NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
+    EMPTY_HASH,
+)
+
+
+def wait_blocks(web3, blocks):
+    target_block = web3.eth.blockNumber + blocks
+    while web3.eth.blockNumber < target_block:
+        gevent.sleep(0.5)
+
+
+def test_payment_channel_proxy_basics(
+    token_network_proxy,
+    private_keys,
+    blockchain_rpc_ports,
+    token_proxy,
+    chain_id,
+    web3,
+):
+    token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
+
+    c1_client = JSONRPCClient(
+        '0.0.0.0',
+        blockchain_rpc_ports[0],
+        private_keys[1],
+    )
+    c2_client = JSONRPCClient(
+        '0.0.0.0',
+        blockchain_rpc_ports[0],
+        private_keys[2],
+    )
+    c1_token_network_proxy = TokenNetwork(
+        c1_client,
+        token_network_address,
+    )
+    c2_token_network_proxy = TokenNetwork(
+        c2_client,
+        token_network_address,
+    )
+
+    channel_proxy_1 = PaymentChannel(c1_token_network_proxy, c2_client.sender)
+    channel_proxy_2 = PaymentChannel(c2_token_network_proxy, c1_client.sender)
+    event_filter = channel_proxy_1.all_events_filter(
+        from_block=web3.eth.blockNumber,
+        to_block='latest',
+    )
+
+    # test basic assumptions
+    assert channel_proxy_1.channel_identifier() == channel_proxy_2.channel_identifier()
+
+    assert channel_proxy_1.opened() is False
+    assert channel_proxy_2.opened() is False
+    assert channel_proxy_1.closed() is False
+    assert channel_proxy_2.closed() is False
+
+    events = event_filter.get_all_entries()
+    assert len(events) == 0  # no event for this channel yet
+
+    # create a channel
+    channel_identifier = c1_token_network_proxy.new_netting_channel(
+        c2_client.sender,
+        NETTINGCHANNEL_SETTLE_TIMEOUT_MIN,
+    )
+    assert channel_identifier is not None
+    assert channel_proxy_1.channel_identifier() == channel_identifier
+
+    assert channel_proxy_1.opened() is True
+
+    # check the settlement timeouts
+    assert channel_proxy_1.settle_block_number() == channel_proxy_2.settle_block_number()
+    assert channel_proxy_1.settle_block_number() == NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
+
+    assert channel_proxy_1.settle_timeout() == channel_proxy_2.settle_timeout()
+    assert channel_proxy_1.settle_timeout() == NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
+
+    events = event_filter.get_all_entries()
+    assert len(events) == 1  # ChannelOpened
+
+    # test deposits
+    initial_token_balance = 100
+    token_proxy.transfer(c1_client.sender, initial_token_balance)
+    initial_balance_c1 = token_proxy.balance_of(c1_client.sender)
+    assert initial_balance_c1 == initial_token_balance
+    initial_balance_c2 = token_proxy.balance_of(c2_client.sender)
+    assert initial_balance_c2 == 0
+
+    # actual deposit
+    channel_proxy_1.deposit(10)
+
+    events = event_filter.get_all_entries()
+    assert len(events) == 2  # ChannelOpened, ChannelNewDeposit
+
+    # balance proof by c2
+    transferred_amount = 3
+    balance_proof = BalanceProof(
+        channel_identifier=encode_hex(channel_identifier),
+        token_network_address=to_checksum_address(token_network_address),
+        nonce=1,
+        chain_id=chain_id,
+        transferred_amount=transferred_amount,
+    )
+    balance_proof.signature = encode_hex(
+        sign_data(encode_hex(private_keys[1]), balance_proof.serialize_bin()),
+    )
+    # correct close
+    c2_token_network_proxy.close(
+        c1_client.sender,
+        balance_proof.nonce,
+        balance_proof.balance_hash,
+        balance_proof.additional_hash,
+        decode_hex(balance_proof.signature),
+    )
+    assert channel_proxy_1.closed() is True
+    assert channel_proxy_2.closed() is True
+
+    events = event_filter.get_all_entries()
+    assert len(events) == 3  # ChannelOpened, ChannelNewDeposit, ChannelClosed
+
+    # check the settlement timeouts again
+    assert channel_proxy_1.settle_block_number() == channel_proxy_2.settle_block_number()
+    assert channel_proxy_1.settle_block_number() != NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
+
+    assert channel_proxy_1.settle_timeout() == channel_proxy_2.settle_timeout()
+    assert channel_proxy_1.settle_timeout() == NETTINGCHANNEL_SETTLE_TIMEOUT_MIN
+
+    # update transfer
+    wait_blocks(c1_client.web3, NETTINGCHANNEL_SETTLE_TIMEOUT_MIN)
+
+    c2_token_network_proxy.settle(
+        0,
+        0,
+        EMPTY_HASH,
+        c1_client.sender,
+        transferred_amount,
+        0,
+        EMPTY_HASH,
+    )
+    assert channel_proxy_1.settled() is True
+    assert channel_proxy_2.settled() is True
+
+    events = event_filter.get_all_entries()
+
+    assert len(events) == 4  # ChannelOpened, ChannelNewDeposit, ChannelClosed, ChannelSettled

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -105,7 +105,7 @@ def test_token_network_proxy_basics(
     initial_token_balance = 100
     token_proxy.transfer(c1_client.sender, initial_token_balance)
     initial_balance_c1 = token_proxy.balance_of(c1_client.sender)
-    assert initial_token_balance == initial_token_balance
+    assert initial_balance_c1 == initial_token_balance
     initial_balance_c2 = token_proxy.balance_of(c2_client.sender)
     assert initial_balance_c2 == 0
     # no negative deposit

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -1,5 +1,4 @@
 import pytest
-import gevent
 from eth_utils import (
     to_canonical_address,
     encode_hex,
@@ -20,14 +19,9 @@ from raiden.exceptions import (
     TransactionThrew,
     ChannelIncorrectStateError,
 )
+from raiden.tests.utils import wait_blocks
 from raiden_libs.messages import BalanceProof
 from raiden_libs.utils.signing import sign_data
-
-
-def wait_blocks(web3, blocks):
-    target_block = web3.eth.blockNumber + blocks
-    while web3.eth.blockNumber < target_block:
-        gevent.sleep(0.5)
 
 
 def test_token_network_proxy_basics(

--- a/raiden/tests/utils/__init__.py
+++ b/raiden/tests/utils/__init__.py
@@ -1,8 +1,17 @@
 import random
 
+import gevent
+from web3 import Web3
+
 
 def get_random_bytes(count):
     """Get an array filed with random numbers"""
     return bytes(
         [random.randint(0, 0xff) for _ in range(count)],
     )
+
+
+def wait_blocks(web3: Web3, blocks: int):
+    target_block = web3.eth.blockNumber + blocks
+    while web3.eth.blockNumber < target_block:
+        gevent.sleep(0.5)

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from typing import Dict
+
+from eth_utils import decode_hex
+from web3.utils.filters import construct_event_filter_params
+from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, EVENT_CHANNEL_OPENED
+
+from raiden.utils.typing import Address, ChannelID, BlockSpecification
+
+
+def get_filter_args_for_channel_from_token_network(
+        token_network_address: Address,
+        channel_identifier: ChannelID,
+        from_block: BlockSpecification = 0,
+        to_block: BlockSpecification = 'latest',
+) -> Dict:
+    event_abi = ContractManager.get_contract_abi(CONTRACT_TOKEN_NETWORK, EVENT_CHANNEL_OPENED)
+
+    # Here the topics for a specific event are created
+    # The first entry of the topics list is the event name, then the first parameter is encoded,
+    # in the case of a token network, the first parameter is always the channel identifier
+    data_filter_set, event_filter_params = construct_event_filter_params(
+        event_abi=event_abi,
+        contract_address=token_network_address,
+        argument_filters={
+            'channel_identifier': decode_hex(channel_identifier),
+        },
+        fromBlock=from_block,
+        toBlock=to_block,
+    )
+
+    # As we want to get all events for a certain channel we remove the event specific code here
+    # and filter just for the channel identifier
+    event_filter_params['topics'][0] = None
+
+    return event_filter_params


### PR DESCRIPTION
- Add `settle_timeout` function back, however this just return the right value as long as the channel is open. See discussion https://github.com/raiden-network/raiden/pull/1551#discussion_r195461907

@hackaugusto To store the correct `settle_timeout` we need to store it ourselves from the `ChannelOpened` event. I can do the changes to the state machine, but that would change the usage of the proxy anyways. 

>> was fixed by adding a filter

Fixes #1549 