### PR TITLE
Resolve address in use

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -289,6 +289,7 @@ class APIServer:
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
                 raise APIServerPortInUseError()
+            raise
 
     def stop(self, timeout=5):
         if getattr(self, 'wsgiserver', None):

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from http import HTTPStatus
+import errno
 import json
-import sys
 import logging
+import socket
 import structlog
+import sys
 
 from flask import Flask, make_response, url_for, send_from_directory, request
 from flask.json import jsonify
@@ -18,6 +20,7 @@ from eth_utils import is_address, to_checksum_address
 from raiden.exceptions import (
     AddressWithoutCode,
     AlreadyRegisteredTokenAddress,
+    APIServerPortInUseError,
     ChannelBusyError,
     ChannelNotFound,
     DuplicatedChannelError,
@@ -273,15 +276,19 @@ class APIServer:
         self.flask_app.run(host=host, port=port, **kwargs)
 
     def start(self, host='127.0.0.1', port=5001):
-        # WSGI expects a stdlib logger, with structlog there's conflict of method names
-        wsgi_log = logging.getLogger(__name__ + '.pywsgi')
-        self.wsgiserver = WSGIServer(
-            (host, port),
-            self.flask_app,
-            log=wsgi_log,
-            error_log=wsgi_log,
-        )
-        self.wsgiserver.start()
+        try:
+            # WSGI expects a stdlib logger, with structlog there's conflict of method names
+            wsgi_log = logging.getLogger(__name__ + '.pywsgi')
+            self.wsgiserver = WSGIServer(
+                (host, port),
+                self.flask_app,
+                log=wsgi_log,
+                error_log=wsgi_log,
+            )
+            self.wsgiserver.start()
+        except socket.error as e:
+            if e.errno == errno.EADDRINUSE:
+                raise APIServerPortInUseError()
 
     def stop(self, timeout=5):
         if getattr(self, 'wsgiserver', None):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -138,3 +138,11 @@ class TransactionThrew(RaidenError):
 
 class InvalidProtocolMessage(RaidenError):
     """Raised on an invalid or an unknown Raiden protocol message"""
+
+
+class APIServerPortInUseError(RaidenError):
+    """Raised when API server port is already in use"""
+
+
+class RaidenServicePortInUseError(RaidenError):
+    """Raised when Raiden service port is already in use"""

--- a/raiden/network/sockfactory.py
+++ b/raiden/network/sockfactory.py
@@ -122,6 +122,7 @@ class SocketFactory:
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
                 raise RaidenServicePortInUseError()
+            raise
 
     def unmap_upnp(self):
         upnpsock.release_port(self.storage['router'], self.source_port)
@@ -180,6 +181,7 @@ class SocketFactory:
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
                 raise RaidenServicePortInUseError()
+            raise
 
     @property
     def strategy_description(self):

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -4,7 +4,6 @@ import sys
 import os
 import tempfile
 import json
-import socket
 import signal
 import shutil
 from copy import deepcopy
@@ -861,8 +860,6 @@ def run(ctx, **kwargs):
                 (listen_host, listen_port),
             )
             sys.exit(1)
-        except socket.error:
-            raise
     elif kwargs['transport'] == 'matrix':
         print('WARNING: The Matrix transport is experimental')
         kwargs['mapped_socket'] = None


### PR DESCRIPTION
Introduced 2 exceptions for both SocketFactory and RaidenAPI
servers. Each of those exceptions are raised when their designated
server's port is already in use. The CLI component in this case would
need to catch those specific exceptions and display error messages
accordingly.

Resolves #1039 