### PR TITLE
bugfix: PRNG must be restored on restarts

### DIFF
--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -204,7 +204,7 @@ def test_actioninitchain_restore():
     state.
 
     Message identifiers are used for confirmation messages, e.g. delivered and
-    processed messages, therefor it's important for each message identifier to
+    processed messages, therefore it's important for each message identifier to
     not collide with a previous identifier, for this reason the PRNG is used.
 
     Additionally, during restarts the state changes are reapplied, and it's
@@ -236,22 +236,6 @@ def test_actioninitchain_restore():
 
 
 def test_chainstate_restore():
-    """ ActionInitChain *must* restore the previous pseudo random generator
-    state.
-
-    Message identifiers are used for confirmation messages, e.g. delivered and
-    processed messages, therefor it's important for each message identifier to
-    not collide with a previous identifier, for this reason the PRNG is used.
-
-    Additionally, during restarts the state changes are reapplied, and it's
-    really important for the re-execution of the state changes to be
-    deterministic, otherwise undefined behavior may happen. For this reason the
-    state of the PRNG must be restored.
-
-    If the above is not respected, the message ids generated during restart
-    will not match the previous IDs and the message queues won't be properly
-    cleared up.
-    """
     pseudo_random_generator = random.Random()
     block_number = 577
     our_address = factories.make_address()

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -6,7 +6,7 @@ from networkx import Graph
 
 from raiden.storage.serialize import JSONSerializer, RaidenJSONDecoder
 from raiden.tests.utils import factories
-from raiden.transfer import state_change
+from raiden.transfer import state, state_change
 from raiden.transfer.merkle_tree import compute_layers
 from raiden.transfer.state import EMPTY_MERKLE_TREE
 from raiden.utils import serialization
@@ -226,6 +226,42 @@ def test_actioninitchain_restore():
         block_number,
         our_address,
         chain_id,
+    )
+
+    decoded_obj = JSONSerializer.deserialize(
+        JSONSerializer.serialize(original_obj),
+    )
+
+    assert original_obj == decoded_obj
+
+
+def test_chainstate_restore():
+    """ ActionInitChain *must* restore the previous pseudo random generator
+    state.
+
+    Message identifiers are used for confirmation messages, e.g. delivered and
+    processed messages, therefor it's important for each message identifier to
+    not collide with a previous identifier, for this reason the PRNG is used.
+
+    Additionally, during restarts the state changes are reapplied, and it's
+    really important for the re-execution of the state changes to be
+    deterministic, otherwise undefined behavior may happen. For this reason the
+    state of the PRNG must be restored.
+
+    If the above is not respected, the message ids generated during restart
+    will not match the previous IDs and the message queues won't be properly
+    cleared up.
+    """
+    pseudo_random_generator = random.Random()
+    block_number = 577
+    our_address = factories.make_address()
+    chain_id = 777
+
+    original_obj = state.ChainState(
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        our_address=our_address,
+        chain_id=chain_id,
     )
 
     decoded_obj = JSONSerializer.deserialize(

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -16,6 +16,7 @@ from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import lpex, pex, serialization, sha3, typing
 from raiden.utils.serialization import map_dict, map_list
+from raiden.transfer.utils import pseudo_random_generator_from_json
 
 SecretHashToLock = typing.Dict[typing.SecretHash, 'HashTimeLockState']
 SecretHashToPartialUnlockProof = typing.Dict[typing.SecretHash, 'UnlockPartialProofState']
@@ -314,13 +315,7 @@ class ChainState(State):
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ChainState':
-        pseudo_random_generator = random.Random()
-
-        # JSON serializes a tuple as a list
-        state = list(data['pseudo_random_generator'])  # copy
-        state[1] = tuple(state[1])  # fix type
-        state = tuple(state)
-        pseudo_random_generator.setstate(state)
+        pseudo_random_generator = pseudo_random_generator_from_json(data)
 
         restored = cls(
             pseudo_random_generator=pseudo_random_generator,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -13,10 +13,9 @@ from raiden.encoding.format import buffer_for
 from raiden.transfer.architecture import SendMessageEvent, State
 from raiden.transfer.merkle_tree import merkleroot
 from raiden.transfer.queue_identifier import QueueIdentifier
-from raiden.transfer.utils import hash_balance_data
+from raiden.transfer.utils import hash_balance_data, pseudo_random_generator_from_json
 from raiden.utils import lpex, pex, serialization, sha3, typing
 from raiden.utils.serialization import map_dict, map_list
-from raiden.transfer.utils import pseudo_random_generator_from_json
 
 SecretHashToLock = typing.Dict[typing.SecretHash, 'HashTimeLockState']
 SecretHashToPartialUnlockProof = typing.Dict[typing.SecretHash, 'UnlockPartialProofState']

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1,6 +1,4 @@
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
-import random
-
 from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.transfer.architecture import ContractReceiveStateChange, StateChange
@@ -11,6 +9,7 @@ from raiden.transfer.state import (
     TokenNetworkState,
     TransactionChannelNewBalance,
 )
+from raiden.transfer.utils import pseudo_random_generator_from_json
 from raiden.utils import pex, sha3, typing
 from raiden.utils.serialization import deserialize_bytes, serialize_bytes
 
@@ -364,13 +363,7 @@ class ActionInitChain(StateChange):
 
     @classmethod
     def from_dict(cls, data) -> 'ActionInitChain':
-        pseudo_random_generator = random.Random()
-
-        # JSON serializes a tuple as a list
-        state = list(data['pseudo_random_generator'])  # copy
-        state[1] = tuple(state[1])  # fix type
-        state = tuple(state)
-        pseudo_random_generator.setstate(state)
+        pseudo_random_generator = pseudo_random_generator_from_json(data)
 
         return cls(
             pseudo_random_generator=pseudo_random_generator,

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -1,3 +1,5 @@
+import random
+
 from web3 import Web3
 
 from raiden.constants import EMPTY_HASH
@@ -18,3 +20,14 @@ def hash_balance_data(
         ['uint256', 'uint256', 'bytes32'],
         [transferred_amount, locked_amount, locksroot],
     )
+
+
+def pseudo_random_generator_from_json(data):
+    # JSON serializes a tuple as a list
+    pseudo_random_generator = random.Random()
+    state = list(data['pseudo_random_generator'])  # copy
+    state[1] = tuple(state[1])  # fix type
+    state = tuple(state)
+    pseudo_random_generator.setstate(state)
+
+    return pseudo_random_generator


### PR DESCRIPTION
If the state of the pseudo random number generator differs during
restarts the generated message ids won't match and the state of the
nodes will become unsychronized.

[ci integration]