### PR TITLE
Fix pip install requirements for raiden libs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ netifaces==0.10.7
 networkx==2.1.0
 psutil==5.4.5
 pycryptodome==3.6.1
-# raiden-libs==0.1.1
 git+https://github.com/raiden-network/raiden-libs.git@9ba6749729b7f7bb940d1483e2d89250820ddca4
 raiden-contracts==0.1.0
 webargs==1.8.1


### PR DESCRIPTION
For some reason doing a `pip install -r requirements-dev.txt` was using the
commented out raiden-libs=0.1.1 and not installing the git+gitcommithash URL dependency.
Removing the commented out requirements makes it work again and raiden runs
correctly.

Was failing due to the `max_retries` argument of the GMatrixClient addition made
only after
[this](https://github.com/raiden-network/raiden-libs/commit/0477ce402a8112d1fddcdd77699151281c68e81f) commit.