### PR TITLE
Fix pyinstaller bundling for raiden-contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ raiden/raidenwebui/node_modules/
 .idea
 .vscode
 .synapse
+raiden/smart_contracts/contracts.json

--- a/raiden.spec
+++ b/raiden.spec
@@ -8,8 +8,6 @@ from raiden.utils import get_system_spec
 
 """
 PyInstaller spec file to build single file or dir distributions
-
-Currently only tested on macOS
 """
 
 # Set to false to produce an exploded single-dir
@@ -67,7 +65,8 @@ sys.modules['FixTk'] = None
 
 executable_name = 'raiden-{}-{}'.format(
     get_system_spec()['raiden'],
-    'macos' if platform.system() == 'Darwin' else platform.system().lower())
+    'macOS' if platform.system() == 'Darwin' else platform.system().lower()
+)
 
 a = Entrypoint(
     'raiden',
@@ -75,11 +74,12 @@ a = Entrypoint(
     'raiden',
     hookspath=['tools/pyinstaller_hooks'],
     runtime_hooks=[
+        'tools/pyinstaller_hooks/runtime_gevent_monkey.py',
         'tools/pyinstaller_hooks/runtime_encoding.py',
+        'tools/pyinstaller_hooks/runtime_raiden_contracts.py',
     ],
-    hiddenimports=['scrypt'],
+    hiddenimports=['scrypt', 'eth_tester'],
     datas=[
-        ('raiden/smart_contracts/*.sol*', 'raiden/smart_contracts'),
         ('raiden/smoketest_config.json', 'raiden'),
     ],
     excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter'],
@@ -96,7 +96,7 @@ if ONEFILE:
         a.datas,
         name=executable_name,
         debug=False,
-        strip=False,
+        strip=True,
         upx=False,
         runtime_tmpdir=None,
         console=True
@@ -107,7 +107,7 @@ else:
         a.scripts,
         exclude_binaries=True,
         name=executable_name,
-        debug=False,
+        debug=True,
         strip=False,
         upx=False,
         console=True

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -6,7 +6,7 @@ from eth_utils import (
     to_normalized_address,
 )
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
-from raiden_contracts.contract_manager import ContractManager, CONTRACTS_SOURCE_DIRS
+from raiden_contracts.contract_manager import CONTRACT_MANAGER
 
 from raiden.exceptions import TransactionThrew
 from raiden.network.rpc.client import check_address_has_code
@@ -23,7 +23,7 @@ class Token:
             token_address,
     ):
         contract = jsonrpc_client.new_contract(
-            ContractManager(CONTRACTS_SOURCE_DIRS).get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
+            CONTRACT_MANAGER.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
             to_normalized_address(token_address),
         )
         self.proxy = ContractProxy(jsonrpc_client, contract)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -6,6 +6,7 @@ from binascii import unhexlify
 from typing import List, Dict
 from json.decoder import JSONDecodeError
 
+from pkg_resources import DistributionNotFound
 from web3 import Web3, HTTPProvider
 from web3.middleware import geth_poa_middleware
 from web3.utils.filters import Filter
@@ -45,8 +46,9 @@ from raiden.constants import NULL_ADDRESS
 
 try:
     from eth_tester.exceptions import BlockNotFound
-except ModuleNotFoundError:
-    BlockNotFound = Exception()
+except (ModuleNotFoundError, DistributionNotFound):
+    class BlockNotFound(Exception):
+        pass
 
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -5,14 +5,16 @@ from eth_utils import (
     decode_hex,
     to_checksum_address,
 )
+from pkg_resources import DistributionNotFound
 from web3.utils.contracts import encode_transaction_data, find_matching_fn_abi
 from web3.utils.abi import get_abi_input_types
 from web3.contract import Contract
 from raiden.utils.filters import decode_event
 try:
     from eth_tester.exceptions import TransactionFailed
-except ModuleNotFoundError:
-    TransactionFailed = Exception()
+except (ModuleNotFoundError, DistributionNotFound):
+    class TransactionFailed(Exception):
+        pass
 
 
 class ContractProxy:

--- a/raiden/network/sockfactory.py
+++ b/raiden/network/sockfactory.py
@@ -117,6 +117,7 @@ class SocketFactory:
             )
             if result is not None:
                 self.storage['router'] = router
+                self.storage['external_port'] = result[1]
                 return PortMappedSocket(self.socket, 'UPnP', result[0], result[1],
                                         router_location=location)
         except socket.error as e:
@@ -125,7 +126,7 @@ class SocketFactory:
             raise
 
     def unmap_upnp(self):
-        upnpsock.release_port(self.storage['router'], self.source_port)
+        upnpsock.release_port(self.storage['router'], self.storage['external_port'])
 
     def map_stun(self):
         try:

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 from eth_utils import decode_hex, to_checksum_address
+from pkg_resources import DistributionNotFound
 
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.network.rpc.client import JSONRPCClient
@@ -10,13 +11,15 @@ from raiden.utils.solc import compile_files_cwd
 
 try:
     from evm.exceptions import ValidationError
-except ModuleNotFoundError:
-    ValidationError = Exception()
+except (ModuleNotFoundError, DistributionNotFound):
+    class ValidationError(Exception):
+        pass
 
 try:
     from eth_tester.exceptions import TransactionFailed
-except ModuleNotFoundError:
-    TransactionFailed = Exception()
+except (ModuleNotFoundError, DistributionNotFound):
+    class TransactionFailed(Exception):
+        pass
 
 # pylint: disable=unused-argument,protected-access
 

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -26,7 +26,6 @@ def deploy_tokens_and_fund_accounts(
         participants (list(address)): participant addresses that will receive tokens
     """
     result = list()
-
     for _ in range(number_of_tokens):
         token_address = deploy_contract_web3(
             CONTRACT_HUMAN_STANDARD_TOKEN,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pycryptodome==3.6.1
 # raiden-libs==???
 # FIXME: replace with released version before merge
 git+https://github.com/raiden-network/raiden-libs.git@f403970bb08bd87e234c27c8977c95746fe451c2#egg=raiden-libs
-git+https://github.com/raiden-network/raiden-contracts.git@1b8ad2f9db571c2e39399fdafd262304b82888b9#egg=raiden-contracts
+git+https://github.com/raiden-network/raiden-contracts.git@2ab91aa4b062d88a124ce050551e2f4b8cb0da57#egg=raiden-contracts
 webargs==1.8.1
 eth-keyfile==0.5.1
 eth_utils==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ install_requires_replacements = {
     ): 'raiden-libs',
     (
         'git+https://github.com/raiden-network/raiden-contracts.git'
-        '@1b8ad2f9db571c2e39399fdafd262304b82888b9#egg=raiden-contracts'
+        '@2ab91aa4b062d88a124ce050551e2f4b8cb0da57#egg=raiden-contracts'
     ): 'raiden-contracts',
 }
 

--- a/tools/pyinstaller_hooks/hook-raiden_contracts.py
+++ b/tools/pyinstaller_hooks/hook-raiden_contracts.py
@@ -1,0 +1,6 @@
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH
+
+
+datas = [
+    (str(CONTRACTS_PRECOMPILED_PATH), '.'),
+]

--- a/tools/pyinstaller_hooks/runtime_encoding.py
+++ b/tools/pyinstaller_hooks/runtime_encoding.py
@@ -1,7 +1,7 @@
 import os
 
 """
-Python 2.7 behaves badly if there is no locale set. This adds a fallback to `en_US.UTF-8`.
+File io can fail if there is no locale set. This adds a fallback to `en_US.UTF-8`.
 """
 
 if not any(k in os.environ for k in ['LC_CTYPE', 'LC_ALL', 'LANG']):

--- a/tools/pyinstaller_hooks/runtime_gevent_monkey.py
+++ b/tools/pyinstaller_hooks/runtime_gevent_monkey.py
@@ -1,0 +1,4 @@
+from gevent.monkey import patch_all
+
+
+patch_all()

--- a/tools/pyinstaller_hooks/runtime_raiden_contracts.py
+++ b/tools/pyinstaller_hooks/runtime_raiden_contracts.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+from raiden_contracts import contract_manager
+
+
+# `sys._MEIPASS` is the root of the extracted pyinstaller bundle
+base_path = Path(sys._MEIPASS)
+
+# Patch location of compiled contracts.
+contract_manager.CONTRACTS_PRECOMPILED_PATH = base_path.joinpath('contracts.json.gz')
+contract_manager.CONTRACT_MANAGER = contract_manager.ContractManager(
+    contract_manager.CONTRACTS_PRECOMPILED_PATH,
+)


### PR DESCRIPTION
Fixes #1550 
Requires raiden-network/raiden-contracts#169, raiden-network/raiden-contracts#178

Also includes a small drive-by-fix for the UPnP port mapper which caused exceptions when exiting Raiden while multiple Raiden nodes were running behind a common UPnP gateway.