### PR TITLE
Show a webui error when JSON-RPC requests fail

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2004` Show a webui error when JSON-RPC requests fail.
 * :bug:`2039` Return error for negative deposits via REST API
 * :feature:`2011` Add a ``--disable-debug-logfile`` argument to disable the always on debug file if required by the user.
 * :bug:`1821` Show a better error message when channel creation fails.

--- a/raiden/ui/web/src/app/components/channel-table/channel-table.component.html
+++ b/raiden/ui/web/src/app/components/channel-table/channel-table.component.html
@@ -17,9 +17,9 @@
           <span [title]="data[col.field]">{{ data[col.field] }}</span>
         </ng-template>
       </p-column>
-      <p-column field="token_address" header="Token" [sortable]="true">
+      <p-column field="userToken" header="Token" [sortable]="true">
         <ng-template let-col let-data="rowData" pTemplate="body">
-          <span [title]="data[col.field]">{{ data[col.field] | token | async }}</span>
+          <span [title]="data[col.field]">{{ data[col.field] | token }}</span>
         </ng-template>
       </p-column>
       <p-column field="balance" header="Balance" [style]="{width: '7em', 'text-align': 'center'}" [sortable]="true"></p-column>

--- a/raiden/ui/web/src/app/components/channel-table/channel-table.component.spec.ts
+++ b/raiden/ui/web/src/app/components/channel-table/channel-table.component.spec.ts
@@ -96,6 +96,13 @@ describe('ChannelTableComponent', () => {
 
     it('should update action when channel has balance', fakeAsync(() => {
 
+        const token: UserToken = {
+            address: '0x0f114A1E9Db192502E7856309cc899952b3db1ED',
+            symbol: 'TST',
+            name: 'Test Suite Token',
+            balance: 20
+        };
+
         const channel1: Channel = {
             state: 'opened',
             channel_identifier: '0xc0ecf413bfc8fc6b0e313b5ae231084e1c397b96ed5c0ec3d5ee3b5558ab20be',
@@ -103,7 +110,8 @@ describe('ChannelTableComponent', () => {
             partner_address: '0x774aFb0652ca2c711fD13e6E9d51620568f6Ca82',
             reveal_timeout: 600,
             balance: 10,
-            settle_timeout: 500
+            settle_timeout: 500,
+            userToken: token
         };
 
         const channel2: Channel = {
@@ -113,7 +121,8 @@ describe('ChannelTableComponent', () => {
             partner_address: '0xFC57d325f23b9121a8488fFdE2E6b3ef1208a20b',
             reveal_timeout: 600,
             balance: 0,
-            settle_timeout: 500
+            settle_timeout: 500,
+            userToken: token
         };
 
         const channel2Balance: Channel = {
@@ -123,7 +132,8 @@ describe('ChannelTableComponent', () => {
             partner_address: '0xFC57d325f23b9121a8488fFdE2E6b3ef1208a20b',
             reveal_timeout: 600,
             balance: 10,
-            settle_timeout: 500
+            settle_timeout: 500,
+            userToken: token
         };
 
         const channel3: Channel = {
@@ -133,7 +143,8 @@ describe('ChannelTableComponent', () => {
             partner_address: '0xfB398E621c15E2BC5Ae6A508D8D89AF1f88c93e8',
             reveal_timeout: 600,
             balance: 10,
-            settle_timeout: 500
+            settle_timeout: 500,
+            userToken: token
         };
 
         const channel4: Channel = {
@@ -143,15 +154,9 @@ describe('ChannelTableComponent', () => {
             partner_address: '0x8A0cE8bDA200D64d858957080bf7eDDD3371135F',
             reveal_timeout: 600,
             balance: 60,
-            settle_timeout: 600
+            settle_timeout: 600,
+            userToken: token
 
-        };
-
-        const token: UserToken = {
-            address: '0x0f114A1E9Db192502E7856309cc899952b3db1ED',
-            symbol: 'TST',
-            name: 'Test Suite Token',
-            balance: 20
         };
 
         raidenServiceSpy

--- a/raiden/ui/web/src/app/models/channel.ts
+++ b/raiden/ui/web/src/app/models/channel.ts
@@ -1,3 +1,5 @@
+import { UserToken } from './usertoken';
+
 export interface Channel {
     channel_identifier: string;
     token_address: string;
@@ -6,4 +8,5 @@ export interface Channel {
     balance: number;
     settle_timeout: number;
     reveal_timeout: number;
+    userToken: UserToken | null;
 }

--- a/raiden/ui/web/src/app/pipes/token.pipe.spec.ts
+++ b/raiden/ui/web/src/app/pipes/token.pipe.spec.ts
@@ -1,27 +1,41 @@
-import { async, inject, TestBed } from '@angular/core/testing';
-import { RaidenService } from '../services/raiden.service';
+import { UserToken } from '../models/usertoken';
 import { TokenPipe } from './token.pipe';
 
 describe('TokenPipe', () => {
-    let service: jasmine.SpyObj<RaidenService>;
 
-    beforeEach(async(() => {
-        service = jasmine.createSpyObj('RaidenService', [
-            'getChannels'
-        ]);
+    let pipe: TokenPipe;
 
-        TestBed.configureTestingModule({
-            providers: [
-                {
-                    provide: RaidenService, useClass: service
-                }
-            ]
-        }).compileComponents();
-    }));
+    const token: UserToken = {
+        address: '0x0f114A1E9Db192502E7856309cc899952b3db1ED',
+        symbol: 'TST',
+        name: 'Test Suite Token',
+        balance: 20
+    };
 
+    beforeAll(() => {
+        pipe = new TokenPipe();
+    });
 
-    it('create an instance', inject([RaidenService], (raidenService: RaidenService) => {
-        const pipe = new TokenPipe(raidenService);
+    it('create an instance', () => {
         expect(pipe).toBeTruthy();
-    }));
+    });
+
+    it('should convert a user token to a string representation', () => {
+        const tokenString = pipe.transform(token);
+        expect(tokenString).toBe(`[${token.symbol}] ${token.name} (${token.address})`);
+    });
+
+    it('should have the following format if symbol is missing', () => {
+        token.symbol = null;
+        const tokenString = pipe.transform(token);
+        expect(tokenString).toBe(`${token.name} (${token.address})`);
+    });
+
+    it('should have the following format if only address is available', () => {
+        token.symbol = null;
+        token.name = null;
+        const tokenString = pipe.transform(token);
+        expect(tokenString).toBe(token.address);
+    });
+
 });

--- a/raiden/ui/web/src/app/pipes/token.pipe.ts
+++ b/raiden/ui/web/src/app/pipes/token.pipe.ts
@@ -1,48 +1,40 @@
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { Pipe, PipeTransform } from '@angular/core';
 import { SelectItem } from 'primeng/primeng';
-
-import { RaidenService } from '../services/raiden.service';
 import { UserToken } from '../models/usertoken';
 
 @Pipe({
-  name: 'token'
+    name: 'token'
 })
 export class TokenPipe implements PipeTransform {
 
-  constructor(private raidenService: RaidenService) {}
+    tokensToSelectItems(tokens: Array<UserToken>): Array<SelectItem> {
+        return tokens.map((token) => ({
+            value: token.address,
+            label: this.tokenToString(token)
+        }));
+    }
 
-  tokenToString(token: UserToken): string {
-    let text = '';
-    if (!token) {
-      return '';
+    transform(token?: UserToken): string {
+        return this.tokenToString(token);
     }
-    if (token.symbol) {
-      text += `[${token.symbol}] `;
-    }
-    if (token.name) {
-      text += `${token.name} `;
-    }
-    if (text) {
-      text += `(${token.address})`;
-    } else {
-      text = token.address;
-    }
-    return text;
-  }
 
-  tokensToSelectItems(tokens: Array<UserToken>): Array<SelectItem> {
-    return tokens.map((token) => ({
-      value: token.address,
-      label: this.tokenToString(token)
-    }));
-  }
-
-  transform(address: string, args?: any): Observable<string> {
-    return this.raidenService.getUserToken(address, false).pipe(
-      map((token) => this.tokenToString(token)),
-    );
-  }
+    private tokenToString(token?: UserToken): string {
+        let text = '';
+        if (!token) {
+            return '';
+        }
+        if (token.symbol) {
+            text += `[${token.symbol}] `;
+        }
+        if (token.name) {
+            text += `${token.name} `;
+        }
+        if (text) {
+            text += `(${token.address})`;
+        } else {
+            text = token.address;
+        }
+        return text;
+    }
 
 }

--- a/raiden/ui/web/src/app/services/raiden.service.spec.ts
+++ b/raiden/ui/web/src/app/services/raiden.service.spec.ts
@@ -1,10 +1,12 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { fakeAsync, flush, inject, TestBed, tick } from '@angular/core/testing';
 import { MockConfig } from '../components/channel-table/channel-table.component.spec';
+import { Channel } from '../models/channel';
+import { UserToken } from '../models/usertoken';
 import { RaidenConfig } from './raiden.config';
 
-import { RaidenService } from './raiden.service';
+import { CallbackFunc, RaidenService } from './raiden.service';
 import { SharedService } from './shared.service';
 
 describe('RaidenService', () => {
@@ -14,6 +16,30 @@ describe('RaidenService', () => {
     let mockHttp: HttpTestingController;
     let sharedService: SharedService;
     let endpoint: String;
+
+    let service: RaidenService;
+
+    const channel1: Channel = {
+        state: 'opened',
+        channel_identifier: '0xc0ecf413bfc8fc6b0e313b5ae231084e1c397b96ed5c0ec3d5ee3b5558ab20be',
+        token_address: '0x0f114A1E9Db192502E7856309cc899952b3db1ED',
+        partner_address: '0x774aFb0652ca2c711fD13e6E9d51620568f6Ca82',
+        reveal_timeout: 600,
+        balance: 10,
+        settle_timeout: 500,
+        userToken: null
+    };
+
+    const channel2: Channel = {
+        state: 'opened',
+        channel_identifier: '0xcf4f8999d22fd1a783fc6236b1ba1599cdc26ebedb36e053b973fc56a3280d0e',
+        token_address: '0x0f114A1E9Db192502E7856309cc899952b3db1ED',
+        partner_address: '0xFC57d325f23b9121a8488fFdE2E6b3ef1208a20b',
+        reveal_timeout: 600,
+        balance: 0,
+        settle_timeout: 500,
+        userToken: null
+    };
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -35,6 +61,8 @@ describe('RaidenService', () => {
 
         endpoint = TestBed.get(RaidenConfig).api;
         sharedService = TestBed.get(SharedService);
+        service = TestBed.get(RaidenService);
+
         spyOn(sharedService, 'msg');
     });
 
@@ -42,7 +70,7 @@ describe('RaidenService', () => {
         backend.verify();
     }));
 
-    it('When token creation fails there should be a nice message', inject([RaidenService], (service: RaidenService) => {
+    it('When token creation fails there should be a nice message', () => {
 
         service.registerToken(tokenAddress).subscribe(() => {
             fail('On next should not be called');
@@ -73,9 +101,9 @@ describe('RaidenService', () => {
         expect(payload.severity).toBe('error', 'Severity should be error');
         expect(payload.summary).toBe('Raiden Error', 'It should be a Raiden Error');
         expect(payload.detail).toBe(errorMessage);
-    }));
+    });
 
-    it('Show a proper response when non-EIP addresses are passed in channel creation', inject([RaidenService], (service: RaidenService) => {
+    it('Show a proper response when non-EIP addresses are passed in channel creation', () => {
         const partnerAddress = '0xc52952ebad56f2c5e5b42bb881481ae27d036475';
 
         service.openChannel(tokenAddress, partnerAddress, 600, 10).subscribe(() => {
@@ -105,5 +133,131 @@ describe('RaidenService', () => {
         expect(payload.summary).toBe('Raiden Error', 'It should be a Raiden Error');
         expect(payload.detail).toBe('partner_address: Not a valid EIP55 encoded address');
 
+    });
+
+    it('should have user token included in the channels', () => {
+
+        const token: UserToken = {
+            address: '0x0f114A1E9Db192502E7856309cc899952b3db1ED',
+            symbol: 'TST',
+            name: 'Test Suite Token',
+            balance: 20
+        };
+
+        service.tokenContract = {
+            at: () => ({
+                name: (callback: CallbackFunc) => {
+                    callback(null, token.name);
+                },
+                balanceOf: (address: String, callback: CallbackFunc) => {
+                    callback(null, {
+                        toNumber: () => token.balance
+                    });
+                },
+                symbol: (callback: CallbackFunc) => {
+                    callback(null, token.symbol);
+                }
+            })
+        };
+
+        service.getChannels().subscribe((channels: Array<Channel>) => {
+            channels.forEach(value => {
+                expect(value.userToken).toBeTruthy('UserToken should not be null');
+                expect(value.userToken.address).toBe(token.address);
+            });
+        }, (error) => {
+            fail(error);
+        });
+
+        const getChannelsRequest = mockHttp.expectOne({
+            url: `${endpoint}/channels`,
+            method: 'GET'
+        });
+
+        getChannelsRequest.flush([
+            channel1,
+            channel2
+        ], {
+            status: 200,
+            statusText: 'All good'
+        });
+    });
+
+    it('should show an error message for JSON RPC errors while fetching channels', () => {
+
+        const rpcError = Error('Invalid JSON RPC response');
+
+        // noinspection JSUnusedLocalSymbols
+        service.tokenContract = {
+            at: () => ({
+                name: (callback: CallbackFunc) => {
+                    throw rpcError;
+                },
+                balanceOf: (address: String, callback: CallbackFunc) => {
+                    throw rpcError;
+                },
+                symbol: (callback: CallbackFunc) => {
+                    throw rpcError;
+                }
+            })
+        };
+
+        service.getChannels().subscribe(() => {
+            fail('Call should fail with error');
+        }, (error) => {
+            expect(error).toBeTruthy();
+        });
+
+        const getChannelsRequest = mockHttp.expectOne({
+            url: `${endpoint}/channels`,
+            method: 'GET'
+        });
+
+        getChannelsRequest.flush([
+            channel1,
+            channel2
+        ], {
+            status: 200,
+            statusText: 'All good'
+        });
+
+        expect(sharedService.msg).toHaveBeenCalledTimes(1);
+
+        // @ts-ignore
+        const payload = sharedService.msg.calls.first().args[0];
+
+        expect(payload.severity).toBe('error', 'Severity should be error');
+        expect(payload.summary).toBe('Raiden Error', 'It should be a Raiden Error');
+        expect(payload.detail).toContain('Could not access the JSON-RPC endpoint');
+    });
+
+
+    it('should show an error message for JSON RPC errors when fetching a token', fakeAsync(() => {
+        const rpcError = Error('Invalid JSON RPC response');
+
+        // noinspection JSUnusedLocalSymbols
+        service.tokenContract = {
+            at: () => ({
+                name: (callback: CallbackFunc) => {
+                    throw rpcError;
+                },
+                balanceOf: (address: String, callback: CallbackFunc) => {
+                    throw rpcError;
+                },
+                symbol: (callback: CallbackFunc) => {
+                    throw rpcError;
+                }
+            })
+        };
+
+        service.getUserToken(tokenAddress, false).subscribe(() => {
+            fail('There should be an error');
+        }, (error) => {
+            expect(error).toBeTruthy();
+            expect(error.message).toContain('Could not access the JSON-RPC endpoint');
+        });
+
+        tick();
+        flush();
     }));
 });

--- a/raiden/ui/web/tslint.json
+++ b/raiden/ui/web/tslint.json
@@ -23,7 +23,8 @@
     "import-spacing": true,
     "indent": [
       true,
-      "spaces"
+      "spaces",
+      4
     ],
     "interface-over-type-literal": true,
     "label-position": true,
@@ -111,6 +112,7 @@
     "whitespace": [
       true,
       "check-branch",
+      "check-module",
       "check-decl",
       "check-operator",
       "check-separator",


### PR DESCRIPTION
* Changes `fetchUserToken` in order to propagate JSON RPC errors, previously any JSON RPC errors were suppressed.
* Since the original message is `Invalid JSON RPC response` a new error with a more informative message is thrown instead. 
* `UserToken` is now included in the channel data.
* `TokenPipe` no longer depends on `RaidenService` instead it will now take the `UserToken` from the `Channel`
* `tslint.json` now includes rules about 4 spaces in code and whitespaces in module import