### PR TITLE
flaky stress test

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -195,7 +195,6 @@ class JSONRPCClient:
         self.sender = sender
         self.web3 = web3
 
-        self._gaslimit_cache = TTLCache(maxsize=16, ttl=RPC_CACHE_TTL)
         self._gasprice_cache = TTLCache(maxsize=16, ttl=RPC_CACHE_TTL)
         self._available_nonce = _available_nonce
         self._nonce_lock = Semaphore()
@@ -218,7 +217,6 @@ class JSONRPCClient:
         """ Return the balance of the account of given address. """
         return self.web3.eth.getBalance(to_checksum_address(account), 'pending')
 
-    @cachedmethod(attrgetter('_gaslimit_cache'))
     def gaslimit(self, location='latest') -> int:
         gas_limit = self.web3.eth.getBlock(location)['gasLimit']
         return gas_limit * 8 // 10

--- a/raiden/tests/integration/test_stress.py
+++ b/raiden/tests/integration/test_stress.py
@@ -347,7 +347,6 @@ def assert_channels(raiden_network, token_network_identifier, deposit):
 @pytest.mark.parametrize('deposit', [5])
 @pytest.mark.parametrize('reveal_timeout', [15])
 @pytest.mark.parametrize('settle_timeout', [120])
-@pytest.mark.skip(reason='Issue 2492')
 def test_stress(
         request,
         raiden_network,


### PR DESCRIPTION
the cache was introducing flakyness in the tests, this happened with
tests that are long running but don't send many transactions, which
makes the block gaslimit decrease significantly after the private
blockchain fixture setup is done