### PR TITLE
nicer formating for the sync message

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -58,8 +58,4 @@ MIN_REQUIRED_SOLC = 'v0.4.23'
 NULL_ADDRESS = '0x' + '0' * 40
 NULL_ADDRESS_BYTES = b'\x00' * 20
 
-# ansi escape code for moving the cursor and clearing the line
-ANSI_ESCAPE_CURSOR_STARTLINE = '\x1b[1000D'
-ANSI_ESCAPE_CLEARLINE = '\x1b[2K'
-
 TESTNET_GASPRICE_MULTIPLIER = 2.0

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -195,6 +195,9 @@ def wait_for_sync_etherscan(
 
         print(syncing_str.format(local_block, etherscan_block), end='')
 
+    # add a newline so that the next print will start have it's own line
+    print('')
+
 
 def wait_for_sync_rpc_api(
         blockchain_service: BlockChainService,
@@ -207,7 +210,7 @@ def wait_for_sync_rpc_api(
 
     for i in count():
         if i % 3 == 0:
-            print(constants.ANSI_ESCAPE_CLEARLINE + constants.ANSI_ESCAPE_CURSOR_STARTLINE, end='')
+            print('\r', end='')
 
         print('.', end='')
         sys.stdout.flush()
@@ -216,6 +219,9 @@ def wait_for_sync_rpc_api(
 
         if blockchain_service.is_synced():
             return
+
+    # add a newline so that the next print will start have it's own line
+    print('')
 
 
 def wait_for_sync(


### PR DESCRIPTION
made sure to have a new line after the synching loop, and stopped using
the ansi codes since that was not working on all shells

[ci skip]