### PR TITLE
Handle 404 when User.get_display_name, better caching on join discovery room

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -888,7 +888,8 @@ class MatrixTransport:
                 user.user_id.encode(),
                 decode_hex(displayname),
             )
-            assert address and recovered and recovered == address
+            if not (address and recovered and recovered == address):
+                return None
         except (DecodeError, TypeError, MatrixRequestError, AssertionError):
             return None
         return address

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -268,6 +268,7 @@ class MatrixTransport:
         self._running = False
         self._client.set_presence_state(UserPresence.OFFLINE.value)
         self._client.stop_listener_thread()
+        self._client.sync_thread = None
 
         # Set all the pending results to False, this will also
         # cause pending retries to be aborted


### PR DESCRIPTION
This also removes the handling of `join` events, monitoring new users through the `m.presence` event sent together which includes also the displayname information, so save one http roundtrip per user, as well as handling when user changes displayName (which was triggering the bug by the events being handled before the user set its displayName).
Fix #2137 