### PR TITLE
Handle json decode error when matrix display name is invalid

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -878,7 +878,7 @@ class MatrixTransport:
             )
             if not (address and recovered and recovered == address):
                 return None
-        except (DecodeError, TypeError, MatrixRequestError, AssertionError):
+        except (DecodeError, TypeError, MatrixRequestError, json.decoder.JSONDecodeError):
             return None
         return address
 


### PR DESCRIPTION
Fix #2233