### PR TITLE
removed pytest --tb=long

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -17,7 +17,6 @@ coverage run \
     --random \
     -v \
     --showlocals \
-    --tb=long \
     --blockchain-type=${BLOCKCHAIN_TYPE} \
     ${TRANSPORT_OPTIONS} \
     ${TEST}


### PR DESCRIPTION
tb=long is producing HUGE stack traces, on the order of thousands lines https://gist.githubusercontent.com/hackaugusto/543af552ca051a2bda0378d07f07ab6f/raw/6b81277867620864aff49842b059a892dd3494de/gistfile1.txt , this reverts the change and leaves the locals flag for debugging