### PR TITLE
Increased pytest reporting detail

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -16,6 +16,8 @@ coverage run \
     --log-config='raiden:DEBUG' \
     --random \
     -v \
+    --showlocals \
+    --tb=long \
     --blockchain-type=${BLOCKCHAIN_TYPE} \
     ${TRANSPORT_OPTIONS} \
     ${TEST}


### PR DESCRIPTION
This is increasing the amount of details reported by pytest on failures.
This is useful when functions are used to assert on state, e.g.
must_contain_entry, which could have the values partially hidden by the
assertion instrospection.

The flag `--show-locals` adds to the end of each frame the list of local
variables and their values.

The flag `--tb=long` shows the source code of each frame with
annotations.