### PR TITLE
Fix automatic macOS bundling by adding a missing dependency

### DIFF
--- a/.travis/prepare_os_osx.sh
+++ b/.travis/prepare_os_osx.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-for tool in automake libtool pkg-config libffi gmp openssl node python3; do
+for tool in automake gmp leveldb libffi libtool node openssl pkg-config python3; do
     brew install ${tool} || brew upgrade ${tool} || true
 done
 

--- a/docs/macos_install_guide.rst
+++ b/docs/macos_install_guide.rst
@@ -24,7 +24,7 @@ checkout of raiden.
 
 #. Install system packages needed for :code:`raiden` and its dependencies::
 
-    $ brew install automake libtool pkg-config libffi gmp openssl
+    $ brew install automake gmp leveldb libffi libtool openssl pkg-config
 
 #. Install `pip`_ (a Python package manager)::
 


### PR DESCRIPTION
Also fixes the macOS install instruction docs.

Second half of the fix for #1893
