### PR TITLE
Use Python 3.6 on ReadTheDocs [skip ci]

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6


### PR DESCRIPTION
We need to use Python 3.6 on ReadTheDocs, otherwise, it will break when using 3.6 only syntax (e.g. `var: Type` w/o value assignment).