### PR TITLE
Stress test crash

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -418,9 +418,10 @@ class APIServer(Runnable):
         # that the actions are valid, e.g. deposit in a channel that has closed
         # while the node was offline.
         if not self.rest_api.raiden_api.raiden:
-            raise RuntimeError(
+            log.critical(
                 'The RaidenService must be started before the API can be used',
             )
+            return api_error(['Raiden Service not running'], HTTPStatus.INTERNAL_SERVER_ERROR)
 
     def _serve_webui(self, file_name='index.html'):  # pylint: disable=redefined-builtin
         try:

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -142,10 +142,6 @@ class App(Runnable):  # pylint: disable=too-few-public-methods
         super().start()
 
     def stop(self):
-        """ Stop the raiden app.
-
-        Args:
-            leave_channels: if True, also close and settle all channels before stopping
-        """
+        """ Stop the raiden app. """
         if not self.raiden.stop_event.is_set():
             self.raiden.stop()

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -23,12 +23,13 @@ from raiden.settings import (
     RED_EYES_CONTRACT_VERSION,
 )
 from raiden.utils import pex, typing
+from raiden.utils.runnable import Runnable
 from raiden_contracts.contract_manager import contracts_precompiled_path
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
-class App:  # pylint: disable=too-few-public-methods
+class App(Runnable):  # pylint: disable=too-few-public-methods
     DEFAULT_CONFIG = {
         'reveal_timeout': DEFAULT_REVEAL_TIMEOUT,
         'settle_timeout': DEFAULT_SETTLE_TIMEOUT,
@@ -122,6 +123,8 @@ class App:  # pylint: disable=too-few-public-methods
         # raiden.ui.console:Console assumes that a services
         # attribute is available for auto-registration
         self.services = dict()
+        super().__init__()
+        self.raiden.link_exception(self.on_error)
 
     def __repr__(self):
         return '<{} {}>'.format(
@@ -129,10 +132,14 @@ class App:  # pylint: disable=too-few-public-methods
             pex(self.raiden.address),
         )
 
+    def _run(self):
+        self.raiden.join()
+
     def start(self):
         """ Start the raiden app. """
         if self.raiden.stop_event.is_set():
             self.raiden.start()
+        super().start()
 
     def stop(self):
         """ Stop the raiden app.

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -340,8 +340,8 @@ class UDPTransport(Runnable):
         and initialize it with `items`.
         """
         recipient = queue_identifier.recipient
-        queue = self.queueids_to_queues.get(queue_identifier)
-        assert queue is None
+        previous_queue = self.queueids_to_queues.get(queue_identifier)
+        assert previous_queue is None
 
         queue = NotifyingQueue(items=items)
         self.queueids_to_queues[queue_identifier] = queue

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import gevent
 import pytest
+from _pytest.outcomes import Failed
 from _pytest.pathlib import LOCK_TIMEOUT, ensure_reset_dir, make_numbered_dir_with_cleanup
 from _pytest.tmpdir import get_user
 
@@ -166,6 +167,7 @@ def dont_exit_pytest():
 
     This allows the test suite to finish in case an exception is unhandled.
     """
+    gevent.get_hub().SYSTEM_ERROR += (Failed, )
     gevent.get_hub().NOT_ERROR = (gevent.GreenletExit, SystemExit)
 
 

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -9,10 +9,14 @@ from raiden.tests.integration.api.utils import create_api_server
 #       the server is no longer running even though the teardown has not
 #       been invoked.
 @pytest.fixture
-def api_server_test_instance(raiden_network, rest_api_port_number):
+def api_server_test_instance(supervisor, raiden_network, rest_api_port_number):
     api_server = create_api_server(raiden_network[0], rest_api_port_number)
+    supervisor.supervise(api_server)
 
     yield api_server
 
     if api_server:
         api_server.stop()
+
+    if api_server:
+        api_server.get()

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -224,8 +224,12 @@ def transfer_and_assert(post_url, identifier, amount):
         raise exception
 
     assert response is not None
-    assert response.headers['Content-Type'] == 'application/json', response.headers['Content-Type']
-    assert response.status_code == HTTPStatus.OK, response.json()
+    if response.status_code != 500:
+        is_json = response.headers['Content-Type'] == 'application/json'
+        assert is_json, response.headers['Content-Type']
+        assert response.status_code == HTTPStatus.OK, response.json()
+    else:
+        log.critical('server is in shutdown')
 
 
 def _wait_for_server(post_url, identifier, amount, port_number):
@@ -241,7 +245,7 @@ def _wait_for_server(post_url, identifier, amount, port_number):
             )
             return
         except (requests.RequestException, requests.ConnectionError):
-            wait_for_listening_port(port_number)
+            wait_for_listening_port(port_number, tries=100)
 
 
 def parallel_bounded_requests(

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -388,11 +388,12 @@ def create_apps(
     return apps
 
 
-def parallel_start_apps(raiden_apps):
+def parallel_start_with_supervisor(raiden_apps, supervisor):
     """Start all the raiden apps in parallel."""
     start_tasks = list()
 
     for app in raiden_apps:
+        supervisor.supervise(app)
         greenlet = gevent.spawn(app.raiden.start)
         greenlet.name = f'Fixture:raiden_network node:{pex(app.raiden.address)}'
         start_tasks.append(greenlet)

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -282,7 +282,7 @@ def sanity_check(state: MediatorTransferState) -> None:
         (pair.payee_state for pair in state.transfers_pair),
         (pair.payer_state for pair in state.transfers_pair),
     )
-    if any(state in STATE_TRANSFER_PAID for state in all_transfers_states):
+    if any(state_ in STATE_TRANSFER_PAID for state_ in all_transfers_states):
         assert state.secret is not None
 
     # the "transitivity" for these values is checked below as part of


### PR DESCRIPTION
Added a test which will crash a sender or a receiver app which a certain
probability. Because the crash is random and it's executed on a long
sequence of requests, it's probably that most of the protocol states
will be coverred by the test.

This is not ideal because the `stop_event` in `RaidenService` is set before the service is properly stopped.

The test reuses the REST API port number, which will be a problem in Mac systems, this is the case because it would be cumbersome to update greenlets from the request pool with an updated URL (with the port number up-to-date) 

Implements #2570