### PR TITLE
Check if token network exists when opening a channel

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`1960` Return E409 when trying to open a channel for a token that is not registered
 * :bug:`1916` Return E409 on two concurrent conflicting channel deposits
 * :bug:`1869` Various matrix improvements. Prevent DOS attacks, and race conditions that caused client crashes. Require peers to be present to send message to them. Improves user discovery across Matrix federation.
 * :bug:`1902` Check for ethnode connection at start and print proper error if Raiden can not connect

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -228,6 +228,13 @@ class RaidenAPI:
             raise DuplicatedChannelError('Channel with given partner address already exists')
 
         registry = self.raiden.chain.token_network_registry(registry_address)
+        token_network_address = registry.get_token_network(token_address)
+
+        if token_network_address is None:
+            raise InvalidAddress(
+                'Token network for token %s does not exist' % to_checksum_address(token_address),
+            )
+
         token_network = self.raiden.chain.token_network(
             registry.get_token_network(token_address),
         )

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -29,6 +29,7 @@ from raiden.exceptions import (
     UnknownTokenAddress,
     DepositOverLimit,
     DuplicatedChannelError,
+    TokenNotRegistered,
 )
 from raiden.settings import (
     DEFAULT_POLL_TIMEOUT,
@@ -231,7 +232,7 @@ class RaidenAPI:
         token_network_address = registry.get_token_network(token_address)
 
         if token_network_address is None:
-            raise InvalidAddress(
+            raise TokenNotRegistered(
                 'Token network for token %s does not exist' % to_checksum_address(token_address),
             )
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -35,6 +35,7 @@ from raiden.exceptions import (
     UnknownTokenAddress,
     DepositOverLimit,
     DepositMismatch,
+    TokenNotRegistered,
 )
 from raiden.api.v1.encoding import (
     AddressListSchema,
@@ -397,7 +398,7 @@ class RestAPI:
                 status_code=HTTPStatus.ACCEPTED,
             )
         except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
-                AddressWithoutCode, DuplicatedChannelError) as e:
+                AddressWithoutCode, DuplicatedChannelError, TokenNotRegistered) as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -85,6 +85,11 @@ class UnknownTokenAddress(RaidenError):
     pass
 
 
+class TokenNotRegistered(RaidenError):
+    """ Raised if there is no token network for token used when opening a channel  """
+    pass
+
+
 class AlreadyRegisteredTokenAddress(RaidenError):
     """ Raised when the token address in already registered with the given network. """
     pass


### PR DESCRIPTION
- fixes bug in Python API - `open_channel` should raise an exception
  if token network does not exist

Fixes #1960 