### PR TITLE
Removed flaky

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ pytest==3.6.2
 pytest-timeout==1.2.1
 pytest-random==0.02
 pytest-cov==2.5.1
-flaky==3.4.0
 grequests==0.3.0
 pexpect==4.6.0
 


### PR DESCRIPTION
The flaky package allows a failling test to be automatically re-executed
a number of times.

The package is quite useful but we are not using it anymore, and the
flaky plugin is messing up the stack trace of a failing test.