### PR TITLE
Old balance proof recovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ templates:
       - .travis/install.sh
     script:
       - .travis/run.sh
+    sudo: true
 
   job-template-integration: &job-template-integration
     <<: *job-template-test
-    sudo: true
 
-dist: trusty
+dist: xenial
 sudo: false
 language: python
 python:

--- a/.travis/prepare_os_linux.sh
+++ b/.travis/prepare_os_linux.sh
@@ -1,1 +1,2 @@
 #!/usr/bin/env bash
+sudo apt-get install sqlite3

--- a/.travis/prepare_os_osx.sh
+++ b/.travis/prepare_os_osx.sh
@@ -8,7 +8,7 @@ PYTHON_36_FORMULA=https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a76
 # Pin to python3.6 for the time being
 brew install ${PYTHON_36_FORMULA} || brew upgrade ${PYTHON_36_FORMULA}
 
-for tool in automake gmp leveldb libffi libtool node openssl pkg-config; do
+for tool in automake gmp leveldb libffi libtool node openssl pkg-config sqlite3; do
     brew install ${tool} || brew upgrade ${tool} || true
 done
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,9 +5,9 @@ Changelog
 * :bug:`2507` Fix a security issue where an attacker could eavesdrop Matrix communications between two nodes in private rooms
 * :bug:`2501` Adds a matrix.private_rooms config to communicate only through private rooms in Matrix
 * :bug:`2449` Fix a race condition when handling channel close events.
+* :bug:`2414` If partner uses our old balance proof on-chain, the raiden client will now recover it from the WAL and properly use it on-chain.
 
 * :release:`0.9.0 <2018-09-14>`
-
 * :feature:`2287` Internal events now have timestamps.
 * :feature:`2307` Matrix discovery rooms now are decentralized, aliased and shared by all servers in the federation
 * :bug:`2461` For received payments events filter based on the initiator.

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -2,7 +2,7 @@ import gevent
 import structlog
 from eth_utils import to_canonical_address
 
-from raiden.blockchain.events import decode_event_to_internal
+from raiden.blockchain.events import Event, decode_event_to_internal
 from raiden.blockchain.state import get_channel_state
 from raiden.connection_manager import ConnectionManager
 from raiden.transfer import views
@@ -29,7 +29,7 @@ from raiden_contracts.constants import (
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
-def handle_tokennetwork_new(raiden, event):
+def handle_tokennetwork_new(raiden: 'RaidenService', event: Event):
     """ Handles a `TokenNetworkCreated` event. """
     data = event.event_data
     token_network_address = data['token_network_address']
@@ -58,7 +58,7 @@ def handle_tokennetwork_new(raiden, event):
     raiden.handle_state_change(new_token_network)
 
 
-def handle_channel_new(raiden, event):
+def handle_channel_new(raiden: 'RaidenService', event: Event):
     data = event.event_data
     token_network_identifier = event.originating_contract
     transaction_hash = event.event_data['transactionHash']
@@ -114,7 +114,7 @@ def handle_channel_new(raiden, event):
     raiden.add_pending_greenlet(retry_connect)
 
 
-def handle_channel_new_balance(raiden, event):
+def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
     data = event.event_data
     channel_identifier = data['channel_identifier']
     token_network_identifier = event.originating_contract
@@ -165,7 +165,7 @@ def handle_channel_new_balance(raiden, event):
             raiden.add_pending_greenlet(join_channel)
 
 
-def handle_channel_closed(raiden, event):
+def handle_channel_closed(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     channel_identifier = data['channel_identifier']
@@ -199,7 +199,7 @@ def handle_channel_closed(raiden, event):
         raiden.handle_state_change(channel_closed)
 
 
-def handle_channel_update_transfer(raiden, event):
+def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     channel_identifier = data['channel_identifier']
@@ -222,7 +222,7 @@ def handle_channel_update_transfer(raiden, event):
         raiden.handle_state_change(channel_transfer_updated)
 
 
-def handle_channel_settled(raiden, event):
+def handle_channel_settled(raiden: 'RaidenService', event: Event):
     data = event.event_data
     token_network_identifier = event.originating_contract
     channel_identifier = event.event_data['channel_identifier']
@@ -246,7 +246,7 @@ def handle_channel_settled(raiden, event):
         raiden.handle_state_change(channel_settled)
 
 
-def handle_channel_batch_unlock(raiden, event):
+def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
 
@@ -266,7 +266,7 @@ def handle_channel_batch_unlock(raiden, event):
     raiden.handle_state_change(unlock_state_change)
 
 
-def handle_secret_revealed(raiden, event):
+def handle_secret_revealed(raiden: 'RaidenService', event: Event):
     secret_registry_address = event.originating_contract
     data = event.event_data
 
@@ -283,7 +283,7 @@ def handle_secret_revealed(raiden, event):
     raiden.handle_state_change(registeredsecret_state_change)
 
 
-def on_blockchain_event(raiden, event):
+def on_blockchain_event(raiden: 'RaidenService', event: Event):
     data = event.event_data
     log.debug(
         'BLOCKCHAIN EVENT',

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -29,7 +29,7 @@ from raiden_contracts.constants import (
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
-def handle_tokennetwork_new(raiden: 'RaidenService', event: Event):
+def handle_tokennetwork_new(raiden, event: Event):
     """ Handles a `TokenNetworkCreated` event. """
     data = event.event_data
     token_network_address = data['token_network_address']
@@ -58,7 +58,7 @@ def handle_tokennetwork_new(raiden: 'RaidenService', event: Event):
     raiden.handle_state_change(new_token_network)
 
 
-def handle_channel_new(raiden: 'RaidenService', event: Event):
+def handle_channel_new(raiden, event: Event):
     data = event.event_data
     token_network_identifier = event.originating_contract
     transaction_hash = event.event_data['transactionHash']
@@ -114,7 +114,7 @@ def handle_channel_new(raiden: 'RaidenService', event: Event):
     raiden.add_pending_greenlet(retry_connect)
 
 
-def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
+def handle_channel_new_balance(raiden, event: Event):
     data = event.event_data
     channel_identifier = data['channel_identifier']
     token_network_identifier = event.originating_contract
@@ -165,7 +165,7 @@ def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
             raiden.add_pending_greenlet(join_channel)
 
 
-def handle_channel_closed(raiden: 'RaidenService', event: Event):
+def handle_channel_closed(raiden, event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     channel_identifier = data['channel_identifier']
@@ -199,7 +199,7 @@ def handle_channel_closed(raiden: 'RaidenService', event: Event):
         raiden.handle_state_change(channel_closed)
 
 
-def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
+def handle_channel_update_transfer(raiden, event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     channel_identifier = data['channel_identifier']
@@ -222,7 +222,7 @@ def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
         raiden.handle_state_change(channel_transfer_updated)
 
 
-def handle_channel_settled(raiden: 'RaidenService', event: Event):
+def handle_channel_settled(raiden, event: Event):
     data = event.event_data
     token_network_identifier = event.originating_contract
     channel_identifier = event.event_data['channel_identifier']
@@ -246,7 +246,7 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
         raiden.handle_state_change(channel_settled)
 
 
-def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
+def handle_channel_batch_unlock(raiden, event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
 
@@ -266,7 +266,7 @@ def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
     raiden.handle_state_change(unlock_state_change)
 
 
-def handle_secret_revealed(raiden: 'RaidenService', event: Event):
+def handle_secret_revealed(raiden, event: Event):
     secret_registry_address = event.originating_contract
     data = event.event_data
 

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -8,6 +8,8 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
 )
 
+SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
+
 UINT64_MAX = 2 ** 64 - 1
 UINT64_MIN = 0
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -170,7 +170,7 @@ class RaidenServicePortInUseError(RaidenError):
     """Raised when Raiden service port is already in use"""
 
 
-class InvalidDBData(RaidenError):
+class InvalidDBData(RaidenUnrecoverableError):
     """Raised when the data of the WAL are in an unexpected format"""
 
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -413,7 +413,7 @@ class RaidenEventHandler:
             chain_id=raiden.chain.network_id,
             token_network_id=channel_settle_event.token_network_identifier,
             channel_identifier=channel_settle_event.channel_identifier,
-            recipient=participants_details.our_details.address,
+            sender=participants_details.partner_details.address,
             balance_hash=participants_details.partner_details.balance_hash,
         )
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -325,18 +325,24 @@ class RaidenEventHandler:
         )
 
         storage = raiden.wal.storage
-        our_state_change = storage.get_state_change_by_data_field(
+        our_state_changes = storage.get_state_changes_by_data_field(
             'balance_hash',
-            participants_details.our_details.balance_hash
+            participants_details.our_details.balance_hash,
         )
 
-        partner_state_change = storage.get_state_change_by_data_field(
+        partner_state_changes = storage.get_state_changes_by_data_field(
             'balance_hash',
-            participants_details.partner_details.balance_hash
+            participants_details.partner_details.balance_hash,
         )
 
-        our_balance_proof = our_state_change.balance_proof
-        partner_balance_proof = partner_state_change.balance_proof
+        our_balance_proof = None
+        partner_balance_proof = None
+
+        if our_state_changes:
+            our_balance_proof = our_state_changes[0].balance_proof
+
+        if partner_state_changes:
+            partner_balance_proof = partner_state_changes[0].balance_proof
 
         our_balance_hash = participants_details.our_details.balance_hash
         if our_balance_proof and our_balance_hash != EMPTY_HASH:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -214,9 +214,10 @@ class RaidenService(Runnable):
             )
 
         storage = sqlite.SQLiteStorage(self.database_path, serialize.JSONSerializer())
-        self.wal = wal.restore_from_latest_snapshot(
-            node.state_transition,
-            storage,
+        self.wal = wal.restore_to_state_change(
+            transition_function=node.state_transition,
+            storage=storage,
+            state_change_identifier='latest',
         )
 
         if self.wal.state_manager.current_state is None:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -213,7 +213,6 @@ class RaidenService(Runnable):
                 self.config['transport']['udp']['external_port'],
             )
 
-        # The database may be :memory:
         storage = sqlite.SQLiteStorage(self.database_path, serialize.JSONSerializer())
         self.wal = wal.restore_from_latest_snapshot(
             node.state_transition,

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,0 +1,44 @@
+from raiden.storage import wal
+from raiden.transfer import node, views
+from raiden.transfer.state import NettingChannelState
+from raiden.transfer.utils import hash_balance_data
+from raiden.utils import typing
+
+
+def channel_state_until_balance_hash(
+        raiden: 'RaidenService',
+        token_address: typing.TokenAddress,
+        channel_identifier: typing.ChannelID,
+        target_balance_hash: bytes
+) -> typing.Optional[NettingChannelState]:
+    """ Go through WAL state changes until a certain hash balance is found. """
+
+    # Restore state from the latest snapshot
+    snapshot = raiden.wal.storage.get_latest_state_snapshot()
+    last_applied_state_change_id, chain_state = snapshot
+    unapplied_state_changes = raiden.wal.storage.get_statechanges_by_identifier(
+        from_identifier=last_applied_state_change_id,
+        to_identifier='latest',
+    )
+    # Create a copy WAL
+    log = wal.wal_from_snapshot(node.state_transition, raiden.wal.storage, chain_state)
+    for state_change in unapplied_state_changes:
+        log.state_manager.dispatch(state_change)
+        channel_state = views.get_channelstate_by_id(
+            chain_state=chain_state,
+            payment_network_id=raiden.default_registry,
+            token_address=token_address,
+            channel_id=channel_identifier
+        )
+        if not channel_state:
+            continue
+
+        partner_latest_balance_proof = channel_state.partner_state.balance_proof
+        balance_hash = hash_balance_data(
+            transferred_amount=partner_latest_balance_proof.transferred_amount,
+            locked_amount=partner_latest_balance_proof.locked_amount,
+            locksroot=partner_latest_balance_proof.locksroot
+        )
+        if target_balance_hash == balance_hash:
+            return channel_state
+    return None

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -40,19 +40,30 @@ def channel_state_until_balance_hash(
         log.state_manager.dispatch(state_change)
         channel_state = views.get_channelstate_by_id(
             chain_state=chain_state,
-            payment_network_id=raiden.default_registry,
+            payment_network_id=raiden.default_registry.address,
             token_address=token_address,
             channel_id=channel_identifier,
         )
         if not channel_state:
             continue
 
+        our_latest_balance_proof = channel_state.our_state.balance_proof
         partner_latest_balance_proof = channel_state.partner_state.balance_proof
-        balance_hash = hash_balance_data(
-            transferred_amount=partner_latest_balance_proof.transferred_amount,
-            locked_amount=partner_latest_balance_proof.locked_amount,
-            locksroot=partner_latest_balance_proof.locksroot,
-        )
+
+        balance_hash = None
+        if partner_latest_balance_proof:
+            balance_hash = hash_balance_data(
+                transferred_amount=partner_latest_balance_proof.transferred_amount,
+                locked_amount=partner_latest_balance_proof.locked_amount,
+                locksroot=partner_latest_balance_proof.locksroot,
+            )
+        elif our_latest_balance_proof:
+            balance_hash = hash_balance_data(
+                transferred_amount=our_latest_balance_proof.transferred_amount,
+                locked_amount=our_latest_balance_proof.locked_amount,
+                locksroot=our_latest_balance_proof.locksroot,
+            )
+
         if target_balance_hash == balance_hash:
             return channel_state
 

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from raiden.storage import wal
 from raiden.transfer import node, views
 from raiden.transfer.state import NettingChannelState
@@ -15,11 +17,23 @@ def channel_state_until_balance_hash(
 
     # Restore state from the latest snapshot
     snapshot = raiden.wal.storage.get_latest_state_snapshot()
+    if not snapshot:
+        # No snapshots were taken before this taking place.
+        # Therefore, we return a copy of the current channel state
+        channel_state = deepcopy(views.get_channelstate_by_id(
+            chain_state=views.state_from_raiden(raiden),
+            payment_network_id=raiden.default_registry.address,
+            token_address=token_address,
+            channel_id=channel_identifier,
+        ))
+        return channel_state
+
     last_applied_state_change_id, chain_state = snapshot
     unapplied_state_changes = raiden.wal.storage.get_statechanges_by_identifier(
         from_identifier=last_applied_state_change_id,
         to_identifier='latest',
     )
+
     # Create a copy WAL
     log = wal.wal_from_snapshot(node.state_transition, raiden.wal.storage, chain_state)
     for state_change in unapplied_state_changes:
@@ -41,4 +55,5 @@ def channel_state_until_balance_hash(
         )
         if target_balance_hash == balance_hash:
             return channel_state
+
     return None

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,80 +1,36 @@
-from contextlib import contextmanager
-from copy import deepcopy
-
+from raiden.exceptions import RaidenUnrecoverableError
 from raiden.transfer import node, views
-from raiden.transfer.architecture import StateManager
 from raiden.transfer.state import NettingChannelState
-from raiden.transfer.utils import hash_balance_data
-from raiden.utils import typing
+from raiden.utils import pex, typing
+
+from .wal import restore_to_state_change
 
 
-@contextmanager
-def temporary_state_manager(state_transition, state):
-    state_manager = StateManager(state_transition, state)
-    try:
-        yield state_manager
-    finally:
-        state_manager = None
-
-
-def channel_state_until_balance_hash(
+def channel_state_until_state_change(
         raiden: 'RaidenService',
         token_address: typing.TokenAddress,
+        token_network_identifier: typing.TokenNetworkID,
         channel_identifier: typing.ChannelID,
-        target_balance_hash: bytes,
+        state_change_identifier: int,
 ) -> typing.Optional[NettingChannelState]:
     """ Go through WAL state changes until a certain balance hash is found. """
-
     # Restore state from the latest snapshot
-    snapshot = raiden.wal.storage.get_latest_state_snapshot()
-    if not snapshot:
-        # No snapshots were taken before this taking place.
-        # Therefore, we return a copy of the current channel state
-        channel_state = deepcopy(views.get_channelstate_by_id(
-            chain_state=views.state_from_raiden(raiden),
-            payment_network_id=raiden.default_registry.address,
-            token_address=token_address,
-            channel_id=channel_identifier,
-        ))
-        return channel_state
-
-    last_applied_state_change_id, chain_state = snapshot
-    unapplied_state_changes = raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier=last_applied_state_change_id,
-        to_identifier='latest',
+    wal = restore_to_state_change(
+        node.state_transition,
+        raiden.wal.storage,
+        state_change_identifier,
     )
 
-    # Create a copy WAL
-    with temporary_state_manager(node.state_transition, chain_state) as state_manager:
-        for state_change in unapplied_state_changes:
-            state_manager.dispatch(state_change)
-            channel_state = views.get_channelstate_by_id(
-                chain_state=chain_state,
-                payment_network_id=raiden.default_registry.address,
-                token_address=token_address,
-                channel_id=channel_identifier,
-            )
-            if not channel_state:
-                continue
+    channel_state = views.get_channelstate_by_id(
+        chain_state=wal.state_manager.current_state,
+        payment_network_id=raiden.default_registry.address,
+        token_address=token_address,
+        channel_id=channel_identifier,
+    )
 
-            our_latest_balance_proof = channel_state.our_state.balance_proof
-            partner_latest_balance_proof = channel_state.partner_state.balance_proof
+    if not channel_state:
+        raise RaidenUnrecoverableError(
+            f"Channel was not found before state_change {pex(state_change_identifier)}",
+        )
 
-            balance_hash = None
-            if partner_latest_balance_proof:
-                balance_hash = hash_balance_data(
-                    transferred_amount=partner_latest_balance_proof.transferred_amount,
-                    locked_amount=partner_latest_balance_proof.locked_amount,
-                    locksroot=partner_latest_balance_proof.locksroot,
-                )
-            elif our_latest_balance_proof:
-                balance_hash = hash_balance_data(
-                    transferred_amount=our_latest_balance_proof.transferred_amount,
-                    locked_amount=our_latest_balance_proof.locked_amount,
-                    locksroot=our_latest_balance_proof.locksroot,
-                )
-
-            if target_balance_hash == balance_hash:
-                return channel_state
-
-        return None
+    return channel_state

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -9,7 +9,7 @@ def channel_state_until_balance_hash(
         raiden: 'RaidenService',
         token_address: typing.TokenAddress,
         channel_identifier: typing.ChannelID,
-        target_balance_hash: bytes
+        target_balance_hash: bytes,
 ) -> typing.Optional[NettingChannelState]:
     """ Go through WAL state changes until a certain hash balance is found. """
 
@@ -28,7 +28,7 @@ def channel_state_until_balance_hash(
             chain_state=chain_state,
             payment_network_id=raiden.default_registry,
             token_address=token_address,
-            channel_id=channel_identifier
+            channel_id=channel_identifier,
         )
         if not channel_state:
             continue
@@ -37,7 +37,7 @@ def channel_state_until_balance_hash(
         balance_hash = hash_balance_data(
             transferred_amount=partner_latest_balance_proof.transferred_amount,
             locked_amount=partner_latest_balance_proof.locked_amount,
-            locksroot=partner_latest_balance_proof.locksroot
+            locksroot=partner_latest_balance_proof.locksroot,
         )
         if target_balance_hash == balance_hash:
             return channel_state

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -142,9 +142,9 @@ class SQLiteStorage:
 
         cursor.execute(
             "SELECT data FROM state_changes WHERE "
-            f"json_extract(data, '$.{field}')'==? "
+            f"json_extract(data, '$.{field}')=? "
             "ORDER BY identifier DESC LIMIT 1",
-            value,
+            (value,),
         )
 
         try:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -2,11 +2,18 @@ import sqlite3
 import threading
 from typing import Any, Optional, Tuple
 
+from raiden.constants import SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 
 # The latest DB version
 RAIDEN_DB_VERSION = 4
+
+
+def assert_sqlite_version():
+    if sqlite3.sqlite_version_info < SQLITE_MIN_REQUIRED_VERSION:
+        return False
+    return True
 
 
 class SQLiteStorage:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -10,7 +10,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 RAIDEN_DB_VERSION = 4
 
 
-def assert_sqlite_version():
+def assert_sqlite_version() -> bool:
     if sqlite3.sqlite_version_info < SQLITE_MIN_REQUIRED_VERSION:
         return False
     return True
@@ -143,7 +143,7 @@ class SQLiteStorage:
 
         return result
 
-    def get_latest_event_by_data_field(self, field, value):
+    def get_latest_event_by_data_field(self, field: str, value: str):
         """ Return all state changes filtered by a named field and value."""
         cursor = self.conn.cursor()
 
@@ -166,7 +166,7 @@ class SQLiteStorage:
 
         return result
 
-    def get_latest_state_change_by_data_field(self, field, value):
+    def get_latest_state_change_by_data_field(self, field: str, value: str):
         """ Return all state changes filtered by a named field and value."""
         cursor = self.conn.cursor()
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -136,14 +136,15 @@ class SQLiteStorage:
 
         return result
 
-    def get_state_change_by_data_field(self, field, value):
+    def get_state_changes_by_data_field(self, field, value):
+        """ Return all state changes filtered by a named field and value."""
         cursor = self.conn.cursor()
 
         cursor.execute(
             "SELECT data FROM state_changes WHERE "
             f"json_extract(data, '$.{field}')'==? "
             "ORDER BY identifier DESC LIMIT 1",
-            value
+            value,
         )
 
         try:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -169,7 +169,10 @@ class SQLiteStorage:
             cursor.execute(
                 'SELECT identifier FROM state_changes ORDER BY identifier DESC LIMIT 1',
             )
-            state_change_id = cursor.fetchone()
+            if cursor.rowcount > 0:
+                state_change_id = cursor.fetchone()[0]
+            else:
+                state_change_id = 0
 
         cursor = self.conn.execute(
             'SELECT statechange_id, data FROM state_snapshot '

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -136,6 +136,28 @@ class SQLiteStorage:
 
         return result
 
+    def get_state_change_by_data_field(self, field, value):
+        cursor = self.conn.cursor()
+
+        cursor.execute(
+            "SELECT data FROM state_changes WHERE "
+            f"json_extract(data, '$.{field}')'==? "
+            "ORDER BY identifier DESC LIMIT 1",
+            value
+        )
+
+        try:
+            result = [
+                self.serializer.deserialize(entry[0])
+                for entry in cursor.fetchall()
+            ]
+        except AttributeError:
+            raise InvalidDBData(
+                'Your local database is corrupt. Bailing ...',
+            )
+
+        return result
+
     def get_statechanges_by_identifier(self, from_identifier, to_identifier):
         if not (from_identifier == 'latest' or isinstance(from_identifier, int)):
             raise ValueError("from_identifier must be an integer or 'latest'")

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -6,11 +6,6 @@ from raiden.transfer.architecture import StateManager
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
-def wal_from_snapshot(transition_function, storage, state) -> 'WriteAheadLog':
-    state_manager = StateManager(transition_function, state)
-    return WriteAheadLog(state_manager, storage)
-
-
 def restore_from_latest_snapshot(transition_function, storage):
     snapshot = storage.get_latest_state_snapshot()
 
@@ -29,7 +24,8 @@ def restore_from_latest_snapshot(transition_function, storage):
             to_identifier='latest',
         )
 
-    wal = wal_from_snapshot(transition_function, storage, state)
+    state_manager = StateManager(transition_function, state)
+    wal = WriteAheadLog(state_manager, storage)
 
     log.debug('Replaying state changes', num_state_changes=len(unapplied_state_changes))
     for state_change in unapplied_state_changes:

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -8,7 +8,7 @@ from raiden.api.python import RaidenAPI
 from raiden.constants import UINT64_MAX
 from raiden.messages import RevealSecret
 from raiden.settings import DEFAULT_NUMBER_OF_CONFIRMATIONS_BLOCK, DEFAULT_RETRY_TIMEOUT
-from raiden.storage.restore import channel_state_until_balance_hash
+from raiden.storage.restore import channel_state_until_state_change
 from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.geth import wait_until_block
 from raiden.tests.utils.network import CHAIN
@@ -263,6 +263,7 @@ def test_batch_unlock(raiden_network, token_addresses, secret_registry_address, 
         alice_to_bob_amount,
         identifier,
     )
+
     secrethash = sha3(secret)
 
     alice_bob_channel_state = get_channelstate(alice_app, bob_app, token_network_identifier)
@@ -285,11 +286,12 @@ def test_batch_unlock(raiden_network, token_addresses, secret_registry_address, 
     our_balance_proof = alice_bob_channel_state.our_state.balance_proof
 
     # Test WAL restore to return the latest channel state
-    restored_channel_state = channel_state_until_balance_hash(
+    restored_channel_state = channel_state_until_state_change(
         alice_app.raiden,
         token_address,
+        token_network_identifier,
         alice_bob_channel_state.identifier,
-        alice_bob_channel_state.our_state.balance_proof.balance_hash,
+        'latest',
     )
 
     our_restored_balance_proof = restored_channel_state.our_state.balance_proof

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1147,9 +1147,9 @@ def test_channel_never_expires_lock_with_secret_onchain():
     lock_secrethash = sha3(lock_secret)
 
     lock = HashTimeLockState(
-        lock_amount,
-        lock_expiration,
-        lock_secrethash,
+        amount=lock_amount,
+        expiration=lock_expiration,
+        secrethash=lock_secrethash,
     )
 
     payment_identifier = 1
@@ -1158,14 +1158,14 @@ def test_channel_never_expires_lock_with_secret_onchain():
     transfer_initiator = factories.make_address()
 
     channel.send_lockedtransfer(
-        channel_state,
-        transfer_initiator,
-        transfer_target,
-        lock_amount,
-        message_identifier,
-        payment_identifier,
-        lock_expiration,
-        lock_secrethash,
+        channel_state=channel_state,
+        initiator=transfer_initiator,
+        target=transfer_target,
+        amount=lock_amount,
+        message_identifier=message_identifier,
+        payment_identifier=payment_identifier,
+        expiration=lock_expiration,
+        secrethash=lock_secrethash,
     )
 
     assert lock.secrethash in channel_state.our_state.secrethashes_to_lockedlocks
@@ -1196,24 +1196,24 @@ def test_channel_must_never_expire_locks_with_onchain_secret():
     lock_secret = b'test_channel_must_accept_expired_locks'
     lock_secrethash = sha3(lock_secret)
     lock = HashTimeLockState(
-        lock_amount,
-        lock_expiration,
-        lock_secrethash,
+        amount=lock_amount,
+        expiration=lock_expiration,
+        secrethash=lock_secrethash,
     )
 
     nonce = 1
     transferred_amount = 0
     receive_lockedtransfer = make_receive_transfer_mediated(
-        channel_state,
-        privkey2,
-        nonce,
-        transferred_amount,
-        lock,
+        channel_state=channel_state,
+        privkey=privkey2,
+        nonce=nonce,
+        transferred_amount=transferred_amount,
+        lock=lock,
     )
 
     is_valid, _, msg = channel.handle_receive_lockedtransfer(
-        channel_state,
-        receive_lockedtransfer,
+        channel_state=channel_state,
+        mediated_transfer=receive_lockedtransfer,
     )
     assert is_valid, msg
 

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -7,7 +7,7 @@ from raiden.exceptions import InvalidDBData
 from raiden.storage.serialize import JSONSerializer
 from raiden.storage.sqlite import RAIDEN_DB_VERSION, SQLiteStorage
 from raiden.storage.utils import TimestampedEvent
-from raiden.storage.wal import WriteAheadLog, restore_from_latest_snapshot
+from raiden.storage.wal import WriteAheadLog, restore_to_state_change
 from raiden.tests.utils import factories
 from raiden.transfer.architecture import State, StateManager, TransitionResult
 from raiden.transfer.events import EventPaymentSentFailed
@@ -215,9 +215,10 @@ def test_restore_without_snapshot():
     )
     wal.log_and_dispatch(block3)
 
-    newwal = restore_from_latest_snapshot(
-        state_transtion_acc,
-        wal.storage,
+    newwal = restore_to_state_change(
+        transition_function=state_transtion_acc,
+        storage=wal.storage,
+        state_change_identifier='latest',
     )
 
     aggregate = newwal.state_manager.current_state

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -794,6 +794,9 @@ def test_initiator_lock_expired():
 
 
 def test_initiator_handle_contract_receive_secret_reveal():
+    """ Make sure the initiator handles ContractReceiveSecretReveal
+    and checks the existence of the transfer's secrethash in
+    secrethashes_to_lockedlocks and secrethashes_to_onchain_unlockedlocks. """
     amount = UNIT_TRANSFER_AMOUNT * 2
     block_number = 1
     refund_pkey, refund_address = factories.make_privkey_address()
@@ -816,11 +819,11 @@ def test_initiator_handle_contract_receive_secret_reveal():
 
     block_number = 10
     current_state = make_initiator_manager_state(
-        available_routes,
-        factories.UNIT_TRANSFER_DESCRIPTION,
-        channel_map,
-        pseudo_random_generator,
-        block_number,
+        routes=available_routes,
+        transfer_description=factories.UNIT_TRANSFER_DESCRIPTION,
+        channel_map=channel_map,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
     )
 
     transfer = current_state.initiator.transfer
@@ -828,17 +831,17 @@ def test_initiator_handle_contract_receive_secret_reveal():
     assert transfer.lock.secrethash in channel1.our_state.secrethashes_to_lockedlocks
 
     state_change = ContractReceiveSecretReveal(
-        factories.make_transaction_hash(),
-        factories.make_address(),
-        transfer.lock.secrethash,
-        UNIT_SECRET,
+        transaction_hash=factories.make_transaction_hash(),
+        secret_registry_address=factories.make_address(),
+        secrethash=transfer.lock.secrethash,
+        secret=UNIT_SECRET,
     )
 
     initiator_manager.handle_onchain_secretreveal(
-        current_state,
-        state_change,
-        channel_map,
-        pseudo_random_generator,
+        payment_state=current_state,
+        state_change=state_change,
+        channelidentifiers_to_channels=channel_map,
+        pseudo_random_generator=pseudo_random_generator,
     )
 
     assert transfer.lock.secrethash in channel1.our_state.secrethashes_to_lockedlocks

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -14,7 +14,7 @@ def test_is_transaction_effect_satisfied(
         token_address=token_network_state.token_address,
         token_network_identifier=token_network_id,
         channel_identifier=netting_channel_state.identifier,
-        partner=HOP2,
+        participant=HOP2,
     )
     state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=UNIT_SECRETHASH,

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -11,9 +11,10 @@ def test_is_transaction_effect_satisfied(
         netting_channel_state,
 ):
     transaction = ContractSendChannelBatchUnlock(
+        token_address=token_network_state.token_address,
         token_network_identifier=token_network_id,
         channel_identifier=netting_channel_state.identifier,
-        merkle_tree_leaves=EMPTY_MERKLE_ROOT,
+        partner=HOP2,
     )
     state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=UNIT_SECRETHASH,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1804,8 +1804,6 @@ def handle_block(
             event = ContractSendChannelSettle(
                 channel_state.identifier,
                 channel_state.token_network_identifier,
-                channel_state.our_state.balance_proof,
-                channel_state.partner_state.balance_proof,
             )
             events.append(event)
 
@@ -1894,7 +1892,7 @@ def handle_channel_settled(
             onchain_unlock = ContractSendChannelBatchUnlock(
                 channel_state.token_network_identifier,
                 channel_state.identifier,
-                merkle_tree_leaves,
+                channel_state.partner_state.address,
             )
             events.append(onchain_unlock)
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1453,11 +1453,11 @@ def register_secret_endstate(
         secrethash: typing.SecretHash,
 ) -> None:
     if is_lock_locked(end_state, secrethash):
-        pendinglock = end_state.secrethashes_to_lockedlocks[secrethash]
+        pending_lock = end_state.secrethashes_to_lockedlocks[secrethash]
         del end_state.secrethashes_to_lockedlocks[secrethash]
 
         end_state.secrethashes_to_unlockedlocks[secrethash] = UnlockPartialProofState(
-            pendinglock,
+            pending_lock,
             secret,
         )
 
@@ -1471,20 +1471,20 @@ def register_onchain_secret_endstate(
     # the lock might be in end_state.secrethashes_to_lockedlocks or
     # end_state.secrethashes_to_unlockedlocks
     # It should be removed from both and moved into secrethashes_to_onchain_unlockedlocks
-    pendinglock = None
+    pending_lock = None
 
     if is_lock_locked(end_state, secrethash):
-        pendinglock = end_state.secrethashes_to_lockedlocks[secrethash]
+        pending_lock = end_state.secrethashes_to_lockedlocks[secrethash]
 
     if secrethash in end_state.secrethashes_to_unlockedlocks:
-        pendinglock = end_state.secrethashes_to_unlockedlocks[secrethash].lock
+        pending_lock = end_state.secrethashes_to_unlockedlocks[secrethash].lock
 
-    if pendinglock:
+    if pending_lock:
         if delete_lock:
             _del_lock(end_state, secrethash)
 
         end_state.secrethashes_to_onchain_unlockedlocks[secrethash] = UnlockPartialProofState(
-            pendinglock,
+            pending_lock,
             secret,
         )
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1890,6 +1890,7 @@ def handle_channel_settled(
 
         if not is_settle_pending and merkle_tree_leaves:
             onchain_unlock = ContractSendChannelBatchUnlock(
+                channel_state.token_address,
                 channel_state.token_network_identifier,
                 channel_state.identifier,
                 channel_state.partner_state.address,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -495,7 +495,7 @@ def is_valid_lock_expired(
         result = (False, msg, None)
 
     elif lock_registered_on_chain:
-        msg = 'Invalid LockExpired message. Secret registered on-chain.'
+        msg = 'Invalid LockExpired mesage. Lock was unlocked on-chain.'
         result = (False, msg, None)
 
     else:

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -59,6 +59,7 @@ class ContractSendChannelClose(ContractSendEvent):
             'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
+            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -168,6 +169,7 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
             'channel_identifier': self.channel_identifier,
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
+            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
         }
 
         return result
@@ -629,6 +631,7 @@ class SendDirectTransfer(SendMessageEvent):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'balance_proof': self.balance_proof,
+            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
             'token_address': to_checksum_address(self.token),
         }
 

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -228,7 +228,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
-            'partner': self.partner,
+            'partner': to_checksum_address(self.partner),
         }
 
         return result
@@ -239,7 +239,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             token_address=to_canonical_address(data['token_address']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
-            partner=data['partner'],
+            partner=to_canonical_address(data['partner']),
         )
 
         return restored

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -217,7 +217,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             self.token_address == other.token_address and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.partner == other.partner and
+            self.partner == other.partner
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -80,16 +80,7 @@ class ContractSendChannelSettle(ContractSendEvent):
             self,
             channel_identifier: typing.ChannelID,
             token_network_identifier: typing.TokenNetworkAddress,
-            our_balance_proof: typing.Union[
-                BalanceProofSignedState,
-                BalanceProofUnsignedState,
-                None,
-            ],
-            partner_balance_proof: typing.Union[
-                BalanceProofSignedState,
-                BalanceProofUnsignedState,
-                None,
-            ],
+
     ):
         if not isinstance(channel_identifier, typing.T_ChannelID):
             raise ValueError('channel_identifier must be a ChannelID instance')
@@ -97,20 +88,8 @@ class ContractSendChannelSettle(ContractSendEvent):
         if not isinstance(token_network_identifier, typing.T_TokenNetworkAddress):
             raise ValueError('token_network_identifier must be a TokenNetworkAddress instance')
 
-        if our_balance_proof and not isinstance(our_balance_proof, BalanceProofUnsignedState):
-            raise ValueError('our_balance_proof must be a BalanceProofSignedState instance')
-
-        is_valid_partner_bp = (
-            partner_balance_proof and
-            not isinstance(partner_balance_proof, BalanceProofSignedState)
-        )
-        if is_valid_partner_bp:
-            raise ValueError('partner_balance_proof must be a BalanceProofSignedState instance')
-
         self.channel_identifier = channel_identifier
         self.token_network_identifier = token_network_identifier
-        self.our_balance_proof = our_balance_proof
-        self.partner_balance_proof = partner_balance_proof
 
     def __repr__(self):
         return '<ContractSendChannelSettle channel:{} token_network:{}>'.format(
@@ -122,9 +101,7 @@ class ContractSendChannelSettle(ContractSendEvent):
         return (
             isinstance(other, ContractSendChannelSettle) and
             self.channel_identifier == other.channel_identifier and
-            self.token_network_identifier == other.token_network_identifier and
-            self.our_balance_proof == other.our_balance_proof and
-            self.partner_balance_proof == other.partner_balance_proof
+            self.token_network_identifier == other.token_network_identifier
         )
 
     def __ne__(self, other):
@@ -136,22 +113,13 @@ class ContractSendChannelSettle(ContractSendEvent):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
         }
 
-        if self.our_balance_proof is not None:
-            result['our_balance_proof'] = self.our_balance_proof
-        if self.partner_balance_proof is not None:
-            result['partner_balance_proof'] = self.partner_balance_proof
-
         return result
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendChannelSettle':
-        our_balance_proof = data.get('our_balance_proof')
-        partner_balance_proof = data.get('partner_balance_proof')
         restored = cls(
             channel_identifier=data['channel_identifier'],
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            our_balance_proof=our_balance_proof,
-            partner_balance_proof=partner_balance_proof,
         )
 
         return restored
@@ -223,21 +191,21 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             self,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
-            merkle_tree_leaves: typing.MerkleTreeLeaves,
+            participant: typing.Address,
     ):
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.merkle_tree_leaves = merkle_tree_leaves
+        self.participant = participant
 
     def __repr__(self):
         return (
             '<ContractSendChannelBatchUnlock '
-            'token_network_id:{} channel:{} merkle_tree_leaves:{}'
+            'token_network_id:{} channel:{} participant:{}'
             '>'
         ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
-            self.merkle_tree_leaves,
+            pex(self.participant)
         )
 
     def __eq__(self, other):
@@ -245,7 +213,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             isinstance(other, ContractSendChannelBatchUnlock) and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.merkle_tree_leaves == other.merkle_tree_leaves
+            self.participant == other.participant
         )
 
     def __ne__(self, other):
@@ -255,7 +223,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
         result = {
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
-            'merkle_tree_leaves': self.merkle_tree_leaves,
+            'participant': self.participant,
         }
 
         return result
@@ -265,7 +233,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
         restored = cls(
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
-            merkle_tree_leaves=data['merkle_tree_leaves'],
+            participant=data['participant'],
         )
 
         return restored

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -54,13 +54,16 @@ class ContractSendChannelClose(ContractSendEvent):
         return not self.__eq__(other)
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
-        return {
+        result = {
             'channel_identifier': self.channel_identifier,
             'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
-            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
+
         }
+        if self.balance_proof:
+            result['balance_hash'] = serialization.serialize_bytes(self.balance_proof.balance_hash)
+        return result
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendChannelClose':
@@ -169,8 +172,9 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
             'channel_identifier': self.channel_identifier,
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
-            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
         }
+        if self.balance_proof:
+            result['balance_hash'] = serialization.serialize_bytes(self.balance_proof.balance_hash)
 
         return result
 
@@ -631,9 +635,10 @@ class SendDirectTransfer(SendMessageEvent):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
             'token_address': to_checksum_address(self.token),
         }
+        if self.balance_proof:
+            result['balance_hash'] = serialization.serialize_bytes(self.balance_proof.balance_hash)
 
         return result
 

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -205,7 +205,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
         ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
-            pex(self.participant)
+            pex(self.participant),
         )
 
     def __eq__(self, other):

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -189,31 +189,35 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
 
     def __init__(
             self,
+            token_address: typing.TokenAddress,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
-            participant: typing.Address,
+            partner: typing.Address,
     ):
+        self.token_address = token_address
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.participant = participant
+        self.partner = partner
 
     def __repr__(self):
         return (
             '<ContractSendChannelBatchUnlock '
-            'token_network_id:{} channel:{} participant:{}'
+            'token_address: {} token_network_id:{} channel:{} partner:{}'
             '>'
         ).format(
+            pex(self.token_address),
             pex(self.token_network_identifier),
             self.channel_identifier,
-            pex(self.participant),
+            pex(self.partner),
         )
 
     def __eq__(self, other):
         return (
             isinstance(other, ContractSendChannelBatchUnlock) and
+            self.token_address == other.token_address and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.participant == other.participant
+            self.partner == other.partner and
         )
 
     def __ne__(self, other):
@@ -221,9 +225,10 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
+            'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
-            'participant': self.participant,
+            'partner': self.partner,
         }
 
         return result
@@ -231,9 +236,10 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendChannelBatchUnlock':
         restored = cls(
+            token_address=to_canonical_address(data['token_address']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
-            participant=data['participant'],
+            partner=data['partner'],
         )
 
         return restored

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -198,23 +198,23 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             token_address: typing.TokenAddress,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
-            partner: typing.Address,
+            participant: typing.Address,
     ):
         self.token_address = token_address
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.partner = partner
+        self.participant = participant
 
     def __repr__(self):
         return (
             '<ContractSendChannelBatchUnlock '
-            'token_address: {} token_network_id:{} channel:{} partner:{}'
+            'token_address: {} token_network_id:{} channel:{} participant:{}'
             '>'
         ).format(
             pex(self.token_address),
             pex(self.token_network_identifier),
             self.channel_identifier,
-            pex(self.partner),
+            pex(self.participant),
         )
 
     def __eq__(self, other):
@@ -223,7 +223,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             self.token_address == other.token_address and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.partner == other.partner
+            self.participant == other.participant
         )
 
     def __ne__(self, other):
@@ -234,7 +234,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
-            'partner': to_checksum_address(self.partner),
+            'participant': to_checksum_address(self.participant),
         }
 
         return result
@@ -245,7 +245,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             token_address=to_canonical_address(data['token_address']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
-            partner=to_canonical_address(data['partner']),
+            participant=to_canonical_address(data['participant']),
         )
 
         return restored

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -66,6 +66,7 @@ class SendLockExpired(SendMessageEvent):
         result = {
             'message_identifier': self.message_identifier,
             'balance_proof': self.balance_proof,
+            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
             'secrethash': serialization.serialize_bytes(self.secrethash),
             'recipient': to_checksum_address(self.recipient),
         }
@@ -296,7 +297,7 @@ class SendBalanceProof(SendMessageEvent):
             'payment_identifier': self.payment_identifier,
             'token_address': to_checksum_address(self.token),
             'secret': serialization.serialize_bytes(self.secret),
-            'balance_proof': self.balance_proof,
+            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
         }
 
         return result
@@ -465,6 +466,7 @@ class SendRefundTransfer(SendMessageEvent):
             'payment_identifier': self.payment_identifier,
             'token_address': to_checksum_address(self.token),
             'balance_proof': self.balance_proof,
+            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
             'lock': self.lock,
             'initiator': to_checksum_address(self.initiator),
             'target': to_checksum_address(self.target),

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -297,6 +297,7 @@ class SendBalanceProof(SendMessageEvent):
             'payment_identifier': self.payment_identifier,
             'token_address': to_checksum_address(self.token),
             'secret': serialization.serialize_bytes(self.secret),
+            'balance_proof': self.balance_proof,
             'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
         }
 

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -102,6 +102,10 @@ class SendLockedTransfer(SendMessageEvent):
 
         self.transfer = transfer
 
+    @property
+    def balance_proof(self):
+        return self.transfer.balance_proof
+
     def __repr__(self):
         return '<SendLockedTransfer msgid:{} transfer:{} recipient:{}>'.format(
             self.message_identifier,
@@ -125,6 +129,10 @@ class SendLockedTransfer(SendMessageEvent):
             'channel_identifier': self.queue_identifier.channel_identifier,
             'message_identifier': self.message_identifier,
             'transfer': self.transfer,
+            'balance_proof': self.transfer.balance_proof,
+            'balance_hash': serialization.serialize_bytes(
+                self.transfer.balance_proof.balance_hash,
+            ),
         }
 
         return result

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -38,10 +38,10 @@ def handle_block(
     locked_lock = channel_state.our_state.secrethashes_to_lockedlocks.get(secrethash)
 
     lock_expired = channel.is_lock_expired(
-        channel_state.our_state,
-        locked_lock,
-        secrethash,
-        state_change.block_number,
+        end_state=channel_state.our_state,
+        locked_lock=locked_lock,
+        secrethash=secrethash,
+        block_number=state_change.block_number,
     )
     if locked_lock and lock_expired:
         # Lock has expired, cleanup...
@@ -308,7 +308,7 @@ def handle_onchain_secretreveal(
         state_change: ContractReceiveSecretReveal,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
-):
+) -> TransitionResult:
     """ Validates and handles a ContractReceiveSecretReveal state change. """
     valid_secret = state_change.secrethash == initiator_state.transfer.lock.secrethash
 

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -273,10 +273,10 @@ def handle_onchain_secretreveal(
     channel_identifier = payment_state.initiator.channel_identifier
     channel_state = channelidentifiers_to_channels[channel_identifier]
     sub_iteration = initiator.handle_onchain_secretreveal(
-        payment_state.initiator,
-        state_change,
-        channel_state,
-        pseudo_random_generator,
+        initiator_state=payment_state.initiator,
+        state_change=state_change,
+        channel_state=channel_state,
+        pseudo_random_generator=pseudo_random_generator,
     )
     iteration = iteration_from_sub(payment_state, sub_iteration)
     return iteration

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -648,10 +648,10 @@ def events_for_onchain_secretreveal(
 
 
 def events_for_unlock_if_closed(
-        channelidentifiers_to_channels,
-        transfers_pair,
-        secret,
-        secrethash,
+        channelidentifiers_to_channels: typing.ChannelMap,
+        transfers_pair: typing.List[MediationPairState],
+        secret: typing.Secret,
+        secrethash: typing.SecretHash,
 ):
     """ Unlock on chain if the payer channel is closed and the secret is known.
     If a channel is closed because of another task a balance proof will not be
@@ -677,6 +677,7 @@ def events_for_unlock_if_closed(
         if not payer_channel_open:
             pair.payer_state = 'payer_waiting_unlock'
             unlock = ContractSendChannelBatchUnlock(
+                payer_channel.token_address,
                 payer_channel.token_network_identifier,
                 payer_channel.identifier,
                 payer_channel.partner_state.address,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -652,7 +652,7 @@ def events_for_unlock_if_closed(
         transfers_pair: typing.List[MediationPairState],
         secret: typing.Secret,
         secrethash: typing.SecretHash,
-):
+) -> typing.List[ContractSendChannelBatchUnlock]:
     """ Unlock on chain if the payer channel is closed and the secret is known.
     If a channel is closed because of another task a balance proof will not be
     received, so there is no reason to wait for the unsafe region before
@@ -706,10 +706,10 @@ def events_for_expired_locks(
         secrethash = mediator_state.secrethash
         locked_lock = channel_state.our_state.secrethashes_to_lockedlocks.get(secrethash)
         lock_expired = channel.is_lock_expired(
-            channel_state.our_state,
-            locked_lock,
-            secrethash,
-            block_number,
+            end_state=channel_state.our_state,
+            locked_lock=locked_lock,
+            secrethash=secrethash,
+            block_number=block_number,
         )
         if locked_lock and lock_expired:
             # Lock has expired, cleanup...

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -705,7 +705,13 @@ def events_for_expired_locks(
 
         secrethash = mediator_state.secrethash
         locked_lock = channel_state.our_state.secrethashes_to_lockedlocks.get(secrethash)
-        if locked_lock and channel.is_lock_expired(locked_lock, secrethash, block_number):
+        lock_expired = channel.is_lock_expired(
+            channel.our_state,
+            locked_lock,
+            secrethash,
+            block_number,
+        )
+        if locked_lock and lock_expired:
             # Lock has expired, cleanup...
             transfer_pair.payee_state = 'payee_expired'
             expired_lock_events = channel.events_for_expired_lock(

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -706,7 +706,7 @@ def events_for_expired_locks(
         secrethash = mediator_state.secrethash
         locked_lock = channel_state.our_state.secrethashes_to_lockedlocks.get(secrethash)
         lock_expired = channel.is_lock_expired(
-            channel.our_state,
+            channel_state.our_state,
             locked_lock,
             secrethash,
             block_number,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -676,18 +676,10 @@ def events_for_unlock_if_closed(
         # The unlock is done by the channel
         if not payer_channel_open:
             pair.payer_state = 'payer_waiting_unlock'
-
-            partner_state = payer_channel.partner_state
-            lock = channel.get_lock(partner_state, secrethash)
-            unlock_proof = channel.compute_proof_for_lock(
-                partner_state,
-                secret,
-                lock,
-            )
             unlock = ContractSendChannelBatchUnlock(
                 payer_channel.token_network_identifier,
                 payer_channel.identifier,
-                [unlock_proof],
+                payer_channel.partner_state.address,
             )
             events.append(unlock)
 

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -262,7 +262,7 @@ class ReceiveLockExpired(StateChange):
         return {
             'sender': to_checksum_address(self.sender),
             'balance_proof': self.balance_proof,
-            'balance_hash': self.balance_proof.balance_hash,
+            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
             'secrethash': serialize_bytes(self.secrethash),
             'message_identifier': self.message_identifier,
         }
@@ -272,6 +272,7 @@ class ReceiveLockExpired(StateChange):
         return cls(
             sender=to_canonical_address(data['sender']),
             balance_proof=data['balance_proof'],
+            balance_hash=deserialize_bytes(data['balance_hash']),
             secrethash=deserialize_bytes(data['secrethash']),
             message_identifier=data['message_identifier'],
         )

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -272,7 +272,6 @@ class ReceiveLockExpired(StateChange):
         return cls(
             sender=to_canonical_address(data['sender']),
             balance_proof=data['balance_proof'],
-            balance_hash=deserialize_bytes(data['balance_hash']),
             secrethash=deserialize_bytes(data['secrethash']),
             message_identifier=data['message_identifier'],
         )

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -108,11 +108,17 @@ class ActionInitMediator(StateChange):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    @property
+    def balance_proof(self):
+        return self.from_transfer.balance_proof
+
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'routes': self.routes,
             'from_route': self.from_route,
             'from_transfer': self.from_transfer,
+            'balance_proof': self.balance_proof,
+            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -162,10 +168,16 @@ class ActionInitTarget(StateChange):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    @property
+    def balance_proof(self):
+        return self.transfer.balance_proof
+
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'route': self.route,
             'transfer': self.transfer,
+            'balance_proof': self.balance_proof,
+            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -262,6 +262,7 @@ class ReceiveLockExpired(StateChange):
         return {
             'sender': to_checksum_address(self.sender),
             'balance_proof': self.balance_proof,
+            'balance_hash': self.balance_proof.balance_hash,
             'secrethash': serialize_bytes(self.secrethash),
             'message_identifier': self.message_identifier,
         }

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1071,7 +1071,7 @@ class ReceiveTransferDirect(StateChange):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'balance_proof': self.balance_proof,
-            'balance_hash': self.balance_proof.balance_hash,
+            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -1081,6 +1081,7 @@ class ReceiveTransferDirect(StateChange):
             message_identifier=data['message_identifier'],
             payment_identifier=data['payment_identifier'],
             balance_proof=data['balance_proof'],
+            balance_hash=deserialize_bytes(data['balance_hash']),
         )
 
 
@@ -1125,7 +1126,7 @@ class ReceiveUnlock(StateChange):
             'message_identifier': self.message_identifier,
             'secret': serialize_bytes(self.secret),
             'balance_proof': self.balance_proof,
-            'balance_hash': self.balance_proof.balance_hash,
+            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -1134,6 +1135,7 @@ class ReceiveUnlock(StateChange):
             message_identifier=data['message_identifier'],
             secret=deserialize_bytes(data['secret']),
             balance_proof=data['balance_proof'],
+            balance_hash=deserialize_bytes(data['balance_hash']),
         )
 
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1081,7 +1081,6 @@ class ReceiveTransferDirect(StateChange):
             message_identifier=data['message_identifier'],
             payment_identifier=data['payment_identifier'],
             balance_proof=data['balance_proof'],
-            balance_hash=deserialize_bytes(data['balance_hash']),
         )
 
 
@@ -1135,7 +1134,6 @@ class ReceiveUnlock(StateChange):
             message_identifier=data['message_identifier'],
             secret=deserialize_bytes(data['secret']),
             balance_proof=data['balance_proof'],
-            balance_hash=deserialize_bytes(data['balance_hash']),
         )
 
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1071,6 +1071,7 @@ class ReceiveTransferDirect(StateChange):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'balance_proof': self.balance_proof,
+            'balance_hash': self.balance_proof.balance_hash,
         }
 
     @classmethod
@@ -1124,6 +1125,7 @@ class ReceiveUnlock(StateChange):
             'message_identifier': self.message_identifier,
             'secret': serialize_bytes(self.secret),
             'balance_proof': self.balance_proof,
+            'balance_hash': self.balance_proof.balance_hash,
         }
 
     @classmethod

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -19,15 +19,15 @@ def get_latest_known_balance_proof_from_state_changes(
 ) -> typing.Optional['BalanceProofSignedState']:
     """ Tries to find the balance proof with the provided balance hash
     in stored state changes. """
-    state_change = storage.get_latest_state_change_by_data_field({
+    state_change_record = storage.get_latest_state_change_by_data_field({
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_id': to_checksum_address(token_network_id),
         'balance_proof.channel_identifier': channel_identifier,
         'balance_proof.sender': to_checksum_address(recipient),
         'balance_hash': serialize_bytes(balance_hash),
     })
-    if state_change:
-        return state_change.balance_proof
+    if state_change_record.data:
+        return state_change_record.data.balance_proof
     return None
 
 
@@ -40,14 +40,14 @@ def get_latest_known_balance_proof_from_events(
 ) -> typing.Optional['BalanceProofSignedState']:
     """ Tries to find the balance proof with the provided balance hash
     in stored events. """
-    event = storage.get_latest_event_by_data_field({
+    event_record = storage.get_latest_event_by_data_field({
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_id),
         'balance_proof.channel_identifier': channel_identifier,
         'balance_hash': serialize_bytes(balance_hash),
     })
-    if event:
-        return event.balance_proof
+    if event_record.data:
+        return event_record.data.balance_proof
 
     return None
 

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -11,7 +11,9 @@ from raiden.utils.serialization import serialize_bytes
 def get_latest_known_balance_proof(
         storage: SQLiteStorage,
         balance_hash: typing.BalanceHash,
-):
+) -> typing.Optional['BalanceProofSignedState']:
+    """ Tries to find the balance proof with the provided balance hash
+    in either latest state change or latest event. """
     state_change = storage.get_latest_state_change_by_data_field(
         'balance_hash',
         serialize_bytes(balance_hash),

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -15,15 +15,15 @@ def get_latest_known_balance_proof_from_state_changes(
         token_network_id: typing.TokenNetworkID,
         channel_identifier: typing.ChannelID,
         balance_hash: typing.BalanceHash,
-        recipient: typing.Address,
+        sender: typing.Address,
 ) -> typing.Optional['BalanceProofSignedState']:
     """ Tries to find the balance proof with the provided balance hash
     in stored state changes. """
     state_change_record = storage.get_latest_state_change_by_data_field({
         'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_id': to_checksum_address(token_network_id),
+        'balance_proof.token_network_identifier': to_checksum_address(token_network_id),
         'balance_proof.channel_identifier': channel_identifier,
-        'balance_proof.sender': to_checksum_address(recipient),
+        'balance_proof.sender': to_checksum_address(sender),
         'balance_hash': serialize_bytes(balance_hash),
     })
     if state_change_record.data:

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -3,7 +3,30 @@ import random
 from web3 import Web3
 
 from raiden.constants import EMPTY_HASH
+from raiden.storage.sqlite import SQLiteStorage
 from raiden.utils import typing
+from raiden.utils.serialization import serialize_bytes
+
+
+def get_latest_known_balance_proof(
+        storage: SQLiteStorage,
+        balance_hash: typing.BalanceHash,
+):
+    state_change = storage.get_latest_state_change_by_data_field(
+        'balance_hash',
+        serialize_bytes(balance_hash),
+    )
+    if state_change:
+        return state_change.balance_proof
+
+    event = storage.get_latest_event_by_data_field(
+        'balance_hash',
+        serialize_bytes(balance_hash),
+    )
+    if event:
+        return event.balance_proof
+
+    return None
 
 
 def hash_balance_data(

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -71,7 +71,7 @@ if True:
         INITIAL_PORT,
         ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE,
     )
-    from raiden.storage.sqlite import RAIDEN_DB_VERSION
+    from raiden.storage.sqlite import RAIDEN_DB_VERSION, assert_sqlite_version
     from raiden.tasks import check_gas_reserve, check_version
     from raiden.utils import (
         get_system_spec,
@@ -591,6 +591,12 @@ def run_app(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,unused-argument
 
     from raiden.app import App
+
+    if not assert_sqlite_version():
+        log.error('SQLite3 should be at least version {}'.format(
+            '.'.join(constants.SQLITE_MIN_REQUIRED_VERSION),
+        ))
+        sys.exit(1)
 
     if transport == 'udp' and not mapped_socket:
         raise RuntimeError('Missing socket')


### PR DESCRIPTION
Resolves #2414 

# Whats Changed
- Updated the Travis image to `xenial` instead of `trusty` as the Sqlite3 version is available in that distro's official repos.
- Added a check for SQLite3 minimum required version
- Fixed the check for `is_valid_lock_expire` and `is_lock_expired` to prevent expiring a lock whose secret is registered on-chain
- Update the settle logic to use balance proofs with balance hashes that match on-chain hashes.
- Update the unlock logic to create a new WAL instance, restore the state changes from the latest snapshot all the way up to a state where balance hash matches values on-chain. Use that restored state to calculate the merkle tree leaves which is then used for unlocking.