### PR TITLE
Add bors.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 dist: trusty
 sudo: true
 
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Uncomment this to enable building pull requests.
+    - master
+
+
 language: python
 python:
 - '3.6'

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,6 @@
+status = [
+  "continuous-integration/travis-ci/push"
+]
+# Uncomment this to use a two hour timeout.
+# The default is one hour.
+#timeout_sec = 7200


### PR DESCRIPTION
As per our real life discussion we can test bors -- don't think that the octopus git merge will be really bad for our team due to the amount of people we got, compared to say rustlang.

Regardless they are [working on](https://github.com/bors-ng/bors-ng/issues/138) introducing a flat-commit workflow like we have at the moment so the moment they do we will both have our cake and we will eat it.

For now we can experiment with just having the cake.

P.S.: Not sure if we need to edit travis.yml too, in order to specify branches in our case. The [getting started guide](https://bors.tech/documentation/getting-started/) sounds a bit confusing to me.