### PR TITLE
Move *Task namedtuples outside the PaymentMappingState

### DIFF
--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -27,9 +27,11 @@ from raiden.transfer.events import (
 )
 from raiden.transfer.state import (
     ChainState,
-    PaymentMappingState,
     PaymentNetworkState,
     TokenNetworkState,
+    InitiatorTask,
+    MediatorTask,
+    TargetTask,
 )
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
@@ -145,7 +147,7 @@ def subdispatch_to_paymenttask(
     if sub_task:
         pseudo_random_generator = chain_state.pseudo_random_generator
 
-        if isinstance(sub_task, PaymentMappingState.InitiatorTask):
+        if isinstance(sub_task, InitiatorTask):
             token_network_identifier = sub_task.token_network_identifier
             token_network_state = views.get_token_network_by_identifier(
                 chain_state,
@@ -161,7 +163,7 @@ def subdispatch_to_paymenttask(
                 )
                 events = sub_iteration.events
 
-        elif isinstance(sub_task, PaymentMappingState.MediatorTask):
+        elif isinstance(sub_task, MediatorTask):
             token_network_identifier = sub_task.token_network_identifier
             token_network_state = views.get_token_network_by_identifier(
                 chain_state,
@@ -178,7 +180,7 @@ def subdispatch_to_paymenttask(
                 )
                 events = sub_iteration.events
 
-        elif isinstance(sub_task, PaymentMappingState.TargetTask):
+        elif isinstance(sub_task, TargetTask):
             token_network_identifier = sub_task.token_network_identifier
             channel_identifier = sub_task.channel_identifier
             token_network_state = views.get_token_network_by_identifier(
@@ -222,7 +224,7 @@ def subdispatch_initiatortask(
         is_valid_subtask = True
         manager_state = None
 
-    elif sub_task and isinstance(sub_task, PaymentMappingState.InitiatorTask):
+    elif sub_task and isinstance(sub_task, InitiatorTask):
         is_valid_subtask = (
             token_network_identifier == sub_task.token_network_identifier
         )
@@ -248,7 +250,7 @@ def subdispatch_initiatortask(
         events = iteration.events
 
         if iteration.new_state:
-            sub_task = PaymentMappingState.InitiatorTask(
+            sub_task = InitiatorTask(
                 token_network_identifier,
                 iteration.new_state,
             )
@@ -273,7 +275,7 @@ def subdispatch_mediatortask(
         is_valid_subtask = True
         mediator_state = None
 
-    elif sub_task and isinstance(sub_task, PaymentMappingState.MediatorTask):
+    elif sub_task and isinstance(sub_task, MediatorTask):
         is_valid_subtask = (
             token_network_identifier == sub_task.token_network_identifier
         )
@@ -299,7 +301,7 @@ def subdispatch_mediatortask(
         events = iteration.events
 
         if iteration.new_state:
-            sub_task = PaymentMappingState.MediatorTask(
+            sub_task = MediatorTask(
                 token_network_identifier,
                 iteration.new_state,
             )
@@ -325,7 +327,7 @@ def subdispatch_targettask(
         is_valid_subtask = True
         target_state = None
 
-    elif sub_task and isinstance(sub_task, PaymentMappingState.TargetTask):
+    elif sub_task and isinstance(sub_task, TargetTask):
         is_valid_subtask = (
             token_network_identifier == sub_task.token_network_identifier
         )
@@ -355,7 +357,7 @@ def subdispatch_targettask(
         events = iteration.events
 
         if iteration.new_state:
-            sub_task = PaymentMappingState.TargetTask(
+            sub_task = TargetTask(
                 token_network_identifier,
                 channel_identifier,
                 iteration.new_state,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -76,6 +76,23 @@ def message_identifier_from_prng(prng):
     return prng.randint(0, UINT64_MAX)
 
 
+InitiatorTask = namedtuple('InitiatorTask', (
+    'token_network_identifier',
+    'manager_state',
+))
+
+MediatorTask = namedtuple('MediatorTask', (
+    'token_network_identifier',
+    'mediator_state',
+))
+
+TargetTask = namedtuple('TargetTask', (
+    'token_network_identifier',
+    'channel_identifier',
+    'target_state',
+))
+
+
 class ChainState(State):
     """ Umbrella object that stores the per blockchain state.
     For each registry smart contract there must be a payment network. Within the
@@ -277,22 +294,6 @@ class PaymentMappingState(State):
     __slots__ = (
         'secrethashes_to_task',
     )
-
-    InitiatorTask = namedtuple('InitiatorTask', (
-        'token_network_identifier',
-        'manager_state',
-    ))
-
-    MediatorTask = namedtuple('MediatorTask', (
-        'token_network_identifier',
-        'mediator_state',
-    ))
-
-    TargetTask = namedtuple('TargetTask', (
-        'token_network_identifier',
-        'channel_identifier',
-        'target_state',
-    ))
 
     def __init__(self):
         self.secrethashes_to_task = dict()

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 import random
 from binascii import hexlify
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from functools import total_ordering
 
 import networkx
@@ -76,21 +76,20 @@ def message_identifier_from_prng(prng):
     return prng.randint(0, UINT64_MAX)
 
 
-InitiatorTask = namedtuple('InitiatorTask', (
-    'token_network_identifier',
-    'manager_state',
-))
+class InitiatorTask(typing.NamedTuple):
+    token_network_identifier: typing.TokenNetworkIdentifier
+    manager_state: 'InitiatorTransferState'
 
-MediatorTask = namedtuple('MediatorTask', (
-    'token_network_identifier',
-    'mediator_state',
-))
 
-TargetTask = namedtuple('TargetTask', (
-    'token_network_identifier',
-    'channel_identifier',
-    'target_state',
-))
+class MediatorTask(typing.NamedTuple):
+    token_network_identifier: typing.TokenNetworkIdentifier
+    mediator_state: 'MediatorTransferState'
+
+
+class TargetTask(typing.NamedTuple):
+    token_network_identifier: typing.TokenNetworkIdentifier
+    channel_identifier: typing.ChannelID
+    target_state: 'TargetTransferState'
 
 
 class ChainState(State):

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -11,8 +11,10 @@ from raiden.transfer.state import (
     NODE_NETWORK_UNKNOWN,
     ChainState,
     PaymentNetworkState,
-    PaymentMappingState,
     TokenNetworkState,
+    InitiatorTask,
+    MediatorTask,
+    TargetTask,
 )
 from raiden.utils import typing
 
@@ -455,11 +457,11 @@ def get_transfer_role(
     transfer_task = chain_state.payment_mapping.secrethashes_to_task.get(secrethash)
 
     result = None
-    if isinstance(transfer_task, PaymentMappingState.InitiatorTask):
+    if isinstance(transfer_task, InitiatorTask):
         result = 'initiator'
-    elif isinstance(transfer_task, PaymentMappingState.MediatorTask):
+    elif isinstance(transfer_task, MediatorTask):
         result = 'mediator'
-    elif isinstance(transfer_task, PaymentMappingState.TargetTask):
+    elif isinstance(transfer_task, TargetTask):
         result = 'target'
 
     return result


### PR DESCRIPTION
Seems like pickle works if a namedtuple is defined globally in a module but won’t be able to figure out the namedtuple exists if it’s embedded inside a class.