### PR TITLE
Add check for blocknumber validity

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -537,7 +537,9 @@ Events are queried by two different endpoints depending on whether they are rela
 to a specific channel or not.
 
 All events can be filtered down by providing the query string arguments ``from_block``
-and/or ``to_block`` to query only a events from a limited range of blocks.
+and/or ``to_block`` to query only a events from a limited range of blocks. The block number 
+argument needs to be in the range of 0 to UINT64_MAX. Any blocknumber outside this range will
+be rejected.
 
 .. http:get:: /api/(version)/events/network
 
@@ -575,6 +577,7 @@ and/or ``to_block`` to query only a events from a limited range of blocks.
 
    :statuscode 200: For successful query
    :statuscode 400: If the provided query string is malformed
+   :statuscode 409: If the given block number argument is invalid
    :statuscode 500: Internal Raiden node error
 
 .. http:get:: /api/(version)/events/tokens/(token_address)
@@ -614,6 +617,7 @@ and/or ``to_block`` to query only a events from a limited range of blocks.
    :statuscode 200: For successful query
    :statuscode 400: If the provided query string is malformed
    :statuscode 404: If the token does not exist
+   :statuscode 409: If the given block number argument is invalid
    :statuscode 500: Internal Raiden node error
 
 .. http:get:: /api/(version)/events/channels/(channel_address)
@@ -656,4 +660,5 @@ and/or ``to_block`` to query only a events from a limited range of blocks.
   :statuscode 200: For successful query
   :statuscode 400: If the provided query string is malformed
   :statuscode 404: If the channel does not exist
+  :statuscode 409: If the given block number argument is invalid
   :statuscode 500: Internal Raiden node error

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -621,9 +621,9 @@ class RaidenAPI:
     def get_channel_events(
             self,
             token_address: typing.Address,
-            partner_address: typing.Address=None,
-            from_block: typing.BlockSpecification=0,
-            to_block: typing.BlockSpecification='latest',
+            partner_address: typing.Address = None,
+            from_block: typing.BlockSpecification = 0,
+            to_block: typing.BlockSpecification = 'latest',
     ):
         token_network_address = self.raiden.default_registry.get_token_network(
             token_address,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -28,6 +28,7 @@ from raiden.exceptions import (
     EthNodeCommunicationError,
     InsufficientFunds,
     InvalidAddress,
+    InvalidBlockNumberInput,
     InvalidAmount,
     InvalidSettleTimeout,
     NoTokenManager,
@@ -547,11 +548,15 @@ class RestAPI:
         return api_response(result=result.data)
 
     def get_network_events(self, registry_address, from_block, to_block):
-        raiden_service_result = self.raiden_api.get_network_events(
-            registry_address,
-            from_block,
-            to_block,
-        )
+        try:
+            raiden_service_result = self.raiden_api.get_network_events(
+                registry_address,
+                from_block,
+                to_block,
+            )
+        except InvalidBlockNumberInput as e:
+            return api_error(str(e), status_code=HTTPStatus.CONFLICT)
+
         return api_response(result=normalize_events_list(raiden_service_result))
 
     def get_token_network_events(self, token_address, from_block, to_block):
@@ -564,6 +569,8 @@ class RestAPI:
             return api_response(result=normalize_events_list(raiden_service_result))
         except UnknownTokenAddress as e:
             return api_error(str(e), status_code=HTTPStatus.NOT_FOUND)
+        except InvalidBlockNumberInput as e:
+            return api_error(str(e), status_code=HTTPStatus.CONFLICT)
 
     def get_channel_events(
             self,
@@ -572,12 +579,16 @@ class RestAPI:
             from_block=None,
             to_block=None,
     ):
-        raiden_service_result = self.raiden_api.get_channel_events(
-            token_address,
-            partner_address,
-            from_block,
-            to_block,
-        )
+        try:
+            raiden_service_result = self.raiden_api.get_channel_events(
+                token_address,
+                partner_address,
+                from_block,
+                to_block,
+            )
+        except InvalidBlockNumberInput as e:
+            return api_error(str(e), status_code=HTTPStatus.CONFLICT)
+
         return api_response(result=normalize_events_list(raiden_service_result))
 
     def get_channel(self, registry_address, token_address, partner_address):

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -23,6 +23,8 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
 
+from raiden.constants import UINT64_MAX
+from raiden.exceptions import InvalidBlockNumberInput
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies import PaymentChannel
 from raiden.utils import pex, typing
@@ -31,6 +33,15 @@ from raiden.utils.filters import (
     get_filter_args_for_all_events_from_channel,
 )
 from raiden.utils.typing import Address, BlockSpecification, ChannelID
+
+
+def verify_block_number(number: typing.BlockSpecification, argname: str):
+    if isinstance(number, int) and (number < 0 or number > UINT64_MAX):
+        raise InvalidBlockNumberInput(
+            'Provided block number {} for {} is invalid. Has to be in the range '
+            'of [0, UINT64_MAX]'.format(number, argname),
+        )
+
 
 EventListener = namedtuple(
     'EventListener',
@@ -58,6 +69,8 @@ def get_contract_events(
     `contract_address` that match the filters `topics`, `from_block`, and
     `to_block`.
     """
+    verify_block_number(from_block, 'from_block')
+    verify_block_number(to_block, 'to_block')
     events = chain.client.get_filter_events(
         contract_address,
         topics=topics,

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -160,3 +160,7 @@ class RaidenServicePortInUseError(RaidenError):
 
 class InvalidDBData(RaidenError):
     """Raised when the data of the WAL are in an unexpected format"""
+
+
+class InvalidBlockNumberInput(RaidenError):
+    """Raised when the user provided a block number that is  < 0 or > UINT64_MAX"""

--- a/raiden/tests/unit/api/test_events.py
+++ b/raiden/tests/unit/api/test_events.py
@@ -1,0 +1,19 @@
+import pytest
+
+from raiden.exceptions import InvalidBlockNumberInput
+from raiden.blockchain.events import get_contract_events
+from raiden.tests.utils.factories import ADDR
+
+
+def test_get_contract_events_invalid_blocknumber():
+    with pytest.raises(InvalidBlockNumberInput):
+        get_contract_events(None, {}, ADDR, [], -1, 0)
+
+    with pytest.raises(InvalidBlockNumberInput):
+        get_contract_events(None, {}, ADDR, [], 999999999999999999999999, 0)
+
+    with pytest.raises(InvalidBlockNumberInput):
+        get_contract_events(None, {}, ADDR, [], 1, -1)
+
+    with pytest.raises(InvalidBlockNumberInput):
+        get_contract_events(None, {}, ADDR, [], 1, 999999999999999999999999)


### PR DESCRIPTION
Apparently in geth the block number argument can only be up to 64 bits in size
and as such arguments with size bigger than that were [rejected](https://github.com/ethereum/go-ethereum/blob/f7d3678c28c4b92e45a458e4785bd0f1cdc20e34/ethclient/ethclient.go#L278) from the geth node itself.

This patch checks that all block number input to the API is within the
acceptable range and throws an error if not. Also added a unit tests for this.

Fix #1809 