### PR TITLE
Ensure matrix.log property returns a logger even if called on __init__

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -264,7 +264,7 @@ class MatrixTransport:
     def log(self):
         if self._bound_logger:
             return self._bound_logger
-        if not getattr(self._client, 'user_id', None):
+        if not getattr(self, '_client', None) or not getattr(self._client, 'user_id', None):
             return log
         self._bound_logger = log.bind(current_user=self._client.user_id)
         return self._bound_logger


### PR DESCRIPTION
Fix #1761