### PR TITLE
Travis speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ script:
 after_script:
   - coveralls
 notifications:
-  slack:
-    secure: Q8/IZikyfs/tzB6UsAgdQ9PAXQUeU5SN6uBRayvFX/gqVoLhB0uQLNXgHoM8x/mnR6w3voVtpNtEqIsCEbxhVqk5ckybVup4pt7vGH9ssElTffhu09TwbfUZpDCUUUMXjBbELAaO9ArOI0h0QLu5yR54eJtX3/EjcP1vUye/urn24YarAwLeV3lSEIQsWpaCAMM0WpRrKcYKb09bWI+uzSumZclUEV3oal84cTEFiZ5YAcUOVB89pfjg4gyl2nIk93v58UeDdxrFBtuGs4AjDpP3xDiPgFlRPgD9xZM4VD99+osVlKi9xJ5jly4c6sg5t5HvU6UXbkYjHZN6EV8n+RYxxR4c3/EL7OkD3PxUBqNyN0YjAkQbXOrmc7MndNJyAx3X+btgC9FbyzB9KALlzb+BWNMBXyZC/IFWiu3TtESz9f7wIxmkLyGwkzw7NvJBKmwqQRXLFnkL61AQESTA8X0U1Ibwy6tt8UK6UqkrU6NELMGd/F3wppLBgKCWJDWqgppG3Da2ZaP829KlmwioSWK/ZrqESRLysJ1bk8XPMlBF4SwVFIxBrWDM33QYjKTzifSEItfxP9y0PnQ0fMzdLgbXRMF3ubmbBE0PZdxibY9K+cueP0aKtkswSP+KUfpKtHmV2LKgtsRXEgM1AnTOoQJ2kQ4KszT6sljIvncxVx8=
   webhooks:
   - secure: IXBsyQtH29Vkh+Pe2exrbE3L8FJMQFqJ8ZRxkACts7cQtB8Iz1vyjWg9nYE9ZuCj/JWEeMZd/09JvwwKUj8ZEzwj59gFwVQFwTAxJbiDLRsn7WpdI5Q2fQ9ZPZIAbPo/mJejeHC+z3d5UgY72hbhqWuPJAa4ApWWKE5mPFUIr9uxgs01ReWs/y5HaPawQkSQAKVWWsS5R52Oyr9CYQNbfqfWcoLvzdiIZpsBi2r4ZK3NGrBZPGo4b+PkDkWjuBhMJ0FVABFCJT/bT2ORFsmsCDwZ4I3vOrKtJGDybmwONZqr0ymfYo1lbcUp0mE0zJ0ApyRtLqEFiTzaQqenlAZmBAtpDZVvpxFuDwZgFxafpNutO3Aj3Xbfe+aaooPfHA7SoxmxG/3gWY+OyaME8EDePfBHM0c1gGsNHmbPLt8k0lmwYKlNTFtFFyRAbL3700j19utkGroOK6CUYbed9YD96UehQTj7HN8rpLTZzSMh39c1JHVyqxsUZKkhQgY4GPgx2RAIiCVrwc6wN3Ebtwft0hA2UhvDodsc/qBAyz/YnSp2oKZKagLy5747torZybtNOGKCaV2fT3mSTxV2UNwPJ/N94dlTquJNx3StHT0IqD3Kfo5HYKJKHeri6lttTDul3rjAs1xxB2aAMutsyg7dRbBMmuKlK9gAtoS3UKthQdk=
 stages:
@@ -58,6 +56,7 @@ jobs:
       install: pip install -r requirements-lint.txt
       before_script: /bin/true
       script: make lint
+      after_script: /bin/true
       env: LINT=1 TEST=""
     - stage: deploy
       if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 before_script:
   ./.travis/before_script.sh
 script:
-  - coverage run -m py.test -Wd --travis-fold=always -vvvvvv --log-config='raiden:DEBUG' --random --blockchain-type=geth $TRANSPORT_OPTIONS $TEST
+  - ./.travis/run.sh
 after_script:
   - coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,19 @@ notifications:
     secure: Q8/IZikyfs/tzB6UsAgdQ9PAXQUeU5SN6uBRayvFX/gqVoLhB0uQLNXgHoM8x/mnR6w3voVtpNtEqIsCEbxhVqk5ckybVup4pt7vGH9ssElTffhu09TwbfUZpDCUUUMXjBbELAaO9ArOI0h0QLu5yR54eJtX3/EjcP1vUye/urn24YarAwLeV3lSEIQsWpaCAMM0WpRrKcYKb09bWI+uzSumZclUEV3oal84cTEFiZ5YAcUOVB89pfjg4gyl2nIk93v58UeDdxrFBtuGs4AjDpP3xDiPgFlRPgD9xZM4VD99+osVlKi9xJ5jly4c6sg5t5HvU6UXbkYjHZN6EV8n+RYxxR4c3/EL7OkD3PxUBqNyN0YjAkQbXOrmc7MndNJyAx3X+btgC9FbyzB9KALlzb+BWNMBXyZC/IFWiu3TtESz9f7wIxmkLyGwkzw7NvJBKmwqQRXLFnkL61AQESTA8X0U1Ibwy6tt8UK6UqkrU6NELMGd/F3wppLBgKCWJDWqgppG3Da2ZaP829KlmwioSWK/ZrqESRLysJ1bk8XPMlBF4SwVFIxBrWDM33QYjKTzifSEItfxP9y0PnQ0fMzdLgbXRMF3ubmbBE0PZdxibY9K+cueP0aKtkswSP+KUfpKtHmV2LKgtsRXEgM1AnTOoQJ2kQ4KszT6sljIvncxVx8=
   webhooks:
   - secure: IXBsyQtH29Vkh+Pe2exrbE3L8FJMQFqJ8ZRxkACts7cQtB8Iz1vyjWg9nYE9ZuCj/JWEeMZd/09JvwwKUj8ZEzwj59gFwVQFwTAxJbiDLRsn7WpdI5Q2fQ9ZPZIAbPo/mJejeHC+z3d5UgY72hbhqWuPJAa4ApWWKE5mPFUIr9uxgs01ReWs/y5HaPawQkSQAKVWWsS5R52Oyr9CYQNbfqfWcoLvzdiIZpsBi2r4ZK3NGrBZPGo4b+PkDkWjuBhMJ0FVABFCJT/bT2ORFsmsCDwZ4I3vOrKtJGDybmwONZqr0ymfYo1lbcUp0mE0zJ0ApyRtLqEFiTzaQqenlAZmBAtpDZVvpxFuDwZgFxafpNutO3Aj3Xbfe+aaooPfHA7SoxmxG/3gWY+OyaME8EDePfBHM0c1gGsNHmbPLt8k0lmwYKlNTFtFFyRAbL3700j19utkGroOK6CUYbed9YD96UehQTj7HN8rpLTZzSMh39c1JHVyqxsUZKkhQgY4GPgx2RAIiCVrwc6wN3Ebtwft0hA2UhvDodsc/qBAyz/YnSp2oKZKagLy5747torZybtNOGKCaV2fT3mSTxV2UNwPJ/N94dlTquJNx3StHT0IqD3Kfo5HYKJKHeri6lttTDul3rjAs1xxB2aAMutsyg7dRbBMmuKlK9gAtoS3UKthQdk=
+stages:
+  - lint
+  - test
+  - deploy
 jobs:
   include:
+    - stage: lint
+      sudo: false
+      before_install: /bin/true
+      install: pip install -r requirements-lint.txt
+      before_script: /bin/true
+      script: make lint
+      env: LINT=1 TEST=""
     - stage: deploy
       if: tag IS present
       before_install: mkdir -p $HOME/.bin; export PATH=$PATH:$HOME/.bin; ./.travis/before_install.sh

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 set -x
 
-if [ -z "$RUN_SYNAPSE" ]; then
+if [[ -z ${RUN_SYNAPSE} ]]; then
     raiden smoketest
 else
     raiden --transport=matrix smoketest --local-matrix="${HOME}/.bin/run_synapse.sh"

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -3,8 +3,6 @@
 set -e
 set -x
 
-make lint
-python setup.py check --restructuredtext --strict
 if [ -z "$RUN_SYNAPSE" ]; then
     raiden smoketest
 else

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -12,7 +12,7 @@ fi
 pip install ${INSTALL_OPT} -U pip wheel coveralls "coverage<4.4"
 pip install ${INSTALL_OPT} pytest-travis-fold
 pip install ${INSTALL_OPT} pyinstaller
-pip install ${INSTALL_OPT} -r requirements-dev.txt
+pip install ${INSTALL_OPT} -U -r requirements-dev.txt
 pip install ${INSTALL_OPT} -e .
 
 pip list --outdated

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -11,7 +11,6 @@ fi
 
 pip install ${INSTALL_OPT} -U pip wheel coveralls "coverage<4.4"
 pip install ${INSTALL_OPT} pytest-travis-fold
-pip install ${INSTALL_OPT} readme_renderer
 pip install ${INSTALL_OPT} pyinstaller
 pip install ${INSTALL_OPT} -r requirements-dev.txt
 pip install ${INSTALL_OPT} -e .

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -9,10 +9,10 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     INSTALL_OPT="--user"
 fi
 
-pip install ${INSTALL_OPT} -U pip wheel coveralls "coverage<4.4"
+pip install ${INSTALL_OPT} --upgrade pip wheel coveralls "coverage<4.4"
 pip install ${INSTALL_OPT} pytest-travis-fold
 pip install ${INSTALL_OPT} pyinstaller
-pip install ${INSTALL_OPT} -U -r requirements-dev.txt
+pip install ${INSTALL_OPT} --upgrade --upgrade-strategy eager -r requirements-dev.txt
 pip install ${INSTALL_OPT} -e .
 
 pip list --outdated

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
+    BLOCKCHAIN_TYPE="geth"
+else
+    BLOCKCHAIN_TYPE="eth-tester"
+fi
+
+coverage run \
+    -m py.test \
+    -Wd \
+    --travis-fold=always \
+    -vvvvvv \
+    --log-config='raiden:DEBUG' \
+    --random \
+    --blockchain-type=${BLOCKCHAIN_TYPE} \
+    ${TRANSPORT_OPTIONS} \
+    ${TEST}

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -5,7 +5,8 @@ set -ex
 if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
     BLOCKCHAIN_TYPE="geth"
 else
-    BLOCKCHAIN_TYPE="tester"
+    # FIXME: chagne to "tester" once the test failures are fixed
+    BLOCKCHAIN_TYPE="geth"
 fi
 
 coverage run \

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -5,7 +5,7 @@ set -ex
 if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
     BLOCKCHAIN_TYPE="geth"
 else
-    BLOCKCHAIN_TYPE="eth-tester"
+    BLOCKCHAIN_TYPE="tester"
 fi
 
 coverage run \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ clean-test:
 
 lint:
 	flake8 raiden/ tools/
+	python setup.py check --restructuredtext --strict
 
 test:
 	python setup.py test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,8 @@
 -r requirements.txt
 
+# Split out to allow quicker lint turnaround on CI
+-r requirements-lint.txt
+
 # Testing
 pytest==3.6.0
 pytest-timeout==1.2.1
@@ -7,10 +10,6 @@ pytest-random==0.02
 pytest-cov==2.5.1
 flaky==3.4.0
 grequests==0.3.0
-flake8==3.5.0
-flake8-bugbear==18.2.0
-flake8-commas==2.0.0
-flake8-tuple==0.2.13
 mirakuru==0.9.0
 
 # Debugging

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 -r requirements-lint.txt
 
 # Testing
-pytest==3.6.0
+pytest==3.6.2
 pytest-timeout==1.2.1
 pytest-random==0.02
 pytest-cov==2.5.1

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,5 @@
+flake8==3.5.0
+flake8-bugbear==18.2.0
+flake8-commas==2.0.0
+flake8-tuple==0.2.13
+readme-renderer==21.0


### PR DESCRIPTION
- ~Uses `eth-tester` during 'regular' Travis runs (PR, pushes, etc.).~ (Only infrastructure for now, the switch will happen once the test failures with tester are fixed)
- `Geth` is only tested during a once a day cron run
- Splits linting out into a separate build stage so failures terminate quicker
