### PR TITLE
Improve connection manager connection retry

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -87,14 +87,10 @@ def handle_channel_new(raiden, event, current_block_number):
             channel_state,
         )
         raiden.handle_state_change(new_channel, current_block_number)
-
         partner_address = channel_state.partner_state.address
-        connection_manager = raiden.connection_manager_for_token_network(token_network_identifier)
 
         if ConnectionManager.BOOTSTRAP_ADDR != partner_address:
             raiden.start_health_check_for(partner_address)
-
-        gevent.spawn(connection_manager.retry_connect)
 
         # Start the listener *after* the channel is registered, to avoid None
         # exceptions (and not applying the event state change).
@@ -113,6 +109,11 @@ def handle_channel_new(raiden, event, current_block_number):
             participant2,
         )
         raiden.handle_state_change(new_route, current_block_number)
+
+    # A new channel is available, run the connection manager in case more
+    # connections are needed
+    connection_manager = raiden.connection_manager_for_token_network(token_network_identifier)
+    gevent.spawn(connection_manager.retry_connect)
 
 
 def handle_channel_new_balance(raiden, event, current_block_number):


### PR DESCRIPTION
The connection manager should be used if there are new channels opened
with the current node *and* if there are new channels available in the
network.

[ci integration]