### PR TITLE
Simplified the filter polling

### DIFF
--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -4,7 +4,6 @@ import structlog
 from eth_utils import encode_hex, event_abi_to_log_topic, is_binary_address, to_normalized_address
 from gevent.event import AsyncResult
 from web3.exceptions import BadFunctionCallOutput
-from web3.utils.filters import Filter
 
 from raiden.exceptions import (
     AddressWrongContract,
@@ -12,7 +11,7 @@ from raiden.exceptions import (
     InvalidAddress,
     TransactionThrew,
 )
-from raiden.network.rpc.client import check_address_has_code
+from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import EXPECTED_CONTRACTS_VERSION
 from raiden.utils import compare_versions, pex, privatekey_to_address, sha3, typing
@@ -130,7 +129,7 @@ class SecretRegistry:
             self,
             from_block: typing.BlockSpecification = 0,
             to_block: typing.BlockSpecification = 'latest',
-    ) -> Filter:
+    ) -> StatelessFilter:
         event_abi = CONTRACT_MANAGER.get_event_abi(
             CONTRACT_SECRET_REGISTRY,
             EVENT_SECRET_REVEALED,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -11,7 +11,6 @@ from eth_utils import (
 )
 from gevent.event import AsyncResult
 from gevent.lock import RLock, Semaphore
-from web3.utils.filters import Filter
 
 from raiden.exceptions import (
     ChannelOutdatedError,
@@ -27,7 +26,7 @@ from raiden.exceptions import (
     WithdrawMismatch,
 )
 from raiden.network.proxies import Token
-from raiden.network.rpc.client import check_address_has_code
+from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import EXPECTED_CONTRACTS_VERSION
 from raiden.utils import compare_versions, pex, privatekey_to_address, typing
@@ -936,7 +935,7 @@ class TokenNetwork:
             topics: List[str] = None,
             from_block: typing.BlockSpecification = None,
             to_block: typing.BlockSpecification = None,
-    ) -> Filter:
+    ) -> StatelessFilter:
         """ Install a new filter for an array of topics emitted by the contract.
         Args:
             topics: A list of event ids to filter for. Can also be None,
@@ -957,7 +956,7 @@ class TokenNetwork:
             self,
             from_block: typing.BlockSpecification = 0,
             to_block: typing.BlockSpecification = 'latest',
-    ) -> Filter:
+    ) -> StatelessFilter:
         """ Install a new filter for all the events emitted by the current token network contract
 
         Args:

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -11,7 +11,6 @@ from eth_utils import (
     to_normalized_address,
 )
 from web3.exceptions import BadFunctionCallOutput
-from web3.utils.filters import Filter
 
 from raiden.constants import NULL_ADDRESS
 from raiden.exceptions import (
@@ -21,7 +20,7 @@ from raiden.exceptions import (
     RaidenRecoverableError,
     TransactionThrew,
 )
-from raiden.network.rpc.client import check_address_has_code
+from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import EXPECTED_CONTRACTS_VERSION
 from raiden.utils import compare_versions, pex, privatekey_to_address, typing
@@ -134,7 +133,7 @@ class TokenNetworkRegistry:
             self,
             from_block: typing.BlockSpecification = 0,
             to_block: typing.BlockSpecification = 'latest',
-    ) -> Filter:
+    ) -> StatelessFilter:
         event_abi = CONTRACT_MANAGER.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY,
             EVENT_TOKEN_NETWORK_CREATED,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -16,7 +16,6 @@ from requests import ConnectTimeout
 from web3 import Web3
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
-from web3.utils.filters import Filter
 
 from raiden.constants import NULL_ADDRESS
 from raiden.exceptions import AddressWithoutCode, EthNodeCommunicationError
@@ -504,7 +503,7 @@ class JSONRPCClient:
             topics: List[str] = None,
             from_block: BlockSpecification = 0,
             to_block: BlockSpecification = 'latest',
-    ) -> Filter:
+    ) -> StatelessFilter:
         """ Create a filter in the ethereum node. """
         return StatelessFilter(
             self.web3,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -396,8 +396,6 @@ class RaidenService(Runnable):
         except gevent.Timeout:
             pass
 
-        self.blockchain_events.reset()
-
         if self.db_lock is not None:
             self.db_lock.release()
 

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -106,19 +106,13 @@ class StatelessFilter(LogFilter):
         self._last_block: int = -1
         self._lock = Semaphore()
 
-    def get_new_entries(self, block_number: int = None):
+    def get_new_entries(self, block_number: int):
         with self._lock:
             filter_params = self.filter_params.copy()
             filter_params['fromBlock'] = max(
                 filter_params.get('fromBlock', 0),
                 self._last_block + 1,
             )
-            # This logic may contain a race condition. It's possible that after
-            # `web.eth.blockNumber` and before `web3.eth.getLogs` a new block is mined.
-            # This is okay because any new logs on this new block will be fetched on the
-            # next call to `get_new_entries`
-            if block_number is None:
-                block_number = self.web3.eth.blockNumber
             if self.filter_params.get('toBlock') in (None, 'latest', 'pending'):
                 filter_params['toBlock'] = block_number or 'latest'
             self._last_block = filter_params.get('toBlock') or block_number


### PR DESCRIPTION
The default implementation of filters provided by web3.py rely on the
ethereum node to keep the state of the from_block number. Although this
is convenient it's a problem when either the Ethereum or Raiden node are
restarted, because the previous block number must be remembered to
re-install the filter.

Since the from_block needs to be known anyways instead of relying on the
remote ethereum node to know the from_block the stateless filter was
introduced, which always rely on the start_block number being known.

This just removes the unused code which supported the web3.py Filter
class.