### PR TITLE
Close the specific queue when a channel is closed

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -36,7 +36,6 @@ from raiden.messages import (
     Message,
     Ping,
     Pong,
-    Processed,
     SignedMessage,
     decode as message_from_bytes,
     from_dict as message_from_dict,
@@ -297,10 +296,7 @@ class MatrixTransport(Runnable):
             queue_identifier=queue_identifier,
         )
 
-        if isinstance(message, Processed):
-            self._send_immediate(queue_identifier, message)
-        else:
-            self._send_with_retry(queue_identifier, message)
+        self._send_with_retry(queue_identifier, message)
 
     @property
     def _queueids_to_queues(self) -> QueueIdsToQueues:
@@ -708,9 +704,7 @@ class MatrixTransport(Runnable):
             #       which means that message order is important which isn't guaranteed between
             #       federated servers.
             #       See: https://matrix.org/docs/spec/client_server/r0.3.0.html#id57
-            if not isinstance(message, Processed):
-                self._spawn(send_delivered_for, message)
-
+            self._spawn(send_delivered_for, message)
             on_message(self._raiden_service, message)
 
         except (InvalidAddress, UnknownAddress, UnknownTokenAddress):

--- a/raiden/tests/integration/test_integration_events.py
+++ b/raiden/tests/integration/test_integration_events.py
@@ -573,31 +573,21 @@ def test_clear_closed_queue(raiden_network, token_addresses, deposit):
         queue_id.channel_identifier == channel_identifier and queue
     ]
 
-    app1.raiden.transport.start(app1.raiden)
-    exception = ValueError('Waiting for transfer received success in the WAL timed out')
-    with gevent.Timeout(seconds=30, exception=exception):
-        waiting.wait_for_transfer_success(
-            app1.raiden,
-            payment_identifier,
-            amount,
-            app1.raiden.alarm.sleep_time,
-        )
-
     # A ChannelClose event will be generated, this will be polled by both apps
-    RaidenAPI(app1.raiden).channel_close(
+    RaidenAPI(app0.raiden).channel_close(
         registry_address,
         token_address,
-        app0.raiden.address,
+        app1.raiden.address,
     )
 
     exception = ValueError('Could not get close event')
     with gevent.Timeout(seconds=30, exception=exception):
         waiting.wait_for_close(
-            app1.raiden,
+            app0.raiden,
             registry_address,
             token_address,
             [channel_identifier],
-            app1.raiden.alarm.sleep_time,
+            app0.raiden.alarm.sleep_time,
         )
 
     # assert all queues with this partner are gone or empty

--- a/raiden/tests/unit/fixtures.py
+++ b/raiden/tests/unit/fixtures.py
@@ -79,5 +79,6 @@ def netting_channel_state(chain_state, token_network_state, payment_network_stat
     )
 
     token_network_state.partneraddresses_to_channels[partner][channel_id] = channel_state
+    token_network_state.channelidentifiers_to_channels[channel_id] = channel_state
 
     return channel_state

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -507,6 +507,21 @@ def handle_token_network_action(
 
         events = iteration.events
 
+        if type(state_change) == ContractReceiveChannelClosed:
+            # cleanup queue for channel
+            channel_state = views.get_channelstate_by_token_network_identifier(
+                chain_state=chain_state,
+                token_network_id=state_change.token_network_identifier,
+                channel_id=state_change.channel_identifier,
+            )
+            if channel_state:
+                queue_id = QueueIdentifier(
+                    recipient=channel_state.partner_state.address,
+                    channel_identifier=state_change.channel_identifier,
+                )
+                if queue_id in chain_state.queueids_to_queues:
+                    chain_state.queueids_to_queues.pop(queue_id)
+
     return TransitionResult(chain_state, events)
 
 


### PR DESCRIPTION
Fix #1611, although it'll still leave behind global-per-receiver queue, but that should be cleaned upon `Delivered` instead of `Processed` (i.e. as soon as the node is online), so it won't have an indefinite lifespan as the channel specific does currently.
Includes regression tests.
Proper fix requires the refactoring being done in #2537 