### PR TITLE
Upgrade pylint to work with python 3.7, isort skip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ clean-test:
 
 lint:
 	flake8 raiden/ tools/
-	isort --ignore-whitespace --settings-path ./ --check-only --recursive --diff .
-	pylint --rcfile .pylint.rc raiden
+	isort --ignore-whitespace --settings-path ./ --check-only --recursive --diff raiden/ -sg */node_modules/*
+	pylint --rcfile .pylint.rc raiden/
 	python setup.py check --restructuredtext --strict
 
 test:

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -10,4 +10,4 @@ flake8-commas==2.0.0
 flake8-tuple==0.2.13
 isort==4.2.15
 readme-renderer==21.0
-pylint==1.9.2
+pylint==2.1.1


### PR DESCRIPTION
Also, restrict `isort` to `raiden/` subfolder and skip raiden/ui/web/node_modules/, when present, which fails isort