### PR TITLE
Implement raiden cli tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,13 +83,13 @@ jobs:
     - stage: integration
       <<: *job-template-integration
       env:
-        - TEST='raiden/tests/integration --ignore=raiden/tests/integration/transfer --ignore=raiden/tests/integration/long_running --ignore=raiden/tests/integration/api --ignore=raiden/tests/integration/contracts'
+        - TEST='raiden/tests/integration --ignore=raiden/tests/integration/transfer --ignore=raiden/tests/integration/long_running --ignore=raiden/tests/integration/api --ignore=raiden/tests/integration/contracts --ignore=raiden/tests/integration/cli'
         - TRANSPORT_OPTIONS='--transport=udp'
 
     - stage: integration
       <<: *job-template-integration
       env:
-        - TEST='raiden/tests/integration --ignore=raiden/tests/integration/transfer --ignore=raiden/tests/integration/long_running --ignore=raiden/tests/integration/api --ignore=raiden/tests/integration/contracts'
+        - TEST='raiden/tests/integration --ignore=raiden/tests/integration/transfer --ignore=raiden/tests/integration/long_running --ignore=raiden/tests/integration/api --ignore=raiden/tests/integration/contracts --ignore=raiden/tests/integration/cli'
         - TRANSPORT_OPTIONS='--transport=matrix --local-matrix=${HOME}/.bin/run_synapse.sh'
         - RUN_SYNAPSE=1
 
@@ -134,6 +134,19 @@ jobs:
       <<: *job-template-integration
       env:
         - TEST='raiden/tests/integration/api'
+        - TRANSPORT_OPTIONS='--transport=matrix --local-matrix=${HOME}/.bin/run_synapse.sh'
+        - RUN_SYNAPSE=1
+
+    - stage: integration
+      <<: *job-template-integration
+      env:
+        - TEST='raiden/tests/integration/cli'
+        - TRANSPORT_OPTIONS='--transport=udp'
+
+    - stage: integration
+      <<: *job-template-integration
+      env:
+        - TEST='raiden/tests/integration/cli'
         - TRANSPORT_OPTIONS='--transport=matrix --local-matrix=${HOME}/.bin/run_synapse.sh'
         - RUN_SYNAPSE=1
 

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -1,32 +1,60 @@
-import os
 import pytest
-
 from raiden.tests.utils.smoketest import (
     load_smoketest_config,
-    start_ethereum,
+    setup_testchain_and_raiden,
 )
+
+
+def append_arg_if_existing(argname, initial_args, new_args):
+    cliname = '--' + argname.replace('_', '-')
+    if argname in initial_args:
+        new_args.extend([cliname, initial_args[argname]])
 
 
 @pytest.fixture(scope='session')
 def blockchain_provider():
-    print("fixture init")
     smoketest_config = load_smoketest_config()
-    ethereum, ethereum_config = start_ethereum(smoketest_config['genesis'])
-    discovery_contract_address = smoketest_config['contracts']['discovery_address']
-    registry_contract_address = smoketest_config['contracts']['registry_address']
-    eth_rpc_endpoint = 'http://127.0.0.1:{}'.format(ethereum_config['rpc'])
-    keystore_path = ethereum_config['keystore']
-    datadir_path = os.path.split(keystore_path)[0]
-    network_id = '627'
-    password_file_path = os.path.join(keystore_path, 'password')
-    with open(password_file_path, 'w') as handler:
-        handler.write('password')
-    return {'ethereum': ethereum,
-            'ethereum_config': ethereum_config,
-            'discovery_contract_address': discovery_contract_address,
-            'registry_contract_address': registry_contract_address,
-            'eth_rpc_endpoint': eth_rpc_endpoint,
-            'keystore_path': keystore_path,
-            'datadir_path': datadir_path,
-            'password_file_path': password_file_path,
-            'network_id': network_id}
+    result = setup_testchain_and_raiden(
+        smoketest_config,
+        'matrix',
+        'auto',
+        lambda x: None,
+    )
+    args = result['args']
+    # The setup of the testchain returns a TextIOWrapper but
+    # for the tests we need a filename
+    args['password_file'] = args['password_file'].name
+    return args
+
+
+@pytest.fixture()
+def removed_args():
+    return None
+
+
+@pytest.fixture()
+def cli_args(blockchain_provider, removed_args):
+    initial_args = blockchain_provider.copy()
+
+    if removed_args is not None:
+        for arg in removed_args:
+            if arg in initial_args:
+                del initial_args[arg]
+
+    args = [
+        '--no-sync-check',
+        '--registry-contract-address',
+        initial_args['registry_contract_address'],
+        '--secret-registry-contract-address',
+        initial_args['secret_registry_contract_address'],
+        '--discovery-contract-address',
+        initial_args['discovery_contract_address'],
+    ]
+
+    append_arg_if_existing('keystore_path', initial_args, args)
+    append_arg_if_existing('password_file', initial_args, args)
+    append_arg_if_existing('datadir', initial_args, args)
+    append_arg_if_existing('network_id', initial_args, args)
+    append_arg_if_existing('eth_rpc_endpoint', initial_args, args)
+
+    return args

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 from raiden.tests.utils.smoketest import (
     load_smoketest_config,
-    start_ethereum
+    start_ethereum,
 )
 
 

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -33,13 +33,23 @@ def removed_args():
 
 
 @pytest.fixture()
-def cli_args(blockchain_provider, removed_args):
+def changed_args():
+    return None
+
+
+@pytest.fixture()
+def cli_args(blockchain_provider, removed_args, changed_args):
     initial_args = blockchain_provider.copy()
 
     if removed_args is not None:
         for arg in removed_args:
             if arg in initial_args:
                 del initial_args[arg]
+
+    if changed_args is not None:
+        for k, v in changed_args.items():
+            if k in initial_args:
+                initial_args[k] = v
 
     args = [
         '--no-sync-check',

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+
+from raiden.tests.utils.smoketest import (
+    load_smoketest_config,
+    start_ethereum
+)
+
+
+@pytest.fixture(scope='session')
+def blockchain_provider():
+    print("fixture init")
+    smoketest_config = load_smoketest_config()
+    ethereum, ethereum_config = start_ethereum(smoketest_config['genesis'])
+    discovery_contract_address = smoketest_config['contracts']['discovery_address']
+    registry_contract_address = smoketest_config['contracts']['registry_address']
+    eth_rpc_endpoint = 'http://127.0.0.1:{}'.format(ethereum_config['rpc'])
+    keystore_path = ethereum_config['keystore']
+    datadir_path = os.path.split(keystore_path)[0]
+    network_id = '627'
+    password_file_path = os.path.join(keystore_path, 'password')
+    with open(password_file_path, 'w') as handler:
+        handler.write('password')
+    return {'ethereum': ethereum,
+            'ethereum_config': ethereum_config,
+            'discovery_contract_address': discovery_contract_address,
+            'registry_contract_address': registry_contract_address,
+            'eth_rpc_endpoint': eth_rpc_endpoint,
+            'keystore_path': keystore_path,
+            'datadir_path': datadir_path,
+            'password_file_path': password_file_path,
+            'network_id': network_id}

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -34,20 +34,11 @@ def test_cli_full_init(cli_args):
 
 
 @pytest.mark.timeout(25)
-def test_cli_missing_keystore_path(blockchain_provider):
-    cli_args = ['--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('changed_args', [{'keystore_path': '.'}])
+def test_cli_wrong_keystore_path(cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
-        child.expect('RuntimeError: No Ethereum accounts found in the user\'s system')
+        child.expect('No Ethereum accounts found in the provided keystore directory')
     except pexpect.TIMEOUT as e:
         print("PEXPECT timed out at", e)
     finally:
@@ -55,25 +46,16 @@ def test_cli_missing_keystore_path(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def test_cli_missing_password_file_enter_password(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('removed_args', [['password_file']])
+def test_cli_missing_password_file_enter_password(blockchain_provider, cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
         child.expect('Select one of them by index to continue: ')
         child.sendline('0')
         child.expect('Enter the password to unlock')
-        with open(blockchain_provider['password_file_path'], 'r') as password_file:
+        with open(blockchain_provider['password_file'], 'r') as password_file:
             password = password_file.readline()
             child.sendline(password)
         child.expect('You are connected')
@@ -85,18 +67,9 @@ def test_cli_missing_password_file_enter_password(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def test_cli_missing_data_dir(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('removed_args', [['data_dir']])
+def test_cli_missing_data_dir(cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -111,44 +84,9 @@ def test_cli_missing_data_dir(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def test_cli_missing_nat(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
-    try:
-        child.expect('Welcome to Raiden')
-        child.expect('no upnp providers found ')
-        child.expect('The following accounts were found in your machine:')
-        child.expect('Select one of them by index to continue: ')
-        child.sendline('0')
-        child.expect('You are connected')
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
-
-
-@pytest.mark.timeout(25)
-def test_cli_wrong_rpc_endpoint(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'] + '0',
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('changed_args', [{'eth_rpc_endpoint': 'http://8.8.8.8:2020'}])
+def test_cli_wrong_rpc_endpoint(cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -162,26 +100,17 @@ def test_cli_wrong_rpc_endpoint(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def test_cli_wrong_network_id_try_mainnet(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', '1',
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('changed_args', [{'network_id': '1'}])
+def test_cli_wrong_network_id_try_mainnet(cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
         child.expect('Select one of them by index to continue: ')
         child.sendline('0')
-        child.expect("The chosen ethereum network 'mainnet' differs from the ethereum "
-                     "client 'smoketest'")
+        child.expect(
+            "The chosen ethereum network 'mainnet' differs from the ethereum "
+            "client 'smoketest'")
     except pexpect.TIMEOUT as e:
         print('Timed out at', e)
     finally:
@@ -189,23 +118,16 @@ def test_cli_wrong_network_id_try_mainnet(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def test_cli_malformed_registry_address(blockchain_provider):
-    malformed_registry_address = blockchain_provider['registry_contract_address'] + '0'
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', malformed_registry_address,
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('changed_args', [{
+    'registry_contract_address': '0xdfD10vAe9CCl5EBf11bc6309A0645eFe9f979584'
+}])
+def test_cli_malformed_registry_address(cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
-        child.expect('Error: Invalid value for "--registry-contract-address"'
-                     ': Provided addresses must be EIP55 checksummed')
+        child.expect(
+            'Error: Invalid value for "--registry-contract-address"'
+            ': Address must be EIP55 checksummed'
+        )
     except pexpect.TIMEOUT as e:
         print("Timed out at", e)
     finally:
@@ -213,48 +135,13 @@ def test_cli_malformed_registry_address(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def test_cli_swap_registry_address_with_discovery_address(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['discovery_contract_address'],
-                '--discovery-contract-address', blockchain_provider['registry_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
-    try:
-        child.expect('Welcome to Raiden')
-        child.expect('The following accounts were found in your machine:')
-        child.expect('Select one of them by index to continue: ')
-        child.sendline('0')
-        child.expect('You are connected')
-        child.expect('web3.exceptions.BadFunctionCallOutput: Could not decode '
-                     'contract function call')
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
-
-
-@pytest.mark.timeout(25)
-def test_cli_registry_address_without_deployed_contract(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address',
-                to_checksum_address('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'),
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+@pytest.mark.parametrize('changed_args', [{
+    'registry_contract_address': to_checksum_address('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'),
+}])
+def test_cli_registry_address_without_deployed_contract(cli_args):
+    # TODO: Change the expectation for this (don't expect a trace) when
+    # https://github.com/raiden-network/raiden/issues/1996 is implemented
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -262,84 +149,6 @@ def test_cli_registry_address_without_deployed_contract(blockchain_provider):
         child.sendline('0')
         child.expect('You are connected')
         child.expect('raiden.exceptions.AddressWithoutCode')
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
-
-
-@pytest.mark.timeout(25)
-def test_cli_missing_discovery_contract_address(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
-    try:
-        child.expect('Welcome to Raiden')
-        child.expect('The following accounts were found in your machine:')
-        child.expect('Select one of them by index to continue: ')
-        child.sendline('0')
-        child.expect('You are connected')
-        child.expect('raiden.exceptions.AddressWithoutCode')
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
-
-
-@pytest.mark.timeout(25)
-def DISABLE_test_cli_eth_client_communication(blockchain_provider,
-                                              deploy_client,
-                                              blockchain_backend):
-    """
-    Test if --eth-client-communication displays dumped serialized communication data.
-    This test case will fail after JSONRPCClient was moved from pyethapp to Raiden.
-
-    Original implementation dumped serialized request and response to stdout.
-    https://github.com/ethereum/pyethapp/blob/develop/pyethapp/rpc_client.py#L381
-
-    Test case simply waits for a JSON string on stdout after triggering RPC call.
-
-    Currently this functionality does not exist anymore and test times out.
-    """
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address'],
-                '--eth-client-communication']
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
-    try:
-        child.expect('Welcome to Raiden')
-        child.expect('The following accounts were found in your machine:')
-        child.expect('Select one of them by index to continue: ')
-        child.sendline('0')
-        child.expect('You are connected')
-        child.expect('The Raiden API RPC server is now running')
-
-        inexisting_address = b'\x01\x02\x03\x04\x05' * 4
-        transaction = {
-            'from': to_checksum_address(deploy_client.sender),
-            'to': to_checksum_address(inexisting_address),
-            'data': b'',
-            'value': 0,
-        }
-        rpc_data = deploy_client.web3.eth.call(transaction)
-        assert rpc_data == b''
-        child.expect('.*{.*}.*')
     except pexpect.TIMEOUT as e:
         print("Timed out at", e)
     finally:

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -1,0 +1,340 @@
+import json
+import pytest
+import pexpect
+import sys
+from click.testing import CliRunner
+from raiden.ui.cli import run
+from eth_utils import to_checksum_address
+
+
+def test_cli_version():
+    runner = CliRunner()
+    result = runner.invoke(run, ["version"])
+    assert result.exit_code == 0
+    result_json = json.loads(result.output)
+    result_expected_keys = ["raiden", "python_implementation", "python_version", "system"]
+    for expected_key in result_expected_keys:
+        assert expected_key in result_json
+
+
+@pytest.mark.timeout(25)
+def test_cli_full_init(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+        child.expect('The Raiden API RPC server is now running')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_missing_keystore_path(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('RuntimeError: No Ethereum accounts found in the user\'s system')
+    except pexpect.TIMEOUT as e:
+        print("PEXPECT timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_missing_password_file_enter_password(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('Enter the password to unlock')
+        with open(blockchain_provider['password_file_path'], 'r') as password_file:
+            password = password_file.readline()
+            child.sendline(password)
+        child.expect('You are connected')
+        child.expect('The Raiden API RPC server is now running')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_missing_data_dir(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+        child.expect('The Raiden API RPC server is now running')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_missing_nat(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('no upnp providers found ')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_wrong_rpc_endpoint(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'] + '0',
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('Could not contact the ethereum node through JSON-RPC')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_wrong_network_id_try_mainnet(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', '1',
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect("The chosen ethereum network 'mainnet' differs from the ethereum client 'smoketest'")
+    except pexpect.TIMEOUT as e:
+        print('Timed out at', e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_malformed_registry_address(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'] + '0',
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Error: Invalid value for "--registry-contract-address"'
+                     ': Provided addresses must be EIP55 checksummed')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_swap_registry_address_with_discovery_address(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['discovery_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['registry_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+        child.expect('web3.exceptions.BadFunctionCallOutput: Could not decode contract function call')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_registry_address_without_deployed_contract(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address',
+                           to_checksum_address('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'),
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+        child.expect('raiden.exceptions.AddressWithoutCode')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def test_cli_missing_discovery_contract_address(blockchain_provider):
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address']],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+        child.expect('raiden.exceptions.AddressWithoutCode: \[Discovery\]')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()
+
+
+@pytest.mark.timeout(25)
+def DISABLE_test_cli_eth_client_communication(blockchain_provider, deploy_client, blockchain_backend):
+    """
+    Test if --eth-client-communication displays dumped serialized communication data.
+    This test case will fail after JSONRPCClient was moved from pyethapp to Raiden.
+
+    Original implementation dumped serialized request and response to stdout.
+    https://github.com/ethereum/pyethapp/blob/develop/pyethapp/rpc_client.py#L381
+
+    Test case simply waits for a JSON string on stdout after triggering RPC call.
+
+    Currently this functionality does not exist anymore and test times out.
+    """
+    child = pexpect.spawn('raiden',
+                          ['--keystore-path', blockchain_provider['keystore_path'],
+                           '--password-file', blockchain_provider['password_file_path'],
+                           '--datadir', blockchain_provider['datadir_path'],
+                           '--nat', 'none',
+                           '--no-sync-check',
+                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                           '--network-id', blockchain_provider['network_id'],
+                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                           '--discovery-contract-address', blockchain_provider['discovery_contract_address'],
+                           '--eth-client-communication'],
+                          logfile=sys.stdout)
+    try:
+        child.expect('Welcome to Raiden')
+        child.expect('The following accounts were found in your machine:')
+        child.expect('Select one of them by index to continue: ')
+        child.sendline('0')
+        child.expect('You are connected')
+        child.expect('The Raiden API RPC server is now running')
+
+        inexisting_address = b'\x01\x02\x03\x04\x05' * 4
+        transaction = {
+            'from': to_checksum_address(deploy_client.sender),
+            'to': to_checksum_address(inexisting_address),
+            'data': b'',
+            'value': 0
+        }
+        rpc_data = deploy_client.web3.eth.call(transaction)
+        assert rpc_data == b''
+        child.expect('.*{.*}.*')
+    except pexpect.TIMEOUT as e:
+        print("Timed out at", e)
+    finally:
+        child.close()

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -19,16 +19,17 @@ def test_cli_version():
 
 @pytest.mark.timeout(25)
 def test_cli_full_init(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -45,15 +46,16 @@ def test_cli_full_init(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_missing_keystore_path(blockchain_provider):
+    cli_args = ['--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('RuntimeError: No Ethereum accounts found in the user\'s system')
@@ -65,15 +67,16 @@ def test_cli_missing_keystore_path(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_missing_password_file_enter_password(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -94,15 +97,16 @@ def test_cli_missing_password_file_enter_password(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_missing_data_dir(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -119,15 +123,16 @@ def test_cli_missing_data_dir(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_missing_nat(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -144,15 +149,16 @@ def test_cli_missing_nat(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_wrong_rpc_endpoint(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'] + '0',
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'] + '0',
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -168,23 +174,25 @@ def test_cli_wrong_rpc_endpoint(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_wrong_network_id_try_mainnet(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', '1',
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', '1',
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
         child.expect('Select one of them by index to continue: ')
         child.sendline('0')
-        child.expect("The chosen ethereum network 'mainnet' differs from the ethereum client 'smoketest'")
+        child.expect("The chosen ethereum network 'mainnet' differs from the ethereum "
+                     "client 'smoketest'")
     except pexpect.TIMEOUT as e:
         print('Timed out at', e)
     finally:
@@ -193,16 +201,18 @@ def test_cli_wrong_network_id_try_mainnet(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_malformed_registry_address(blockchain_provider):
+    malformed_registry_address = blockchain_provider['registry_contract_address'] + '0'
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', malformed_registry_address,
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'] + '0',
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Error: Invalid value for "--registry-contract-address"'
@@ -215,16 +225,17 @@ def test_cli_malformed_registry_address(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_swap_registry_address_with_discovery_address(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['discovery_contract_address'],
+                '--discovery-contract-address', blockchain_provider['registry_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['discovery_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['registry_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -232,7 +243,8 @@ def test_cli_swap_registry_address_with_discovery_address(blockchain_provider):
         child.expect('Select one of them by index to continue: ')
         child.sendline('0')
         child.expect('You are connected')
-        child.expect('web3.exceptions.BadFunctionCallOutput: Could not decode contract function call')
+        child.expect('web3.exceptions.BadFunctionCallOutput: Could not decode '
+                     'contract function call')
     except pexpect.TIMEOUT as e:
         print("Timed out at", e)
     finally:
@@ -241,17 +253,18 @@ def test_cli_swap_registry_address_with_discovery_address(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_registry_address_without_deployed_contract(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address',
+                to_checksum_address('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'),
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address',
-                           to_checksum_address('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'),
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -268,15 +281,16 @@ def test_cli_registry_address_without_deployed_contract(blockchain_provider):
 
 @pytest.mark.timeout(25)
 def test_cli_missing_discovery_contract_address(blockchain_provider):
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address']]
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address']],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -284,7 +298,7 @@ def test_cli_missing_discovery_contract_address(blockchain_provider):
         child.expect('Select one of them by index to continue: ')
         child.sendline('0')
         child.expect('You are connected')
-        child.expect('raiden.exceptions.AddressWithoutCode: \[Discovery\]')
+        child.expect('raiden.exceptions.AddressWithoutCode')
     except pexpect.TIMEOUT as e:
         print("Timed out at", e)
     finally:
@@ -292,7 +306,9 @@ def test_cli_missing_discovery_contract_address(blockchain_provider):
 
 
 @pytest.mark.timeout(25)
-def DISABLE_test_cli_eth_client_communication(blockchain_provider, deploy_client, blockchain_backend):
+def DISABLE_test_cli_eth_client_communication(blockchain_provider,
+                                              deploy_client,
+                                              blockchain_backend):
     """
     Test if --eth-client-communication displays dumped serialized communication data.
     This test case will fail after JSONRPCClient was moved from pyethapp to Raiden.
@@ -304,17 +320,18 @@ def DISABLE_test_cli_eth_client_communication(blockchain_provider, deploy_client
 
     Currently this functionality does not exist anymore and test times out.
     """
+    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
+                '--password-file', blockchain_provider['password_file_path'],
+                '--datadir', blockchain_provider['datadir_path'],
+                '--nat', 'none',
+                '--no-sync-check',
+                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
+                '--network-id', blockchain_provider['network_id'],
+                '--registry-contract-address', blockchain_provider['registry_contract_address'],
+                '--discovery-contract-address', blockchain_provider['discovery_contract_address'],
+                '--eth-client-communication']
     child = pexpect.spawn('raiden',
-                          ['--keystore-path', blockchain_provider['keystore_path'],
-                           '--password-file', blockchain_provider['password_file_path'],
-                           '--datadir', blockchain_provider['datadir_path'],
-                           '--nat', 'none',
-                           '--no-sync-check',
-                           '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                           '--network-id', blockchain_provider['network_id'],
-                           '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                           '--discovery-contract-address', blockchain_provider['discovery_contract_address'],
-                           '--eth-client-communication'],
+                          cli_args,
                           logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
@@ -329,7 +346,7 @@ def DISABLE_test_cli_eth_client_communication(blockchain_provider, deploy_client
             'from': to_checksum_address(deploy_client.sender),
             'to': to_checksum_address(inexisting_address),
             'data': b'',
-            'value': 0
+            'value': 0,
         }
         rpc_data = deploy_client.web3.eth.call(transaction)
         assert rpc_data == b''

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -119,14 +119,14 @@ def test_cli_wrong_network_id_try_mainnet(cli_args):
 
 @pytest.mark.timeout(25)
 @pytest.mark.parametrize('changed_args', [{
-    'registry_contract_address': '0xdfD10vAe9CCl5EBf11bc6309A0645eFe9f979584'
+    'registry_contract_address': '0xdfD10vAe9CCl5EBf11bc6309A0645eFe9f979584',
 }])
 def test_cli_malformed_registry_address(cli_args):
     child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect(
             'Error: Invalid value for "--registry-contract-address"'
-            ': Address must be EIP55 checksummed'
+            ': Address must be EIP55 checksummed',
         )
     except pexpect.TIMEOUT as e:
         print("Timed out at", e)

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -18,19 +18,8 @@ def test_cli_version():
 
 
 @pytest.mark.timeout(25)
-def test_cli_full_init(blockchain_provider):
-    cli_args = ['--keystore-path', blockchain_provider['keystore_path'],
-                '--password-file', blockchain_provider['password_file_path'],
-                '--datadir', blockchain_provider['datadir_path'],
-                '--nat', 'none',
-                '--no-sync-check',
-                '--eth-rpc-endpoint', blockchain_provider['eth_rpc_endpoint'],
-                '--network-id', blockchain_provider['network_id'],
-                '--registry-contract-address', blockchain_provider['registry_contract_address'],
-                '--discovery-contract-address', blockchain_provider['discovery_contract_address']]
-    child = pexpect.spawn('raiden',
-                          cli_args,
-                          logfile=sys.stdout)
+def test_cli_full_init(cli_args):
+    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -7,19 +7,29 @@ from raiden.ui.cli import run
 from eth_utils import to_checksum_address
 
 
+def spawn_raiden(args):
+    return pexpect.spawn(sys.executable, ['-m', 'raiden'] + args, logfile=sys.stdout)
+
+
 def test_cli_version():
     runner = CliRunner()
-    result = runner.invoke(run, ["version"])
+    result = runner.invoke(run, ['version'])
     assert result.exit_code == 0
     result_json = json.loads(result.output)
-    result_expected_keys = ["raiden", "python_implementation", "python_version", "system"]
+    result_expected_keys = [
+        'raiden',
+        'python_implementation',
+        'python_version',
+        'system',
+        'distribution',
+    ]
     for expected_key in result_expected_keys:
         assert expected_key in result_json
 
 
 @pytest.mark.timeout(25)
 def test_cli_full_init(cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -28,7 +38,7 @@ def test_cli_full_init(cli_args):
         child.expect('You are connected')
         child.expect('The Raiden API RPC server is now running')
     except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
+        print('Timed out at', e)
     finally:
         child.close()
 
@@ -36,11 +46,11 @@ def test_cli_full_init(cli_args):
 @pytest.mark.timeout(25)
 @pytest.mark.parametrize('changed_args', [{'keystore_path': '.'}])
 def test_cli_wrong_keystore_path(cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('No Ethereum accounts found in the provided keystore directory')
     except pexpect.TIMEOUT as e:
-        print("PEXPECT timed out at", e)
+        print('PEXPECT timed out at', e)
     finally:
         child.close()
 
@@ -48,7 +58,7 @@ def test_cli_wrong_keystore_path(cli_args):
 @pytest.mark.timeout(25)
 @pytest.mark.parametrize('removed_args', [['password_file']])
 def test_cli_missing_password_file_enter_password(blockchain_provider, cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -61,7 +71,7 @@ def test_cli_missing_password_file_enter_password(blockchain_provider, cli_args)
         child.expect('You are connected')
         child.expect('The Raiden API RPC server is now running')
     except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
+        print('Timed out at', e)
     finally:
         child.close()
 
@@ -69,7 +79,7 @@ def test_cli_missing_password_file_enter_password(blockchain_provider, cli_args)
 @pytest.mark.timeout(25)
 @pytest.mark.parametrize('removed_args', [['data_dir']])
 def test_cli_missing_data_dir(cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -78,7 +88,7 @@ def test_cli_missing_data_dir(cli_args):
         child.expect('You are connected')
         child.expect('The Raiden API RPC server is now running')
     except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
+        print('Timed out at', e)
     finally:
         child.close()
 
@@ -86,7 +96,7 @@ def test_cli_missing_data_dir(cli_args):
 @pytest.mark.timeout(25)
 @pytest.mark.parametrize('changed_args', [{'eth_rpc_endpoint': 'http://8.8.8.8:2020'}])
 def test_cli_wrong_rpc_endpoint(cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -94,7 +104,7 @@ def test_cli_wrong_rpc_endpoint(cli_args):
         child.sendline('0')
         child.expect('Could not contact the ethereum node through JSON-RPC')
     except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
+        print('Timed out at', e)
     finally:
         child.close()
 
@@ -102,7 +112,7 @@ def test_cli_wrong_rpc_endpoint(cli_args):
 @pytest.mark.timeout(25)
 @pytest.mark.parametrize('changed_args', [{'network_id': '1'}])
 def test_cli_wrong_network_id_try_mainnet(cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -122,14 +132,14 @@ def test_cli_wrong_network_id_try_mainnet(cli_args):
     'registry_contract_address': '0xdfD10vAe9CCl5EBf11bc6309A0645eFe9f979584',
 }])
 def test_cli_malformed_registry_address(cli_args):
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect(
             'Error: Invalid value for "--registry-contract-address"'
             ': Address must be EIP55 checksummed',
         )
     except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
+        print('Timed out at', e)
     finally:
         child.close()
 
@@ -141,7 +151,7 @@ def test_cli_malformed_registry_address(cli_args):
 def test_cli_registry_address_without_deployed_contract(cli_args):
     # TODO: Change the expectation for this (don't expect a trace) when
     # https://github.com/raiden-network/raiden/issues/1996 is implemented
-    child = pexpect.spawn('raiden', cli_args, logfile=sys.stdout)
+    child = spawn_raiden(cli_args)
     try:
         child.expect('Welcome to Raiden')
         child.expect('The following accounts were found in your machine:')
@@ -150,6 +160,6 @@ def test_cli_registry_address_without_deployed_contract(cli_args):
         child.expect('You are connected')
         child.expect('raiden.exceptions.AddressWithoutCode')
     except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
+        print('Timed out at', e)
     finally:
         child.close()

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -341,6 +341,7 @@ def setup_testchain_and_raiden(smoketest_config, transport, matrix_server, print
         keystore_path=ethereum_config['keystore'],
         address=ethereum_config['address'],
         network_id='627',
+        sync_check=False,
         transport=transport,
         matrix_server='http://localhost:8008'
                       if matrix_server == 'auto'
@@ -351,6 +352,7 @@ def setup_testchain_and_raiden(smoketest_config, transport, matrix_server, print
         handler.write('password')
 
     args['password_file'] = click.File()(password_file)
+    args['datadir'] = args['keystore_path']
     return dict(
         args=args,
         contract_addresses=contract_addresses,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -1067,9 +1067,7 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
 
     port = next(get_free_port('127.0.0.1', 5001))
 
-    args['datadir'] = args['keystore_path']
     args['api_address'] = 'localhost:' + str(port)
-    args['sync_check'] = False
 
     def _run_smoketest():
         print_step('Starting Raiden')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pytest-random==0.02
 pytest-cov==2.5.1
 flaky==3.4.0
 grequests==0.3.0
+pexpect==4.6.0
 
 # Debugging
 pdbpp==0.9.2


### PR DESCRIPTION
This pull request adds the following tests:

test_cli_missing_discovery_contract_address
test_cli_wrong_rpc_endpoint
test_cli_wrong_network_id_try_mainnet
test_cli_swap_registry_address_with_discovery_address
test_cli_full_init
test_cli_registry_address_without_deployed_contract
test_cli_missing_data_dir
test_cli_version
test_cli_malformed_registry_address
test_cli_missing_keystore_path
test_cli_missing_password_file_enter_password
test_cli_missing_nat

that test most of the CLI used parameters and wrong scenarios.

There is also a disabled test case DISABLE_test_cli_eth_client_communication
that times out due to functionality removed after commit 2ec2bad.