### PR TITLE
Handled exceptions

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -942,7 +942,7 @@ class RestAPI:
                 amount=amount,
                 identifier=identifier,
             )
-        except (InvalidAmount, InvalidAddress) as e:
+        except (InvalidAmount, InvalidAddress, UnknownTokenAddress) as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -9,6 +9,8 @@ from gevent.lock import Semaphore
 from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.exceptions import (
+    DepositMismatch,
+    DepositOverLimit,
     DuplicatedChannelError,
     InsufficientFunds,
     InvalidAmount,
@@ -284,8 +286,8 @@ class ConnectionManager:
             log.exception('connection manager: deposit failed')
         except RaidenRecoverableError:
             log.exception('connection manager: channel not in opened state')
-        except InsufficientFunds as e:
-            log.error(f'connection manager: {str(e)}')
+        except (DepositOverLimit, DepositMismatch, InsufficientFunds) as e:
+            log.error('connection manager: _join_partner', _exception=e, partner=pex(partner))
 
     def _open_channels(self) -> bool:
         """ Open channels until there are `self.initial_channel_target`


### PR DESCRIPTION
Handle exception described in #2499 also found an unhandled exception in rest.py which was thrown when calling [transfer](https://github.com/raiden-network/raiden/blob/master/raiden/api/rest.py#L947), more exactly it was thrown [here](https://github.com/raiden-network/raiden/blob/master/raiden/api/python.py#L650).

[ci integration]