### PR TITLE
Do not take target address into account in filtering for events with no such attribute

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug: `2373` Include events for received payments in the payment events API endpoint.
 * :feature: `862` Switch WAL serialization format to JSON in order to facilitate for WAL upgradability.
 * :feature: `2363` Add copy functionality for addresses shown on the webui.
 * :bug:`2356` Create a new database per token network registry.

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -50,13 +50,15 @@ def event_filter(
         token_network_identifier: typing.TokenNetworkID = None,
         target_address: typing.Address = None,
 ):
+    event_target = getattr(event, 'target', None)
     return (
         isinstance(event, EVENTS_PAYMENT_HISTORY_RELATED) and (
             token_network_identifier is None or
             token_network_identifier == event.token_network_identifier
         ) and (
             target_address is None or
-            getattr(event, 'target', None) == target_address
+            event_target is None or
+            event_target == target_address
         )
     )
 


### PR DESCRIPTION
Fix #2373 