### PR TITLE
Remove coverage and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ templates:
       - .travis/install.sh
     script:
       - .travis/run.sh
-    after_script:
-      - coveralls
 
   job-template-integration: &job-template-integration
     <<: *job-template-test

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -9,8 +9,7 @@ elif [ -z ${BLOCKCHAIN_TYPE} ]; then
     BLOCKCHAIN_TYPE="geth"
 fi
 
-coverage run \
-    -m py.test \
+py.test \
     -Wd \
     --travis-fold=always \
     --log-config='raiden:DEBUG' \


### PR DESCRIPTION
Coveralls reports are not really useful and running pytest through coverage
makes it much slower in Travis which is already slow enough. This is an attempt
to speed it up

[ci integration]