### PR TITLE
Secret reveal mediator

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -33,6 +33,7 @@ from raiden.transfer.state import (
 from raiden.transfer.state_change import Block
 from raiden.transfer.events import ContractSendSecretReveal
 from raiden.tests.utils import factories
+from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.factories import (
     ADDR,
     HOP1,
@@ -1111,8 +1112,9 @@ def test_events_for_onchain_secretreveal():
         block_number,
     )
 
-    assert isinstance(events[0], ContractSendSecretReveal)
-    assert events[0].secret == UNIT_SECRET
+    assert must_contain_entry(events, ContractSendSecretReveal, {
+        'secret': UNIT_SECRET,
+    })
 
 
 def test_events_for_close_hold_for_unpaid_payee():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -104,7 +104,7 @@ def test_events_for_close():
     assert events[0].channel_identifier == from_route.channel_identifier
 
 
-def test_events_for_onchain_secretregister():
+def test_events_for_onchain_secretreveal():
     """ Secret must be registered on-chain when the unsafe region is reached and
     the secret is known.
     """
@@ -141,10 +141,10 @@ def test_events_for_onchain_secretregister():
     unsafe_to_wait = expiration - from_channel.reveal_timeout
 
     state = TargetTransferState(from_route, from_transfer)
-    events = target.events_for_onchain_secretregister(state, from_channel, safe_to_wait)
+    events = target.events_for_onchain_secretreveal(state, from_channel, safe_to_wait)
     assert not events
 
-    events = target.events_for_onchain_secretregister(state, from_channel, unsafe_to_wait)
+    events = target.events_for_onchain_secretreveal(state, from_channel, unsafe_to_wait)
     assert events
     assert isinstance(events[0], ContractSendSecretReveal)
     assert events[0].secret == UNIT_SECRET

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -47,7 +47,7 @@ def events_for_close(target_state, channel_state, block_number):
     return list()
 
 
-def events_for_onchain_secretregister(target_state, channel_state, block_number):
+def events_for_onchain_secretreveal(target_state, channel_state, block_number):
     """ Emits the event for revealing the secret on-chain if the transfer cannot
     to be settled off-chain.
     """
@@ -68,7 +68,7 @@ def events_for_onchain_secretregister(target_state, channel_state, block_number)
             channel_state.partner_state,
             transfer.lock.secrethash,
         )
-        return secret_registry.events_for_onchain_secretregister(
+        return secret_registry.events_for_onchain_secretreveal(
             channel_state,
             block_number,
             secret,
@@ -234,7 +234,7 @@ def handle_block(target_state, channel_state, block_number):
         # TODO: to be removed
         events = events_for_close(target_state, channel_state, block_number)
 
-        events.extend(events_for_onchain_secretregister(target_state, channel_state, block_number))
+        events.extend(events_for_onchain_secretreveal(target_state, channel_state, block_number))
     else:
         events = list()
 

--- a/raiden/transfer/secret_registry.py
+++ b/raiden/transfer/secret_registry.py
@@ -9,7 +9,7 @@ from raiden.transfer.state import (
 )
 
 
-def events_for_onchain_secretregister(
+def events_for_onchain_secretreveal(
         channel_state: NettingChannelState,
         block_number: typing.BlockNumber,
         secret: typing.Secret,


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden/issues/1584

- adds logic to reveal the secret on-chain in the unsafe region, for the `mediator`
- unit test