### PR TITLE
Fix pyflakes 2.0.0 errors

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -72,7 +72,7 @@ class App:  # pylint: disable=too-few-public-methods
             default_registry: TokenNetworkRegistry,
             default_secret_registry: SecretRegistry,
             transport,
-            raiden_event_handler: 'RaidenEventHandler',
+            raiden_event_handler,
             discovery: Discovery = None,
     ):
         raiden = RaidenService(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -134,7 +134,7 @@ class RaidenService(Runnable):
             default_secret_registry: SecretRegistry,
             private_key_bin,
             transport,
-            raiden_event_handler: 'RaidenEventHandler',
+            raiden_event_handler,
             config,
             discovery=None,
     ):

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -15,7 +15,7 @@ CHECK_VERSION_INTERVAL = 3 * 60 * 60
 CHECK_GAS_RESERVE_INTERVAL = 60 * 60
 LATEST = 'https://api.github.com/repos/raiden-network/raiden/releases/latest'
 RELEASE_PAGE = 'https://github.com/raiden-network/raiden/releases'
-SECURITY_EXPRESSION = '\[CRITICAL UPDATE.*?\]'
+SECURITY_EXPRESSION = r'\[CRITICAL UPDATE.*?\]'
 
 REMOVE_CALLBACK = object()
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -10,7 +10,7 @@ def pack_balance_proof(
         channel_identifier: typing.ChannelID,
         token_network_identifier: typing.TokenNetworkID,
         chain_id: typing.ChainID,
-        msg_type: MessageTypeId=MessageTypeId.BALANCE_PROOF,
+        msg_type: MessageTypeId = MessageTypeId.BALANCE_PROOF,
 ) -> bytes:
     return pack_data([
         'address',

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -89,7 +89,7 @@ class InitiatorTask(State):
     def __init__(
             self,
             token_network_identifier: typing.TokenNetworkID,
-            manager_state: 'InitiatorTransferState',
+            manager_state,
     ):
         self.token_network_identifier = token_network_identifier
         self.manager_state = manager_state
@@ -133,7 +133,7 @@ class MediatorTask(State):
     def __init__(
             self,
             token_network_identifier: typing.TokenNetworkID,
-            mediator_state: 'MediatorTransferState',
+            mediator_state,
     ):
         self.token_network_identifier = token_network_identifier
         self.mediator_state = mediator_state
@@ -181,7 +181,7 @@ class TargetTask(State):
             self,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
-            target_state: 'TargetTransferState',
+            target_state,
     ):
         self.token_network_identifier = token_network_identifier
         self.target_state = target_state


### PR DESCRIPTION
In my archlinux machine I got the following flake8:

`3.5.0 (mccabe: 0.6.1, pycodestyle: 2.4.0, pyflakes: 2.0.0) CPython 3.7.0 on Linux `
In our venv and in travis we got
`3.5.0 (flake8-bugbear: 18.2.0, flake8-tuple: 0.2.13, flake8_commas: 2.0.0, mccabe: 0.6.1, pycodestyle: 2.3.1, pyflakes: 1.6.0) CPython 3.7.0 on Linux`


I am not sure I remember how I made this work for my system as flake8 `3.5.0` explicitly states 

```
flake8 3.5.0 has requirement pycodestyle<2.4.0,>=2.0.0, but you'll have pycodestyle 2.4.0 which is incompatible.
flake8 3.5.0 has requirement pyflakes<1.7.0,>=1.5.0, but you'll have pyflakes 2.0.0 which is incompatible.
```

But I probably messed with something and it works on my machine. If I try to add it to specify the latest pyflakes and pycodestyle in our venv:

```diff
diff --git a/constraints.txt b/constraints.txt                                                                                                                                                                                                                                  
index b0326162..13975ea4 100644
--- a/constraints.txt
+++ b/constraints.txt
@@ -58,8 +58,10 @@ py-evm==0.2.0a32
 py-geth==2.0.1
 py-solc==3.1.0
 pycparser==2.18
+pycodestyle==2.4.0
 pycryptodome==3.6.6
 pyethash==0.1.27
+pyflakes==2.0.0
 pysha3==1.0.2
 pystun-patched-for-raiden==0.1.0
 pytest==3.8.0
```

then we hit the [incompatibility bug](https://github.com/PyCQA/pycodestyle/issues/741) that flake8 and pyflakes have. So at least until `flake8` makes a release compatible with latest `pyflakes` and `pycodestyle` we can't use them in our venv.

But since I managed to make it work in my system I am using this PR to fix the errors seen:

```
raiden/raiden_service.py:137:35: F821 undefined name 'RaidenEventHandler'                                                                                                                                                                                           
raiden/app.py:75:35: F821 undefined name 'RaidenEventHandler'                                                                                                                                                                                                                    
raiden/transfer/balance_proof.py:13:32: E252 missing whitespace around parameter equals                                                                                                                                                                                          
raiden/transfer/balance_proof.py:13:33: E252 missing whitespace around parameter equals                                                                                                                                                                                          
raiden/transfer/state.py:92:28: F821 undefined name 'InitiatorTransferState'                                                                                                                                                                                         
raiden/transfer/state.py:136:29: F821 undefined name 'MediatorTransferState'                                                                                                                                                                                                     
raiden/transfer/state.py:184:27: F821 undefined name 'TargetTransferState' 
```