### PR TITLE
Add test for resubmitting a transaction with same gas price

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -190,6 +190,10 @@ class ReplacementTransactionUnderpriced(RaidenError):
     """Raised when a replacement transaction is rejected by the blockchain"""
 
 
+class TransactionAlreadyPending(RaidenError):
+    """Raised when a transaction is already pending"""
+
+
 class ChannelOutdatedError(RaidenError):
     """ Raised when an action is invoked on a channel whose
     identifier has been replaced with a new channel identifier

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -190,7 +190,7 @@ class ReplacementTransactionUnderpriced(RaidenError):
     """Raised when a replacement transaction is rejected by the blockchain"""
 
 
-class TransactionAlreadyPending(RaidenError):
+class TransactionAlreadyPending(RaidenUnrecoverableError):
     """Raised when a transaction is already pending"""
 
 

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-arguments,redefined-outer-name
 import pytest
+
 from raiden.tests.integration.api.utils import create_api_server
 
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -53,6 +53,7 @@ if True:
         RaidenError,
         RaidenServicePortInUseError,
         ReplacementTransactionUnderpriced,
+        TransactionAlreadyPending,
     )
     from raiden.log_config import configure_logging
     from raiden.network.blockchain_service import BlockChainService
@@ -945,7 +946,7 @@ class NodeRunner:
                 # Shouldn't happen
                 raise RuntimeError(f"Invalid transport type '{self._options['transport']}'")
             app.stop()
-        except ReplacementTransactionUnderpriced as e:
+        except (ReplacementTransactionUnderpriced, TransactionAlreadyPending) as e:
             print(
                 '{}. Please make sure that this Raiden node is the '
                 'only user of the selected account'.format(str(e)),


### PR DESCRIPTION
The current test_duplicated_transaction_raises test didn't explicitly
set the gas price, this fixes this. It also adds a test for resubmitting
the same tx with the same gas price and checks that the error message
from geth is handled properly.

Also a pre-requisite for #2276 