### PR TITLE
Do not skip events in case some blocks are missing

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -322,6 +322,9 @@ class BlockchainEvents:
         self.event_listeners = list()
 
     def add_event_listener(self, event_name, eth_filter, abi):
+        existing_listeners = [x.event_name for x in self.event_listeners]
+        if event_name in existing_listeners:
+            return
         event = EventListener(
             event_name,
             eth_filter,
@@ -348,7 +351,7 @@ class BlockchainEvents:
             channel_manager_proxy,
             from_block: typing.BlockSpecification = 'latest',
     ):
-        channelnew = channel_manager_proxy.channelnew_filter(from_block)
+        channelnew = channel_manager_proxy.channelnew_filter(from_block=from_block)
         manager_address = channel_manager_proxy.address
 
         self.add_event_listener(
@@ -376,7 +379,7 @@ class BlockchainEvents:
             netting_channel_proxy,
             from_block: typing.BlockSpecification = 'latest',
     ):
-        netting_channel_events = netting_channel_proxy.all_events_filter(from_block)
+        netting_channel_events = netting_channel_proxy.all_events_filter(from_block=from_block)
         channel_address = netting_channel_proxy.address
 
         self.add_event_listener(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -54,11 +54,17 @@ def handle_tokennetwork_new(raiden, event, current_block_number):
 
     # Install the filters first to avoid missing changes, as a consequence
     # some events might be applied twice.
-    raiden.blockchain_events.add_channel_manager_listener(manager_proxy)
+    raiden.blockchain_events.add_channel_manager_listener(
+        manager_proxy,
+        from_block=data['blockNumber'],
+    )
     for channel_proxy in netting_channel_proxies:
-        raiden.blockchain_events.add_netting_channel_listener(channel_proxy)
+        raiden.blockchain_events.add_netting_channel_listener(
+            channel_proxy,
+            from_block=data['blockNumber'],
+        )
 
-    token_address = data_decoder(event.event_data['args']['token_address'])
+    token_address = data_decoder(data['args']['token_address'])
 
     token_network_state = TokenNetworkState(
         manager_address,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -88,7 +88,10 @@ def handle_tokennetwork_new2(raiden, event, current_block_number):
         token_network_registry_address,
     )
     token_network_proxy = token_network_registry_proxy.token_network(token_network_address)
-    raiden.blockchain_events.add_token_network_listener(token_network_proxy)
+    raiden.blockchain_events.add_token_network_listener(
+        token_network_proxy,
+        from_block=data['blockNumber'],
+    )
 
     token_address = data_decoder(event.event_data['args']['token_address'])
 
@@ -143,7 +146,10 @@ def handle_channel_new(raiden, event, current_block_number):
         #
         # TODO: install the filter on the same block or previous block in which
         # the channel state was queried
-        raiden.blockchain_events.add_netting_channel_listener(channel_proxy)
+        raiden.blockchain_events.add_netting_channel_listener(
+            channel_proxy,
+            from_block=data['blockNumber'],
+        )
 
     else:
         new_route = ContractReceiveRouteNew(

--- a/raiden/tests/integration/fixtures/backend_tester.py
+++ b/raiden/tests/integration/fixtures/backend_tester.py
@@ -14,6 +14,7 @@ def fund_accounts(web3, blockchain_type, faucet_address, private_keys, ethereum_
         if to_checksum_address(privatekey_to_address(key)) not in ethereum_tester.get_accounts():
             ethereum_tester.add_account(encode_hex(key))
 
+    for key in private_keys:
         ethereum_tester.send_transaction({
             'from': faucet_address,
             'to': to_checksum_address(privatekey_to_address(key)),

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -1,5 +1,6 @@
 import os
 import itertools
+import gevent
 
 import pytest
 from eth_utils import to_canonical_address, is_address, is_same_address
@@ -66,6 +67,15 @@ def test_new_netting_contract(raiden_network, token_amount, settle_timeout):
         peer1_address,
         settle_timeout,
     )
+    exception = RuntimeError("Timeout while waiting for a new channel")
+    with gevent.Timeout(seconds=10, exception=exception):
+        waiting.wait_for_newchannel(
+            app1.raiden,
+            registry_address,
+            token_address,
+            app0.raiden.address,
+            app1.raiden.alarm.wait_time,
+        )
 
     # check contract state
     netting_channel_01 = blockchain_service0.netting_channel(netting_address_01)


### PR DESCRIPTION
- new filter for netting channel & registry is created with a block number of the event. Default value of `pending` can't be used, because if alarm misses some blocks, some events might be missing.
- `BlockchainEvents::add_event_listener()` now won't add a listener if a listener with a same name already exists (maybe we can change `event_listeners` from `list` to `dict`)