### PR TITLE
Block on busy channel

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -114,11 +114,6 @@ class DuplicatedChannelError(RaidenError):
     """Raised if someone tries to create a channel that already exists."""
 
 
-class ChannelBusyError(RaidenError):
-    """Raised if someone tries to perform an operation on a channel that
-    conflicts with an ongoing operation."""
-
-
 class ChannelIncorrectStateError(RaidenError):
     """Raised if someone tries to perform an operation on a channel that
     is in an incompatible state."""

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -57,7 +57,7 @@ class PaymentChannel:
 
     @contextmanager
     def lock_or_raise(self):
-        with self.token_network.lock_or_raise(self.participant2):
+        with self.token_network.channel_operations_lock[self.participant2]:
             yield
 
     def token_address(self) -> typing.Address:

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -497,12 +497,12 @@ class TokenNetwork:
             receipt_or_none = check_transaction_threw(self.client, transaction_hash)
 
             if receipt_or_none:
-                if token.allowance(self.node_address, self.address) != amount_to_deposit:
+                if token.allowance(self.node_address, self.address) < amount_to_deposit:
                     log_msg = (
                         'deposit failed. The allowance is insufficient, check concurrent deposits '
                         'for the same token network but different proxies.'
                     )
-                if token.balance_of(self.node_address) < amount_to_deposit:
+                elif token.balance_of(self.node_address) < amount_to_deposit:
                     log_msg = 'deposit failed. The address doesnt have funds'
                 else:
                     log_msg = 'deposit failed'

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -33,7 +33,6 @@ from raiden.exceptions import (
     DuplicatedChannelError,
     ChannelIncorrectStateError,
     SamePeerAddress,
-    ChannelBusyError,
     TransactionThrew,
     InvalidAddress,
     ContractVersionMismatch,
@@ -106,15 +105,9 @@ class TokenNetwork:
             lock = RLock()
             self.channel_operations_lock[partner] = lock
 
-        if not lock.acquire(blocking=False):
-            raise ChannelBusyError(
-                f'Channel between {self.node_address} and {partner} is '
-                f'busy with another ongoing operation.',
-            )
-
-        yield
-
-        lock.release()
+        # __enter__ will call aquire with blocking=True
+        with lock:
+            yield
 
     def token_address(self) -> typing.Address:
         """ Return the token of this manager. """

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1,6 +1,5 @@
 from binascii import unhexlify
 from collections import defaultdict
-from contextlib import contextmanager
 from typing import List, Dict, Optional
 
 import structlog
@@ -97,14 +96,6 @@ class TokenNetwork:
             raise RuntimeError(f"Call to '{function_name}' returned nothing")
 
         return call_result
-
-    @contextmanager
-    def lock_or_raise(self, partner):
-        lock = self.channel_operations_lock[partner]
-
-        # __enter__ will call aquire with blocking=True
-        with lock:
-            yield
 
     def token_address(self) -> typing.Address:
         """ Return the token of this manager. """
@@ -418,7 +409,7 @@ class TokenNetwork:
         token_address = self.token_address()
         token = Token(self.client, token_address)
 
-        with self.lock_or_raise(partner), self.deposit_lock:
+        with self.channel_operations_lock[partner], self.deposit_lock:
             # setTotalDeposit requires a monotonically increasing value. This
             # is used to handle concurrent actions:
             #
@@ -549,7 +540,7 @@ class TokenNetwork:
                 'Channel is not in an opened state. It cannot be closed.',
             )
 
-        with self.lock_or_raise(partner):
+        with self.channel_operations_lock[partner]:
             transaction_hash = self.proxy.transact(
                 'closeChannel',
                 partner,
@@ -650,7 +641,7 @@ class TokenNetwork:
             total_withdraw=total_withdraw,
         )
 
-        with self.lock_or_raise(partner):
+        with self.channel_operations_lock[partner]:
             transaction_hash = self.proxy.transact(
                 'setTotalWithdraw',
                 self.node_address,
@@ -756,7 +747,7 @@ class TokenNetwork:
         }
         log.info('settle called', **log_details)
 
-        with self.lock_or_raise(partner):
+        with self.channel_operations_lock[partner]:
             our_maximum = transferred_amount + locked_amount
             partner_maximum = partner_transferred_amount + partner_locked_amount
 


### PR DESCRIPTION
This PR makes the token network proxy block instead of throwing a `ChannelBusyError`.

This is changing some behaviour of the API, but that should be fine for now.

Fixes #1839