### PR TITLE
Mention account ownership requirements in the docs

### DIFF
--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -107,6 +107,9 @@ Please refer to the :ref:`detailed step-by-step guide <macos_development_setup>`
 Firing it up
 =============
 
+In order to use Raiden it is required to have a specific ethereum account dedicated to Raiden. Create an account for Raiden and fill it up with ETH and some tokens you want to have in payment channels and let the Raiden client manage it.
+**Creating any manual transaction with the account that Raiden uses, while the Raiden client is running, can result to undefined behaviour**.
+
 Using geth
 **********
 


### PR DESCRIPTION
The reason for this PR is to remind our users, and ourselves that we have this implicit requirement that the Ethereum account for Raiden is not externally managed in anyway.

Doing so can result in strange behavior caused by:
- race with Raiden signed transactions and nonces against manually sent transactions by the user of the ethereum node
- logic of waiting for the transactions sent to the blockchain to be mined against sending transactions manually with higher gas
- e.t.c.