### PR TITLE
Fixed the call to settle

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -267,23 +267,25 @@ def handle_contract_send_channelsettle(
         partner_locked_amount = 0
         partner_locksroot = b''
 
-    # The smart contract requires the first balance proof to be the one with
-    # the smaller transferred_amount. This is used to simplify overflow checks
-    # in the smart contract.
-    if our_transferred_amount < partner_transferred_amount:
-        first_transferred_amount = partner_transferred_amount
-        first_locked_amount = partner_locked_amount
-        first_locksroot = partner_locksroot
-        second_transferred_amount = our_transferred_amount
-        second_locked_amount = our_locked_amount
-        second_locksroot = our_locksroot
-    else:
+    our_max_transferred = our_transferred_amount + our_locked_amount
+    partner_max_transferred = partner_transferred_amount + partner_locked_amount
+
+    # The smart contract requires the max transferred of the /first/ balance
+    # proof to be /smaller/.
+    if our_max_transferred < partner_max_transferred:
         first_transferred_amount = our_transferred_amount
         first_locked_amount = our_locked_amount
         first_locksroot = our_locksroot
         second_transferred_amount = partner_transferred_amount
         second_locked_amount = partner_locked_amount
         second_locksroot = partner_locksroot
+    else:
+        first_transferred_amount = partner_transferred_amount
+        first_locked_amount = partner_locked_amount
+        first_locksroot = partner_locksroot
+        second_transferred_amount = our_transferred_amount
+        second_locked_amount = our_locked_amount
+        second_locksroot = our_locksroot
 
     try:
         channel.settle(


### PR DESCRIPTION
The smart contract function `settleChannel` enforces order of the
arguments based on sum of transferred and locked amount.

    function settleChannel(
        address participant1,
        uint256 participant1_transferred_amount,
        uint256 participant1_locked_amount,
        bytes32 participant1_locksroot,
        address participant2,
        uint256 participant2_transferred_amount,
        uint256 participant2_locked_amount,
        bytes32 participant2_locksroot
    )

These values must correspond to two valid balance proofs
(TokenNetwork.sol:504):

    require(verifyBalanceHashData(
        participant1_state,
        participant1_transferred_amount,
        participant1_locked_amount,
        participant1_locksroot
    ));
    require(verifyBalanceHashData(
        participant2_state,
        participant2_transferred_amount,
        participant2_locked_amount,
        participant2_locksroot
    ));

And the sum of the transferred and locked amount of the second
participant (TokenNetwork.sol:915-925):

    participant1_max_transferred = failsafe_addition(
        participant1_settlement.transferred,
        participant1_settlement.locked
    );
    participant2_max_transferred = failsafe_addition(
        participant2_settlement.transferred,
        participant2_settlement.locked
    );

Must be larger than the sum for the first (TokenNetwork.sol:929):

    require(participant2_max_transferred >= participant1_max_transferred);

[raiden-contracts repo commit ba5d2601b12905c4dd23f585340af7bd635516fa]