### PR TITLE
Remove usage of raiden.utils.decode_hex function

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -35,14 +35,6 @@ def random_secret():
     return os.urandom(32)
 
 
-def decode_hex(s) -> bytes:
-    if isinstance(s, str):
-        return bytes.fromhex(s)
-    if isinstance(s, (bytes, bytearray)):
-        return unhexlify(s)
-    raise TypeError('Value must be an instance of str or bytes')
-
-
 def sha3(data: bytes) -> bytes:
     return keccak(data)
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import json
 import os
-from binascii import hexlify
 
 import click
 import structlog
@@ -10,7 +9,7 @@ from eth_utils import to_checksum_address
 from raiden.log_config import configure_logging
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.ui.cli import prompt_account
-from raiden.utils import decode_hex, get_contract_path
+from raiden.utils import get_contract_path
 from raiden.utils.solc import compile_files_cwd
 
 log = structlog.get_logger(__name__)
@@ -112,9 +111,9 @@ def deploy_all(client):
     return deployed
 
 
-def get_privatekey_hex(keystore_path):
-    address_hex, privatekey_bin = prompt_account(None, keystore_path, None)
-    return hexlify(privatekey_bin)
+def get_privatekey(keystore_path):
+    address_hex, privatekey = prompt_account(None, keystore_path, None)
+    return privatekey
 
 
 @click.command(help="Deploy the Raiden smart contracts.\n\n"
@@ -127,9 +126,7 @@ def get_privatekey_hex(keystore_path):
 def main(keystore_path, pretty, gas_price, port):
     configure_logging({'': 'DEBUG'}, colorize=True)
 
-    privatekey_hex = get_privatekey_hex(keystore_path)
-
-    privatekey = decode_hex(privatekey_hex)
+    privatekey = get_privatekey(keystore_path)
 
     gas_price_in_wei = gas_price * 1000000000
     patch_deploy_solidity_contract()

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -10,6 +10,8 @@ import gevent
 from gevent import monkey, server
 import structlog
 
+from eth_utils import decode_hex
+
 from raiden.app import App
 from raiden.api.python import RaidenAPI
 from raiden.network.blockchain_service import BlockChainService
@@ -19,7 +21,7 @@ from raiden.network.protocol import UDPTransport
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
 from raiden.ui.console import ConsoleTools
-from raiden.utils import split_endpoint, decode_hex
+from raiden.utils import split_endpoint
 from raiden.settings import GAS_PRICE
 
 monkey.patch_all()


### PR DESCRIPTION
Get rid of all usages of `raiden.utils.decode_hex` function.

Related to #1422