### PR TITLE
Remove wrong 202 return code from API docs

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -463,7 +463,6 @@ Connection Management
           "funds": 1337
       }
 
-   :statuscode 202: The joining of the token network for the token has been started but did not finish yet. Please check again once the related transaction has been mined.
    :statuscode 204: For a successful connection creation.
    :statuscode 402: If any of the channel deposits fail due to insufficient ETH balance to pay for the gas of the on-chain transactions.
    :statuscode 408: If a timeout happened during any of the transactions.


### PR DESCRIPTION
⚠️ DO NOT MERGE YET

Small fix for the REST docs

@czepluch Please have a look, maybe I'm missing something here. But from the code it seems like it is 204: https://github.com/raiden-network/raiden/blob/master/raiden/api/rest.py#L665