### PR TITLE
Fix Logging at ContractReceivechannelbatchunlock

### DIFF
--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -536,7 +536,7 @@ class ContractReceiveChannelBatchUnlock(StateChange):
         if not isinstance(partner, typing.T_Address):
             raise ValueError('partner must be of type address')
 
-        self.token_network_identifier = token_network_identifier
+        self.payment_network_identifier = token_network_identifier
         self.participant = participant
         self.partner = partner
         self.locksroot = locksroot
@@ -546,7 +546,8 @@ class ContractReceiveChannelBatchUnlock(StateChange):
     def __repr__(self):
         return (
             '<ContractReceiveChannelBatchUnlock'
-            'paymentid:{} token:{} channelid:{} participant:{} unlocked:{} returned:{}'
+            'paymentid:{} token:{} channelid:{} merkle_leaves:{} '
+            'participant:{} unlocked:{} returned:{}'
             '>'
         ).format(
             self.payment_network_identifier,

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -519,7 +519,7 @@ class ContractReceiveChannelBatchUnlock(StateChange):
 
     def __init__(
             self,
-            token_network_identifier: typing.PaymentNetworkID,
+            token_network_identifier: typing.TokenNetworkIdentifier,
             participant: typing.Address,
             partner: typing.Address,
             locksroot: typing.Locksroot,
@@ -527,8 +527,8 @@ class ContractReceiveChannelBatchUnlock(StateChange):
             returned_tokens: typing.TokenAmount,
     ):
 
-        if not isinstance(token_network_identifier, typing.T_PaymentNetworkID):
-            raise ValueError('payment_network_identifier must be of type PaymentNetworkID')
+        if not isinstance(token_network_identifier, typing.T_TokenNetworkIdentifier):
+            raise ValueError('token_network_identifier must be of type TokenNtetworkIdentifier')
 
         if not isinstance(participant, typing.T_Address):
             raise ValueError('participant must be of type address')
@@ -536,7 +536,7 @@ class ContractReceiveChannelBatchUnlock(StateChange):
         if not isinstance(partner, typing.T_Address):
             raise ValueError('partner must be of type address')
 
-        self.payment_network_identifier = token_network_identifier
+        self.token_network_identifier = token_network_identifier
         self.participant = participant
         self.partner = partner
         self.locksroot = locksroot
@@ -546,11 +546,11 @@ class ContractReceiveChannelBatchUnlock(StateChange):
     def __repr__(self):
         return (
             '<ContractReceiveChannelBatchUnlock'
-            'paymentid:{} token:{} channelid:{} merkle_leaves:{} '
+            'tokennetworkid:{} token:{} channelid:{} merkle_leaves:{} '
             'participant:{} unlocked:{} returned:{}'
             '>'
         ).format(
-            self.payment_network_identifier,
+            self.token_network_identifier,
             self.token_address,
             self.channel_identifier,
             self.merkle_tree_leaves,
@@ -562,7 +562,7 @@ class ContractReceiveChannelBatchUnlock(StateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelBatchUnlock) and
-            self.payment_network_identifier == other.payment_network_identifier and
+            self.token_network_identifier == other.token_network_identifier and
             self.token_address == other.token_address and
             self.channel_identifier == other.channel_identifier and
             self.merkle_tree_leaves == other.merkle_tree_leaves and


### PR DESCRIPTION
Got this trace when running a test. The logging function of `ContractReceiveChannelBatchUnlock` was broken.

```
  File "/usr/lib64/python3.6/logging/__init__.py", line 993, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.6/logging/__init__.py", line 839, in format
    return fmt.format(record)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/stdlib.py", line 459, in format
    record.msg = self.processor(logger, meth_name, ed)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/dev.py", line 210, in __call__
    for key in sorted(event_dict.keys())
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/dev.py", line 210, in <genexpr>
    for key in sorted(event_dict.keys())
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/dev.py", line 167, in _repr
    return repr(inst)
  File "/home/lefteris/ew/raiden/raiden/transfer/state_change.py", line 552, in __repr__
    self.payment_network_identifier,
AttributeError: 'ContractReceiveChannelBatchUnlock' object has no attribute 'payment_network_identifier'
Call stack:
  File "/home/lefteris/ew/raiden/raiden/tasks.py", line 56, in _run
    self.poll_for_new_block()
  File "/home/lefteris/ew/raiden/raiden/tasks.py", line 95, in poll_for_new_block
    result = callback(current_block, chain_id)
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 380, in _callback_new_block
    on_blockchain_event(self, event, current_block_number, chain_id)
  File "/home/lefteris/ew/raiden/raiden/blockchain_events_handler.py", line 267, in on_blockchain_event
    handle_channel_batch_unlock(raiden, event, current_block_number)
  File "/home/lefteris/ew/raiden/raiden/blockchain_events_handler.py", line 217, in handle_channel_batch_unlock
    raiden.handle_state_change(unlock_state_change, current_block_number)
  File "/home/lefteris/ew/raiden/raiden/raiden_service.py", line 331, in handle_state_change
    log.debug('STATE CHANGE', node=pex(self.address), state_change=state_change)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/stdlib.py", line 61, in debug
    return self._proxy_to_logger("debug", event, *args, **kw)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/stdlib.py", line 119, in _proxy_to_logger
    **event_kw)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.6/site-packages/structlog/_base.py", line 177, in _proxy_to_logger
    return getattr(self._logger, method_name)(*args, **kw)
Unable to print the message and arguments - possible formatting error.
Use the traceback above to help find the error.
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib64/python3.6/logging/__init__.py", line 993, in emit
    msg = self.format(record)
  File "/usr/lib64/python3.6/logging/__init__.py", line 839, in format
    return fmt.format(record)
  File "/usr/lib64/python3.6/logging/__init__.py", line 576, in format
    record.message = record.getMessage()
  File "/usr/lib64/python3.6/logging/__init__.py", line 336, in getMessage
    msg = str(self.msg)
  File "/home/lefteris/ew/raiden/raiden/transfer/state_change.py", line 552, in __repr__
    self.payment_network_identifier,
AttributeError: 'ContractReceiveChannelBatchUnlock' object has no attribute 'payment_network_identifier'
```