### PR TITLE
Fix crash on raiden startup

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -95,7 +95,7 @@ class App:  # pylint: disable=too-few-public-methods
             log.warning(
                 'Older versions of the database exist in '
                 f'{db_base_path}. Since a newer breaking version is introduced, '
-                'it is advised that you leave all token networks before upgrading and ',
+                'it is advised that you leave all token networks before upgrading and '
                 'then proceed with the upgrade.',
             )
 


### PR DESCRIPTION
Fixes this traceback on startup on master:
```
Traceback (most recent call last):
  File "/Users/paul/Work/venv-raiden/bin/raiden", line 11, in <module>
    load_entry_point('raiden', 'console_scripts', 'raiden')()
  File "/Users/paul/Work/raiden/raiden/__main__.py", line 11, in main
    run(auto_envvar_prefix='RAIDEN')  # pylint: disable=no-value-for-parameter
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/paul/Work/raiden/raiden/ui/cli.py", line 1192, in run
    NodeRunner(kwargs, ctx).run()
  File "/Users/paul/Work/raiden/raiden/ui/cli.py", line 1023, in run
    app = self._run_app()
  File "/Users/paul/Work/raiden/raiden/ui/cli.py", line 1042, in _run_app
    app_ = run_app(**self._options)
  File "/Users/paul/Work/raiden/raiden/ui/cli.py", line 844, in run_app
    discovery=discovery,
  File "/Users/paul/Work/raiden/raiden/app.py", line 99, in __init__
    'then proceed with the upgrade.',
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/structlog/stdlib.py", line 75, in warning
    return self._proxy_to_logger("warning", event, *args, **kw)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/structlog/stdlib.py", line 119, in _proxy_to_logger
    method_name, event=event, **event_kw
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/structlog/_base.py", line 191, in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/structlog/_base.py", line 151, in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
  File "/Users/paul/Work/venv-raiden/lib/python3.6/site-packages/structlog/stdlib.py", line 280, in __call__
    event_dict["event"] = event_dict["event"] % args
TypeError: not all arguments converted during string formatting
```