### PR TITLE
Raiden must use a single TokenNetworkProxy per TN

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -218,7 +218,9 @@ class RaidenAPI:
             raise InvalidAddress('Expected binary address format for partner in channel open')
 
         registry = self.raiden.chain.token_network_registry(registry_address)
-        token_network = registry.token_network_by_token(token_address)
+        token_network_address = registry.get_token_network(token_address)
+        token_network = self.raiden.chain.token_network(token_network_address)
+
         channel_identifier = token_network.new_netting_channel(
             partner_address,
             settle_timeout,
@@ -293,7 +295,8 @@ class RaidenAPI:
         token = self.raiden.chain.token(token_address)
         netcontract_address = channel_state.identifier
         token_network_registry = self.raiden.chain.token_network_registry(registry_address)
-        token_network_proxy = token_network_registry.token_network_by_token(token_address)
+        token_network_address = token_network_registry.get_token_network(token_address)
+        token_network_proxy = self.raiden.chain.token_network(token_network_address)
         channel_proxy = self.raiden.chain.payment_channel(
             token_network_proxy.address,
             netcontract_address,
@@ -621,9 +624,9 @@ class RaidenAPI:
     def get_channel_events(
             self,
             token_address: typing.Address,
-            partner_address: typing.Address=None,
-            from_block: typing.BlockSpecification=0,
-            to_block: typing.BlockSpecification='latest',
+            partner_address: typing.Address = None,
+            from_block: typing.BlockSpecification = 0,
+            to_block: typing.BlockSpecification = 'latest',
     ):
         token_network_address = self.raiden.default_registry.get_token_network(
             token_address,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -30,7 +30,6 @@ from raiden.exceptions import (
     InvalidAddress,
     InvalidAmount,
     InvalidSettleTimeout,
-    NoTokenManager,
     SamePeerAddress,
     TransactionThrew,
     UnknownTokenAddress,
@@ -383,7 +382,7 @@ class RestAPI:
                 reveal_timeout,
             )
         except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
-                AddressWithoutCode, NoTokenManager, DuplicatedChannelError) as e:
+                AddressWithoutCode, DuplicatedChannelError) as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -41,11 +41,7 @@ def handle_tokennetwork_new(raiden, event, current_block_number):
     data = event.event_data
     token_network_address = data['token_network_address']
 
-    token_network_registry_address = event.originating_contract
-    token_network_registry_proxy = raiden.chain.token_network_registry(
-        token_network_registry_address,
-    )
-    token_network_proxy = token_network_registry_proxy.token_network(token_network_address)
+    token_network_proxy = raiden.chain.token_network(token_network_address)
     raiden.blockchain_events.add_token_network_listener(
         token_network_proxy,
         from_block=data['blockNumber'],

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -114,10 +114,6 @@ class AddressWithoutCode(RaidenError):
     pass
 
 
-class NoTokenManager(RaidenError):
-    """Manager for a given token does not exist."""
-
-
 class DuplicatedChannelError(RaidenError):
     """Raised if someone tries to create a channel that already exists."""
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -1,4 +1,4 @@
-from binascii import hexlify, unhexlify
+from binascii import unhexlify
 from typing import Optional
 
 import structlog
@@ -13,15 +13,14 @@ from eth_utils import (
     is_same_address,
 )
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
-
-from raiden.utils import typing, compare_versions
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     EVENT_TOKEN_NETWORK_CREATED,
 )
+
+from raiden.utils import typing, compare_versions
 from raiden.constants import NULL_ADDRESS
 from raiden.exceptions import (
-    NoTokenManager,
     TransactionThrew,
     InvalidAddress,
     ContractVersionMismatch,
@@ -33,7 +32,6 @@ from raiden.utils import (
 from raiden.settings import (
     EXPECTED_CONTRACTS_VERSION,
 )
-from raiden.network.proxies.token_network import TokenNetwork
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.transactions import (
     check_transaction_threw,
@@ -77,6 +75,9 @@ class TokenNetworkRegistry:
         """ Return the token network address for the given token or None if
         there is no correspoding address.
         """
+        if not isinstance(token_address, typing.T_TargetAddress):
+            raise ValueError('token_address must be an address')
+
         address = self.proxy.contract.functions.token_to_token_networks(
             to_checksum_address(token_address),
         ).call()
@@ -124,10 +125,6 @@ class TokenNetworkRegistry:
             )
 
             raise RuntimeError('token_to_token_networks failed')
-        self.token_to_tokennetwork[token_address] = TokenNetwork(
-            self.client,
-            token_network_address,
-        )
 
         log.info(
             'add_token sucessful',
@@ -158,57 +155,10 @@ class TokenNetworkRegistry:
             to_block=to_block,
         )
 
-    def token_network(self, token_network_address: typing.TokenNetworkAddress):
-        """ Return a proxy to interact with a TokenNetwork. """
-        if not is_binary_address(token_network_address):
-            raise InvalidAddress('Expected binary address format for token network')
-
-        if token_network_address not in self.address_to_tokennetwork:
-            token_network = TokenNetwork(
-                self.client,
-                token_network_address,
-            )
-
-            token_address = token_network.token_address()
-
-            self.token_to_tokennetwork[token_address] = token_network
-            self.address_to_tokennetwork[token_network_address] = token_network
-
-        return self.address_to_tokennetwork[token_network_address]
-
-    def token_network_by_token(self, token_address: typing.TokenAddress):
-        """ Find the token network for `token_address` and return a proxy to
-        interact with it.
-
-        If the token is not already registered it raises `EthNodeCommunicationError`,
-        since we try to instantiate a Token Network with an empty address.
-        """
-        if not is_binary_address(token_address):
-            raise InvalidAddress('Expected binary address format for token')
-
-        if token_address not in self.token_to_tokennetwork:
-            check_address_has_code(self.client, token_address)  # check that the token exists
-            token_network_address = self.get_token_network(token_address)
-
-            if token_network_address is None:
-                raise NoTokenManager(
-                    'TokenNetwork for token 0x{} does not exist'.format(hexlify(token_address)),
-                )
-
-            token_network = TokenNetwork(
-                self.client,
-                token_network_address,
-            )
-
-            self.token_to_tokennetwork[token_address] = token_network
-            self.address_to_tokennetwork[token_network_address] = token_network
-
-        return self.token_to_tokennetwork[token_address]
-
     def filter_token_added_events(self):
-        filter = self.proxy.contract.events.TokenNetworkCreated.createFilter(fromBlock=0)
-        events = filter.get_all_entries()
-        self.proxy.contract.web3.eth.uninstallFilter(filter.filter_id)
+        filter_ = self.proxy.contract.events.TokenNetworkCreated.createFilter(fromBlock=0)
+        events = filter_.get_all_entries()
+        self.proxy.contract.web3.eth.uninstallFilter(filter_.filter_id)
 
         return events
 

--- a/raiden/tests/integration/contracts/test_network_registry.py
+++ b/raiden/tests/integration/contracts/test_network_registry.py
@@ -5,12 +5,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
 )
 
-from raiden.exceptions import (
-    TransactionThrew,
-    InvalidAddress,
-    AddressWithoutCode,
-    NoTokenManager,
-)
+from raiden.exceptions import TransactionThrew
 from raiden.tests.utils.factories import make_address
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 
@@ -46,13 +41,9 @@ def test_network_registry(token_network_registry_proxy: TokenNetworkRegistry, de
         token_network_address,
     )
 
-    with pytest.raises(AddressWithoutCode):
-        token_network_registry_proxy.token_network_by_token(bad_token_address)
-    with pytest.raises(InvalidAddress):
-        token_network_registry_proxy.token_network_by_token(None)
-    with pytest.raises(NoTokenManager):
-        token_network_registry_proxy.token_network_by_token(token_network_address)
-    token_manager = token_network_registry_proxy.token_network_by_token(
-        test_token_address,
-    )
-    assert token_manager is not None
+    with pytest.raises(ValueError):
+        assert token_network_registry_proxy.get_token_network(None) is None
+
+    assert token_network_registry_proxy.get_token_network(bad_token_address) is None
+    assert token_network_registry_proxy.get_token_network(token_network_address) is None
+    assert token_network_registry_proxy.get_token_network(test_token_address) is not None

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -19,7 +19,8 @@ def test_channel_with_self(raiden_network, settle_timeout, token_addresses):
     )
     assert not current_chanels
 
-    token_network0 = app0.raiden.default_registry.token_network_by_token(token_address)
+    token_network_address = app0.raiden.default_registry.get_token_network(token_address)
+    token_network0 = app0.raiden.chain.token_network(token_network_address)
 
     with pytest.raises(SamePeerAddress) as excinfo:
         token_network0.new_netting_channel(

--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -141,7 +141,7 @@ def test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
 
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
-def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, retry_timeout):
+def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -151,7 +151,8 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, re
         token_address,
     )
 
-    manager0 = app0.raiden.default_registry.token_network_by_token(token_address)
+    token_network_address = app0.raiden.default_registry.get_token_network(token_address)
+    manager0 = app0.raiden.chain.token_network(token_network_address)
 
     channelcount0 = views.total_token_network_channels(
         views.state_from_app(app0),

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -78,7 +78,9 @@ def payment_channel_open_and_deposit(app0, app1, token_address, deposit, settle_
     """ Open a new channel with app0 and app1 as participants """
     assert token_address
 
-    token_network_proxy = app0.raiden.default_registry.token_network_by_token(token_address)
+    token_network_address = app0.raiden.default_registry.get_token_network(token_address)
+    token_network_proxy = app0.raiden.chain.token_network(token_network_address)
+
     channel_identifier = token_network_proxy.new_netting_channel(
         app1.raiden.address,
         settle_timeout,


### PR DESCRIPTION
The TokenNetworkRegistry class had two methods to instantiate
TokenNetwork proxies in addition to the method available on the
BlockchainService class. This allowed multiple version of the
TokenNetworkProxy to coexist on the same process, making the locking
useless.