### PR TITLE
Use one database per registry

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -47,6 +47,7 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils import (
     pex,
+    lpex,
     privatekey_to_address,
     random_secret,
     create_default_identifier,
@@ -260,6 +261,17 @@ class RaidenService(Runnable):
                 last_restored_block=last_log_block_number,
                 node=pex(self.address),
             )
+
+            known_networks = views.get_payment_network_identifiers(views.state_from_raiden(self))
+            if known_networks and self.default_registry.address not in known_networks:
+                configured_registry = pex(self.default_registry.address)
+                known_registries = lpex(known_networks)
+                raise RuntimeError(
+                    f'Token network address mismatch.\n'
+                    f'Raiden is configured to use the smart contract '
+                    f'{configured_registry}, which conflicts with the current known '
+                    f'smart contracts {known_registries}',
+                )
 
         # Restore the current snapshot group
         self.snapshot_group = last_log_block_number // SNAPSHOT_BLOCK_COUNT

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -131,6 +131,12 @@ def get_our_capacity_for_token_network(
     return total_deposit
 
 
+def get_payment_network_identifiers(
+        chain_state: ChainState,
+) -> typing.List[typing.PaymentNetworkID]:
+    return list(chain_state.identifiers_to_paymentnetworks.keys())
+
+
 def get_token_network_registry_by_token_network_identifier(
         chain_state: ChainState,
         token_network_identifier: typing.Address,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -703,9 +703,9 @@ def run_app(
 
     database_path = os.path.join(
         datadir,
+        f'node_{pex(address)}',
         f'netid_{net_id}',
-        pex(token_network_registry.address),
-        address_hex[:8],
+        f'network_{pex(token_network_registry.address)}',
         f'v{RAIDEN_DB_VERSION}_log.db',
     )
     config['database_path'] = database_path

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -72,6 +72,7 @@ from raiden.utils import (
     get_system_spec,
     is_supported_client,
     merge_dict,
+    pex,
     split_endpoint,
     typing,
 )
@@ -662,20 +663,6 @@ def run_app(
     if sync_check:
         check_synced(blockchain_service)
 
-    database_path = os.path.join(
-        datadir,
-        'netid_%s' % net_id,
-        address_hex[:8],
-        f'v{RAIDEN_DB_VERSION}_log.db',
-    )
-    config['database_path'] = database_path
-    print(
-        '\nYou are connected to the \'{}\' network and the DB path is: {}'.format(
-            constants.ID_TO_NETWORKNAME.get(net_id) or net_id,
-            database_path,
-        ),
-    )
-
     contract_addresses_given = (
         registry_contract_address is not None and
         secret_registry_contract_address is not None and
@@ -713,6 +700,22 @@ def run_app(
         handle_contract_no_code('secret registry', secret_registry_contract_address)
     except AddressWrongContract:
         handle_contract_wrong_address('secret registry', secret_registry_contract_address)
+
+    database_path = os.path.join(
+        datadir,
+        f'netid_{net_id}',
+        pex(token_network_registry.address),
+        address_hex[:8],
+        f'v{RAIDEN_DB_VERSION}_log.db',
+    )
+    config['database_path'] = database_path
+
+    print(
+        '\nYou are connected to the \'{}\' network and the DB path is: {}'.format(
+            constants.ID_TO_NETWORKNAME.get(net_id) or net_id,
+            database_path,
+        ),
+    )
 
     discovery = None
     if transport == 'udp':

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -770,6 +770,9 @@ def run_app(
 
     try:
         raiden_app.start()
+    except RuntimeError as e:
+        click.secho(f'FATAL: {e}', fg='red')
+        sys.exit(1)
     except filelock.Timeout:
         name_or_id = constants.ID_TO_NETWORKNAME.get(network_id, network_id)
         print(


### PR DESCRIPTION
Because the REST API assumes that there is only one registry address being used, we cannot use the same database from previous runs. This PR automatically makes a new database when a new smart contract is deployed to avoid weird behavior in the API.