### PR TITLE
Fix travis cron job deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,9 +194,7 @@ jobs:
 #          branch: master
 
       - provider: s3
-        # Remove once https://github.com/travis-ci/dpl/issues/865 is fixed
-        edge:
-          branch: ha-s3-endpoint
+        edge: true
         skip_cleanup: true
         access_key_id: MK22XIZDUYA3EWBHGAKD
         secret_access_key:
@@ -255,9 +253,7 @@ jobs:
             repo: raiden-network/raiden
             branch: master
         - provider: s3
-          # Remove once https://github.com/travis-ci/dpl/issues/865 is fixed
-          edge:
-            branch: ha-s3-endpoint
+          edge: true
           skip_cleanup: true
           access_key_id: MK22XIZDUYA3EWBHGAKD
           secret_access_key:


### PR DESCRIPTION
Last night Travis failed at the cron job deployment stage. Seems that an
experimental branch was removed and we need to adjust our `travis.yml`

Job that failed: https://travis-ci.org/raiden-network/raiden/jobs/429885609