### PR TITLE
removed module level loggers

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -12,8 +12,6 @@ from eth_utils import to_checksum_address
 from raiden.utils import privatekey_to_address, privtopub
 from raiden.utils.typing import AddressHex
 
-log = structlog.get_logger(__name__)
-
 
 def _find_datadir() -> str:
     home = os.path.expanduser('~')
@@ -79,6 +77,7 @@ def check_keystore_json(jsondata: Dict) -> bool:
 
 class AccountManager:
     def __init__(self, keystore_path: str = None):
+        log = structlog.get_logger(__name__)
         self.keystore_path = keystore_path
         self.accounts = {}
         if self.keystore_path is None:

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -30,8 +30,6 @@ from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils import pex, typing
 from raiden.utils.gas_reserve import has_enough_gas_reserve
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 EVENTS_PAYMENT_HISTORY_RELATED = (
     EventPaymentSentSuccess,
     EventPaymentSentFailed,
@@ -84,6 +82,7 @@ class RaidenAPI:
 
     def __init__(self, raiden):
         self.raiden = raiden
+        self.log = structlog.get_logger(__name__)
 
     @property
     def address(self):
@@ -301,7 +300,7 @@ class RaidenAPI:
                 settle_timeout,
             )
         except DuplicatedChannelError:
-            log.info('partner opened channel first')
+            self.log.info('partner opened channel first')
 
         waiting.wait_for_newchannel(
             self.raiden,
@@ -645,7 +644,7 @@ class RaidenAPI:
         if token_address not in valid_tokens:
             raise UnknownTokenAddress('Token address is not known.')
 
-        log.debug(
+        self.log.debug(
             'initiating transfer',
             initiator=pex(self.raiden.address),
             target=pex(target),

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -1,4 +1,3 @@
-import structlog
 from flask import Blueprint
 from flask_restful import Resource
 from webargs.flaskparser import use_kwargs
@@ -13,8 +12,6 @@ from raiden.api.v1.encoding import (
     RaidenEventsRequestSchema,
 )
 from raiden.utils import typing
-
-log = structlog.get_logger(__name__)
 
 
 def create_blueprint():

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,6 +1,5 @@
 from binascii import unhexlify
 
-import structlog
 from eth_utils import to_checksum_address
 
 from raiden.exceptions import InvalidSettleTimeout
@@ -22,8 +21,6 @@ from raiden.settings import (
     INITIAL_PORT,
 )
 from raiden.utils import pex, typing
-
-log = structlog.get_logger(__name__)
 
 
 class App:  # pylint: disable=too-few-public-methods

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from typing import Dict, List
 
-import structlog
 from eth_utils import encode_hex, event_abi_to_log_topic, to_canonical_address
 
 from raiden.constants import UINT64_MAX
@@ -45,7 +44,6 @@ Proxies = namedtuple(
 
 # `new_filter` uses None to signal the absence of topics filters
 ALL_EVENTS = None
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def get_contract_events(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -26,8 +26,6 @@ from raiden_contracts.constants import (
     ChannelEvent,
 )
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 def handle_tokennetwork_new(raiden, event: Event):
     """ Handles a `TokenNetworkCreated` event. """
@@ -285,6 +283,7 @@ def handle_secret_revealed(raiden, event: Event):
 
 def on_blockchain_event(raiden: 'RaidenService', event: Event):
     data = event.event_data
+    log = structlog.get_logger(__name__)
     log.debug(
         'BLOCKCHAIN EVENT',
         node=pex(raiden.address),

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -22,10 +22,6 @@ DELIVERED = 12
 LOCKEXPIRED = 13
 
 
-# pylint: disable=invalid-name
-log = structlog.get_logger(__name__)
-
-
 nonce = make_field('nonce', 8, '8s', integer(0, UINT64_MAX))
 payment_identifier = make_field('payment_identifier', 8, '8s', integer(0, UINT64_MAX))
 chain_id = make_field('chain_id', 32, '32s', integer(0, UINT256_MAX))
@@ -258,6 +254,8 @@ CMDID_MESSAGE = {
 
 def wrap(data):
     """ Try to decode data into a message, might return None if the data is invalid. """
+    log = structlog.get_logger(__name__)
+
     try:
         cmdid = data[0]
     except IndexError:

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -26,8 +26,6 @@ from raiden.transfer.state import balanceproof_from_envelope
 from raiden.transfer.state_change import ReceiveProcessed, ReceiveTransferDirect, ReceiveUnlock
 from raiden.utils import random_secret
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 def handle_message_secretrequest(raiden: RaidenService, message: SecretRequest):
     secret_request = ReceiveSecretRequest(
@@ -152,7 +150,7 @@ def on_message(raiden: RaidenService, message: Message):
     elif type(message) == Processed:
         handle_message_processed(raiden, message)
     else:
-        log.error('Unknown message cmdid {}'.format(message.cmdid))
+        structlog.get_logger(__name__).error('Unknown message cmdid {}'.format(message.cmdid))
         return False
 
     # Inform the transport that it's okay to send a Delivered message

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1,6 +1,5 @@
 from operator import attrgetter
 
-import structlog
 from cachetools import LRUCache, cached
 from eth_utils import (
     big_endian_to_int,
@@ -61,7 +60,6 @@ __all__ = (
     'from_dict',
 )
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 _senders_cache = LRUCache(maxsize=128)
 _hashes_cache = LRUCache(maxsize=128)
 _lock_bytes_cache = LRUCache(maxsize=128)

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -1,5 +1,4 @@
 import gevent
-import structlog
 from cachetools.func import ttl_cache
 from eth_utils import is_binary_address
 from gevent.lock import Semaphore
@@ -15,8 +14,6 @@ from raiden.network.proxies import (
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import privatekey_to_address
 from raiden.utils.typing import Address, ChannelID, T_ChannelID
-
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class BlockChainService:

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -7,8 +7,6 @@ from raiden.exceptions import InvalidAddress, UnknownAddress
 from raiden.network import proxies
 from raiden.utils import host_port_to_endpoint, pex, split_endpoint
 
-log = structlog.get_logger(__name__)
-
 
 class Discovery:
     """ Mock mapping address: host, port """
@@ -53,6 +51,7 @@ class ContractDiscovery(Discovery):
 
         self.node_address = node_address
         self.discovery_proxy = discovery_proxy
+        self.log = structlog.get_logger(__name__)
 
     def register(self, node_address: bytes, host: str, port: int):
         if node_address != self.node_address:
@@ -75,7 +74,7 @@ class ContractDiscovery(Discovery):
             current_value = None
 
         if current_value == (host, port):
-            log.info(
+            self.log.info(
                 'endpoint already registered',
                 node_address=pex(node_address),
                 host=host,
@@ -84,7 +83,7 @@ class ContractDiscovery(Discovery):
         else:
             endpoint = host_port_to_endpoint(host, port)
             self.discovery_proxy.register_endpoint(node_address, endpoint)
-            log.info(
+            self.log.info(
                 'registered endpoint in discovery',
                 node_address=pex(node_address),
                 host=host,

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -19,8 +19,6 @@ from raiden.utils import compare_versions, pex, privatekey_to_address, sha3, typ
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, EVENT_SECRET_REVEALED
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 class SecretRegistry:
     def __init__(
@@ -52,6 +50,7 @@ class SecretRegistry:
         self.client = jsonrpc_client
         self.node_address = privatekey_to_address(self.client.privkey)
         self.open_secret_transactions = dict()
+        self.log = structlog.get_logger(__name__)
 
     def register_secret(self, secret: typing.Secret):
         self.register_secret_batch([secret])
@@ -67,7 +66,7 @@ class SecretRegistry:
                     secret_batch.append(secret)
                     self.open_secret_transactions[secret] = secret_registry_transaction
             else:
-                log.info(
+                self.log.info(
                     f'secret {encode_hex(secrethash)} already registered.',
                     node=pex(self.node_address),
                     contract=pex(self.address),
@@ -77,7 +76,7 @@ class SecretRegistry:
         if not secret_batch:
             return
 
-        log.info(
+        self.log.info(
             'registerSecretBatch called',
             node=pex(self.node_address),
             contract=pex(self.address),
@@ -104,7 +103,7 @@ class SecretRegistry:
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
 
         if receipt_or_none:
-            log.critical(
+            self.log.critical(
                 'registerSecretBatch failed',
                 node=pex(self.node_address),
                 contract=pex(self.address),
@@ -112,7 +111,7 @@ class SecretRegistry:
             )
             raise TransactionThrew('registerSecretBatch', receipt_or_none)
 
-        log.info(
+        self.log.info(
             'registerSecretBatch successful',
             node=pex(self.node_address),
             contract=pex(self.address),

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -28,8 +28,6 @@ from raiden.utils import compare_versions, pex, privatekey_to_address, typing
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 class TokenNetworkRegistry:
     def __init__(
@@ -61,6 +59,7 @@ class TokenNetworkRegistry:
         self.proxy = proxy
         self.client = jsonrpc_client
         self.node_address = privatekey_to_address(self.client.privkey)
+        self.log = structlog.get_logger(__name__)
 
     def get_token_network(self, token_address: typing.TokenAddress) -> Optional[typing.Address]:
         """ Return the token network address for the given token or None if
@@ -83,7 +82,7 @@ class TokenNetworkRegistry:
         if not is_binary_address(token_address):
             raise InvalidAddress('Expected binary address format for token')
 
-        log.info(
+        self.log.info(
             'add_token called',
             node=pex(self.node_address),
             token_address=pex(token_address),
@@ -98,7 +97,7 @@ class TokenNetworkRegistry:
         self.client.poll(transaction_hash)
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
         if receipt_or_none:
-            log.info(
+            self.log.info(
                 'add_token failed',
                 node=pex(self.node_address),
                 token_address=pex(token_address),
@@ -111,7 +110,7 @@ class TokenNetworkRegistry:
         token_network_address = self.get_token_network(token_address)
 
         if token_network_address is None:
-            log.info(
+            self.log.info(
                 'add_token failed and check_transaction_threw didnt detect it',
                 node=pex(self.node_address),
                 token_address=pex(token_address),
@@ -120,7 +119,7 @@ class TokenNetworkRegistry:
 
             raise RuntimeError('token_to_token_networks failed')
 
-        log.info(
+        self.log.info(
             'add_token successful',
             node=pex(self.node_address),
             token_address=pex(token_address),

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -38,9 +38,6 @@ except (ModuleNotFoundError, DistributionNotFound):
         pass
 
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
-
 def make_connection_test_middleware(client):
     def connection_test_middleware(make_request, web3):
         """ Creates middleware that checks if the provider is connected. """
@@ -202,7 +199,8 @@ class JSONRPCClient:
         self._nonce_lock = Semaphore()
         self._nonce_offset = nonce_offset
 
-        log.debug(
+        self.log = structlog.get_logger(__name__)
+        self.log.debug(
             'JSONRPCClient created',
             sender=pex(self.sender),
             available_nonce=_available_nonce,
@@ -326,7 +324,7 @@ class JSONRPCClient:
 
             deployment_order.pop()  # remove `contract_name` from the list
 
-            log.debug('Deploying dependencies: {}'.format(str(deployment_order)))
+            self.log.debug('Deploying dependencies: {}'.format(str(deployment_order)))
 
             for deploy_contract in deployment_order:
                 dependency_contract = all_contracts[deploy_contract]
@@ -421,7 +419,7 @@ class JSONRPCClient:
                 'gasPrice': gas_price,
             }
             node_gas_price = self.web3.eth.gasPrice
-            log.debug(
+            self.log.debug(
                 'Calculated gas price for transaction',
                 calculated_gas_price=gas_price,
                 node_gas_price=node_gas_price,
@@ -439,12 +437,12 @@ class JSONRPCClient:
                 'gasLimit': transaction['gas'],
                 'gasPrice': transaction['gasPrice'],
             }
-            log.debug('send_raw_transaction called', **log_details)
+            self.log.debug('send_raw_transaction called', **log_details)
 
             tx_hash = self.web3.eth.sendRawTransaction(signed_txn.rawTransaction)
             self._available_nonce += 1
 
-            log.debug('send_raw_transaction returned', tx_hash=tx_hash, **log_details)
+            self.log.debug('send_raw_transaction returned', tx_hash=tx_hash, **log_details)
             return tx_hash
 
     def poll(self, transaction_hash: bytes, confirmations: int = None):

--- a/raiden/network/stunsock.py
+++ b/raiden/network/stunsock.py
@@ -3,8 +3,6 @@ import stun
 
 from raiden.exceptions import STUNUnavailableException
 
-log = structlog.get_logger(__name__)
-
 
 def stun_socket(
     socket,
@@ -13,6 +11,7 @@ def stun_socket(
     stun_host=None,
     stun_port=3478,
 ):
+    log = structlog.get_logger(__name__)
     timeout = socket.gettimeout()
     socket.settimeout(2)
     log.debug('Initiating STUN', source_ip=source_ip, source_port=source_port)

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -76,8 +76,6 @@ from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.network.matrix import GMatrixClient, Room
 from raiden_libs.utils.signing import eth_recover, eth_sign
 
-log = structlog.get_logger(__name__)
-
 _CT = TypeVar('CT')  # class type
 _CIT = Union[_CT, Type[_CT]]  # class or instance type
 _RT = TypeVar('RT')  # return type
@@ -165,7 +163,7 @@ class MatrixTransport(Runnable):
                         f"Unable to find a reachable Matrix server. "
                         f"Please check your network connectivity.",
                     ) from ex
-                log.warning(f"Selected server '{self._server_url}' not usable. Retrying.")
+                self.log.warning(f"Selected server '{self._server_url}' not usable. Retrying.")
 
         self.greenlets = list()
 
@@ -340,6 +338,7 @@ class MatrixTransport(Runnable):
     @property
     @cachedmethod(_cachegetter('__log_cache', dict), key=attrgetter('_user_id'))
     def log(self):
+        log = structlog.get_logger(__name__)
         if not self._user_id:
             return log
         return log.bind(current_user=self._user_id, node=pex(self._raiden_service.address))
@@ -964,7 +963,7 @@ class MatrixTransport(Runnable):
                 invitees=invitees_uids,
                 is_public=True,
             )
-            log.warning(
+            self.log.warning(
                 'Could not create nor join a named room. Successfuly created an unnamed one',
                 room=room,
                 invitees=invitees,

--- a/raiden/network/transport/udp/healthcheck.py
+++ b/raiden/network/transport/udp/healthcheck.py
@@ -17,9 +17,6 @@ from raiden.utils import pex, typing
 # type alias to avoid both circular dependencies and flake8 errors
 UDPTransport = 'UDPTransport'
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
-
 HealthEvents = namedtuple('HealthEvents', (
     'event_healthy',
     'event_unhealthy',
@@ -39,7 +36,7 @@ def healthcheck(
 ):
     """ Sends a periodical Ping to `recipient` to check its health. """
     # pylint: disable=too-many-branches
-
+    log = structlog.get_logger(__name__)
     log.debug(
         'starting healthcheck for',
         node=pex(transport.raiden.address),

--- a/raiden/network/transport/udp/udp_utils.py
+++ b/raiden/network/transport/udp/udp_utils.py
@@ -8,7 +8,6 @@ from raiden.utils import pex, typing
 
 # type alias to avoid both circular dependencies and flake8 errors
 UDPTransport = 'UDPTransport'
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def event_first_of(*events: _AbstractLinkable) -> Event:
@@ -88,7 +87,7 @@ def retry(
     Returns:
         bool: True if the message was acknowledged, False otherwise.
     """
-
+    log = structlog.get_logger(__name__)
     async_result = transport.maybe_sendraw_with_result(
         recipient,
         messagedata,
@@ -151,7 +150,7 @@ def retry_with_recovery(
         backoff must be an infinite iterator, otherwise this task will
         become a hot loop.
     """
-
+    log = structlog.get_logger(__name__)
     # The underlying unhealthy will be cleared, care must be taken to properly
     # clear stop_or_unhealthy too.
     stop_or_unhealthy = event_first_of(

--- a/raiden/network/upnpsock.py
+++ b/raiden/network/upnpsock.py
@@ -6,8 +6,6 @@ import structlog
 MAX_PORT = 65535
 RAIDEN_IDENTIFICATOR = 'raiden-network udp service'
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 NON_MAPPABLE = [
     '127.0.0.1',
     '0.0.0.0',
@@ -26,7 +24,7 @@ def valid_mappable_ipv4(address):
     try:
         parsed = ipaddress.ip_address(address_uni)
     except ValueError:
-        log.debug('invalid IPv4 address', input=address)
+        structlog.get_logger(__name__).debug('invalid IPv4 address', input=address)
         return False
     if parsed is not None and parsed.version == 4:
         return True
@@ -43,6 +41,7 @@ def connect():
     upnp = miniupnpc.UPnP()
     upnp.discoverdelay = 200
     providers = upnp.discover()
+    log = structlog.get_logger(__name__)
     if providers > 1:
         log.debug('multiple upnp providers found', num_providers=providers)
     elif providers < 1:
@@ -84,6 +83,8 @@ def open_port(upnp, internal_port, external_start_port=None):
 
     if upnp is None:
         return
+
+    log = structlog.get_logger(__name__)
 
     def register(internal, external):
         # test existing mappings
@@ -169,6 +170,7 @@ def release_port(upnp, external_port):
         success (boolean): if the release was successful.
     """
     mapping = upnp.getspecificportmapping(external_port, 'UDP')
+    log = structlog.get_logger(__name__)
 
     if mapping is None:
         log.error('could not find a port mapping', external=external_port)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -45,7 +45,6 @@ from raiden_libs.utils.signing import eth_sign
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 UNEVENTFUL_EVENTS = (
     EventTransferReceivedInvalidDirectTransfer,
     EventPaymentReceivedSuccess,
@@ -56,6 +55,9 @@ UNEVENTFUL_EVENTS = (
 
 
 class RaidenEventHandler:
+    def __init__(self):
+        self.log = structlog.get_logger(__name__)
+
     def on_raiden_event(self, raiden: RaidenService, event: Event):
         # pylint: disable=too-many-branches
 
@@ -94,7 +96,7 @@ class RaidenEventHandler:
         elif type(event) in UNEVENTFUL_EVENTS:
             pass
         else:
-            log.error('Unknown event {}'.format(type(event)))
+            self.log.error('Unknown event {}'.format(type(event)))
 
     def handle_send_lockexpired(
             self,
@@ -220,7 +222,7 @@ class RaidenEventHandler:
             unlock_failed_event: EventUnlockFailed,
     ):
         # pylint: disable=unused-argument
-        log.error(
+        self.log.error(
             'UnlockFailed!',
             secrethash=pex(unlock_failed_event.secrethash),
             reason=unlock_failed_event.reason,
@@ -297,7 +299,7 @@ class RaidenEventHandler:
                     our_signature,
                 )
             except ChannelOutdatedError as e:
-                log.error(str(e))
+                self.log.error(str(e))
 
     def handle_contract_send_channelunlock(
             self,
@@ -375,7 +377,7 @@ class RaidenEventHandler:
         try:
             payment_channel.unlock(merkle_tree_leaves)
         except ChannelOutdatedError as e:
-            log.error(str(e))
+            self.log.error(str(e))
 
     def handle_contract_send_channelsettle(
             self,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -14,8 +14,6 @@ from raiden.transfer.state import (
 )
 from raiden.utils import pex, typing
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 def get_ordered_partners(
         network_graph: networkx.Graph,
@@ -63,6 +61,7 @@ def get_best_routes(
     # rate from in the range [0.0,1.0].
 
     available_routes = list()
+    log = structlog.get_logger(__name__)
 
     token_network = views.get_token_network_by_identifier(
         chain_state,

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -4,10 +4,9 @@ import structlog
 
 from raiden.transfer.architecture import StateManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 def restore_to_state_change(transition_function, storage, state_change_identifier):
+    log = structlog.get_logger(__name__)
     snapshot = storage.get_snapshot_closest_to_state_change(state_change_identifier)
 
     from_state_change_id = 0

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -18,7 +18,6 @@ RELEASE_PAGE = 'https://github.com/raiden-network/raiden/releases'
 SECURITY_EXPRESSION = r'\[CRITICAL UPDATE.*?\]'
 
 REMOVE_CALLBACK = object()
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 def check_version(current_version: str):
@@ -53,6 +52,8 @@ def check_version(current_version: str):
 
 def check_gas_reserve(raiden):
     """ Check periodically for gas reserve in the account """
+    log = structlog.get_logger(__name__)
+
     while True:
         has_enough_balance, estimated_required_balance = gas_reserve.has_enough_gas_reserve(
             raiden,
@@ -87,6 +88,7 @@ class AlarmTask(Runnable):
         self.chain_id = None
         self.last_block_number = None
         self._stop_event = AsyncResult()
+        self.log = structlog.get_logger(__name__)
 
         # TODO: Start with a larger sleep_time and decrease it as the
         # probability of a new block increases.
@@ -140,7 +142,7 @@ class AlarmTask(Runnable):
                 )
 
             if latest_block_number != last_block_number:
-                log.debug(
+                self.log.debug(
                     'new block',
                     number=latest_block_number,
                     gas_limit=latest_block['gasLimit'],
@@ -149,7 +151,7 @@ class AlarmTask(Runnable):
 
                 if latest_block_number > last_block_number + 1:
                     missed_blocks = latest_block_number - last_block_number - 1
-                    log.info(
+                    self.log.info(
                         'missed blocks',
                         missed_blocks=missed_blocks,
                         latest_block=latest_block,
@@ -164,7 +166,7 @@ class AlarmTask(Runnable):
         chain_id = self.chain.network_id
         latest_block = self.chain.get_block(block_identifier='latest')
 
-        log.debug(
+        self.log.debug(
             'starting at block number',
             number=latest_block['number'],
             gas_limit=latest_block['gasLimit'],

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -1,6 +1,5 @@
 import gevent
 import pytest
-import structlog
 
 from raiden.tests.utils.network import (
     CHAIN,
@@ -12,8 +11,6 @@ from raiden.tests.utils.network import (
     wait_for_channels,
 )
 from raiden.tests.utils.tests import shutdown_apps_and_cleanup_tasks
-
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 @pytest.fixture

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -1,6 +1,5 @@
 import gevent
 import pytest
-import structlog
 
 from raiden.api.python import RaidenAPI
 from raiden.tests.utils.events import must_contain_entry
@@ -8,8 +7,6 @@ from raiden.tests.utils.network import CHAIN
 from raiden.transfer.events import EventPaymentReceivedSuccess
 from raiden.utils import wait_until
 from raiden.utils.echo_node import EchoNode
-
-log = structlog.get_logger(__name__)
 
 
 @pytest.mark.parametrize('number_of_nodes', [4])

--- a/raiden/tests/integration/test_stress.py
+++ b/raiden/tests/integration/test_stress.py
@@ -1,3 +1,4 @@
+import logging
 from http import HTTPStatus
 from itertools import combinations, count
 
@@ -18,8 +19,7 @@ from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.integration.api.utils import wait_for_listening_port
 from raiden.tests.utils.transfer import assert_synced_channel_state, wait_assert
 from raiden.transfer import views
-
-log = structlog.get_logger(__name__)
+from raiden.utils.cli import LogLevelConfigType
 
 
 def _url_for(apiserver, endpoint, **kwargs):
@@ -30,6 +30,55 @@ def _url_for(apiserver, endpoint, **kwargs):
 
     with apiserver.flask_app.app_context():
         return url_for('v1_resources.{}'.format(endpoint), **kwargs)
+
+
+def _trimmed_logging(logger_level_config):
+    structlog.reset_defaults()
+
+    logger_level_config = logger_level_config or dict()
+    logger_level_config.setdefault('filelock', 'ERROR')
+    logger_level_config.setdefault('', 'DEBUG')
+
+    processors = [
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    logging.config.dictConfig(
+        {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'plain': {
+                    '()': structlog.stdlib.ProcessorFormatter,
+                    'processor': structlog.dev.ConsoleRenderer(colors=False),
+                    'foreign_pre_chain': processors,
+                },
+            },
+            'handlers': {
+                'default': {
+                    'class': 'logging.StreamHandler',
+                    'level': 'DEBUG',
+                    'formatter': 'plain',
+                },
+            },
+            'loggers': {
+                '': {
+                    'handlers': ['default'],
+                    'propagate': True,
+                },
+            },
+        },
+    )
+    structlog.configure(
+        processors=processors + [
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
 
 
 def start_apiserver(raiden_app, rest_api_port_number):
@@ -130,7 +179,7 @@ def transfer_and_assert(server_from, server_to, token_address, identifier, amoun
     )
     json = {'amount': amount, 'identifier': identifier}
 
-    log.debug('PAYMENT REQUEST', url=url, json=json)
+    structlog.get_logger(__name__).debug('PAYMENT REQUEST', url=url, json=json)
 
     request = grequests.post(url, json=json)
     response = request.send().response
@@ -296,8 +345,8 @@ def assert_channels(raiden_network, token_network_identifier, deposit):
 @pytest.mark.parametrize('deposit', [5])
 @pytest.mark.parametrize('reveal_timeout', [15])
 @pytest.mark.parametrize('settle_timeout', [120])
-@pytest.mark.skip(reason='Issue 2492')
 def test_stress(
+        request,
         raiden_network,
         deposit,
         retry_timeout,
@@ -305,6 +354,15 @@ def test_stress(
         port_generator,
         skip_if_not_udp,
 ):
+
+    config_converter = LogLevelConfigType()
+    logging_levels = config_converter.convert(
+        value=request.config.option.log_config,
+        param=None,
+        ctx=None,
+    )
+    _trimmed_logging(logging_levels)
+
     token_address = token_addresses[0]
     rest_apis = start_apiserver_for_network(raiden_network, port_generator)
     identifier_generator = count()
@@ -314,6 +372,14 @@ def test_stress(
         views.state_from_app(raiden_network[0]),
         raiden_network[0].raiden.default_registry.address,
         token_address,
+    )
+
+    # restart the apps to reconfigure the logging
+    raiden_network, rest_apis = restart_network_and_apiservers(
+        raiden_network,
+        rest_apis,
+        port_generator,
+        retry_timeout,
     )
 
     for _ in range(3):

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -3,7 +3,6 @@ import os
 from unittest.mock import patch
 
 import pytest
-import structlog
 from eth_utils import encode_hex
 
 from raiden.accounts import AccountManager
@@ -11,8 +10,6 @@ from raiden.utils import get_project_root
 
 KEYFILE_INACCESSIBLE = 'UTC--2017-06-20T16-33-00.000000000Z--inaccessible'
 KEYFILE_INVALID = 'UTC--2017-06-20T16-06-00.000000000Z--invalid'
-
-log = structlog.get_logger()
 
 
 @pytest.yield_fixture(scope='module')

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from itertools import cycle
 
 import pytest
-import structlog
 
 from raiden.constants import UINT64_MAX
 from raiden.messages import DirectTransfer, Secret
@@ -61,9 +60,6 @@ from raiden.transfer.state_change import (
     ReceiveUnlock,
 )
 from raiden.utils import privatekey_to_address, random_secret, sha3
-
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 PartnerStateModel = namedtuple(
     'PartnerStateModel',

--- a/raiden/tests/utils/geth.py
+++ b/raiden/tests/utils/geth.py
@@ -19,9 +19,6 @@ from raiden.tests.fixtures.variables import DEFAULT_BALANCE_BIN, DEFAULT_PASSPHR
 from raiden.tests.utils.genesis import GENESIS_STUB
 from raiden.utils import privatekey_to_address, privtopub, typing
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
-
 GethNodeDescription = namedtuple(
     'GethNodeDescription',
     [
@@ -104,7 +101,7 @@ def geth_to_cmd(
     if node.get('mine', False):
         cmd.append('--mine')
 
-    log.debug('geth command', command=cmd)
+    structlog.get_logger(__name__).debug('geth command', command=cmd)
 
     return cmd
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -3,7 +3,6 @@ from binascii import hexlify
 from collections import namedtuple
 
 import gevent
-import structlog
 from gevent import server
 
 from raiden import waiting
@@ -16,8 +15,6 @@ from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.utils import merge_dict
-
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 CHAIN = object()  # Flag used by create a network does make a loop with the channels
 BlockchainServices = namedtuple(

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -1,8 +1,6 @@
 # pylint: disable=too-few-public-methods
 from copy import deepcopy
 
-import structlog
-
 from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.utils.typing import (
     Address,
@@ -37,8 +35,6 @@ from raiden.utils.typing import (
 # processed, i.e. the state change must be self contained and the result state
 # tree must be serializable to produce a snapshot. To enforce this inputs and
 # outputs are separated under different class hierarquies (StateChange and Event).
-
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class State:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -110,8 +110,6 @@ if True:
         CONTRACT_TOKEN_NETWORK_REGISTRY,
     )
 
-log = structlog.get_logger(__name__)
-
 
 ETHEREUM_NODE_COMMUNICATION_ERROR = (
     '\n'
@@ -613,6 +611,7 @@ def run_app(
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,unused-argument
 
     from raiden.app import App
+    log = structlog.get_logger(__name__)
 
     if not assert_sqlite_version():
         log.error('SQLite3 should be at least version {}'.format(
@@ -952,6 +951,7 @@ class NodeRunner:
         self._options = options
         self._ctx = ctx
         self._raiden_api = None
+        self.log = structlog.get_logger(__name__)
 
     @property
     def _welcome_string(self):
@@ -995,7 +995,7 @@ class NodeRunner:
         )
 
         if self._options['config_file']:
-            log.debug('Using config file', config_file=self._options['config_file'])
+            self.log.debug('Using config file', config_file=self._options['config_file'])
 
         # TODO:
         # - Ask for confirmation to quit if there are any locked transfers that did

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -3,8 +3,6 @@ from typing import Sequence
 import structlog
 from gevent import Greenlet
 
-log = structlog.get_logger(__name__)
-
 
 class Runnable:
     """Greenlet-like class, __run() inside one, but can be stopped and restarted
@@ -62,7 +60,8 @@ class Runnable:
         """ Default callback for substasks link_exception
 
         Default callback re-raises the exception inside _run() """
-        log.error(
+
+        structlog.get_logger(__name__).error(
             'Runnable subtask died!',
             this=self,
             running=bool(self),

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -13,8 +13,6 @@ from raiden.utils import typing
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
-
 
 def wait_for_block(
         raiden: RaidenService,
@@ -132,8 +130,13 @@ def wait_for_payment_balance(
         partner_address,
     )
 
+    log = structlog.get_logger(__name__)
     while balance(channel_state) < target_balance:
-        log.critical('wait', b=balance(channel_state), t=target_balance)
+        log.critical(
+            'waiting for balance',
+            current_balance=balance(channel_state),
+            target_balance=target_balance,
+        )
         gevent.sleep(retry_timeout)
         channel_state = views.get_channelstate_for(
             views.state_from_raiden(raiden),


### PR DESCRIPTION
structlog's are lazy, and will be configured on first usage, this allows
the module level loggers to be instantiated at import time and be
configured latter. Although this is convenient, it doesn't allow for the
loggers to be reconfigured during a test session, since the logger will
stick to the first configuration used in the session, and further calls
to configure will not have effect since a new logger is not
instantiated.

This fixes the above, and allows tests to reconfigure the the logging
library. This is a step towards reducing the log size in the build,
which become necessary since travis has a maximum size for logs.

[ci integration]