### PR TITLE
Adjust proxies for changed ChannelID

### DIFF
--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -12,6 +12,7 @@ from raiden_contracts.constants import (
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
 from web3.utils.filters import Filter
 
+from raiden.constants import UINT64_MAX
 from raiden.utils import typing
 from raiden.utils.filters import (
     get_filter_args_for_specific_event_from_channel,
@@ -26,6 +27,10 @@ class PaymentChannel:
             token_network: TokenNetwork,
             channel_identifier: typing.ChannelID,
     ):
+
+        if 0 > channel_identifier > UINT64_MAX:
+            raise ValueError
+
         filter_args = get_filter_args_for_specific_event_from_channel(
             token_network_address=token_network.address,
             channel_identifier=channel_identifier,
@@ -106,6 +111,7 @@ class PaymentChannel:
     def set_total_deposit(self, total_deposit: typing.TokenAmount):
         self.token_network.set_total_deposit(
             channel_identifier=self.channel_identifier,
+            participant=self.participant1,
             total_deposit=total_deposit,
             partner=self.participant2,
         )
@@ -121,8 +127,8 @@ class PaymentChannel:
         self.token_network.close(
             channel_identifier=self.channel_identifier,
             partner=self.participant2,
-            nonce=nonce,
             balance_hash=balance_hash,
+            nonce=nonce,
             additional_hash=additional_hash,
             signature=signature,
         )
@@ -139,8 +145,8 @@ class PaymentChannel:
         self.token_network.update_transfer(
             channel_identifier=self.channel_identifier,
             partner=self.participant2,
-            nonce=nonce,
             balance_hash=balance_hash,
+            nonce=nonce,
             additional_hash=additional_hash,
             closing_signature=partner_signature,
             non_closing_signature=signature,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -167,7 +167,7 @@ class TokenNetwork:
             'new_netting_channel called',
             peer1=pex(self.node_address),
             peer2=pex(partner),
-            channel_identifier=channel_identifier,
+            channel_identifier=str(channel_identifier),
         )
 
         return channel_identifier
@@ -507,6 +507,7 @@ class TokenNetwork:
 
             transaction_hash = self.proxy.transact(
                 'setTotalDeposit',
+                channel_identifier,
                 self.node_address,
                 total_deposit,
                 partner,
@@ -541,8 +542,8 @@ class TokenNetwork:
             self,
             channel_identifier: typing.ChannelID,
             partner: typing.Address,
-            nonce: typing.Nonce,
             balance_hash: typing.BalanceHash,
+            nonce: typing.Nonce,
             additional_hash: typing.AdditionalHash,
             signature: typing.Signature,
     ):
@@ -601,8 +602,8 @@ class TokenNetwork:
             self,
             channel_identifier: typing.ChannelID,
             partner: typing.Address,
-            nonce: typing.Nonce,
             balance_hash: typing.BalanceHash,
+            nonce: typing.Nonce,
             additional_hash: typing.AdditionalHash,
             closing_signature: typing.Signature,
             non_closing_signature: typing.Signature,
@@ -627,6 +628,7 @@ class TokenNetwork:
 
         transaction_hash = self.proxy.transact(
             'updateNonClosingBalanceProof',
+            channel_identifier,
             partner,
             self.node_address,
             balance_hash,
@@ -718,6 +720,7 @@ class TokenNetwork:
 
         transaction_hash = self.proxy.transact(
             'unlock',
+            channel_identifier,
             self.node_address,
             partner,
             leaves_packed,
@@ -785,6 +788,7 @@ class TokenNetwork:
             if our_bp_is_larger:
                 transaction_hash = self.proxy.transact(
                     'settleChannel',
+                    self.channel_identifier,
                     partner,
                     partner_transferred_amount,
                     partner_locked_amount,
@@ -797,6 +801,7 @@ class TokenNetwork:
             else:
                 transaction_hash = self.proxy.transact(
                     'settleChannel',
+                    self.channel_identifier,
                     self.node_address,
                     transferred_amount,
                     locked_amount,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -114,7 +114,7 @@ class TokenNetwork:
             settle_timeout: The settle timout to use for this channel.
 
         Returns:
-            The address of the new netting channel.
+            The ChannelID (int) of the new netting channel.
         """
         if not is_binary_address(partner):
             raise InvalidAddress('Expected binary address format for channel partner')
@@ -167,7 +167,7 @@ class TokenNetwork:
             'new_netting_channel called',
             peer1=pex(self.node_address),
             peer2=pex(partner),
-            channel_identifier=encode_hex(channel_identifier),
+            channel_identifier=channel_identifier,
         )
 
         return channel_identifier
@@ -209,10 +209,16 @@ class TokenNetwork:
             participant2: typing.Address,
     ) -> Dict:
         """ Returns a dictionary with the channel participant information. """
-        data = self._call_and_check_result(
-            'getChannelParticipantInfo',
+
+        channel_identifier = self._call_and_check_result(
+            'getChannelIdentifier',
             to_checksum_address(participant1),
             to_checksum_address(participant2),
+        )
+        data = self._call_and_check_result(
+            'getChannelParticipantInfo',
+            channel_identifier,
+            to_checksum_address(participant1),
         )
         return {
             'deposit': data[0],
@@ -224,18 +230,23 @@ class TokenNetwork:
 
     def detail_channel(self, participant1: typing.Address, participant2: typing.Address) -> Dict:
         """ Returns a dictionary with the channel specific information. """
+        channel_identifier = self._call_and_check_result(
+            'getChannelIdentifier',
+            to_checksum_address(participant1),
+            to_checksum_address(participant2),
+        )
         channel_data = self._call_and_check_result(
             'getChannelInfo',
             to_checksum_address(participant1),
             to_checksum_address(participant2),
         )
 
-        assert isinstance(channel_data[0], typing.T_ChannelID)
+        assert isinstance(channel_identifier, typing.T_ChannelID)
 
         return {
-            'channel_identifier': channel_data[0],
-            'settle_block_number': channel_data[1],
-            'state': channel_data[2],
+            'channel_identifier': channel_identifier,
+            'settle_block_number': channel_data[0],
+            'state': channel_data[1],
         }
 
     def detail_participants(

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -23,7 +23,7 @@ BlockNumber = NewType('BlockNumber', T_BlockNumber)
 T_BlockTimeout = int
 BlockTimeout = NewType('BlockTimeout', T_BlockTimeout)
 
-T_ChannelID = bytes
+T_ChannelID = int
 ChannelID = NewType('ChannelID', T_ChannelID)
 
 T_ChannelState = int


### PR DESCRIPTION
As implied by [current](https://github.com/raiden-network/raiden-contracts/pull/198) changes of  signatures of contract functions and some helpers (As described in #1940 and specified [here](https://github.com/raiden-network/raiden-contracts/issues/193))

What has been done w.r.t. #1940: 
- `ChannelID` type from `bytes` to `int`
- `detail_participant` and `detail_channel` have been changed to work with the new channel identifier
(as well as functions composed from those, i.e. `detail_participants`, `detail`)

- Added an overflow/underflow check for the `channel_identifier`
- added appropriate arguments to `set_total_deposit` function
- inverted the argument order of `balance_hash/nonce` in close
to be consistent with the contracts (optional)
- inverted the argument order of `balance_hash/nonce` in update_transfer
to be consistent with the contracts (optional)
- added `channel_identifier` to `unlock`

-  added `channel_identifier` + `partner` to
`token_network.setTotalDeposit` call inside `set_total_deposit`
- reordered `close` arguments to be consistent with contracts (optional)
- reordered `update_transfer` arguments to be consistent with contracts (optional)
- added `channel_identifer` to `token_network.updateNonClosingBalanceProof `call
inside update_transfer
- added `channel_identifier` to `token_network.unlock` call inside `unlock`
- added `channel_identifier` to `token_network.settleChannel` call inside `settle`
for both cases