### PR TITLE
fix test_query_events

### DIFF
--- a/raiden/tests/integration/test_events.py
+++ b/raiden/tests/integration/test_events.py
@@ -195,7 +195,7 @@ def test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
 
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
-def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout):
+def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout, retry_timeout):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -245,6 +245,8 @@ def test_query_events(raiden_chain, token_addresses, deposit, settle_timeout):
         token_address,
         app1.raiden.address,
     )
+
+    wait_both_channel_open(app0, app1, registry_address, token_address, retry_timeout)
 
     events = get_token_network_events(
         app0.raiden.chain,


### PR DESCRIPTION
Added waiting for the newly open channel to be registered on both nodes.

The [test was failing](https://travis-ci.org/raiden-network/raiden/jobs/404382403#L1445) because `app1` didn't always have enough time to fetch the `ChannelOpened` event
```
        assert_synched_channel_state(
            token_network_identifier,
            app0, 0, [],
>           app1, 0, [],
        )

    def assert_synched_channel_state(
            token_network_identifier,
            app0,
            balance0,
            pending_locks0,
            app1,
            balance1,
            pending_locks1,
    ):
        """ Assert the values of two synched channels.
    
        Note:
            This assert does not work for an intermediate state, where one message
            hasn't been delivered yet or has been completely lost."""
        # pylint: disable=too-many-arguments
    
        channel0 = get_channelstate(app0, app1, token_network_identifier)
        channel1 = get_channelstate(app1, app0, token_network_identifier)
    
>       assert channel0.our_state.contract_balance == channel1.partner_state.contract_balance
E       AttributeError: 'NoneType' object has no attribute 'partner_state'
```