### PR TITLE
simplified random_marker fixture

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -19,9 +19,6 @@ gevent.get_hub().SYSTEM_ERROR = BaseException
 gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
 
 
-CATCH_LOG_HANDLER_NAME = 'catch_log_handler'
-
-
 def pytest_addoption(parser):
     parser.addoption(
         '--blockchain-type',

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -15,9 +15,6 @@ from raiden.exceptions import RaidenShuttingDown
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.log_config import configure_logging
 
-gevent.get_hub().SYSTEM_ERROR = BaseException
-gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
-
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -3,7 +3,7 @@ import os
 import random
 
 import pytest
-from eth_utils import to_normalized_address
+from eth_utils import to_normalized_address, remove_0x_prefix
 from raiden.network.utils import get_free_port
 
 from raiden.utils import privatekey_to_address
@@ -63,9 +63,7 @@ def random_marker():
     value.
     """
     random_hex = hex(random.getrandbits(100))
-
-    # strip the leading 0x and trailing L
-    return random_hex[2:-1]
+    return remove_0x_prefix(random_hex)
 
 
 @pytest.fixture

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -75,12 +75,6 @@ def deposit():
 
 
 @pytest.fixture
-def both_participants_deposit():
-    """ Boolean flag indicating if both participants of a channel put a deposit. """
-    return True
-
-
-@pytest.fixture
 def number_of_tokens():
     """ Number of tokens pre-registered in the test Registry. """
     return 1


### PR DESCRIPTION
python3 doesnt add the `L` suffix to the hex encoded number, and we can
use the eth_utils tools to remove the `0x` prefix