### PR TITLE
Fix polling mechanism issues

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`2282` Fixes internal webui error that would not propagate channel updates.
+* :bug:`2284` Fixes balance notifications showing for wrong channels.
 * :bug:`2285` Request user acknowledgement for the experimental software disclaimer.
 * :bug:`2277` Fixes sorting by balance for tokens and channels.
 * :bug:`2278` Fixes leave network button request.

--- a/raiden/ui/web/src/app/services/channel-polling.service.spec.ts
+++ b/raiden/ui/web/src/app/services/channel-polling.service.spec.ts
@@ -44,6 +44,15 @@ describe('ChannelPollingService', () => {
         decimals: 8
     };
 
+    const token2: UserToken = {
+        address: '0xeB7f4BBAa1714F3E5a12fF8B681908D7b98BD195',
+        symbol: 'TST2',
+        name: 'Test Suite Token 2',
+        balance: 20,
+        decimals: 8
+    };
+
+
     const channel1: Channel = {
         state: 'opened',
         channel_identifier: 1,
@@ -54,6 +63,18 @@ describe('ChannelPollingService', () => {
         total_deposit: 10,
         settle_timeout: 500,
         userToken: token
+    };
+
+    const channel1Network2: Channel = {
+        state: 'opened',
+        channel_identifier: 1,
+        token_address: '0xeB7f4BBAa1714F3E5a12fF8B681908D7b98BD195',
+        partner_address: '0x774aFb0652ca2c711fD13e6E9d51620568f6Ca82',
+        reveal_timeout: 600,
+        balance: 20,
+        total_deposit: 10,
+        settle_timeout: 500,
+        userToken: token2
     };
 
     const channel1Updated: Channel = {
@@ -116,55 +137,64 @@ describe('ChannelPollingService', () => {
 
     it('should show a notification on balance increases', fakeAsync(() => {
         raidenServiceSpy.and.returnValues(from([[channel1], [channel1Updated]]));
-        const subcription = pollingService.channels().subscribe();
+        const subscription = pollingService.channels().subscribe();
         expect(sharedService.info).toHaveBeenCalledTimes(1);
         // @ts-ignore
         const payload = sharedService.info.calls.first().args[0];
         expect(payload.title).toBe('Balance Update');
-        subcription.unsubscribe();
+        subscription.unsubscribe();
         flush();
     }));
 
     it('should not show a notification on when balance is reduced', fakeAsync(() => {
         raidenServiceSpy.and.returnValues(from([[channel1], [channel1UpdatedNegative]]));
-        const subcription = pollingService.channels().subscribe();
+        const subscription = pollingService.channels().subscribe();
         expect(sharedService.info).toHaveBeenCalledTimes(0);
-        subcription.unsubscribe();
+        subscription.unsubscribe();
         flush();
     }));
 
     it('should not send notification about channel the first time loading the channels', fakeAsync(() => {
         raidenServiceSpy.and.returnValues(from([[], [channel1]]));
-        const subcription = pollingService.channels().subscribe();
+        const subscription = pollingService.channels().subscribe();
         expect(sharedService.info).toHaveBeenCalledTimes(0);
-        subcription.unsubscribe();
+        subscription.unsubscribe();
         flush();
     }));
 
     it('should show notification if new channels are detected', fakeAsync(() => {
         raidenServiceSpy.and.returnValues(from([[channel1], [channel1, channel2]]));
-        const subcription = pollingService.channels().subscribe();
+        const subscription = pollingService.channels().subscribe();
         expect(sharedService.info).toHaveBeenCalledTimes(1);
         // @ts-ignore
         const payload = sharedService.info.calls.first().args[0];
         expect(payload.title).toBe('New channel');
-        subcription.unsubscribe();
+        subscription.unsubscribe();
         flush();
     }));
 
     it('should not show a notification if no new channels are detected', fakeAsync(() => {
         raidenServiceSpy.and.returnValues(from([[channel1], [channel1]]));
-        const subcription = pollingService.channels().subscribe();
+        const subscription = pollingService.channels().subscribe();
         expect(sharedService.info).toHaveBeenCalledTimes(0);
-        subcription.unsubscribe();
+        subscription.unsubscribe();
         flush();
     }));
 
     it('should not throw if a channel is removed from the list', fakeAsync(() => {
         raidenServiceSpy.and.returnValues(from([[channel1, channel2], [channel1]]));
-        const subcription = pollingService.channels().subscribe();
+        const subscription = pollingService.channels().subscribe();
         expect(sharedService.info).toHaveBeenCalledTimes(0);
-        subcription.unsubscribe();
+        subscription.unsubscribe();
+        flush();
+    }));
+
+
+    it('should not show a notification for the same identifier on different network', fakeAsync(() => {
+        raidenServiceSpy.and.returnValues(from([[channel1, channel1Network2], [channel1Network2]]));
+        const subscription = pollingService.channels().subscribe();
+        expect(sharedService.info).toHaveBeenCalledTimes(0);
+        subscription.unsubscribe();
         flush();
     }));
 });

--- a/raiden/ui/web/src/app/services/channel-polling.service.spec.ts
+++ b/raiden/ui/web/src/app/services/channel-polling.service.spec.ts
@@ -159,4 +159,12 @@ describe('ChannelPollingService', () => {
         subcription.unsubscribe();
         flush();
     }));
+
+    it('should not throw if a channel is removed from the list', fakeAsync(() => {
+        raidenServiceSpy.and.returnValues(from([[channel1, channel2], [channel1]]));
+        const subcription = pollingService.channels().subscribe();
+        expect(sharedService.info).toHaveBeenCalledTimes(0);
+        subcription.unsubscribe();
+        flush();
+    }));
 });

--- a/raiden/ui/web/src/app/services/channel-polling.service.ts
+++ b/raiden/ui/web/src/app/services/channel-polling.service.ts
@@ -81,7 +81,7 @@ export class ChannelPollingService {
 
     // noinspection JSMethodCanBeStatic
     private isTheSameChannel(channel1: Channel, channel2: Channel): boolean {
-        return channel1.channel_identifier === channel2.channel_identifier;
+        return channel1.channel_identifier === channel2.channel_identifier && channel1.token_address === channel2.token_address;
     }
 
     private informAboutNewChannel(channel: Channel) {

--- a/raiden/ui/web/src/app/services/channel-polling.service.ts
+++ b/raiden/ui/web/src/app/services/channel-polling.service.ts
@@ -72,7 +72,7 @@ export class ChannelPollingService {
     private checkForBalanceChanges(oldChannels: Channel[], newChannels: Channel[]) {
         for (const oldChannel of oldChannels) {
             const newChannel = newChannels.find(channel => this.isTheSameChannel(oldChannel, channel));
-            if (newChannel.balance <= oldChannel.balance) {
+            if (!newChannel || newChannel.balance <= oldChannel.balance) {
                 continue;
             }
             this.informAboutBalanceUpdate(newChannel, oldChannel.balance);


### PR DESCRIPTION
Changes channel identification mechanism to include `token_address` along with `channel_identifier`
Add check for newChannel being null when checking for balance changes.

Closes #2282
Closes #2284 