### PR TITLE
Fix `from` key missing from tx receipt by getting it from tx directly

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -283,7 +283,7 @@ class JSONRPCClient:
         return self.web3.eth.getTransactionReceipt(encode_hex(tx_hash))
 
     def get_transaction_from(self, tx_hash: bytes) -> Optional[Address]:
-        receipt = self.web3.eth.getTransactionReceipt(encode_hex(tx_hash))
+        receipt = self.web3.eth.getTransaction(encode_hex(tx_hash))
 
         if receipt:
             return to_canonical_address(receipt['from'])


### PR DESCRIPTION
Fix #2211 