### PR TITLE
travis: removed coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ templates:
       - .travis/install.sh
     script:
       - .travis/run.sh
-    after_script:
-      - coveralls
 
   job-template-integration: &job-template-integration
     <<: *job-template-test
@@ -55,8 +53,6 @@ notifications:
   webhooks:
   # Chat notification
   - secure: IXBsyQtH29Vkh+Pe2exrbE3L8FJMQFqJ8ZRxkACts7cQtB8Iz1vyjWg9nYE9ZuCj/JWEeMZd/09JvwwKUj8ZEzwj59gFwVQFwTAxJbiDLRsn7WpdI5Q2fQ9ZPZIAbPo/mJejeHC+z3d5UgY72hbhqWuPJAa4ApWWKE5mPFUIr9uxgs01ReWs/y5HaPawQkSQAKVWWsS5R52Oyr9CYQNbfqfWcoLvzdiIZpsBi2r4ZK3NGrBZPGo4b+PkDkWjuBhMJ0FVABFCJT/bT2ORFsmsCDwZ4I3vOrKtJGDybmwONZqr0ymfYo1lbcUp0mE0zJ0ApyRtLqEFiTzaQqenlAZmBAtpDZVvpxFuDwZgFxafpNutO3Aj3Xbfe+aaooPfHA7SoxmxG/3gWY+OyaME8EDePfBHM0c1gGsNHmbPLt8k0lmwYKlNTFtFFyRAbL3700j19utkGroOK6CUYbed9YD96UehQTj7HN8rpLTZzSMh39c1JHVyqxsUZKkhQgY4GPgx2RAIiCVrwc6wN3Ebtwft0hA2UhvDodsc/qBAyz/YnSp2oKZKagLy5747torZybtNOGKCaV2fT3mSTxV2UNwPJ/N94dlTquJNx3StHT0IqD3Kfo5HYKJKHeri6lttTDul3rjAs1xxB2aAMutsyg7dRbBMmuKlK9gAtoS3UKthQdk=
-  # coveralls 'parallel build done' trigger
-  - secure: "eFjTor3HH4OiMkBYJAbiri09AV86KbMoPi9khESCOTicM/AnofrAdObguxa4v/s1d2AXbpaEpvy59R2ZaocucwSnw2UoCa/VgTPZf8FOazShn001g0PN2LS6hQFxCTFDowOHZKx9P2jqoUf17rtUDDbGfin6L/aaykJ9MCXxJKY+jlf8roDGArbaXHqntkhphNYuFsmaHHqQqjuRUdCB+Ys8BAQavsePWpyJ0kjlPo4UuSasn6OpRnrz7E6K/3tziFJB0l4hTghU2wzDYF9V+eF9jIyoqoUkcgqTeyjjAO2Rf1If20gQerf09wC8xl965VLgzZ/oQCp4WpIFzorJielLwdE498N0S/gZ0GktqO3jPfS97JaH2+ZkSb2yUdTSLxTHCva9mgqpnQAK8AOEndjMUupbc0UXe440MJzX1wT6IaQ2IwibRwADWAgUqOu5XSaV+rWPvKbBl54NwO7yAVxV20PbKqJMFAYiuVKnRRqnLDhKsZpPxEf0nfrbu/VARKeVuWEg6LkaBFPA4r+EjCQFhT/hwB/DFjoYSCf5PpFcvwL1Tl2gpQcxFhDHKHAITLwYCVCiQHkG1MdQt4fTaBUEm+BcmIbZ4FVfTYbCdys7Hge6RTKxVl8Xe7jDgibHXF4wTPHR81crX9Xk3nUm6VwJzluaTUi1OKj8Nathqbk="
 
 jobs:
   include:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -9,7 +9,7 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     INSTALL_OPT="--user"
 fi
 
-pip install ${INSTALL_OPT} --upgrade pip wheel coveralls "coverage<4.4"
+pip install ${INSTALL_OPT} --upgrade pip wheel
 pip install ${INSTALL_OPT} pytest-travis-fold
 pip install ${INSTALL_OPT} pyinstaller
 pip install ${INSTALL_OPT} -c constraints.txt --upgrade --upgrade-strategy eager -r requirements-dev.txt

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -9,8 +9,7 @@ elif [ -z ${BLOCKCHAIN_TYPE} ]; then
     BLOCKCHAIN_TYPE="geth"
 fi
 
-coverage run \
-    -m py.test \
+py.test \
     -Wd \
     --travis-fold=always \
     --log-config='raiden:DEBUG' \


### PR DESCRIPTION
coveralls reports are inconsistent, probably because we have PRs that
don't run the integrations tests. Additionally the tool is slowing down
the execution of the tests. Removing it for now.

[ci integration]