### PR TITLE
Removed address_by_endpoint from the proxies

### DIFF
--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -1,5 +1,4 @@
 import socket
-from typing import Tuple
 from eth_utils import is_binary_address
 
 import structlog
@@ -41,12 +40,6 @@ class Discovery:
             return self.nodeid_to_hostport[node_address]
         except KeyError:
             raise InvalidAddress('Unknown address {}'.format(pex(node_address)))
-
-    def nodeid_by_host_port(self, host_port):
-        for nodeid, value_hostport in self.nodeid_to_hostport.items():
-            if value_hostport == host_port:
-                return nodeid
-        return None
 
 
 class ContractDiscovery(Discovery):
@@ -107,11 +100,6 @@ class ContractDiscovery(Discovery):
         endpoint = self.discovery_proxy.endpoint_by_address(node_address)
         host_port = split_endpoint(endpoint)
         return host_port
-
-    def nodeid_by_host_port(self, host_port: Tuple[str, int]):
-        host, port = host_port
-        endpoint = host_port_to_endpoint(host, port)
-        return self.discovery_proxy.address_by_endpoint(endpoint)
 
     def version(self):
         return self.discovery_proxy.version()

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -1,5 +1,4 @@
 from eth_utils import (
-    to_canonical_address,
     to_checksum_address,
     is_binary_address,
     to_normalized_address,
@@ -84,14 +83,6 @@ class Discovery:
             raise UnknownAddress('Unknown address {}'.format(pex(node_address_bin)))
 
         return endpoint
-
-    def address_by_endpoint(self, endpoint):
-        address = self.proxy.contract.functions.findAddressByEndpoint(endpoint).call()
-
-        if address == self.not_found_address:  # the 0 address means nothing found
-            return None
-
-        return to_canonical_address(address)
 
     def version(self):
         return self.proxy.contract.functions.contract_version().call()

--- a/raiden/tests/integration/test_endpointregistry.py
+++ b/raiden/tests/integration/test_endpointregistry.py
@@ -32,16 +32,10 @@ def test_endpointregistry(private_keys, blockchain_services):
     with pytest.raises(UnknownAddress):
         contract_discovery.get(unregistered_address)
 
-    assert contract_discovery.nodeid_by_host_port(('127.0.0.1', 44444)) is None
-
     contract_discovery.register(my_address, '127.0.0.1', 44444)
-
-    assert contract_discovery.nodeid_by_host_port(('127.0.0.1', 44444)) == my_address
     assert contract_discovery.get(my_address) == ('127.0.0.1', 44444)
 
     contract_discovery.register(my_address, '127.0.0.1', 88888)
-
-    assert contract_discovery.nodeid_by_host_port(('127.0.0.1', 88888)) == my_address
     assert contract_discovery.get(my_address) == ('127.0.0.1', 88888)
 
     with pytest.raises(UnknownAddress):

--- a/raiden/tests/unit/test_mock.py
+++ b/raiden/tests/unit/test_mock.py
@@ -13,14 +13,10 @@ def test_mock_registry_api_compliance():
     with pytest.raises(InvalidAddress):
         contract_discovery_instance.get(address)
 
-    assert contract_discovery_instance.nodeid_by_host_port(('127.0.0.1', 44444)) is None
-
     # `update_endpoint` and 'classic' `register` do the same
     contract_discovery_instance.register(address, '127.0.0.1', 44444)
-    assert contract_discovery_instance.nodeid_by_host_port(('127.0.0.1', 44444)) == address
     assert contract_discovery_instance.get(address) == ('127.0.0.1', 44444)
 
     # `register`ing twice does update do the same
     contract_discovery_instance.register(address, '127.0.0.1', 88888)
-    assert contract_discovery_instance.nodeid_by_host_port(('127.0.0.1', 88888)) == address
     assert contract_discovery_instance.get(address) == ('127.0.0.1', 88888)


### PR DESCRIPTION
The smart contract function address_by_endpoint allowed a malicious node
to set its address for an endpoint which it did not control. The
functionality was not used and buggy, this removes it.

[ci integration]