### PR TITLE
Contract address presets for multiple chain ids

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from enum import Enum
 
 from eth_utils import to_canonical_address
@@ -37,8 +36,9 @@ ETH_RPC_DEFAULT_PORT = 8545
 HTTP_PORT = 80
 HTTPS_PORT = 443
 
-
 EMPTY_HASH = b'\x00' * 32
+
+START_QUERY_BLOCK_KEY = 'DefaultStartBlock'
 
 MAINNET = 'mainnet'
 ROPSTEN = 'ropsten'
@@ -54,15 +54,12 @@ ID_TO_NETWORKNAME = {
     627: SMOKETEST,
 }
 
-ID_TO_QUERY_BLOCK = defaultdict(int, {
-    3: 3604000,  # 924 blocks before token network registry deployment
-})
-
-ID_TO_CONTRACT_ADDRESSES = {
+ID_TO_NETWORK_CONFIG = {
     3: {
         CONTRACT_ENDPOINT_REGISTRY: to_canonical_address(ROPSTEN_DISCOVERY_ADDRESS),
         CONTRACT_SECRET_REGISTRY: to_canonical_address(ROPSTEN_SECRET_REGISTRY_ADDRESS),
         CONTRACT_TOKEN_NETWORK_REGISTRY: to_canonical_address(ROPSTEN_REGISTRY_ADDRESS),
+        START_QUERY_BLOCK_KEY: 3604000,  # 924 blocks before token network registry deployment
     },
 }
 

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,6 +1,15 @@
 from collections import defaultdict
 from enum import Enum
 
+from eth_utils import to_canonical_address
+
+from raiden_contracts.constants import (
+    CONTRACT_ENDPOINT_REGISTRY,
+    CONTRACT_SECRET_REGISTRY,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
+)
+
+
 UINT64_MAX = 2 ** 64 - 1
 UINT64_MIN = 0
 
@@ -48,6 +57,14 @@ ID_TO_NETWORKNAME = {
 ID_TO_QUERY_BLOCK = defaultdict(int, {
     3: 3604000,  # 924 blocks before token network registry deployment
 })
+
+ID_TO_CONTRACT_ADDRESSES = {
+    3: {
+        CONTRACT_ENDPOINT_REGISTRY: to_canonical_address(ROPSTEN_DISCOVERY_ADDRESS),
+        CONTRACT_SECRET_REGISTRY: to_canonical_address(ROPSTEN_SECRET_REGISTRY_ADDRESS),
+        CONTRACT_TOKEN_NETWORK_REGISTRY: to_canonical_address(ROPSTEN_REGISTRY_ADDRESS),
+    },
+}
 
 NETWORKNAME_TO_ID = {
     name: id

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -604,7 +604,7 @@ def run_app(
         secret_registry_contract_address is not None and
         discovery_contract_address is not None
     )
-    contract_addresses_known = net_id in constants.ID_TO_CONTRACT_ADDRESSES
+    contract_addresses_known = net_id in constants.ID_TO_NETWORK_CONFIG
 
     if not contract_addresses_given and not contract_addresses_known:
         print((
@@ -613,7 +613,7 @@ def run_app(
               ).format(net_id))
         sys.exit(1)
 
-    contract_addresses = constants.ID_TO_CONTRACT_ADDRESSES.get(net_id, dict())
+    contract_addresses = constants.ID_TO_NETWORK_CONFIG.get(net_id, dict())
 
     try:
         token_network_registry = blockchain_service.token_network_registry(
@@ -676,10 +676,12 @@ def run_app(
         raise RuntimeError(f'Unknown transport type "{transport}" given')
 
     try:
+        chain_config = constants.ID_TO_NETWORK_CONFIG.get(net_id, {})
+        start_block = chain_config.get(constants.START_QUERY_BLOCK_KEY, 0)
         raiden_app = App(
             config=config,
             chain=blockchain_service,
-            query_start_block=constants.ID_TO_QUERY_BLOCK[net_id],
+            query_start_block=start_block,
             default_registry=token_network_registry,
             default_secret_registry=secret_registry,
             transport=transport,


### PR DESCRIPTION
This commit adds a dictionary to the constants that maps from chain_id
to the contract addresses.

Fixes #1928