### PR TITLE
start/stop should raise if called in the wrong state

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -152,8 +152,7 @@ class App:  # pylint: disable=too-few-public-methods
 
     def start(self):
         """ Start the raiden app. """
-        if self.raiden.stop_event.is_set():
-            self.raiden.start()
+        self.raiden.start()
 
     def stop(self):
         """ Stop the raiden app.
@@ -161,5 +160,4 @@ class App:  # pylint: disable=too-few-public-methods
         Args:
             leave_channels: if True, also close and settle all channels before stopping
         """
-        if not self.raiden.stop_event.is_set():
-            self.raiden.stop()
+        self.raiden.stop()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -427,7 +427,7 @@ class RaidenService(Runnable):
     def stop(self):
         """ Stop the node gracefully. Raise if any stop-time error occurred on any subtask """
         if self.stop_event.ready():  # not started
-            return
+            raise RuntimeError(f'{self!r} already stopped')
 
         # Needs to come before any greenlets joining
         self.stop_event.set()

--- a/raiden/tests/utils/tests.py
+++ b/raiden/tests/utils/tests.py
@@ -16,7 +16,8 @@ def cleanup_tasks():
 
 def shutdown_apps_and_cleanup_tasks(raiden_apps):
     for app in raiden_apps:
-        app.stop()
+        if app:
+            app.stop()
 
     # Two tests in sequence could run a UDP server on the same port, a hanging
     # greenlet from the previous tests could send packet to the new server and


### PR DESCRIPTION
implements the exception discussed here: https://github.com/raiden-network/raiden/pull/2208/files#r214349471