### PR TITLE
Matrix private rooms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`2507` Fix a security issue where an attacker could eavesdrop Matrix communications between two nodes in private rooms
+* :bug:`2501` Adds a matrix.private_rooms config to communicate only through private rooms in Matrix
 * :bug:`2449` Fix a race condition when handling channel close events.
 
 * :release:`0.9.0 <2018-09-14>`

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -304,3 +304,8 @@ def database_paths(tmpdir, private_keys):
         database_paths.append(os.path.join(app_dir, 'log.db'))
 
     return database_paths
+
+
+@pytest.fixture
+def private_rooms():
+    return True

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -37,6 +37,7 @@ def raiden_chain(
         nat_keepalive_retries,
         nat_keepalive_timeout,
         local_matrix_server,
+        private_rooms,
 ):
 
     if len(token_addresses) != 1:
@@ -65,6 +66,7 @@ def raiden_chain(
         nat_keepalive_retries,
         nat_keepalive_timeout,
         local_matrix_server,
+        private_rooms,
     )
 
     start_tasks = [gevent.spawn(app.raiden.start) for app in raiden_apps]
@@ -131,6 +133,7 @@ def raiden_network(
         nat_keepalive_retries,
         nat_keepalive_timeout,
         local_matrix_server,
+        private_rooms,
 ):
 
     raiden_apps = create_apps(
@@ -151,6 +154,7 @@ def raiden_network(
         nat_keepalive_retries,
         nat_keepalive_timeout,
         local_matrix_server,
+        private_rooms,
     )
 
     start_tasks = [gevent.spawn(app.raiden.start) for app in raiden_apps]

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -16,8 +16,26 @@ class TransportProtocol(Enum):
 
 
 @pytest.fixture
-def transport_config():
-    return TransportConfig(protocol=TransportProtocol.UDP, parameters=None)
+def transport(request):
+    """ 'all' replaced by parametrize in conftest.pytest_generate_tests """
+    return request.config.getoption('transport')
+
+
+@pytest.fixture
+def transport_config(request, transport):
+    if transport == 'udp':
+        return TransportConfig(protocol=TransportProtocol.UDP, parameters=None)
+    elif transport == 'matrix':
+        command = request.config.getoption('local_matrix')
+        return TransportConfig(
+            protocol=TransportProtocol.MATRIX,
+            parameters=MatrixTransportConfig(
+                command=command,
+                server=request.config.getoption('matrix_server'),
+            ),
+        )
+    else:
+        return None
     # can be changed with command line options, see tests/conftest.py
 
 
@@ -35,6 +53,13 @@ def skip_if_not_matrix(request):
     if request.config.option.transport in ('matrix', 'all'):
         return
     pytest.skip('This test works only with Matrix transport')
+
+
+@pytest.fixture
+def public_and_private_rooms():
+    """If present in a test, conftest.pytest_generate_tests will parametrize private_rooms fixture
+    """
+    return True
 
 
 @pytest.fixture

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -19,6 +19,7 @@ def mock_matrix(
         retry_interval,
         retries_before_backoff,
         local_matrix_server,
+        private_rooms,
 ):
 
     from matrix_client.user import User
@@ -52,7 +53,7 @@ def mock_matrix(
         server_name='matrix.local.raiden',
         available_servers=[],
         discovery_room='discovery',
-        private_rooms=True,
+        private_rooms=private_rooms,
     )
 
     transport = MatrixTransport(config)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -15,6 +15,7 @@ def test_mediated_transfer(
         deposit,
         token_addresses,
         network_wait,
+        public_and_private_rooms,
 ):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
@@ -59,6 +60,7 @@ def test_mediated_transfer_with_entire_deposit(
         token_addresses,
         deposit,
         network_wait,
+        public_and_private_rooms,
 ):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -263,6 +263,7 @@ def create_apps(
         nat_keepalive_retries,
         nat_keepalive_timeout,
         local_matrix_url=None,
+        private_rooms=None,
 ):
     """ Create the apps."""
     # pylint: disable=too-many-locals
@@ -313,7 +314,7 @@ def create_apps(
                             'retry_interval': retry_interval,
                             'server': local_matrix_url,
                             'server_name': 'matrix.local.raiden',
-                            'private_rooms': True,
+                            'private_rooms': private_rooms,
                         },
                     },
                 },

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -313,6 +313,7 @@ def create_apps(
                             'retry_interval': retry_interval,
                             'server': local_matrix_url,
                             'server_name': 'matrix.local.raiden',
+                            'private_rooms': True,
                         },
                     },
                 },


### PR DESCRIPTION
Fix #2501 
Fix #2507
And possibly also #473 for Matrix transport

A `config['transport']['matrix']['private_rooms']` boolean configures if we should use and require private rooms.

If `False`, we can still be invited and talk in private ones, but it isn't required and the ones we create aren't, as per the previous behavior (including canonical room names, for easy debugging), usually suited for tests deployments.

If `True`, the rooms we create are private, unnamed, invite only rooms, and only the validated users for the peer we created that room for will be invited.

If someone else creates a room and invite us, we join and that room is only valid ever to communicate with that peer which invited us (so an attacker can't pull us into talking with another peer in their room), **if and only if** the room is also private.

If we require private rooms, and someone invites us to a public one, we add it to the list of possible rooms, but don't use it as it don't meet the required privacy level, usually meaning creating a new, private room by ourselves and inviting that user (this list of possible rooms for each user is saved on the server, through matrix's `account_data`, and also protects us from races when both users create room and invite each other simultaneously).