### PR TITLE
Python API: don't check if Raiden is running

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -52,15 +52,6 @@ class RaidenAPI:
     # pylint: disable=too-many-public-methods
 
     def __init__(self, raiden):
-        # We cannot accept requests before the node has synchronized with the
-        # blockchain, which is done during the call to RaidenService.start.
-        # Otherwise there is no guarantee that the node is in a valid state and
-        # that the actions are valid, e.g. deposit in a channel that has closed
-        # while the node was offline.
-        if not raiden.start_event.is_set():
-            raise RuntimeError(
-                'The RaidenService must be started before the API can be used',
-            )
         self.raiden = raiden
 
     @property


### PR DESCRIPTION
Revert check for running Raiden node when instantiating python Raiden API.

Fixes: #2057 