### PR TITLE
fixed test_batch_unlock

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -235,51 +235,51 @@ def test_api_get_channel_list(
         token_addresses,
         reveal_timeout,
 ):
-        partner_address = '0x61C808D82A3Ac53231750daDc13c777b59310bD9'
+    partner_address = '0x61C808D82A3Ac53231750daDc13c777b59310bD9'
 
-        request = grequests.get(
-            api_url_for(
-                api_backend,
-                'channelsresource',
-            ),
-        )
-        response = request.send().response
-        assert_proper_response(response, HTTPStatus.OK)
-        assert response.json() == []
+    request = grequests.get(
+        api_url_for(
+            api_backend,
+            'channelsresource',
+        ),
+    )
+    response = request.send().response
+    assert_proper_response(response, HTTPStatus.OK)
+    assert response.json() == []
 
-        # let's create a new channel
-        token_address = token_addresses[0]
-        settle_timeout = 1650
-        channel_data_obj = {
-            'partner_address': partner_address,
-            'token_address': to_checksum_address(token_address),
-            'settle_timeout': settle_timeout,
-            'reveal_timeout': reveal_timeout,
-        }
+    # let's create a new channel
+    token_address = token_addresses[0]
+    settle_timeout = 1650
+    channel_data_obj = {
+        'partner_address': partner_address,
+        'token_address': to_checksum_address(token_address),
+        'settle_timeout': settle_timeout,
+        'reveal_timeout': reveal_timeout,
+    }
 
-        request = grequests.put(
-            api_url_for(
-                api_backend,
-                'channelsresource',
-            ),
-            json=channel_data_obj,
-        )
-        response = request.send().response
+    request = grequests.put(
+        api_url_for(
+            api_backend,
+            'channelsresource',
+        ),
+        json=channel_data_obj,
+    )
+    response = request.send().response
 
-        assert_proper_response(response, HTTPStatus.CREATED)
+    assert_proper_response(response, HTTPStatus.CREATED)
 
-        request = grequests.get(
-            api_url_for(
-                api_backend,
-                'channelsresource',
-            ),
-        )
-        response = request.send().response
-        assert_proper_response(response, HTTPStatus.OK)
-        channel_info = response.json()[0]
-        assert channel_info['partner_address'] == partner_address
-        assert channel_info['token_address'] == to_checksum_address(token_address)
-        assert 'token_network_identifier' in channel_info
+    request = grequests.get(
+        api_url_for(
+            api_backend,
+            'channelsresource',
+        ),
+    )
+    response = request.send().response
+    assert_proper_response(response, HTTPStatus.OK)
+    channel_info = response.json()[0]
+    assert channel_info['partner_address'] == partner_address
+    assert channel_info['token_address'] == to_checksum_address(token_address)
+    assert 'token_network_identifier' in channel_info
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
@@ -288,25 +288,25 @@ def test_api_channel_status_channel_nonexistant(
         api_backend,
         token_addresses,
 ):
-        partner_address = '0x61C808D82A3Ac53231750daDc13c777b59310bD9'
-        token_address = token_addresses[0]
+    partner_address = '0x61C808D82A3Ac53231750daDc13c777b59310bD9'
+    token_address = token_addresses[0]
 
-        request = grequests.get(
-            api_url_for(
-                api_backend,
-                'channelsresourcebytokenandpartneraddress',
-                token_address=token_address,
-                partner_address=partner_address,
-            ),
+    request = grequests.get(
+        api_url_for(
+            api_backend,
+            'channelsresourcebytokenandpartneraddress',
+            token_address=token_address,
+            partner_address=partner_address,
+        ),
+    )
+    response = request.send().response
+    assert_proper_response(response, HTTPStatus.NOT_FOUND)
+    assert response.json()['errors'] == (
+        "Channel with partner '{}' for token '{}' could not be found.".format(
+            to_checksum_address(partner_address),
+            to_checksum_address(token_address),
         )
-        response = request.send().response
-        assert_proper_response(response, HTTPStatus.NOT_FOUND)
-        assert response.json()['errors'] == (
-            "Channel with partner '{}' for token '{}' could not be found.".format(
-                to_checksum_address(partner_address),
-                to_checksum_address(token_address),
-            )
-        )
+    )
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
@@ -1194,6 +1194,6 @@ def test_api_deposit_limit(
     )
     response = request.send().response
 
-    assert_proper_response(response, HTTPStatus.EXPECTATION_FAILED)
+    assert_proper_response(response, HTTPStatus.CONFLICT)
     response = response.json()
     assert response['errors'] == 'The deposit of 10001 is bigger than the current limit of 10000'

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -9,9 +9,9 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
     TEST_SETTLE_TIMEOUT_MAX,
 )
+from raiden_libs.messages import BalanceProof
+from raiden_libs.utils.signing import sign_data
 
-from raiden.network.rpc.client import JSONRPCClient
-from raiden.network.proxies import TokenNetwork
 from raiden.constants import EMPTY_HASH
 from raiden.exceptions import (
     InvalidSettleTimeout,
@@ -21,9 +21,9 @@ from raiden.exceptions import (
     ChannelIncorrectStateError,
     DepositMismatch,
 )
+from raiden.network.proxies import TokenNetwork
+from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils import wait_blocks
-from raiden_libs.messages import BalanceProof
-from raiden_libs.utils.signing import sign_data
 
 
 def test_token_network_deposit_race(
@@ -31,7 +31,6 @@ def test_token_network_deposit_race(
         private_keys,
         blockchain_rpc_ports,
         token_proxy,
-        chain_id,
         web3,
 ):
     assert token_network_proxy.settlement_timeout_min() == TEST_SETTLE_TIMEOUT_MIN

--- a/raiden/tests/integration/long_running/flaky/test_token_networks.py
+++ b/raiden/tests/integration/long_running/flaky/test_token_networks.py
@@ -72,6 +72,7 @@ def saturated_count(connection_managers, registry_address, token_address):
 # - Check if this test needs to be adapted for the matrix transport
 #   layer when activating it again. It might as it depends on the
 #   raiden_network fixture.
+@pytest.mark.skip(reason='issue #1924')
 @pytest.mark.parametrize('number_of_nodes', [6])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('settle_timeout', [6])

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -269,6 +269,8 @@ def test_recovery_blockchain_events(
 
     del app0  # from here on the app0_restart should be used
 
+    app0_restart.raiden.start()
+
     # wait for the nodes' healthcheck to update the network statuses
     waiting.wait_for_healthy(
         app0_restart.raiden,


### PR DESCRIPTION
The secret registration was being done before the channel was close,
that create a race which made the test fail with the matrix transport.
The test failed because the nodes learned about the secret and unlocked
the transfer off-chain before the channel was closed, making the batch
unlock unecessary, and therefor the test failed.

Fixes #1870 