### PR TITLE
Serialize calls to _get_room_for_address to prevent races

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -7,11 +7,10 @@ from functools import wraps
 from operator import attrgetter, itemgetter
 from random import Random
 from urllib.parse import urlparse
-from weakref import WeakValueDictionary
 
 import gevent
 import structlog
-from cachetools import TTLCache, cachedmethod
+from cachetools import LRUCache, TTLCache, cachedmethod
 from eth_utils import (
     decode_hex,
     encode_hex,
@@ -1183,8 +1182,8 @@ class MatrixTransport(Runnable):
         return address
 
     @cachedmethod(
-        _factorygetter('__users_cache', WeakValueDictionary),
-        key=lambda _, user: user.user_id if isinstance(user, User) else user,
+        _factorygetter('__users_cache', lambda: LRUCache(128)),
+        key=lambda _, user: getattr(user, 'user_id', user),
     )
     def _get_user(self, user: Union[User, str]) -> User:
         """ Creates an User from an user_id, if none, or fetch a cached User """


### PR DESCRIPTION
Fix #2594 
Replicating [my comment](https://github.com/raiden-network/raiden/issues/2594#issuecomment-425083356) in above issue:

My debugging of this have show it is caused by a race condition on matrix's `_get_room_for_address` method. This method have the following workflow:
1. Get current room for that user
2. If there's any, return it, or else:
3. Get candidates
4. Get candidate's displayname and validate it
5. Create a room for that address, and invite the valid peers/partner's users
6. Set the crated room as the one to use for this address
6.1 Clear old (>2) rooms for this address

Well, obviously between 1 and 6, there's a lot of matrix http requests, io and context switches. This wasn't a problem before 6.1 was added, as all rooms would be valid for this user, but as we're eventually leaving these (not so) old rooms, the rooms ended up empty before the partner got all invites, triggering synapse to try to clean the room, but still inviting the partner to it, which made it fail due to a bug where empty rooms goes to limbo: they're queued for clean up, but are not yet, and users trying to join or access it after may get some weird results.
Solution is to not create rooms we'll leave before the partner has the opportunity to join, and this is done ensuring these races doesn't occur (so one and only one room is created for each partner). Serializing access to this method will do.

Note it only happened on tests, specifically `raiden/tests/integration/test_send_queued_messages.py::test_send_queued_messages`, due to it spawning several `send_async` messages at the same time for an user that didn't have a room yet, which wouldn't happen in the real world.