### PR TITLE
fix exception type

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1114,7 +1114,7 @@ class TokenNetwork:
                     'Channel cannot be settled before settlement window is over',
                 )
 
-            raise RaidenRecoverableError(
+            raise RaidenUnrecoverableError(
                 "Settling this channel failed although the channel's current state "
-                "is closed. Maybe it was already settled by the other participant?",
+                "is closed.",
             )

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -289,7 +289,7 @@ def test_token_network_proxy_basics(
     wait_blocks(c1_client.web3, TEST_SETTLE_TIMEOUT_MIN)
 
     # try to settle using incorrect data
-    with pytest.raises(RaidenRecoverableError):
+    with pytest.raises(RaidenUnrecoverableError):
         c2_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=1,
@@ -504,7 +504,7 @@ def test_token_network_proxy_update_transfer(
     wait_blocks(c1_client.web3, 10)
 
     # settling with an invalid amount
-    with pytest.raises(RaidenRecoverableError):
+    with pytest.raises(RaidenUnrecoverableError):
         c1_token_network_proxy.settle(
             channel_identifier=channel_identifier,
             transferred_amount=2,


### PR DESCRIPTION
If the channel is closed, and the settlement window is over, then
settle is allowed, if the transaction failled then there is a bug with
the settlement or the code which calls the smart contract.

ref: https://github.com/raiden-network/raiden/pull/2432#discussion_r217073302

I have the impression that settle failed because of https://github.com/raiden-network/raiden/issues/2410