### PR TITLE
Provide error if no ethereum account files found in keystore path

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :bug:`1899` Print proper error without throwing exception if no accounts are found in the keystore
+
+* :release:`0.4.0 <2018-07-19>`
+
 * :feature:`1518` Update installation docs with Homebrew tap and update Homebrew formula on release
 * :feature:`1195` Improve AccountManager error handling if keyfile is invalid.
 * :bug:`1237` Inform the user if geth binary is missing during raiden smoketest.

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -706,7 +706,12 @@ def app(
 def prompt_account(address_hex, keystore_path, password_file):
     accmgr = AccountManager(keystore_path)
     if not accmgr.accounts:
-        raise RuntimeError('No Ethereum accounts found in the user\'s system')
+        print(
+            'No Ethereum accounts found in the provided keystore directory {}. '
+            'Please provide a directory containing valid ethereum account '
+            'files.'.format(keystore_path),
+        )
+        sys.exit(1)
 
     if not accmgr.address_in_keystore(address_hex):
         # check if an address has been passed


### PR DESCRIPTION
Fix #1899 