### PR TITLE
Remove flake8-coding module

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -6,7 +6,6 @@
 # version here
 flake8==3.5.0
 flake8-bugbear==18.2.0
-flake8-coding==1.3.0
 flake8-commas==2.0.0
 flake8-tuple==0.2.13
 readme-renderer==21.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,6 @@
 ignore = E701, E731, E402, W504, C814
 max-line-length = 99
 exclude = raiden/ui/web/node_modules/ tools/ansible/contrib
-# We don't want any 'encoding: ...' headers in source files
-no-accept-encodings = True
 
 [pep8]
 ignore = E731, E402, W504, C814


### PR DESCRIPTION
It does not work with python 3.7 and renders flake8 unusable (it crashes). An issue along
with a fix has been reported to the maintainer
[here](https://github.com/tk0miya/flake8-coding/issues/16) but the repo seems to
no longer be actively maintained.

And to be honest we don't really need this module. The only thing it adds is a
check for the magic comment in the beginning of the file.

[skip ci]