### PR TITLE
Added RaidenEventHandler class

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -81,6 +81,7 @@ class App:  # pylint: disable=too-few-public-methods
             default_registry: TokenNetworkRegistry,
             default_secret_registry: SecretRegistry,
             transport,
+            raiden_event_handler: 'RaidenEventHandler',
             discovery: Discovery = None,
     ):
         raiden = RaidenService(
@@ -90,6 +91,7 @@ class App:  # pylint: disable=too-few-public-methods
             default_secret_registry=default_secret_registry,
             private_key_bin=unhexlify(config['privatekey_hex']),
             transport=transport,
+            raiden_event_handler=raiden_event_handler,
             config=config,
             discovery=discovery,
         )

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -2,7 +2,6 @@ import structlog
 
 from raiden.exceptions import (
     ChannelOutdatedError,
-    RaidenRecoverableError,
 )
 from raiden.messages import message_from_sendevent
 from raiden.transfer.architecture import Event
@@ -48,322 +47,320 @@ UNEVENTFUL_EVENTS = (
 )
 
 
-def handle_send_lockexpired(
-        raiden: RaidenService,
-        send_lock_expired: SendLockExpired,
-):
-    lock_expired_message = message_from_sendevent(send_lock_expired, raiden.address)
-    raiden.sign(lock_expired_message)
-    raiden.transport.send_async(
-        send_lock_expired.queue_identifier,
-        lock_expired_message,
-    )
+class RaidenEventHandler:
+    def on_raiden_event(self, raiden: RaidenService, event: Event):
+        # pylint: disable=too-many-branches
 
-
-def handle_send_lockedtransfer(
-        raiden: RaidenService,
-        send_locked_transfer: SendLockedTransfer,
-):
-    mediated_transfer_message = message_from_sendevent(send_locked_transfer, raiden.address)
-    raiden.sign(mediated_transfer_message)
-    raiden.transport.send_async(
-        send_locked_transfer.queue_identifier,
-        mediated_transfer_message,
-    )
-
-
-def handle_send_directtransfer(
-        raiden: RaidenService,
-        send_direct_transfer: SendDirectTransfer,
-):
-    direct_transfer_message = message_from_sendevent(send_direct_transfer, raiden.address)
-    raiden.sign(direct_transfer_message)
-    raiden.transport.send_async(
-        send_direct_transfer.queue_identifier,
-        direct_transfer_message,
-    )
-
-
-def handle_send_revealsecret(
-        raiden: RaidenService,
-        reveal_secret_event: SendRevealSecret,
-):
-    reveal_secret_message = message_from_sendevent(reveal_secret_event, raiden.address)
-    raiden.sign(reveal_secret_message)
-    raiden.transport.send_async(
-        reveal_secret_event.queue_identifier,
-        reveal_secret_message,
-    )
-
-
-def handle_send_balanceproof(
-        raiden: RaidenService,
-        balance_proof_event: SendBalanceProof,
-):
-    secret_message = message_from_sendevent(balance_proof_event, raiden.address)
-    raiden.sign(secret_message)
-    raiden.transport.send_async(
-        balance_proof_event.queue_identifier,
-        secret_message,
-    )
-
-
-def handle_send_secretrequest(
-        raiden: RaidenService,
-        secret_request_event: SendSecretRequest,
-):
-    secret_request_message = message_from_sendevent(secret_request_event, raiden.address)
-    raiden.sign(secret_request_message)
-    raiden.transport.send_async(
-        secret_request_event.queue_identifier,
-        secret_request_message,
-    )
-
-
-def handle_send_refundtransfer(
-        raiden: RaidenService,
-        refund_transfer_event: SendRefundTransfer,
-):
-    refund_transfer_message = message_from_sendevent(refund_transfer_event, raiden.address)
-    raiden.sign(refund_transfer_message)
-    raiden.transport.send_async(
-        refund_transfer_event.queue_identifier,
-        refund_transfer_message,
-    )
-
-
-def handle_send_processed(
-        raiden: RaidenService,
-        processed_event: SendProcessed,
-):
-    processed_message = message_from_sendevent(processed_event, raiden.address)
-    raiden.sign(processed_message)
-    raiden.transport.send_async(
-        processed_event.queue_identifier,
-        processed_message,
-    )
-
-
-def handle_paymentsentsuccess(
-        raiden: RaidenService,
-        payment_sent_success_event: EventPaymentSentSuccess,
-):
-    assert payment_sent_success_event.identifier in raiden.identifier_to_results
-
-    result = raiden.identifier_to_results[payment_sent_success_event.identifier]
-    result.set(True)
-
-    del raiden.identifier_to_results[payment_sent_success_event.identifier]
-
-
-def handle_paymentsentfailed(
-        raiden: RaidenService,
-        payment_sent_failed_event: EventPaymentSentFailed,
-):
-    assert payment_sent_failed_event.identifier in raiden.identifier_to_results
-
-    result = raiden.identifier_to_results[payment_sent_failed_event.identifier]
-    result.set(False)
-    del raiden.identifier_to_results[payment_sent_failed_event.identifier]
-
-
-def handle_unlockfailed(
-        raiden: RaidenService,
-        unlock_failed_event: EventUnlockFailed,
-):
-    # pylint: disable=unused-argument
-    log.error(
-        'UnlockFailed!',
-        secrethash=pex(unlock_failed_event.secrethash),
-        reason=unlock_failed_event.reason,
-    )
-
-
-def handle_contract_send_secretreveal(
-        raiden: RaidenService,
-        channel_close_event: ContractSendSecretReveal,
-):
-    raiden.default_secret_registry.register_secret(channel_close_event.secret)
-
-
-def handle_contract_send_channelclose(
-        raiden: RaidenService,
-        channel_close_event: ContractSendChannelClose,
-):
-    balance_proof = channel_close_event.balance_proof
-
-    if balance_proof:
-        nonce = balance_proof.nonce
-        balance_hash = balance_proof.balance_hash
-        signature = balance_proof.signature
-        message_hash = balance_proof.message_hash
-
-    else:
-        nonce = 0
-        balance_hash = EMPTY_HASH
-        signature = EMPTY_SIGNATURE
-        message_hash = EMPTY_HASH
-
-    channel_proxy = raiden.chain.payment_channel(
-        token_network_address=channel_close_event.token_network_identifier,
-        channel_id=channel_close_event.channel_identifier,
-    )
-
-    channel_proxy.close(
-        nonce,
-        balance_hash,
-        message_hash,
-        signature,
-    )
-
-
-def handle_contract_send_channelupdate(
-        raiden: RaidenService,
-        channel_update_event: ContractSendChannelUpdateTransfer,
-):
-    balance_proof = channel_update_event.balance_proof
-
-    if balance_proof:
-        channel = raiden.chain.payment_channel(
-            token_network_address=channel_update_event.token_network_identifier,
-            channel_id=channel_update_event.channel_identifier,
-        )
-
-        non_closing_data = pack_balance_proof_update(
-            nonce=balance_proof.nonce,
-            balance_hash=balance_proof.balance_hash,
-            additional_hash=balance_proof.message_hash,
-            channel_identifier=balance_proof.channel_identifier,
-            token_network_identifier=balance_proof.token_network_identifier,
-            chain_id=balance_proof.chain_id,
-            partner_signature=balance_proof.signature,
-        )
-        our_signature = eth_sign(privkey=raiden.privkey, data=non_closing_data)
-
-        try:
-            channel.update_transfer(
-                balance_proof.nonce,
-                balance_proof.balance_hash,
-                balance_proof.message_hash,
-                balance_proof.signature,
-                our_signature,
-            )
-        except ChannelOutdatedError as e:
-            log.error(str(e))
-
-
-def handle_contract_send_channelunlock(
-        raiden: RaidenService,
-        channel_unlock_event: ContractSendChannelBatchUnlock,
-):
-    channel = raiden.chain.payment_channel(
-        channel_unlock_event.token_network_identifier,
-        channel_unlock_event.channel_identifier,
-    )
-
-    try:
-        channel.unlock(channel_unlock_event.merkle_tree_leaves)
-    except ChannelOutdatedError as e:
-        log.error(str(e))
-
-
-def handle_contract_send_channelsettle(
-        raiden: RaidenService,
-        channel_settle_event: ContractSendChannelSettle,
-):
-    channel = raiden.chain.payment_channel(
-        token_network_address=channel_settle_event.token_network_identifier,
-        channel_id=channel_settle_event.channel_identifier,
-    )
-    our_balance_proof = channel_settle_event.our_balance_proof
-    partner_balance_proof = channel_settle_event.partner_balance_proof
-
-    if our_balance_proof:
-        our_transferred_amount = our_balance_proof.transferred_amount
-        our_locked_amount = our_balance_proof.locked_amount
-        our_locksroot = our_balance_proof.locksroot
-    else:
-        our_transferred_amount = 0
-        our_locked_amount = 0
-        our_locksroot = EMPTY_HASH
-
-    if partner_balance_proof:
-        partner_transferred_amount = partner_balance_proof.transferred_amount
-        partner_locked_amount = partner_balance_proof.locked_amount
-        partner_locksroot = partner_balance_proof.locksroot
-    else:
-        partner_transferred_amount = 0
-        partner_locked_amount = 0
-        partner_locksroot = EMPTY_HASH
-
-    our_max_transferred = our_transferred_amount + our_locked_amount
-    partner_max_transferred = partner_transferred_amount + partner_locked_amount
-
-    # The smart contract requires the max transferred of the /first/ balance
-    # proof to be /smaller/.
-    if our_max_transferred < partner_max_transferred:
-        first_transferred_amount = our_transferred_amount
-        first_locked_amount = our_locked_amount
-        first_locksroot = our_locksroot
-        second_transferred_amount = partner_transferred_amount
-        second_locked_amount = partner_locked_amount
-        second_locksroot = partner_locksroot
-    else:
-        first_transferred_amount = partner_transferred_amount
-        first_locked_amount = partner_locked_amount
-        first_locksroot = partner_locksroot
-        second_transferred_amount = our_transferred_amount
-        second_locked_amount = our_locked_amount
-        second_locksroot = our_locksroot
-
-    channel.settle(
-        first_transferred_amount,
-        first_locked_amount,
-        first_locksroot,
-        second_transferred_amount,
-        second_locked_amount,
-        second_locksroot,
-    )
-
-
-def on_raiden_event(raiden: RaidenService, event: Event):
-    # pylint: disable=too-many-branches
-    try:
         if type(event) == SendLockExpired:
-            handle_send_lockexpired(raiden, event)
+            self.handle_send_lockexpired(raiden, event)
         elif type(event) == SendLockedTransfer:
-            handle_send_lockedtransfer(raiden, event)
+            self.handle_send_lockedtransfer(raiden, event)
         elif type(event) == SendDirectTransfer:
-            handle_send_directtransfer(raiden, event)
+            self.handle_send_directtransfer(raiden, event)
         elif type(event) == SendRevealSecret:
-            handle_send_revealsecret(raiden, event)
+            self.handle_send_revealsecret(raiden, event)
         elif type(event) == SendBalanceProof:
-            handle_send_balanceproof(raiden, event)
+            self.handle_send_balanceproof(raiden, event)
         elif type(event) == SendSecretRequest:
-            handle_send_secretrequest(raiden, event)
+            self.handle_send_secretrequest(raiden, event)
         elif type(event) == SendRefundTransfer:
-            handle_send_refundtransfer(raiden, event)
+            self.handle_send_refundtransfer(raiden, event)
         elif type(event) == SendProcessed:
-            handle_send_processed(raiden, event)
+            self.handle_send_processed(raiden, event)
         elif type(event) == EventPaymentSentSuccess:
-            handle_paymentsentsuccess(raiden, event)
+            self.handle_paymentsentsuccess(raiden, event)
         elif type(event) == EventPaymentSentFailed:
-            handle_paymentsentfailed(raiden, event)
+            self.handle_paymentsentfailed(raiden, event)
         elif type(event) == EventUnlockFailed:
-            handle_unlockfailed(raiden, event)
+            self.handle_unlockfailed(raiden, event)
         elif type(event) == ContractSendSecretReveal:
-            handle_contract_send_secretreveal(raiden, event)
+            self.handle_contract_send_secretreveal(raiden, event)
         elif type(event) == ContractSendChannelClose:
-            handle_contract_send_channelclose(raiden, event)
+            self.handle_contract_send_channelclose(raiden, event)
         elif type(event) == ContractSendChannelUpdateTransfer:
-            handle_contract_send_channelupdate(raiden, event)
+            self.handle_contract_send_channelupdate(raiden, event)
         elif type(event) == ContractSendChannelBatchUnlock:
-            handle_contract_send_channelunlock(raiden, event)
+            self.handle_contract_send_channelunlock(raiden, event)
         elif type(event) == ContractSendChannelSettle:
-            handle_contract_send_channelsettle(raiden, event)
+            self.handle_contract_send_channelsettle(raiden, event)
         elif type(event) in UNEVENTFUL_EVENTS:
             pass
         else:
             log.error('Unknown event {}'.format(type(event)))
-    except RaidenRecoverableError as e:
-        log.error(str(e))
+
+    def handle_send_lockexpired(
+            self,
+            raiden: RaidenService,
+            send_lock_expired: SendLockExpired,
+    ):
+        lock_expired_message = message_from_sendevent(send_lock_expired, raiden.address)
+        raiden.sign(lock_expired_message)
+        raiden.transport.send_async(
+            send_lock_expired.queue_identifier,
+            lock_expired_message,
+        )
+
+    def handle_send_lockedtransfer(
+            self,
+            raiden: RaidenService,
+            send_locked_transfer: SendLockedTransfer,
+    ):
+        mediated_transfer_message = message_from_sendevent(send_locked_transfer, raiden.address)
+        raiden.sign(mediated_transfer_message)
+        raiden.transport.send_async(
+            send_locked_transfer.queue_identifier,
+            mediated_transfer_message,
+        )
+
+    def handle_send_directtransfer(
+            self,
+            raiden: RaidenService,
+            send_direct_transfer: SendDirectTransfer,
+    ):
+        direct_transfer_message = message_from_sendevent(send_direct_transfer, raiden.address)
+        raiden.sign(direct_transfer_message)
+        raiden.transport.send_async(
+            send_direct_transfer.queue_identifier,
+            direct_transfer_message,
+        )
+
+    def handle_send_revealsecret(
+            self,
+            raiden: RaidenService,
+            reveal_secret_event: SendRevealSecret,
+    ):
+        reveal_secret_message = message_from_sendevent(reveal_secret_event, raiden.address)
+        raiden.sign(reveal_secret_message)
+        raiden.transport.send_async(
+            reveal_secret_event.queue_identifier,
+            reveal_secret_message,
+        )
+
+    def handle_send_balanceproof(
+            self,
+            raiden: RaidenService,
+            balance_proof_event: SendBalanceProof,
+    ):
+        secret_message = message_from_sendevent(balance_proof_event, raiden.address)
+        raiden.sign(secret_message)
+        raiden.transport.send_async(
+            balance_proof_event.queue_identifier,
+            secret_message,
+        )
+
+    def handle_send_secretrequest(
+            self,
+            raiden: RaidenService,
+            secret_request_event: SendSecretRequest,
+    ):
+        secret_request_message = message_from_sendevent(secret_request_event, raiden.address)
+        raiden.sign(secret_request_message)
+        raiden.transport.send_async(
+            secret_request_event.queue_identifier,
+            secret_request_message,
+        )
+
+    def handle_send_refundtransfer(
+            self,
+            raiden: RaidenService,
+            refund_transfer_event: SendRefundTransfer,
+    ):
+        refund_transfer_message = message_from_sendevent(refund_transfer_event, raiden.address)
+        raiden.sign(refund_transfer_message)
+        raiden.transport.send_async(
+            refund_transfer_event.queue_identifier,
+            refund_transfer_message,
+        )
+
+    def handle_send_processed(
+            self,
+            raiden: RaidenService,
+            processed_event: SendProcessed,
+    ):
+        processed_message = message_from_sendevent(processed_event, raiden.address)
+        raiden.sign(processed_message)
+        raiden.transport.send_async(
+            processed_event.queue_identifier,
+            processed_message,
+        )
+
+    def handle_paymentsentsuccess(
+            self,
+            raiden: RaidenService,
+            payment_sent_success_event: EventPaymentSentSuccess,
+    ):
+        assert payment_sent_success_event.identifier in raiden.identifier_to_results
+
+        result = raiden.identifier_to_results[payment_sent_success_event.identifier]
+        result.set(True)
+        del raiden.identifier_to_results[payment_sent_success_event.identifier]
+
+    def handle_paymentsentfailed(
+            self,
+            raiden: RaidenService,
+            payment_sent_failed_event: EventPaymentSentFailed,
+    ):
+        assert payment_sent_failed_event.identifier in raiden.identifier_to_results
+
+        result = raiden.identifier_to_results[payment_sent_failed_event.identifier]
+        result.set(False)
+        del raiden.identifier_to_results[payment_sent_failed_event.identifier]
+
+    def handle_unlockfailed(
+            self,
+            raiden: RaidenService,
+            unlock_failed_event: EventUnlockFailed,
+    ):
+        # pylint: disable=unused-argument
+        log.error(
+            'UnlockFailed!',
+            secrethash=pex(unlock_failed_event.secrethash),
+            reason=unlock_failed_event.reason,
+        )
+
+    def handle_contract_send_secretreveal(
+            self,
+            raiden: RaidenService,
+            channel_close_event: ContractSendSecretReveal,
+    ):
+        raiden.default_secret_registry.register_secret(channel_close_event.secret)
+
+    def handle_contract_send_channelclose(
+            self,
+            raiden: RaidenService,
+            channel_close_event: ContractSendChannelClose,
+    ):
+        balance_proof = channel_close_event.balance_proof
+
+        if balance_proof:
+            nonce = balance_proof.nonce
+            balance_hash = balance_proof.balance_hash
+            signature = balance_proof.signature
+            message_hash = balance_proof.message_hash
+
+        else:
+            nonce = 0
+            balance_hash = EMPTY_HASH
+            signature = EMPTY_SIGNATURE
+            message_hash = EMPTY_HASH
+
+        channel_proxy = raiden.chain.payment_channel(
+            token_network_address=channel_close_event.token_network_identifier,
+            channel_id=channel_close_event.channel_identifier,
+        )
+
+        channel_proxy.close(
+            nonce,
+            balance_hash,
+            message_hash,
+            signature,
+        )
+
+    def handle_contract_send_channelupdate(
+            self,
+            raiden: RaidenService,
+            channel_update_event: ContractSendChannelUpdateTransfer,
+    ):
+        balance_proof = channel_update_event.balance_proof
+
+        if balance_proof:
+            channel = raiden.chain.payment_channel(
+                token_network_address=channel_update_event.token_network_identifier,
+                channel_id=channel_update_event.channel_identifier,
+            )
+
+            non_closing_data = pack_balance_proof_update(
+                nonce=balance_proof.nonce,
+                balance_hash=balance_proof.balance_hash,
+                additional_hash=balance_proof.message_hash,
+                channel_identifier=balance_proof.channel_identifier,
+                token_network_identifier=balance_proof.token_network_identifier,
+                chain_id=balance_proof.chain_id,
+                partner_signature=balance_proof.signature,
+            )
+            our_signature = eth_sign(privkey=raiden.privkey, data=non_closing_data)
+
+            try:
+                channel.update_transfer(
+                    balance_proof.nonce,
+                    balance_proof.balance_hash,
+                    balance_proof.message_hash,
+                    balance_proof.signature,
+                    our_signature,
+                )
+            except ChannelOutdatedError as e:
+                log.error(str(e))
+
+    def handle_contract_send_channelunlock(
+            self,
+            raiden: RaidenService,
+            channel_unlock_event: ContractSendChannelBatchUnlock,
+    ):
+        channel = raiden.chain.payment_channel(
+            channel_unlock_event.token_network_identifier,
+            channel_unlock_event.channel_identifier,
+        )
+
+        try:
+            channel.unlock(channel_unlock_event.merkle_tree_leaves)
+        except ChannelOutdatedError as e:
+            log.error(str(e))
+
+    def handle_contract_send_channelsettle(
+            self,
+            raiden: RaidenService,
+            channel_settle_event: ContractSendChannelSettle,
+    ):
+        channel = raiden.chain.payment_channel(
+            token_network_address=channel_settle_event.token_network_identifier,
+            channel_id=channel_settle_event.channel_identifier,
+        )
+        our_balance_proof = channel_settle_event.our_balance_proof
+        partner_balance_proof = channel_settle_event.partner_balance_proof
+
+        if our_balance_proof:
+            our_transferred_amount = our_balance_proof.transferred_amount
+            our_locked_amount = our_balance_proof.locked_amount
+            our_locksroot = our_balance_proof.locksroot
+        else:
+            our_transferred_amount = 0
+            our_locked_amount = 0
+            our_locksroot = EMPTY_HASH
+
+        if partner_balance_proof:
+            partner_transferred_amount = partner_balance_proof.transferred_amount
+            partner_locked_amount = partner_balance_proof.locked_amount
+            partner_locksroot = partner_balance_proof.locksroot
+        else:
+            partner_transferred_amount = 0
+            partner_locked_amount = 0
+            partner_locksroot = EMPTY_HASH
+
+        our_max_transferred = our_transferred_amount + our_locked_amount
+        partner_max_transferred = partner_transferred_amount + partner_locked_amount
+
+        # The smart contract requires the max transferred of the /first/ balance
+        # proof to be /smaller/.
+        if our_max_transferred < partner_max_transferred:
+            first_transferred_amount = our_transferred_amount
+            first_locked_amount = our_locked_amount
+            first_locksroot = our_locksroot
+            second_transferred_amount = partner_transferred_amount
+            second_locked_amount = partner_locked_amount
+            second_locksroot = partner_locksroot
+        else:
+            first_transferred_amount = partner_transferred_amount
+            first_locked_amount = partner_locked_amount
+            first_locksroot = partner_locksroot
+            second_transferred_amount = our_transferred_amount
+            second_locked_amount = our_locked_amount
+            second_locksroot = our_locksroot
+
+        channel.settle(
+            first_transferred_amount,
+            first_locked_amount,
+            first_locksroot,
+            second_transferred_amount,
+            second_locked_amount,
+            second_locksroot,
+        )

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -16,6 +16,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelClosed,
     ContractReceiveChannelSettled,
 )
+from raiden.raiden_event_handler import RaidenEventHandler
 
 
 @pytest.mark.skip(reason='issue 2360')
@@ -68,6 +69,8 @@ def test_recovery_happy_case(
         app0.raiden.config['transport']['udp'],
     )
 
+    raiden_event_handler = RaidenEventHandler()
+
     app0_restart = App(
         config=app0.config,
         chain=app0.raiden.chain,
@@ -75,6 +78,7 @@ def test_recovery_happy_case(
         default_registry=app0.raiden.default_registry,
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
+        raiden_event_handler=raiden_event_handler,
         discovery=app0.raiden.discovery,
     )
 
@@ -204,6 +208,8 @@ def test_recovery_unhappy_case(
         retry_timeout,
     )
 
+    raiden_event_handler = RaidenEventHandler()
+
     app0_restart = App(
         config=app0.config,
         chain=app0.raiden.chain,
@@ -211,6 +217,7 @@ def test_recovery_unhappy_case(
         default_registry=app0.raiden.default_registry,
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
+        raiden_event_handler=raiden_event_handler,
         discovery=app0.raiden.discovery,
     )
     del app0  # from here on the app0_restart should be used
@@ -271,6 +278,8 @@ def test_recovery_blockchain_events(
     import gevent
     gevent.sleep(1)
 
+    raiden_event_handler = RaidenEventHandler()
+
     app0_restart = App(
         config=app0.config,
         chain=app0.raiden.chain,
@@ -278,6 +287,7 @@ def test_recovery_blockchain_events(
         default_registry=app0.raiden.default_registry,
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
+        raiden_event_handler=raiden_event_handler,
         discovery=app0.raiden.discovery,
     )
 

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -1,14 +1,16 @@
 import pytest
 import gevent
+
+from raiden.app import App
 from raiden import waiting
-from raiden.transfer import views
+from raiden.network.transport import MatrixTransport
+from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
     direct_transfer,
     assert_synced_channel_state,
 )
-from raiden.network.transport import MatrixTransport
-from raiden.app import App
+from raiden.transfer import views
 
 
 @pytest.mark.parametrize('deposit', [10])
@@ -55,6 +57,8 @@ def test_send_queued_messages(
         app0.raiden.config['transport']['matrix'],
     )
 
+    raiden_event_handler = RaidenEventHandler()
+
     app0_restart = App(
         config=app0.config,
         chain=app0.raiden.chain,
@@ -62,6 +66,7 @@ def test_send_queued_messages(
         default_registry=app0.raiden.default_registry,
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
+        raiden_event_handler=raiden_event_handler,
         discovery=app0.raiden.discovery,
     )
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -12,6 +12,7 @@ from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
 from raiden.network.transport import MatrixTransport, UDPTransport
+from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.utils import merge_dict
@@ -341,6 +342,8 @@ def create_apps(
                 config['transport']['udp'],
             )
 
+        raiden_event_handler = RaidenEventHandler()
+
         app = App(
             config=config_copy,
             chain=blockchain,
@@ -348,6 +351,7 @@ def create_apps(
             default_registry=registry,
             default_secret_registry=secret_registry,
             transport=transport,
+            raiden_event_handler=raiden_event_handler,
             discovery=discovery,
         )
         apps.append(app)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -96,6 +96,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
 )
 from raiden.storage.sqlite import RAIDEN_DB_VERSION
+from raiden.raiden_event_handler import RaidenEventHandler
 
 
 log = structlog.get_logger(__name__)
@@ -754,6 +755,8 @@ def run_app(
     else:
         raise RuntimeError(f'Unknown transport type "{transport}" given')
 
+    raiden_event_handler = RaidenEventHandler()
+
     try:
         chain_config = constants.ID_TO_NETWORK_CONFIG.get(net_id, {})
         start_block = chain_config.get(constants.START_QUERY_BLOCK_KEY, 0)
@@ -764,6 +767,7 @@ def run_app(
             default_registry=token_network_registry,
             default_secret_registry=secret_registry,
             transport=transport,
+            raiden_event_handler=raiden_event_handler,
             discovery=discovery,
         )
     except RaidenError as e:

--- a/tools/scenario_runner.py
+++ b/tools/scenario_runner.py
@@ -11,17 +11,18 @@ import structlog
 from eth_utils import decode_hex
 from web3 import Web3, HTTPProvider
 
-from raiden.app import App
 from raiden.api.python import RaidenAPI
+from raiden.app import App
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.discovery import ContractDiscovery
 from raiden.network.protocol import NODE_NETWORK_REACHABLE
 from raiden.network.protocol import UDPTransport
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
+from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.ui.console import ConsoleTools
-from raiden.utils import split_endpoint
 from raiden.utils.gevent_utils import RaidenGreenletEvent
+from raiden.utils import split_endpoint
 
 gevent.monkey.patch_all()
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
@@ -124,6 +125,8 @@ def run(
         config=config['transport']['udp'],
     )
 
+    raiden_event_handler = RaidenEventHandler()
+
     app = App(
         config=config,
         chain=blockchain_service,
@@ -131,6 +134,7 @@ def run(
         default_registry=registry,
         default_secret_registry=secret_registry,
         transport=transport,
+        raiden_event_handler=raiden_event_handler,
         discovery=discovery,
     )
     app.start()


### PR DESCRIPTION
Made the event handler into a class and allowed it to be injected
through the App and RaidenService. This class can now be overwritten and
the protocol can be controlled by a custom handler class. This is
intended to be used in testing, where control over the messages is
required, e.g. a test for the secret being registered on-chain needs to
stop the unlock message.

[ci integration]