### PR TITLE
Wait for initial sync to complete on matrix

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1112,5 +1112,5 @@ class TokenNetwork:
 
             raise RaidenRecoverableError(
                 "Settling this channel failed although the channel's current state "
-                "is closed. Maybe it was already settled by the other participant?"
+                "is closed. Maybe it was already settled by the other participant?",
             )

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -190,6 +190,10 @@ class MatrixTransport(Runnable):
         self._raiden_service = raiden_service
 
         self._login_or_register()
+        if self._client._handle_thread:
+            # wait on _handle_thread for initial sync
+            # this is needed so the rooms are populated before we _inventory_rooms
+            self._client._handle_thread.get()
         self._join_discovery_room()
         self._inventory_rooms()
 
@@ -439,6 +443,7 @@ class MatrixTransport(Runnable):
             self._maybe_invite_user(user)
 
     def _inventory_rooms(self):
+        self.log.debug('INVENTORY ROOMS', rooms=self._client.rooms)
         for room in self._client.rooms.values():
             if any(self._discovery_room_alias in alias for alias in room.aliases):
                 continue

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -1,6 +1,9 @@
 from typing import Sequence
 
+import structlog
 from gevent import Greenlet
+
+log = structlog.get_logger(__name__)
 
 
 class Runnable:
@@ -59,6 +62,13 @@ class Runnable:
         """ Default callback for substasks link_exception
 
         Default callback re-raises the exception inside _run() """
+        log.error(
+            'Runnable subtask died!',
+            this=self,
+            running=bool(self),
+            subtask=subtask,
+            exc=subtask.exception,
+        )
         if not self.greenlet:
             return
         self.greenlet.kill(subtask.exception)


### PR DESCRIPTION
Since raiden-network/raiden-libs#122, we handle the response in a separate greenlet, calling the callbacks serially. This made the initial sync not finish before calling `MatrixTransport._inventory_rooms`, which made we not listen on all the rooms we should. This fixes it by waiting initial sync to finish before proceeding.
Also, adds some logging to Runnable to debug if a child dies and the parent is killed
Fix #2437 