### PR TITLE
Bump geth to v1.8.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ python:
 
 env:
   global:
-  - GETH_URL_LINUX='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.0-5f540757.tar.gz'
-  - GETH_URL_MACOS='https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.8.0-5f540757.tar.gz'
-  - GETH_VERSION='1.8.0'
+  - GETH_URL_LINUX='https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.8.13-225171a4.tar.gz'
+  - GETH_URL_MACOS='https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.8.13-225171a4.tar.gz'
+  - GETH_VERSION='1.8.13'
   - SOLC_URL_LINUX='https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux'
   - SOLC_URL_MACOS='https://www.dropbox.com/s/4amq3on2ds1dq36/solc_0.4.23?dl=0'
   - SOLC_VERSION='v0.4.23'

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get install -y git-core wget
 
 RUN wget -O /usr/bin/solc ${SOLC_URL_LINUX} && chmod +x /usr/bin/solc
-RUN wget -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && cd /tmp && tar xzvf geth.tar.gz && mv geth-linux-amd64-1.8.0-5f540757/geth /usr/bin/geth && rm geth.tar.gz
+RUN wget -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && cd /tmp && tar xzvf geth.tar.gz && mv geth-linux-amd64-*/geth /usr/bin/geth && rm geth.tar.gz
 RUN wget -O /tmp/node.tar.gz https://nodejs.org/download/release/v8.11.3/node-v8.11.3-linux-x64.tar.gz && cd /tmp && tar xzvf node.tar.gz && mkdir /tmp/node_modules && chmod -R a+rwX /tmp/node_modules && rm node.tar.gz
 
 

--- a/tools/testnet/files/dockerfiles/geth-testnet/Dockerfile
+++ b/tools/testnet/files/dockerfiles/geth-testnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.8.0
+FROM ethereum/client-go:v1.8.13
 MAINTAINER Ulrich Petri <ulrich@brainbot.com>
 
 RUN \


### PR DESCRIPTION
Noticed we have not upgraded the Geth we use in Travis for a long time. I (and I guess most of you) have been using latest geth locally for a long time so I guess it's time for Travis to follow suit.