### PR TITLE
Snapshot every configured number of blocks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`682` Store a Snapshot of WAL state as recovery optimization.
 * :bug:`2125`: Show proper error message for invalid tokens on ``/connections``.
 * :feature:`1949` Add an endpoint to query the payment history.
 * :feature:`2084` Rename the ``/transfers/`` endpoint to ``/payments/``.

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -75,6 +75,8 @@ NULL_ADDRESS_BYTES = b'\x00' * 20
 
 TESTNET_GASPRICE_MULTIPLIER = 2.0
 
+SNAPSHOT_BLOCK_COUNT = 5000
+
 # calculated as of raiden-contracts@0dbe840c366841b414a11c78d8721046440b2a15
 # https://github.com/raiden-network/raiden-contracts/tree/0dbe840c366841b414a11c78d8721046440b2a15
 GAS_REQUIRED_FOR_OPEN_CHANNEL = 109921

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -13,6 +13,7 @@ from gevent.lock import Semaphore
 
 from raiden import constants, routing, waiting
 from raiden.connection_manager import ConnectionManager
+from raiden.constants import SNAPSHOT_BLOCK_COUNT
 from raiden.exceptions import InvalidAddress, RaidenShuttingDown
 from raiden.messages import LockedTransfer, SignedMessage
 from raiden.network.blockchain_service import BlockChainService
@@ -349,6 +350,13 @@ class RaidenService:
 
         if block_number is None:
             block_number = self.get_block_number()
+
+        # Take a snapshot every SNAPSHOT_BLOCK_COUNT
+        # TODO: Gather more data about storage requirements
+        # and update the value to specify how often we need
+        # capturing a snapshot should take place
+        if block_number % SNAPSHOT_BLOCK_COUNT == 0:
+            self.wal.snapshot()
 
         event_list = self.wal.log_and_dispatch(state_change, block_number)
 


### PR DESCRIPTION
Resolves #682.

According to my discussion with @hackaugusto, we don't have enough data such as storage requirements to decide how often we need to capture a snapshot. Therefore, we're proposing this simplistic approach of capturing a snapshot every 5K blocks.