### PR TITLE
Fix some error handlers

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -93,6 +93,7 @@ ERROR_STATUS_CODES = [
     HTTPStatus.BAD_REQUEST,
     HTTPStatus.NOT_FOUND,
     HTTPStatus.NOT_IMPLEMENTED,
+    HTTPStatus.INTERNAL_SERVER_ERROR,
 ]
 
 URLS_V1 = [
@@ -467,6 +468,7 @@ class APIServer(Runnable):
             exc_info=True,
         )
         self.greenlet.kill(exception)
+        return api_error([str(exception)], HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 class RestAPI:

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -1251,7 +1251,7 @@ class MatrixTransport(Runnable):
 
         keep_rooms: Set[_RoomID] = set()
 
-        for address_hex, room_ids in _address_to_room_ids.items():
+        for address_hex, room_ids in list(_address_to_room_ids.items()):
             if not room_ids:  # None or empty
                 room_ids = list()
             if not isinstance(room_ids, list):  # old version, single room

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -387,14 +387,13 @@ class RaidenService(Runnable):
         #
         # We need a timeout to prevent an endless loop from trying to
         # contact the disconnected client
-        try:
-            self.transport.stop()
-            self.alarm.stop()
-            self.transport.get()
-            self.alarm.get()
-            self.blockchain_events.uninstall_all_event_listeners()
-        except gevent.Timeout:
-            pass
+        self.transport.stop()
+        self.alarm.stop()
+
+        self.transport.join()
+        self.alarm.join()
+
+        self.blockchain_events.uninstall_all_event_listeners()
 
         if self.db_lock is not None:
             self.db_lock.release()


### PR DESCRIPTION
Fix #2590 
Fix #2592 
A `KeyError` needed to be handled, as it was caused by a race when `/sync` cleaned the room from `_client.rooms` dict before `room.leave` tried cleaning it with `del self.client.rooms[room_id]`, which raised this exception even if the room was properly cleaned.
Also, rest exceptions weren't being properly raised because `flask-restful` was eating it before the default flask `errorhandler`.