### PR TITLE
Add eth-tester validation

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -13,6 +13,7 @@ UINT256_MAX = 2 ** 256 - 1
 class EthClient(Enum):
     GETH = 1
     PARITY = 2
+    TESTER = 3
 
 
 # Deployed to Ropsten revival on 2018-07-09 from

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -68,6 +68,8 @@ def is_supported_client(
         ]
         if (major, minor, patch) >= (1, 7, 2):
             return True, constants.EthClient.GETH
+    elif client_version.startswith('EthereumTester'):
+        return True, constants.EthClient.TESTER
 
     return False, None
 


### PR DESCRIPTION
Small patch that adds `eth-tester` to client validation.