### PR TITLE
Follow-up after network type PR

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -391,12 +391,13 @@ class APIServer(Runnable):
 
             web3 = self.flask_app.config.get('WEB3_ENDPOINT')
             if 'config.' in file_name and file_name.endswith('.json'):
+                network_type = self.rest_api.raiden_api.raiden.config['network_type'].name.lower()
                 config = {
                     'raiden': self._api_prefix,
                     'web3': web3,
                     'settle_timeout': self.rest_api.raiden_api.raiden.config['settle_timeout'],
                     'reveal_timeout': self.rest_api.raiden_api.raiden.config['reveal_timeout'],
-                    'network_type': self.rest_api.raiden_api.raiden.config['network_type'],
+                    'network_type': network_type,
                 }
 
                 # if raiden sees eth rpc endpoint as localhost, replace it by Host header,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -701,9 +701,9 @@ def run_app(
 
     if net_id in ID_TO_NETWORK_CONFIG:
         contract_addresses_known = True
-        contract_addresses = ID_TO_NETWORK_CONFIG['net_id']['contract_addresses']
+        contract_addresses = ID_TO_NETWORK_CONFIG[net_id]['contract_addresses']
         not_allowed = (
-            ID_TO_NETWORK_CONFIG['network_type'] == NetworkType.MAIN and
+            ID_TO_NETWORK_CONFIG[net_id] == NetworkType.MAIN and
             config['network_type'] == NetworkType.TEST
         )
         if not_allowed:


### PR DESCRIPTION
- Fixes raiden app start
- Sends a string and not an enum to the webui for network_type