### PR TITLE
Rename to ContractSendChannelBatchUnlock & contract-related raiden event handlers

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -164,7 +164,7 @@ def handle_unlockfailed(
     )
 
 
-def handle_contract_secretreveal(
+def handle_contract_send_secretreveal(
         raiden: 'RaidenService',
         channel_close_event: ContractSendSecretReveal,
 ):
@@ -172,7 +172,7 @@ def handle_contract_secretreveal(
     secret_registry.register_secret(channel_close_event.secret)
 
 
-def handle_contract_channelclose(
+def handle_contract_send_channelclose(
         raiden: RaidenService,
         channel_close_event: ContractSendChannelClose,
 ):
@@ -206,7 +206,7 @@ def handle_contract_channelclose(
     )
 
 
-def handle_contract_channelupdate(
+def handle_contract_send_channelupdate(
         raiden: RaidenService,
         channel_update_event: ContractSendChannelUpdateTransfer,
 ):
@@ -224,9 +224,9 @@ def handle_contract_channelupdate(
         )
 
 
-def handle_contract_channelunlock(
+def handle_contract_send_channelunlock(
         raiden: RaidenService,
-        channel_unlock_event: ContractSendChannelUnlock,
+        channel_unlock_event: ContractSendChannelBatchUnlock,
 ):
     channel = raiden.chain.netting_channel(channel_unlock_event.channel_identifier)
     block_number = raiden.get_block_number()
@@ -240,16 +240,16 @@ def handle_contract_channelunlock(
             channel.unlock(unlock_proof)
 
 
-def handle_contract_channelunlock2(
+def handle_contract_send_channelunlock2(
         raiden: 'RaidenService',
-        channel_unlock_event: ContractSendChannelUnlock,
+        channel_unlock_event: ContractSendChannelBatchUnlock,
 ):
     channel = raiden.chain.netting_channel(channel_unlock_event.channel_identifier)
 
     channel.unlock(channel_unlock_event.unlock_proofs)
 
 
-def handle_contract_channelsettle(
+def handle_contract_send_channelsettle(
         raiden: RaidenService,
         channel_settle_event: ContractSendChannelSettle,
 ):
@@ -281,16 +281,16 @@ def on_raiden_event(raiden: RaidenService, event: Event):
     elif type(event) == EventUnlockFailed:
         handle_unlockfailed(raiden, event)
     elif type(event) == ContractSendSecretReveal:
-        # handle_contract_secretreveal(raiden, event)
+        # handle_contract_send_secretreveal(raiden, event)
         pass
     elif type(event) == ContractSendChannelClose:
-        handle_contract_channelclose(raiden, event)
+        handle_contract_send_channelclose(raiden, event)
     elif type(event) == ContractSendChannelUpdateTransfer:
-        handle_contract_channelupdate(raiden, event)
-    elif type(event) == ContractSendChannelUnlock:
-        handle_contract_channelunlock(raiden, event)
+        handle_contract_send_channelupdate(raiden, event)
+    elif type(event) == ContractSendChannelBatchUnlock:
+        handle_contract_send_channelunlock(raiden, event)
     elif type(event) == ContractSendChannelSettle:
-        handle_contract_channelsettle(raiden, event)
+        handle_contract_send_channelsettle(raiden, event)
     elif type(event) in UNEVENTFUL_EVENTS:
         pass
     else:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -11,7 +11,7 @@ from raiden.transfer.events import (
     ContractSendChannelClose,
     ContractSendChannelSettle,
     ContractSendChannelUpdateTransfer,
-    ContractSendChannelUnlock,
+    ContractSendChannelBatchUnlock,
     EventTransferReceivedSuccess,
     EventTransferSentFailed,
     EventTransferSentSuccess,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -18,7 +18,7 @@ from raiden.messages import (
 from raiden.settings import DEFAULT_NUMBER_OF_CONFIRMATIONS_BLOCK
 from raiden.transfer import channel
 from raiden.transfer.events import (
-    ContractSendChannelUnlock,
+    ContractSendChannelBatchUnlock,
     EventTransferReceivedInvalidDirectTransfer,
     EventTransferReceivedSuccess,
 )
@@ -1289,7 +1289,7 @@ def test_channelstate_unlock():
         closed_block_number,
     )
     iteration = channel.handle_channel_closed(channel_state, state_change)
-    assert must_contain_entry(iteration.events, ContractSendChannelUnlock, {})
+    assert must_contain_entry(iteration.events, ContractSendChannelBatchUnlock, {})
 
 
 def test_channel_unlock_must_not_change_merkletree():

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -12,7 +12,7 @@ from raiden.transfer.events import (
     ContractSendChannelClose,
     ContractSendChannelSettle,
     ContractSendChannelUpdateTransfer,
-    ContractSendChannelUnlock,
+    ContractSendChannelBatchUnlock,
     EventTransferReceivedInvalidDirectTransfer,
     EventTransferReceivedSuccess,
     EventTransferSentFailed,
@@ -1386,7 +1386,7 @@ def handle_channel_closed(
 
         unlock_proofs = get_known_unlocks(channel_state.partner_state)
         if unlock_proofs:
-            onchain_unlock = ContractSendChannelUnlock(
+            onchain_unlock = ContractSendChannelBatchUnlock(
                 channel_state.identifier,
                 unlock_proofs,
             )
@@ -1449,7 +1449,7 @@ def handle_channel_settled2(
 
         unlock_proofs = get_batch_unlock(channel_state.partner_state)
         if unlock_proofs:
-            onchain_unlock = ContractSendChannelUnlock(
+            onchain_unlock = ContractSendChannelBatchUnlock(
                 channel_state.identifier,
                 unlock_proofs,
             )
@@ -1533,7 +1533,7 @@ def handle_channel_unlock(
         if is_lock_pending(our_state, secrethash):
             lock = get_lock(our_state, secrethash)
             proof = compute_proof_for_lock(our_state, secret, lock)
-            unlock = ContractSendChannelUnlock(channel_state.identifier, [proof])
+            unlock = ContractSendChannelBatchUnlock(channel_state.identifier, [proof])
             events.append(unlock)
 
         register_secret(channel_state, secret, secrethash)

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -83,7 +83,7 @@ class ContractSendChannelUpdateTransfer(Event):
         return not self.__eq__(other)
 
 
-class ContractSendChannelUnlock(Event):
+class ContractSendChannelBatchUnlock(Event):
     """ Event emitted when the lock must be claimed on-chain. """
 
     def __init__(self, channel_identifier, unlock_proofs):
@@ -91,14 +91,14 @@ class ContractSendChannelUnlock(Event):
         self.unlock_proofs = unlock_proofs
 
     def __repr__(self):
-        return '<ContractSendChannelUnlock channel:{} unlock_proofs:{}>'.format(
+        return '<ContractSendChannelBatchUnlock channel:{} unlock_proofs:{}>'.format(
             pex(self.channel_identifier),
             self.unlock_proofs,
         )
 
     def __eq__(self, other):
         return (
-            isinstance(other, ContractSendChannelUnlock) and
+            isinstance(other, ContractSendChannelBatchUnlock) and
             self.channel_identifier == other.channel_identifier and
             self.unlock_proofs == other.unlock_proofs
         )

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 from raiden.transfer import channel
 from raiden.transfer.architecture import TransitionResult
 from raiden.transfer.events import (
-    ContractSendChannelUnlock,
+    ContractSendChannelBatchUnlock,
     SendProcessed,
 )
 from raiden.transfer.mediated_transfer.events import (
@@ -726,7 +726,7 @@ def events_for_unlock_if_closed(
                 secret,
                 lock,
             )
-            unlock = ContractSendChannelUnlock(
+            unlock = ContractSendChannelBatchUnlock(
                 payer_channel.identifier,
                 [unlock_proof],
             )

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -456,7 +456,7 @@ class MediationPairState(State):
         'payer_pending',
         'payer_secret_revealed',    # SendRevealSecret was sent
         'payer_waiting_close',      # ContractSendChannelClose was sent
-        'payer_waiting_unlock',   # ContractSendChannelUnlock was sent
+        'payer_waiting_unlock',   # ContractSendChannelBatchUnlock was sent
         'payer_contract_unlock',  # ContractReceiveChannelUnlock for the above send received
         'payer_balance_proof',      # ReceiveUnlock was received
         'payer_expired',            # None of the above happened and the lock expired


### PR DESCRIPTION
As suggested in https://github.com/raiden-network/raiden/pull/1560#discussion_r196388864

Rename `ContractSendChannelUnlock` to `ContractSendChannelBatchUnlock`
Add `_send` in contract-related raiden event handlers names

bors r+