### PR TITLE
console cleanup

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -129,11 +129,6 @@ class App:  # pylint: disable=too-few-public-methods
                 f'network id {chain.network_id}',
             )
             sys.exit(1)
-        self.start_console = self.config['console']
-
-        # raiden.ui.console:Console assumes that a services
-        # attribute is available for auto-registration
-        self.services = dict()
 
     def __repr__(self):
         return '<{} {}>'.format(


### PR DESCRIPTION
- Removed SigIntHandler, it was never used because the raiden.ui.cli
only instantiates Console if the flag for it is enabled.
  - This class was used to enable the console once the node is running,
  by hooking up to the Ctrl-C signal and starting the console then
- Removed the BaseService class, this was only used for the Console
- Stopped overwritting the start method from gevent.Greenlet, this is
not the official documented way of inhereting a greenlet.
- removed the interrupt signal from Console, since the class
SigIntHandler was removed
- Removed the related attributers in the App class, which were used by
the console, since the Console has a direct reference to it