### PR TITLE
Removed block_number from the events storage

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -544,22 +544,24 @@ Payments
 Querying Events
 ===============
 
-Events are kept by the node. Once an event endpoint is queried the relevant events
-from either the beginning of time or the given block are returned. Events are returned in a sorted list with the most recent events on the top of the list.
+Events are kept by the node. A normal user should only care about the events exposed for payments. Those events show if a payment failed or if it was successful. But at the moment we expose all of the events in the REST api mainly for debugging purposes. 
 
 In Raiden we distinguish between two types of events: ``blockchain_events`` and ``raiden_events``.
 ``blockchain_events`` are events that are being emitted by the smart contracts.
-``raiden_events`` are events happening in the Raiden node. For now, it's being used for debugging purpose.
+``raiden_events`` are events happening in the Raiden node.
+
+The payment events are a very small subset of ``raiden_events``.
 
 .. NOTE::
-      All raiden event endpoints are for debugging only and might get removed in the future.
+      All raiden event endpoints are for debugging only and might get removed in the future. They are placed under the ``_debug`` document in the REST URI.
 
-All events can be filtered down by providing the query string arguments ``from_block``
+Blockchain events can be filtered down by providing the query string arguments ``from_block``
 and/or ``to_block`` to only query events from a limited range of blocks. The block number
 argument needs to be in the range of 0 to UINT64_MAX. Any block number outside this range will
 be rejected.
+For ``raiden_events`` you can provide a ``limit`` and an ``offset`` number which would define the limit of results to return and the offset from which to return results respectively.
 
-.. http:get:: /api/(version)/events/network
+.. http:get:: /api/(version)/_debug/blockchain_events/network
 
    Query for token network creations.
 
@@ -571,7 +573,7 @@ be rejected.
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/events/network HTTP/1.1
+      GET /api/1/_debug/blockchain_events/network HTTP/1.1
       Host: localhost:5001
 
    **Example Response**:
@@ -602,7 +604,7 @@ be rejected.
    :statuscode 409: If the given block number argument is invalid
    :statuscode 500: Internal Raiden node error
 
-.. http:get:: /api/(version)/blockchain_events/tokens/(token_address)
+.. http:get:: /api/(version)/_debug/blockchain_events/tokens/(token_address)
 
    Query for all blockchain events happening on a token network.
 
@@ -610,7 +612,7 @@ be rejected.
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/blockchain_events/tokens/0x0f114A1E9Db192502E7856309cc899952b3db1ED HTTP/1.1
+      GET /api/1/_debug/blockchain_events/tokens/0x0f114A1E9Db192502E7856309cc899952b3db1ED HTTP/1.1
       Host: localhost:5001
 
    **Example Response**:
@@ -659,7 +661,7 @@ be rejected.
    :statuscode 409: If the given block number or token_address arguments are invalid
    :statuscode 500: Internal Raiden node error
 
-.. http:get:: /api/(version)/blockchain_events/payment_networks/(token_address)/channels/(partner_address)
+.. http:get:: /api/(version)/_debug/blockchain_events/payment_networks/(token_address)/channels/(partner_address)
 
    Query for ``blockchain_events`` tied to all the channels which are part of the token network.
    If the partner_address is not provided it will show the events for all the channels.
@@ -668,7 +670,7 @@ be rejected.
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/blockchain_events/payment_networks/0x0f114A1E9Db192502E7856309cc899952b3db1ED/channels/ HTTP/1.1
+      GET /api/1/_debug/blockchain_events/payment_networks/0x0f114A1E9Db192502E7856309cc899952b3db1ED/channels/ HTTP/1.1
       Host: localhost:5001
 
   **Example Response**:
@@ -700,7 +702,7 @@ be rejected.
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/blockchain_events/payment_networks/0x0f114A1E9Db192502E7856309cc899952b3db1ED/channels/0x82641569b2062B545431cF6D7F0A418582865ba7 HTTP/1.1
+      GET /api/1/_debug/blockchain_events/payment_networks/0x0f114A1E9Db192502E7856309cc899952b3db1ED/channels/0x82641569b2062B545431cF6D7F0A418582865ba7 HTTP/1.1
       Host: localhost:5001
 
   **Example Response**:
@@ -755,19 +757,16 @@ be rejected.
 
      [
          {
-             block_number: 3694255,
              event: "EventPaymentReceivedSuccess",
              amount: 5,
              initiator: "0x82641569b2062B545431cF6D7F0A418582865ba7"
          },
          {
-             block_number: 3694245,
              event: "EventPaymentSentSuccess",
              amount: 35,
              target: "0x82641569b2062B545431cF6D7F0A418582865ba7"
          },
          {
-             block_number: 3694216,
              event: "EventPaymentSentSuccess",
              amount: 20,
              target: "0x82641569b2062B545431cF6D7F0A418582865ba7"
@@ -780,9 +779,9 @@ be rejected.
   :statuscode 500: Internal Raiden node error
 
 
-Now for the Raiden events:
+Now for the internal Raiden events:
 
-.. http:get:: /api/(version)/raiden_events/tokens/(token_address)
+.. http:get:: /api/(version)/_debug/raiden_events/tokens/(token_address)
 
    Query for Raiden internal node events.
 
@@ -790,7 +789,7 @@ Now for the Raiden events:
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/raiden_events/tokens/0xb2eef045d5c05cfc9b351a59cc5c4597de6487e2 HTTP/1.1
+      GET /api/1/_debug/raiden_events/tokens/0xb2eef045d5c05cfc9b351a59cc5c4597de6487e2 HTTP/1.1
       Host: localhost:5001
 
   **Example Response**:
@@ -801,7 +800,6 @@ Now for the Raiden events:
      Content-Type: application/json
 
     [{
-        'block_number': 36,
         'event': 'SendLockedTransfer',
         'message_identifier': 17084435898865420397,
         'recipient': '0x636f37d785257d919931acff318f70fb7da4f903',
@@ -815,7 +813,6 @@ Now for the Raiden events:
                       'target:0x636f37d785257d919931acff318f70fb7da4f903>'
      },
      {
-        'block_number': 36,
         'event': 'SendRevealSecret',
         'message_identifier': 9182020688704924936,
         'recipient': '0x636f37d785257d919931acff318f70fb7da4f903',
@@ -824,7 +821,6 @@ Now for the Raiden events:
      },
      {
         'amount': 200,
-        'block_number': 36,
         'event': 'EventPaymentSentSuccess',
         'identifier': 43,
         'payment_network_identifier': '0x41ac2632d8c233784783e50ec6678cdc43f74c76',
@@ -838,7 +834,7 @@ Now for the Raiden events:
   :statuscode 409: If the given block number or token_address arguments are invalid
   :statuscode 500: Internal Raiden node error
 
-.. http:get:: /api/(version)/raiden_events/networks/(token_address)/channels/(partner_address)
+.. http:get:: /api/(version)/_debug/raiden_events/networks/(token_address)/channels/(partner_address)
 
    Query for Raiden internal node events.
 
@@ -846,7 +842,7 @@ Now for the Raiden events:
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/1/raiden_events/networks/0x7150c717eb60978713f4ddaa288cf3101581cd81/channels/ HTTP/1.1
+      GET /api/1/_debug/raiden_events/networks/0x7150c717eb60978713f4ddaa288cf3101581cd81/channels/ HTTP/1.1
       Host: localhost:5001
 
   **Example Response**:
@@ -857,7 +853,6 @@ Now for the Raiden events:
      Content-Type: application/json
 
     [{
-        'block_number': 36,
         'event': 'SendLockedTransfer',
         'message_identifier': 16700893459475179678,
         'recipient': '0x1d2cb001f807882c4a862731cbb77390e641a8fd',
@@ -871,7 +866,6 @@ Now for the Raiden events:
                   'target:0x1d2cb001f807882c4a862731cbb77390e641a8fd>'
      },
      {
-        'block_number': 36,
         'event': 'SendRevealSecret',
         'message_identifier': 17638248769110067506,
         'recipient': '0x1d2cb001f807882c4a862731cbb77390e641a8fd',
@@ -880,7 +874,6 @@ Now for the Raiden events:
      },
      {
         'amount': 200,
-        'block_number': 36,
         'event': 'EventPaymentSentSuccess',
         'identifier': 42,
         'payment_network_identifier': '0xf6febb9ca9efab37e495612dff0e30964cbb2c15',
@@ -888,7 +881,6 @@ Now for the Raiden events:
         'token_network_identifier': '0xb12596e59a7fa29c0f7c349261cd91148a496dc8'
      },
      {
-        'block_number': 36,
         'event': 'EventUnlockSuccess',
         'identifier': 42,
         'secrethash': '0x8ee5cb32c24203b9d62dd55359c3494f4a1694039fb0ce7c2c46bdf619b54c76'
@@ -897,7 +889,6 @@ Now for the Raiden events:
         'balance_proof': '<BalanceProofUnsignedState nonce:2 transferred_amount:200 '
                        'locked_amount:0 locksroot:00000000 token_network:b12596e5 '
                        'channel_identifier:1 chain_id: 337>',
-        'block_number': 36,
         'event': 'SendBalanceProof',
         'message_identifier': 42,
         'payment_identifier': 5518212473974981549,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -116,7 +116,7 @@ URLS_V1 = [
     (
         (
             '/blockchain_events/payment_networks/'
-            '<hexaddress:token_address>/channels/<hexaddress:partner_address>',
+            '<hexaddress:token_address>/channels/<hexaddress:partner_address>'
         ),
         ChannelBlockchainEventsResource,
     ),
@@ -343,6 +343,7 @@ class APIServer:
         self.wsgiserver = None
         self.greenlet = None
         self.flask_app.register_blueprint(self.blueprint)
+
         self.flask_app.config['WEBUI_PATH'] = '../ui/web/dist/'
         if is_frozen():
             # Inside frozen pyinstaller image

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -710,7 +710,7 @@ class RestAPI:
         result = self.address_list_schema.dump(tokens_list)
         return api_response(result=result.data)
 
-    def get_network_events(
+    def get_blockchain_events_network(
             self,
             registry_address: typing.PaymentNetworkID,
             from_block: typing.BlockSpecification = 0,
@@ -733,7 +733,7 @@ class RestAPI:
 
         return api_response(result=normalize_events_list(raiden_service_result))
 
-    def get_token_network_events_blockchain(
+    def get_blockchain_events_token_network(
             self,
             token_address: typing.TokenAddress,
             from_block: typing.BlockSpecification = 0,
@@ -744,7 +744,7 @@ class RestAPI:
             token_address=token_address,
         )
         try:
-            raiden_service_result = self.raiden_api.get_token_network_events_blockchain(
+            raiden_service_result = self.raiden_api.get_blockchain_events_token_network(
                 token_address=token_address,
                 from_block=from_block,
                 to_block=to_block,
@@ -824,7 +824,7 @@ class RestAPI:
         except InvalidAddress as e:
             return api_error(str(e), status_code=HTTPStatus.CONFLICT)
 
-    def get_channel_events_blockchain(
+    def get_blockchain_events_channel(
             self,
             token_address: typing.TokenAddress,
             partner_address: typing.Address = None,
@@ -837,7 +837,7 @@ class RestAPI:
             partner_address=partner_address,
         )
         try:
-            raiden_service_result = self.raiden_api.get_channel_events_blockchain(
+            raiden_service_result = self.raiden_api.get_blockchain_events_channel(
                 token_address=token_address,
                 partner_address=partner_address,
                 from_block=from_block,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -755,7 +755,7 @@ class RestAPI:
         except (InvalidBlockNumberInput, InvalidAddress) as e:
             return api_error(str(e), status_code=HTTPStatus.CONFLICT)
 
-    def get_payment_history(
+    def get_raiden_events_payment_history(
             self,
             token_address: typing.TokenAddress = None,
             target_address: typing.Address = None,
@@ -768,24 +768,12 @@ class RestAPI:
             target_address=optional_address_to_string(target_address),
         )
         try:
-            if token_address is None and target_address is None:
-                raiden_service_result = self.raiden_api.get_payment_history(
-                    limit=limit,
-                    offset=offset,
-                )
-            elif target_address is None:
-                raiden_service_result = self.raiden_api.get_payment_history_for_token(
-                    token_address=token_address,
-                    limit=limit,
-                    offset=offset,
-                )
-            else:
-                raiden_service_result = self.raiden_api.get_payment_history_for_token_and_target(
-                    token_address,
-                    target_address,
-                    limit=limit,
-                    offset=offset,
-                )
+            raiden_service_result = self.raiden_api.get_raiden_events_payment_history(
+                token_address=token_address,
+                target_address=target_address,
+                limit=limit,
+                offset=offset,
+            )
         except (InvalidBlockNumberInput, InvalidAddress) as e:
             return api_error(str(e), status_code=HTTPStatus.CONFLICT)
 
@@ -803,7 +791,7 @@ class RestAPI:
             result.append(serialized_event.data)
         return api_response(result=result)
 
-    def get_token_network_events_raiden(
+    def get_raiden_events_token_network(
             self,
             token_address: typing.TokenAddress,
             limit: int = None,
@@ -814,7 +802,7 @@ class RestAPI:
             token_address=token_address,
         )
         try:
-            raiden_service_result = self.raiden_api.get_token_network_events_raiden(
+            raiden_service_result = self.raiden_api.get_raiden_events_token_network(
                 token_address=token_address,
                 limit=limit,
                 offset=offset,
@@ -849,7 +837,7 @@ class RestAPI:
         except UnknownTokenAddress as e:
             return api_error(str(e), status_code=HTTPStatus.NOT_FOUND)
 
-    def get_channel_events_raiden(
+    def get_raiden_events_channel(
             self,
             token_address: typing.TokenAddress,
             partner_address: typing.Address = None,
@@ -864,7 +852,7 @@ class RestAPI:
             offset=offset,
         )
         try:
-            raiden_service_result = self.raiden_api.get_channel_events_raiden(
+            raiden_service_result = self.raiden_api.get_raiden_events_channel(
                 token_address=token_address,
                 partner_address=partner_address,
                 limit=limit,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -726,20 +726,14 @@ class RestAPI:
     def get_token_network_events_blockchain(
             self,
             token_address: typing.TokenAddress,
-            from_block: typing.BlockSpecification,
-            to_block: typing.BlockSpecification,
     ):
         log.debug(
             'Getting token network blockchain events',
-            token_address=to_checksum_address(token_address),
-            from_block=from_block,
-            to_block=to_block,
+            token_address=token_address,
         )
         try:
             raiden_service_result = self.raiden_api.get_token_network_events_blockchain(
                 token_address,
-                from_block,
-                to_block,
             )
             return api_response(result=normalize_events_list(raiden_service_result))
         except UnknownTokenAddress as e:
@@ -793,20 +787,14 @@ class RestAPI:
     def get_token_network_events_raiden(
             self,
             token_address: typing.TokenAddress,
-            from_block: typing.BlockSpecification,
-            to_block: typing.BlockSpecification,
     ):
         log.debug(
             'Getting token network internal events',
-            token_address=to_checksum_address(token_address),
-            from_block=from_block,
-            to_block=to_block,
+            token_address=token_address,
         )
         try:
             raiden_service_result = self.raiden_api.get_token_network_events_raiden(
                 token_address,
-                from_block,
-                to_block,
             )
             raiden_service_result = convert_to_serializable(raiden_service_result)
             return api_response(result=normalize_events_list(raiden_service_result))
@@ -817,22 +805,16 @@ class RestAPI:
             self,
             token_address: typing.TokenAddress,
             partner_address: typing.Address = None,
-            from_block: typing.BlockSpecification = None,
-            to_block: typing.BlockSpecification = None,
     ):
         log.debug(
             'Getting channel blockchain events',
-            token_address=to_checksum_address(token_address),
-            partner_address=optional_address_to_string(partner_address),
-            from_block=from_block,
-            to_block=to_block,
+            token_address=token_address,
+            partner_address=partner_address,
         )
         try:
             raiden_service_result = self.raiden_api.get_channel_events_blockchain(
                 token_address,
                 partner_address,
-                from_block,
-                to_block,
             )
             return api_response(result=normalize_events_list(raiden_service_result))
         except (InvalidBlockNumberInput, InvalidAddress) as e:

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -162,16 +162,6 @@ class RaidenEventsRequestSchema(BaseSchema):
         decoding_class = dict
 
 
-class PaymentEventRequestSchema(BaseSchema):
-    from_block = fields.Integer(missing=None)
-    to_block = fields.Integer(missing=None)
-
-    class Meta:
-        strict = True
-        # decoding to a dict is required by the @use_kwargs decorator from webargs
-        decoding_class = dict
-
-
 class AddressSchema(BaseSchema):
     address = AddressField()
 

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -281,7 +281,7 @@ class ConnectionsLeaveSchema(BaseSchema):
 class EventPaymentSentFailedSchema(BaseSchema):
     block_number = fields.Integer()
     identifier = fields.Integer()
-    event = fields.Str()
+    event = fields.Constant('EventPaymentSentFailed')
     reason = fields.Str()
     target = AddressField()
 
@@ -294,7 +294,7 @@ class EventPaymentSentFailedSchema(BaseSchema):
 class EventPaymentSentSuccessSchema(BaseSchema):
     block_number = fields.Integer()
     identifier = fields.Integer()
-    event = fields.Str()
+    event = fields.Constant('EventPaymentSentSuccess')
     amount = fields.Integer()
     target = AddressField()
 
@@ -307,7 +307,7 @@ class EventPaymentSentSuccessSchema(BaseSchema):
 class EventPaymentReceivedSuccessSchema(BaseSchema):
     block_number = fields.Integer()
     identifier = fields.Integer()
-    event = fields.Str()
+    event = fields.Constant('EventPaymentReceivedSuccess')
     amount = fields.Integer()
     initiator = AddressField()
 

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -142,7 +142,27 @@ class BaseListSchema(Schema):
         return decoding_class(list_)
 
 
-class EventRequestSchema(BaseSchema):
+class BlockchainEventsRequestSchema(BaseSchema):
+    from_block = fields.Integer(missing=None)
+    to_block = fields.Integer(missing=None)
+
+    class Meta:
+        strict = True
+        # decoding to a dict is required by the @use_kwargs decorator from webargs
+        decoding_class = dict
+
+
+class RaidenEventsRequestSchema(BaseSchema):
+    limit = fields.Integer(missing=None)
+    offset = fields.Integer(missing=None)
+
+    class Meta:
+        strict = True
+        # decoding to a dict is required by the @use_kwargs decorator from webargs
+        decoding_class = dict
+
+
+class PaymentEventRequestSchema(BaseSchema):
     from_block = fields.Integer(missing=None)
     to_block = fields.Integer(missing=None)
 

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -8,7 +8,6 @@ from raiden.api.v1.encoding import (
     ConnectionsLeaveSchema,
     BlockchainEventsRequestSchema,
     RaidenEventsRequestSchema,
-    PaymentEventRequestSchema,
     PaymentSchema,
 )
 from raiden.utils import typing
@@ -95,7 +94,7 @@ class PartnersResourceByTokenAddress(BaseResource):
         )
 
 
-class NetworkEventsResource(BaseResource):
+class BlockchainEventsNetworkResource(BaseResource):
 
     get_schema = BlockchainEventsRequestSchema()
 
@@ -111,7 +110,7 @@ class NetworkEventsResource(BaseResource):
         )
 
 
-class TokenBlockchainEventsResource(BaseResource):
+class BlockchainEventsTokenResource(BaseResource):
 
     get_schema = BlockchainEventsRequestSchema()
 
@@ -144,26 +143,13 @@ class ChannelBlockchainEventsResource(BaseResource):
         )
 
 
-class TokenRaidenEventsResource(BaseResource):
-
-    get_schema = RaidenEventsRequestSchema()
-
-    @use_kwargs(get_schema, locations=('query',))
-    def get(self, token_address, limit, offset):
-        return self.rest_api.get_raiden_events_token_network(
-            token_address=token_address,
-            limit=limit,
-            offset=offset,
-        )
-
-
-class ChannelRaidenEventsResource(BaseResource):
+class RaidenInternalEventsResource(BaseResource):
 
     get_schema = RaidenEventsRequestSchema()
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, token_address, partner_address=None, limit=None, offset=None):
-        return self.rest_api.get_raiden_events_channel(
+        return self.rest_api.get_raiden_internal_events(
             token_address=token_address,
             partner_address=partner_address,
             limit=limit,
@@ -222,7 +208,7 @@ class PaymentResource(BaseResource):
     post_schema = PaymentSchema(
         only=('amount', 'identifier'),
     )
-    get_schema = PaymentEventRequestSchema()
+    get_schema = RaidenEventsRequestSchema()
 
     @use_kwargs(get_schema, locations=('query',))
     def get(

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -113,14 +113,9 @@ class TokenBlockchainEventsResource(BaseResource):
     get_schema = EventRequestSchema()
 
     @use_kwargs(get_schema, locations=('query',))
-    def get(self, token_address, from_block, to_block):
-        from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
-        to_block = to_block or 'latest'
-
+    def get(self, token_address):
         return self.rest_api.get_token_network_events_blockchain(
             token_address=token_address,
-            from_block=from_block,
-            to_block=to_block,
         )
 
 
@@ -129,13 +124,9 @@ class TokenRaidenEventsResource(BaseResource):
     get_schema = EventRequestSchema()
 
     @use_kwargs(get_schema, locations=('query',))
-    def get(self, token_address, from_block, to_block):
-        from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
-        to_block = to_block or 'latest'
+    def get(self, token_address):
         return self.rest_api.get_token_network_events_raiden(
             token_address=token_address,
-            from_block=from_block,
-            to_block=to_block,
         )
 
 
@@ -160,14 +151,10 @@ class ChannelRaidenEventsResource(BaseResource):
     get_schema = EventRequestSchema()
 
     @use_kwargs(get_schema, locations=('query',))
-    def get(self, token_address, partner_address=None, from_block=None, to_block=None):
-        from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
-        to_block = to_block or 'latest'
+    def get(self, token_address, partner_address=None):
         return self.rest_api.get_channel_events_raiden(
             token_address=token_address,
             partner_address=partner_address,
-            from_block=from_block,
-            to_block=to_block,
         )
 
 

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -150,7 +150,7 @@ class TokenRaidenEventsResource(BaseResource):
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, token_address, limit, offset):
-        return self.rest_api.get_token_network_events_raiden(
+        return self.rest_api.get_raiden_events_token_network(
             token_address=token_address,
             limit=limit,
             offset=offset,
@@ -163,7 +163,7 @@ class ChannelRaidenEventsResource(BaseResource):
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, token_address, partner_address=None, limit=None, offset=None):
-        return self.rest_api.get_channel_events_raiden(
+        return self.rest_api.get_raiden_events_channel(
             token_address=token_address,
             partner_address=partner_address,
             limit=limit,
@@ -232,7 +232,7 @@ class PaymentResource(BaseResource):
             limit: int = None,
             offset: int = None,
     ):
-        return self.rest_api.get_payment_history(
+        return self.rest_api.get_raiden_events_payment_history(
             token_address=token_address,
             target_address=target_address,
             limit=limit,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -104,7 +104,7 @@ class NetworkEventsResource(BaseResource):
         from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
         to_block = to_block or 'latest'
 
-        return self.rest_api.get_network_events(
+        return self.rest_api.get_blockchain_events_network(
             registry_address=self.rest_api.raiden_api.raiden.default_registry.address,
             from_block=from_block,
             to_block=to_block,
@@ -120,7 +120,7 @@ class TokenBlockchainEventsResource(BaseResource):
         from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
         to_block = to_block or 'latest'
 
-        return self.rest_api.get_token_network_events_blockchain(
+        return self.rest_api.get_blockchain_events_token_network(
             token_address=token_address,
             from_block=from_block,
             to_block=to_block,
@@ -136,7 +136,7 @@ class ChannelBlockchainEventsResource(BaseResource):
         from_block = from_block or self.rest_api.raiden_api.raiden.query_start_block
         to_block = to_block or 'latest'
 
-        return self.rest_api.get_channel_events_blockchain(
+        return self.rest_api.get_blockchain_events_channel(
             token_address=token_address,
             partner_address=partner_address,
             from_block=from_block,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -354,13 +354,11 @@ class RaidenService:
     def handle_state_change(self, state_change):
         log.debug('STATE CHANGE', node=pex(self.address), state_change=state_change)
 
-        if block_number is None:
-            block_number = self.get_block_number()
-
         # Take a snapshot every SNAPSHOT_BLOCK_COUNT
         # TODO: Gather more data about storage requirements
         # and update the value to specify how often we need
         # capturing a snapshot should take place
+        block_number = self.get_block_number()
         new_snapshot_group = block_number // SNAPSHOT_BLOCK_COUNT
         if new_snapshot_group > self.snapshot_group:
             log.debug(f'Storing snapshot at block: {block_number}')

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -169,7 +169,10 @@ class SQLiteStorage:
 
         return result
 
-    def get_events(self, limit: int = -1, offset: int = 0):
+    def get_events(self, limit: int = None, offset: int = None):
+        limit = -1 if limit is None else limit
+        offset = 0 if offset is None else offset
+
         if not isinstance(limit, int):
             raise ValueError('limit must be an integer')
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -188,13 +188,13 @@ class SQLiteStorage:
 
         if to_identifier == 'latest':
             cursor.execute(
-                'SELECT data FROM state_events WHERE identifier >= ?',
+                'SELECT data FROM state_events WHERE identifier >= ? ORDER BY identifier ASC',
                 (from_identifier,),
             )
         else:
             cursor.execute(
-                'SELECT data FROM state_events WHERE identifier '
-                'BETWEEN ? AND ?', (from_identifier, to_identifier),
+                'SELECT data FROM state_events WHERE identifier BETWEEN ? AND ? '
+                'ORDER BY identifier ASC', (from_identifier, to_identifier),
             )
 
         result = [

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -169,7 +169,7 @@ class SQLiteStorage:
 
         return result
 
-    def get_events_by_identifier(self, from_identifier, to_identifier):
+    def get_events_by_identifier(self, from_identifier, to_identifier, limit=-1, offset=0):
         if not (from_identifier == 'latest' or isinstance(from_identifier, int)):
             raise ValueError("from_identifier must be an integer or 'latest'")
 
@@ -186,15 +186,18 @@ class SQLiteStorage:
             )
             from_identifier = cursor.fetchone()
 
+        limit_offset_clause = f'LIMIT {limit} OFFSET {offset}'
         if to_identifier == 'latest':
             cursor.execute(
-                'SELECT data FROM state_events WHERE identifier >= ? ORDER BY identifier ASC',
+                'SELECT data FROM state_events WHERE identifier >= ? '
+                f'ORDER BY identifier ASC {limit_offset_clause}',
                 (from_identifier,),
             )
         else:
             cursor.execute(
                 'SELECT data FROM state_events WHERE identifier BETWEEN ? AND ? '
-                'ORDER BY identifier ASC', (from_identifier, to_identifier),
+                f'ORDER BY identifier ASC {limit_offset_clause}',
+                (from_identifier, to_identifier),
             )
 
         result = [

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -25,7 +25,6 @@ DB_CREATE_STATE_EVENTS = '''
 CREATE TABLE IF NOT EXISTS state_events (
     identifier INTEGER PRIMARY KEY,
     source_statechange_id INTEGER NOT NULL,
-    block_number INTEGER NOT NULL,
     data BINARY,
     FOREIGN KEY(source_statechange_id) REFERENCES state_changes(identifier)
 );

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -39,7 +39,7 @@ class WriteAheadLog:
         self.state_change_id = None
         self.storage = storage
 
-    def log_and_dispatch(self, state_change, block_number):
+    def log_and_dispatch(self, state_change):
         """ Log and apply a state change.
 
         This function will first write the state change to the write-ahead-log,
@@ -53,7 +53,7 @@ class WriteAheadLog:
         events = self.state_manager.dispatch(state_change)
 
         self.state_change_id = state_change_id
-        self.storage.write_events(state_change_id, block_number, events)
+        self.storage.write_events(state_change_id, events)
 
         return events
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -152,7 +152,7 @@ class AlarmTask(gevent.Greenlet):
                         current_block=current_block,
                     )
 
-                self.run_callbacks(current_block, chain_id)
+                self.run_callbacks(current_block)
 
     def first_run(self):
         # callbacks must be executed during the first run to update the node state
@@ -163,13 +163,13 @@ class AlarmTask(gevent.Greenlet):
 
         log.debug('starting at block number', current_block=current_block)
 
-        self.run_callbacks(current_block, chain_id)
+        self.run_callbacks(current_block)
         self.chain_id = chain_id
 
-    def run_callbacks(self, current_block, chain_id):
+    def run_callbacks(self, current_block):
         remove = list()
         for callback in self.callbacks:
-            result = callback(current_block, chain_id)
+            result = callback(current_block)
             if result is REMOVE_CALLBACK:
                 remove.append(callback)
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -76,7 +76,6 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
 
     token_events = api1.get_token_network_events_blockchain(
         token_address,
-        channel12.open_transaction.finished_block_number,
     )
     assert token_events[0]['event'] == ChannelEvent.OPENED
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -58,7 +58,6 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     event_list1 = api1.get_channel_events_blockchain(
         token_address,
         channel12.partner_state.address,
-        channel12.open_transaction.finished_block_number,
     )
     assert any(
         (
@@ -112,7 +111,6 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     event_list2 = api1.get_channel_events_blockchain(
         token_address,
         channel12.partner_state.address,
-        channel12.open_transaction.finished_block_number,
     )
     assert any(
         (
@@ -134,7 +132,6 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     event_list3 = api1.get_channel_events_blockchain(
         token_address,
         channel12.partner_state.address,
-        channel12.open_transaction.finished_block_number,
     )
     assert len(event_list3) > len(event_list2)
     assert any(

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -55,7 +55,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     channel12 = get_channelstate(node1, node2, token_network_identifier)
     assert channel.get_status(channel12) == CHANNEL_STATE_OPENED
 
-    event_list1 = api1.get_channel_events_blockchain(
+    event_list1 = api1.get_blockchain_events_channel(
         token_address,
         channel12.partner_state.address,
     )
@@ -74,7 +74,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
         for event in event_list1
     )
 
-    token_events = api1.get_token_network_events_blockchain(
+    token_events = api1.get_blockchain_events_token_network(
         token_address,
     )
     assert token_events[0]['event'] == ChannelEvent.OPENED
@@ -107,7 +107,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     assert api1.get_node_network_state(api2.address) == NODE_NETWORK_REACHABLE
     assert api2.get_node_network_state(api1.address) == NODE_NETWORK_REACHABLE
 
-    event_list2 = api1.get_channel_events_blockchain(
+    event_list2 = api1.get_blockchain_events_channel(
         token_address,
         channel12.partner_state.address,
     )
@@ -128,7 +128,7 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     # Load the new state with the channel closed
     channel12 = get_channelstate(node1, node2, token_network_identifier)
 
-    event_list3 = api1.get_channel_events_blockchain(
+    event_list3 = api1.get_blockchain_events_channel(
         token_address,
         channel12.partner_state.address,
     )

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1091,7 +1091,7 @@ def test_network_events(api_backend, token_addresses):
     request = grequests.get(
         api_url_for(
             api_backend,
-            'networkeventsresource',
+            'blockchaineventsnetworkresource',
             from_block=0,
         ),
     )
@@ -1126,7 +1126,7 @@ def test_token_events(api_backend, token_addresses):
     request = grequests.get(
         api_url_for(
             api_backend,
-            'tokenblockchaineventsresource',
+            'blockchaineventstokenresource',
             token_address=token_address,
             from_block=0,
         ),
@@ -1350,67 +1350,6 @@ def test_payment_events_endpoints(api_backend, raiden_network, token_addresses):
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])
-def test_channel_transfer_events(api_backend, raiden_network, token_addresses):
-    _, app1 = raiden_network
-    amount = 200
-    identifier = 43
-    token_address = token_addresses[0]
-
-    target1_address = app1.raiden.address
-
-    api_server, _ = api_backend
-
-    # payment 1
-    request = grequests.post(
-        api_url_for(
-            api_backend,
-            'token_target_paymentresource',
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target1_address),
-        ),
-        json={'amount': amount, 'identifier': identifier},
-    )
-    request.send()
-
-    # payment 2
-    request = grequests.post(
-        api_url_for(
-            api_backend,
-            'token_target_paymentresource',
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target1_address),
-        ),
-        json={'amount': amount, 'identifier': identifier},
-    )
-    request.send()
-
-    # testing the raiden events endpoint
-    request = grequests.get(
-        api_url_for(
-            api_backend,
-            'tokenraideneventsresource',
-            token_address=token_address,
-            from_block=0,
-        ),
-    )
-
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-
-    response = response.json()
-    assert len(response) > 0
-
-    events_list = []
-    for event in response:
-        # taking the name of the event
-        events_list.append(event['event'])
-
-    assert 'SendLockedTransfer' in events_list
-    assert 'EventPaymentSentSuccess' in events_list
-    assert 'SendBalanceProof' in events_list
-
-
-@pytest.mark.parametrize('number_of_nodes', [2])
 def test_channel_events_raiden(api_backend, raiden_network, token_addresses):
     _, app1 = raiden_network
     amount = 200
@@ -1429,51 +1368,3 @@ def test_channel_events_raiden(api_backend, raiden_network, token_addresses):
     )
     response = request.send().response
     assert_proper_response(response)
-
-    request = grequests.get(
-        api_url_for(
-            api_backend,
-            'tokenchanneleventsresourceraiden',
-            partner_address=None,
-            token_address=token_address,
-            from_block=0,
-        ),
-    )
-
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-    response = response.json()
-    assert len(response) > 0
-
-    events_list = []
-    for event in response:
-        # taking the name of the event
-        events_list.append(event['event'])
-
-    assert 'SendLockedTransfer' in events_list
-    assert 'EventPaymentSentSuccess' in events_list
-    assert 'SendBalanceProof' in events_list
-
-    request = grequests.get(
-        api_url_for(
-            api_backend,
-            'tokenchanneleventsresourceraiden',
-            partner_address=target_address,
-            token_address=token_address,
-            from_block=0,
-        ),
-    )
-
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-
-    response = response.json()
-    assert len(response) > 0
-    events_list = []
-    for event in response:
-        # taking the name of the event
-        events_list.append(event['event'])
-
-    assert 'SendLockedTransfer' in events_list
-    assert 'EventPaymentSentSuccess' in events_list
-    assert 'SendBalanceProof' in events_list

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -95,7 +95,9 @@ def test_echo_node_response(token_addresses, raiden_chain, network_wait):
     # Check that all transfers were handled correctly
     def test_events(handled_transfer):
         app = address_to_app[handled_transfer.initiator]
-        events = RaidenAPI(app.raiden).get_payment_history_for_token(token_address)
+        events = RaidenAPI(app.raiden).get_raiden_events_payment_history(
+            token_address=token_address,
+        )
 
         received = {
             event.identifier: event
@@ -188,7 +190,9 @@ def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
     def get_echoed_transfer(sent_transfer):
         """For a given transfer sent to echo node, get the corresponding echoed transfer"""
         app = address_to_app[sent_transfer.initiator]
-        events = RaidenAPI(app.raiden).get_payment_history_for_token(token_address)
+        events = RaidenAPI(app.raiden).get_raiden_events_payment_history(
+            token_address=token_address,
+        )
 
         def is_valid(event):
             return (

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -46,7 +46,7 @@ def test_event_transfer_received_success(
 
     def test_events(amount, address):
         return must_contain_entry(
-            receiver_app.raiden.wal.storage.get_events_by_identifier(0, 'latest'),
+            receiver_app.raiden.wal.storage.get_events(),
             EventPaymentReceivedSuccess,
             {'amount': amount, 'initiator': address},
         )

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -21,9 +21,9 @@ log = structlog.get_logger(__name__)
 @pytest.mark.parametrize('reveal_timeout', [15])
 @pytest.mark.parametrize('settle_timeout', [120])
 def test_event_transfer_received_success(
-    token_addresses,
-    raiden_chain,
-    network_wait,
+        token_addresses,
+        raiden_chain,
+        network_wait,
 ):
     app0, app1, app2, receiver_app = raiden_chain
     token_address = token_addresses[0]
@@ -45,10 +45,8 @@ def test_event_transfer_received_success(
     gevent.sleep(1)
 
     def test_events(amount, address):
-        events = receiver_app.raiden.wal.storage.get_events_by_block(0, 'latest')
-        events = [e[1] for e in events]
         return must_contain_entry(
-            events,
+            receiver_app.raiden.wal.storage.get_events_by_identifier(0, 'latest'),
             EventPaymentReceivedSuccess,
             {'amount': amount, 'initiator': address},
         )

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -272,7 +272,6 @@ def test_api_channel_events(raiden_chain, token_addresses):
     app0_events = RaidenAPI(app0.raiden).get_channel_events_blockchain(
         token_address,
         app1.raiden.address,
-        from_block=0,
     )
 
     assert must_have_event(app0_events, {'event': ChannelEvent.DEPOSIT})
@@ -282,12 +281,9 @@ def test_api_channel_events(raiden_chain, token_addresses):
     # assert must_have_event(results, {'event': 'EventTransferSentSuccess'})
 
     app0_events = app0.raiden.wal.storage.get_events_by_identifier(0, 'latest')
-    max_block = max(event[0] for event in app0_events)
     results = RaidenAPI(app0.raiden).get_channel_events_blockchain(
         token_address,
         app1.raiden.address,
-        from_block=max_block + 1,
-        to_block=max_block + 100,
     )
     assert not results
 
@@ -301,7 +297,6 @@ def test_api_channel_events(raiden_chain, token_addresses):
     app1_events = RaidenAPI(app1.raiden).get_channel_events_blockchain(
         token_address,
         app0.raiden.address,
-        from_block=0,
     )
     assert must_have_event(app1_events, {'event': ChannelEvent.DEPOSIT})
 

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -269,7 +269,7 @@ def test_api_channel_events(raiden_chain, token_addresses):
         identifier=1,
     )
 
-    app0_events = RaidenAPI(app0.raiden).get_channel_events_blockchain(
+    app0_events = RaidenAPI(app0.raiden).get_blockchain_events_channel(
         token_address,
         app1.raiden.address,
     )
@@ -281,7 +281,7 @@ def test_api_channel_events(raiden_chain, token_addresses):
     # assert must_have_event(results, {'event': 'EventTransferSentSuccess'})
 
     app0_events = app0.raiden.wal.storage.get_events_by_identifier(0, 'latest')
-    results = RaidenAPI(app0.raiden).get_channel_events_blockchain(
+    results = RaidenAPI(app0.raiden).get_blockchain_events_channel(
         token_address,
         app1.raiden.address,
     )
@@ -294,7 +294,7 @@ def test_api_channel_events(raiden_chain, token_addresses):
     )
     any(isinstance(event, EventPaymentReceivedSuccess) for _, event in app1_events)
 
-    app1_events = RaidenAPI(app1.raiden).get_channel_events_blockchain(
+    app1_events = RaidenAPI(app1.raiden).get_blockchain_events_channel(
         token_address,
         app0.raiden.address,
     )

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -287,7 +287,7 @@ def test_api_channel_events(raiden_chain, token_addresses):
     )
     assert not results
 
-    app1_events = RaidenAPI(app1.raiden).get_channel_events_raiden(
+    app1_events = RaidenAPI(app1.raiden).get_raiden_events_channel(
         token_address,
         app0.raiden.address,
         from_block=0,

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -117,7 +117,7 @@ def test_regression_revealsecret_after_secret(raiden_network, token_addresses, t
     assert transfer.wait()
 
     event = must_contain_entry(
-        app1.raiden.wal.storage.get_events_by_identifier(0, 'latest'),
+        app1.raiden.wal.storage.get_events(),
         SendRevealSecret,
         {},
     )

--- a/raiden/tests/integration/transfer/test_directransfer_events.py
+++ b/raiden/tests/integration/transfer/test_directransfer_events.py
@@ -31,20 +31,14 @@ def test_initiator_log_directransfer_success(raiden_chain, token_addresses, depo
         identifier,
     )
 
-    app0_all_events = app0.raiden.wal.storage.get_events_by_identifier(
-        from_identifier=0,
-        to_identifier='latest',
-    )
+    app0_all_events = app0.raiden.wal.storage.get_events()
     assert must_contain_entry(app0_all_events, EventPaymentSentSuccess, {
         'identifier': identifier,
         'amount': amount,
         'target': app1.raiden.address,
     })
 
-    app1_all_events = app1.raiden.wal.storage.get_events_by_identifier(
-        from_identifier=0,
-        to_identifier='latest',
-    )
+    app1_all_events = app1.raiden.wal.storage.get_events()
     assert must_contain_entry(app1_all_events, EventPaymentReceivedSuccess, {
         'identifier': identifier,
         'amount': amount,

--- a/raiden/tests/integration/transfer/test_directransfer_events.py
+++ b/raiden/tests/integration/transfer/test_directransfer_events.py
@@ -31,22 +31,20 @@ def test_initiator_log_directransfer_success(raiden_chain, token_addresses, depo
         identifier,
     )
 
-    app0_events = app0.raiden.wal.storage.get_events_by_identifier(
+    app0_all_events = app0.raiden.wal.storage.get_events_by_identifier(
         from_identifier=0,
         to_identifier='latest',
     )
-    app0_all_events = [event for _, event in app0_events]
     assert must_contain_entry(app0_all_events, EventPaymentSentSuccess, {
         'identifier': identifier,
         'amount': amount,
         'target': app1.raiden.address,
     })
 
-    app1_state_events = app1.raiden.wal.storage.get_events_by_identifier(
+    app1_all_events = app1.raiden.wal.storage.get_events_by_identifier(
         from_identifier=0,
         to_identifier='latest',
     )
-    app1_all_events = [event for _, event in app1_state_events]
     assert must_contain_entry(app1_all_events, EventPaymentReceivedSuccess, {
         'identifier': identifier,
         'amount': amount,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -36,10 +36,7 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
     )
 
     def test_initiator_events():
-        initiator_events = app0.raiden.wal.storage.get_events_by_identifier(
-            from_identifier=0,
-            to_identifier='latest',
-        )
+        initiator_events = app0.raiden.wal.storage.get_events()
         return (
             must_contain_entry(initiator_events, SendRevealSecret, {}) and
             must_contain_entry(initiator_events, EventUnlockSuccess, {})
@@ -48,10 +45,7 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
     assert wait_until(test_initiator_events, network_wait)
 
     def test_mediator_events():
-        mediator_events = app1.raiden.wal.storage.get_events_by_identifier(
-            from_identifier=0,
-            to_identifier='latest',
-        )
+        mediator_events = app1.raiden.wal.storage.get_events()
         return (
             must_contain_entry(mediator_events, EventUnlockSuccess, {}) and
             must_contain_entry(mediator_events, EventUnlockClaimSuccess, {})
@@ -60,10 +54,7 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
     assert wait_until(test_mediator_events, network_wait)
 
     def test_target_events():
-        target_events = app2.raiden.wal.storage.get_events_by_identifier(
-            from_identifier=0,
-            to_identifier='latest',
-        )
+        target_events = app2.raiden.wal.storage.get_events()
         return (
             must_contain_entry(target_events, SendSecretRequest, {}) and
             must_contain_entry(target_events, SendRevealSecret, {}) and

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -36,11 +36,10 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
     )
 
     def test_initiator_events():
-        initiator_blockevents = app0.raiden.wal.storage.get_events_by_identifier(
+        initiator_events = app0.raiden.wal.storage.get_events_by_identifier(
             from_identifier=0,
             to_identifier='latest',
         )
-        initiator_events = [blocknumber_event[1] for blocknumber_event in initiator_blockevents]
         return (
             must_contain_entry(initiator_events, SendRevealSecret, {}) and
             must_contain_entry(initiator_events, EventUnlockSuccess, {})
@@ -49,11 +48,10 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
     assert wait_until(test_initiator_events, network_wait)
 
     def test_mediator_events():
-        mediator_blockevents = app1.raiden.wal.storage.get_events_by_identifier(
+        mediator_events = app1.raiden.wal.storage.get_events_by_identifier(
             from_identifier=0,
             to_identifier='latest',
         )
-        mediator_events = [blocknumber_event[1] for blocknumber_event in mediator_blockevents]
         return (
             must_contain_entry(mediator_events, EventUnlockSuccess, {}) and
             must_contain_entry(mediator_events, EventUnlockClaimSuccess, {})
@@ -62,11 +60,10 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
     assert wait_until(test_mediator_events, network_wait)
 
     def test_target_events():
-        target_blockevents = app2.raiden.wal.storage.get_events_by_identifier(
+        target_events = app2.raiden.wal.storage.get_events_by_identifier(
             from_identifier=0,
             to_identifier='latest',
         )
-        target_events = [blocknumber_event[1] for blocknumber_event in target_blockevents]
         return (
             must_contain_entry(target_events, SendSecretRequest, {}) and
             must_contain_entry(target_events, SendRevealSecret, {}) and

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -89,7 +89,7 @@ def test_write_read_log():
     )
     count1 = len(state_changes1)
 
-    wal.log_and_dispatch(block, block_number)
+    wal.log_and_dispatch(block)
 
     state_changes2 = wal.storage.get_statechanges_by_identifier(
         from_identifier=0,
@@ -98,7 +98,7 @@ def test_write_read_log():
     count2 = len(state_changes2)
     assert count1 + 1 == count2
 
-    wal.log_and_dispatch(contract_receive_unlock, block_number)
+    wal.log_and_dispatch(contract_receive_unlock)
 
     state_changes3 = wal.storage.get_statechanges_by_identifier(
         from_identifier=0,
@@ -137,13 +137,11 @@ def test_write_read_events():
 
     event = EventPaymentSentFailed(2, 3, 1, 'address', 'whatever')
     event_list = [event]
-    block_number = 10
 
     with pytest.raises(sqlite3.IntegrityError):
         unexisting_state_change_id = 1
         wal.storage.write_events(
             unexisting_state_change_id,
-            block_number,
             event_list,
         )
 
@@ -155,7 +153,6 @@ def test_write_read_events():
     state_change_id = wal.storage.write_state_change('statechangedata')
     wal.storage.write_events(
         state_change_id,
-        block_number,
         event_list,
     )
 
@@ -166,16 +163,15 @@ def test_write_read_events():
     assert len(previous_events) + 1 == len(new_events)
 
     latest_event = new_events[-1]
-    assert latest_event[0] == block_number
-    assert isinstance(latest_event[1], EventPaymentSentFailed)
+    assert isinstance(latest_event, EventPaymentSentFailed)
 
 
 def test_restore_without_snapshot():
     wal = new_wal()
 
-    wal.log_and_dispatch(Block(5), 5)
-    wal.log_and_dispatch(Block(7), 7)
-    wal.log_and_dispatch(Block(8), 8)
+    wal.log_and_dispatch(Block(5))
+    wal.log_and_dispatch(Block(7))
+    wal.log_and_dispatch(Block(8))
 
     newwal = restore_from_latest_snapshot(
         state_transtion_acc,

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -145,10 +145,7 @@ def test_write_read_events():
             event_list,
         )
 
-    previous_events = wal.storage.get_events_by_identifier(
-        from_identifier=0,
-        to_identifier='latest',
-    )
+    previous_events = wal.storage.get_events()
 
     state_change_id = wal.storage.write_state_change('statechangedata')
     wal.storage.write_events(
@@ -156,10 +153,7 @@ def test_write_read_events():
         event_list,
     )
 
-    new_events = wal.storage.get_events_by_identifier(
-        from_identifier=0,
-        to_identifier='latest',
-    )
+    new_events = wal.storage.get_events()
     assert len(previous_events) + 1 == len(new_events)
 
     latest_event = new_events[-1]

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -43,7 +43,7 @@ def must_contain_entry(item_list, type_, data):
 
 def raiden_events_must_contain_entry(raiden, type_, data):
     return must_contain_entry(
-        [x[1] for x in raiden.wal.storage.get_events_by_identifier(0, 'latest')],
+        raiden.wal.storage.get_events_by_identifier(0, 'latest'),
         type_,
         data,
     )

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -43,7 +43,7 @@ def must_contain_entry(item_list, type_, data):
 
 def raiden_events_must_contain_entry(raiden, type_, data):
     return must_contain_entry(
-        raiden.wal.storage.get_events_by_identifier(0, 'latest'),
+        raiden.wal.storage.get_events(),
         type_,
         data,
     )

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -166,7 +166,6 @@ def pending_mediated_transfer(app_chain, token_network_identifier, amount, ident
     )
     events = initiator_app.raiden.wal.log_and_dispatch(
         init_initiator_statechange,
-        initiator_app.raiden.get_block_number(),
     )
     send_transfermessage = must_contain_entry(events, SendLockedTransfer, {})
     transfermessage = LockedTransfer.from_event(send_transfermessage)
@@ -176,7 +175,6 @@ def pending_mediated_transfer(app_chain, token_network_identifier, amount, ident
         mediator_init_statechange = mediator_init(mediator_app.raiden, transfermessage)
         events = mediator_app.raiden.wal.log_and_dispatch(
             mediator_init_statechange,
-            mediator_app.raiden.get_block_number(),
         )
         send_transfermessage = must_contain_entry(events, SendLockedTransfer, {})
         transfermessage = LockedTransfer.from_event(send_transfermessage)
@@ -186,7 +184,6 @@ def pending_mediated_transfer(app_chain, token_network_identifier, amount, ident
     mediator_init_statechange = target_init(transfermessage)
     events = target_app.raiden.wal.log_and_dispatch(
         mediator_init_statechange,
-        target_app.raiden.get_block_number(),
     )
     return secret
 

--- a/raiden/ui/web/src/app/components/event-list/event-list.component.ts
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.ts
@@ -64,7 +64,7 @@ export class EventListComponent implements OnInit {
                 if (fromBlock > latestBlock) {
                     return of([]);
                 }
-                const obs = this.raidenService.getEvents(
+                const obs = this.raidenService.getBlockchainEvents(
                     this.eventsParam,
                     fromBlock,
                     latestBlock);

--- a/raiden/ui/web/src/app/services/raiden.service.ts
+++ b/raiden/ui/web/src/app/services/raiden.service.ts
@@ -273,19 +273,21 @@ export class RaidenService {
         );
     }
 
-    public getEvents(
+    public getBlockchainEvents(
         eventsParam: EventsParam,
         fromBlock?: number,
         toBlock?: number,
     ): Observable<Array<Event>> {
         let path: string;
         const channel = eventsParam.channel;
+        const basePath = '_debug/blockchain_events';
+
         if (channel) {
-            path = `blockchain_events/payment_networks/${channel.token_address}/channels/${channel.partner_address}`;
+            path = `${basePath}/payment_networks/${channel.token_address}/channels/${channel.partner_address}`;
         } else if (eventsParam.token) {
-            path = `blockchain_events/tokens/${eventsParam.token}`;
+            path = `${basePath}/tokens/${eventsParam.token}`;
         } else {
-            path = 'events/network';
+            path = `${basePath}/network`;
         }
         let params = new HttpParams();
         if (fromBlock) {

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -71,7 +71,7 @@ class EchoNode:
         self.echo_worker_greenlet = gevent.spawn(self.echo_worker)
         log.info('Echo node started')
 
-    def echo_node_alarm_callback(self, block_number, chain_id):
+    def echo_node_alarm_callback(self, block_number):
         """ This can be registered with the raiden AlarmTask.
         If `EchoNode.stop()` is called, it will give the return signal to be removed from
         the AlarmTask callbacks.
@@ -100,7 +100,6 @@ class EchoNode:
                 else:
                     received_transfers = self.api.get_payment_history_for_token(
                         self.token_address,
-                        from_block=self.last_poll_block,
                     )
 
                     # received transfer is a tuple of (block_number, event)

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -98,7 +98,7 @@ class EchoNode:
                 if not locked:
                     return
                 else:
-                    received_transfers = self.api.get_payment_history_for_token(
+                    received_transfers = self.api.get_raiden_events_payment_history(
                         token_address=self.token_address,
                         offset=self.last_poll_offset,
                     )

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -296,8 +296,7 @@ def wait_for_transfer_success(
     found = False
     while not found:
         state_events = raiden.wal.storage.get_events_by_identifier(0, 'latest')
-        for event_tuple in state_events:
-            event = event_tuple[1]
+        for event in state_events:
             found = (
                 isinstance(event, EventPaymentReceivedSuccess) and
                 event.identifier == payment_identifier and

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -295,7 +295,7 @@ def wait_for_transfer_success(
     """
     found = False
     while not found:
-        state_events = raiden.wal.storage.get_events_by_identifier(0, 'latest')
+        state_events = raiden.wal.storage.get_events()
         for event in state_events:
             found = (
                 isinstance(event, EventPaymentReceivedSuccess) and


### PR DESCRIPTION
The block number is provided through the
RaidenService.handle_state_change function, the block number used in
this function varies with the type of the state change.

Events from the blockchain can use a consistent value (the block number
from the event), but state changes for user actions or protocol messages
must use the current block number known by the node, which will vary on
restart. To avoid inconsistencies on the block_number on restarts, this
value was removed.