### PR TITLE
fix call to log.error

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -346,4 +346,4 @@ def on_raiden_event(raiden: RaidenService, event: Event):
         else:
             log.error('Unknown event {}'.format(type(event)))
     except RaidenRecoverableError as e:
-        log.error(e)
+        log.error(str(e))


### PR DESCRIPTION
the first argument must be a string