### PR TITLE
made geth the default blockchain

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--blockchain-type',
         choices=['geth', 'tester'],
-        default='tester',
+        default='geth',
     )
 
     parser.addoption(


### PR DESCRIPTION
tester not should be the default blockchain, it doesn't behave *exactly*
like geth and can fail differently then an actually ethereum client, as
a consequence tests passing locally does not imply that the build will
be green.