### PR TITLE
Fix smoketest matrix support

### DIFF
--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -73,6 +73,7 @@ Additional dependencies for development installations
 
 - You need to make sure that your system has ``solc``, the ethereum solidity compiler installed. Refer to `its documentation`_ for the installation steps.
 - You will also need to obtain the `system dependencies for pyethapp <https://github.com/ethereum/pyethapp/#installation-on-ubuntudebian>`_.
+- For running ``raiden smoketest``, you will need to have ``synapse`` installed. Run ``./tools/install_synapse.sh`` (synapse needs ``tk`` as a dependency).
 
 .. _its documentation: http://solidity.readthedocs.io/en/latest/installing-solidity.html
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -567,7 +567,7 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
                     },
                 }
                 success = _run_smoketest()
-        except (PermissionError, ProcessExitedWithError):
+        except (PermissionError, ProcessExitedWithError, FileNotFoundError):
             append_report('Matrix server start exception', traceback.format_exc())
             print_step(
                 f'Error during smoketest setup, report was written to {report_file}',

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -1,4 +1,6 @@
 import os
+import shlex
+import shutil
 import socket
 import subprocess
 
@@ -45,6 +47,12 @@ class HTTPExecutor(MiHTTPExecutor):
                 stdin = stdout = stderr = self.stdio
             env = os.environ.copy()
             env[ENV_UUID] = self._uuid
+
+            executable = shlex.split(command)[0]
+            if shutil.which(executable) is None:
+                raise FileNotFoundError(f'Can not execute {executable}, '
+                                        'check that the executable exists.')
+
             self.process = subprocess.Popen(
                 command,
                 shell=self._shell,

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -49,6 +49,8 @@ class HTTPExecutor(MiHTTPExecutor):
             env[ENV_UUID] = self._uuid
 
             executable = shlex.split(command)[0]
+            executable = os.path.expanduser(executable)
+            executable = os.path.expandvars(executable)
             if shutil.which(executable) is None:
                 raise FileNotFoundError(f'Can not execute {executable}, '
                                         'check that the executable exists.')

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -79,3 +79,7 @@ class HTTPExecutor(MiHTTPExecutor):
                 ) from e
             raise
         return self
+
+    def running(self) -> bool:
+        """ Include pre_start_check in running, so stop will wait for the underlying listener """
+        return super().running() or self.pre_start_check()


### PR DESCRIPTION
Currently a local `smoketest` fails without proper logging, if `synapse` wasn't installed.
This PR documents the need for running `tools/install_synapse.sh` for developers and adds proper checks for starting `synapse`.