### PR TITLE
Simplify jsonrpc constructor

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import sys
 import warnings
 from binascii import unhexlify
 from json.decoder import JSONDecodeError
@@ -203,11 +202,7 @@ class JSONRPCClient:
         except ConnectTimeout:
             raise EthNodeCommunicationError('couldnt reach the ethereum node')
 
-        supported, eth_node = is_supported_client(version)
-
-        if not supported:
-            print('You need a Byzantium enabled ethereum node. Parity >= 1.7.6 or Geth >= 1.7.2')
-            sys.exit(1)
+        _, eth_node = is_supported_client(version)
 
         sender = privatekey_to_address(privkey)
         transaction_count = web3.eth.getTransactionCount(to_checksum_address(sender), 'pending')

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -7,7 +7,7 @@ from json.decoder import JSONDecodeError
 
 from requests import ConnectTimeout
 from pkg_resources import DistributionNotFound
-from web3 import Web3, HTTPProvider
+from web3 import Web3
 from web3.middleware import geth_poa_middleware
 from web3.utils.filters import Filter
 from eth_utils import (
@@ -188,18 +188,13 @@ class JSONRPCClient:
 
     def __init__(
             self,
-            host: str,
-            port: int,
+            web3: Web3,
             privkey: bytes,
             gasprice: int = None,
             nonce_offset: int = 0,
-            web3: Web3 = None,
     ):
         if privkey is None or len(privkey) != 32:
             raise ValueError('Invalid private key')
-
-        endpoint = 'http://{}:{}'.format(host, port)
-        web3: Web3 = web3 or Web3(HTTPProvider(endpoint))
 
         monkey_patch_web3(web3, self)
 
@@ -220,7 +215,6 @@ class JSONRPCClient:
 
         self.eth_node = eth_node
         self.given_gas_price = gasprice
-        self.port = port
         self.privkey = privkey
         self.sender = sender
         # Needs to be initialized to None in the beginning since JSONRPCClient

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -57,9 +57,9 @@ def inspect_client_error(val_err: ValueError, eth_node: str) -> ClientErrorInspe
 
 class ContractProxy:
     def __init__(
-        self,
-        jsonrpc_client,
-        contract: Contract,
+            self,
+            jsonrpc_client,
+            contract: Contract,
     ):
         if contract is None:
             raise ValueError('Contract must not be None')

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -23,25 +23,14 @@ from raiden.utils import (
 def test_payment_channel_proxy_basics(
         token_network_proxy,
         private_keys,
-        blockchain_rpc_ports,
         token_proxy,
         chain_id,
         web3,
 ):
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
-    c1_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[1],
-        web3=web3,
-    )
-    c2_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[2],
-        web3=web3,
-    )
+    c1_client = JSONRPCClient(web3, private_keys[1])
+    c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         c1_client,
         token_network_address,
@@ -62,7 +51,7 @@ def test_payment_channel_proxy_basics(
     channel_proxy_1 = PaymentChannel(c1_token_network_proxy, channel_identifier)
     channel_proxy_2 = PaymentChannel(c2_token_network_proxy, channel_identifier)
 
-    channel_filter, unlock_filter = channel_proxy_1.all_events_filter(
+    channel_filter, _ = channel_proxy_1.all_events_filter(
         from_block=web3.eth.blockNumber,
         to_block='latest',
     )
@@ -149,8 +138,6 @@ def test_payment_channel_proxy_basics(
 def test_payment_channel_outdated_channel_close(
         token_network_proxy,
         private_keys,
-        blockchain_rpc_ports,
-        token_proxy,
         chain_id,
         web3,
 ):
@@ -158,12 +145,7 @@ def test_payment_channel_outdated_channel_close(
 
     partner = privatekey_to_address(private_keys[0])
 
-    client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[1],
-        web3=web3,
-    )
+    client = JSONRPCClient(web3, private_keys[1])
     token_network_proxy = TokenNetwork(
         client,
         token_network_address,

--- a/raiden/tests/integration/contracts/test_token.py
+++ b/raiden/tests/integration/contracts/test_token.py
@@ -1,25 +1,20 @@
-from raiden.utils import privatekey_to_address
 from eth_utils import to_canonical_address, to_checksum_address
+
 from raiden.network.proxies import Token
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.utils import privatekey_to_address
 
 
 def test_token(
-    deploy_client,
-    token_proxy,
-    private_keys,
-    blockchain_rpc_ports,
-    web3,
+        deploy_client,
+        token_proxy,
+        private_keys,
+        web3,
 ):
     privkey = private_keys[1]
     address = privatekey_to_address(privkey)
     address = to_canonical_address(address)
-    other_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        privkey,
-        web3=web3,
-    )
+    other_client = JSONRPCClient(web3, privkey)
     other_token_proxy = Token(
         other_client,
         to_canonical_address(token_proxy.proxy.contract.address),

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -29,7 +29,6 @@ from raiden.tests.utils import wait_blocks
 def test_token_network_deposit_race(
         token_network_proxy,
         private_keys,
-        blockchain_rpc_ports,
         token_proxy,
         web3,
 ):
@@ -38,18 +37,8 @@ def test_token_network_deposit_race(
 
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
-    c1_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[1],
-        web3=web3,
-    )
-    c2_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[2],
-        web3=web3,
-    )
+    c1_client = JSONRPCClient(web3, private_keys[1])
+    c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         c1_client,
         token_network_address,
@@ -77,7 +66,6 @@ def test_token_network_deposit_race(
 def test_token_network_proxy_basics(
         token_network_proxy,
         private_keys,
-        blockchain_rpc_ports,
         token_proxy,
         chain_id,
         web3,
@@ -88,18 +76,8 @@ def test_token_network_proxy_basics(
 
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
-    c1_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[1],
-        web3=web3,
-    )
-    c2_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[2],
-        web3=web3,
-    )
+    c1_client = JSONRPCClient(web3, private_keys[1])
+    c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         c1_client,
         token_network_address,
@@ -249,7 +227,6 @@ def test_token_network_proxy_basics(
 def test_token_network_proxy_update_transfer(
         token_network_proxy,
         private_keys,
-        blockchain_rpc_ports,
         token_proxy,
         chain_id,
         web3,
@@ -257,18 +234,8 @@ def test_token_network_proxy_update_transfer(
     """Tests channel lifecycle, with `update_transfer` before settling"""
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
-    c1_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[1],
-        web3=web3,
-    )
-    c2_client = JSONRPCClient(
-        '0.0.0.0',
-        blockchain_rpc_ports[0],
-        private_keys[2],
-        web3=web3,
-    )
+    c1_client = JSONRPCClient(web3, private_keys[1])
+    c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         c1_client,
         token_network_address,

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -32,9 +32,7 @@ def endpoint_discovery_services(blockchain_services, endpoint_registry_address):
 
 
 @pytest.fixture(scope='session')
-def ethereum_tester(
-    patch_genesis_gas_limit,
-):
+def ethereum_tester(patch_genesis_gas_limit):
     """Returns an instance of an Ethereum tester"""
     tester = EthereumTester(PyEVMBackend())
     tester.set_fork_block('FORK_BYZANTIUM', 0)
@@ -127,15 +125,7 @@ def web3(
 
 @pytest.fixture
 def deploy_client(blockchain_rpc_ports, deploy_key, web3):
-    host = '0.0.0.0'
-    rpc_port = blockchain_rpc_ports[0]
-
-    return JSONRPCClient(
-        host,
-        rpc_port,
-        deploy_key,
-        web3=web3,
-    )
+    return JSONRPCClient(web3, deploy_key)
 
 
 @pytest.fixture

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -123,10 +123,8 @@ def test_duplicated_transaction_raises(deploy_client):
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     second_client = JSONRPCClient(
-        '0.0.0.0',
-        deploy_client.port,
+        deploy_client.web3,
         deploy_client.privkey,
-        web3=deploy_client.web3,
     )
 
     second_proxy = second_client.new_contract_proxy(

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -341,21 +341,14 @@ def jsonrpc_services(
         private_keys,
         secret_registry_address,
         token_network_registry_address,
-        web3=None,
+        web3,
 ):
     secret_registry = deploy_service.secret_registry(secret_registry_address)
     deploy_registry = deploy_service.token_network_registry(token_network_registry_address)
 
-    host = '0.0.0.0'
     blockchain_services = list()
     for privkey in private_keys:
-        rpc_client = JSONRPCClient(
-            host,
-            deploy_service.client.port,
-            privkey,
-            web3=web3,
-        )
-
+        rpc_client = JSONRPCClient(web3, privkey)
         blockchain = BlockChainService(privkey, rpc_client)
         blockchain_services.append(blockchain)
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -312,13 +312,8 @@ def setup_testchain_and_raiden(smoketest_config, transport, matrix_server, print
     geth_wait_and_check(web3_client, privatekeys, random_marker)
 
     print_step('Deploying Raiden contracts')
-    host = '0.0.0.0'
-    client = JSONRPCClient(
-        host,
-        ethereum_config['rpc'],
-        get_private_key(),
-        web3=web3_client,
-    )
+
+    client = JSONRPCClient(web3_client, get_private_key())
     contract_addresses = deploy_smoketest_contracts(client, 627)
     token_contract = deploy_token(client)
     token = token_contract(1000, 0, 'TKN', 'TKN')

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -31,6 +31,7 @@ from eth_utils import (
 )
 from mirakuru import ProcessExitedWithError
 from requests.exceptions import RequestException
+from web3 import Web3, HTTPProvider
 
 from raiden import constants
 from raiden.accounts import AccountManager
@@ -62,7 +63,6 @@ from raiden.settings import (
 )
 from raiden.tasks import check_version, check_gas_reserve
 from raiden.utils import (
-    eth_endpoint_to_hostport,
     get_system_spec,
     merge_dict,
     split_endpoint,
@@ -597,13 +597,12 @@ def run_app(
     privatekey_hex = hexlify(privatekey_bin)
     config['privatekey_hex'] = privatekey_hex
 
-    rpc_host, rpc_port = eth_endpoint_to_hostport(eth_rpc_endpoint)
+    web3 = Web3(HTTPProvider(eth_rpc_endpoint))
 
     rpc_client = JSONRPCClient(
-        rpc_host,
-        rpc_port,
+        web3,
         privatekey_bin,
-        gas_price,
+        gasprice=gas_price,
     )
 
     blockchain_service = BlockChainService(privatekey_bin, rpc_client)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -603,7 +603,7 @@ def run_app(
     try:
         node_version = web3.version.node  # pylint: disable=no-member
     except ConnectTimeout:
-        raise EthNodeCommunicationError('couldnt reach the ethereum node')
+        raise EthNodeCommunicationError("Couldn't connect to the ethereum node")
 
     supported, _ = is_supported_client(node_version)
     if not supported:

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -5,6 +5,7 @@ import os
 import click
 import structlog
 from eth_utils import to_checksum_address
+from web3 import Web3, HTTPProvider
 
 from raiden.log_config import configure_logging
 from raiden.network.rpc.client import JSONRPCClient
@@ -33,6 +34,7 @@ def patch_deploy_solidity_contract():
         Removes the AST node representing the line
         `    libraries = dict(libraries)`
         """
+
         def visit_Assign(self, node):  # pylint: disable=no-self-use
             is_libraries = (
                 len(node.targets) == 1 and
@@ -84,11 +86,11 @@ def main(keystore_path, pretty, gas_price, port):
     gas_price_in_wei = gas_price * 1000000000
     patch_deploy_solidity_contract()
     host = '127.0.0.1'
+    web3 = Web3(HTTPProvider(f'http://{host}:{port}'))
     client = JSONRPCClient(
-        host,
-        port,
+        web3,
         privatekey,
-        gas_price_in_wei,
+        gasprice=gas_price_in_wei,
     )
 
     deployed = deploy_contracts(client)

--- a/tools/init_blockchain.py
+++ b/tools/init_blockchain.py
@@ -1,6 +1,7 @@
 import gevent
-
+from web3 import Web3, HTTPProvider
 from eth_utils import to_checksum_address, encode_hex
+
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import get_contract_path, sha3
 from raiden.utils.solc import compile_files_cwd
@@ -8,11 +9,9 @@ from raiden.utils.solc import compile_files_cwd
 
 def connect(host='127.0.0.1', port=8545):
     """Create a jsonrpcclient instance, using the 'zero-privatekey'. """
-    client = JSONRPCClient(
-        host,
-        port,
-        privkey=b'1' * 64,
-    )
+    privkey = b'1' * 64
+    web3 = Web3(HTTPProvider(f'http://{host}:{port}'))
+    client = JSONRPCClient(web3, privkey)
     return client
 
 

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -8,8 +8,8 @@ import random
 import click
 import gevent
 import structlog
-
 from eth_utils import decode_hex
+from web3 import Web3, HTTPProvider
 
 from raiden.app import App
 from raiden.api.python import RaidenAPI
@@ -93,11 +93,8 @@ def run(
 
     privatekey_bin = decode_hex(privatekey)
 
-    rpc_client = JSONRPCClient(
-        '127.0.0.1',
-        8545,
-        privatekey_bin,
-    )
+    web3 = Web3(HTTPProvider(f'http://127.0.0.1:8545'))
+    rpc_client = JSONRPCClient(web3, privatekey_bin)
 
     blockchain_service = BlockChainService(privatekey_bin, rpc_client)
 

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import click
+from web3 import Web3, HTTPProvider
 
 from raiden.network.rpc.client import JSONRPCClient
 
@@ -14,11 +15,8 @@ WEI_TO_ETH = 10 ** 18
 @click.option("-p", "--port", default=8545)
 @click.option("-h", "--host", default="127.0.0.1")
 def main(private_key, eth_amount, targets_file, port, host):
-    client = JSONRPCClient(
-        host,
-        port,
-        private_key,
-    )
+    web3 = Web3(HTTPProvider(f'http://{host}:{port}'))
+    client = JSONRPCClient(web3, private_key)
 
     targets = [t.strip() for t in targets_file]
     balance = client.balance(client.sender)
@@ -39,4 +37,4 @@ def main(private_key, eth_amount, targets_file, port, host):
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
review after #2064

The arguments host and port were ignored the argument web3 was given,
this could lead to inconsistencies among the web3 instance and the
JSONRPCClient's attributes host/port. This change removes the extranous
arguments and requires the web3 instance