### PR TITLE
Exclude node_modules directory from pytest detection

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = coverage
 
 [pytest]
 timeout = 540
+norecursedirs = node_modules
 
 [testenv]
 deps =


### PR DESCRIPTION
After building the web ui if you attempt to run all the tests using pytest raiden, it will try to collect tests in the web-ui's node_modules directory that belong to the node-gyp tool. This will cause the collection process to fail