### PR TITLE
on-chain secret reveal is the same as off-chain

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -842,6 +842,7 @@ def test_initiator_handle_contract_receive_secret_reveal():
         payment_state=current_state,
         state_change=state_change,
         channelidentifiers_to_channels=channel_map,
+        pseudo_random_generator=pseudo_random_generator,
     )
 
     assert events.must_contain_entry(iteration.events, SendBalanceProof, {

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -3,6 +3,7 @@ import random
 
 import gevent
 from coincurve import PrivateKey
+from gevent.event import AsyncResult
 
 from raiden.constants import UINT64_MAX
 from raiden.message_handler import on_message
@@ -150,6 +151,10 @@ def pending_mediated_transfer(app_chain, token_network_identifier, amount, ident
         token_network_identifier,
         target,
     )
+
+    init_initiator_identifier = init_initiator_statechange.transfer.payment_identifier
+    initiator_app.raiden.identifier_to_results[init_initiator_identifier] = AsyncResult()
+
     events = initiator_app.raiden.wal.log_and_dispatch(
         init_initiator_statechange,
     )
@@ -159,6 +164,10 @@ def pending_mediated_transfer(app_chain, token_network_identifier, amount, ident
 
     for mediator_app in app_chain[1:-1]:
         mediator_init_statechange = mediator_init(mediator_app.raiden, transfermessage)
+
+        mediator_init_identifier = init_initiator_statechange.transfer.payment_identifier
+        mediator_app.raiden.identifier_to_results[mediator_init_identifier] = AsyncResult()
+
         events = mediator_app.raiden.wal.log_and_dispatch(
             mediator_init_statechange,
         )

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -29,11 +29,11 @@ from raiden.utils import typing
 
 
 def events_for_unlock_lock(
-        initiator_state,
-        channel_state,
-        secret,
-        secrethash,
-        pseudo_random_generator,
+        initiator_state: InitiatorTransferState,
+        channel_state: NettingChannelState,
+        secret: typing.Secret,
+        secrethash: typing.SecretHash,
+        pseudo_random_generator: random.Random,
 ):
     # next hop learned the secret, unlock the token locally and send the
     # lock claim message to next hop
@@ -326,6 +326,7 @@ def handle_onchain_secretreveal(
         initiator_state: InitiatorTransferState,
         state_change: ContractReceiveSecretReveal,
         channel_state: NettingChannelState,
+        pseudo_random_generator: random.Random,
 ) -> TransitionResult:
     """ When a secret is revealed on-chain all nodes learn the secret.
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -337,8 +337,15 @@ def handle_onchain_secretreveal(
     """
     is_valid_secret = state_change.secrethash == initiator_state.transfer.lock.secrethash
     is_channel_open = channel.get_status(channel_state) == CHANNEL_STATE_OPENED
+    is_lock_expired = state_change.block_number > initiator_state.transfer.lock.expiration
 
-    if is_valid_secret and is_channel_open:
+    is_lock_unlocked = (
+        is_valid_secret and
+        is_channel_open and
+        not is_lock_expired
+    )
+
+    if is_lock_unlocked:
         events = events_for_unlock_lock(
             initiator_state,
             channel_state,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -268,6 +268,7 @@ def handle_onchain_secretreveal(
         payment_state: InitiatorPaymentState,
         state_change: ReceiveSecretReveal,
         channelidentifiers_to_channels: typing.ChannelMap,
+        pseudo_random_generator: random.Random,
 ) -> TransitionResult:
     channel_identifier = payment_state.initiator.channel_identifier
     channel_state = channelidentifiers_to_channels[channel_identifier]
@@ -275,6 +276,7 @@ def handle_onchain_secretreveal(
         initiator_state=payment_state.initiator,
         state_change=state_change,
         channel_state=channel_state,
+        pseudo_random_generator=pseudo_random_generator,
     )
     iteration = iteration_from_sub(payment_state, sub_iteration)
     return iteration
@@ -348,6 +350,7 @@ def state_transition(
             payment_state,
             state_change,
             channelidentifiers_to_channels,
+            pseudo_random_generator,
         )
     else:
         iteration = TransitionResult(payment_state, list())


### PR DESCRIPTION
If a secret is revealed on-chain then all the world knows it, including
the next hop of the transfer, therefore the initiator doesn't need to
wait for the next hop to send a secret reveal message to confirm that it
knows the secret.