### PR TITLE
Clean expired transactions

### DIFF
--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -2,9 +2,10 @@
 from copy import deepcopy
 from raiden.utils.typing import (
     Address,
+    BlockExpiration,
+    ChannelID,
     List,
     MessageID,
-    ChannelID,
     QueueIdentifier,
     T_ChannelID,
 )
@@ -108,6 +109,11 @@ class SendMessageEvent(Event):
 
 class ContractSendEvent(Event):
     pass
+
+
+class ContractSendExpirableEvent(ContractSendEvent):
+    def __init__(self, expiration: BlockExpiration):
+        self.expiration = expiration
 
 
 class ContractReceiveStateChange(StateChange):

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1713,9 +1713,11 @@ def handle_channel_closed(
             balance_proof
         )
         if call_update:
+            expiration = state_change.closed_block_number + channel_state.settle_timeout
             # The channel was closed by our partner, if there is a balance
             # proof available update this node half of the state
             update = ContractSendChannelUpdateTransfer(
+                expiration,
                 channel_state.identifier,
                 channel_state.token_network_identifier,
                 balance_proof,

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -1,6 +1,7 @@
 from raiden.constants import UINT256_MAX
 from raiden.transfer.architecture import (
     ContractSendEvent,
+    ContractSendExpirableEvent,
     Event,
     SendMessageEvent,
 )
@@ -102,10 +103,18 @@ class ContractSendChannelSettle(ContractSendEvent):
         return not self.__eq__(other)
 
 
-class ContractSendChannelUpdateTransfer(ContractSendEvent):
+class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     """ Event emitted if the netting channel balance proof must be updated. """
 
-    def __init__(self, channel_identifier, token_network_identifier, balance_proof):
+    def __init__(
+            self,
+            expiration: typing.BlockExpiration,
+            channel_identifier: typing.ChainID,
+            token_network_identifier: typing.TokenNetworkID,
+            balance_proof: BalanceProofSignedState,
+    ):
+        super().__init__(expiration)
+
         self.channel_identifier = channel_identifier
         self.token_network_identifier = token_network_identifier
         self.balance_proof = balance_proof
@@ -162,13 +171,14 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
         return not self.__eq__(other)
 
 
-class ContractSendSecretReveal(ContractSendEvent):
+class ContractSendSecretReveal(ContractSendExpirableEvent):
     """ Event emitted when the lock must be claimed on-chain. """
 
-    def __init__(self, secret: typing.Secret):
+    def __init__(self, expiration: typing.BlockExpiration, secret: typing.Secret):
         if not isinstance(secret, typing.T_Secret):
             raise ValueError('secret must be a Secret instance')
 
+        super().__init__(expiration)
         self.secret = secret
 
     def __repr__(self):

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -713,9 +713,10 @@ def events_for_onchain_secretreveal(
 
     for pair in reversed(pending_transfers_pairs):
         payer_channel = get_payer_channel(channelidentifiers_to_channels, pair)
+        expiration = pair.payer_transfer.lock.expiration
 
         safe_to_wait = is_safe_to_wait(
-            pair.payer_transfer.lock.expiration,
+            expiration,
             payer_channel.reveal_timeout,
             block_number,
         )
@@ -733,8 +734,8 @@ def events_for_onchain_secretreveal(
             )
             reveal_events = secret_registry.events_for_onchain_secretreveal(
                 payer_channel,
-                block_number,
                 secret,
+                expiration,
             )
             events.extend(reveal_events)
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -53,9 +53,10 @@ def events_for_onchain_secretreveal(target_state, channel_state, block_number):
     to be settled off-chain.
     """
     transfer = target_state.transfer
+    expiration = transfer.lock.expiration
 
     safe_to_wait = is_safe_to_wait(
-        transfer.lock.expiration,
+        expiration,
         channel_state.reveal_timeout,
         block_number,
     )
@@ -71,8 +72,8 @@ def events_for_onchain_secretreveal(target_state, channel_state, block_number):
         )
         return secret_registry.events_for_onchain_secretreveal(
             channel_state,
-            block_number,
             secret,
+            expiration,
         )
 
     return list()

--- a/raiden/transfer/secret_registry.py
+++ b/raiden/transfer/secret_registry.py
@@ -11,8 +11,8 @@ from raiden.transfer.state import (
 
 def events_for_onchain_secretreveal(
         channel_state: NettingChannelState,
-        block_number: typing.BlockNumber,
         secret: typing.Secret,
+        expiration: typing.BlockExpiration,
 ) -> typing.List[Event]:
     events = list()
 
@@ -20,7 +20,7 @@ def events_for_onchain_secretreveal(
         raise ValueError('secret must be a Secret instance')
 
     if get_status(channel_state) in CHANNEL_STATES_PRIOR_TO_CLOSED + (CHANNEL_STATE_CLOSED, ):
-        reveal_event = ContractSendSecretReveal(secret)
+        reveal_event = ContractSendSecretReveal(expiration, secret)
         events.append(reveal_event)
 
     return events


### PR DESCRIPTION
Transactions that are time dependent, i.e. must be mined before a given
block number, must be removed from the pending queue if time window is
lost.

[ci integration]