### PR TITLE
Fix identifier to results

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -134,6 +134,9 @@ def handle_transfersentsuccess(
         raiden: RaidenService,
         transfer_sent_success_event: EventPaymentSentSuccess,
 ):
+    if transfer_sent_success_event.identifier not in raiden.identifier_to_results:
+        return
+
     result = raiden.identifier_to_results[transfer_sent_success_event.identifier]
     result.set(True)
 
@@ -144,6 +147,9 @@ def handle_paymentsentfailed(
         raiden: RaidenService,
         payment_sent_failed_event: EventPaymentSentFailed,
 ):
+    if payment_sent_failed_event.identifier not in raiden.identifier_to_results:
+        return
+
     result = raiden.identifier_to_results[payment_sent_failed_event.identifier]
     result.set(False)
     del raiden.identifier_to_results[payment_sent_failed_event.identifier]

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -130,17 +130,17 @@ def handle_send_processed(
     )
 
 
-def handle_transfersentsuccess(
+def handle_paymentsentsuccess(
         raiden: RaidenService,
-        transfer_sent_success_event: EventPaymentSentSuccess,
+        payment_sent_success_event: EventPaymentSentSuccess,
 ):
-    if transfer_sent_success_event.identifier not in raiden.identifier_to_results:
+    if payment_sent_success_event.identifier not in raiden.identifier_to_results:
         return
 
-    result = raiden.identifier_to_results[transfer_sent_success_event.identifier]
+    result = raiden.identifier_to_results[payment_sent_success_event.identifier]
     result.set(True)
 
-    del raiden.identifier_to_results[transfer_sent_success_event.identifier]
+    del raiden.identifier_to_results[payment_sent_success_event.identifier]
 
 
 def handle_paymentsentfailed(
@@ -348,7 +348,7 @@ def on_raiden_event(raiden: RaidenService, event: Event):
     elif type(event) == SendProcessed:
         handle_send_processed(raiden, event)
     elif type(event) == EventPaymentSentSuccess:
-        handle_transfersentsuccess(raiden, event)
+        handle_paymentsentsuccess(raiden, event)
     elif type(event) == EventPaymentSentFailed:
         handle_paymentsentfailed(raiden, event)
     elif type(event) == EventUnlockFailed:


### PR DESCRIPTION
Failing test traceback during the https://github.com/raiden-network/raiden/pull/2153 PR CI tests.

```
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/matrix_client/room.py", line 308, in _put_event
    listener['callback'](self, event)
  File "/home/travis/build/raiden-network/raiden/raiden/network/transport/matrix.py", line 505, in _handle_message
    self._receive_message(message)
  File "/home/travis/build/raiden-network/raiden/raiden/network/transport/matrix.py", line 548, in _receive_message
    if on_message(self._raiden_service, message) and not isinstance(message, Processed):
  File "/home/travis/build/raiden-network/raiden/raiden/message_handler.py", line 141, in on_message
    handle_message_processed(raiden, message)
  File "/home/travis/build/raiden-network/raiden/raiden/message_handler.py", line 122, in handle_message_processed
    raiden.handle_state_change(processed)
  File "/home/travis/build/raiden-network/raiden/raiden/raiden_service.py", line 378, in handle_state_change
    on_raiden_event(self, event)
  File "/home/travis/build/raiden-network/raiden/raiden/raiden_event_handler.py", line 345, in on_raiden_event
    handle_transfersentsuccess(raiden, event)
  File "/home/travis/build/raiden-network/raiden/raiden/raiden_event_handler.py", line 137, in handle_transfersentsuccess
    result = raiden.identifier_to_results[transfer_sent_success_event.identifier]
KeyError: 7
```