### PR TITLE
Decentralize discovery room

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`2307` Matrix discovery rooms now are decentralized, aliased and shared by all servers in the federation
 * :feature:`2252` Adds payment history page to the webui.
 * :bug:`2367` Token network selection dropdown will not filter out not connected networks.
 * :bug:`2453` Connection manager will no longer be stuck if there are no available channel partners

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -53,10 +53,7 @@ class App:  # pylint: disable=too-few-public-methods
                     'https://transport02.raiden.network',
                     'https://transport03.raiden.network',
                 ],
-                'discovery_room': {
-                    'alias_fragment': 'discovery',
-                    'server': 'transport01.raiden.network',
-                },
+                'discovery_room': 'discovery',
                 'retries_before_backoff': DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
                 'retry_interval': DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
                 'server': 'auto',

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -401,7 +401,7 @@ class MatrixTransport(Runnable):
         self._discovery_room_alias = self._make_room_alias(self._config['discovery_room'])
 
         servers = self._config.get('available_servers') or list()
-        servers = [urlparse(s).hostname for s in servers]
+        servers = [urlparse(s).hostname for s in servers if urlparse(s).hostname]
         if self._server_name not in servers:
             servers.append(self._server_name)
         servers.sort(key=lambda s: '' if s == self._server_name else s)  # our server goes first

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -116,6 +116,9 @@ class UserPresence(Enum):
     UNKNOWN = 'unknown'
 
 
+_JOIN_RETRIES = 5
+
+
 class MatrixTransport(Runnable):
     _room_prefix = 'raiden'
     _room_sep = '_'
@@ -352,7 +355,7 @@ class MatrixTransport(Runnable):
         rand = Random()  # deterministic, random secret for username suffixes
         rand.seed(seed)
         # try login and register on first 5 possible accounts
-        for i in range(5):
+        for i in range(_JOIN_RETRIES):
             base_username = to_normalized_address(self._raiden_service.address)
             username = base_username
             if i:
@@ -429,7 +432,7 @@ class MatrixTransport(Runnable):
                 break
         else:
             self.log.debug('Could not join any discovery room, trying to create one')
-            for _ in range(5):
+            for _ in range(_JOIN_RETRIES):
                 try:
                     discovery_room = self._client.create_room(
                         self._discovery_room_alias,
@@ -821,7 +824,7 @@ class MatrixTransport(Runnable):
         room_name_full = f'#{room_name}:{self._server_name}'
         invitees_uids = [user.user_id for user in invitees]
 
-        for _ in range(5):
+        for _ in range(_JOIN_RETRIES):
             # try joining room
             try:
                 room = self._client.join_room(room_name_full)

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -50,10 +50,7 @@ def mock_matrix(
             'https://transport02.raiden.network',
             'https://transport03.raiden.network',
         ],
-        discovery_room={
-            'alias_fragment': 'discovery',
-            'server': 'transport01.raiden.network',
-        },
+        discovery_room='discovery',
     )
 
     transport = MatrixTransport(config)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -308,10 +308,7 @@ def create_apps(
                     'transport_type': 'matrix',
                     'transport': {
                         'matrix': {
-                            'discovery_room': {
-                                'alias_fragment': 'discovery',
-                                'server': 'matrix.local.raiden',
-                            },
+                            'discovery_room': 'discovery',
                             'retries_before_backoff': retries_before_backoff,
                             'retry_interval': retry_interval,
                             'server': local_matrix_url,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -1302,7 +1302,6 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
                 args['extra_config'] = {
                     'transport': {
                         'matrix': {
-                            'discovery_room': {'server': 'matrix.local.raiden'},
                             'server_name': 'matrix.local.raiden',
                         },
                     },

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -1303,6 +1303,7 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
                     'transport': {
                         'matrix': {
                             'server_name': 'matrix.local.raiden',
+                            'available_servers': [],
                         },
                     },
                 }
@@ -1316,6 +1317,14 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
             success = False
     elif args['transport'] == 'matrix' and local_matrix.lower() == "none":
         args['mapped_socket'] = None
+        args['extra_config'] = {
+            'transport': {
+                'matrix': {
+                    'server_name': 'matrix.local.raiden',
+                    'available_servers': [],
+                },
+            },
+        }
         success = _run_smoketest()
     else:
         # Shouldn't happen


### PR DESCRIPTION
Now, a discovery room with canonical name is tried in all available servers, starting with ours. If can join in a different server than ours, but our server doesn't have an alias for it, create the alias, so every server shares a single room, each one aliasing it to the canonical name on itself.
A discovery room creating is attempted only if can't join in any available server, and it isn't fatal, as races may occur on tests, but on tests peers doesn't actually need to join it, as they're on the same synapse test server and therefore there's no need for the discovery room
Fixes #2307 