### PR TITLE
Onchain secret registration handling when lock has expired

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -51,9 +51,10 @@ def handle_tokennetwork_new(raiden, event: Event):
     assert transaction_hash, 'A mined transaction must have the hash field'
 
     new_token_network = ContractReceiveNewTokenNetwork(
-        transaction_hash,
-        event.originating_contract,
-        token_network_state,
+        transaction_hash=transaction_hash,
+        payment_network_identifier=event.originating_contract,
+        token_network=token_network_state,
+        block_number=data['block_number'],
     )
     raiden.handle_state_change(new_token_network)
 
@@ -85,9 +86,10 @@ def handle_channel_new(raiden, event: Event):
         )
 
         new_channel = ContractReceiveChannelNew(
-            transaction_hash,
-            token_network_identifier,
-            channel_state,
+            transaction_hash=transaction_hash,
+            token_network_identifier=token_network_identifier,
+            channel_state=channel_state,
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(new_channel)
 
@@ -99,11 +101,12 @@ def handle_channel_new(raiden, event: Event):
     # Raiden node is not participant of channel
     else:
         new_route = ContractReceiveRouteNew(
-            transaction_hash,
-            token_network_identifier,
-            channel_identifier,
-            participant1,
-            participant2,
+            transaction_hash=transaction_hash,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            participant1=participant1,
+            participant2=participant2,
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(new_route)
 
@@ -144,10 +147,11 @@ def handle_channel_new_balance(raiden, event: Event):
         )
 
         newbalance_statechange = ContractReceiveChannelNewBalance(
-            transaction_hash,
-            token_network_identifier,
-            channel_identifier,
-            deposit_transaction,
+            transaction_hash=transaction_hash,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            deposit_transaction=deposit_transaction,
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(newbalance_statechange)
 
@@ -186,7 +190,7 @@ def handle_channel_closed(raiden, event: Event):
             transaction_from=data['closing_participant'],
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
-            closed_block_number=data['block_number'],
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(channel_closed)
     else:
@@ -195,6 +199,7 @@ def handle_channel_closed(raiden, event: Event):
             transaction_hash=transaction_hash,
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(channel_closed)
 
@@ -218,6 +223,7 @@ def handle_channel_update_transfer(raiden, event: Event):
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
             nonce=data['args']['nonce'],
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(channel_transfer_updated)
 
@@ -238,10 +244,10 @@ def handle_channel_settled(raiden, event: Event):
 
     if channel_state:
         channel_settled = ContractReceiveChannelSettled(
-            transaction_hash,
-            token_network_identifier,
-            channel_identifier,
-            data['block_number'],
+            transaction_hash=transaction_hash,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            block_number=data['block_number'],
         )
         raiden.handle_state_change(channel_settled)
 
@@ -254,13 +260,14 @@ def handle_channel_batch_unlock(raiden, event: Event):
     assert transaction_hash, 'A mined transaction must have the hash field'
 
     unlock_state_change = ContractReceiveChannelBatchUnlock(
-        transaction_hash,
-        token_network_identifier,
-        data['participant'],
-        data['partner'],
-        data['locksroot'],
-        data['unlocked_amount'],
-        data['returned_tokens'],
+        transaction_hash=transaction_hash,
+        token_network_identifier=token_network_identifier,
+        participant=data['participant'],
+        partner=data['partner'],
+        locksroot=data['locksroot'],
+        unlocked_amount=data['unlocked_amount'],
+        returned_tokens=data['returned_tokens'],
+        block_number=data['block_number'],
     )
 
     raiden.handle_state_change(unlock_state_change)
@@ -274,10 +281,11 @@ def handle_secret_revealed(raiden, event: Event):
     assert transaction_hash, 'A mined transaction must have the hash field'
 
     registeredsecret_state_change = ContractReceiveSecretReveal(
-        transaction_hash,
-        secret_registry_address,
-        data['secrethash'],
-        data['secret'],
+        transaction_hash=transaction_hash,
+        secret_registry_address=secret_registry_address,
+        secrethash=data['secrethash'],
+        secret=data['secret'],
+        block_number=data['block_number'],
     )
 
     raiden.handle_state_change(registeredsecret_state_change)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -246,6 +246,7 @@ class RaidenService(Runnable):
             state_change = ContractReceiveNewPaymentNetwork(
                 constants.EMPTY_HASH,
                 payment_network,
+                block_number,
             )
             self.handle_state_change(state_change)
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 4
+RAIDEN_DB_VERSION = 5
 
 
 class EventRecord(typing.NamedTuple):

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -119,7 +119,7 @@ def test_settle_is_automatically_called(raiden_network, token_addresses, deposit
         'token_network_identifier': token_network_identifier,
         'channel_identifier': channel_identifier,
         'transaction_from': app1.raiden.address,
-        'closed_block_number': channel_state.close_transaction.finished_block_number,
+        'block_number': channel_state.close_transaction.finished_block_number,
     })
 
     assert must_contain_entry(state_changes, ContractReceiveChannelSettled, {

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -269,6 +269,7 @@ def test_channelstate_update_contract_balance():
         channel_state.token_network_identifier,
         channel_state.identifier,
         deposit_transaction,
+        block_number,
     )
 
     pseudo_random_generator = random.Random()
@@ -315,6 +316,7 @@ def test_channelstate_decreasing_contract_balance():
         channel_state.token_network_identifier,
         channel_state.identifier,
         deposit_transaction,
+        deposit_block_number,
     )
 
     pseudo_random_generator = random.Random()
@@ -354,6 +356,7 @@ def test_channelstate_repeated_contract_balance():
         channel_state.token_network_identifier,
         channel_state.identifier,
         deposit_transaction,
+        deposit_block_number,
     )
 
     our_model2 = our_model1._replace(
@@ -407,6 +410,7 @@ def test_deposit_must_wait_for_confirmation():
         channel_state.token_network_identifier,
         channel_state.identifier,
         deposit_transaction,
+        block_number,
     )
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
@@ -1747,6 +1751,7 @@ def test_update_transfer():
         channel_state.token_network_identifier,
         channel_state.identifier,
         23,
+        closed_block_number + 1,
     )
 
     update_block_number = 20

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1174,6 +1174,7 @@ def test_channel_never_expires_lock_with_secret_onchain():
         channel_state=channel_state,
         secret=lock_secret,
         secrethash=lock.secrethash,
+        secret_reveal_block_number=lock_expiration - 1,
         delete_lock=True,
     )
 
@@ -1223,6 +1224,7 @@ def test_channel_must_never_expire_locks_with_onchain_secret():
         channel_state=channel_state,
         secret=lock_secret,
         secrethash=lock_secrethash,
+        secret_reveal_block_number=1,
         delete_lock=False,
     )
 

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -36,6 +36,7 @@ def test_contract_receive_channelnew_must_be_idempotent():
         factories.make_transaction_hash(),
         token_network_id,
         channel_state1,
+        block_number,
     )
 
     token_network.state_transition(
@@ -60,6 +61,7 @@ def test_contract_receive_channelnew_must_be_idempotent():
         factories.make_transaction_hash(),
         token_network_id,
         channel_state2,
+        block_number + 1,
     )
 
     # replay the ContractReceiveChannelNew state change
@@ -97,6 +99,7 @@ def test_channel_settle_must_properly_cleanup():
         factories.make_transaction_hash(),
         token_network_id,
         channel_state,
+        open_block_number,
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -169,6 +172,7 @@ def test_channel_data_removed_after_unlock(
         factories.make_transaction_hash(),
         token_network_state.address,
         channel_state,
+        open_block_number,
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -252,6 +256,7 @@ def test_channel_data_removed_after_unlock(
         locksroot=lock_secrethash,
         unlocked_amount=lock_amount,
         returned_tokens=0,
+        block_number=closed_block_number + 1,
     )
     channel_unlock_iteration = token_network.state_transition(
         payment_network_identifier,
@@ -290,6 +295,7 @@ def test_multiple_channel_states(
         factories.make_transaction_hash(),
         token_network_state.address,
         channel_state,
+        open_block_number,
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -374,6 +380,7 @@ def test_multiple_channel_states(
         factories.make_transaction_hash(),
         token_network_state.address,
         new_channel_state,
+        closed_block_number + 1,
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -416,6 +423,7 @@ def test_routing_updates(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_state=channel_state,
+        block_number=open_block_number,
     )
 
     channel_new_iteration1 = token_network.state_transition(
@@ -440,6 +448,7 @@ def test_routing_updates(
         channel_identifier=new_channel_identifier,
         participant1=address2,
         participant2=address3,
+        block_number=open_block_number,
     )
 
     channel_new_iteration2 = token_network.state_transition(
@@ -465,7 +474,7 @@ def test_routing_updates(
         transaction_from=channel_state.partner_state.address,
         token_network_identifier=token_network_state.address,
         channel_identifier=channel_state.identifier,
-        closed_block_number=closed_block_number,
+        block_number=closed_block_number,
     )
 
     channel_closed_iteration1 = token_network.state_transition(
@@ -484,7 +493,7 @@ def test_routing_updates(
         transaction_from=channel_state.our_state.address,
         token_network_identifier=token_network_state.address,
         channel_identifier=channel_state.identifier,
-        closed_block_number=closed_block_number,
+        block_number=closed_block_number,
     )
 
     channel_closed_iteration2 = token_network.state_transition(
@@ -507,6 +516,7 @@ def test_routing_updates(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_identifier=new_channel_identifier,
+        block_number=closed_block_number,
     )
 
     channel_closed_iteration3 = token_network.state_transition(
@@ -524,6 +534,7 @@ def test_routing_updates(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_identifier=new_channel_identifier,
+        block_number=closed_block_number + 10,
     )
 
     channel_closed_iteration4 = token_network.state_transition(

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -78,13 +78,14 @@ def test_write_read_log():
     partner = factories.make_address()
     locksroot = sha3(b'test_write_read_log')
     contract_receive_unlock = ContractReceiveChannelBatchUnlock(
-        factories.make_transaction_hash(),
-        factories.make_address(),
-        participant,
-        partner,
-        locksroot,
-        unlocked_amount,
-        returned_amount,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=factories.make_address(),
+        participant=participant,
+        partner=partner,
+        locksroot=locksroot,
+        unlocked_amount=unlocked_amount,
+        returned_tokens=returned_amount,
+        block_number=block_number,
     )
 
     state_changes1 = wal.storage.get_statechanges_by_identifier(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -835,6 +835,7 @@ def test_initiator_handle_contract_receive_secret_reveal():
         secret_registry_address=factories.make_address(),
         secrethash=transfer.lock.secrethash,
         secret=UNIT_SECRET,
+        block_number=block_number + 1,
     )
 
     initiator_manager.handle_onchain_secretreveal(

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -24,6 +24,7 @@ def test_is_transaction_effect_satisfied(
         locksroot=EMPTY_MERKLE_ROOT,
         unlocked_amount=0,
         returned_tokens=0,
+        block_number=1,
     )
     # unlock for a channel in which this node is not a participant must return False
     assert not is_transaction_effect_satisfied(chain_state, transaction, state_change)

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -5,9 +5,11 @@ from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.utils.typing import (
     Address,
     BlockExpiration,
+    BlockNumber,
     ChannelID,
     List,
     MessageID,
+    T_BlockNumber,
     T_ChannelID,
     TransactionHash,
 )
@@ -156,13 +158,18 @@ class ContractSendExpirableEvent(ContractSendEvent):
 class ContractReceiveStateChange(StateChange):
     """ Marker used for state changes which represent on-chain logs. """
 
-    def __init__(self, transaction_hash: TransactionHash):
+    def __init__(self, transaction_hash: TransactionHash, block_number: BlockNumber):
+        if not isinstance(block_number, T_BlockNumber):
+            raise ValueError('block_number must be of type block_number')
+
         self.transaction_hash = transaction_hash
+        self.block_number = block_number
 
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveStateChange) and
-            self.transaction_hash == other.transaction_hash
+            self.transaction_hash == other.transaction_hash and
+            self.block_number == other.block_number
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1836,7 +1836,7 @@ def handle_channel_closed(
     )
 
     if just_closed:
-        set_closed(channel_state, state_change.closed_block_number)
+        set_closed(channel_state, state_change.block_number)
 
         balance_proof = channel_state.partner_state.balance_proof
         call_update = (
@@ -1845,7 +1845,7 @@ def handle_channel_closed(
             channel_state.update_transaction is None
         )
         if call_update:
-            expiration = state_change.closed_block_number + channel_state.settle_timeout
+            expiration = state_change.block_number + channel_state.settle_timeout
             # The channel was closed by our partner, if there is a balance
             # proof available update this node half of the state
             update = ContractSendChannelUpdateTransfer(
@@ -1855,7 +1855,7 @@ def handle_channel_closed(
                 balance_proof,
             )
             channel_state.update_transaction = TransactionExecutionStatus(
-                started_block_number=state_change.closed_block_number,
+                started_block_number=state_change.block_number,
                 finished_block_number=None,
                 result=None,
             )
@@ -1890,7 +1890,7 @@ def handle_channel_settled(
     # At the moment each participant unlocks its receiving half of the
     # channel automatically
     if state_change.channel_identifier == channel_state.identifier:
-        set_settled(channel_state, state_change.settle_block_number)
+        set_settled(channel_state, state_change.block_number)
 
         is_settle_pending = channel_state.our_unlock_transaction is not None
         merkle_tree_leaves = get_batch_unlock(channel_state.partner_state)

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -319,6 +319,7 @@ def handle_onchain_secretreveal(
             channel_state=channel_state,
             secret=state_change.secret,
             secrethash=state_change.secrethash,
+            secret_reveal_block_number=state_change.block_number,
             delete_lock=False,
         )
         iteration.new_state = initiator_state

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1018,6 +1018,8 @@ def handle_secretreveal(
     is_valid_reveal = mediator_state_change.secrethash == mediator_state.secrethash
 
     if is_secret_unknown and is_valid_reveal:
+        # If secret reveal was triggered on-chain, we would compare against
+        # the block number at which the event was emitted.
         if isinstance(mediator_state_change, ContractReceiveSecretReveal):
             block_number = mediator_state_change.block_number
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -176,9 +176,10 @@ def handle_secretreveal(
             )
         elif isinstance(state_change, ContractReceiveSecretReveal):
             channel.register_onchain_secret(
-                channel_state,
-                state_change.secret,
-                state_change.secrethash,
+                channel_state=channel_state,
+                secret=state_change.secret,
+                secrethash=state_change.secrethash,
+                secret_reveal_block_number=state_change.block_number,
             )
         else:
             assert False, 'Got unexpected StateChange'

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -233,17 +233,19 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             transaction_hash: typing.TransactionHash,
             token_network_identifier: typing.TokenNetworkID,
             channel_state: NettingChannelState,
+            block_number: typing.BlockNumber,
     ):
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.channel_state = channel_state
         self.channel_identifier = channel_state.identifier
 
     def __repr__(self):
-        return '<ContractReceiveChannelNew token_network:{} state:{}>'.format(
+        return '<ContractReceiveChannelNew token_network:{} state:{} block:{}>'.format(
             pex(self.token_network_identifier),
             self.channel_state,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -262,6 +264,7 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_state': self.channel_state,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -282,17 +285,13 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             transaction_from: typing.Address,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
-            closed_block_number: typing.BlockNumber,
+            block_number: typing.BlockNumber,
     ):
-        if not isinstance(closed_block_number, typing.T_BlockNumber):
-            raise ValueError('closed_block_number must be of type block_number')
-
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.transaction_from = transaction_from
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.closed_block_number = closed_block_number
 
     def __repr__(self):
         return (
@@ -303,7 +302,7 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             pex(self.token_network_identifier),
             self.channel_identifier,
             pex(self.transaction_from),
-            self.closed_block_number,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -312,7 +311,6 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             self.transaction_from == other.transaction_from and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.closed_block_number == other.closed_block_number and
             super().__eq__(other)
         )
 
@@ -325,7 +323,7 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             'transaction_from': to_checksum_address(self.transaction_from),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
-            'closed_block_number': self.closed_block_number,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -335,7 +333,7 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             transaction_from=to_canonical_address(data['transaction_from']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
-            closed_block_number=data['closed_block_number'],
+            block_number=data['block_number'],
         )
 
 
@@ -451,8 +449,9 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
             deposit_transaction: TransactionChannelNewBalance,
+            block_number: typing.BlockNumber,
     ):
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
@@ -460,11 +459,14 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
 
     def __repr__(self):
         return (
-            '<ContractReceiveChannelNewBalance token_network:{} channel:{} transaction:{}>'.format(
-                pex(self.token_network_identifier),
-                self.channel_identifier,
-                self.deposit_transaction,
-            )
+            '<ContractReceiveChannelNewBalance'
+            ' token_network:{} channel:{} transaction:{} block:{}'
+            '>'
+        ).format(
+            pex(self.token_network_identifier),
+            self.channel_identifier,
+            self.deposit_transaction,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -485,6 +487,7 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
             'deposit_transaction': self.deposit_transaction,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -494,6 +497,7 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
             deposit_transaction=data['deposit_transaction'],
+            block_number=data['block_number'],
         )
 
 
@@ -505,16 +509,12 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             transaction_hash: typing.TransactionHash,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
-            settle_block_number: typing.BlockNumber,
+            block_number: typing.BlockNumber,
     ):
-        if not isinstance(settle_block_number, int):
-            raise ValueError('settle_block_number must be of type int')
-
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
-        self.settle_block_number = settle_block_number
 
     def __repr__(self):
         return (
@@ -522,7 +522,7 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
         ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
-            self.settle_block_number,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -530,7 +530,6 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             isinstance(other, ContractReceiveChannelSettled) and
             self.token_network_identifier == other.token_network_identifier and
             self.channel_identifier == other.channel_identifier and
-            self.settle_block_number == other.settle_block_number and
             super().__eq__(other)
         )
 
@@ -542,7 +541,7 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
-            'settle_block_number': self.settle_block_number,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -551,7 +550,7 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
-            settle_block_number=data['settle_block_number'],
+            block_number=data['block_number'],
         )
 
 
@@ -625,17 +624,19 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
             self,
             transaction_hash: typing.TransactionHash,
             payment_network: PaymentNetworkState,
+            block_number: typing.BlockNumber,
     ):
         if not isinstance(payment_network, PaymentNetworkState):
             raise ValueError('payment_network must be a PaymentNetworkState instance')
 
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.payment_network = payment_network
 
     def __repr__(self):
-        return '<ContractReceiveNewPaymentNetwork network:{}>'.format(
+        return '<ContractReceiveNewPaymentNetwork network:{} block:{}>'.format(
             self.payment_network,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -652,6 +653,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'payment_network': self.payment_network,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -659,6 +661,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             payment_network=data['payment_network'],
+            block_number=data['block_number'],
         )
 
 
@@ -670,19 +673,21 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             transaction_hash: typing.TransactionHash,
             payment_network_identifier: typing.PaymentNetworkID,
             token_network: TokenNetworkState,
+            block_number: typing.BlockNumber,
     ):
         if not isinstance(token_network, TokenNetworkState):
             raise ValueError('token_network must be a TokenNetworkState instance')
 
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.payment_network_identifier = payment_network_identifier
         self.token_network = token_network
 
     def __repr__(self):
-        return '<ContractReceiveNewTokenNetwork payment_network:{} network:{}>'.format(
+        return '<ContractReceiveNewTokenNetwork payment_network:{} network:{} block:{}>'.format(
             pex(self.payment_network_identifier),
             self.token_network,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -701,6 +706,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network': self.token_network,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -709,6 +715,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network=data['token_network'],
+            block_number=data['block_number'],
         )
 
 
@@ -721,6 +728,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             secret_registry_address: typing.SecretRegistryAddress,
             secrethash: typing.SecretHash,
             secret: typing.Secret,
+            block_number: typing.BlockNumber,
     ):
         if not isinstance(secret_registry_address, typing.T_SecretRegistryAddress):
             raise ValueError('secret_registry_address must be of type SecretRegistryAddress')
@@ -729,17 +737,22 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
         if not isinstance(secret, typing.T_Secret):
             raise ValueError('secret must be of type Secret')
 
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.secret_registry_address = secret_registry_address
         self.secrethash = secrethash
         self.secret = secret
 
     def __repr__(self):
-        return '<ContractReceiveSecretReveal secret_registry:{} secrethash:{} secret:{}>'.format(
+        return (
+            '<ContractReceiveSecretReveal'
+            ' secret_registry:{} secrethash:{} secret:{} block:{}'
+            '>'
+        ).format(
             pex(self.secret_registry_address),
             pex(self.secrethash),
             pex(self.secret),
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -760,6 +773,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             'secret_registry_address': to_checksum_address(self.secret_registry_address),
             'secrethash': serialize_bytes(self.secrethash),
             'secret': serialize_bytes(self.secret),
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -769,6 +783,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             secret_registry_address=to_canonical_address(data['secret_registry_address']),
             secrethash=deserialize_bytes(data['secrethash']),
             secret=deserialize_bytes(data['secret']),
+            block_number=data['block_number'],
         )
 
 
@@ -792,6 +807,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             locksroot: typing.Locksroot,
             unlocked_amount: typing.TokenAmount,
             returned_tokens: typing.TokenAmount,
+            block_number: typing.BlockNumber,
     ):
 
         if not isinstance(token_network_identifier, typing.T_TokenNetworkID):
@@ -803,7 +819,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
         if not isinstance(partner, typing.T_Address):
             raise ValueError('partner must be of type address')
 
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.participant = participant
@@ -814,8 +830,9 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
 
     def __repr__(self):
         return (
-            '<ContractReceiveChannelBatchUnlock'
-            'token_network:{} participant:{} partner:{} locksroot:{} unlocked:{} returned:{}'
+            '<ContractReceiveChannelBatchUnlock '
+            ' token_network:{} participant:{} partner:{}'
+            ' locksroot:{} unlocked:{} returned:{} block:{}'
             '>'
         ).format(
             self.token_network_identifier,
@@ -824,6 +841,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             self.locksroot,
             self.unlocked_amount,
             self.returned_tokens,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -850,6 +868,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             'locksroot': serialize_bytes(self.locksroot),
             'unlocked_amount': self.unlocked_amount,
             'returned_tokens': self.returned_tokens,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -862,6 +881,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             locksroot=deserialize_bytes(data['locksroot']),
             unlocked_amount=data['unlocked_amount'],
             returned_tokens=data['returned_tokens'],
+            block_number=data['block_number'],
         )
 
 
@@ -875,6 +895,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
             channel_identifier: typing.ChannelID,
             participant1: typing.Address,
             participant2: typing.Address,
+            block_number: typing.BlockNumber,
     ):
 
         if not isinstance(participant1, typing.T_Address):
@@ -883,7 +904,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
         if not isinstance(participant2, typing.T_Address):
             raise ValueError('participant2 must be of type address')
 
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
@@ -891,11 +912,16 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
         self.participant2 = participant2
 
     def __repr__(self):
-        return '<ContractReceiveRouteNew token_network:{} id:{} node1:{} node2:{}>'.format(
+        return (
+            '<ContractReceiveRouteNew'
+            ' token_network:{} id:{} node1:{}'
+            ' node2:{} block:{}>'
+        ).format(
             pex(self.token_network_identifier),
             self.channel_identifier,
             pex(self.participant1),
             pex(self.participant2),
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -918,6 +944,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
             'channel_identifier': self.channel_identifier,
             'participant1': to_checksum_address(self.participant1),
             'participant2': to_checksum_address(self.participant2),
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -928,6 +955,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
             channel_identifier=data['channel_identifier'],
             participant1=to_canonical_address(data['participant1']),
             participant2=to_canonical_address(data['participant2']),
+            block_number=data['block_number'],
         )
 
 
@@ -939,16 +967,18 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
             transaction_hash: typing.TransactionHash,
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
+            block_number: typing.BlockNumber,
     ):
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
 
     def __repr__(self):
-        return '<ContractReceiveRouteClosed token_network:{} id:{}>'.format(
+        return '<ContractReceiveRouteClosed token_network:{} id:{} block:{}>'.format(
             pex(self.token_network_identifier),
             self.channel_identifier,
+            self.block_number,
         )
 
     def __eq__(self, other):
@@ -967,6 +997,7 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -975,6 +1006,7 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
+            block_number=data['block_number'],
         )
 
 
@@ -985,15 +1017,16 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
             nonce: typing.Nonce,
+            block_number: typing.block_number,
     ):
-        super().__init__(transaction_hash)
+        super().__init__(transaction_hash, block_number)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
         self.nonce = nonce
 
     def __repr__(self):
-        return f'<ContractReceiveUpdateTransfer nonce:{self.nonce}>'
+        return f'<ContractReceiveUpdateTransfer nonce:{self.nonce} block:{self.block_number}>'
 
     def __eq__(self, other):
         return (
@@ -1013,6 +1046,7 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
             'nonce': self.nonce,
+            'block_number': self.block_number,
         }
 
     @classmethod
@@ -1022,6 +1056,7 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=data['channel_identifier'],
             nonce=data['nonce'],
+            block_number=data['block_number'],
         )
 
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -273,6 +273,7 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_state=data['channel_state'],
+            block_number=data['block_number'],
         )
 
 
@@ -1017,7 +1018,7 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             token_network_identifier: typing.TokenNetworkID,
             channel_identifier: typing.ChannelID,
             nonce: typing.Nonce,
-            block_number: typing.block_number,
+            block_number: typing.BlockNumber,
     ):
         super().__init__(transaction_hash, block_number)
 


### PR DESCRIPTION
Resolves #2535 

### What changed
1. Changed all `ContractReceive*` state changes to have the block number at which the event was emitted.
2. Use the `ContractReceiveSecretReveal`'s block number to check against the lock the state_change is unlocking. If the lock has already expired, then the `ContractReceiveSecretReveal` becomes a no-op.