### PR TITLE
Use conditions: v0 as opt-out of new default v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+conditions: v0
 stages:
   - name: lint
   - name: test


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-06-21-build-conditions-v1-is-available
Fix #1918