### PR TITLE
Resolve CLI test failures. 

### DIFF
--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -8,7 +8,11 @@ from eth_utils import to_checksum_address
 
 
 def spawn_raiden(args):
-    return pexpect.spawn(sys.executable, ['-m', 'raiden'] + args, logfile=sys.stdout)
+    return pexpect.spawn(
+        sys.executable, ['-m', 'raiden'] + args,
+        logfile=sys.stdout,
+        encoding='utf-8',
+    )
 
 
 def test_cli_version():
@@ -157,7 +161,6 @@ def test_cli_registry_address_without_deployed_contract(cli_args):
     child = spawn_raiden(cli_args)
     try:
         expect_cli_until_account_selection(child)
-        child.expect('You are connected')
         child.expect('contract does not contain code')
     except pexpect.TIMEOUT as e:
         print('Timed out at', e)


### PR DESCRIPTION
This fixes issues in the CLI integration tests. Example failure:
https://travis-ci.org/raiden-network/raiden/jobs/425197821

Failed locally for 2 reasons:
1. An error was taking place passing bytes such as `b' blah blah'` while `self.logfile.write` was expecting a string. setting `encoding` fixes that.
2. The test was expecting `You are connected` while this wasn't being printed. 