### PR TITLE
Contributing update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,13 +287,6 @@ string. So this is okay:
 s = "Augusto's computer is awesome"
 ```
 
-
-**Naming Style**
-
-Use [Snake Case](https://en.wikipedia.org/wiki/Snake_case) for variable and
-function names and [Camel Case](https://en.wikipedia.org/wiki/Camel_case) for
-class names.
-
 **Naming Convention**
 
 Use descriptive variable names and avoid short abbreviations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ that is not enforced and is there just to encourage short lines.
 **Function definitions formatting**
 
 The line length must be [smaller than 100 characters](#python), so the
-function definition must be splitted when this limited is reached. When
+function definition must be split when this limit is reached. When
 splitting the function arguments, each must go into its own line, followed by
 the argument type and a comma, and indented with 8 spaces.
 
@@ -377,7 +377,7 @@ Address = NewType('Address', bytes)
 ```
 
 These type definitions can not be used for type comparisons. To make this
-possible always define a associated alias, which must start with `T_`.
+possible always define an associated alias, which must start with `T_`.
 
 ```python
 T_Address = bytes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,10 +120,6 @@ Install the development dependencies:
 
 ## Development Guidelines
 
-In this section we are going to describe the coding rules for contributing to
-the raiden repository. All code you write should strive to comply with these
-rules.
-
 ### Testing
 
 To run the tests use pytest
@@ -167,6 +163,10 @@ Thus we setup the following rules:
   places are stdout, communication with the ethereum node e.t.c.
 
 ### Coding Style
+
+In this section we are going to describe the coding rules for contributing to
+the raiden repository. All code you write should strive to comply with these
+rules.
 
 #### General Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ tests to run, just use the appropriate folder
 
 ### Commiting Rules
 
-For an exchaustive guide read [this](http://chris.beams.io/posts/git-commit/)
+For an exhaustive guide read [this](http://chris.beams.io/posts/git-commit/)
 guide. It's all really good advice. Some rules that you should always follow though are:
 
 - A commit title not exceeding 50 characters

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,10 +197,9 @@ instead it should be:
 
 Raiden is written in Python and we follow the official Python style guide
 [PEP8](https://www.python.org/dev/peps/pep-0008/). It is highly recommended to
-use the [flake8](https://pypi.python.org/pypi/flake8) tool in order to
-automatically determine any and all style violations. The customizeable part of
-flake can be seen in the [configuration file](setup.cfg). For all the rest
-which are not configurable here is some general guidelines.
+use the [linting tools](requirements-lint.txt) in order to automatically
+determine any and all style violations. The customizable part of pylint is at
+[.pylint.rc](.pylint.rc).
 
 **Line Length**
 Flake8 will warn you for 99 characters which is the hard limit on the max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ and what are the requirements for a Pull Request to be opened against Raiden.
     - [Coding Style](#coding-style)
     - [Workflow](#workflow)
 
-
 ## Contributing
 
 There are two ways you can contribute to the development. You can either open
@@ -25,14 +24,17 @@ then you should open an issue against the repository. All issues should
 contain:
 
 **For Feature Requests:**
-- A description of what you would like to see implemented
-- An explanation of why you believe this would make a good addition to Raiden
+
+- A description of what you would like to see implemented.
+- An explanation of why you believe this would make a good addition to Raiden.
 
 **For Bugs:**
-- A short description of the problem
-- Detailed description of your system, raiden version, geth version, solidity version e.t.c.
-- What was the exact unexpected thing that occured
-- What you were expecting to happen instead
+
+- A short description of the problem.
+- Detailed description of your system, raiden version, geth version, solidity
+  version e.t.c.
+- What was the exact unexpected thing that occured.
+- What you were expecting to happen instead.
 
 ### Creating a Pull Request
 
@@ -40,7 +42,8 @@ If you have some coding abilities and would like to contribute to the actual
 codebase of Raiden then you can open a Pull Request(PR) against the repository.
 
 All PRs should be:
-- Self-contained
+
+- Self-contained.
 - As short as possible and address a single issue or even a part of an issue.
   Consider breaking long PRs into smaller ones.
 
@@ -171,7 +174,8 @@ In this section we are going to see style rules that should be followed across a
 
 **Line breaks after operators**
 
-For long expressions where we break the expression at the operators the line break should come **after** the operator and not before.
+For long expressions where we break the expression at the operators the line
+break should come **after** the operator and not before.
 
 The following should be avoided:
 
@@ -202,13 +206,14 @@ determine any and all style violations. The customizable part of pylint is at
 [.pylint.rc](.pylint.rc).
 
 **Line Length**
+
 Flake8 will warn you for 99 characters which is the hard limit on the max
 length. Try not to go above it. We also have a soft limit on 80 characters but
 that is not enforced and is there just to encourage short lines.
 
 **Function definitions formatting**
 
-The line length must be [smaller than 100 characters](#line-length), so the
+The line length must be [smaller than 100 characters](#python), so the
 function definition must be splitted when this limited is reached. When
 splitting the function arguments, each must go into its own line, followed by
 the argument type and a comma, and indented with 8 spaces.
@@ -291,8 +296,8 @@ s = "Augusto's computer is awesome"
 
 Use descriptive variable names and avoid short abbreviations.
 
-
 The following is bad:
+
 ```python
 mgr = Manager()
 a = AccountBalanceHolder()
@@ -342,9 +347,11 @@ a tiny change in performance.
 
 Class attributes and functions:
 
-All class members should be private by default and they should start with a leading `_`. Whatever is part of the interface of
-the class should not have the leading underscore. The public interface of the class is what we should be testing in our tests
-and it should be the only way other parts of the code use the class through.
+All class members should be private by default and they should start with a
+leading `_`. Whatever is part of the interface of the class should not have the
+leading underscore. The public interface of the class is what we should be
+testing in our tests and it should be the only way other parts of the code use
+the class through.
 
 Minimal Example:
 
@@ -362,22 +369,24 @@ class Diary(object):
 
 **NewTypes and type comparisons**
 
-For often used types it makes sense to define new types using the `typing.NewType` function.
-New type names should be capitalized.
+For often used types it makes sense to define new types using the
+`typing.NewType` function.  New type names should be capitalized.
+
 ```python
 Address = NewType('Address', bytes)
 ```
 
-These type definitions can not be used for type comparisons. To make this possible always
-define a associated alias, which must start with `T_`.
+These type definitions can not be used for type comparisons. To make this
+possible always define a associated alias, which must start with `T_`.
+
 ```python
 T_Address = bytes
 ```
 
 **typing.Optional convention**
 
-For typing.Optional we follow the convention that if the argument has a default value of `None` then we should omit
-the use of `typing.Optional[]`
+For typing.Optional we follow the convention that if the argument has a default
+value of `None` then we should omit the use of `typing.Optional[]`.
 
 Good Example:
 
@@ -392,7 +401,6 @@ Bad Example:
 
 def foo(a: typing.Optional[int] = None)
 ```
-
 
 #### Solidity
 
@@ -414,13 +422,11 @@ function iDoSomething(uint awesome_argument) {
 }
 ```
 
-
 **Documentation**
 
 Code should be documented. For docstrings the [Google
 conventions](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 are used.
-
 
 ### Workflow
 
@@ -436,9 +442,16 @@ so and all tests pass your feature/fix will be merged.
 
 #### Updating documentation/spec
 
-If a PR you are working on is updating something in the REST API, then make sure to also update the respective [documentation](https://github.com/raiden-network/raiden/blob/master/docs/rest_api.rst). The documentation update can also be in a different PR but should be taken care of and linked to the initial PR.
+If a PR you are working on is updating something in the REST API, then make
+sure to also update the respective
+[documentation](https://github.com/raiden-network/raiden/blob/master/docs/rest_api.rst).
+The documentation update can also be in a different PR but should be taken care
+of and linked to the initial PR.
 
-If a PR you are working on is making a protocol change then make sure to also update the [specification](https://github.com/raiden-network/spec). The spec update can also be introduced in a different PR but should be taken care of and linked to the initial PR.
+If a PR you are working on is making a protocol change then make sure to also
+update the [specification](https://github.com/raiden-network/spec). The spec
+update can also be introduced in a different PR but should be taken care of and
+linked to the initial PR.
 
 #### Contributing to other people's PRs
 
@@ -471,8 +484,20 @@ Congratulations, you have added to someone else's PR!
 
 #### Integrating Pull Requests
 
-When integrating a succesfull Pull Request into the codebase we have the option of using either a "Rebase and Merge" or to "Create a Merge commit". Unfortunately in Github the default option is to "Create a Merge commit". This is not our preferred option as
-in this way we can't be sure that the result of the merge will also have all tests passing, since there may be other patches merged since the PR opened. But there are many PRs which we definitely know won't have any conflicts and for which enforcing rebase would make no sense and only waste our time. As such we provide the option to use both at our own discretion. So the general guidelines are:
+When integrating a succesfull Pull Request into the codebase we have the option
+of using either a "Rebase and Merge" or to "Create a Merge commit".
+Unfortunately in Github the default option is to "Create a Merge commit". This
+is not our preferred option as in this way we can't be sure that the result of
+the merge will also have all tests passing, since there may be other patches
+merged since the PR opened. But there are many PRs which we definitely know
+won't have any conflicts and for which enforcing rebase would make no sense and
+only waste our time. As such we provide the option to use both at our own
+discretion. So the general guidelines are:
 
-- If there are patches that have been merged to master since the PR was opened, on top of which our current PR may have different behaviour then use **Rebase and Merge**.
-- If there are patches that have been merged to master since the PR was opened which touch documentation, infrastucture or completely unrelated parts of the code then you can freely use **Create a Merge Commit** and save the time of rebasing.
+- If there are patches that have been merged to master since the PR was opened,
+  on top of which our current PR may have different behaviour then use **Rebase
+  and Merge**.
+- If there are patches that have been merged to master since the PR was opened
+  which touch documentation, infrastucture or completely unrelated parts of the
+  code then you can freely use **Create a Merge Commit** and save the time of
+  rebasing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,46 +206,30 @@ Flake8 will warn you for 99 characters which is the hard limit on the max
 length. Try not to go above it. We also have a soft limit on 80 characters but
 that is not enforced and is there just to encourage short lines.
 
-**Breaking function definitions when line is above 99 characters**
+**Function definitions formatting**
 
-Always put each argument into its own line. Look at the following examples to
-understand:
+The line length must be [smaller than 100 characters](#line-length), so the
+function definition must be splitted when this limited is reached. When
+splitting the function arguments, each must go into its own line, followed by
+the argument type and a comma, and indented with 8 spaces.
 
-The following should be avoided
+The following is not allowed:
+
 ```python
 
-def function_with_many_args(argument1, argument2, argument3, argument4, argument5, argument6, argument7):
+def function_with_many_args(argument1: Type1, argument2: Type2, argument3: Type3) -> ReturnType:
     pass
 ```
 
-and instead you should
+This must be used instead:
 
 ```python
 
 def function_with_many_args(
-        argument1,
-        argument2,
-        argument3,
-        argument4,
-        argument5,
-        argument6,
-        argument7,
-):
-    pass
-```
-
-That means 8 spaces (double indentation after the opening parentheses of the function.
-
-**Functions with type annotations**
-
-When using type annotations the function should be just like in the above section but also include
-the types of the arguments and the return type.
-
-```python
-def a(
-        b: B,
-        c: C,
-) -> D:
+        argument1: Type1,
+        argument2: Type2,
+        argument3: Type3,
+) -> ReturnType:
     pass
 ```
 
@@ -279,33 +263,6 @@ def a(
 ```
 
 The closing quotes should be on their own line. If in doubt consult the PEP.
-
-**Breaking function calls when line is above 99 characters**
-
-Much like in the above example the following should be avoided
-
-```python
-
-function_call_with_many_arguments(argument1, argument2, argument3, argument4, argument5, argument6, argument7)
-
-```
-
-and instead you should
-
-```python
-
-function_call_with_many_arguments(
-    argument1,
-    argument2,
-    argument3,
-    argument4,
-    argument5,
-    argument6,
-    argument7,
-)
-```
-
-Difference being that you can place the closing parentheses in the next line.
 
 **Usage of single and double quotes**
 


### PR DESCRIPTION
This changes the contributing guide to:

- point the user to the `requirements-lint.txt`, which includes isort/pylint/flake8 and flake8's extensions that we use.
- merged the two sections about function formatting, the goal is to make it shorter and more self contained. it also fixed some wording `Always put each argument into its own line` -> `The line length must be smaller than 100 characters`.
- removed section which repeats the pep8 naming conventions, since pep8 is linked in the document.