### PR TITLE
Remove channel_identifier usage to search for channels

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -18,7 +18,6 @@ from raiden.transfer.events import (
     EventTransferReceivedSuccess,
 )
 from raiden.transfer.state_change import ActionChannelClose
-from raiden.transfer.utils import calculate_channel_identifier
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     ChannelBusyError,
@@ -68,19 +67,18 @@ class RaidenAPI:
         if not is_binary_address(partner_address):
             raise InvalidAddress('Expected binary address format for partner in get_channel')
 
-        channel_identifer = calculate_channel_identifier(self.raiden.address, partner_address)
-
         channel_list = self.get_channel_list(registry_address, token_address, partner_address)
-        for channel in channel_list:
-            if channel.identifier == channel_identifer:
-                return channel
+        assert len(channel_list) <= 1
 
-        raise ChannelNotFound(
-            "Channel with partner '{}' for token '{}' could not be found.".format(
-                to_checksum_address(partner_address),
-                to_checksum_address(token_address),
-            ),
-        )
+        if not channel_list:
+            raise ChannelNotFound(
+                "Channel with partner '{}' for token '{}' could not be found.".format(
+                    to_checksum_address(partner_address),
+                    to_checksum_address(token_address),
+                ),
+            )
+
+        return channel_list[0]
 
     def token_network_register(
             self,

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -22,9 +22,8 @@ from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     CHANNEL_STATE_CLOSED,
 )
-from raiden.transfer.utils import calculate_channel_identifier
+from raiden.tests.utils import dicts_are_equal
 from raiden.tests.utils.smartcontracts import deploy_contract_web3
-from raiden.utils import data_encoder
 
 # pylint: disable=too-many-locals,unused-argument,too-many-lines
 
@@ -340,12 +339,8 @@ def test_api_open_and_deposit_channel(
     expected_response = channel_data_obj
     expected_response['balance'] = 0
     expected_response['state'] = CHANNEL_STATE_OPENED
-    first_channel_identifier = data_encoder(calculate_channel_identifier(
-        api_backend[1].raiden_api.raiden.address,
-        to_canonical_address(first_partner_address),
-    ))
-    expected_response['channel_identifier'] = first_channel_identifier
-    assert response == expected_response
+    expected_response['channel_identifier'] = dicts_are_equal.IGNORE_VALUE
+    assert dicts_are_equal(response, expected_response)
 
     # now let's open a channel and make a deposit too
     second_partner_address = '0x29FA6cf0Cce24582a9B20DB94Be4B6E017896038'
@@ -371,12 +366,8 @@ def test_api_open_and_deposit_channel(
     expected_response = channel_data_obj
     expected_response['balance'] = balance
     expected_response['state'] = CHANNEL_STATE_OPENED
-    second_channel_identifier = data_encoder(calculate_channel_identifier(
-        api_backend[1].raiden_api.raiden.address,
-        to_canonical_address(second_partner_address),
-    ))
-    expected_response['channel_identifier'] = second_channel_identifier
-    assert response == expected_response
+    expected_response['channel_identifier'] = dicts_are_equal.IGNORE_VALUE
+    assert dicts_are_equal(response, expected_response)
 
     # let's deposit on the first channel
     request = grequests.patch(
@@ -392,7 +383,7 @@ def test_api_open_and_deposit_channel(
     assert_proper_response(response)
     response = response.json()
     expected_response = {
-        'channel_identifier': first_channel_identifier,
+        'channel_identifier': dicts_are_equal.IGNORE_VALUE,
         'partner_address': first_partner_address,
         'token_address': to_checksum_address(token_address),
         'settle_timeout': settle_timeout,
@@ -400,7 +391,7 @@ def test_api_open_and_deposit_channel(
         'state': CHANNEL_STATE_OPENED,
         'balance': balance,
     }
-    assert response == expected_response
+    assert dicts_are_equal(response, expected_response)
 
     # finally let's try querying for the second channel
     request = grequests.get(
@@ -416,7 +407,7 @@ def test_api_open_and_deposit_channel(
     assert_proper_response(response)
     response = response.json()
     expected_response = {
-        'channel_identifier': second_channel_identifier,
+        'channel_identifier': dicts_are_equal.IGNORE_VALUE,
         'partner_address': second_partner_address,
         'token_address': to_checksum_address(token_address),
         'settle_timeout': settle_timeout,
@@ -424,7 +415,7 @@ def test_api_open_and_deposit_channel(
         'state': CHANNEL_STATE_OPENED,
         'balance': balance,
     }
-    assert response == expected_response
+    assert dicts_are_equal(response, expected_response)
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
@@ -459,12 +450,8 @@ def test_api_open_close_and_settle_channel(
     expected_response['balance'] = balance
     expected_response['state'] = CHANNEL_STATE_OPENED
     expected_response['reveal_timeout'] = reveal_timeout
-    channel_identifier = data_encoder(calculate_channel_identifier(
-        api_backend[1].raiden_api.raiden.address,
-        to_canonical_address(partner_address),
-    ))
-    expected_response['channel_identifier'] = channel_identifier
-    assert response == expected_response
+    expected_response['channel_identifier'] = dicts_are_equal.IGNORE_VALUE
+    assert dicts_are_equal(response, expected_response)
 
     # let's close the channel
     request = grequests.patch(
@@ -479,7 +466,7 @@ def test_api_open_close_and_settle_channel(
     response = request.send().response
     assert_proper_response(response)
     expected_response = {
-        'channel_identifier': channel_identifier,
+        'channel_identifier': dicts_are_equal.IGNORE_VALUE,
         'partner_address': partner_address,
         'token_address': to_checksum_address(token_address),
         'settle_timeout': settle_timeout,
@@ -487,7 +474,7 @@ def test_api_open_close_and_settle_channel(
         'state': CHANNEL_STATE_CLOSED,
         'balance': balance,
     }
-    assert response.json() == expected_response
+    assert dicts_are_equal(response.json(), expected_response)
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
@@ -1009,12 +996,8 @@ def test_api_deposit_limit(
     expected_response = channel_data_obj
     expected_response['balance'] = balance_working
     expected_response['state'] = CHANNEL_STATE_OPENED
-    first_channel_identifier = data_encoder(calculate_channel_identifier(
-        api_backend[1].raiden_api.raiden.address,
-        to_canonical_address(first_partner_address),
-    ))
-    expected_response['channel_identifier'] = first_channel_identifier
-    assert response == expected_response
+    expected_response['channel_identifier'] = dicts_are_equal.IGNORE_VALUE
+    assert dicts_are_equal(response, expected_response)
 
     # now let's open a channel and deposit a bit more than the limit
     second_partner_address = '0x29FA6cf0Cce24582a9B20DB94Be4B6E017896038'

--- a/raiden/tests/utils/__init__.py
+++ b/raiden/tests/utils/__init__.py
@@ -18,8 +18,8 @@ def wait_blocks(web3: Web3, blocks: int):
 
 
 def dicts_are_equal(a: dict, b: dict) -> bool:
-    """Compare dicts, but allows ignoring specific values through the
-    dicts_are_equal.IGNORE_VALUE identifier"""
+    """Compares dicts, but allows ignoring specific values through the
+    dicts_are_equal.IGNORE_VALUE object"""
     if set(a.keys()) != set(b.keys()):
         return False
     for k in a.keys():

--- a/raiden/tests/utils/__init__.py
+++ b/raiden/tests/utils/__init__.py
@@ -15,3 +15,23 @@ def wait_blocks(web3: Web3, blocks: int):
     target_block = web3.eth.blockNumber + blocks
     while web3.eth.blockNumber < target_block:
         gevent.sleep(0.5)
+
+
+def dicts_are_equal(a: dict, b: dict) -> bool:
+    """Compare dicts, but allows ignoring specific values through the
+    dicts_are_equal.IGNORE_VALUE identifier"""
+    if set(a.keys()) != set(b.keys()):
+        return False
+    for k in a.keys():
+        va, vb = a[k], b[k]
+        if dicts_are_equal.IGNORE_VALUE in (va, vb):
+            continue
+        elif isinstance(va, dict) and isinstance(vb, dict):
+            if not dicts_are_equal(va, vb):
+                return False
+        elif va != vb:
+            return False
+    return True
+
+
+dicts_are_equal.IGNORE_VALUE = object()

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -1,5 +1,4 @@
 from web3 import Web3
-from eth_utils import to_normalized_address, to_checksum_address
 
 from raiden.utils import typing
 
@@ -13,26 +12,3 @@ def hash_balance_data(
         ['uint256', 'uint256', 'bytes32'],
         [transferred_amount, locked_amount, locksroot],
     )
-
-
-def calculate_channel_identifier(
-        participant1: typing.T_Address,
-        participant2: typing.T_Address,
-) -> str:
-    """ Calculate the channel identifier between two participants in the same
-    way that the TokenNetwork contract does"""
-    participant1 = to_normalized_address(participant1)
-    participant2 = to_normalized_address(participant2)
-
-    c_participant1 = to_checksum_address(participant1)
-    c_participant2 = to_checksum_address(participant2)
-    if participant1 < participant2:
-        return Web3.soliditySha3(
-            ['address', 'address'],
-            [c_participant1, c_participant2],
-        )
-    else:
-        return Web3.soliditySha3(
-            ['address', 'address'],
-            [c_participant2, c_participant1],
-        )


### PR DESCRIPTION
This identifier has a nonce on the blockchain, which makes it very hard
to be calculated only from the parameters given in the request.
As there should never exist more than 1 channel open for each tuple
(registry_address, token_address, own_address, partner_address), we can
just use it to search for the channels we want to interact with.
Channel_identifier is still returned in the request, for information,
but its value is ignored in the tests.
Fix #1765 , broken by the changes introduced in https://github.com/raiden-network/raiden-contracts/pull/170