### PR TITLE
Increment DB version after #2399

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -3,11 +3,10 @@ import threading
 from typing import Any, Optional, Tuple
 
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
-
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES
 
 # The latest DB version
-RAIDEN_DB_VERSION = 1
+RAIDEN_DB_VERSION = 2
 
 
 class SQLiteStorage:


### PR DESCRIPTION
After https://github.com/raiden-network/raiden/pull/2399 we need to increment
the DB version as there has been a breaking DB change and raiden should create a
new DB.

Fix #2440