### PR TITLE
Skip test_echo_node.py::test_event_transfer_received_success if not udp

### DIFF
--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -20,7 +20,7 @@ from raiden.tests.utils.events import (
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('reveal_timeout', [18])
 @pytest.mark.parametrize('settle_timeout', [64])
-def test_event_transfer_received_success(token_addresses, raiden_chain):
+def test_event_transfer_received_success(token_addresses, raiden_chain, skip_if_not_udp):
     app0, app1, app2, receiver_app = raiden_chain
     token_address = token_addresses[0]
 


### PR DESCRIPTION
This test was flaky with Matrix, couldn't reproduce locally, still looking for a proper solution.