### PR TITLE
Fix UDP logging

### DIFF
--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -98,7 +98,7 @@ def single_queue_send(
     # Wait for the endpoint registration or to quit
     log.debug(
         'queue: waiting for node to become healthy',
-        node=pex(transport.address),
+        node=pex(transport.raiden.address),
         queue_identifier=queue_identifier,
         queue_size=len(queue),
     )
@@ -110,7 +110,7 @@ def single_queue_send(
 
     log.debug(
         'queue: processing queue',
-        node=pex(transport.address),
+        node=pex(transport.raiden.address),
         queue_identifier=queue_identifier,
         queue_size=len(queue),
     )
@@ -121,7 +121,7 @@ def single_queue_send(
         if event_stop.is_set():
             log.debug(
                 'queue: stopping',
-                node=pex(transport.address),
+                node=pex(transport.raiden.address),
                 queue_identifier=queue_identifier,
                 queue_size=len(queue),
             )
@@ -133,7 +133,7 @@ def single_queue_send(
 
         log.debug(
             'queue: sending message',
-            node=pex(transport.address),
+            node=pex(transport.raiden.address),
             recipient=pex(recipient),
             msgid=message_id,
             queue_identifier=queue_identifier,

--- a/raiden/network/transport/udp/udp_utils.py
+++ b/raiden/network/transport/udp/udp_utils.py
@@ -110,7 +110,7 @@ def retry(
 
         log.debug(
             'retrying message',
-            node=pex(transport.address),
+            node=pex(transport.raiden.address),
             recipient=pex(recipient),
             msgid=message_id,
         )
@@ -170,7 +170,7 @@ def retry_with_recovery(
         if event_unhealthy.is_set():
             log.debug(
                 'waiting for recipient to become available',
-                node=pex(transport.address),
+                node=pex(transport.raiden.address),
                 recipient=pex(recipient),
             )
             wait_recovery(

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -64,8 +64,14 @@ class Runnable:
 
     # redirect missing members to underlying greenlet for compatibility
     # but better use greenlet directly for now, to make use of the c extension optimizations
-    def __getattr__(self, name):
-        return getattr(self.greenlet, name)
+    def __getattribute__(self, name):
+        try:
+            return super().__getattribute__(name)
+        except AttributeError as ex:
+            try:
+                return getattr(self.greenlet, name)
+            except AttributeError:
+                raise ex from None
 
     def __bool__(self):
         return bool(self.greenlet)


### PR DESCRIPTION
Fix udp `AttributeError` of missing `address` member of `UDPTransport`, introduced in #2345 , which broke `master`
Also, fix shadowing of `Runnable`s subclasses `AttributeError` exceptions when redirecting members' access to `Runnable.greenlet` instance, which made it harder to read the logs on this type of errors, introduced in #2208 