### PR TITLE
Gevent exception handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,6 +408,23 @@ define a associated alias, which must start with `T_`.
 T_Address = bytes
 ```
 
+##### Particuliarities
+
+**Concurrency/Usage of gevent**
+
+Raiden uses a patched version of gevent for concurrency.
+
+The patching is necessary to enforce our security policy: Unhandled exceptions that occur inside a
+`gevent.Greenlet` are by default not propagated outside of it. However, we require Raiden to halt
+at every unhandled exception. To achieve this, the internal error handler of gevent is patched
+and the `Greenlet` class replaced with a customized `RaidenGreenlet` throughout the project.
+
+**The methods `link`, `link_exception`, `link_value` and `rawlink` of the `Greenlet` class are
+broken by the patching and must never be used.** For example, an exception handler linked to a
+greenlet by `link_exception` will not be called; the exception will instead be bubbled up and
+cause Raiden to crash. `RaidenGreenlet` provides the equivalent methods `link_safe`,
+`link_exception_safe` and `rawlink_safe` to be used instead.
+
 
 #### Solidity
 

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -139,7 +139,7 @@ class ConnectionManager:
     def leave_async(self):
         """ Async version of `leave()` """
         leave_result = AsyncResult()
-        gevent.spawn(self.leave).link(leave_result)
+        gevent.spawn(self.leave).link_safe(leave_result)
         return leave_result
 
     def leave(self, registry_address):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -191,3 +191,11 @@ class ChannelOutdatedError(RaidenError):
 class InsufficientGasReserve(RaidenError):
     """ Raised when an action cannot be done because the available balance
     is not sufficient for the lifecycles of all active channels. """
+
+
+class UnhandledExceptionInGreenlet(RaidenError):
+    """Raised when a Greenlet has been linked but the
+    linked functions failed to handle an exception."""
+
+    def __init__(self, exception):
+        super().__init__(f'{type(exception)} ({str(exception) or "-"})')

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -202,7 +202,7 @@ class MatrixTransport:
 
         # TODO: Add (better) error handling strategy
         self._client.start_listener_thread()
-        self._client.sync_thread.link_exception(self._client_exception_handler)
+        self._client.sync_thread.link_exception_safe(self._client_exception_handler)
         self.greenlets.append(self._client.sync_thread)
 
         # TODO: Add greenlet that regularly refreshes our presence state

--- a/raiden/network/transport/udp/udp_utils.py
+++ b/raiden/network/transport/udp/udp_utils.py
@@ -23,7 +23,7 @@ def event_first_of(*events: _AbstractLinkable) -> Event:
         raise ValueError('all events must be linkable')
 
     for event in events:
-        event.rawlink(lambda _: first_finished.set())
+        event.rawlink_safe(lambda _: first_finished.set())
 
     return first_finished
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -277,7 +277,7 @@ class RaidenService:
             def set_start_on_registration(_):
                 self.start_event.set()
 
-            endpoint_registration_greenlet.link(set_start_on_registration)
+            endpoint_registration_greenlet.link_safe(set_start_on_registration)
         else:
             self.start_event.set()
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -10,6 +10,7 @@ from web3 import Web3
 
 from raiden.exceptions import RaidenShuttingDown
 from raiden.utils import get_system_spec, gas_reserve
+from raiden.utils.gevent_utils import RaidenGreenlet
 
 CHECK_VERSION_INTERVAL = 3 * 60 * 60
 CHECK_GAS_RESERVE_INTERVAL = 60 * 60
@@ -76,7 +77,7 @@ def check_gas_reserve(raiden):
         gevent.sleep(CHECK_GAS_RESERVE_INTERVAL)
 
 
-class AlarmTask(gevent.Greenlet):
+class AlarmTask(RaidenGreenlet):
     """ Task to notify when a block is mined. """
 
     def __init__(self, chain):

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -10,6 +10,7 @@ monkey.patch_all()
 import pytest
 
 from raiden.utils.cli import LogLevelConfigType
+from raiden.utils.gevent_utils import configure_gevent, undo_configure_gevent
 from raiden.exceptions import RaidenShuttingDown
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.log_config import configure_logging
@@ -160,6 +161,20 @@ def dont_exit_pytest():
     """
     gevent.get_hub().SYSTEM_ERROR = BaseException
     gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit, RaidenShuttingDown)
+
+
+@pytest.fixture
+def with_configure_gevent():
+    """ Switch to the custom gevent configuration that we use when running Raiden.
+
+    Override the dont_exit_pytest fixture for the duration of a test.
+    """
+    gevent.get_hub().SYSTEM_ERROR = (KeyboardInterrupt, SystemExit, SystemError)  # default values
+    gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit)
+    configure_gevent()
+    yield
+    undo_configure_gevent()
+    dont_exit_pytest()
 
 
 if sys.platform == 'darwin':

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -3,10 +3,10 @@ import os
 import pytest
 import psutil
 import gevent
-from gevent import Greenlet
 
 from raiden.api.python import RaidenAPI
 from raiden.api.rest import RestAPI, APIServer
+from raiden.utils.gevent_utils import RaidenGreenlet
 
 
 def wait_for_listening_port(port_number, tries=10, sleep=0.1, pid=None):
@@ -36,7 +36,7 @@ def api_backend(raiden_network, rest_api_port_number):
     api_server.flask_app.config['SERVER_NAME'] = 'localhost:{}'.format(rest_api_port_number)
 
     # TODO: Find out why tests fail with debug=True
-    server = Greenlet.spawn(
+    server = RaidenGreenlet.spawn(
         api_server.run,
         port=rest_api_port_number,
         debug=False,

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -1,3 +1,8 @@
+import gevent
+import pytest
+
+from raiden.exceptions import UnhandledExceptionInGreenlet
+
 from raiden.utils import privtopub, sha3
 
 
@@ -7,3 +12,62 @@ def test_privtopub():
               '705f70c7554b26e82b90d2d1bbbaf711b10c6c8b807077f4070200a8fb4c6b771')
 
     assert pubkey == privtopub(privkey).hex()
+
+
+def test_patched_gevent_exception_handling(with_configure_gevent):
+    with pytest.raises(_ExceptionInGreenlet):  # exception is bubbled up
+        greenlet = gevent.spawn(_exception_raising_greenlet)
+        greenlet.join()
+
+    with pytest.raises(_ExceptionInGreenlet):
+        greenlet = gevent.spawn_later(0.1, _exception_raising_greenlet)
+        greenlet.join()
+
+    try:
+        greenlet1 = gevent.spawn(_exception_raising_greenlet)
+        greenlet2 = gevent.spawn_later(0.1, _exception_raising_greenlet)
+        greenlet3 = gevent.spawn_later(0.1, _exception_raising_greenlet)
+        greenlet1.link_exception_safe(_swallow_exception)
+        greenlet2.rawlink_safe(_swallow_exception)
+        greenlet3.link_safe(_swallow_exception)
+        greenlet1.join()
+        greenlet2.join()
+        greenlet3.join()
+    except Exception:
+        assert False, 'This should not be propagated out of the greenlet'
+
+    with pytest.raises(UnhandledExceptionInGreenlet, message='_ExceptionInGreenlet (msg)'):
+        greenlet = gevent.spawn_later(0.1, _exception_raising_greenlet)
+        greenlet.link_exception_safe(_reraise_exception)
+        greenlet.join()
+
+    with pytest.raises(UnhandledExceptionInGreenlet, message='_ExceptionInGreenlet (msg)'):
+        greenlet = gevent.spawn(_exception_raising_greenlet)
+        greenlet.rawlink_safe(_reraise_exception)
+        greenlet.join()
+
+    with pytest.raises(UnhandledExceptionInGreenlet, message='_ExceptionInGreenlet (msg)'):
+        greenlet = gevent.spawn(_exception_raising_greenlet)
+        greenlet.link_safe(_reraise_exception)
+        greenlet.join()
+
+
+class _ExceptionInGreenlet(Exception):
+    pass
+
+
+def _exception_raising_greenlet():
+    raise _ExceptionInGreenlet('msg')
+
+
+def _swallow_exception(greenlet):
+    try:
+        greenlet.get()
+    except _ExceptionInGreenlet:
+        pass
+    else:
+        assert False, 'greenlet.get() did not raise the expected exception.'
+
+
+def _reraise_exception(greenlet):
+    greenlet.get()

--- a/raiden/tests/utils/tester.py
+++ b/raiden/tests/utils/tester.py
@@ -2,6 +2,7 @@ import gevent
 from gevent.event import Event
 from eth_utils import encode_hex, to_checksum_address
 from raiden.utils import privatekey_to_address
+from raiden.utils.gevent_utils import RaidenGreenlet
 
 from raiden.tests.fixtures.variables import DEFAULT_BALANCE
 
@@ -23,7 +24,7 @@ def fund_accounts(web3, private_keys, ethereum_tester):
         })
 
 
-class Miner(gevent.Greenlet):
+class Miner(RaidenGreenlet):
     def __init__(self, web3, mine_sleep=1):
         super().__init__()
         self.web3 = web3

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -15,6 +15,7 @@ from raiden.network.proxies import TokenNetwork
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
 from raiden.utils import get_contract_path, safe_address_decode, typing
 from raiden.utils.solc import compile_files_cwd
+from raiden.utils.gevent_utils import RaidenGreenlet
 
 GUI_GEVENT = 'gevent'
 
@@ -83,7 +84,7 @@ class GeventInputHook:
         self.manager.clear_inputhook()
 
 
-class Console(gevent.Greenlet):
+class Console(RaidenGreenlet):
     """ A service starting an interactive ipython session when receiving the
     SIGSTP signal (e.g. via keyboard shortcut CTRL-Z).
     """

--- a/raiden/utils/gevent_utils.py
+++ b/raiden/utils/gevent_utils.py
@@ -63,6 +63,21 @@ def configure_gevent():
 
     gevent.spawn = RaidenGreenlet.spawn
     gevent.spawn_later = RaidenGreenlet.spawn_later
+    hub._default_system_error = hub.SYSTEM_ERROR
+    hub._default_handle_error = hub.__class__.handle_error
     hub.SYSTEM_ERROR = hub.SYSTEM_ERROR + (UnhandledExceptionInGreenlet,)
     hub.__class__.handle_error = _patch_handle_error(hub.__class__.handle_error)
     hub._patched = True
+
+
+def undo_configure_gevent():
+    hub = gevent.get_hub()
+
+    if not getattr(hub, '_patched', False):
+        return
+
+    gevent.spawn = gevent.Greenlet.spawn
+    gevent.spawn_later = gevent.Greenlet.spawn_later
+    hub.SYSTEM_ERROR = hub._default_system_error
+    hub.__class__.handle_error = hub._default_handle_error
+    hub._patched = False

--- a/raiden/utils/gevent_utils.py
+++ b/raiden/utils/gevent_utils.py
@@ -1,30 +1,68 @@
 import gevent
 
+from raiden.exceptions import UnhandledExceptionInGreenlet
 
-def _make_greenlet_error_handler(original_handler):
-    def handle_error(self, context, type, value, tb):
-        if not issubclass(type, self.NOT_ERROR):
+
+class RaidenGreenlet(gevent.Greenlet):
+    def link_safe(self, callable):
+        self.is_safe_linked = True
+        super(RaidenGreenlet, self).link(self._wrap_link(callable))
+
+    def link_exception_safe(self, callable):
+        self.is_safe_linked = True
+        super(RaidenGreenlet, self).link_exception(self._wrap_link(callable))
+
+    def rawlink_safe(self, callable):
+        self.is_safe_linked = True
+        super(RaidenGreenlet, self).rawlink(self._wrap_link(callable))
+
+    @staticmethod
+    def _wrap_link(callable):
+        def wrapped_callable(greenlet):
+            try:
+                callable(greenlet)
+            except gevent.get_hub().SYSTEM_ERROR:
+                raise
+            except Exception as exception:
+                raise UnhandledExceptionInGreenlet(exception) from exception
+        return wrapped_callable
+
+
+def _patch_handle_error(original_handler):
+    def patched_handle_error(self, context, type, value, tb):
+        safe_linked = getattr(gevent.getcurrent(), 'is_safe_linked', False)
+        if safe_linked or issubclass(type, self.NOT_ERROR):
+            original_handler(self, context, type, value, tb)
+        else:
+            self.print_exception(context, type, value, tb)
             self.handle_system_error(type, value)
-    return handle_error
+    return patched_handle_error
 
 
 def configure_gevent():
     """
     Configure the gevent `Hub` as follows:
 
-      - Set `SYSTEM_ERROR` to `BaseException` to exit the process on any unhandled exception in
-        greenlets.
+      - Patch the `handle_error` method to bubble up any uncaught exception to the main greenlet,
+        with two restrictions: We stick to the default error handling if
+        - any of `link_exception_safe`, `link_safe` or `rawlink_safe` have been called on the
+          greenlet, we expect all Exceptions to be taken care of and stick to the default
+          behavior. Uncaught exceptions in the linked functions themselves will raise a
+          `RaidenFatalError`
+        - or the exception is listed in NOT_ERROR. This includes DNS resolve errors as well as
+          GreenletExit.
 
-      - Replace the default gevent Hub's error handler with one that only forwards exception types
-        not listed in `NOT_ERROR` to the default implementation.
-        This is necessary to avoid DNS resolver errors bubbling up into the event loop.
+      Notice that this breaks the usual `gevent.Greenlet` linking methods. Functions linked via
+      `rawlink`, `link` and `link_exception` will not be called if an exception is raised inside
+      a Greenlet, the exception will be bubbled up instead.
     """
     hub = gevent.get_hub()
 
     if getattr(hub, '_patched', False):
         return
 
-    hub.NOT_ERROR = (gevent.GreenletExit,)
-    hub.SYSTEM_ERROR = (BaseException,)
-    hub.__class__.handle_error = _make_greenlet_error_handler(hub.handle_error)
+    gevent.spawn = RaidenGreenlet.spawn
+    gevent.spawn_later = RaidenGreenlet.spawn_later
+    hub.SYSTEM_ERROR = hub.SYSTEM_ERROR + (UnhandledExceptionInGreenlet,)
+    hub.__class__.handle_error = _patch_handle_error(hub.__class__.handle_error)
     hub._patched = True


### PR DESCRIPTION
New approach to handle exceptions inside greenlet and make sure all unhandled exceptions bubble up to the main greenlet.

Fixes: #1829