### PR TITLE
Fix `skip_if_not_udp` fixture

### DIFF
--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -23,8 +23,10 @@ def transport_config():
 
 
 @pytest.fixture
-def skip_if_not_udp():
+def skip_if_not_udp(request):
     """Skip the test if not run with UDP transport"""
+    if request.config.option.transport == 'udp':
+        return
     pytest.skip('This test works only with UDP transport')
 
 


### PR DESCRIPTION
- fixture is buggy and skips everything (my bad). This fixes it so only non-udp tests are skipped.