### PR TITLE
Return E409 on concurrent deposits

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1916` Return E409 on two concurrent conflicting channel deposits
 * :bug:`1869` Various matrix improvements. Prevent DOS attacks, and race conditions that caused client crashes. Require peers to be present to send message to them. Improves user discovery across Matrix federation.
 * :bug:`1902` Check for ethnode connection at start and print proper error if Raiden can not connect
 * :bug:`1911` The syncing message is now printed properly and does not repeat across the screen

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -378,6 +378,7 @@ Channel Management
    :statuscode 409:
     - Provided channel does not exist or
     - ``state`` and ``total_deposit`` have been attempted to update in the same request.
+   :statuscode 417: Attempt to deposit more tokens than the testing limit, or attempt to deposit lower amount than on-chain balance of the channel.
    :statuscode 500: Internal Raiden node error
 
 Connection Management

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -377,8 +377,9 @@ Channel Management
    :statuscode 408: Deposit event was not read in time by the Ethereum node
    :statuscode 409:
     - Provided channel does not exist or
-    - ``state`` and ``total_deposit`` have been attempted to update in the same request.
-   :statuscode 417: Attempt to deposit more tokens than the testing limit, or attempt to deposit lower amount than on-chain balance of the channel.
+    - ``state`` and ``total_deposit`` have been attempted to update in the same request or
+    - attempt to deposit token amount lower than on-chain balance of the channel
+    - attempt to deposit more tokens than the testing limit
    :statuscode 500: Internal Raiden node error
 
 Connection Management

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -34,6 +34,7 @@ from raiden.exceptions import (
     TransactionThrew,
     UnknownTokenAddress,
     DepositOverLimit,
+    DepositMismatch,
 )
 from raiden.api.v1.encoding import (
     AddressListSchema,
@@ -432,6 +433,11 @@ class RestAPI:
                     errors=str(e),
                     status_code=HTTPStatus.EXPECTATION_FAILED,
                 )
+            except DepositMismatch as e:
+                return api_error(
+                    errors=str(e),
+                    status_code=HTTPStatus.EXPECTATION_FAILED,
+                )
 
         channel_state = views.get_channelstate_for(
             views.state_from_raiden(self.raiden_api.raiden),
@@ -703,6 +709,11 @@ class RestAPI:
                 status_code=HTTPStatus.PAYMENT_REQUIRED,
             )
         except DepositOverLimit as e:
+            return api_error(
+                errors=str(e),
+                status_code=HTTPStatus.EXPECTATION_FAILED,
+            )
+        except DepositMismatch as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.EXPECTATION_FAILED,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -80,7 +80,6 @@ ERROR_STATUS_CODES = [
     HTTPStatus.PAYMENT_REQUIRED,
     HTTPStatus.BAD_REQUEST,
     HTTPStatus.NOT_FOUND,
-    HTTPStatus.EXPECTATION_FAILED,
 ]
 
 URLS_V1 = [
@@ -431,12 +430,12 @@ class RestAPI:
             except DepositOverLimit as e:
                 return api_error(
                     errors=str(e),
-                    status_code=HTTPStatus.EXPECTATION_FAILED,
+                    status_code=HTTPStatus.CONFLICT,
                 )
             except DepositMismatch as e:
                 return api_error(
                     errors=str(e),
-                    status_code=HTTPStatus.EXPECTATION_FAILED,
+                    status_code=HTTPStatus.CONFLICT,
                 )
 
         channel_state = views.get_channelstate_for(
@@ -711,12 +710,12 @@ class RestAPI:
         except DepositOverLimit as e:
             return api_error(
                 errors=str(e),
-                status_code=HTTPStatus.EXPECTATION_FAILED,
+                status_code=HTTPStatus.CONFLICT,
             )
         except DepositMismatch as e:
             return api_error(
                 errors=str(e),
-                status_code=HTTPStatus.EXPECTATION_FAILED,
+                status_code=HTTPStatus.CONFLICT,
             )
 
         updated_channel_state = self.raiden_api.get_channel(

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -41,6 +41,15 @@ class DepositOverLimit(RaidenError):
     pass
 
 
+class DepositMismatch(RaidenError):
+    """ Raised when the requested deposit is lower than actual channel deposit
+
+    Used when a *user* tries to deposit a given amount of token in a channel,
+    but the on-chain amount is already higher.
+    """
+    pass
+
+
 class InvalidAddress(RaidenError):
     """ Raised when the user provided value is not a valid address. """
     pass

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -36,6 +36,7 @@ from raiden.exceptions import (
     InvalidAddress,
     ContractVersionMismatch,
     InvalidSettleTimeout,
+    DepositMismatch,
 )
 from raiden.settings import (
     EXPECTED_CONTRACTS_VERSION,
@@ -423,6 +424,11 @@ class TokenNetwork:
             #
             current_deposit = self.detail_participant(self.node_address, partner)['deposit']
             amount_to_deposit = total_deposit - current_deposit
+            if total_deposit < current_deposit:
+                raise DepositMismatch(
+                    f'Current deposit ({current_deposit}) is already larger '
+                    f'than requested total deposit amount ({total_deposit})',
+                )
             if amount_to_deposit <= 0:
                 raise ValueError(f'deposit {amount_to_deposit} must be greater than 0.')
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -427,7 +427,7 @@ class TokenNetwork:
             if total_deposit < current_deposit:
                 raise DepositMismatch(
                     f'Current deposit ({current_deposit}) is already larger '
-                    f'than requested total deposit amount ({total_deposit})',
+                    f'than the requested total deposit amount ({total_deposit})',
                 )
             if amount_to_deposit <= 0:
                 raise ValueError(f'deposit {amount_to_deposit} must be greater than 0.')


### PR DESCRIPTION
## what is wrong
If two deposits are made at the same time, and second deposit is lower than the first one, `TokenNetwork` contract proxy will use incorrect (negative) amount for the update. This will cause an exception being propagated to the REST api, which will return E500 to the client.

## how was it fixed
`TokenNetwork` proxy checks if the actual on-chain value is lower than the target amount inside the lock-protected block.

Fixes #1916 