### PR TITLE
disable pytest's captlogs if --log-config is used

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -73,6 +73,9 @@ def logging_level(request):
 
     For integration tests this also sets the geth verbosity.
     """
+    # disable pytest's built in log capture, otherwise logs are printed twice
+    request.config.option.showcapture = 'no'
+
     if request.config.option.log_cli_level:
         level = request.config.option.log_cli_level
     elif request.config.option.verbose > 3:


### PR DESCRIPTION
pytest's always captures the log output and prints after the test is
executed, with separators for the test setup/execution/teardown. This
however means that all the log output from a test run is duplicated.
This will automatically disable pytest's option if `--log-config` is
used.