### PR TITLE
target: deliver once semantics

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -898,6 +898,9 @@ def handle_init(
         from_transfer,
     )
     if not is_valid:
+        # If the balance proof is not valid, do *not* create a task. Otherwise it's
+        # possible for an attacker to send multiple invalid transfers, and increase
+        # the memory usage of this Node.
         return TransitionResult(None, events)
 
     iteration = mediate_transfer(

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -110,12 +110,12 @@ def handle_inittarget(
     )
 
     if is_valid:
-        # An valid balance proof does not mean the payment itself is still valid,
-        # e.g. the lock may be near expiration or have expired. This is fine, the
+        # A valid balance proof does not mean the payment itself is still valid.
+        # e.g. the lock may be near expiration or have expired. This is fine. The
         # message with an unusable lock must be handled to properly synchronize the
         # local view of the partner's channel state, allowing the next balance
         # proofs to be handled. This however, must only be done once, which is
-        # enforced by the nonce is increasing sequentially, which is verified by
+        # enforced by the nonce increasing sequentially, which is verified by
         # the handler handle_receive_lockedtransfer.
         target_state = TargetTransferState(route, transfer)
 


### PR DESCRIPTION
Recap: To avoid having to rewrite messages, the recipient of a message
must accept a valid message for an expire transfer. This is required
because a sender may be online and try to send a transfer through a node
which just went offline, when the node comes back online the transfer's
lock could have enterred the danger zone or have expired, but the sender
did not rewrite its message queue. In this case the recipient's channel
must validate the received balance proof, but not the transfer, and the
corresponding task (either mediator or target), **must not** continue
with the protocol if the current block is after the start of the danger
zone.

This however, doesn't mean the same message must be processed twice.
It's important for a node to have deliver once semantics, which is
achieved by the retry logic in the sender, with the sequential nonce in
the receiver, which is part of the balance proof.

This commit fixed the target task, to processed the balance proof only
once. And it keeps the logic to accept transfers with an expired lock,
allowing nodes to properly synchronize.

[ci integration]