### PR TITLE
Timestamps for internal events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`2287` Internal events now have timestamps.
 * :feature:`2307` Matrix discovery rooms now are decentralized, aliased and shared by all servers in the federation
 * :feature:`2252` Adds payment history page to the webui.
 * :bug:`2367` Token network selection dropdown will not filter out not connected networks.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -561,6 +561,9 @@ argument needs to be in the range of 0 to UINT64_MAX. Any block number outside t
 be rejected.
 For ``raiden_events`` you can provide a ``limit`` and an ``offset`` number which would define the limit of results to return and the offset from which to return results respectively.
 
+``raiden_events`` contain a timestamp field, ``log_time``, indicating when they were written to the write-ahead log.
+The format of ``log_time`` is ISO8601 with milliseconds.
+
 .. http:get:: /api/(version)/_debug/blockchain_events/network
 
    Query for token network creations.
@@ -804,6 +807,7 @@ Now for the internal Raiden events:
 
     [{
         'event': 'SendLockedTransfer',
+        'log_time': '2018-09-07T14:49:18.852',
         'message_identifier': 17084435898865420397,
         'recipient': '0x636f37d785257d919931acff318f70fb7da4f903',
         'transfer': '<LockedTransferUnsignedState id:43 '
@@ -817,6 +821,7 @@ Now for the internal Raiden events:
      },
      {
         'event': 'SendSecretReveal',
+        'log_time': '2018-09-07T14:49:20.351,
         'message_identifier': 9182020688704924936,
         'recipient': '0x636f37d785257d919931acff318f70fb7da4f903',
         'secret': '0xcefe6d325fc2b01f47d303417ddd14d788a31c0b078610b427a85b2141bc514d',
@@ -826,6 +831,7 @@ Now for the internal Raiden events:
         'amount': 200,
         'event': 'EventPaymentSentSuccess',
         'identifier': 43,
+        'log_time': '2018-09-07T14:49:23.664',
         'payment_network_identifier': '0x41ac2632d8c233784783e50ec6678cdc43f74c76',
         'target': '0x636F37d785257D919931ACFf318F70fB7Da4f903',
         'token_network_identifier': '0xedf18937be4064dfbe3e307bd193e812b723ac6f'

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -673,7 +673,7 @@ class RaidenAPI:
         )
         return async_result
 
-    def get_raiden_events_payment_history(
+    def get_raiden_events_payment_history_with_timestamps(
             self,
             token_address: typing.TokenAddress = None,
             target_address: typing.Address = None,
@@ -701,11 +701,11 @@ class RaidenAPI:
 
         events = [
             event
-            for event in self.raiden.wal.storage.get_events(
+            for event in self.raiden.wal.storage.get_events_with_timestamps(
                 limit=limit,
                 offset=offset,
             ) if event_filter_for_payments(
-                event,
+                event.wrapped_event,
                 self.address,
                 token_network_identifier,
                 target_address,
@@ -714,8 +714,24 @@ class RaidenAPI:
 
         return events
 
-    def get_raiden_internal_events(self, limit: int = None, offset: int = None):
-        return self.raiden.wal.storage.get_events(limit=limit, offset=offset)
+    def get_raiden_events_payment_history(
+            self,
+            token_address: typing.TokenAddress = None,
+            target_address: typing.Address = None,
+            limit: int = None,
+            offset: int = None,
+    ):
+        timestamped_events = self.get_raiden_events_payment_history_with_timestamps(
+            token_address,
+            target_address,
+            limit,
+            offset,
+        )
+
+        return [event.wrapped_event for event in timestamped_events]
+
+    def get_raiden_internal_events_with_timestamps(self, limit: int = None, offset: int = None):
+        return self.raiden.wal.storage.get_events_with_timestamps(limit=limit, offset=offset)
 
     transfer = transfer_and_wait
 

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -274,9 +274,10 @@ class EventPaymentSentFailedSchema(BaseSchema):
     event = fields.Constant('EventPaymentSentFailed')
     reason = fields.Str()
     target = AddressField()
+    log_time = fields.String()
 
     class Meta:
-        fields = ('block_number', 'event', 'reason', 'target')
+        fields = ('block_number', 'event', 'reason', 'target', 'log_time')
         strict = True
         decoding_class = dict
 
@@ -287,9 +288,10 @@ class EventPaymentSentSuccessSchema(BaseSchema):
     event = fields.Constant('EventPaymentSentSuccess')
     amount = fields.Integer()
     target = AddressField()
+    log_time = fields.String()
 
     class Meta:
-        fields = ('block_number', 'event', 'amount', 'target', 'identifier')
+        fields = ('block_number', 'event', 'amount', 'target', 'identifier', 'log_time')
         strict = True
         decoding_class = dict
 
@@ -300,8 +302,9 @@ class EventPaymentReceivedSuccessSchema(BaseSchema):
     event = fields.Constant('EventPaymentReceivedSuccess')
     amount = fields.Integer()
     initiator = AddressField()
+    log_time = fields.String()
 
     class Meta:
-        fields = ('block_number', 'event', 'amount', 'initiator', 'identifier')
+        fields = ('block_number', 'event', 'amount', 'initiator', 'identifier', 'log_time')
         strict = True
         decoding_class = dict

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -149,7 +149,7 @@ class RaidenInternalEventsResource(BaseResource):
 
     @use_kwargs(get_schema, locations=('query',))
     def get(self, token_address, partner_address=None, limit=None, offset=None):
-        return self.rest_api.get_raiden_internal_events(
+        return self.rest_api.get_raiden_internal_events_with_timestamps(
             token_address=token_address,
             partner_address=partner_address,
             limit=limit,
@@ -218,7 +218,7 @@ class PaymentResource(BaseResource):
             limit: int = None,
             offset: int = None,
     ):
-        return self.rest_api.get_raiden_events_payment_history(
+        return self.rest_api.get_raiden_events_payment_history_with_timestamps(
             token_address=token_address,
             target_address=target_address,
             limit=limit,

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -1,3 +1,11 @@
+from collections import namedtuple
+
+
+class TimestampedEvent(namedtuple('TimestampedEvent', 'wrapped_event log_time')):
+    def __getattr__(self, item):
+        return getattr(self.wrapped_event, item)
+
+
 DB_CREATE_SETTINGS = '''
 CREATE TABLE IF NOT EXISTS settings (
     name VARCHAR[24] NOT NULL PRIMARY KEY,
@@ -25,6 +33,7 @@ DB_CREATE_STATE_EVENTS = '''
 CREATE TABLE IF NOT EXISTS state_events (
     identifier INTEGER PRIMARY KEY,
     source_statechange_id INTEGER NOT NULL,
+    log_time TEXT,
     data JSON,
     FOREIGN KEY(source_statechange_id) REFERENCES state_changes(identifier)
 );

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import structlog
 
 from raiden.transfer.architecture import StateManager
@@ -49,11 +50,12 @@ class WriteAheadLog:
         Events produced by applying state change are also saved.
         """
         state_change_id = self.storage.write_state_change(state_change)
+        self.state_change_id = state_change_id
 
         events = self.state_manager.dispatch(state_change)
 
-        self.state_change_id = state_change_id
-        self.storage.write_events(state_change_id, events)
+        timestamp = datetime.utcnow().isoformat(timespec='milliseconds')
+        self.storage.write_events(state_change_id, events, timestamp)
 
         return events
 

--- a/raiden/tests/unit/api/test_api_events.py
+++ b/raiden/tests/unit/api/test_api_events.py
@@ -1,8 +1,13 @@
 import pytest
 
+from raiden.api.v1.encoding import EventPaymentSentFailedSchema
 from raiden.blockchain.events import get_contract_events
 from raiden.exceptions import InvalidBlockNumberInput
+from raiden.storage.utils import TimestampedEvent
+
+from raiden.tests.utils import factories
 from raiden.tests.utils.factories import ADDR
+from raiden.transfer.events import EventPaymentSentFailed
 
 
 def test_get_contract_events_invalid_blocknumber():
@@ -17,3 +22,26 @@ def test_get_contract_events_invalid_blocknumber():
 
     with pytest.raises(InvalidBlockNumberInput):
         get_contract_events(None, {}, ADDR, [], 1, 999999999999999999999999)
+
+
+def test_v1_event_payment_sent_failed_schema():
+    event = EventPaymentSentFailed(
+        factories.make_payment_network_identifier(),
+        factories.make_address(),
+        1,
+        factories.make_address(),
+        'whatever',
+    )
+    log_time = '2018-09-07T20:02:35.000'
+
+    timestamped = TimestampedEvent(event, log_time)
+
+    dumped = EventPaymentSentFailedSchema().dump(timestamped)
+
+    expected = {
+        'event': 'EventPaymentSentFailed',
+        'log_time': log_time,
+        'reason': 'whatever',
+    }
+
+    assert all(dumped.data.get(key) == value for key, value in expected.items())

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -168,7 +168,7 @@ def test_write_read_events():
             '2018-08-31T17:38:00.000',
         )
 
-    previous_events = wal.storage.get_events()
+    previous_events = wal.storage.get_events_with_timestamps()
 
     log_time = '2018-09-07T20:02:35.0000'
     state_change_id = wal.storage.write_state_change('statechangedata')
@@ -178,7 +178,7 @@ def test_write_read_events():
         log_time,
     )
 
-    new_events = wal.storage.get_events()
+    new_events = wal.storage.get_events_with_timestamps()
     assert len(previous_events) + 1 == len(new_events)
 
     latest_event = new_events[-1]


### PR DESCRIPTION
Add a timestamp column to the database to record the time when internal events are logged.

Solves #2287.