### PR TITLE
NotifyingQueue must start set if it has items

### DIFF
--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -375,6 +375,7 @@ class UDPTransport(Runnable):
             'new queue created for',
             node=pex(self.raiden.address),
             queue_identifier=queue_identifier,
+            items_qty=len(items),
         )
 
         return queue

--- a/raiden/tests/unit/test_notifyingqueue.py
+++ b/raiden/tests/unit/test_notifyingqueue.py
@@ -34,3 +34,8 @@ def test_event_must_be_set():
     element = 1
     gevent.spawn_later(spawn_after_seconds, add_element_to_queue, queue, element)
     assert data_or_stop.wait()
+
+
+def test_not_empty():
+    queue = NotifyingQueue(items=[1, 2])
+    assert queue.is_set()

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -9,6 +9,9 @@ class NotifyingQueue(Event):
         super().__init__()
         self._queue = Queue(maxsize, items)
 
+        if items:
+            self.set()
+
     def put(self, item):
         """ Add new item to the queue. """
         self._queue.put(item)


### PR DESCRIPTION
For the queue to be processed on restarts, where the node has pending
messages from the previous runs, the previous messages must be passed to
the queue and the queue must be set.