### PR TITLE
Turn deprecated log.warn() to log.warning

### DIFF
--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -242,7 +242,7 @@ def wrap(data):
     try:
         cmdid = data[0]
     except IndexError:
-        log.warn('data is empty')
+        log.warning('data is empty')
         return
 
     try:

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -549,7 +549,7 @@ class MatrixTransport:
                 self._send_immediate(message.sender, json.dumps(delivered_message.to_dict()))
 
         except (InvalidAddress, UnknownAddress, UnknownTokenAddress):
-            self.log.warn('Exception while processing message', exc_info=True)
+            self.log.warning('Exception while processing message', exc_info=True)
             return
 
     def _send_queued_messages(


### PR DESCRIPTION
As per the python
[docs](https://docs.python.org/3/library/logging.html#logging.Logger.warning)
log.warn() is deprecated