### PR TITLE
[Breaking] Fix treee typo

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -258,7 +258,7 @@ def handle_contract_send_channelunlock(
         channel_unlock_event.channel_identifier,
     )
     try:
-        channel.unlock(channel_unlock_event.merkle_treee_leaves)
+        channel.unlock(channel_unlock_event.merkle_tree_leaves)
     except ChannelOutdatedError as e:
         log.error(str(e))
 

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -143,20 +143,20 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
 class ContractSendChannelBatchUnlock(ContractSendEvent):
     """ Event emitted when the lock must be claimed on-chain. """
 
-    def __init__(self, token_network_identifier, channel_identifier, merkle_treee_leaves):
+    def __init__(self, token_network_identifier, channel_identifier, merkle_tree_leaves):
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.merkle_treee_leaves = merkle_treee_leaves
+        self.merkle_tree_leaves = merkle_tree_leaves
 
     def __repr__(self):
         return (
             '<ContractSendChannelBatchUnlock '
-            'token_network_id:{} channel:{} merkle_treee_leaves:{}'
+            'token_network_id:{} channel:{} merkle_tree_leaves:{}'
             '>'
         ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
-            self.merkle_treee_leaves,
+            self.merkle_tree_leaves,
         )
 
     def __eq__(self, other):
@@ -164,7 +164,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             isinstance(other, ContractSendChannelBatchUnlock) and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.merkle_treee_leaves == other.merkle_treee_leaves
+            self.merkle_tree_leaves == other.merkle_tree_leaves
         )
 
     def __ne__(self, other):


### PR DESCRIPTION
This fixes a type `treee` in the client's codebase.
The change is breaking during WAL restoration