### PR TITLE
Set query_start_block depending on the network identifier

### DIFF
--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -100,7 +100,7 @@ class NetworkEventsResource(BaseResource):
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, from_block, to_block):
-        from_block = from_block or 0
+        from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
         to_block = to_block or 'latest'
         return self.rest_api.get_network_events(
             registry_address=self.rest_api.raiden_api.raiden.default_registry.address,
@@ -115,7 +115,7 @@ class TokenEventsResource(BaseResource):
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, token_address, from_block, to_block):
-        from_block = from_block or 0
+        from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
         to_block = to_block or 'latest'
         return self.rest_api.get_token_network_events(
             token_address=token_address,
@@ -130,7 +130,7 @@ class ChannelEventsResource(BaseResource):
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, token_network_address, channel_identifier, from_block, to_block):
-        from_block = from_block or 0
+        from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
         to_block = to_block or 'latest'
         return self.rest_api.get_channel_events(
             token_network_address=token_network_address,

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -3,7 +3,7 @@ import sys
 import structlog
 from binascii import unhexlify
 from eth_utils import to_normalized_address, to_checksum_address
-from typing import Dict
+from raiden.utils import typing
 
 import gevent
 
@@ -80,8 +80,9 @@ class App:  # pylint: disable=too-few-public-methods
 
     def __init__(
             self,
-            config: Dict,
+            config: typing.Dict,
             chain: BlockChainService,
+            query_start_block: typing.BlockNumber,
             default_registry: TokenNetworkRegistry,
             default_secret_registry: SecretRegistry,
             transport,
@@ -110,13 +111,14 @@ class App:  # pylint: disable=too-few-public-methods
 
         try:
             self.raiden = RaidenService(
-                chain,
-                default_registry,
-                default_secret_registry,
-                unhexlify(config['privatekey_hex']),
-                transport,
-                config,
-                discovery,
+                chain=chain,
+                query_start_block=query_start_block,
+                default_registry=default_registry,
+                default_secret_registry=default_secret_registry,
+                private_key_bin=unhexlify(config['privatekey_hex']),
+                transport=transport,
+                config=config,
+                discovery=discovery,
             )
         except filelock.Timeout:
             pubkey = to_normalized_address(

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 UINT64_MAX = 2 ** 64 - 1
 UINT64_MIN = 0
 
@@ -34,6 +36,10 @@ ID_TO_NETWORKNAME = {
     42: KOVAN,
     627: SMOKETEST,
 }
+
+ID_TO_QUERY_BLOCK = defaultdict(int, {
+    3: 3622000,  # 52 blocks before token network registry deployment
+})
 
 NETWORKNAME_TO_ID = {
     name: id

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -48,6 +48,7 @@ from raiden.utils import (
     privatekey_to_address,
     random_secret,
     create_default_identifier,
+    typing,
 )
 from raiden.storage import wal, serialize, sqlite
 
@@ -144,6 +145,7 @@ class RaidenService:
     def __init__(
             self,
             chain: BlockChainService,
+            query_start_block: typing.BlockNumber,
             default_registry: TokenNetworkRegistry,
             default_secret_registry: SecretRegistry,
             private_key_bin,
@@ -159,6 +161,7 @@ class RaidenService:
 
         self.chain: BlockChainService = chain
         self.default_registry = default_registry
+        self.query_start_block = query_start_block
         self.default_secret_registry = default_secret_registry
         self.config = config
         self.privkey = private_key_bin

--- a/raiden/tests/benchmark/speed_simulation.py
+++ b/raiden/tests/benchmark/speed_simulation.py
@@ -81,6 +81,7 @@ def setup_tps(
         config_path,
         privatekey,
         registry_address,
+        secret_registry_address,
         token_address,
         deposit,
         settle_timeout):
@@ -140,6 +141,7 @@ def tps_run(
         privatekey,
         rpc_server,
         registry_address,
+        secret_registry_address,
         token_address,
         transfer_amount,
         parallel):
@@ -193,13 +195,14 @@ def tps_run(
         config['protocol'],
     )
 
-    # FIXME: This is missing the registry
-    # FIXME: This is missing the secret registry
     app = App(
-        config,
-        blockchain_service,
-        transport,
-        discovery,
+        config=config,
+        chain=blockchain_service,
+        query_start_block=0,
+        default_registry=registry_address,
+        default_secret_registry=secret_registry_address,
+        transport=transport,
+        discovery=discovery,
     )
 
     for _ in range(parallel):
@@ -264,6 +267,7 @@ def main():
             unhexlify(args.privatekey),
             args.rpc_server,
             args.registry_address,
+            args.secret_registry_address,
             TOKEN_ADDRESS,
             TRANSFER_AMOUNT,
             args.parallel,
@@ -275,6 +279,7 @@ def main():
             args.config,
             unhexlify(args.privatekey),
             args.registry_address,
+            args.secret_registry_address,
             TOKEN_ADDRESS,
             deposit,
             DEFAULT_SETTLE_TIMEOUT,

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -59,12 +59,13 @@ def test_recovery_happy_case(
     )
 
     app0_restart = App(
-        app0.config,
-        app0.raiden.chain,
-        app0.raiden.default_registry,
-        app0.raiden.default_secret_registry,
-        new_transport,
-        app0.raiden.discovery,
+        config=app0.config,
+        chain=app0.raiden.chain,
+        query_start_block=0,
+        default_registry=app0.raiden.default_registry,
+        default_secret_registry=app0.raiden.default_secret_registry,
+        transport=new_transport,
+        discovery=app0.raiden.discovery,
     )
 
     app0.stop()
@@ -190,12 +191,13 @@ def test_recovery_unhappy_case(
     )
 
     app0_restart = App(
-        app0.config,
-        app0.raiden.chain,
-        app0.raiden.default_registry,
-        app0.raiden.default_secret_registry,
-        new_transport,
-        app0.raiden.discovery,
+        config=app0.config,
+        chain=app0.raiden.chain,
+        query_start_block=0,
+        default_registry=app0.raiden.default_registry,
+        default_secret_registry=app0.raiden.default_secret_registry,
+        transport=new_transport,
+        discovery=app0.raiden.discovery,
     )
     del app0  # from here on the app0_restart should be used
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -325,12 +325,13 @@ def create_apps(
             )
 
         app = App(
-            config_copy,
-            blockchain,
-            registry,
-            secret_registry,
-            transport,
-            discovery,
+            config=config_copy,
+            chain=blockchain,
+            query_start_block=0,
+            default_registry=registry,
+            default_secret_registry=secret_registry,
+            transport=transport,
+            discovery=discovery,
         )
         apps.append(app)
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -684,12 +684,13 @@ def app(
 
     try:
         raiden_app = App(
-            config,
-            blockchain_service,
-            token_network_registry,
-            secret_registry,
-            transport,
-            discovery,
+            config=config,
+            chain=blockchain_service,
+            query_start_block=constants.ID_TO_QUERY_BLOCK[net_id],
+            default_registry=token_network_registry,
+            default_secret_registry=secret_registry,
+            transport=transport,
+            discovery=discovery,
         )
     except (InvalidSettleTimeout, InvalidDBData) as e:
         print(f'FATAL: {str(e)}')

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -127,12 +127,13 @@ def run(
     )
 
     app = App(
-        config,
-        blockchain_service,
-        registry,
-        secret_registry,
-        transport,
-        discovery,
+        config=config,
+        chain=blockchain_service,
+        query_start_block=0,
+        default_registry=registry,
+        default_secret_registry=secret_registry,
+        transport=transport,
+        discovery=discovery,
     )
 
     app.discovery.register(


### PR DESCRIPTION
Depending on the network identifier (mainnet, ropsten e.t.c.) set a different
query start block and forward it to the api event filters.

Fix #1738