### PR TITLE
[SP] Implement http status code matching

### DIFF
--- a/tools/scenario-player/example-scenarios/scenario-basic.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-basic.yaml
@@ -117,3 +117,8 @@ scenario:
 #            - close_channel: {from: 0, to: 1}
 #            - close_channel: {from: 1, to: 2}
 #      - assert: {from: 0, to: 1, total_deposit: 100, balance: 5, state: "closed"}
+
+# Status code matching (int or regex):
+#      - open_channel: {from: 0, to: 1}
+#      - open_channel: {from: 0, to: 1, expected_http_status: 409}
+#      - open_channel: {from: 0, to: 1, expected_http_status: '4.9'}

--- a/tools/scenario-player/scenario_player/exceptions.py
+++ b/tools/scenario-player/scenario_player/exceptions.py
@@ -26,6 +26,10 @@ class RESTAPIError(ScenarioError):
     pass
 
 
+class RESTAPIStatusMismatchError(ScenarioError):
+    pass
+
+
 class UnknownTaskTypeError(ScenarioError):
     pass
 

--- a/tools/scenario-player/scenario_player/tasks/channels.py
+++ b/tools/scenario-player/scenario_player/tasks/channels.py
@@ -70,16 +70,19 @@ class AssertTask(ChannelActionTask):
     _name = 'assert'
     _method = 'get'
 
-    def _process_response(self, response: dict):
+    def _process_response(self, response_dict: dict):
+        response_dict = super()._process_response(response_dict)
         for field in ['balance', 'total_deposit', 'state']:
             if field not in self._config:
                 continue
-            if field not in response:
-                raise ScenarioAssertionError(f'Field "{field}" is missing in channel: {response}')
-            if response[field] != self._config[field]:
+            if field not in response_dict:
+                raise ScenarioAssertionError(
+                    f'Field "{field}" is missing in channel: {response_dict}',
+                )
+            if response_dict[field] != self._config[field]:
                 raise ScenarioAssertionError(
                     f'Value mismatch for "{field}". '
                     f'Should: "{self._config[field]}" '
-                    f'Is: "{response[field]}" '
-                    f'Channel: {response}',
+                    f'Is: "{response_dict[field]}" '
+                    f'Channel: {response_dict}',
                 )

--- a/tools/scenario-player/scenario_player/tasks/raiden_api.py
+++ b/tools/scenario-player/scenario_player/tasks/raiden_api.py
@@ -1,6 +1,10 @@
+import re
+from typing import Any, Union
+
 from requests import RequestException
 
-from scenario_player.exceptions import RESTAPIError
+from scenario_player.exceptions import RESTAPIError, RESTAPIStatusMismatchError
+from scenario_player.runner import ScenarioRunner
 
 from .base import Task
 
@@ -9,6 +13,19 @@ class RaidenAPIActionTask(Task):
     _name = ''
     _url_template = ""
     _method = 'get'
+    _expected_http_status: Union[int, str] = '2..'
+
+    def __init__(
+        self,
+        runner: ScenarioRunner,
+        config: Any,
+        parent: 'Task' = None,
+        abort_on_fail=True,
+    ) -> None:
+        super().__init__(runner, config, parent, abort_on_fail)
+
+        self._expected_http_status = config.get('expected_http_status', self._expected_http_status)
+        self._http_status_re = re.compile(f'^{self._expected_http_status}$')
 
     @property
     def _request_params(self):
@@ -22,8 +39,8 @@ class RaidenAPIActionTask(Task):
     def _target_host(self):
         return self._runner.raiden_nodes[self._config['from']]
 
-    def _process_response(self, response: dict):
-        return response
+    def _process_response(self, response_dict: dict):
+        return response_dict
 
     def _run(self, *args, **kwargs):
         url = self._url_template.format(
@@ -35,8 +52,11 @@ class RaidenAPIActionTask(Task):
             resp = self._runner.session.request(self._method, url, json=self._request_params)
         except RequestException as ex:
             raise RESTAPIError(f'Error performing REST-API call: {self._name}') from ex
-        if not 199 < resp.status_code < 300:
-            raise RESTAPIError(f'Status {resp.status_code} while fetching {url}: {resp.text}')
+        if not self._http_status_re.match(str(resp.status_code)):
+            raise RESTAPIStatusMismatchError(
+                f'HTTP status code "{resp.status_code}" while fetching {url}. '
+                f'Expected {self._expected_http_status}: {resp.text}',
+            )
         try:
             return self._process_response(resp.json())
         except (ValueError, UnicodeDecodeError) as ex:


### PR DESCRIPTION
All Raiden API tasks now take an `expected_http_status` argument which defaults to `2..` and is parsed as a regex (integers are also accepted).
If the API call's http status doesn't match the regex a `RESTAPIStatusMismatchError` exception is raised.

This can be used to test for various failure cases.