### PR TITLE
Fix typo in set_secret

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -435,7 +435,7 @@ def set_secret(state, channelidentifiers_to_channels, secret, secrethash):
         )
 
         payee_channel = channelidentifiers_to_channels[
-            pair.payer_transfer.balance_proof.channel_address
+            pair.payee_transfer.balance_proof.channel_address
         ]
         channel.register_secret(
             payee_channel,


### PR DESCRIPTION
This doesn't make sense right now as `payer_channel` and `payee_channel` would be the same.

- [ ] Write a test for this