### PR TITLE
Crash the node if EthNodeCommunicationError is raised

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2655` Raiden node will now properly crash if communication with the ethereum node is lost.
 * :bug:`2630` If a smaller deposit than ``total_deposit`` is given to the deposit RPC call then return 409 Conflict and not 200 OK.
 
 * :release:`0.11.0 <2018-09-28>`

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -131,7 +131,6 @@ Deploying
       }
 
    :statuscode 201: A token network for the token has been successfully created.
-   :statuscode 202: Creation of the token network for the token has been started but did not finish yet. Please check again once the related transaction has been mined.
    :statuscode 402: Insufficient ETH to pay for the gas of the register on-chain transaction
    :statuscode 404: The given token address is invalid.
    :statuscode 409:
@@ -327,7 +326,6 @@ Channel Management
       }
 
    :statuscode 201: Channel created successfully
-   :statuscode 202: Creation of the channel has been started but did not finish yet. Please check again once the related transaction has been mined.
    :statuscode 400: Provided JSON is in some way malformed
    :statuscode 402: Insufficient ETH to pay for the gas of the channel open on-chain transaction
    :statuscode 408: Deposit event was not read in time by the Ethereum node
@@ -388,7 +386,6 @@ Channel Management
       }
 
    :statuscode 200: Success
-   :statuscode 202: The requested action has been started but did not finish yet. Please check again once the related transaction has been mined.
    :statuscode 400:
     - The provided JSON is in some way malformed, or
     - there is nothing to do since neither ``state`` nor ``total_deposit`` have been given, or
@@ -463,7 +460,6 @@ Connection Management
           "funds": 1337
       }
 
-   :statuscode 202: The joining of the token network for the token has been started but did not finish yet. Please check again once the related transaction has been mined.
    :statuscode 204: For a successful connection creation.
    :statuscode 402: If any of the channel deposits fail due to insufficient ETH balance to pay for the gas of the on-chain transactions.
    :statuscode 408: If a timeout happened during any of the transactions.

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -55,7 +55,6 @@ from raiden.exceptions import (
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
-    EthNodeCommunicationError,
     InsufficientFunds,
     InsufficientGasReserve,
     InvalidAddress,
@@ -514,11 +513,6 @@ class RestAPI:
                 registry_address,
                 token_address,
             )
-        except EthNodeCommunicationError:
-            return api_response(
-                result='',
-                status_code=HTTPStatus.ACCEPTED,
-            )
         except (InvalidAddress, AlreadyRegisteredTokenAddress, TransactionThrew) as e:
             return api_error(
                 errors=str(e),
@@ -557,11 +551,6 @@ class RestAPI:
                 partner_address,
                 settle_timeout,
             )
-        except EthNodeCommunicationError:
-            return api_response(
-                result='',
-                status_code=HTTPStatus.ACCEPTED,
-            )
         except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
                 AddressWithoutCode, DuplicatedChannelError, TokenNotRegistered) as e:
             return api_error(
@@ -589,11 +578,6 @@ class RestAPI:
                     token_address=token_address,
                     partner_address=partner_address,
                     total_deposit=total_deposit,
-                )
-            except EthNodeCommunicationError:
-                return api_response(
-                    result='',
-                    status_code=HTTPStatus.ACCEPTED,
                 )
             except InsufficientFunds as e:
                 return api_error(
@@ -643,11 +627,6 @@ class RestAPI:
                 funds,
                 initial_channel_target,
                 joinable_funds_target,
-            )
-        except EthNodeCommunicationError:
-            return api_response(
-                result='',
-                status_code=HTTPStatus.ACCEPTED,
             )
         except (InsufficientFunds, InsufficientGasReserve) as e:
             return api_error(
@@ -1028,11 +1007,6 @@ class RestAPI:
                 channel_state.partner_state.address,
                 total_deposit,
             )
-        except EthNodeCommunicationError:
-            return api_response(
-                result='',
-                status_code=HTTPStatus.ACCEPTED,
-            )
         except InsufficientFunds as e:
             return api_error(
                 errors=str(e),
@@ -1080,11 +1054,6 @@ class RestAPI:
                 registry_address,
                 channel_state.token_address,
                 channel_state.partner_state.address,
-            )
-        except EthNodeCommunicationError:
-            return api_response(
-                result='',
-                status_code=HTTPStatus.ACCEPTED,
             )
         except InsufficientFunds as e:
             return api_error(


### PR DESCRIPTION
Fix #2655 

We no longer silently ignore loss of communication with the Ethereum node inside the Rest API.

A crash will look like this:

```
2018-10-04 06:58:47 [critical ] Unhandled exception when processing endpoint request [raiden.api.rest]
Traceback (most recent call last):                                      
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()                             
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)            
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/flask_restful/__init__.py", line 480, in wrapper
    resp = resource(*args, **kwargs)                                  
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/flask/views.py", line 88, in view
    return self.dispatch_request(*args, **kwargs)                                                           
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/flask_restful/__init__.py", line 595, in dispatch_request
    resp = meth(*args, **kwargs)                                                                        
  File "/home/lefteris/ew/raiden/raiden/api/v1/resources.py", line 45, in get
    self.rest_api.raiden_api.raiden.default_registry.address,                                              
  File "/home/lefteris/ew/raiden/raiden/api/rest.py", line 723, in get_channel_list
    partner_address,                                                                                      
  File "/home/lefteris/ew/raiden/raiden/api/python.py", line 546, in get_channel_list
    raise EthNodeCommunicationError('foo')                                                                
raiden.exceptions.EthNodeCommunicationError: foo
Traceback (most recent call last):                                                                               
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/lefteris/ew/raiden/raiden/api/rest.py", line 426, in _run
    self.wsgiserver.serve_forever()
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/gevent/baseserver.py", line 364, in serve_forever
    self._stop_event.wait()
  File "src/gevent/event.py", line 240, in gevent._event.Event.wait       
  File "src/gevent/event.py", line 140, in gevent._event._AbstractLinkable._wait
  File "src/gevent/event.py", line 117, in gevent._event._AbstractLinkable._wait_core
  File "src/gevent/event.py", line 119, in gevent._event._AbstractLinkable._wait_core
  File "src/gevent/_greenlet_primitives.py", line 59, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 59, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 63, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/__greenlet_primitives.pxd", line 35, in gevent.__greenlet_primitives._greenlet_switch
raiden.exceptions.EthNodeCommunicationError: foo                           
2018-10-04T06:58:47Z <Greenlet "APIServer|Greenlet-3" at 0x7ff7bc49fe18: <bound method APIServer._run of <raiden.api.rest.APIServer object at 0x7ff7ba8430b8>>> failed with EthNodeCommunicationError
                                                                           
2018-10-04 06:58:47 [info     ] 127.0.0.1 - - [2018-10-04 08:58:47] "GET /api/1/channels HTTP/1.1" 500 174 0.006376 [raiden.api.rest.pywsgi]
                                                                                                              
Could not contact the ethereum node through JSON-RPC.
Please make sure that JSON-RPC is enabled for these interfaces:            
                                                                       
    eth_*, net_*, web3_*           
                                                                                                                        
geth: https://github.com/ethereum/go-ethereum/wiki/Management-APIs
                                                                   
Traceback (most recent call last):                                              
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run          
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 1162, in stop_task          
    task.get()  # re-raise                                                                                            
  File "src/gevent/greenlet.py", line 633, in gevent._greenlet.Greenlet.get                                           
  File "src/gevent/greenlet.py", line 312, in gevent._greenlet.Greenlet._raise_exception                              
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/gevent/_compat.py", line 47, in reraise
    raise value.with_traceback(tb) 
File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/lefteris/ew/raiden/raiden/api/rest.py", line 426, in _run
    self.wsgiserver.serve_forever()
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/gevent/baseserver.py", line 364, in serve_forever
    self._stop_event.wait()
  File "src/gevent/event.py", line 240, in gevent._event.Event.wait
  File "src/gevent/event.py", line 140, in gevent._event._AbstractLinkable._wait
  File "src/gevent/event.py", line 117, in gevent._event._AbstractLinkable._wait_core
  File "src/gevent/event.py", line 119, in gevent._event._AbstractLinkable._wait_core
  File "src/gevent/_greenlet_primitives.py", line 59, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 59, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 63, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/__greenlet_primitives.pxd", line 35, in gevent.__greenlet_primitives._greenlet_switch
raiden.exceptions.EthNodeCommunicationError: foo
2018-10-04T06:58:47Z <Greenlet "Greenlet-4" at 0x7ff7bb8f08c8: stop_task(<raiden.api.rest.APIServer object at 0x7ff7ba8430b)> failed with EthNodeCommunicationError                                                                                                             

Traceback (most recent call last):
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 1135, in _run_app
    sys.exit(1)
SystemExit: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/lefteris/ew/raiden/raiden/__main__.py", line 15, in <module>
    main()
  File "/home/lefteris/ew/raiden/raiden/__main__.py", line 11, in main
    run(auto_envvar_prefix='RAIDEN')  # pylint: disable=no-value-for-parameter
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 1204, in run
    NodeRunner(kwargs, ctx).run()
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 1035, in run
    app = self._run_app()
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 1167, in _run_app
    raise_error=True,
  File "src/gevent/greenlet.py", line 849, in gevent._greenlet.joinall
  File "src/gevent/greenlet.py", line 865, in gevent._greenlet.joinall
  File "src/gevent/greenlet.py", line 312, in gevent._greenlet.Greenlet._raise_exception
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/gevent/_compat.py", line 47, in reraise
    raise value.with_traceback(tb)
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/lefteris/ew/raiden/raiden/ui/cli.py", line 1162, in stop_task
    task.get()  # re-raise
  File "src/gevent/greenlet.py", line 633, in gevent._greenlet.Greenlet.get
  File "src/gevent/greenlet.py", line 312, in gevent._greenlet.Greenlet._raise_exception
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/gevent/_compat.py", line 47, in reraise
    raise value.with_traceback(tb)
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/lefteris/ew/raiden/raiden/api/rest.py", line 426, in _run
    self.wsgiserver.serve_forever()
  File "/home/lefteris/.virtualenvs/raiden/lib/python3.7/site-packages/gevent/baseserver.py", line 364, in serve_forever
    self._stop_event.wait()
  File "src/gevent/event.py", line 240, in gevent._event.Event.wait
  File "src/gevent/event.py", line 140, in gevent._event._AbstractLinkable._wait
  File "src/gevent/event.py", line 117, in gevent._event._AbstractLinkable._wait_core
  File "src/gevent/event.py", line 119, in gevent._event._AbstractLinkable._wait_core
  File "src/gevent/_greenlet_primitives.py", line 59, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 59, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 63, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/__greenlet_primitives.pxd", line 35, in gevent.__greenlet_primitives._greenlet_switch
raiden.exceptions.EthNodeCommunicationError: foo

```