### PR TITLE
Add logging for WAL and state replay

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -208,6 +208,7 @@ class RaidenService:
         )
 
         if self.wal.state_manager.current_state is None:
+            log.debug('No recoverable state available, created inital state')
             block_number = self.chain.block_number()
 
             state_change = ActionInitChain(
@@ -232,6 +233,7 @@ class RaidenService:
             # for that given block have been processed, filters can be safely
             # installed starting from this position without losing events.
             last_log_block_number = views.block_number(self.wal.state_manager.current_state)
+            log.debug('Restored state from WAL', last_restored_block=last_log_block_number)
 
         # Install the filters using the correct from_block value, otherwise
         # blockchain logs can be lost.


### PR DESCRIPTION
As I found out in #2054 it is quite hard to read from the log what's happening during startup. This adds more debug logging to solve that in the future.

One open question is if we should log all state changes as they get replayed.