### PR TITLE
Remove unused slot at TargetTransferstate

### DIFF
--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -164,7 +164,6 @@ class TargetTransferState(State):
         'route',
         'transfer',
         'secret',
-        'hahslock',
         'state',
     )
 


### PR DESCRIPTION
Funny story on how I spotted that. I was grepping for "hashlock" but mispelled
it and came across that little beauty.