### PR TITLE
[WIP] Remove usage of [un]hexlify functions

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -2,9 +2,10 @@ import getpass
 import json
 import os
 import sys
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 from typing import Dict
 
+from eth_utils import encode_hex
 from eth_keyfile import decode_keyfile_json
 import structlog
 
@@ -212,7 +213,7 @@ class Account:
             'version': self.keystore['version'],
         }
         if include_address and self.address is not None:
-            d['address'] = hexlify(self.address)
+            d['address'] = encode_hex(self.address)
         if include_id and self.uuid is not None:
             d['id'] = self.uuid
         return json.dumps(d)
@@ -308,7 +309,7 @@ class Account:
 
     def __repr__(self):
         if self.address is not None:
-            address = hexlify(self.address)
+            address = encode_hex(self.address)
         else:
             address = '?'
         return '<Account(address={address}, id={id})>'.format(address=address, id=self.uuid)

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -1,5 +1,4 @@
 import binascii
-from binascii import unhexlify
 
 from marshmallow import (
     fields,
@@ -16,6 +15,7 @@ from werkzeug.routing import (
 )
 from eth_utils import (
     encode_hex,
+    decode_hex,
     is_checksum_address,
     to_checksum_address,
 )
@@ -53,7 +53,7 @@ class HexAddressConverter(BaseConverter):
             raise ValidationError()
 
         try:
-            value = unhexlify(value[2:])
+            value = decode_hex(value)
         except TypeError:
             raise ValidationError()
 
@@ -85,7 +85,7 @@ class AddressField(fields.Field):
             self.fail('invalid_checksum')
 
         try:
-            value = unhexlify(value[2:])
+            value = decode_hex(value)
         except binascii.Error:
             self.fail('invalid_data')
 

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -14,7 +14,11 @@ from werkzeug.routing import (
     BaseConverter,
     ValidationError,
 )
-from eth_utils import is_checksum_address, to_checksum_address
+from eth_utils import (
+    encode_hex,
+    is_checksum_address,
+    to_checksum_address,
+)
 
 
 from raiden.api.objects import (
@@ -37,7 +41,7 @@ from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     CHANNEL_STATE_SETTLED,
 )
-from raiden.utils import data_encoder, data_decoder
+from raiden.utils import data_decoder
 
 
 class HexAddressConverter(BaseConverter):
@@ -93,7 +97,7 @@ class AddressField(fields.Field):
 
 class DataField(fields.Field):
     def _serialize(self, value, attr, obj):
-        return data_encoder(value)
+        return encode_hex(value)
 
     def _deserialize(self, value, attr, data):
         return data_decoder(value)

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,8 +1,7 @@
 import filelock
 import sys
 import structlog
-from binascii import unhexlify
-from eth_utils import to_normalized_address
+from eth_utils import to_normalized_address, decode_hex
 from typing import Dict
 
 import gevent
@@ -94,14 +93,14 @@ class App:  # pylint: disable=too-few-public-methods
                 chain,
                 default_registry,
                 default_secret_registry,
-                unhexlify(config['privatekey_hex']),
+                decode_hex(config['privatekey_hex']),
                 transport,
                 config,
                 discovery,
             )
         except filelock.Timeout:
             pubkey = to_normalized_address(
-                privatekey_to_address(unhexlify(self.config['privatekey_hex'])),
+                privatekey_to_address(decode_hex(config['privatekey_hex'])),
             )
             print(
                 f'FATAL: Another Raiden instance already running for account {pubkey} on '

--- a/raiden/network/proxies/registry.py
+++ b/raiden/network/proxies/registry.py
@@ -1,7 +1,8 @@
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 
 import structlog
 from eth_utils import (
+    encode_hex,
     is_binary_address,
     to_checksum_address,
     to_normalized_address,
@@ -203,7 +204,7 @@ class Registry:
 
             if manager_address is None:
                 raise NoTokenManager(
-                    'Manager for token 0x{} does not exist'.format(hexlify(token_address)),
+                    'Manager for token {} does not exist'.format(encode_hex(token_address)),
                 )
 
             manager = ChannelManager(

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -1,4 +1,4 @@
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 from typing import Optional
 
 import structlog
@@ -196,7 +196,7 @@ class TokenNetworkRegistry:
 
             if token_network_address is None:
                 raise NoTokenManager(
-                    'TokenNetwork for token 0x{} does not exist'.format(hexlify(token_address)),
+                    'TokenNetwork for token {} does not exist'.format(encode_hex(token_address)),
                 )
 
             token_network = TokenNetwork(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -30,7 +30,6 @@ from raiden.exceptions import (
 )
 from raiden.settings import GAS_PRICE, GAS_LIMIT, RPC_CACHE_TTL
 from raiden.utils import (
-    data_encoder,
     privatekey_to_address,
     quantity_encoder,
 )
@@ -167,7 +166,7 @@ def format_data_for_rpccall(
         'value': quantity_encoder(value),
         'gasPrice': quantity_encoder(gasprice),
         'gas': quantity_encoder(startgas),
-        'data': data_encoder(data),
+        'data': encode_hex(data),
     }
 
 
@@ -521,7 +520,7 @@ class JSONRPCClient:
                 'transaction_hash length must be 32 (it might be hex encoded)',
             )
 
-        transaction_hash = data_encoder(transaction_hash)
+        transaction_hash = encode_hex(transaction_hash)
 
         deadline = None
         if timeout:

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -1,5 +1,4 @@
 import socket
-from binascii import hexlify
 
 import cachetools
 import gevent
@@ -9,7 +8,7 @@ from gevent.event import (
 )
 from gevent.server import DatagramServer
 import structlog
-from eth_utils import is_binary_address
+from eth_utils import is_binary_address, encode_hex
 
 from raiden.transfer.architecture import SendMessageEvent
 from raiden.exceptions import (
@@ -444,7 +443,7 @@ class UDPTransport:
             log.error(
                 'INVALID MESSAGE: Packet larger than maximum size',
                 node=pex(self.raiden.address),
-                message=hexlify(messagedata),
+                message=encode_hex(messagedata),
                 length=len(messagedata),
             )
             return
@@ -463,7 +462,7 @@ class UDPTransport:
             log.error(
                 'INVALID MESSAGE: Unknown cmdid',
                 node=pex(self.raiden.address),
-                message=hexlify(messagedata),
+                message=encode_hex(messagedata),
             )
 
     def receive_message(self, message: Message):

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -1,5 +1,8 @@
-from binascii import hexlify
-from eth_utils import denoms, int_to_big_endian
+from eth_utils import (
+    denoms,
+    encode_hex,
+    int_to_big_endian,
+)
 
 INITIAL_PORT = 38647
 
@@ -7,7 +10,7 @@ RPC_CACHE_TTL = 600
 CACHE_TTL = 60
 ESTIMATED_BLOCK_TIME = 7
 GAS_LIMIT = 10 * 10**6
-GAS_LIMIT_HEX = '0x' + hexlify(int_to_big_endian(GAS_LIMIT)).decode('utf-8')
+GAS_LIMIT_HEX = encode_hex(int_to_big_endian(GAS_LIMIT))
 GAS_PRICE = denoms.shannon * 20
 
 DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF = 5

--- a/raiden/tests/utils/blockchain.py
+++ b/raiden/tests/utils/blockchain.py
@@ -1,4 +1,3 @@
-from binascii import hexlify
 import json
 import io
 import os
@@ -110,7 +109,7 @@ def geth_create_account(datadir, privkey):
     """
     keyfile_path = os.path.join(datadir, 'keyfile')
     with open(keyfile_path, 'wb') as handler:
-        handler.write(hexlify(privkey))
+        handler.write(encode_hex(privkey))
 
     password_path = os.path.join(datadir, 'pw')
     with open(password_path, 'w') as handler:
@@ -205,7 +204,7 @@ def geth_wait_and_check(web3, privatekeys, random_marker):
             jsonrpc_running = True
 
             block = response['result']
-            running_marker = block['extraData'][2:len(random_marker) + 2]
+            running_marker = block['extraData']
             if running_marker != random_marker:
                 raise RuntimeError(
                     'the test marker does not match, maybe two tests are running in '

--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -1,4 +1,4 @@
-from binascii import hexlify
+from eth_utils import encode_hex
 
 from raiden.settings import GAS_LIMIT_HEX
 
@@ -17,7 +17,7 @@ GENESIS_STUB = {
     'coinbase': '0x0000000000000000000000000000000000000000',
     'timestamp': '0x00',
     'parentHash': '0x0000000000000000000000000000000000000000000000000000000000000000',
-    'extraData': '0x' + hexlify(b'raiden').decode(),
+    'extraData': encode_hex(b'raiden'),
     'gasLimit': GAS_LIMIT_HEX,
     # add precompiled addresses with minimal balance to avoid deletion
     'alloc': {'%040x' % precompiled: {'balance': '0x1'} for precompiled in range(256)},

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -1,12 +1,11 @@
 """ Utilities to set-up a Raiden network. """
-from binascii import hexlify
 from collections import namedtuple
 from os import environ
 
 import gevent
 from gevent import server
 import structlog
-from eth_utils import decode_hex
+from eth_utils import encode_hex, decode_hex
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY
 
 from raiden import waiting
@@ -255,7 +254,7 @@ def create_apps(
             'port': port,
             'external_ip': host,
             'external_port': port,
-            'privatekey_hex': hexlify(private_key),
+            'privatekey_hex': encode_hex(private_key),
             'reveal_timeout': reveal_timeout,
             'settle_timeout': settle_timeout,
             'database_path': database_paths[idx],

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,4 +1,3 @@
-from binascii import hexlify
 from binascii import unhexlify
 from http import HTTPStatus
 from string import Template
@@ -13,7 +12,11 @@ import tempfile
 import time
 import traceback
 
-from eth_utils import to_checksum_address, to_canonical_address
+from eth_utils import (
+    encode_hex,
+    to_checksum_address,
+    to_canonical_address,
+)
 
 from raiden.accounts import AccountManager
 from raiden.connection_manager import ConnectionManager
@@ -104,7 +107,7 @@ def run_restapi_smoketests(raiden_service, test_config):
 
     response_json = response.json()
     assert (response_json[0]['partner_address'] ==
-            '0x' + hexlify(ConnectionManager.BOOTSTRAP_ADDR).decode())
+            encode_hex(ConnectionManager.BOOTSTRAP_ADDR))
     assert response_json[0]['state'] == 'opened'
     assert response_json[0]['balance'] > 0
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1,7 +1,8 @@
 # pylint: disable=too-many-lines
 import heapq
-from binascii import hexlify
 from collections import namedtuple
+
+from eth_utils import encode_hex
 
 from raiden.constants import UINT256_MAX
 from raiden.transfer.architecture import StateChange, Event
@@ -271,8 +272,8 @@ def is_valid_directtransfer(
             'Invalid DirectTransfer message. '
             "Balance proof's locksroot changed, expected: {} got: {}."
         ).format(
-            hexlify(current_locksroot).decode(),
-            hexlify(received_balance_proof.locksroot).decode(),
+            encode_hex(current_locksroot),
+            encode_hex(received_balance_proof.locksroot),
         )
 
         result = (False, msg)
@@ -324,8 +325,8 @@ def is_valid_directtransfer(
             'Invalid DirectTransfer message. '
             'Balance proof is tied to the wrong channel, expected: {} got: {}'
         ).format(
-            hexlify(channel_state.identifier).decode(),
-            hexlify(received_balance_proof.channel_address).decode(),
+            encode_hex(channel_state.identifier),
+            encode_hex(received_balance_proof.channel_address),
         )
         result = (False, msg)
 
@@ -413,8 +414,8 @@ def is_valid_lockedtransfer(
                 'Invalid LockedTransfer message. '
                 "Balance proof's locksroot didn't match, expected: {} got: {}."
             ).format(
-                hexlify(locksroot_with_lock).decode(),
-                hexlify(received_balance_proof.locksroot).decode(),
+                encode_hex(locksroot_with_lock),
+                encode_hex(received_balance_proof.locksroot),
             )
 
             result = (False, msg, None)
@@ -464,8 +465,8 @@ def is_valid_lockedtransfer(
                 'Invalid LockedTransfer message. '
                 'Balance proof is tied to the wrong channel, expected: {} got: {}'
             ).format(
-                hexlify(channel_state.identifier).decode(),
-                hexlify(received_balance_proof.channel_address).decode(),
+                encode_hex(channel_state.identifier),
+                encode_hex(received_balance_proof.channel_address),
             )
             result = (False, msg, None)
 
@@ -521,14 +522,14 @@ def is_valid_unlock(
     # unlock on-chain for the non-closing party.
     if get_status(channel_state) != CHANNEL_STATE_OPENED:
         msg = 'Invalid Unlock message for {}. The channel is already closed.'.format(
-            hexlify(unlock.secrethash).decode(),
+            encode_hex(unlock.secrethash),
         )
 
         result = (False, msg, None)
 
     elif lock is None:
         msg = 'Invalid Secret message. There is no correspoding lock for {}'.format(
-            hexlify(unlock.secrethash).decode(),
+            encode_hex(unlock.secrethash),
         )
 
         result = (False, msg, None)
@@ -561,8 +562,8 @@ def is_valid_unlock(
             'Invalid Secret message. '
             "Balance proof's locksroot didn't match, expected: {} got: {}."
         ).format(
-            hexlify(locksroot_without_lock).decode(),
-            hexlify(received_balance_proof.locksroot).decode(),
+            encode_hex(locksroot_without_lock),
+            encode_hex(received_balance_proof.locksroot),
         )
 
         result = (False, msg, None)
@@ -601,7 +602,7 @@ def is_valid_unlock(
             'Balance proof is tied to the wrong channel, expected: {} got: {}'
         ).format(
             channel_state.identifier,
-            hexlify(received_balance_proof.channel_address).decode(),
+            encode_hex(received_balance_proof.channel_address),
         )
         result = (False, msg, None)
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 import random
-from binascii import hexlify
 from collections import namedtuple
+from eth_utils import encode_hex
 
 import networkx
 
@@ -680,8 +680,8 @@ class UnlockProofState(State):
         self.secret = secret
 
     def __repr__(self):
-        full_proof = [hexlify(entry) for entry in self.merkle_proof]
-        return f'<UnlockProofState proof:{full_proof} lock:{hexlify(self.lock_encoded)}>'
+        full_proof = [encode_hex(entry) for entry in self.merkle_proof]
+        return f'<UnlockProofState proof:{full_proof} lock:{encode_hex(self.lock_encoded)}>'
 
     def __eq__(self, other):
         return (

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -1,7 +1,6 @@
 import gevent.monkey
 gevent.monkey.patch_all()
 
-from binascii import hexlify
 import sys
 import os
 import tempfile
@@ -20,6 +19,7 @@ import requests
 from eth_utils import (
     to_int,
     denoms,
+    encode_hex,
     to_checksum_address,
     to_normalized_address,
     to_canonical_address,
@@ -552,8 +552,7 @@ def app(
     timeout = max_unresponsive_time / DEFAULT_NAT_KEEPALIVE_RETRIES
     config['transport']['nat_keepalive_timeout'] = timeout
 
-    privatekey_hex = hexlify(privatekey_bin)
-    config['privatekey_hex'] = privatekey_hex
+    config['privatekey_hex'] = encode_hex(privatekey_bin)
 
     rpc_host, rpc_port = eth_endpoint_to_hostport(eth_rpc_endpoint)
 
@@ -878,7 +877,7 @@ def version(short, **kwargs):  # pylint: disable=unused-argument
 @click.pass_context
 def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-argument
     """ Test, that the raiden installation is sane. """
-    import binascii
+    from eth_utils import encode_hex
     from web3.middleware import geth_poa_middleware
     from raiden.api.python import RaidenAPI
     from raiden.blockchain.abi import get_static_or_compile
@@ -950,7 +949,7 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
     port = ethereum_config['rpc']
     web3_client = web3([port])
     web3_client.middleware_stack.inject(geth_poa_middleware, layer=0)
-    random_marker = binascii.hexlify(b'raiden').decode()
+    random_marker = encode_hex(b'raiden')
     privatekeys = []
     geth_wait_and_check(web3_client, privatekeys, random_marker)
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -1,4 +1,3 @@
-from binascii import hexlify
 import errno
 import io
 import logging
@@ -8,7 +7,12 @@ import signal
 import sys
 import time
 
-from eth_utils import denoms, to_checksum_address
+from eth_utils import (
+    denoms,
+    encode_hex,
+    decode_hex,
+    to_checksum_address,
+)
 import gevent
 from gevent.event import Event
 import IPython
@@ -327,7 +331,7 @@ class ConsoleTools:
             contract_path=contract_path,
             timeout=timeout,
         )
-        token_address_hex = hexlify(token_proxy.contract_address)
+        token_address_hex = encode_hex(token_proxy.contract_address)
         if auto_register:
             self.register_token(registry_address, token_address_hex)
         print("Successfully created {}the token '{}'.".format(
@@ -350,7 +354,7 @@ class ConsoleTools:
         registry = self._raiden.chain.registry(registry_address_hex)
 
         # Add the ERC20 token to the raiden registry
-        token_address = safe_address_decode(token_address_hex)
+        token_address = decode_hex(token_address_hex)
         registry.add_token(token_address)
 
         # Obtain the channel manager for the token

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -91,11 +91,6 @@ def address_checksum_and_decode(addr: str) -> typing.Address:
     return addr
 
 
-def data_encoder(data: bytes, length: int = 0) -> str:
-    data = hexlify(data)
-    return '0x' + data.rjust(length * 2, b'0').decode()
-
-
 def data_decoder(data: str) -> bytes:
     assert data[:2] == '0x'
     data = data[2:]  # remove 0x

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -1,4 +1,4 @@
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 import os
 import re
 import string
@@ -10,7 +10,12 @@ from itertools import zip_longest
 
 import gevent
 from coincurve import PrivateKey
-from eth_utils import remove_0x_prefix, keccak, is_checksum_address
+from eth_utils import (
+    keccak,
+    encode_hex,
+    remove_0x_prefix,
+    is_checksum_address,
+)
 
 import raiden
 from raiden import constants
@@ -104,7 +109,7 @@ def quantity_encoder(i: int) -> str:
 
 
 def pex(data: bytes) -> str:
-    return hexlify(data).decode()[:8]
+    return encode_hex(data)[2:10]
 
 
 def lpex(lst: Iterable[bytes]) -> List[str]:


### PR DESCRIPTION
Work is still in progress.

Get rid of some usages of `[un]hexlify` functions where obvious. And also get rid of all usages of `raiden.utils.data_encoder`.

Related to #1654