### PR TITLE
bugfix: transport can be used during shutdown

### DIFF
--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -439,8 +439,6 @@ class UDPTransport(Runnable):
                 message=message,
             )
 
-            assert not self.event_stop.is_set()
-
     def maybe_send(self, recipient: typing.Address, message: Message):
         """ Send message to recipient if the transport is running. """
 


### PR DESCRIPTION
there is no synchronization from the to ensure that stop_event is set
after existing tasks which want to send messages, therefor it's not safe
to assert on the event state.