### PR TITLE
logging: logs before & after all transactions

### DIFF
--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -1,11 +1,15 @@
+import structlog
 from eth_utils import is_binary_address, to_checksum_address, to_normalized_address
 
 from raiden.exceptions import TransactionThrew
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
+from raiden.utils import pex, privatekey_to_address
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import CONTRACT_MANAGER
+
+log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class Token:
@@ -27,6 +31,7 @@ class Token:
 
         self.address = token_address
         self.client = jsonrpc_client
+        self.node_address = privatekey_to_address(jsonrpc_client.privkey)
         self.proxy = proxy
 
     def allowance(self, owner, spender):
@@ -35,14 +40,26 @@ class Token:
             to_checksum_address(spender),
         ).call()
 
-    def approve(self, contract_address, allowance):
-        """ Aprove `contract_address` to transfer up to `deposit` amount of token. """
-        # TODO: check that `contract_address` is a netting channel and that
-        # `self.address` is one of the participants (maybe add this logic into
-        # `NettingChannel` and keep this straight forward)
+    def approve(self, allowed_address, allowance):
+        """ Aprove `allowed_address` to transfer up to `deposit` amount of token.
+
+        Note:
+
+            For channel deposit please use the channel proxy, since it does
+            additional validations.
+        """
+
+        log_details = {
+            'node': pex(self.node_address),
+            'contract': pex(self.address),
+            'allowed_address': pex(allowed_address),
+            'allowance': allowance,
+        }
+        log.debug('approve called', **log_details)
+
         transaction_hash = self.proxy.transact(
             'approve',
-            to_checksum_address(contract_address),
+            to_checksum_address(allowed_address),
             allowance,
         )
 
@@ -61,7 +78,6 @@ class Token:
                     "contract is not a valid ERC20 token or you don't have funds "
                     "to use for openning a channel. "
                 )
-                raise TransactionThrew(msg, receipt_or_none)
 
             # The approve call failed, check the user has enough balance
             # (assuming the token smart contract may check for the maximum
@@ -73,18 +89,22 @@ class Token:
                     'approve failed. Please make sure the corresponding smart '
                     'contract is a valid ERC20 token.'
                 ).format(user_balance)
-                raise TransactionThrew(msg, receipt_or_none)
 
             # If the user has enough balance, warn the user the smart contract
             # may not have the approve function.
             else:
                 msg = (
-                    'Approve failed. \n'
-                    'Your account balance is {}, the request allowance is {}. '
-                    'The smart contract may be rejecting your request for the '
-                    'lack of balance.'
-                ).format(user_balance, allowance)
-                raise TransactionThrew(msg, receipt_or_none)
+                    f'Approve failed. \n'
+                    f'Your account balance is {user_balance}, '
+                    f'the request allowance is {allowance}. '
+                    f'The smart contract may be rejecting your request for the '
+                    f'lack of balance.'
+                )
+
+            log.critical(f'approve failed, {msg}', **log_details)
+            raise TransactionThrew(msg, receipt_or_none)
+
+        log.info('approve successful', **log_details)
 
     def balance_of(self, address):
         """ Return the balance of `address`. """
@@ -93,6 +113,14 @@ class Token:
         ).call()
 
     def transfer(self, to_address, amount):
+        log_details = {
+            'node': pex(self.node_address),
+            'contract': pex(self.address),
+            'to_address': pex(to_address),
+            'amount': amount,
+        }
+        log.debug('transfer called', **log_details)
+
         transaction_hash = self.proxy.transact(
             'transfer',
             to_checksum_address(to_address),
@@ -102,6 +130,8 @@ class Token:
         self.client.poll(transaction_hash)
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
         if receipt_or_none:
+            log.critical('transfer failed', **log_details)
             raise TransactionThrew('Transfer', receipt_or_none)
 
-        # TODO: check Transfer event
+        # TODO: check Transfer event (issue: #2598)
+        log.info('transfer successful', **log_details)


### PR DESCRIPTION
To make debugging easier some of the proxies have logs for before and
after the transaction is sent. This adds these logs lines to the missing
proxies.

The general guidelined followed was:
- logs prior to the transaction sent are debugging logs
- logs after the transaction is mined are:
  - critical if the transaction failed in an unrecoverable manner
  - info if the transaction failed in a recoverable manner
  - info if the transaction was successful
- the logs are formatedd with `<smart_contract_function_name> <state>`,
where state is one of these:
  - called
  - failed
  - successful

This did improve the logging but it's not covering all cases, specially
the checks done in the channel proxy which can raise an exception