### PR TITLE
User superclass __eq__ for inheriting statechanges and events

### DIFF
--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -107,6 +107,17 @@ class SendMessageEvent(Event):
         )
         self.message_identifier = message_identifier
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, SendMessageEvent) and
+            self.recipient == other.recipient and
+            self.queue_identifier == other.queue_identifier and
+            self.message_identifier == other.message_identifier
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class ContractSendEvent(Event):
     pass
@@ -116,10 +127,28 @@ class ContractSendExpirableEvent(ContractSendEvent):
     def __init__(self, expiration: BlockExpiration):
         self.expiration = expiration
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, ContractSendExpirableEvent) and
+            self.expiration == other.expiration
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class ContractReceiveStateChange(StateChange):
     def __init__(self, transaction_hash: TransactionHash):
         self.transaction_hash = transaction_hash
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ContractReceiveStateChange) and
+            self.transaction_hash == other.transaction_hash
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class StateManager:

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -133,7 +133,8 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
             isinstance(other, ContractSendChannelUpdateTransfer) and
             self.channel_identifier == other.channel_identifier and
             self.token_network_identifier == other.token_network_identifier and
-            self.balance_proof == other.balance_proof
+            self.balance_proof == other.balance_proof and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -188,7 +189,8 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
     def __eq__(self, other):
         return (
             isinstance(other, ContractSendSecretReveal) and
-            self.secret == other.secret
+            self.secret == other.secret and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -432,12 +434,10 @@ class SendDirectTransfer(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendDirectTransfer) and
-            self.message_identifier == other.message_identifier and
             self.payment_identifier == other.payment_identifier and
-            self.queue_identifier == other.queue_identifier and
             self.balance_proof == other.balance_proof and
             self.token == other.token and
-            self.recipient == other.recipient
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -456,8 +456,7 @@ class SendProcessed(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendProcessed) and
-            self.message_identifier == other.message_identifier and
-            self.recipient == other.recipient
+            super().__eq__(other)
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -59,9 +59,8 @@ class SendLockedTransfer(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendLockedTransfer) and
-            self.message_identifier == other.message_identifier and
             self.transfer == other.transfer and
-            self.recipient == other.recipient
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -121,11 +120,9 @@ class SendRevealSecret(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendRevealSecret) and
-            self.recipient == other.recipient and
-            self.queue_identifier == other.queue_identifier and
-            self.message_identifier == other.message_identifier and
             self.secret == other.secret and
-            self.secrethash == other.secrethash
+            self.secrethash == other.secrethash and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -181,14 +178,12 @@ class SendBalanceProof(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendBalanceProof) and
-            self.recipient == other.recipient and
-            self.queue_identifier == other.queue_identifier and
-            self.message_identifier == other.message_identifier and
             self.payment_identifier == other.payment_identifier and
             self.token == other.token and
             self.recipient == other.recipient and
             self.secret == other.secret and
-            self.balance_proof == other.balance_proof
+            self.balance_proof == other.balance_proof and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -235,14 +230,12 @@ class SendSecretRequest(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendSecretRequest) and
-            self.recipient == other.recipient and
-            self.queue_identifier == other.queue_identifier and
-            self.message_identifier == other.message_identifier and
             self.payment_identifier == other.payment_identifier and
             self.amount == other.amount and
             self.expiration == other.expiration and
             self.secrethash == other.secrethash and
-            self.recipient == other.recipient
+            self.recipient == other.recipient and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -298,16 +291,14 @@ class SendRefundTransfer(SendMessageEvent):
     def __eq__(self, other):
         return (
             isinstance(other, SendRefundTransfer) and
-            self.recipient == other.recipient and
-            self.queue_identifier == other.queue_identifier and
-            self.message_identifier == other.message_identifier and
             self.payment_identifier == other.payment_identifier and
             self.token == other.token and
             self.balance_proof == other.balance_proof and
             self.lock == other.lock and
             self.initiator == other.initiator and
             self.target == other.target and
-            self.recipient == other.recipient
+            self.recipient == other.recipient and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -178,9 +178,9 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelNew) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
-            self.channel_state == other.channel_state
+            self.channel_state == other.channel_state and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -223,11 +223,11 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelClosed) and
-            self.transaction_hash == other.transaction_hash and
             self.transaction_from == other.transaction_from and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.closed_block_number == other.closed_block_number
+            self.closed_block_number == other.closed_block_number and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -332,10 +332,10 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelNewBalance) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.deposit_transaction == other.deposit_transaction
+            self.deposit_transaction == other.deposit_transaction and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -373,10 +373,10 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelSettled) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.settle_block_number == other.settle_block_number
+            self.settle_block_number == other.settle_block_number and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -452,8 +452,8 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveNewPaymentNetwork) and
-            self.transaction_hash == other.transaction_hash and
-            self.payment_network == other.payment_network
+            self.payment_network == other.payment_network and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -486,9 +486,9 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveNewTokenNetwork) and
-            self.transaction_hash == other.transaction_hash and
             self.payment_network_identifier == other.payment_network_identifier and
-            self.token_network == other.token_network
+            self.token_network == other.token_network and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -528,10 +528,10 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveSecretReveal) and
-            self.transaction_hash == other.transaction_hash and
             self.secret_registry_address == other.secret_registry_address and
             self.secrethash == other.secrethash and
-            self.secret == other.secret
+            self.secret == other.secret and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -595,13 +595,13 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelBatchUnlock) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
             self.participant == other.participant and
             self.partner == other.partner and
             self.locksroot == other.locksroot and
             self.unlocked_amount == other.unlocked_amount and
-            self.returned_tokens == other.returned_tokens
+            self.returned_tokens == other.returned_tokens and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -644,11 +644,11 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveRouteNew) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
             self.participant1 == other.participant1 and
-            self.participant2 == other.participant2
+            self.participant2 == other.participant2 and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -678,9 +678,9 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveRouteClosed) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
-            self.channel_identifier == other.channel_identifier
+            self.channel_identifier == other.channel_identifier and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):
@@ -707,10 +707,10 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveUpdateTransfer) and
-            self.transaction_hash == other.transaction_hash and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.nonce == other.nonce
+            self.nonce == other.nonce and
+            super().__eq__(other)
         )
 
     def __ne__(self, other):


### PR DESCRIPTION
Some of the state changes and events which inherited from another one were not
testing for equality of attributes of the inherited class. This patch aims to
fix that.

[ci integration]