### PR TITLE
Properly synchronizing the raiden node with the BC

### DIFF
--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -18,7 +18,6 @@ log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 @pytest.fixture
 def raiden_chain(
-        request,
         token_addresses,
         token_network_registry_address,
         channels_per_node,
@@ -68,10 +67,12 @@ def raiden_chain(
         local_matrix_server,
     )
 
+    from_block = 0
     for app in raiden_apps:
-        app.raiden.install_and_query_all_blockchain_filters(
-            app.raiden.default_registry.address,
-            app.raiden.default_secret_registry.address,
+        app.raiden.install_all_blockchain_filters(
+            app.raiden.default_registry,
+            app.raiden.default_secret_registry,
+            from_block,
         )
 
     app_channels = create_sequential_channels(
@@ -108,7 +109,6 @@ def raiden_chain(
 
 @pytest.fixture
 def raiden_network(
-        request,
         token_addresses,
         token_network_registry_address,
         channels_per_node,
@@ -182,9 +182,6 @@ def raiden_network(
 
     with gevent.Timeout(seconds=5, exception=exception):
         wait_for_alarm_start(raiden_apps)
-
-    for app in raiden_apps:
-        app.raiden.alarm.poll_for_new_block()
 
     yield raiden_apps
 

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -142,9 +142,11 @@ def run(
         listen_port,
     )
 
-    app.raiden.install_and_query_all_blockchain_filters(
-        app.raiden.default_registry.address,
-        app.raiden.default_secret_registry.address,
+    from_block = 0
+    app.raiden.install_all_blockchain_filters(
+        app.raiden.default_registry,
+        app.raiden.default_secret_registry,
+        from_block,
     )
 
     if scenario:


### PR DESCRIPTION
During startup all filters must be queried to synchronize the node's
state. This must be done after the node's state is primed (either
initialized or restored from a snapshot), the filters are installed, and
prior to the transport being started.

This changes:
- `install_and_query_all_blockchain_filters` was using
`RaidenService.get_block_number` as the value for the filters
`to_block`, which is not updated until the alarm task is executed,
meaning the node's state was not updated before the AlarmTask was
scheduled.
- Removed from the `AlarmTask` an unused attribute named `response_queue`
- Removed the buggy sleep timeout computation from the `AlarmTask` (the
work_time was always zero)
- Inlined the method poll_for_new_block in the AlarmTask loop
- Added a check if the chain_id of the underlying ethereum node changes

[ci integration]