### PR TITLE
Fix block number at sync check

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -1,10 +1,7 @@
 import gevent
 from cachetools.func import ttl_cache
 import structlog
-from eth_utils import (
-    to_int,
-    is_binary_address,
-)
+from eth_utils import is_binary_address
 
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.proxies import (
@@ -57,7 +54,7 @@ class BlockChainService:
             return True
 
         current_block = self.block_number()
-        highest_block = to_int(hexstr=result['highestBlock'])
+        highest_block = result['highestBlock']
 
         if highest_block - current_block > 2:
             return False


### PR DESCRIPTION
During the start of Raiden at the sync_check we had a `to_int()` call that used to expect a hexstr. Now with web3 the conversion of the RPC call to an int happens automatically and to_int fails with the following exception trace: 

```
Traceback (most recent call last):                                    
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)                                                                                   
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)                                                                             
  File "/home/lefteris/ew/raiden/raiden/__main__.py", line 15, in <module>                                                                                                                                                                                                      
    main()                                                                                                 
  File "/home/lefteris/ew/raiden/raiden/__main__.py", line 11, in main
    run(auto_envvar_prefix='RAIDEN')                                                                      
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)                                                                     
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)                                                                                        
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)                                  
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)                       
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)                                                                      
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)                
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 966, in run
    app_ = _run_app()                                                        
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 887, in _run_app
    app_ = ctx.invoke(app, **kwargs)                                          
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)                                                           
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 621, in app
    check_synced(blockchain_service)                                                         
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 144, in check_synced
    sleep=3,                                                                                 
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 253, in wait_for_sync
    wait_for_sync_rpc_api(blockchain_service, sleep)            
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 219, in wait_for_sync_rpc_api
    if blockchain_service.is_synced():                                                                                                                                                                                                                                           
  File "/home/lefteris/ew/raiden/raiden/network/blockchain_service.py", line 60, in is_synced
    highest_block = to_int(hexstr=result['highestBlock'])
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/eth_utils/decorators.py", line 72, in wrapper                                                                                                                                                            
    _assert_hexstr_or_text_kwarg_is_text_type(**kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/eth_utils/decorators.py", line 46, in _assert_hexstr_or_text_kwarg_is_text_type
    "Instead, value was: %r" % (repr(next(list(kwargs.values()))))

```