### PR TITLE
test utils required web3 4.6.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pytest-random==0.02
 pytest-cov==2.5.1
 grequests==0.3.0
 pexpect==4.6.0
+web3==4.6.0
 
 # Debugging
 pdbpp==0.9.2


### PR DESCRIPTION
[raiden.tests.utils.events](https://github.com/raiden-network/raiden/blob/d632594b507ea0178d881283b86ea9dc480f40d1/raiden/tests/utils/events.py#L1) uses `web3.datastructures`, which is available on the latest release only