### PR TITLE
Fix matrix undefined retries by watching the message queues instead of internal async_results

### DIFF
--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -131,8 +131,11 @@ def channels_per_node():
 
 
 @pytest.fixture
-def retry_interval():
-    return 0.5
+def retry_interval(request):
+    if request.config.option.transport == 'matrix':
+        return 5
+    else:
+        return 0.5
 
 
 @pytest.fixture

--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -16,7 +16,7 @@ def pytest_generate_tests(metafunc):
         transport = metafunc.config.getoption('transport')
         transport_config = list()
 
-        if transport in ('udp', 'all'):
+        if transport in ('udp', 'all') and 'skip_if_not_matrix' not in metafunc.fixturenames:
             transport_config.append(
                 TransportConfig(protocol=TransportProtocol.UDP, parameters=None),
             )

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -25,7 +25,7 @@ def transport_config():
 @pytest.fixture
 def skip_if_not_udp(request):
     """Skip the test if not run with UDP transport"""
-    if request.config.option.transport == 'udp':
+    if request.config.option.transport in ('udp', 'all'):
         return
     pytest.skip('This test works only with UDP transport')
 
@@ -33,7 +33,7 @@ def skip_if_not_udp(request):
 @pytest.fixture
 def skip_if_not_matrix(request):
     """Skip the test if not run with Matrix transport"""
-    if request.config.option.transport == 'matrix':
+    if request.config.option.transport in ('matrix', 'all'):
         return
     pytest.skip('This test works only with Matrix transport')
 

--- a/raiden/tests/integration/transfer/test_directransfer.py
+++ b/raiden/tests/integration/transfer/test_directransfer.py
@@ -66,7 +66,7 @@ def test_direct_transfer_to_offline_node(raiden_network, token_addresses, deposi
 
     app1.raiden.start()
     exception = ValueError('Waiting for transfer received success in the WAL timed out')
-    with gevent.Timeout(seconds=5, exception=exception):
+    with gevent.Timeout(seconds=60, exception=exception):
         wait_for_transfer_success(
             app1.raiden,
             payment_identifier,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from raiden.messages import LockedTransfer, RevealSecret
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
@@ -98,6 +99,71 @@ def test_mediated_transfer_with_entire_deposit(
         token_network_identifier,
         app1, deposit * 2, [],
         app2, 0, [],
+        func=assert_synced_channel_state,
+        timeout=network_wait,
+    )
+
+
+class _patch_transport:
+    def __init__(self, transport_patched):
+        self.patched = transport_patched
+        self.patched._receive_message_unpatched = self.patched._receive_message
+        self.patched._receive_message = lambda msg: self._receive_message(msg)
+        self.done = False
+        self.message = None
+
+    def _receive_message(self, message):
+        if not self.done and self.message is None and isinstance(message, LockedTransfer):
+            self.message = message
+            return
+        self.patched._receive_message_unpatched(message)
+        if not self.done and self.message is not None and isinstance(message, RevealSecret):
+            self.patched._receive_message(self.message)
+            self.done = True
+
+
+@pytest.mark.parametrize('channels_per_node', [CHAIN])
+@pytest.mark.parametrize('number_of_nodes', [3])
+def test_mediated_transfer_messages_out_of_order(
+        raiden_network,
+        number_of_nodes,
+        deposit,
+        token_addresses,
+        network_wait,
+        skip_if_not_matrix,
+):
+    app0, app1, app2 = raiden_network
+    _patch_transport(app1.raiden.transport)
+    _patch_transport(app2.raiden.transport)
+    token_address = token_addresses[0]
+    chain_state = views.state_from_app(app0)
+    payment_network_id = app0.raiden.default_registry.address
+    token_network_identifier = views.get_token_network_identifier_by_token_address(
+        chain_state,
+        payment_network_id,
+        token_address,
+    )
+
+    amount = 10
+    mediated_transfer(
+        app0,
+        app2,
+        token_network_identifier,
+        amount,
+        timeout=network_wait * number_of_nodes,
+    )
+
+    wait_assert(
+        token_network_identifier,
+        app0, deposit - amount, [],
+        app1, deposit + amount, [],
+        func=assert_synced_channel_state,
+        timeout=network_wait,
+    )
+    wait_assert(
+        token_network_identifier,
+        app1, deposit - amount, [],
+        app2, deposit + amount, [],
         func=assert_synced_channel_state,
         timeout=network_wait,
     )

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -1,7 +1,6 @@
 """ Utilities to set-up a Raiden network. """
 from binascii import hexlify
 from collections import namedtuple
-from os import environ
 
 import gevent
 from gevent import server
@@ -320,8 +319,6 @@ def create_apps(
                     },
                 },
             )
-            if 'TRAVIS' in environ:
-                config['transport']['matrix']['login_retry_wait'] = 1.5
 
         config_copy = App.DEFAULT_CONFIG.copy()
         config_copy.update(config)

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -9,13 +9,14 @@ import networkx
 from raiden.constants import UINT256_MAX, UINT64_MAX
 from raiden.encoding.format import buffer_for
 from raiden.encoding import messages
-from raiden.transfer.architecture import State
+from raiden.transfer.architecture import State, SendMessageEvent
 from raiden.transfer.merkle_tree import merkleroot
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import lpex, pex, sha3, typing
 
 SecretHashToLock = typing.Dict[typing.SecretHash, 'HashTimeLockState']
 SecretHashToPartialUnlockProof = typing.Dict[typing.SecretHash, 'UnlockPartialProofState']
+QueueIdsToQueues = typing.Dict[typing.QueueIdentifier, typing.List[SendMessageEvent]]
 
 CHANNEL_STATE_CLOSED = 'closed'
 CHANNEL_STATE_CLOSING = 'waiting_for_close'
@@ -133,7 +134,7 @@ class ChainState(State):
         self.payment_mapping = PaymentMappingState()
         self.pending_transactions = list()
         self.pseudo_random_generator = pseudo_random_generator
-        self.queueids_to_queues = dict()
+        self.queueids_to_queues: QueueIdsToQueues = dict()
 
     def __repr__(self):
         return '<ChainState block:{} networks:{} qty_transfers:{} chain_id:{}>'.format(

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -1,5 +1,5 @@
 from raiden.transfer import channel
-from raiden.transfer.architecture import ContractSendEvent, SendMessageEvent
+from raiden.transfer.architecture import ContractSendEvent
 from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     CHANNEL_STATE_CLOSING,
@@ -15,6 +15,7 @@ from raiden.transfer.state import (
     InitiatorTask,
     MediatorTask,
     TargetTask,
+    QueueIdsToQueues,
 )
 from raiden.utils import typing
 
@@ -74,7 +75,7 @@ def get_pending_transactions(chain_state: ChainState) -> typing.List[ContractSen
 
 def get_all_messagequeues(
         chain_state: ChainState,
-) -> typing.Dict[typing.QueueIdentifier, typing.List[SendMessageEvent]]:
+) -> QueueIdsToQueues:
     return chain_state.queueids_to_queues
 
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -1,5 +1,5 @@
 from raiden.transfer import channel
-from raiden.transfer.architecture import ContractSendEvent
+from raiden.transfer.architecture import ContractSendEvent, SendMessageEvent
 from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     CHANNEL_STATE_CLOSING,
@@ -72,7 +72,9 @@ def get_pending_transactions(chain_state: ChainState) -> typing.List[ContractSen
     return chain_state.pending_transactions
 
 
-def get_all_messagequeues(chain_state: ChainState) -> typing.Dict:
+def get_all_messagequeues(
+        chain_state: ChainState,
+) -> typing.Dict[typing.QueueIdentifier, typing.List[SendMessageEvent]]:
     return chain_state.queueids_to_queues
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ raiden-libs==0.1.4
 raiden-contracts==0.2.0
 webargs==1.8.1
 eth-keyfile==0.5.1
-eth_utils==1.0.3
+eth-utils==1.2.0
 structlog
 colorama
 py-solc

--- a/tools/install_synapse.sh
+++ b/tools/install_synapse.sh
@@ -66,7 +66,11 @@ cp "${BASEDIR}/tools/synapse-config.yaml" "${DESTDIR}/"
 cat > "${DESTDIR}/run_synapse.sh" << EOF
 #!/usr/bin/env bash
 # redirect synapse stderr logs to stdout
-exec 2>&1
+if [[ -n "\${STDOUT_SYNAPSE}" ]]; then
+  exec 2>&1
+else
+  exec &> /dev/null
+fi
 SYNAPSEDIR=\$( dirname "\$0" )
 exec "\${SYNAPSEDIR}/synapse" \
   --server-name="\${SYNAPSE_SERVER_NAME:-${SYNAPSE_SERVER_NAME}}" \


### PR DESCRIPTION
Needed for #1611 and #2208 (contains fixes unrelated to that issue which were accumlating there)
- matrix transport will retry sending a message while it's still in the queue (depending on Raiden upper logic to clean it when successful or not and stop/give up retrying)
- send only if the node is online, or else keeps waiting and send when it comes online
- send Delivered before Processed
- fix an up to 2s delay on first message sent to a partner related to join/create room loop sleep
- cache messages handling for some seconds to prevent a synapse bug when a single send/put message generates 2 event copies, and we only want to handle it once
- fix a race on create/join discovery room in tests, retrying for some times until succesful