### PR TITLE
Fixes `skip_if_not_udp` fixture

### DIFF
--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -4,8 +4,6 @@ from raiden.tests.integration.fixtures.raiden_network import *  # noqa: F401,F40
 from raiden.tests.integration.fixtures.smartcontracts import *  # noqa: F401,F403
 from raiden.tests.integration.fixtures.transport import *  # noqa: F401,F403
 
-import pytest
-
 from raiden.tests.integration.fixtures.transport import (
     MatrixTransportConfig,
     TransportConfig,
@@ -15,7 +13,6 @@ from raiden.tests.utils.patch_connection_pool import patch_http_connection_pool
 
 
 def pytest_generate_tests(metafunc):
-
     if 'transport_config' in metafunc.fixturenames:
         transport = metafunc.config.getoption('transport')
         transport_config = list()
@@ -38,9 +35,6 @@ def pytest_generate_tests(metafunc):
             )
 
         metafunc.parametrize('transport_config', transport_config)
-
-        if not transport_config:
-            pytest.skip(f"Test does not apply to transport setting '{transport}'")
 
 
 # since we are running everything in a single thread, patch urrlib to allow more connections

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -24,8 +24,8 @@ def transport_config():
 
 @pytest.fixture
 def skip_if_not_udp():
-    """Dummy fixture. Request it to run a test with udp only."""
-    return None
+    """Skip the test if not run with UDP transport"""
+    pytest.skip('This test works only with UDP transport')
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes invalid use of `pytest.skip()` during test discovery.