### PR TITLE
Allow numeric network ids

### DIFF
--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -258,7 +258,9 @@ class NATChoiceType(click.Choice):
 
 class NetworkChoiceType(click.Choice):
     def convert(self, value, param, ctx):
-        if isinstance(value, str) and value.isnumeric():
+        if isinstance(value, int):
+            return value
+        elif isinstance(value, str) and value.isnumeric():
             try:
                 return int(value)
             except ValueError:


### PR DESCRIPTION
If a numeric network id is set in the config file it will be an int.