### PR TITLE
Replace max_retries for retry_timeout and retry_delay in Matrix

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -131,11 +131,12 @@ class MatrixTransport:
         self._raiden_service: RaidenService = None
         self._config = config
 
-        def http_retry_delay() -> Union[float, Iterable[float]]:
+        def _http_retry_delay() -> Iterable[float]:
+            # below constants are defined in raiden.app.App.DEFAULT_CONFIG
             return udp_utils.timeout_exponential_backoff(
-                self._config['retries_before_backoff'],  # default = 5
-                self._config['retry_interval'] / 5,  # default=5/5=1s
-                self._config['retry_interval'],  # default=5s
+                self._config['retries_before_backoff'],
+                self._config['retry_interval'] / 5,
+                self._config['retry_interval'],
             )
 
         while True:
@@ -146,7 +147,7 @@ class MatrixTransport:
                 self._server_url,
                 http_pool_maxsize=4,
                 http_retry_timeout=40,
-                http_retry_delay=http_retry_delay,
+                http_retry_delay=_http_retry_delay,
             )
             try:
                 self._client.api._send('GET', '/versions', api_path='/_matrix/client')

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ netifaces==0.10.7
 networkx==2.1.0
 psutil==5.4.5
 pycryptodome==3.6.1
-raiden-libs==0.1.2
+git+https://github.com/andrevmatos/raiden-libs@matrix
 raiden-contracts==0.1.0
 webargs==1.8.1
 eth-keyfile==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,10 @@ history = ''
 
 install_requires_replacements = {
     'git+https://github.com/LefterisJP/pystun@develop#egg=pystun': 'pystun',
+    (
+        'git+https://github.com/andrevmatos/raiden-libs'
+        '@matrix'
+    ): 'raiden-libs',
 }
 
 install_requires = list(set(


### PR DESCRIPTION
Depends on raiden-network/raiden-libs#117
Fixes #2119, #2069, #2058, #2042 and #2029 and try to improve the handling on the hard-to-reproduce issues #1917 and #1897 . 
This PR aims to handle all possible causes of network issues by handling and retrying them at the top-level.