### PR TITLE
Check presence and if not online, do not send message

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -579,7 +579,12 @@ class MatrixTransport:
         room = self._get_room_for_address(receiver_address)
         if not room:
             return
-        self.log.debug('SEND', room=room, data=data)
+        presence = self._address_to_presence[receiver_address]
+        if presence == UserPresence.OFFLINE:
+            self.log.debug('NOT SENDING, USER IS OFFLINE', room=room, data=data)
+            return
+
+        self.log.debug('SEND', room=room, data=data, presence=presence)
         room.send_text(data)
 
     def _get_room_for_address(


### PR DESCRIPTION
Potential work in progress for #1917

The DEBUG log here may be an overkill but could help in a lot of debugging situations.

I discovered that the exceptions in #1917 only happens due to my node trying to send messages to nodes for which a room was created in the past but the target is now currently offline. As a simple fix I just don't send the message in this case.

Need feedback if this is the correct approach.