### PR TITLE
change open to opened in example responses

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -166,7 +166,7 @@ Querying Information About Channels and Tokens
               "token_address": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
               "balance": 25000000,
               "total_deposit": 35000000,
-              "state": "open",
+              "state": "opened",
               "settle_timeout": 100,
               "reveal_timeout": 30
           }
@@ -200,7 +200,7 @@ Querying Information About Channels and Tokens
           "token_address": "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8",
           "balance": 25000000,
           "total_deposit": 35000000,
-          "state": "open",
+          "state": "opened",
           "settle_timeout": 100,
           "reveal_timeout": 30
       }


### PR DESCRIPTION
according to Channel Object specification:

state should be the current state of the channel represented by a string. Possible value are: - 'opened': The channel is open and tokens are tradeable - 'closed': The channel has been closed by a participant - 'settled': The channel has been closed by a participant and also settled.

