### PR TITLE
Handle insufficient eth for gas

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -735,6 +735,11 @@ class RestAPI:
                 result='',
                 status_code=HTTPStatus.ACCEPTED,
             )
+        except InsufficientFunds as e:
+            return api_error(
+                errors=str(e),
+                status_code=HTTPStatus.PAYMENT_REQUIRED,
+            )
 
         updated_channel_state = self.raiden_api.get_channel(
             registry_address,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -362,6 +362,11 @@ class RestAPI:
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,
             )
+        except InsufficientFunds as e:
+            return api_error(
+                errors=str(e),
+                status_code=HTTPStatus.PAYMENT_REQUIRED,
+            )
 
         return api_response(
             result=dict(token_network_address=to_checksum_address(token_network_address)),

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -402,6 +402,11 @@ class RestAPI:
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,
             )
+        except InsufficientFunds as e:
+            return api_error(
+                errors=str(e),
+                status_code=HTTPStatus.PAYMENT_REQUIRED,
+            )
 
         if balance:
             # make initial deposit

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -326,7 +326,7 @@ class BlockchainEvents:
         ]
         self.event_listeners = listeners
 
-    def poll_blockchain_events(self, block_number: int=None):
+    def poll_blockchain_events(self, block_number: int = None):
         # When we test with geth if the contracts have already been deployed
         # before the filter creation we need to use `get_all_entries` to make
         # sure we get all the events. With tester this is not required.

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from enum import Enum
 
 UINT64_MAX = 2 ** 64 - 1
 UINT64_MIN = 0
@@ -7,6 +8,12 @@ INT64_MAX = 2 ** 63 - 1
 INT64_MIN = -(2 ** 63)
 
 UINT256_MAX = 2 ** 256 - 1
+
+
+class EthClient(Enum):
+    GETH = 1
+    PARITY = 2
+
 
 # Deployed to Ropsten revival on 2018-07-09 from
 # raiden-contracts@42ad67c10f82899c11dc4654c7daed2422f415aa

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -461,6 +461,7 @@ class JSONRPCClient:
             value: int = 0,
             data: bytes = b'',
             startgas: int = None,
+            gasprice: int = None,
     ):
         """ Helper to send signed messages.
 
@@ -473,7 +474,7 @@ class JSONRPCClient:
 
         transaction = dict(
             nonce=self.nonce(),
-            gasPrice=self.gasprice(),
+            gasPrice=gasprice or self.gasprice(),
             gas=self.check_startgas(startgas),
             value=value,
             data=data,

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -35,12 +35,18 @@ def inspect_client_error(val_err: ValueError, eth_node: str) -> ClienErrorInspec
     except json.JSONDecodeError:
         return ClienErrorInspectResult.PROPAGATE_ERROR
 
-    insufficient_funds = (
-        (error['code'] == -32000 and eth_node == EthClient.GETH) or
-        (error['code'] == -32015 and eth_node == EthClient.PARITY)
+    insufficient_funds_geth = (
+        error['code'] == -32000 and
+        eth_node == EthClient.GETH and
+        'insufficient funds' in error['message']
+    )
+    insufficient_funds_parity = (
+        error['code'] == -32010 and
+        eth_node == EthClient.PARITY and
+        'Insufficient funds' in error['message']
     )
 
-    if insufficient_funds:
+    if insufficient_funds_geth or insufficient_funds_parity:
         return ClienErrorInspectResult.INSUFFICIENT_FUNDS
 
     return ClienErrorInspectResult.PROPAGATE_ERROR

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -28,8 +28,10 @@ class ClienErrorInspectResult(Enum):
 
 
 def inspect_client_error(val_err: ValueError, eth_node: str) -> ClienErrorInspectResult:
+    # both clients return invalid json. They use single quotes while json needs double ones.
+    json_response = str(val_err).replace("'", '"')
     try:
-        error = json.loads(str(val_err))
+        error = json.loads(json_response)
     except json.JSONDecodeError:
         return ClienErrorInspectResult.PROPAGATE_ERROR
 

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -1,6 +1,5 @@
 import pytest
 import gevent
-from eth_utils import to_checksum_address
 
 from raiden_contracts.constants import (
     CONTRACT_HUMAN_STANDARD_TOKEN,

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -1,6 +1,5 @@
 import pytest
 import gevent
-from binascii import unhexlify
 from eth_utils import to_checksum_address
 
 from raiden_contracts.constants import (
@@ -14,8 +13,8 @@ from raiden.exceptions import (
     InvalidAddress,
     InsufficientFunds,
 )
+from raiden.tests.utils.client import burn_all_eth
 from raiden.tests.utils.events import must_have_event
-from raiden.tests.utils.factories import HOP1
 from raiden.tests.utils.transfer import (
     assert_synched_channel_state,
     direct_transfer,
@@ -89,14 +88,7 @@ def test_register_token_insufficient_eth(raiden_network, token_amount):
     assert token_address not in api1.get_tokens_list(registry_address)
 
     # app1.raiden loses all its ETH because it has been naughty
-    address = to_checksum_address(app1.raiden.address)
-    client = app1.raiden.chain.client
-    web3 = client.web3
-    gas_price = web3.eth.gasPrice
-    value = web3.eth.getBalance(address) - gas_price * 21000
-    transaction_hash_hex = client.send_transaction(to=HOP1, value=value, startgas=21000)
-    transaction_hash = unhexlify(transaction_hash_hex)
-    client.poll(transaction_hash)
+    burn_all_eth(app1.raiden)
 
     # At this point we should get the InsufficientFunds exception
     with pytest.raises(InsufficientFunds):

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -2,57 +2,66 @@ from raiden.utils import (
     is_minified_address,
     is_supported_client,
 )
+from raiden.constants import EthClient
 
 
 def test_check_json_rpc_geth():
-    assert is_supported_client('Geth/v1.7.3-unstable-e9295163/linux-amd64/go1.9.1')
-    assert is_supported_client('Geth/v1.7.2-unstable-e9295163/linux-amd64/go1.9.1')
-    assert is_supported_client('Geth/v1.8.2-unstable-e9295163/linux-amd64/go1.9.1')
-    assert is_supported_client('Geth/v2.0.3-unstable-e9295163/linux-amd64/go1.9.1')
-    assert is_supported_client('Geth/v11.55.86-unstable-e9295163/linux-amd64/go1.9.1')
-    assert is_supported_client('Geth/v999.999.999-unstable-e9295163/linux-amd64/go1.9.1')
+    g1, client = is_supported_client('Geth/v1.7.3-unstable-e9295163/linux-amd64/go1.9.1')
+    g2, _ = is_supported_client('Geth/v1.7.2-unstable-e9295163/linux-amd64/go1.9.1')
+    g3, _ = is_supported_client('Geth/v1.8.2-unstable-e9295163/linux-amd64/go1.9.1')
+    g4, _ = is_supported_client('Geth/v2.0.3-unstable-e9295163/linux-amd64/go1.9.1')
+    g5, _ = is_supported_client('Geth/v11.55.86-unstable-e9295163/linux-amd64/go1.9.1')
+    g6, _ = is_supported_client('Geth/v999.999.999-unstable-e9295163/linux-amd64/go1.9.1')
+    assert client == EthClient.GETH
+    assert all([g1, g2, g3, g4, g5, g6])
 
-    assert not is_supported_client('Geth/v1.7.1-unstable-e9295163/linux-amd64/go1.9.1')
-    assert not is_supported_client('Geth/v0.7.1-unstable-e9295163/linux-amd64/go1.9.1')
-    assert not is_supported_client('Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1')
-    assert not is_supported_client('Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1')
+    b1, client = is_supported_client('Geth/v1.7.1-unstable-e9295163/linux-amd64/go1.9.1')
+    b2, _ = is_supported_client('Geth/v0.7.1-unstable-e9295163/linux-amd64/go1.9.1')
+    b3, _ = is_supported_client('Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1')
+    b4, _ = is_supported_client('Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1')
+    assert not client
+    assert not any([b1, b2, b3, b4])
 
 
 def test_check_json_rpc_parity():
-    assert is_supported_client(
+    g1, client = is_supported_client(
         'Parity//v1.7.6-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert is_supported_client(
+    g2, _ = is_supported_client(
         'Parity//v1.7.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert is_supported_client(
+    g3, _ = is_supported_client(
         'Parity//v1.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert is_supported_client(
+    g4, _ = is_supported_client(
         'Parity//v2.9.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert is_supported_client(
+    g5, _ = is_supported_client(
         'Parity//v23.94.75-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert is_supported_client(
+    g6, _ = is_supported_client(
         'Parity//v99.994.975-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
+    assert client == EthClient.PARITY
+    assert all([g1, g2, g3, g4, g5, g6])
 
-    assert not is_supported_client(
+    b1, client = is_supported_client(
         'Parity//v1.7.5-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert not is_supported_client(
+    b2, _ = is_supported_client(
         'Parity//v1.5.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert not is_supported_client(
+    b3, _ = is_supported_client(
         'Parity//v0.7.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert not is_supported_client(
+    b4, _ = is_supported_client(
         'Parity//v0.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
-    assert not is_supported_client(
+    b5, _ = is_supported_client(
         'Parity//v0.0.0-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0',
     )
+    assert not client
+    assert not any([b1, b2, b3, b4, b5])
 
 
 def test_minified_address_checker():

--- a/raiden/tests/utils/client.py
+++ b/raiden/tests/utils/client.py
@@ -15,7 +15,7 @@ def burn_all_eth(raiden_service):
         to=HOP1,
         value=value,
         startgas=21000,
-        gasprice=gas_price
+        gasprice=gas_price,
     )
     transaction_hash = unhexlify(transaction_hash_hex)
     client.poll(transaction_hash)

--- a/raiden/tests/utils/client.py
+++ b/raiden/tests/utils/client.py
@@ -11,6 +11,11 @@ def burn_all_eth(raiden_service):
     web3 = client.web3
     gas_price = web3.eth.gasPrice
     value = web3.eth.getBalance(address) - gas_price * 21000
-    transaction_hash_hex = client.send_transaction(to=HOP1, value=value, startgas=21000)
+    transaction_hash_hex = client.send_transaction(
+        to=HOP1,
+        value=value,
+        startgas=21000,
+        gasprice=gas_price
+    )
     transaction_hash = unhexlify(transaction_hash_hex)
     client.poll(transaction_hash)

--- a/raiden/tests/utils/client.py
+++ b/raiden/tests/utils/client.py
@@ -1,0 +1,16 @@
+from binascii import unhexlify
+from eth_utils import to_checksum_address
+
+from raiden.tests.utils.factories import HOP1
+
+
+def burn_all_eth(raiden_service):
+    """Burns all the ETH on the account of the given raiden service"""
+    address = to_checksum_address(raiden_service.address)
+    client = raiden_service.chain.client
+    web3 = client.web3
+    gas_price = web3.eth.gasPrice
+    value = web3.eth.getBalance(address) - gas_price * 21000
+    transaction_hash_hex = client.send_transaction(to=HOP1, value=value, startgas=21000)
+    transaction_hash = unhexlify(transaction_hash_hex)
+    client.poll(transaction_hash)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -68,7 +68,6 @@ from raiden.utils import (
     eth_endpoint_to_hostport,
     get_system_spec,
     is_minified_address,
-    is_supported_client,
     merge_dict,
     split_endpoint,
     typing,
@@ -94,7 +93,7 @@ LOG_CONFIG_OPTION_NAME = 'log_config'
 
 def check_json_rpc(blockchain_service: BlockChainService) -> None:
     try:
-        client_version = blockchain_service.client.web3.version.node
+        blockchain_service.client.web3.version.node
     except (requests.exceptions.ConnectionError, EthNodeCommunicationError):
         print(
             '\n'
@@ -106,10 +105,6 @@ def check_json_rpc(blockchain_service: BlockChainService) -> None:
             'geth: https://github.com/ethereum/go-ethereum/wiki/Management-APIs\n',
         )
         sys.exit(1)
-    else:
-        if not is_supported_client(client_version):
-            print('You need a Byzantium enabled ethereum node. Parity >= 1.7.6 or Geth >= 1.7.2')
-            sys.exit(1)
 
 
 def check_synced(blockchain_service: BlockChainService) -> None:

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -13,8 +13,8 @@ from eth_utils import remove_0x_prefix, keccak, is_checksum_address
 
 import raiden
 from raiden import constants
-from raiden.utils import typing
 from raiden.exceptions import InvalidAddress
+from raiden.utils import typing
 
 
 def safe_address_decode(address):
@@ -53,21 +53,23 @@ def is_minified_address(addr):
     return re.compile('(0x)?[a-f0-9]{6,8}').match(addr)
 
 
-def is_supported_client(client_version):
+def is_supported_client(
+        client_version: str,
+) -> typing.Tuple[bool, typing.Optional[constants.EthClient]]:
     if client_version.startswith('Parity'):
         major, minor, patch = [
             int(x) for x in re.search(r'//v(\d+)\.(\d+)\.(\d+)', client_version).groups()
         ]
         if (major, minor, patch) >= (1, 7, 6):
-            return True
+            return True, constants.EthClient.PARITY
     elif client_version.startswith('Geth'):
         major, minor, patch = [
             int(x) for x in re.search(r'/v(\d+)\.(\d+)\.(\d+)', client_version).groups()
         ]
         if (major, minor, patch) >= (1, 7, 2):
-            return True
+            return True, constants.EthClient.GETH
 
-    return False
+    return False, None
 
 
 def address_checksum_and_decode(addr: str) -> typing.Address:

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -111,7 +111,7 @@ class StatelessFilter(LogFilter):
         self._last_block: int = -1
         self._lock = Semaphore()
 
-    def get_new_entries(self, block_number: int=None):
+    def get_new_entries(self, block_number: int = None):
         with self._lock:
             filter_params = self.filter_params.copy()
             filter_params['fromBlock'] = max(
@@ -132,7 +132,7 @@ class StatelessFilter(LogFilter):
             except BlockNotFound:
                 return []
 
-    def get_all_entries(self, block_number: int=None):
+    def get_all_entries(self, block_number: int = None):
         with self._lock:
             filter_params = self.filter_params.copy()
             if block_number is None:


### PR DESCRIPTION
Fix #1815 

- Introduce a function to handle ethereum node json rpc errors depending on the underlying client
- For all errors that have to do with lack of ETH for gas for a transaction throw the `InsufficientFunds` raiden error. 
- Handle `InsufficientFunds` in the API and return the `PAYMENT_REQUIRED` api error.
- Add tests for all the API calls that create underlying blockchain transactions where the user runs out of funds.