### PR TITLE
Add descending order by block_number as default for blockchain events on webui.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2512` Add descending order by block_number as default for blockchain events on webui.
 * :bug:`2507` Fix a security issue where an attacker could eavesdrop Matrix communications between two nodes in private rooms
 * :bug:`2501` Adds a matrix.private_rooms config to communicate only through private rooms in Matrix
 * :bug:`2449` Fix a race condition when handling channel close events.

--- a/raiden/ui/web/src/app/components/event-list/event-list.component.html
+++ b/raiden/ui/web/src/app/components/event-list/event-list.component.html
@@ -14,7 +14,11 @@
 
     <div class="mat-elevation-z8">
 
-        <mat-table [dataSource]="dataSource" matSort [trackBy]="trackByFn">
+        <mat-table [dataSource]="dataSource"
+                   matSort
+                   [trackBy]="trackByFn"
+                   matSortActive="block_number"
+                   matSortDirection="desc">
             <ng-container matColumnDef="block_number">
                 <mat-header-cell *matHeaderCellDef mat-sort-header fxFlex="15"> Block Number</mat-header-cell>
                 <mat-cell *matCellDef="let row" fxFlex="15"> {{row.block_number}}</mat-cell>


### PR DESCRIPTION
Closes #2512 