### PR TITLE
Fix logging if debug logfile is disabled

### DIFF
--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -252,6 +252,5 @@ def configure_logging(
 
     # set raiden logging level to DEBUG, to be able to intercept all messages,
     # which should then be filtered by the specific filters
-    if not disable_debug_logfile:
-        structlog.get_logger('').setLevel('DEBUG')
-        structlog.get_logger('raiden').setLevel('DEBUG')
+    structlog.get_logger('').setLevel('DEBUG')
+    structlog.get_logger('raiden').setLevel('DEBUG')


### PR DESCRIPTION
In my previous [PR](https://github.com/raiden-network/raiden/pull/2021) there
was a mistake due to conditionally setting the level if disable debug logfile is
given.

This is now fixed and I tested both with and without `--disable-debug-logfile`
and the desired behaviour is now there.