### PR TITLE
Fix flaky `raiden_chain` fixture, re-enable tests

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -285,10 +285,13 @@ class BlockchainEvents:
 
     def __init__(self):
         self.event_listeners = list()
-        self.first_run = True
 
     def reset(self):
-        self.first_run = True
+        listeners = [
+            event_listener._replace(first_run=True)
+            for event_listener in self.event_listeners
+        ]
+        self.event_listeners = listeners
 
     def poll_blockchain_events(self):
         # When we test with geth if the contracts have already been deployed

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -285,7 +285,7 @@ class MatrixTransport:
                 username = f'{username}.{rand.randint(0, 0xffffffff):08x}'
 
             try:
-                self._client.login_with_password(username, password)
+                self._client.login(username, password)
                 self.log.info(
                     'LOGIN',
                     homeserver=self._server_name,
@@ -584,7 +584,7 @@ class MatrixTransport:
         room_candidates = self._client.search_room_directory(room_name)
         if room_candidates:
             room = room_candidates[0]
-            if room.room_id not in self._client.get_rooms():
+            if room.room_id not in self._client.rooms:
                 room = self._client.join_room(room.room_id)
         else:
             # no room with expected name => create one and invite peer
@@ -773,7 +773,7 @@ class MatrixTransport:
         room_id = self._address_to_roomid.get(address)
         if not room_id:
             return
-        if room_id not in self._client.get_rooms():
+        if room_id not in self._client.rooms:
             self._address_to_roomid.pop(address)
             return
 

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -368,8 +368,9 @@ class MatrixTransport:
                         discovery=self._discovery_room_alias_full,
                     )
                     return
-                self._address_to_roomid[peer_address] = room.room_id
-                room.add_listener(self._handle_message)
+                if peer_address not in self._address_to_roomid:
+                    self._address_to_roomid[peer_address] = room.room_id
+                    room.add_listener(self._handle_message, 'm.room.message')
             self.log.debug(
                 'ROOM',
                 room_id=room_id,
@@ -395,8 +396,9 @@ class MatrixTransport:
             )
             room.leave()
             return
-        self._address_to_roomid[peer_address] = room.room_id
-        room.add_listener(self._handle_message, 'm.room.message')
+        if peer_address not in self._address_to_roomid:
+            self._address_to_roomid[peer_address] = room.room_id
+            room.add_listener(self._handle_message, 'm.room.message')
         self.log.debug(
             'Invited to a room',
             room_id=room_id,
@@ -607,13 +609,14 @@ class MatrixTransport:
 
             room = self._get_unlisted_room(room_name, invitees=[user.user_id for user in peers])
 
-        room.add_listener(self._handle_message, 'm.room.message')
+        if receiver_address not in self._address_to_roomid:
+            self._address_to_roomid[receiver_address] = room.room_id
+            room.add_listener(self._handle_message, 'm.room.message')
         self.log.info(
             'CHANNEL ROOM',
             peer_address=to_normalized_address(receiver_address),
             room=room,
         )
-        self._address_to_roomid[receiver_address] = room.room_id
         return room
 
     def _get_unlisted_room(self, room_name, invitees):

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1,4 +1,3 @@
-import os
 from http import HTTPStatus
 
 import pytest
@@ -500,10 +499,6 @@ def test_api_channel_state_change_errors(
     assert_response_with_error(response, HTTPStatus.CONFLICT)
 
 
-@pytest.mark.skipif(
-    'TRAVIS' in os.environ,
-    reason='Flaky test on Travis. See issue #1552',
-)
 @pytest.mark.parametrize('number_of_tokens', [2])
 def test_api_tokens(api_backend, blockchain_services, token_addresses):
     partner_address = '0x61C808D82A3Ac53231750daDc13c777b59310bD9'

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -87,7 +87,7 @@ def raiden_chain(
     gevent.wait(greenlets)
 
     exception = RuntimeError('`raiden_chain` fixture setup failed, nodes are unreachable')
-    with gevent.Timeout(seconds=60, exception=exception):
+    with gevent.Timeout(seconds=30, exception=exception):
         wait_for_channels(
             app_channels,
             blockchain_services.deploy_registry.address,

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -1,4 +1,3 @@
-import os
 import itertools
 import gevent
 
@@ -207,10 +206,6 @@ def test_channelmanager_graph_building(
         assert total_pairs == len(manager.channels_addresses())
 
 
-@pytest.mark.skipif(
-    'TRAVIS' in os.environ,
-    reason='Flaky test due to mark.timeout not being scheduled. Issue #319',
-)
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_blockchain(
         web3,

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -25,7 +25,6 @@ def test_event_transfer_received_success(
     token_addresses,
     raiden_chain,
     network_wait,
-    skip_if_not_udp,
 ):
     app0, app1, app2, receiver_app = raiden_chain
     token_address = token_addresses[0]

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -11,6 +11,9 @@ from raiden.tests.utils.events import (
 )
 
 from raiden.utils import wait_until
+import structlog
+
+log = structlog.get_logger(__name__)
 
 
 @pytest.mark.parametrize('number_of_nodes', [4])
@@ -197,17 +200,13 @@ def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
         received = {
             event['identifier']: event
             for event in events
-            if event['event'] == 'EventTransferReceivedSuccess'
+            if event['event'] == 'EventTransferReceivedSuccess' and
+            event['initiator'] == echo_app.raiden.address and
+            event['identifier'] == sent_transfer['identifier'] + event['amount']
         }
         if len(received) != 1:
             return
-        transfer = received.popitem()[1]
-        if (
-                transfer['initiator'] != echo_app.raiden.address or
-                transfer['identifier'] != sent_transfer['identifier'] + transfer['amount']
-        ):
-            return
-        return transfer
+        return received.popitem()[1]
 
     def received_is_of_size(size):
         """Return transfers received from echo_node when there's size transfers"""

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -2,7 +2,6 @@ import random
 
 import gevent
 import pytest
-import os
 
 from raiden.constants import UINT64_MAX
 from raiden.messages import (
@@ -29,10 +28,6 @@ from raiden.utils import sha3
 @pytest.mark.parametrize('number_of_nodes', [5])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('settle_timeout', [32])  # default settlement is too low for 3 hops
-@pytest.mark.skipif(
-    'TRAVIS' in os.environ,
-    reason='Missing events cause stuck test & exit due to test timeout on Travis. Issue #1502',
-)
 def test_regression_unfiltered_routes(
         raiden_network,
         token_addresses,

--- a/raiden/tests/integration/transfer/test_directransfer_events.py
+++ b/raiden/tests/integration/transfer/test_directransfer_events.py
@@ -36,7 +36,7 @@ def test_initiator_log_directransfer_success(raiden_chain, token_addresses, depo
         to_identifier='latest',
     )
     app0_all_events = [event for _, event in app0_events]
-    must_contain_entry(app0_all_events, EventTransferSentSuccess, {
+    assert must_contain_entry(app0_all_events, EventTransferSentSuccess, {
         'identifier': identifier,
         'amount': amount,
         'target': app1.raiden.address,
@@ -47,7 +47,7 @@ def test_initiator_log_directransfer_success(raiden_chain, token_addresses, depo
         to_identifier='latest',
     )
     app1_all_events = [event for _, event in app1_state_events]
-    must_contain_entry(app1_all_events, EventTransferReceivedSuccess, {
+    assert must_contain_entry(app1_all_events, EventTransferReceivedSuccess, {
         'identifier': identifier,
         'amount': amount,
         'initiator': app0.raiden.address,

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -188,7 +188,6 @@ def test_refund_transfer_after_2nd_hop(
         token_addresses,
         deposit,
         network_wait,
-        skip_if_not_udp,
 ):
     """Test the refund transfer sent due to failure after 2nd hop"""
     # Topology:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -53,6 +53,7 @@ from raiden.settings import (
     ETHERSCAN_API,
     INITIAL_PORT,
     ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE,
+    DEFAULT_TRANSPORT_RETRY_INTERVAL,
 )
 from raiden.utils import (
     eth_endpoint_to_hostport,
@@ -663,6 +664,9 @@ def app(
             config['transport'],
         )
     elif transport == 'matrix':
+        # matrix gets spammed with the default retry-interval of 1s, wait a little more
+        if config['transport']['retry_interval'] == DEFAULT_TRANSPORT_RETRY_INTERVAL:
+            config['transport']['retry_interval'] *= 5
         transport = MatrixTransport(config['matrix'])
     else:
         raise RuntimeError(f'Unknown transport type "{transport}" given')

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -245,8 +245,8 @@ class EchoNode:
                 num_handled_transfers=self.num_handled_transfers + 1,
             )
 
-            self.api.transfer_and_wait(
-                transfer.registry_address,
+            self.api.transfer(
+                self.api.raiden.default_registry.address,
                 self.token_address,
                 echo_amount,
                 transfer['initiator'],

--- a/tools/install_synapse.sh
+++ b/tools/install_synapse.sh
@@ -45,12 +45,12 @@ if [[ ! -x ${SYNAPSE} ]]; then
         "${SYNDIR}/app/homeserver.py"
     rm -f ${DESTDIR}/synapse.*
     cp dist/synapse "${SYNAPSE}"
-    ln -fs "${SYNAPSE}" "${SYNAPSE_LINK}"
 
     popd
     [[ -n ${RMBUILDDIR} ]] && rm -r "${BUILDDIR}"
 fi
 
+ln -fs "${SYNAPSE}" "${SYNAPSE_LINK}"
 cp "${BASEDIR}/raiden/tests/test_files/synapse-config.yaml" "${DESTDIR}/"
 "${SYNAPSE}" --server-name="${SYNAPSE_SERVER_NAME}" \
            --config-path="${DESTDIR}/synapse-config.yaml" \
@@ -59,11 +59,9 @@ cp "${BASEDIR}/raiden/tests/test_files/synapse-config.yaml" "${DESTDIR}/"
 cat > "${DESTDIR}/run_synapse.sh" << EOF
 #!/usr/bin/env bash
 SYNAPSEDIR=\$( dirname "\$0" )
-if [[ -z \${TRAVIS} ]]; then
-  LOG_FILE="\${SYNAPSEDIR}/homeserver.log"
-  [[ -f \${LOG_FILE} ]] && rm "\${LOG_FILE}"
-  LOGGING_OPTION="--log-file \${LOG_FILE}"
-fi
+LOG_FILE="\${SYNAPSEDIR}/homeserver.log"
+[[ -f \${LOG_FILE} ]] && rm "\${LOG_FILE}"
+LOGGING_OPTION="--log-file \${LOG_FILE}"
 exec "\${SYNAPSEDIR}/synapse" \
   --server-name="\${SYNAPSE_SERVER_NAME:-${SYNAPSE_SERVER_NAME}}" \
   --config-path="\${SYNAPSEDIR}/synapse-config.yaml" \


### PR DESCRIPTION
Fix #647 , #1423, #1502 , #1552 , #1704
This PR fixes a lot of problems witnessed mainly with Matrix, due to its longer response times, but were not caused by it, but mostly by events not being properly handled.

Flaky test fixed:
- `raiden/tests/integration/test_echo_node.py::test_event_transfer_received_success`

Tests fixed and unskipped:
- `raiden/tests/integration/test_echo_node.py::test_echo_node_response`
- `raiden/tests/integration/test_echo_node.py::test_echo_node_lottery`
- `raiden/tests/integration/api/test_restapi.py::test_api_tokens`
- `raiden/tests/integration/test_blockchainservice.py::test_blockchain`
- `raiden/tests/integration/test_regression.py::test_regression_unfiltered_routes`
- `raiden/tests/integration/transfer/test_refundtransfer.py::test_refund_transfer_after_2nd_hop`

Tests fixed that were wrong but not failing:
- `raiden/tests/integration/transfer/test_directransfer_events.py::test_initiator_log_directransfer_success`