### PR TITLE
Implement a cache for the eth_getBlockByHash call

### DIFF
--- a/raiden/network/rpc/middleware.py
+++ b/raiden/network/rpc/middleware.py
@@ -1,0 +1,53 @@
+import functools
+from json.decoder import JSONDecodeError
+
+import lru
+from web3.middleware.cache import construct_simple_cache_middleware
+
+from raiden.exceptions import EthNodeCommunicationError
+
+
+def make_connection_test_middleware():
+    def connection_test_middleware(make_request, web3):
+        """ Creates middleware that checks if the provider is connected. """
+
+        def middleware(method, params):
+            try:
+                if web3.isConnected():
+                    return make_request(method, params)
+                else:
+                    raise EthNodeCommunicationError('Web3 provider not connected')
+
+            # the isConnected check doesn't currently catch JSON errors
+            # see https://github.com/ethereum/web3.py/issues/866
+            except JSONDecodeError:
+                raise EthNodeCommunicationError('Web3 provider not connected')
+
+        return middleware
+    return connection_test_middleware
+
+
+connection_test_middleware = make_connection_test_middleware()
+
+
+BLOCK_HASH_CACHE_RPC_WHITELIST = {
+    'eth_getBlockByHash',
+}
+
+
+def _should_cache(_method, _params, response):
+    if 'error' in response:
+        return False
+    elif 'result' not in response:
+        return False
+
+    if response['result'] is None:
+        return False
+    return True
+
+
+block_hash_cache_middleware = construct_simple_cache_middleware(
+    # default sample size of gas price strategies is 120
+    cache_class=functools.partial(lru.LRU, 150),
+    rpc_whitelist=BLOCK_HASH_CACHE_RPC_WHITELIST,
+)

--- a/raiden/network/rpc/middleware.py
+++ b/raiden/network/rpc/middleware.py
@@ -1,7 +1,7 @@
 import functools
 from json.decoder import JSONDecodeError
 
-import lru
+from cachetools import LRUCache
 from web3.middleware.cache import construct_simple_cache_middleware
 
 from raiden.exceptions import EthNodeCommunicationError
@@ -35,19 +35,8 @@ BLOCK_HASH_CACHE_RPC_WHITELIST = {
 }
 
 
-def _should_cache(_method, _params, response):
-    if 'error' in response:
-        return False
-    elif 'result' not in response:
-        return False
-
-    if response['result'] is None:
-        return False
-    return True
-
-
 block_hash_cache_middleware = construct_simple_cache_middleware(
     # default sample size of gas price strategies is 120
-    cache_class=functools.partial(lru.LRU, 150),
+    cache_class=functools.partial(LRUCache, 150),
     rpc_whitelist=BLOCK_HASH_CACHE_RPC_WHITELIST,
 )

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -2,7 +2,6 @@ from eth_utils import denoms, to_hex
 
 INITIAL_PORT = 38647
 
-RPC_CACHE_TTL = 600
 CACHE_TTL = 60
 GAS_LIMIT = 10 * 10**6
 GAS_LIMIT_HEX = to_hex(GAS_LIMIT)


### PR DESCRIPTION
This will cache block infos to avoid downloading the blocks again and
again for the gas price strategies.

This is in addition to #2670 , to make sure we have up to date gas price estimates.