### PR TITLE
Removed unused flag leave_channels

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -132,13 +132,10 @@ class App:  # pylint: disable=too-few-public-methods
         """ Start the raiden app. """
         self.raiden.start()
 
-    def stop(self, leave_channels: bool = False):
+    def stop(self):
         """ Stop the raiden app.
 
         Args:
             leave_channels: if True, also close and settle all channels before stopping
         """
-        if leave_channels:
-            self.raiden.close_and_settle()
-
         self.raiden.stop()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -221,7 +221,10 @@ class RaidenService:
         )
 
         if self.wal.state_manager.current_state is None:
-            log.debug('No recoverable state available, created inital state')
+            log.debug(
+                'No recoverable state available, created inital state',
+                node=pex(self.address),
+            )
             block_number = self.chain.block_number()
 
             state_change = ActionInitChain(
@@ -250,7 +253,11 @@ class RaidenService:
             # for that given block have been processed, filters can be safely
             # installed starting from this position without losing events.
             last_log_block_number = views.block_number(self.wal.state_manager.current_state)
-            log.debug('Restored state from WAL', last_restored_block=last_log_block_number)
+            log.debug(
+                'Restored state from WAL',
+                last_restored_block=last_log_block_number,
+                node=pex(self.address),
+            )
 
         # Restore the current snapshot group
         self.snapshot_group = last_log_block_number // SNAPSHOT_BLOCK_COUNT
@@ -283,6 +290,7 @@ class RaidenService:
         log.debug(
             'Processing pending transactions',
             num_pending_transactions=len(pending_transactions),
+            node=pex(self.address),
         )
         with self.dispatch_events_lock:
             for transaction in pending_transactions:

--- a/raiden/tests/utils/tests.py
+++ b/raiden/tests/utils/tests.py
@@ -19,7 +19,7 @@ def cleanup_tasks():
 def shutdown_apps_and_cleanup_tasks(raiden_apps):
     for app in raiden_apps:
         try:
-            app.stop(leave_channels=False)
+            app.stop()
         except RaidenShuttingDown:
             pass
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -925,7 +925,7 @@ class NodeRunner:
             else:
                 # Shouldn't happen
                 raise RuntimeError(f"Invalid transport type '{self._options['transport']}'")
-            app.stop(leave_channels=False)
+            app.stop()
         except ReplacementTransactionUnderpriced as e:
             print(
                 '{}. Please make sure that this Raiden node is the '


### PR DESCRIPTION
The user can still close all channels through the REST API