### PR TITLE
Stateless filter

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -352,7 +352,8 @@ class BlockchainEvents:
 
     def uninstall_all_event_listeners(self):
         for listener in self.event_listeners:
-            listener.filter.web3.eth.uninstallFilter(listener.filter.filter_id)
+            if listener.filter.filter_id:
+                listener.filter.web3.eth.uninstallFilter(listener.filter.filter_id)
 
         self.event_listeners = list()
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -158,7 +158,8 @@ class TokenNetworkRegistry:
     def filter_token_added_events(self):
         filter_ = self.proxy.contract.events.TokenNetworkCreated.createFilter(fromBlock=0)
         events = filter_.get_all_entries()
-        self.proxy.contract.web3.eth.uninstallFilter(filter_.filter_id)
+        if filter_.filter_id:
+            self.proxy.contract.web3.eth.uninstallFilter(filter_.filter_id)
 
         return events
 

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -35,6 +35,7 @@ from raiden.utils import (
     quantity_encoder,
 )
 from raiden.utils.typing import Address
+from raiden.utils.filters import StatelessFilter
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils.solc import (
     solidity_unresolved_symbols,
@@ -563,12 +564,15 @@ class JSONRPCClient:
             to_block: typing.BlockSpecification = 'latest',
     ) -> Filter:
         """ Create a filter in the ethereum node. """
-        return self.web3.eth.filter({
-            'fromBlock': from_block,
-            'toBlock': to_block,
-            'address': to_normalized_address(contract_address),
-            'topics': topics,
-        })
+        return StatelessFilter(
+            self.web3,
+            {
+                'fromBlock': from_block,
+                'toBlock': to_block,
+                'address': to_normalized_address(contract_address),
+                'topics': topics,
+            },
+        )
 
     def get_filter_events(
             self,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -373,7 +373,7 @@ class RaidenService:
         # expected side-effects are properly applied (introduced by the commit
         # 3686b3275ff7c0b669a6d5e2b34109c3bdf1921d)
         with self.event_poll_lock:
-            for event in self.blockchain_events.poll_blockchain_events():
+            for event in self.blockchain_events.poll_blockchain_events(current_block_number):
                 # These state changes will be procesed with a block_number
                 # which is /larger/ than the ChainState's block_number.
                 on_blockchain_event(self, event, current_block_number, chain_id)
@@ -413,7 +413,9 @@ class RaidenService:
             )
 
             chain_id = self.chain.network_id
-            for event in self.blockchain_events.poll_blockchain_events():
+            for event in self.blockchain_events.poll_blockchain_events(
+                self.get_block_number(),
+            ):
                 on_blockchain_event(
                     self,
                     event, event.event_data['block_number'],

--- a/raiden/tests/integration/long_running/flaky/test_token_networks.py
+++ b/raiden/tests/integration/long_running/flaky/test_token_networks.py
@@ -52,6 +52,7 @@ def saturated_count(connection_managers, open_channel_views):
 #   raiden_network fixture.
 
 
+@pytest.mark.xfail(reason='Some issues in this test, see raiden #691')
 @pytest.mark.parametrize('number_of_nodes', [6])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('settle_timeout', [6])


### PR DESCRIPTION
This web3's Filter replacement class keep the filter's argument, and use `eth_getLogs` on them, updating the `fromBlock` accordingly. It avoid installing the filter and depending on node's state (it's stateless on
the node, not in itself).
Fix #1785