### PR TITLE
Handle EventTransferReceivedInvalidDirectTransfer by ignoring

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -9,6 +9,7 @@ from raiden.transfer.events import (
     ContractSendChannelSettle,
     ContractSendChannelUpdateTransfer,
     ContractSendChannelBatchUnlock,
+    EventTransferReceivedInvalidDirectTransfer,
     EventTransferReceivedSuccess,
     EventTransferSentFailed,
     EventTransferSentSuccess,
@@ -33,6 +34,7 @@ RaidenService = 'RaidenService'
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 UNEVENTFUL_EVENTS = (
+    EventTransferReceivedInvalidDirectTransfer,
     EventTransferReceivedSuccess,
     EventUnlockSuccess,
     EventUnlockClaimFailed,


### PR DESCRIPTION
At the moment if an `EventTransferReceivedInvalidDirectTransfer` is processed it's logged as an error due to being an unknown event. Since we don't handle it in any specific way yet, just add it to `UNEVENTFUL_EVENTS` so that it's not logged as an unknown event type.