### PR TITLE
tests: stop using memory database

### DIFF
--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -294,25 +294,8 @@ def rest_api_port_number(port_generator):
 
 
 @pytest.fixture
-def in_memory_database():
-    """A boolean value indicating whether the sqlite3 databases will be in memory
-    or in normal files. Defaults to True (in memory)."""
-    return True
-
-
-@pytest.fixture
-def database_paths(tmpdir, private_keys, in_memory_database):
-    """ Sqlite database paths for each app.
-    """
-    # According to http://www.sqlite.org/inmemorydb.html each memory connection will
-    # create a unique in-memory DB, which is exactly what we need in this case for
-    # each different Raiden app
-    if in_memory_database:
-        return [
-            ':memory:'
-            for position in range(len(private_keys))
-        ]
-
+def database_paths(tmpdir, private_keys):
+    """ Sqlite database paths for each app. """
     database_paths = list()
     for pkey in private_keys:
         app_dir = os.path.join(

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -18,7 +18,6 @@ from raiden.transfer.state_change import (
 )
 
 
-@pytest.mark.parametrize('in_memory_database', [False])
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
@@ -131,7 +130,6 @@ def test_recovery_happy_case(
     )
 
 
-@pytest.mark.parametrize('in_memory_database', [False])
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
@@ -226,7 +224,6 @@ def test_recovery_unhappy_case(
     })
 
 
-@pytest.mark.parametrize('in_memory_database', [False])
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [2])

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -11,7 +11,6 @@ from raiden.network.transport import MatrixTransport
 from raiden.app import App
 
 
-@pytest.mark.parametrize('in_memory_database', [False])
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [2])


### PR DESCRIPTION
Using the memory database is just a bad surprise when a test for
restartability is written.

[ci integration]