### PR TITLE
bugfix: target must send processed

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -5,7 +5,11 @@ import pytest
 
 from raiden.constants import UINT64_MAX
 from raiden.transfer import channel
-from raiden.transfer.events import ContractSendChannelClose, ContractSendSecretReveal
+from raiden.transfer.events import (
+    ContractSendChannelClose,
+    ContractSendSecretReveal,
+    SendProcessed,
+)
 from raiden.transfer.mediated_transfer import target
 from raiden.transfer.mediated_transfer.state import TargetTransferState
 from raiden.transfer.mediated_transfer.state_change import (
@@ -223,14 +227,13 @@ def test_handle_inittarget():
         block_number,
     )
 
-    events = iteration.events
-    assert events
-    assert isinstance(events[0], SendSecretRequest)
-
-    assert events[0].payment_identifier == from_transfer.payment_identifier
-    assert events[0].amount == from_transfer.lock.amount
-    assert events[0].secrethash == from_transfer.lock.secrethash
-    assert events[0].recipient == initiator
+    assert must_contain_entry(iteration.events, SendSecretRequest, {
+        'payment_identifier': from_transfer.payment_identifier,
+        'amount': from_transfer.lock.amount,
+        'secrethash': from_transfer.lock.secrethash,
+        'recipient': initiator,
+    })
+    assert must_contain_entry(iteration.events, SendProcessed, {})
 
 
 def test_handle_inittarget_bad_expiration():

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -95,7 +95,7 @@ def handle_inittarget(
     )
 
     assert channel_state.identifier == transfer.balance_proof.channel_identifier
-    is_valid, _, errormsg = channel.handle_receive_lockedtransfer(
+    is_valid, channel_events, errormsg = channel.handle_receive_lockedtransfer(
         channel_state,
         transfer,
     )
@@ -121,7 +121,8 @@ def handle_inittarget(
             secrethash=transfer.lock.secrethash,
         )
 
-        iteration = TransitionResult(target_state, [secret_request])
+        channel_events.append(secret_request)
+        iteration = TransitionResult(target_state, channel_events)
     else:
         if not is_valid:
             failure_reason = errormsg
@@ -133,7 +134,9 @@ def handle_inittarget(
             secrethash=transfer.lock.secrethash,
             reason=failure_reason,
         )
-        iteration = TransitionResult(target_state, [unlock_failed])
+
+        channel_events.append(unlock_failed)
+        iteration = TransitionResult(target_state, channel_events)
 
     return iteration
 


### PR DESCRIPTION
the mediated transfer received by the target must be confirmed,
otherwise the previous hop won't send the unlock message and the lock
will be unlocked on-chain.