### PR TITLE
More explicit install instructions and minor fixes

### DIFF
--- a/docs/api_walkthrough.rst
+++ b/docs/api_walkthrough.rst
@@ -62,6 +62,7 @@ To register a token simply use the endpoint listed below:
 
    PUT /api/1/tokens/0x9aBa529db3FF2D8409A1da4C9eB148879b046700 HTTP/1.1
    Host: localhost:5001
+   Content-Type: application/json
 
 If successful this call will return the address of the freshly created Channel Manager like this:
 
@@ -122,7 +123,7 @@ Here it's interesting to notice that a ``channel_identifier`` has been generated
 
 Depositing to a channel
 ------------------------
-A payment channel is now open between the user's node and a counterparty. However, since only one of the nodes has deposited to the channel, only that node can make transfers at this point in time. Now would be a good time to notify the counterparty that a channel has been opened with it, so that it can also deposit to the channel. All the counterparty needs in order to do this is to use the endpoint consisting of a combination of the ``token_address` and the ``participant_address`:
+A payment channel is now open between the user's node and a counterparty. However, since only one of the nodes has deposited to the channel, only that node can make transfers at this point in time. Now would be a good time to notify the counterparty that a channel has been opened with it, so that it can also deposit to the channel. All the counterparty needs in order to do this is to use the endpoint consisting of a combination of the ``token_address`` and the ``participant_address``:
 
 .. http:example:: curl wget httpie python-requests
 
@@ -210,6 +211,7 @@ If at some point it is desired to leave the token network, the ``leave`` endpoin
 
    DELETE /api/1/connections/0xc9d55C7bbd80C0c2AEd865e9CA13D015096ce671 HTTP/1.1
    Host: localhost:5001
+   Content-Type: application/json
 
 This call will take some time to finalize, due to the nature of the way that settlement of payment channels work. For instance there is a ``settlement_timeout`` period after calling ``close`` that needs to expire before ``settle`` can be called.
 
@@ -240,6 +242,7 @@ Transferring tokens to another node is quite easy. The address of the token desi
 
    POST /api/1/transfers/0xc9d55C7bbd80C0c2AEd865e9CA13D015096ce671/0x61C808D82A3Ac53231750daDc13c777b59310bD9 HTTP/1.1
    Host: localhost:5001
+   Content-Type: application/json
 
    {
        "amount": 42
@@ -253,10 +256,11 @@ If there is a path in the network with enough capacity and the address sending t
 
    GET /api/1/events/channels/0xc9d55C7bbd80C0c2AEd865e9CA13D015096ce671/0x61C808D82A3Ac53231750daDc13c777b59310bD9?from_block=1337 HTTP/1.1
    Host: localhost:5001
+   Content-Type: application/json
 
 Which will return a list of events. All that then needs to be done is to filter for incoming transfers.
 
-Please note that one of the most powerful features of Raiden is that users can send transfers to anyone connected to the network as long as there is a path to them with enough capacity, and not just to the nodes that a user is directly connected to. This is called a *mediated transfers*.
+Please note that one of the most powerful features of Raiden is that users can send transfers to anyone connected to the network as long as there is a path to them with enough capacity, and not just to the nodes that a user is directly connected to. This is called *mediated transfers*.
 
 
 .. _close:

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -43,7 +43,9 @@ Or you can use Homebrew to install the most up to date binary::
     brew tap raiden-network/raiden
     brew install raiden
 
-An Ethereum client is required in both cases.
+An Ethereum client is required in both cases. The Raiden binary takes the same command line
+arguments as the ``raiden`` script.
+
 
 Dependencies
 ************
@@ -107,7 +109,7 @@ Firing it up
 =============
 
 In order to use Raiden it is required to have a specific ethereum account dedicated to Raiden. Create an account for Raiden and fill it up with ETH and some tokens you want to have in payment channels and let the Raiden client manage it.
-**Creating any manual transaction with the account that Raiden uses, while the Raiden client is running, can result to undefined behaviour**.
+**Creating any manual transaction with the account that Raiden uses, while the Raiden client is running, can result in undefined behaviour**.
 
 Using geth
 **********
@@ -131,15 +133,12 @@ Run the client and let it sync with the Ropsten testnet::
 
     parity --chain ropsten --bootnodes "enode://20c9ad97c081d63397d7b685a412227a40e23c8bdc6688c6f37e97cfbc22d2b4d1db1510d8f61e6a8866ad7f0e17c02b14182d37ea7c3c8b9c2683aeb6b733a1@52.169.14.227:30303,enode://6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d@13.84.180.240:30303"
 
-After syncing the chain, create an account on the Ropsten testnet by navigating to the url that parity shows.  It is usually::
-
-    http://127.0.0.1:8180
-
+After syncing the chain, an existing Ethereum account can be used or a new one can be generated using ``parity-ethkey``.
 After account creation, launch Raiden with the path of your keystore supplied::
 
     raiden --keystore-path ~/.local/share/io.parity.ethereum/keys/test
 
-Select the Ethereum account when prompted, and type in the account's password.
+Select the desired Ethereum account when prompted, and type in the account's password.
 
 
 See the :doc:`API walkthrough <api_walkthrough>` for further instructions on how to interact with Raiden.


### PR DESCRIPTION
This PR makes the install instructions more explicit in regards to how
to run the Raiden binary.

Furthermore it also fixes some of the REST calls that had some missing
headers which resulted in the curl request not working