### PR TITLE
Matrix improvements

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -103,7 +103,7 @@ def handle_channel_new(raiden, event, current_block_number):
         # the channel state was queried
         raiden.blockchain_events.add_payment_channel_listener(
             channel_proxy,
-            from_block=data['blockNumber'],
+            from_block=data['blockNumber'] + 1,
         )
 
     else:

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -356,3 +356,12 @@ class ConnectionManager:
             - This attribute must be accessed with the lock held.
         """
         return self.initial_channel_target < 1
+
+    def __repr__(self) -> str:
+        open_channels = views.get_channelstate_open(
+            chain_state=views.state_from_raiden(self.raiden),
+            payment_network_id=self.registry_address,
+            token_address=self.token_address,
+        )
+        return f'{self.__class__.__name__}(target={self.initial_channel_target} ' +\
+            f'channels={len(open_channels)}:{open_channels!r})'

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -542,7 +542,7 @@ class RaidenService:
         whereas the mediated transfer requires 6 messages.
         """
 
-        self.transport.start_health_check(target)
+        self.start_health_check_for(target)
 
         if identifier is None:
             identifier = create_default_identifier()
@@ -564,7 +564,7 @@ class RaidenService:
             identifier,
     ):
 
-        self.transport.start_health_check(target)
+        self.start_health_check_for(target)
 
         if identifier is None:
             identifier = create_default_identifier()
@@ -598,5 +598,6 @@ class RaidenService:
         self.handle_state_change(init_mediator_statechange)
 
     def target_mediated_transfer(self, transfer: LockedTransfer):
+        self.start_health_check_for(transfer.initiator)
         init_target_statechange = target_init(transfer)
         self.handle_state_change(init_target_statechange)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -57,6 +57,7 @@ def test_mediated_transfer(
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_mediated_transfer_with_entire_deposit(
         raiden_network,
+        number_of_nodes,
         token_addresses,
         deposit,
         network_wait,
@@ -75,7 +76,7 @@ def test_mediated_transfer_with_entire_deposit(
         app2,
         token_network_identifier,
         deposit,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     mediated_transfer(
@@ -83,7 +84,7 @@ def test_mediated_transfer_with_entire_deposit(
         app0,
         token_network_identifier,
         deposit * 2,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     wait_assert(

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -15,8 +15,7 @@ from raiden.transfer.mediated_transfer.events import (
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
-def test_mediated_transfer_events(raiden_network, token_addresses, network_wait):
-    network_wait *= 1.4
+def test_mediated_transfer_events(raiden_network, number_of_nodes, token_addresses, network_wait):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -33,7 +32,7 @@ def test_mediated_transfer_events(raiden_network, token_addresses, network_wait)
         app2,
         token_network_identifier,
         amount,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     def test_initiator_events():

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -87,6 +87,7 @@ def test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_receive_lockedtransfer_invalidnonce(
         raiden_network,
+        number_of_nodes,
         deposit,
         token_addresses,
         reveal_timeout,
@@ -108,7 +109,7 @@ def test_receive_lockedtransfer_invalidnonce(
         app2,
         token_network_identifier,
         amount,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     amount = 10

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -76,7 +76,7 @@ def test_refund_messages(raiden_chain, token_addresses, deposit):
 @pytest.mark.parametrize('privatekey_seed', ['test_refund_transfer:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
-def test_refund_transfer(raiden_chain, token_addresses, deposit, network_wait):
+def test_refund_transfer(raiden_chain, number_of_nodes, token_addresses, deposit, network_wait):
     """A failed transfer must send a refund back.
 
     TODO:
@@ -105,7 +105,7 @@ def test_refund_transfer(raiden_chain, token_addresses, deposit, network_wait):
         token_network_identifier,
         amount_path,
         identifier_path,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     # drain the channel app1 -> app2
@@ -185,6 +185,7 @@ def test_refund_transfer(raiden_chain, token_addresses, deposit, network_wait):
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_refund_transfer_after_2nd_hop(
         raiden_chain,
+        number_of_nodes,
         token_addresses,
         deposit,
         network_wait,
@@ -212,7 +213,7 @@ def test_refund_transfer_after_2nd_hop(
         token_network_identifier,
         amount_path,
         identifier_path,
-        timeout=network_wait,
+        timeout=network_wait * number_of_nodes,
     )
 
     # drain the channel app2 -> app3

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -124,8 +124,8 @@ class StatelessFilter(LogFilter):
             # next call to `get_new_entries`
             if block_number is None:
                 block_number = self.web3.eth.blockNumber
-            if self.filter_params.get('toBlock') in ('latest', 'pending'):
-                filter_params['toBlock'] = block_number
+            if self.filter_params.get('toBlock') in (None, 'latest', 'pending'):
+                filter_params['toBlock'] = block_number or 'latest'
             self._last_block = filter_params.get('toBlock') or block_number
             try:
                 return self.web3.eth.getLogs(filter_params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,10 @@ netifaces==0.10.7
 networkx==2.1.0
 psutil==5.4.5
 pycryptodome==3.6.1
-raiden-libs==0.1.0
+#raiden-libs==0.1.0
 raiden-contracts==0.1.0
 # FIXME: replace with released version before merge
-# git+https://github.com/raiden-network/raiden-libs.git@588f62700685cac09882a8f2f13c12ebc90640d0#egg=raiden-libs
+git+https://github.com/raiden-network/raiden-libs.git@f40a867f5d8ea89b1386fd6cc4c66f8eff886fea#egg=raiden-libs
 # git+https://github.com/raiden-network/raiden-contracts.git@2ab91aa4b062d88a124ce050551e2f4b8cb0da57#egg=raiden-contracts
 webargs==1.8.1
 eth-keyfile==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ install_requires_replacements = {
     'git+https://github.com/LefterisJP/pystun@develop#egg=pystun': 'pystun',
     (
         'git+https://github.com/raiden-network/raiden-libs.git'
-        '@588f62700685cac09882a8f2f13c12ebc90640d0'
+        '@f40a867f5d8ea89b1386fd6cc4c66f8eff886fea'
         '#egg=raiden-libs'
     ): 'raiden-libs',
     (


### PR DESCRIPTION
Some big, but internal to Matrix Transport, changes, which should make room creation, selection and reuse way more reliable:
- Now, matrix doesn't rely on the room name to find or validate it
- Communication rooms are choosen by creation or invitation events only, and could be anonymous rooms
- Room names are used only for better information/debugging, and optional
- When trying to contact a client, checks if we were invited to some room by him, and use it, or try to create a room and invite them. Creates an annonymous room with him if there's conflict on server (prevents a DoS by someone pre-creating the rooms with the pair names)
- This `address->room_id` mappins are stored on matrix server for persistence (done in https://github.com/raiden-network/raiden-libs/pull/107), but not essential, as if we can't contact the client, we can just create another room and invite them to it
- Prevents a lot of race conditions on room names creation/invitation, by updating the room we use to talk with that address upon receiving a validated message from him in another room
- All these rooms are still listened on (in case the user roams of server), but we filter and handle only messages by users we have `start_health_check`ed.
- Requires/assert `start_health_check` to peers to be able to send a message to them. The only situation it was not done before was between the node receiving a mediated transfer and the sender of it, which was fixed on this PR.

Fix #1843 