### PR TITLE
Bump gevent to 1.3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ colorama
 py-solc
 web3==4.4.1
 pysha3==1.0.2
-gevent==1.3.2
+gevent==1.3.6
 pytoml==0.1.18


### PR DESCRIPTION
Now that gevent has included a fix for https://github.com/gevent/gevent/issues/1260 in a release we should bump to it so that we don't have to manually recompile gevent whenever we use python 3.7