### PR TITLE
Fix `identifier_to_results` items lifecycle

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -134,8 +134,7 @@ def handle_paymentsentsuccess(
         raiden: RaidenService,
         payment_sent_success_event: EventPaymentSentSuccess,
 ):
-    if payment_sent_success_event.identifier not in raiden.identifier_to_results:
-        return
+    assert payment_sent_success_event.identifier in raiden.identifier_to_results
 
     result = raiden.identifier_to_results[payment_sent_success_event.identifier]
     result.set(True)
@@ -147,8 +146,7 @@ def handle_paymentsentfailed(
         raiden: RaidenService,
         payment_sent_failed_event: EventPaymentSentFailed,
 ):
-    if payment_sent_failed_event.identifier not in raiden.identifier_to_results:
-        return
+    assert payment_sent_failed_event.identifier in raiden.identifier_to_results
 
     result = raiden.identifier_to_results[payment_sent_failed_event.identifier]
     result.set(False)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -561,6 +561,9 @@ class RaidenService:
             amount,
         )
 
+        async_result = AsyncResult()
+        self.identifier_to_results[identifier] = async_result
+
         self.handle_state_change(direct_transfer)
 
     def start_mediated_transfer(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -52,6 +52,7 @@ from raiden.utils import (
     create_default_identifier,
     typing,
 )
+from raiden.transfer.events import SendDirectTransfer
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -290,6 +291,11 @@ class RaidenService:
         self.alarm.start()
 
         queueids_to_queues = views.get_all_messagequeues(chain_state)
+        # repopulate identifier_to_results for pending transfers
+        for queue_messages in queueids_to_queues.values():
+            for message in queue_messages:
+                if isinstance(message, SendDirectTransfer):
+                    self.identifier_to_results[message.payment_identifier] = AsyncResult()
         self.transport.start(self, queueids_to_queues)
 
         # Health check needs the transport layer

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -125,7 +125,7 @@ def mediated_transfer(
         target_app.raiden.address,
         identifier,
     )
-    assert async_result.wait(timeout)
+    assert async_result.wait(timeout), f'timeout for transfer id={identifier}'
     gevent.sleep(0.3)  # let the other nodes synch
 
 


### PR DESCRIPTION
- fixes bug where `id -> AsyncResult` pair wasn't created for direct transfers.
- repopulates `identifier_to_results` on startup if there are any pending transfers