### PR TITLE
Increase network timeout for mediated transfer test

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -124,7 +124,7 @@ class _patch_transport:
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
-@pytest.skip('Currently fails on travis')
+@pytest.mark.parametrize('network_wait', [15])
 def test_mediated_transfer_messages_out_of_order(
         raiden_network,
         number_of_nodes,


### PR DESCRIPTION
- Increased timeout to 15s. With default value of five the node failed to register the payment within the wait period.