### PR TITLE
JSONRPCClient nonce simplification

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -5,6 +5,7 @@ import warnings
 from binascii import unhexlify
 from json.decoder import JSONDecodeError
 
+from requests import ConnectTimeout
 from pkg_resources import DistributionNotFound
 from web3 import Web3, HTTPProvider
 from web3.middleware import geth_poa_middleware
@@ -201,7 +202,13 @@ class JSONRPCClient:
         web3: Web3 = web3 or Web3(HTTPProvider(endpoint))
 
         monkey_patch_web3(web3, self)
-        supported, eth_node = is_supported_client(web3.version.node)
+
+        try:
+            version = web3.version.node
+        except ConnectTimeout:
+            raise EthNodeCommunicationError('couldnt reach the ethereum node')
+
+        supported, eth_node = is_supported_client(version)
 
         if not supported:
             print('You need a Byzantium enabled ethereum node. Parity >= 1.7.6 or Geth >= 1.7.2')


### PR DESCRIPTION
- Updating the nonce from the ethereum client is useless if there is no
synchronization among the account's users, where a users may be another
application or multiple JSONRPCClient objects used in Raiden. Because
of this, the logic to update the local nonce view was removed, either
the Raiden node should fully control the account and only one
JSONRPCClient instance per private key is used, or remote signing should
be used.
- To debug nonce problems, i.e. transaction replacement errors, it's
necessary to know if there is more than one JSONRPCClient instance per
account, or if the locking mechanism is not working properly. For the
first case a debug log was added in the JSONRPCClient constructor, for
the latter the send raw transaction was wrapped with log lines to make
it easier to detect concurrent calls.

[ci integration]