### PR TITLE
Minor logs fixes and improvements

### DIFF
--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -1,7 +1,8 @@
 import logging
 import logging.config
-import re
+import os
 import sys
+import re
 from traceback import TracebackException
 from functools import wraps
 from typing import Dict, Callable, Pattern, Tuple, List
@@ -255,3 +256,11 @@ def configure_logging(
     # all messages, which are then be filtered by the `RaidenFilter`
     structlog.get_logger('').setLevel(logger_level_config.get('', DEFAULT_LOG_LEVEL))
     structlog.get_logger('raiden').setLevel('DEBUG')
+
+    # rollover RotatingFileHandler on startup, to split logs also per-session
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            handler.flush()
+            if os.stat(handler.baseFilename).st_size > 0:
+                handler.doRollover()

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -133,7 +133,7 @@ def _get_log_file_handler() -> Dict:
     }
 
 
-def redactor(blacklist: Dict[Pattern, str]) -> Callable:
+def redactor(blacklist: Dict[Pattern, str]) -> Callable[[str], str]:
     """Returns a function which transforms a str, replacing all matches for its replacement"""
     def processor_wrapper(msg: str) -> str:
         for regex, repl in blacklist.items():
@@ -151,6 +151,7 @@ def _wrap_tracebackexception_format(redact: Callable[[str], str]):
     else:
         prev_fmt = TracebackException._orig_format = TracebackException.format
 
+    @wraps(TracebackException._orig_format)
     def tracebackexception_format(self, *, chain=True):
         for line in prev_fmt(self, chain=chain):
             yield redact(line)

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -253,4 +253,5 @@ def configure_logging(
 
     # set logging level of the root logger to DEBUG, to be able to intercept
     # all messages, which are then be filtered by the `RaidenFilter`
-    structlog.get_logger('').setLevel('DEBUG')
+    structlog.get_logger('').setLevel(logger_level_config.get('', DEFAULT_LOG_LEVEL))
+    structlog.get_logger('raiden').setLevel('DEBUG')

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -79,7 +79,9 @@ def get_best_routes(
 
     if not neighbors_heap:
         log.warning(
-            'No routes available from %s to %s' % (pex(from_address), pex(to_address)),
+            'No routes available',
+            from_address=pex(from_address),
+            to_address=pex(to_address),
         )
 
     while neighbors_heap:
@@ -99,8 +101,9 @@ def get_best_routes(
 
         if channel.get_status(channel_state) != CHANNEL_STATE_OPENED:
             log.info(
-                'channel %s - %s is not opened, ignoring' %
-                (pex(from_address), pex(partner_address)),
+                'channel is not opened, ignoring',
+                from_address=pex(from_address),
+                partner_address=pex(partner_address),
             )
             continue
 
@@ -111,16 +114,21 @@ def get_best_routes(
 
         if amount > distributable:
             log.info(
-                'channel %s - %s doesnt have enough funds [%s], ignoring' %
-                (pex(from_address), pex(partner_address), amount),
+                'channel doesnt have enough funds, ignoring',
+                from_address=pex(from_address),
+                partner_address=pex(partner_address),
+                amount=amount,
+                distributable=distributable,
             )
             continue
 
         network_state = network_statuses.get(partner_address, NODE_NETWORK_UNKNOWN)
         if network_state != NODE_NETWORK_REACHABLE:
             log.info(
-                'partner for channel %s - %s is not %s, ignoring' %
-                (pex(from_address), pex(partner_address), NODE_NETWORK_REACHABLE),
+                'partner for channel state isn\'t reachable, ignoring',
+                from_address=pex(from_address),
+                partner_address=pex(partner_address),
+                status=network_state,
             )
             continue
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict
 from urllib.parse import urljoin, urlparse
+from subprocess import DEVNULL
 
 import click
 import filelock
@@ -1235,6 +1236,7 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
                 local_matrix,
                 url=urljoin(args['matrix_server'], '/_matrix/client/versions'),
                 method='GET',
+                io=DEVNULL,
                 timeout=30,
                 shell=True,
             ):

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -1,13 +1,17 @@
 import socket
+import os
+import subprocess
 from mirakuru.http import HTTPExecutor as MiHTTPExecutor, HTTPConnection, HTTPException
+from mirakuru.base import ENV_UUID
 
 
 class HTTPExecutor(MiHTTPExecutor):
     """ Subclass off mirakuru.HTTPExecutor, which allows other methods than HEAD """
 
-    def __init__(self, *args, method='HEAD', **kwargs):
+    def __init__(self, *args, method='HEAD', io=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.method = method
+        self.stdio = io
 
     def after_start_check(self):
         """ Check if defined URL returns expected status to a <method> request. """
@@ -23,3 +27,33 @@ class HTTPExecutor(MiHTTPExecutor):
 
         except (HTTPException, socket.timeout, socket.error):
             return False
+
+    def start(self):
+        """ Reimplements SimpleExecutor.start by setting stdin/out to None instead of PIPE
+
+        It may break input/output/communicate, but will ensure child output redirects won't
+        break parent process
+        """
+        if self.process is None:
+            command = self.command
+            if not self._shell:
+                command = self.command_parts
+            if isinstance(self.stdio, (list, tuple)):
+                stdin, stdout, stderr = self.stdio
+            else:
+                stdin = stdout = stderr = self.stdio
+            env = os.environ.copy()
+            env[ENV_UUID] = self._uuid
+            self.process = subprocess.Popen(
+                command,
+                shell=self._shell,
+                stdin=stdin,
+                stdout=stdout,
+                stderr=stderr,
+                universal_newlines=True,
+                preexec_fn=os.setsid,
+                env=env,
+            )
+
+        self._set_timeout()
+        return self

--- a/tools/install_synapse.sh
+++ b/tools/install_synapse.sh
@@ -65,13 +65,11 @@ cp "${BASEDIR}/tools/synapse-config.yaml" "${DESTDIR}/"
 
 cat > "${DESTDIR}/run_synapse.sh" << EOF
 #!/usr/bin/env bash
+# redirect synapse stderr logs to stdout
+exec 2>&1
 SYNAPSEDIR=\$( dirname "\$0" )
-LOG_FILE="\${SYNAPSEDIR}/homeserver.log"
-[[ -f \${LOG_FILE} ]] && rm "\${LOG_FILE}"
-LOGGING_OPTION="--log-file \${LOG_FILE}"
 exec "\${SYNAPSEDIR}/synapse" \
   --server-name="\${SYNAPSE_SERVER_NAME:-${SYNAPSE_SERVER_NAME}}" \
-  --config-path="\${SYNAPSEDIR}/synapse-config.yaml" \
-  \${LOGGING_OPTION} \$@
+  --config-path="\${SYNAPSEDIR}/synapse-config.yaml" \$@
 EOF
 chmod 775 "${DESTDIR}/run_synapse.sh"


### PR DESCRIPTION
- Re-enable synapse logs, but output them to `stdout`, so pytest folding will keep them separated from most useful ones on `stderr`, like logging/structlog/raiden logs (can still be overriden through `--local-matrix` option/command) [requested [here](https://github.com/raiden-network/raiden/issues/2163#issuecomment-412548604)]
- Set default logging level on root logger, to avoid pytest capturing every debug log on every module, and spamming our logs (can still be overriden through `--log-config=":DEBUG"`)
- Rollover rotating debug log file on startup, to also split them per-session (maxSize will still split them on 5MB mark)
- Minor logs adaptation to structlog syntax