### PR TITLE
 Fix set_total_deposit error handling 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2283` Fix API server Internal server error at token deposits.
 * :bug:`2336` Fixes webui wallet page not loading data due to error.
 
 * :release:`0.7.0 <2018-08-31>`

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -540,7 +540,7 @@ class TokenNetwork:
                 # Can happen if two calls to deposit happen and then we get here on the second call
                 raise DepositMismatch(
                     f'total_deposit - current_deposit =  '
-                    f'{amount_to_deposit} must be greater than 0.'
+                    f'{amount_to_deposit} must be greater than 0.',
                 )
 
             # A node may be setting up multiple channels for the same token

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -537,7 +537,11 @@ class TokenNetwork:
                     f'than the requested total deposit amount ({total_deposit})',
                 )
             if amount_to_deposit <= 0:
-                raise ValueError(f'deposit {amount_to_deposit} must be greater than 0.')
+                # Can happen if two calls to deposit happen and then we get here on the second call
+                raise DepositMismatch(
+                    f'total_deposit - current_deposit =  '
+                    f'{amount_to_deposit} must be greater than 0.'
+                )
 
             # A node may be setting up multiple channels for the same token
             # concurrently. Because each deposit changes the user balance this
@@ -553,9 +557,9 @@ class TokenNetwork:
             #
             current_balance = token.balance_of(self.node_address)
             if current_balance < amount_to_deposit:
-                raise ValueError(
-                    f'deposit {amount_to_deposit} can not be larger than the '
-                    f'available balance {current_balance}, '
+                raise DepositMismatch(
+                    f'total_deposit - current_deposit =  {amount_to_deposit} can not '
+                    f'be larger than the available balance {current_balance}, '
                     f'for token at address {pex(token_address)}',
                 )
 

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -182,7 +182,7 @@ def test_token_network_proxy_basics(
 
     # channel is open.
     # deposit with no balance
-    with pytest.raises(ValueError):
+    with pytest.raises(DepositMismatch):
         c1_token_network_proxy.set_total_deposit(
             channel_identifier,
             101,


### PR DESCRIPTION
Fix #2283 

If f two calls on the deposit happen one after another then a `ValueError` will be
thrown for the second one. We don't catch `ValueError`s which will result in a
crash (500 Interval server error).

Turned them to `DepositMismatch` exception and also made the error string more informative