### PR TITLE
Some fixes for integration tests with tester

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,12 +2,16 @@
 
 set -ex
 
-if [ -z ${BLOCKCHAIN_TYPE} ] && [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
+TRAVIS_COMMIT_MSG=`git log --format=%B --no-merges --topo-order -n 1`
+if [[ -z ${BLOCKCHAIN_TYPE} && ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
     BLOCKCHAIN_TYPE="geth"
-elif [ -z ${BLOCKCHAIN_TYPE} ]; then
-    # FIXME: change to "tester" once the test failures are fixed
+elif [[ -z ${BLOCKCHAIN_TYPE} && "${TRAVIS_COMMIT_MSG}" =~ '[tester]' ]]; then
+    BLOCKCHAIN_TYPE="tester"
+elif [[ -z ${BLOCKCHAIN_TYPE} ]]; then
     BLOCKCHAIN_TYPE="geth"
 fi
+
+echo MSG=${TRAVIS_COMMIT_MSG}, BC=${BLOCKCHAIN_TYPE}
 
 coverage run \
     -m py.test \

--- a/.travis/run_smoketest.sh
+++ b/.travis/run_smoketest.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
+
+TRAVIS_COMMIT_MSG=`git log --format=%B --no-merges --topo-order -n 1`
+if [[ -z ${BLOCKCHAIN_TYPE} && ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
+    BLOCKCHAIN_TYPE="geth"
+elif [[ -z ${BLOCKCHAIN_TYPE} && "${TRAVIS_COMMIT_MSG}" =~ '[tester]' ]]; then
+    BLOCKCHAIN_TYPE="tester"
+elif [[ -z ${BLOCKCHAIN_TYPE} ]]; then
+    BLOCKCHAIN_TYPE="geth"
+fi
+
+echo MSG=${TRAVIS_COMMIT_MSG}, BC=${BLOCKCHAIN_TYPE}
 
 if [[ -z ${RUN_SYNAPSE} ]]; then
     raiden --transport=udp smoketest

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -76,7 +76,7 @@ def saturated_count(connection_managers, registry_address, token_address):
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('settle_timeout', [6])
 @pytest.mark.parametrize('reveal_timeout', [3])
-def test_participant_selection(raiden_network, token_addresses, skip_if_tester):
+def test_participant_selection(raiden_network, token_addresses):
     registry_address = raiden_network[0].raiden.default_registry.address
 
     # pylint: disable=too-many-locals


### PR DESCRIPTION
Geth and parity seems to not have problems with `[<topic>, [<topic>, <topic>]]` topics list, but it's not in the spec and tester crashes with it. Simplest fix is to, when using list of lists, be consistent with that.
Together with #2015, fixes #1865 