### PR TITLE
Remove usage of raiden.utils.encode_hex function

### DIFF
--- a/raiden/network/proxies/netting_channel.py
+++ b/raiden/network/proxies/netting_channel.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from binascii import unhexlify
 from gevent.lock import RLock
-from eth_utils import to_normalized_address, to_canonical_address
+
+from eth_utils import (
+    encode_hex,
+    to_normalized_address,
+    to_canonical_address,
+)
 
 import structlog
 from web3.exceptions import BadFunctionCallOutput
@@ -29,7 +34,6 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
     releasing,
-    encode_hex,
 )
 from raiden.utils import typing
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -8,6 +8,7 @@ from raiden.utils import typing
 import structlog
 from web3.utils.filters import Filter
 from eth_utils import (
+    encode_hex,
     is_binary_address,
     to_normalized_address,
     to_canonical_address,
@@ -45,7 +46,6 @@ from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
 )
 from raiden.utils import (
-    encode_hex,
     pex,
     privatekey_to_address,
     releasing,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -12,6 +12,7 @@ from web3.middleware import geth_poa_middleware
 from web3.utils.filters import Filter
 from eth_utils import (
     to_int,
+    encode_hex,
     to_checksum_address,
     to_canonical_address,
     remove_0x_prefix,
@@ -33,7 +34,6 @@ from raiden.utils import (
     data_encoder,
     privatekey_to_address,
     quantity_encoder,
-    encode_hex,
 )
 from raiden.utils.typing import Address
 from raiden.network.rpc.smartcontract_proxy import ContractProxy

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -112,8 +112,8 @@ def test_payment_channel_proxy_basics(
     c2_token_network_proxy.close(
         c1_client.sender,
         balance_proof.nonce,
-        balance_proof.balance_hash,
-        balance_proof.additional_hash,
+        decode_hex(balance_proof.balance_hash),
+        decode_hex(balance_proof.additional_hash),
         decode_hex(balance_proof.signature),
     )
     assert channel_proxy_1.closed() is True

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -130,16 +130,16 @@ def test_token_network_proxy_basics(
         c2_token_network_proxy.close(
             c1_client.sender,
             balance_proof.nonce,
-            balance_proof.balance_hash,
-            balance_proof.additional_hash,
+            decode_hex(balance_proof.balance_hash),
+            decode_hex(balance_proof.additional_hash),
             b'\x11' * 65,
         )
     # correct close
     c2_token_network_proxy.close(
         c1_client.sender,
         balance_proof.nonce,
-        balance_proof.balance_hash,
-        balance_proof.additional_hash,
+        decode_hex(balance_proof.balance_hash),
+        decode_hex(balance_proof.additional_hash),
         decode_hex(balance_proof.signature),
     )
     assert c1_token_network_proxy.channel_is_closed(c2_client.sender) is True
@@ -149,8 +149,8 @@ def test_token_network_proxy_basics(
         c2_token_network_proxy.close(
             c1_client.sender,
             balance_proof.nonce,
-            balance_proof.balance_hash,
-            balance_proof.additional_hash,
+            decode_hex(balance_proof.balance_hash),
+            decode_hex(balance_proof.additional_hash),
             decode_hex(balance_proof.signature),
         )
     # update transfer
@@ -247,8 +247,8 @@ def test_token_network_proxy_update_transfer(
     c1_token_network_proxy.close(
         c2_client.sender,
         balance_proof_c2.nonce,
-        balance_proof_c2.balance_hash,
-        balance_proof_c2.additional_hash,
+        decode_hex(balance_proof_c2.balance_hash),
+        decode_hex(balance_proof_c2.additional_hash),
         decode_hex(balance_proof_c2.signature),
     )
 

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from raiden.accounts import AccountManager
-from raiden.utils import get_project_root, encode_hex
+from raiden.utils import get_project_root
+from eth_utils import encode_hex
 
 KEYFILE_INACCESSIBLE = 'UTC--2017-06-20T16-33-00.000000000Z--inaccessible'
 KEYFILE_INVALID = 'UTC--2017-06-20T16-06-00.000000000Z--invalid'
@@ -56,16 +57,16 @@ def test_get_account_in_keystore(test_keystore):
 
 def test_get_privkey(test_keystore):
     account_manager = AccountManager(test_keystore)
-    assert 'f696ecb5c767263c797a035db6f6008d38d852960ed33a491a58390b003fb605' == encode_hex(
+    assert '0xf696ecb5c767263c797a035db6f6008d38d852960ed33a491a58390b003fb605' == encode_hex(
         account_manager.get_privkey('0d5a0e4fece4b84365b9b8dba6e6d41348c73645', '123'),
     )
-    assert 'f696ecb5c767263c797a035db6f6008d38d852960ed33a491a58390b003fb605' == encode_hex(
+    assert '0xf696ecb5c767263c797a035db6f6008d38d852960ed33a491a58390b003fb605' == encode_hex(
         account_manager.get_privkey('0x0d5a0e4fece4b84365b9b8dba6e6d41348c73645', '123'),
     )
-    assert '36fa966441f259501110ba88f8212dfd7f8bacb07862a7d5cf8f31c1a64551e5' == encode_hex(
+    assert '0x36fa966441f259501110ba88f8212dfd7f8bacb07862a7d5cf8f31c1a64551e5' == encode_hex(
         account_manager.get_privkey('3593403033d18b82f7b4a0f18e1ed24623d23b20', '123'),
     )
-    assert '36fa966441f259501110ba88f8212dfd7f8bacb07862a7d5cf8f31c1a64551e5' == encode_hex(
+    assert '0x36fa966441f259501110ba88f8212dfd7f8bacb07862a7d5cf8f31c1a64551e5' == encode_hex(
         account_manager.get_privkey('0x3593403033d18b82f7b4a0f18e1ed24623d23b20', '123'),
     )
 

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -12,6 +12,8 @@ import gevent
 
 from eth_utils import (
     denoms,
+    encode_hex,
+    remove_0x_prefix,
     to_checksum_address,
     to_normalized_address,
 )
@@ -21,7 +23,6 @@ from requests import ConnectionError
 from raiden.utils import (
     privatekey_to_address,
     privtopub,
-    encode_hex,
 )
 from raiden.tests.utils.genesis import GENESIS_STUB
 
@@ -256,8 +257,8 @@ def geth_create_blockchain(
             config['unlock'] = 0
 
         config['nodekey'] = key
-        config['nodekeyhex'] = encode_hex(key)
-        config['pub'] = encode_hex(privtopub(key))
+        config['nodekeyhex'] = remove_0x_prefix(encode_hex(key))
+        config['pub'] = remove_0x_prefix(encode_hex(privtopub(key)))
         config['address'] = address
         config['port'] = p2p_port
         config['rpcport'] = rpc_port

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 from raiden.transfer.architecture import State
-from raiden.utils import pex, sha3, typing, encode_hex
+from raiden.utils import pex, sha3, typing
 from raiden.transfer.state import (
     EMPTY_MERKLE_ROOT,
     balanceproof_from_envelope,
@@ -10,6 +10,8 @@ from raiden.transfer.state import (
     HashTimeLockState,
     RouteState,
 )
+
+from eth_utils import encode_hex
 
 
 def lockedtransfersigned_from_message(message):

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -44,14 +44,6 @@ def decode_hex(s) -> bytes:
     raise TypeError('Value must be an instance of str or bytes')
 
 
-def encode_hex(b) -> str:
-    if isinstance(b, str):
-        b = bytes(b, 'utf-8')
-    if isinstance(b, (bytes, bytearray)):
-        return str(hexlify(b), 'utf-8')
-    raise TypeError('Value must be an instance of str or bytes')
-
-
 def sha3(data: bytes) -> bytes:
     return keccak(data)
 

--- a/tools/genesis_builder.py
+++ b/tools/genesis_builder.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from binascii import hexlify
 
-from eth_utils import denoms
+from eth_utils import denoms, encode_hex
 
-from raiden.utils import privatekey_to_address, sha3, encode_hex
+from raiden.utils import privatekey_to_address, sha3
 from raiden.tests.utils.blockchain import GENESIS_STUB
 
 CLUSTER_NAME = 'raiden'

--- a/tools/startcluster.py
+++ b/tools/startcluster.py
@@ -7,12 +7,13 @@ import tempfile
 import signal
 from subprocess import Popen, PIPE
 
+from eth_utils import encode_hex
+
 from genesis_builder import mk_genesis, generate_accounts
 from raiden.utils import (
     privtopub as privtopub_enode,
     privatekey_to_address,
     sha3,
-    encode_hex,
 )
 from raiden.settings import INITIAL_PORT
 


### PR DESCRIPTION
Get rid of all usages of `raiden.utils.encode_hex` function and modify related test cases accordingly.

Related to #1422