### PR TITLE
Handle Recoverable / Unrecoverable exceptions

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -16,7 +16,6 @@ from raiden.exceptions import (
     TransactionThrew,
     InsufficientFunds,
     RaidenRecoverableError,
-    RaidenUnrecoverableError,
 )
 from raiden.transfer import views
 from raiden.utils.typing import Address
@@ -215,7 +214,7 @@ class ConnectionManager:
                     partner_address,
                     joining_funds,
                 )
-            except (RaidenRecoverableError, RaidenUnrecoverableError):
+            except RaidenRecoverableError:
                 log.exception('connection manager join: channel not in opened state')
             else:
                 log.debug(
@@ -285,7 +284,7 @@ class ConnectionManager:
             )
         except TransactionThrew:
             log.exception('connection manager: deposit failed')
-        except (RaidenRecoverableError, RaidenUnrecoverableError):
+        except RaidenRecoverableError:
             log.exception('connection manager: channel not in opened state')
         except InsufficientFunds as e:
             log.error(f'connection manager: {str(e)}')

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -14,8 +14,9 @@ from raiden.utils import pex, typing
 from raiden.exceptions import (
     InvalidAmount,
     TransactionThrew,
-    ChannelIncorrectStateError,
     InsufficientFunds,
+    RaidenRecoverableError,
+    RaidenUnrecoverableError,
 )
 from raiden.transfer import views
 from raiden.utils.typing import Address
@@ -214,7 +215,7 @@ class ConnectionManager:
                     partner_address,
                     joining_funds,
                 )
-            except ChannelIncorrectStateError:
+            except (RaidenRecoverableError, RaidenUnrecoverableError):
                 log.exception('connection manager join: channel not in opened state')
             else:
                 log.debug(
@@ -284,7 +285,7 @@ class ConnectionManager:
             )
         except TransactionThrew:
             log.exception('connection manager: deposit failed')
-        except ChannelIncorrectStateError:
+        except (RaidenRecoverableError, RaidenUnrecoverableError):
             log.exception('connection manager: channel not in opened state')
         except InsufficientFunds as e:
             log.error(f'connection manager: {str(e)}')

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -138,15 +138,6 @@ class AddressWrongContract(RaidenError):
     pass
 
 
-class DuplicatedChannelError(RaidenRecoverableError):
-    """Raised if someone tries to create a channel that already exists."""
-
-
-class ChannelIncorrectStateError(RaidenRecoverableError):
-    """Raised if someone tries to perform an operation on a channel that
-    is in an incompatible state."""
-
-
 class ContractVersionMismatch(RaidenError):
     """Raised if deployed version of the contract differs."""
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -138,6 +138,10 @@ class AddressWrongContract(RaidenError):
     pass
 
 
+class DuplicatedChannelError(RaidenError):
+    """Raised if someone tries to create a channel that already exists."""
+
+
 class ContractVersionMismatch(RaidenError):
     """Raised if deployed version of the contract differs."""
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -138,7 +138,7 @@ class AddressWrongContract(RaidenError):
     pass
 
 
-class DuplicatedChannelError(RaidenError):
+class DuplicatedChannelError(RaidenRecoverableError):
     """Raised if someone tries to create a channel that already exists."""
 
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -49,10 +49,19 @@ class DepositOverLimit(RaidenError):
     pass
 
 
-class DepositMismatch(RaidenError):
+class DepositMismatch(RaidenUnrecoverableError):
     """ Raised when the requested deposit is lower than actual channel deposit
 
     Used when a *user* tries to deposit a given amount of token in a channel,
+    but the on-chain amount is already higher.
+    """
+    pass
+
+
+class WithdrawMismatch(RaidenUnrecoverableError):
+    """ Raised when the requested withdraw is lower than actual channel withdraw
+
+    Used when a *user* tries to withdraw a given amount of token from a channel,
     but the on-chain amount is already higher.
     """
     pass

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -142,7 +142,7 @@ class DuplicatedChannelError(RaidenRecoverableError):
     """Raised if someone tries to create a channel that already exists."""
 
 
-class ChannelIncorrectStateError(RaidenError):
+class ChannelIncorrectStateError(RaidenRecoverableError):
     """Raised if someone tries to perform an operation on a channel that
     is in an incompatible state."""
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -49,7 +49,7 @@ class DepositOverLimit(RaidenError):
     pass
 
 
-class DepositMismatch(RaidenUnrecoverableError):
+class DepositMismatch(RaidenRecoverableError):
     """ Raised when the requested deposit is lower than actual channel deposit
 
     Used when a *user* tries to deposit a given amount of token in a channel,
@@ -58,7 +58,7 @@ class DepositMismatch(RaidenUnrecoverableError):
     pass
 
 
-class WithdrawMismatch(RaidenUnrecoverableError):
+class WithdrawMismatch(RaidenRecoverableError):
     """ Raised when the requested withdraw is lower than actual channel withdraw
 
     Used when a *user* tries to withdraw a given amount of token from a channel,

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -5,6 +5,14 @@ class RaidenError(Exception):
     pass
 
 
+class RaidenRecoverableError(RaidenError):
+    pass
+
+
+class RaidenUnrecoverableError(RaidenError):
+    pass
+
+
 # Exceptions raised due to programming errors
 
 class HashLengthNot32(RaidenError):

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -20,7 +20,6 @@ from raiden.exceptions import (
     ContractVersionMismatch,
     InvalidAddress,
     TransactionThrew,
-    # RaidenRecoverableError,
 )
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.transactions import (
@@ -91,9 +90,6 @@ class SecretRegistry:
                     contract=pex(self.address),
                     secrethash=encode_hex(secrethash),
                 )
-                # raise RaidenRecoverableError(
-                #     f'secret {encode_hex(secrethash)} already registered.',
-                # )
 
         if not secret_batch:
             return

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -20,7 +20,7 @@ from raiden.exceptions import (
     ContractVersionMismatch,
     InvalidAddress,
     TransactionThrew,
-    SecretAlreadyRegistered,
+    RaidenRecoverableError,
 )
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.transactions import (
@@ -85,7 +85,7 @@ class SecretRegistry:
                     secret_batch.append(secret)
                     self.open_secret_transactions[secret] = secret_registry_transaction
             else:
-                raise SecretAlreadyRegistered(
+                raise RaidenRecoverableError(
                     f'secret {encode_hex(secrethash)} already registered.',
                 )
 

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -20,6 +20,7 @@ from raiden.exceptions import (
     ContractVersionMismatch,
     InvalidAddress,
     TransactionThrew,
+    SecretAlreadyRegistered,
 )
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.transactions import (
@@ -84,11 +85,8 @@ class SecretRegistry:
                     secret_batch.append(secret)
                     self.open_secret_transactions[secret] = secret_registry_transaction
             else:
-                log.info(
-                    'secret already registered',
-                    node=pex(self.node_address),
-                    contract=pex(self.address),
-                    secrethash=encode_hex(secrethash),
+                raise SecretAlreadyRegistered(
+                    f'secret {encode_hex(secrethash)} already registered.',
                 )
 
         if not secret_batch:

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -20,7 +20,7 @@ from raiden.exceptions import (
     ContractVersionMismatch,
     InvalidAddress,
     TransactionThrew,
-    RaidenRecoverableError,
+    # RaidenRecoverableError,
 )
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.transactions import (
@@ -85,9 +85,15 @@ class SecretRegistry:
                     secret_batch.append(secret)
                     self.open_secret_transactions[secret] = secret_registry_transaction
             else:
-                raise RaidenRecoverableError(
+                log.info(
                     f'secret {encode_hex(secrethash)} already registered.',
+                    node=pex(self.node_address),
+                    contract=pex(self.address),
+                    secrethash=encode_hex(secrethash),
                 )
+                # raise RaidenRecoverableError(
+                #     f'secret {encode_hex(secrethash)} already registered.',
+                # )
 
         if not secret_batch:
             return

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1097,7 +1097,7 @@ class TokenNetwork:
         # Deposit was prohibited because the channel is settled
         elif channel_state == ChannelState.SETTLED:
             raise RaidenUnrecoverableError(
-                'Channel is not in an settled state',
+                'Channel is settled',
             )
         # Deposit was prohibited because the channel is closed
         elif channel_state == ChannelState.CLOSED:

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -406,7 +406,10 @@ class TokenNetwork:
             channel_identifier: typing.ChannelID = None,
     ) -> bool:
         """ Returns true if the channel is in an open state, false otherwise. """
-        channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
+        try:
+            channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
+        except RaidenRecoverableError:
+            return False
         return channel_state == ChannelState.OPENED
 
     def channel_is_closed(
@@ -416,7 +419,10 @@ class TokenNetwork:
             channel_identifier: typing.ChannelID = None,
     ) -> bool:
         """ Returns true if the channel is in a closed state, false otherwise. """
-        channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
+        try:
+            channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
+        except RaidenRecoverableError:
+            return False
         return channel_state == ChannelState.CLOSED
 
     def channel_is_settled(
@@ -426,7 +432,10 @@ class TokenNetwork:
             channel_identifier: typing.ChannelID = None,
     ) -> bool:
         """ Returns true if the channel is in a settled state, false otherwise. """
-        channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
+        try:
+            channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
+        except RaidenRecoverableError:
+            return False
         return channel_state >= ChannelState.SETTLED
 
     def closing_address(
@@ -438,11 +447,11 @@ class TokenNetwork:
         """ Returns the address of the closer, if the channel is closed and not settled. None
         otherwise. """
 
-        channel_data = self.detail_channel(
-            participant1=participant1,
-            participant2=participant2,
-            channel_identifier=channel_identifier,
-        )
+        try:
+            channel_data = self.detail_channel(participant1, participant2, channel_identifier)
+        except RaidenRecoverableError:
+            return None
+
         if channel_data.state >= ChannelState.SETTLED:
             return None
 
@@ -1038,10 +1047,13 @@ class TokenNetwork:
         Checks whether an operation is being execute on a channel
         between two participants using an old channel identifier
         """
-        onchain_channel_details = self.detail_channel(
-            participant1,
-            participant2,
-        )
+        try:
+            onchain_channel_details = self.detail_channel(
+                participant1,
+                participant2,
+            )
+        except RaidenRecoverableError:
+            return
 
         onchain_channel_identifier = onchain_channel_details.channel_identifier
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -29,7 +29,6 @@ from raiden.exceptions import (
     DuplicatedChannelError,
     InvalidAddress,
     InvalidSettleTimeout,
-    NonSettledChannelExists,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
     SamePeerAddress,
@@ -187,7 +186,7 @@ class TokenNetwork:
                 peer1=pex(self.node_address),
                 peer2=pex(partner),
             )
-            raise NonSettledChannelExists('creating new channel failed')
+            raise RaidenUnrecoverableError('creating new channel failed')
 
         channel_identifier = self.detail_channel(self.node_address, partner).channel_identifier
 
@@ -649,7 +648,8 @@ class TokenNetwork:
 
         Raises:
             ChannelBusyError: If the channel is busy with another operation.
-            ChannelIncorrectStateError: If the channel is not in the open state.
+            RaidenRecoverableError: If the channel is already closed.
+            RaidenUnrecoverableError: If the channel does not exist or is settled.
         """
 
         log_details = {

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -250,7 +250,7 @@ class TokenNetwork:
             participant2: typing.Address,
             channel_identifier: typing.ChannelID = None,
     ) -> bool:
-        """Returns if the chann el exists and is in a non-settled state"""
+        """Returns if the channel exists and is in a non-settled state"""
         try:
             channel_state = self._get_channel_state(participant1, participant2, channel_identifier)
         except RaidenRecoverableError:
@@ -792,8 +792,8 @@ class TokenNetwork:
                 'setTotalWithdraw',
                 channel_identifier,
                 self.node_address,
-                partner,
                 total_withdraw,
+                partner,
                 partner_signature,
                 signature,
             )
@@ -1106,15 +1106,12 @@ class TokenNetwork:
             channel_identifier,
         )
 
-        if participant_details.our_details.deposit < deposit_amount:
-            raise RaidenUnrecoverableError('Deposit amount decreased')
-
         channel_state = self._get_channel_state(
             participant1=self.node_address,
             participant2=participant2,
             channel_identifier=channel_identifier,
         )
-        # Check if deposit is being mode on a nonexistent channel
+        # Check if deposit is being made on a nonexistent channel
         if channel_state in (ChannelState.NONEXISTENT, ChannelState.REMOVED):
             raise RaidenUnrecoverableError(
                 f'Channel between participant {participant1} '
@@ -1130,6 +1127,8 @@ class TokenNetwork:
             raise RaidenRecoverableError(
                 'Channel is already closed',
             )
+        elif participant_details.our_details.deposit < deposit_amount:
+            raise RaidenUnrecoverableError('Deposit amount decreased')
 
     def _check_channel_state_for_withdraw(
             self,
@@ -1170,7 +1169,7 @@ class TokenNetwork:
     def _check_channel_state_for_settle(self, participant1, participant2, channel_identifier):
         channel_data = self.detail_channel(participant1, participant2, channel_identifier)
         if channel_data.state == ChannelState.SETTLED:
-            raise RaidenRecoverableError(
+            raise RaidenUnrecoverableError(
                 'Channel is not in a closed state. It cannot be settled',
             )
         elif channel_data.state == ChannelState.REMOVED:

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1167,25 +1167,21 @@ class TokenNetwork:
             )
 
     def _check_channel_state_for_settle(self, participant1, participant2, channel_identifier):
-        channel_state = self._get_channel_state(
-            participant1=participant1,
-            participant2=participant2,
-            channel_identifier=channel_identifier,
-        )
-        if channel_state == ChannelState.SETTLED:
+        channel_data = self.detail_channel(participant1, participant2, channel_identifier)
+        if channel_data.state == ChannelState.SETTLED:
             raise RaidenRecoverableError(
                 'Channel is not in a closed state. It cannot be settled',
             )
-        elif channel_state == ChannelState.REMOVED:
+        elif channel_data.state == ChannelState.REMOVED:
             raise RaidenUnrecoverableError(
                 'Channel is already unlocked. It cannot be settled',
             )
-        elif channel_state == ChannelState.OPENED:
+        elif channel_data.state == ChannelState.OPENED:
             raise RaidenUnrecoverableError(
                 'Channel is still open. It cannot be settled',
             )
-        elif channel_state == ChannelState.CLOSED:
-            if channel_state.settle_block_number < self.client.block_number():
+        elif channel_data.state == ChannelState.CLOSED:
+            if self.client.block_number() < channel_data.settle_block_number:
                 raise RaidenUnrecoverableError(
                     'Channel cannot be settled before settlement window is over',
                 )

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -24,7 +24,7 @@ from raiden.exceptions import (
     AddressWrongContract,
     InvalidAddress,
     ContractVersionMismatch,
-    TokenAlreadyRegistered,
+    RaidenRecoverableError,
 )
 from raiden.utils import (
     pex,
@@ -114,7 +114,8 @@ class TokenNetworkRegistry:
                 token_address=pex(token_address),
                 registry_address=pex(self.address),
             )
-            raise TokenAlreadyRegistered()
+            raise RaidenRecoverableError('Token already registered')
+
         token_network_address = self.get_token_network(token_address)
 
         if token_network_address is None:

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -25,6 +25,7 @@ from raiden.exceptions import (
     InvalidAddress,
     ContractVersionMismatch,
     RaidenRecoverableError,
+    TransactionThrew,
 )
 from raiden.utils import (
     pex,
@@ -114,7 +115,9 @@ class TokenNetworkRegistry:
                 token_address=pex(token_address),
                 registry_address=pex(self.address),
             )
-            raise RaidenRecoverableError('Token already registered')
+            if self.get_token_network(token_address):
+                raise RaidenRecoverableError('Token already registered')
+            raise TransactionThrew('createERC20TokenNetwork', receipt_or_none)
 
         token_network_address = self.get_token_network(token_address)
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -22,7 +22,6 @@ from raiden.utils import typing, compare_versions
 from raiden.constants import NULL_ADDRESS
 from raiden.exceptions import (
     AddressWrongContract,
-    TransactionThrew,
     InvalidAddress,
     ContractVersionMismatch,
     TokenAlreadyRegistered,

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -25,6 +25,7 @@ from raiden.exceptions import (
     TransactionThrew,
     InvalidAddress,
     ContractVersionMismatch,
+    TokenAlreadyRegistered,
 )
 from raiden.utils import (
     pex,
@@ -114,7 +115,7 @@ class TokenNetworkRegistry:
                 token_address=pex(token_address),
                 registry_address=pex(self.address),
             )
-            raise TransactionThrew('createERC20TokenNetwork', receipt_or_none)
+            raise TokenAlreadyRegistered()
         token_network_address = self.get_token_network(token_address)
 
         if token_network_address is None:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -2,7 +2,6 @@ import structlog
 
 from raiden.exceptions import (
     ChannelOutdatedError,
-    RaidenError,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
@@ -206,7 +205,7 @@ def handle_contract_send_channelclose(
             message_hash,
             signature,
         )
-    except RaidenError as e:
+    except (RaidenRecoverableError, RaidenUnrecoverableError) as e:
         log.error(str(e))
 
 
@@ -312,7 +311,7 @@ def handle_contract_send_channelsettle(
             second_locked_amount,
             second_locksroot,
         )
-    except RaidenError as e:
+    except (RaidenRecoverableError, RaidenUnrecoverableError) as e:
         log.error(str(e))
 
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -247,8 +247,9 @@ def handle_contract_send_channelunlock(
         channel_unlock_event.token_network_identifier,
         channel_unlock_event.channel_identifier,
     )
+
     try:
-        channel.unlock(channel_unlock_event.merkle_treee_leaves)
+        channel.unlock(channel_unlock_event.merkle_tree_leaves)
     except ChannelOutdatedError as e:
         log.error(str(e))
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -352,9 +352,5 @@ def on_raiden_event(raiden: RaidenService, event: Event):
             pass
         else:
             log.error('Unknown event {}'.format(type(event)))
-    except RaidenRecoverableError as e:
-        log.error(e)
-        # TODO: Dispatch a state change to remove transaction
-        # from the transaction queue
-    except RaidenUnrecoverableError as e:
+    except (RaidenRecoverableError, RaidenUnrecoverableError) as e:
         log.error(e)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -3,7 +3,6 @@ import structlog
 from raiden.exceptions import (
     ChannelOutdatedError,
     RaidenRecoverableError,
-    RaidenUnrecoverableError,
 )
 from raiden.messages import message_from_sendevent
 from raiden.transfer.architecture import Event
@@ -198,15 +197,12 @@ def handle_contract_send_channelclose(
         channel_id=channel_close_event.channel_identifier,
     )
 
-    try:
-        channel_proxy.close(
-            nonce,
-            balance_hash,
-            message_hash,
-            signature,
-        )
-    except (RaidenRecoverableError, RaidenUnrecoverableError) as e:
-        log.error(str(e))
+    channel_proxy.close(
+        nonce,
+        balance_hash,
+        message_hash,
+        signature,
+    )
 
 
 def handle_contract_send_channelupdate(
@@ -248,7 +244,7 @@ def handle_contract_send_channelunlock(
     )
 
     try:
-        channel.unlock(channel_unlock_event.merkle_tree_leaves)
+        channel.unlock(channel_unlock_event.merkle_treee_leaves)
     except ChannelOutdatedError as e:
         log.error(str(e))
 
@@ -302,17 +298,14 @@ def handle_contract_send_channelsettle(
         second_locked_amount = our_locked_amount
         second_locksroot = our_locksroot
 
-    try:
-        channel.settle(
-            first_transferred_amount,
-            first_locked_amount,
-            first_locksroot,
-            second_transferred_amount,
-            second_locked_amount,
-            second_locksroot,
-        )
-    except (RaidenRecoverableError, RaidenUnrecoverableError) as e:
-        log.error(str(e))
+    channel.settle(
+        first_transferred_amount,
+        first_locked_amount,
+        first_locksroot,
+        second_transferred_amount,
+        second_locked_amount,
+        second_locksroot,
+    )
 
 
 def on_raiden_event(raiden: RaidenService, event: Event):
@@ -352,5 +345,5 @@ def on_raiden_event(raiden: RaidenService, event: Event):
             pass
         else:
             log.error('Unknown event {}'.format(type(event)))
-    except (RaidenRecoverableError, RaidenUnrecoverableError) as e:
+    except RaidenRecoverableError as e:
         log.error(e)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -21,7 +21,7 @@ from raiden.transfer.events import (
 )
 from raiden.exceptions import (
     RaidenRecoverableError,
-    RaidenUnrecoverableError
+    RaidenUnrecoverableError,
 )
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockFailed,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -19,6 +19,10 @@ from raiden.transfer.events import (
     SendDirectTransfer,
     SendProcessed,
 )
+from raiden.exceptions import (
+    RaidenRecoverableError,
+    RaidenUnrecoverableError
+)
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockFailed,
     EventUnlockSuccess,
@@ -332,38 +336,44 @@ def handle_contract_send_channelsettle(
 
 def on_raiden_event(raiden: RaidenService, event: Event):
     # pylint: disable=too-many-branches
-
-    if type(event) == SendLockedTransfer:
-        handle_send_lockedtransfer(raiden, event)
-    elif type(event) == SendDirectTransfer:
-        handle_send_directtransfer(raiden, event)
-    elif type(event) == SendRevealSecret:
-        handle_send_revealsecret(raiden, event)
-    elif type(event) == SendBalanceProof:
-        handle_send_balanceproof(raiden, event)
-    elif type(event) == SendSecretRequest:
-        handle_send_secretrequest(raiden, event)
-    elif type(event) == SendRefundTransfer:
-        handle_send_refundtransfer(raiden, event)
-    elif type(event) == SendProcessed:
-        handle_send_processed(raiden, event)
-    elif type(event) == EventPaymentSentSuccess:
-        handle_paymentsentsuccess(raiden, event)
-    elif type(event) == EventPaymentSentFailed:
-        handle_paymentsentfailed(raiden, event)
-    elif type(event) == EventUnlockFailed:
-        handle_unlockfailed(raiden, event)
-    elif type(event) == ContractSendSecretReveal:
-        handle_contract_send_secretreveal(raiden, event)
-    elif type(event) == ContractSendChannelClose:
-        handle_contract_send_channelclose(raiden, event)
-    elif type(event) == ContractSendChannelUpdateTransfer:
-        handle_contract_send_channelupdate(raiden, event)
-    elif type(event) == ContractSendChannelBatchUnlock:
-        handle_contract_send_channelunlock(raiden, event)
-    elif type(event) == ContractSendChannelSettle:
-        handle_contract_send_channelsettle(raiden, event)
-    elif type(event) in UNEVENTFUL_EVENTS:
-        pass
-    else:
-        log.error('Unknown event {}'.format(type(event)))
+    try:
+        if type(event) == SendLockedTransfer:
+            handle_send_lockedtransfer(raiden, event)
+        elif type(event) == SendDirectTransfer:
+            handle_send_directtransfer(raiden, event)
+        elif type(event) == SendRevealSecret:
+            handle_send_revealsecret(raiden, event)
+        elif type(event) == SendBalanceProof:
+            handle_send_balanceproof(raiden, event)
+        elif type(event) == SendSecretRequest:
+            handle_send_secretrequest(raiden, event)
+        elif type(event) == SendRefundTransfer:
+            handle_send_refundtransfer(raiden, event)
+        elif type(event) == SendProcessed:
+            handle_send_processed(raiden, event)
+        elif type(event) == EventPaymentSentSuccess:
+            handle_paymentsentsuccess(raiden, event)
+        elif type(event) == EventPaymentSentFailed:
+            handle_paymentsentfailed(raiden, event)
+        elif type(event) == EventUnlockFailed:
+            handle_unlockfailed(raiden, event)
+        elif type(event) == ContractSendSecretReveal:
+            handle_contract_send_secretreveal(raiden, event)
+        elif type(event) == ContractSendChannelClose:
+            handle_contract_send_channelclose(raiden, event)
+        elif type(event) == ContractSendChannelUpdateTransfer:
+            handle_contract_send_channelupdate(raiden, event)
+        elif type(event) == ContractSendChannelBatchUnlock:
+            handle_contract_send_channelunlock(raiden, event)
+        elif type(event) == ContractSendChannelSettle:
+            handle_contract_send_channelsettle(raiden, event)
+        elif type(event) in UNEVENTFUL_EVENTS:
+            pass
+        else:
+            log.error('Unknown event {}'.format(type(event)))
+    except RaidenRecoverableError as e:
+        log.error(e)
+        # TODO: Dispatch a state change to remove transaction
+        # from the transaction queue
+    except RaidenUnrecoverableError as e:
+        log.error(e)

--- a/raiden/tests/integration/contracts/test_network_registry.py
+++ b/raiden/tests/integration/contracts/test_network_registry.py
@@ -5,7 +5,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
 )
 
-from raiden.exceptions import TransactionThrew
+from raiden.exceptions import RaidenRecoverableError, TransactionThrew
 from raiden.tests.utils.factories import make_address
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 
@@ -26,6 +26,14 @@ def test_network_registry(token_network_registry_proxy: TokenNetworkRegistry, de
     token_network_address = token_network_registry_proxy.add_token(
         test_token_address,
     )
+
+    with pytest.raises(RaidenRecoverableError) as exc:
+        token_network_address = token_network_registry_proxy.add_token(
+            test_token_address,
+        )
+
+        assert 'Token already registered' in str(exc)
+
     logs = event_filter.get_all_entries()
     assert len(logs) == 1
     decoded_event = token_network_registry_proxy.proxy.decode_event(logs[0])

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -3,7 +3,6 @@ import pytest
 import types
 from eth_utils import keccak
 
-from raiden.exceptions import RaidenRecoverableError
 from raiden.tests.utils import get_random_bytes
 from raiden.network.proxies import SecretRegistry
 
@@ -59,10 +58,7 @@ def secret_registry_proxy_patched(secret_registry_proxy):
         for secret in secrets:
             assert secret not in self.trigger
             self.trigger[secret] = True
-        try:
-            return _register_secret_batch(secrets)
-        except RaidenRecoverableError:
-            pass
+        return _register_secret_batch(secrets)
 
     secret_registry_patched._register_secret_batch = types.MethodType(
         register_secret_batch_patched,

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -1,8 +1,10 @@
-from eth_utils import keccak
-from raiden.tests.utils import get_random_bytes
+import gevent
 import pytest
 import types
-import gevent
+from eth_utils import keccak
+
+from raiden.exceptions import RaidenRecoverableError
+from raiden.tests.utils import get_random_bytes
 from raiden.network.proxies import SecretRegistry
 
 
@@ -57,7 +59,10 @@ def secret_registry_proxy_patched(secret_registry_proxy):
         for secret in secrets:
             assert secret not in self.trigger
             self.trigger[secret] = True
-        return _register_secret_batch(secrets)
+        try:
+            return _register_secret_batch(secrets)
+        except RaidenRecoverableError:
+            pass
 
     secret_registry_patched._register_secret_batch = types.MethodType(
         register_secret_batch_patched,

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -88,6 +88,14 @@ def test_token_network_proxy_basics(
         token_network_address,
     )
 
+    initial_token_balance = 100
+    token_proxy.transfer(c1_client.sender, initial_token_balance)
+    token_proxy.transfer(c2_client.sender, initial_token_balance)
+    initial_balance_c1 = token_proxy.balance_of(c1_client.sender)
+    assert initial_balance_c1 == initial_token_balance
+    initial_balance_c2 = token_proxy.balance_of(c2_client.sender)
+    assert initial_balance_c2 == initial_token_balance
+
     # instantiating a new channel - test basic assumptions
     assert c1_token_network_proxy.channel_exists_and_not_settled(
         c1_client.sender,
@@ -179,14 +187,7 @@ def test_token_network_proxy_basics(
             10,
             c2_client.sender,
         )
-    # test deposits
-    initial_token_balance = 100
-    token_proxy.transfer(c1_client.sender, initial_token_balance)
-    token_proxy.transfer(c2_client.sender, initial_token_balance)
-    initial_balance_c1 = token_proxy.balance_of(c1_client.sender)
-    assert initial_balance_c1 == initial_token_balance
-    initial_balance_c2 = token_proxy.balance_of(c2_client.sender)
-    assert initial_balance_c2 == initial_token_balance
+
     # no negative deposit
     with pytest.raises(DepositMismatch):
         c1_token_network_proxy.set_total_deposit(
@@ -513,7 +514,7 @@ def test_token_network_proxy_update_transfer(
     wait_blocks(c1_client.web3, 10)
 
     # settling with an invalid amount
-    with pytest.raises(RaidenUnrecoverableError):
+    with pytest.raises(RaidenRecoverableError):
         c1_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=2,

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -526,15 +526,7 @@ def test_token_network_proxy_update_transfer(
     assert (token_proxy.balance_of(c1_client.sender) ==
             (initial_balance_c1 + transferred_amount_c2 - transferred_amount_c1))
 
-    with pytest.raises(RaidenRecoverableError) as exc:
-        c2_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            20,
-            c1_client.sender,
-        )
-
-        assert 'not in an open state' in str(exc)
-
+    # Already settled
     with pytest.raises(RaidenUnrecoverableError) as exc:
         c2_token_network_proxy.set_total_deposit(
             channel_identifier,
@@ -542,4 +534,4 @@ def test_token_network_proxy_update_transfer(
             c1_client.sender,
         )
 
-        assert 'channel is settled' in str(exc)
+        assert 'getChannelIdentifier returned 0' in str(exc)

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -19,6 +19,7 @@ from raiden.exceptions import (
     DuplicatedChannelError,
     TransactionThrew,
     DepositMismatch,
+    WithdrawMismatch,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
@@ -184,7 +185,7 @@ def test_token_network_proxy_basics(
     with pytest.raises(ValueError):
         c1_token_network_proxy.set_total_deposit(
             channel_identifier,
-            10,
+            101,
             c2_client.sender,
         )
 
@@ -203,7 +204,7 @@ def test_token_network_proxy_basics(
     )
 
     # no negative deposit
-    with pytest.raises(RaidenUnrecoverableError):
+    with pytest.raises(WithdrawMismatch):
         c1_token_network_proxy.withdraw(
             channel_identifier,
             c2_client.sender,
@@ -235,7 +236,7 @@ def test_token_network_proxy_basics(
             signature=b'\x11' * 65,
         )
 
-    with pytest.raises(RaidenUnrecoverableError) as exc:
+    with pytest.raises(RaidenRecoverableError) as exc:
         c1_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=transferred_amount,
@@ -305,7 +306,7 @@ def test_token_network_proxy_basics(
     wait_blocks(c1_client.web3, TEST_SETTLE_TIMEOUT_MIN)
 
     # try to settle using incorrect data
-    with pytest.raises(RaidenUnrecoverableError):
+    with pytest.raises(RaidenRecoverableError):
         c2_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=1,

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -18,8 +18,9 @@ from raiden.exceptions import (
     SamePeerAddress,
     DuplicatedChannelError,
     TransactionThrew,
-    ChannelIncorrectStateError,
     DepositMismatch,
+    RaidenRecoverableError,
+    RaidenUnrecoverableError,
 )
 from raiden.network.proxies import TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
@@ -204,7 +205,7 @@ def test_token_network_proxy_basics(
         channel_identifier=channel_identifier,
     ) is True
     # closing already closed channel
-    with pytest.raises(ChannelIncorrectStateError):
+    with pytest.raises(RaidenRecoverableError):
         c2_token_network_proxy.close(
             channel_identifier=channel_identifier,
             partner=c1_client.sender,
@@ -217,7 +218,7 @@ def test_token_network_proxy_basics(
     wait_blocks(c1_client.web3, TEST_SETTLE_TIMEOUT_MIN)
 
     # try to settle using incorrect data
-    with pytest.raises(ChannelIncorrectStateError):
+    with pytest.raises(RaidenUnrecoverableError):
         c2_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=1,
@@ -359,7 +360,7 @@ def test_token_network_proxy_update_transfer(
     wait_blocks(c1_client.web3, TEST_SETTLE_TIMEOUT_MIN)
 
     # settling with an invalid amount
-    with pytest.raises(ChannelIncorrectStateError):
+    with pytest.raises(RaidenUnrecoverableError):
         c1_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=2,

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -143,20 +143,20 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
 class ContractSendChannelBatchUnlock(ContractSendEvent):
     """ Event emitted when the lock must be claimed on-chain. """
 
-    def __init__(self, token_network_identifier, channel_identifier, merkle_tree_leaves):
+    def __init__(self, token_network_identifier, channel_identifier, merkle_treee_leaves):
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.merkle_tree_leaves = merkle_tree_leaves
+        self.merkle_treee_leaves = merkle_treee_leaves
 
     def __repr__(self):
         return (
             '<ContractSendChannelBatchUnlock '
-            'token_network_id:{} channel:{} merkle_tree_leaves:{}'
+            'token_network_id:{} channel:{} merkle_treee_leaves:{}'
             '>'
         ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
-            self.merkle_tree_leaves,
+            self.merkle_treee_leaves,
         )
 
     def __eq__(self, other):
@@ -164,7 +164,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             isinstance(other, ContractSendChannelBatchUnlock) and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.merkle_tree_leaves == other.merkle_tree_leaves
+            self.merkle_treee_leaves == other.merkle_treee_leaves
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -143,20 +143,20 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
 class ContractSendChannelBatchUnlock(ContractSendEvent):
     """ Event emitted when the lock must be claimed on-chain. """
 
-    def __init__(self, token_network_identifier, channel_identifier, merkle_treee_leaves):
+    def __init__(self, token_network_identifier, channel_identifier, merkle_tree_leaves):
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.merkle_treee_leaves = merkle_treee_leaves
+        self.merkle_tree_leaves = merkle_tree_leaves
 
     def __repr__(self):
         return (
             '<ContractSendChannelBatchUnlock '
-            'token_network_id:{} channel:{} merkle_treee_leaves:{}'
+            'token_network_id:{} channel:{} merkle_tree_leaves:{}'
             '>'
         ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
-            self.merkle_treee_leaves,
+            self.merkle_tree_leaves,
         )
 
     def __eq__(self, other):
@@ -164,7 +164,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             isinstance(other, ContractSendChannelBatchUnlock) and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.merkle_treee_leaves == other.merkle_treee_leaves
+            self.merkle_tree_leaves == other.merkle_tree_leaves
         )
 
     def __ne__(self, other):


### PR DESCRIPTION
Resolves #1966 

Created follow up issues:
- https://github.com/raiden-network/raiden/issues/2194
- https://github.com/raiden-network/raiden/issues/2195

Also, skipped implementing the following points:
- Recoverable: An unlock fails because that participant channel state is already unlocked
- Unrecoverable: unlock while the channel was never settled

@hackaugusto i figured this would add some complexity to the tests as locks require gathering certain states / data to be able to pass them to the unlock call... i think it's possible to add those checks on higher-level tests where all proxy calls go through the token_network and nettingchannel state machines, but i haven't checked on what needs to be done there to implement those cases.

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Type</th>
<th scope="col" class="org-left">Section</th>
<th scope="col" class="org-left">Implemented</th>
<th scope="col" class="org-left">Tested</th>
<th scope="col" class="org-left">Notes</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left">Unrecoverable</td>
<td class="org-left">Invalid operations on the token network:Open while a non-settled channel exists</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">Deposit, Withdraw, or Close for a channel that was never opened</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">Deposit, Withdraw, or Close for a channel that was settled</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">Deposit or Withdraw which fails because the monotonic value decreased, because such operations are disallowed by the Raiden node.</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">updateTransfer for a channel that was never closed</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">settle for a channel that was never closed (this assumes the settlement window is larger than the nº of confirmation blocks)</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">settle for a channel that was closed but the settlement window is not over</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">unlock while the channel was never settled</td>
<td class="org-left">Yes</td>
<td class="org-left">No</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">settle with invalid balance proof data</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">Follow up issue</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">close with an invalid balance proof hash</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">updateTransfer with an invalid balance proof hash</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">Recoverable</td>
<td class="org-left">The transaction start gas was higher than the block gas limit</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">Follow up issue</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">A transaction to a smart contract address which has selfdestructed</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">Follow up issue</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">A transaction which hit a revert</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">Follow up issue</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">Race operations on the secret registry: The secret is already registered</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">Token Registry: The token is already registered</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">Token Network: An open which fails because the channel is already open</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">A deposit or withdraw which fails because the channel is closed</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">A close fails because the channel is already closed</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">A settle fails because the channel is already settled</td>
<td class="org-left">Yes</td>
<td class="org-left">Yes</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">An unlock fails because that participant channel state is already unlocked</td>
<td class="org-left">No</td>
<td class="org-left">No</td>
<td class="org-left">&#xa0;</td>
</tr>


<tr>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
<td class="org-left">&#xa0;</td>
</tr>
</tbody>
</table>

