### PR TITLE
Lower the logging level of missed blocks

### DIFF
--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -114,7 +114,7 @@ class AlarmTask(gevent.Greenlet):
 
                 if current_block > last_block_number + 1:
                     missed_blocks = current_block - last_block_number - 1
-                    log.error(
+                    log.info(
                         'missed blocks',
                         missed_blocks=missed_blocks,
                         current_block=current_block,


### PR DESCRIPTION
The current `error` level might give the impression that something dangerous happened. But we handle that case internally, so I think `info` is fine.

@LefterisJP 