### PR TITLE
bugfix: rowcount doesn't work with select statements

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -169,14 +169,16 @@ class SQLiteStorage:
             cursor.execute(
                 'SELECT identifier FROM state_changes ORDER BY identifier DESC LIMIT 1',
             )
-            if cursor.rowcount > 0:
-                state_change_id = cursor.fetchone()[0]
+            result = cursor.fetchone()
+
+            if result:
+                state_change_id = result[0]
             else:
                 state_change_id = 0
 
         cursor = self.conn.execute(
             'SELECT statechange_id, data FROM state_snapshot '
-            'WHERE statechange_id <= ?'
+            'WHERE statechange_id <= ? '
             'ORDER BY identifier DESC LIMIT 1',
             (state_change_id, ),
         )


### PR DESCRIPTION
From the python3's sqlite3 docs:

> As required by the Python DB API Spec, the rowcount attribute “is -1 in
> case no executeXX() has been performed on the cursor or the rowcount of
> the last operation is not determinable by the interface”. This includes
> SELECT statements because we cannot determine the number of rows a query
> produced until all rows were fetched.

rowcount always returned -1, and the code to load the latest snapshot
assumed there was never a snapshot available, as a consequence all the
state changes where replaied on restarts