### PR TITLE
New handle close channel - handle_contract_send_channelclose2

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -29,6 +29,7 @@ from raiden.transfer.mediated_transfer.events import (
     SendRevealSecret,
     SendSecretRequest,
 )
+from raiden.transfer.balance_proof import hash_balance_data
 from raiden.utils import pex
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
@@ -205,6 +206,38 @@ def handle_contract_send_channelclose(
     )
 
 
+def handle_contract_send_channelclose2(
+        raiden: RaidenService,
+        channel_close_event: ContractSendChannelClose,
+):
+    balance_proof = channel_close_event.balance_proof
+
+    if balance_proof:
+        nonce = balance_proof.nonce
+        balance_hash = hash_balance_data(
+            balance_proof.transferred_amount,
+            balance_proof.locked_amount,
+            balance_proof.locksroot,
+        )
+        signature = balance_proof.signature
+        message_hash = balance_proof.message_hash
+
+    else:
+        nonce = 0
+        balance_hash = b''
+        signature = b''
+        message_hash = b''
+
+    channel = raiden.chain.payment_channel(channel_close_event.channel_identifier)
+
+    channel.close(
+        nonce,
+        balance_hash,
+        message_hash,
+        signature,
+    )
+
+
 def handle_contract_send_channelupdate(
         raiden: RaidenService,
         channel_update_event: ContractSendChannelUpdateTransfer,
@@ -283,6 +316,7 @@ def on_raiden_event(raiden: RaidenService, event: Event):
         handle_contract_send_secretreveal(raiden, event)
     elif type(event) == ContractSendChannelClose:
         handle_contract_send_channelclose(raiden, event)
+        # handle_contract_send_channelclose2(raiden, event)
     elif type(event) == ContractSendChannelUpdateTransfer:
         handle_contract_send_channelupdate(raiden, event)
     elif type(event) == ContractSendChannelBatchUnlock:


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden/issues/1619

- use `balance_hash`
- use new channel proxy