### PR TITLE
using raiden-contract's precompiled contracts

### DIFF
--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -6,11 +6,7 @@ from raiden.network.proxies import (
     TokenNetwork,
 )
 
-from raiden_contracts.contract_manager import (
-    CONTRACT_MANAGER,
-    ContractManager,
-    CONTRACTS_SOURCE_DIRS,
-)
+from raiden_contracts.contract_manager import CONTRACT_MANAGER
 from eth_utils import to_canonical_address
 
 from raiden_contracts.constants import (
@@ -131,8 +127,7 @@ def deploy_token(deploy_client):
             ),
         )
 
-        manager = ContractManager(CONTRACTS_SOURCE_DIRS)
-        contract_abi = manager.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN)
+        contract_abi = CONTRACT_MANAGER.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN)
         return deploy_client.new_contract_proxy(
             contract_interface=contract_abi,
             contract_address=token_address,

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -2,7 +2,7 @@ from binascii import unhexlify
 
 from eth_utils import remove_0x_prefix
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
-from raiden_contracts.contract_manager import ContractManager, CONTRACTS_SOURCE_DIRS
+from raiden_contracts.contract_manager import CONTRACT_MANAGER
 
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
@@ -58,8 +58,7 @@ def deploy_contract_web3(
         num_confirmations: int = None,
         constructor_arguments: typing.Tuple[typing.Any, ...] = (),
 ) -> typing.Address:
-    manager = ContractManager(CONTRACTS_SOURCE_DIRS)
-    contract_interface = manager.get_contract(contract_name)
+    contract_interface = CONTRACT_MANAGER.get_contract(contract_name)
 
     contract = deploy_client.web3.eth.contract(
         abi=contract_interface['abi'],


### PR DESCRIPTION
the most recent version of the raiden-contract ContractManager includes
the test smart contracts, so we don't need to compile the smart
contracts in the fixures anymore