### PR TITLE
Increase the time a notification stays visible on the webui

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2517` Increase the time a notification stays visible on the webui.
 * :bug:`2512` Add descending order by block_number as default for blockchain events on webui.
 * :bug:`2507` Fix a security issue where an attacker could eavesdrop Matrix communications between two nodes in private rooms
 * :bug:`2501` Adds a matrix.private_rooms config to communicate only through private rooms in Matrix

--- a/raiden/ui/web/src/app/app.module.ts
+++ b/raiden/ui/web/src/app/app.module.ts
@@ -93,7 +93,11 @@ export function ConfigLoader(raidenConfig: RaidenConfig) {
         HttpClientModule,
         BrowserAnimationsModule,
         MaterialComponentsModule,
-        ToastrModule.forRoot(),
+        ToastrModule.forRoot({
+            timeOut: 5000,
+            extendedTimeOut: 10000,
+            preventDuplicates: true
+        }),
         ClipboardModule,
     ],
     providers: [


### PR DESCRIPTION
Closes #2517

`timeOut` is the timeout after a notification appears and has been now globally increased to 5 seconds from 3 seconds that was the default value.
`extendedTimeOut` starts as soon as the user hovers over the notification and is set to 10 seconds

I did some manual testing, and it seems to work the way we want it to work.