### PR TITLE
connection manager: retry only after channel new

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 
+* :bug:`2453` Connection manager will no longer be stuck if there are no available channel partners
 * :bug:`2437` Fix a bug where neighbors couldn't communicate through matrix after restart
 * :bug:`2370` Fixes a few issues with the token amount input.
 * :bug:`2439` Return properly filtered results from the API payments event endpoint

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -231,9 +231,8 @@ class ConnectionManager:
         If the connection manager has no funds, this is a noop.
         """
         with self.lock:
-            while self._funds_remaining > 0 and not self._leaving_state:
-                if not self._open_channels():
-                    break
+            if self._funds_remaining > 0 and not self._leaving_state:
+                self._open_channels()
 
     def _find_new_partners(self):
         """ Search the token network for potential channel partners. """


### PR DESCRIPTION
if the connection manager didnt open enough channels in the first run,
it's because there are not enough nodes in the network to open channels
with. A hot loop is useless for this scneario, instead the node should
wait until a new address join the network before retrying.

fix #2453