### PR TITLE
New send settle transaction handler & event

### DIFF
--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -117,7 +117,6 @@ class PaymentChannel:
             transferred_amount: int,
             locked_amount: int,
             locksroot: typing.Locksroot,
-            partner: typing.Address,
             partner_transferred_amount: int,
             partner_locked_amount: int,
             partner_locksroot: typing.Locksroot,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -308,6 +308,24 @@ def handle_contract_send_channelsettle(
     channel.settle()
 
 
+def handle_contract_send_channelsettle2(
+        raiden: RaidenService,
+        channel_settle_event: ContractSendChannelSettle,
+):
+    channel = raiden.chain.payment_channel(channel_settle_event.channel_identifier)
+    our_balance_proof = channel_settle_event.our_balance_proof
+    partner_balance_proof = channel_settle_event.partner_balance_proof
+
+    channel.settle(
+        our_balance_proof.transferred_amount,
+        our_balance_proof.locked_amount,
+        our_balance_proof.locksroot,
+        partner_balance_proof.transferred_amount,
+        partner_balance_proof.locked_amount,
+        partner_balance_proof.locksroot,
+    )
+
+
 def on_raiden_event(raiden: RaidenService, event: Event):
     # pylint: disable=too-many-branches
 
@@ -343,6 +361,7 @@ def on_raiden_event(raiden: RaidenService, event: Event):
         handle_contract_send_channelunlock(raiden, event)
     elif type(event) == ContractSendChannelSettle:
         handle_contract_send_channelsettle(raiden, event)
+        # handle_contract_send_channelsettle2(raiden, event)
     elif type(event) in UNEVENTFUL_EVENTS:
         pass
     else:

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1524,7 +1524,11 @@ def handle_block(
                 None,
                 None,
             )
-            event = ContractSendChannelSettle(channel_state.identifier)
+            event = ContractSendChannelSettle(
+                channel_state.identifier,
+                channel_state.our_state.balance_proof,
+                channel_state.partner_state.balance_proof,
+            )
             events.append(event)
 
     while is_deposit_confirmed(channel_state, block_number):

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -3,6 +3,7 @@ from raiden.transfer.architecture import (
     Event,
     SendMessageEvent,
 )
+from raiden.transfer.state import BalanceProofSignedState, BalanceProofUnsignedState
 from raiden.utils import pex, typing, sha3
 # pylint: disable=too-many-arguments,too-few-public-methods
 
@@ -40,8 +41,38 @@ class ContractSendChannelClose(Event):
 class ContractSendChannelSettle(Event):
     """ Event emitted if the netting channel must be settled. """
 
-    def __init__(self, channel_identifier):
+    def __init__(
+            self,
+            channel_identifier: typing.ChannelID,
+            our_balance_proof: typing.Union[
+                BalanceProofSignedState,
+                BalanceProofUnsignedState,
+                None,
+            ],
+            partner_balance_proof: typing.Union[
+                BalanceProofSignedState,
+                BalanceProofUnsignedState,
+                None,
+            ],
+    ):
+        if not isinstance(channel_identifier, typing.T_ChannelID):
+            raise ValueError('channel_identifier must be a ChannelID instance')
+
+        if our_balance_proof and not isinstance(
+            our_balance_proof,
+            (BalanceProofUnsignedState, BalanceProofSignedState),
+        ):
+            raise ValueError('our_balance_proof must be a BalanceProofSignedState instance')
+
+        if partner_balance_proof and not isinstance(
+            partner_balance_proof,
+            (BalanceProofUnsignedState, BalanceProofSignedState),
+        ):
+            raise ValueError('partner_balance_proof must be a BalanceProofSignedState instance')
+
         self.channel_identifier = channel_identifier
+        self.our_balance_proof = our_balance_proof
+        self.partner_balance_proof = partner_balance_proof
 
     def __repr__(self):
         return '<ContractSendChannelSettle channel:{}>'.format(
@@ -51,7 +82,9 @@ class ContractSendChannelSettle(Event):
     def __eq__(self, other):
         return (
             isinstance(other, ContractSendChannelSettle) and
-            self.channel_identifier == other.channel_identifier
+            self.channel_identifier == other.channel_identifier and
+            self.our_balance_proof == other.our_balance_proof and
+            self.partner_balance_proof == other.partner_balance_proof
         )
 
     def __ne__(self, other):


### PR DESCRIPTION
fixes https://github.com/raiden-network/raiden/issues/1622

- event now contains the participant's balance proofs
- new raiden event handler `handle_contract_send_channelsettle2`