### PR TITLE
Remove send queued from transports start and to service

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -14,6 +14,7 @@ from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.encoding import messages
 from raiden.encoding.format import buffer_for
 from raiden.exceptions import InvalidProtocolMessage
+from raiden.transfer.architecture import SendMessageEvent
 from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.transfer.events import SendDirectTransfer, SendProcessed
 from raiden.transfer.mediated_transfer.events import (
@@ -115,7 +116,7 @@ def assert_transfer_values(payment_identifier, token, recipient):
         raise ValueError('recipient is an invalid address')
 
 
-def decode(data):
+def decode(data: bytes):
     try:
         klass = CMDID_TO_CLASS[data[0]]
     except KeyError:
@@ -123,7 +124,7 @@ def decode(data):
     return klass.decode(data)
 
 
-def from_dict(data):
+def from_dict(data: dict):
     try:
         klass = CLASSNAME_TO_CLASS[data['type']]
     except KeyError:
@@ -138,7 +139,7 @@ def from_dict(data):
     return klass.from_dict(data)
 
 
-def message_from_sendevent(send_event, our_address):
+def message_from_sendevent(send_event: SendMessageEvent, our_address: Address) -> 'Message':
     if type(send_event) == SendLockedTransfer:
         message = LockedTransfer.from_event(send_event)
     elif type(send_event) == SendDirectTransfer:

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -182,7 +182,6 @@ class MatrixTransport(Runnable):
     def start(
         self,
         raiden_service: RaidenService,
-        initial_queues: QueueIdsToQueues,
     ):
         if not self._stop_event.ready():
             raise RuntimeError(f'{self!r} already started')
@@ -204,7 +203,6 @@ class MatrixTransport(Runnable):
         self.greenlets = [self._client.sync_thread]
 
         self._client.set_presence_state(UserPresence.ONLINE.value)
-        self._send_queued_messages(initial_queues)
 
         self.log.info('TRANSPORT STARTED', config=self._config)
 
@@ -676,12 +674,6 @@ class MatrixTransport(Runnable):
         except (InvalidAddress, UnknownAddress, UnknownTokenAddress):
             self.log.warning('Exception while processing message', exc_info=True)
             return
-
-    def _send_queued_messages(self, queueids_to_queues):
-        for queue_identifier, messages in queueids_to_queues.items():
-            for message in messages:
-                self.start_health_check(queue_identifier.recipient)
-                self.send_async(queue_identifier, message)
 
     def _send_with_retry(
         self,

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -199,7 +199,6 @@ class UDPTransport(Runnable):
     def start(
             self,
             raiden: RaidenService,
-            queueids_to_queues: typing.Dict[QueueIdentifier, typing.List[Message]],
     ):
         if not self.event_stop.ready():
             raise RuntimeError('UDPTransport started while running')
@@ -211,13 +210,6 @@ class UDPTransport(Runnable):
         # server.stop() clears the handle. Since this may be a restart the
         # handle must always be set
         self.server.set_handle(self.receive)
-
-        for queue_identifier, queue in queueids_to_queues.items():
-            encoded_queue = [
-                (message.encode(), message.message_identifier)
-                for message in queue
-            ]
-            self.init_queue_for(queue_identifier, encoded_queue)
 
         self.server.start()
         super().start()


### PR DESCRIPTION
Both transports currently basically do `send_async` on each message on these queues anyway. This was done once to allow batch send, but it was never implemented and matrix doesn't even support batch send messages, so it was useless and cluttered the interface (send_async receives a
queue of events and a Message, and start received a queue of messages since #2420).
The transports need to be aware of the events queues anyway, to eventually stop retrying the message once it's cleaned (TODO for UDP), so we can't avoid knowing about the events, but now the serialization
always occurs either in RaidenEventHandler or in RaidenService when starting the transports, so consistent usage of `messages.message_from_sendevent` 
Followup of #2420 and replaces #2458