### PR TITLE
Use raiden contracts v0.4.1 and bump version to v0.12.0

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.12.0
 commit = True
 tag = False
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -65,7 +65,7 @@ pystun-patched-for-raiden==0.1.0
 pytest==3.8.0
 pytoml==0.1.19
 pytz==2018.5
-raiden-contracts==0.4.0
+raiden-contracts==0.4.1
 raiden-libs==0.1.6
 requests==2.19.1
 rlp==1.0.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -66,7 +66,7 @@ pytest==3.8.0
 pytoml==0.1.19
 pytz==2018.5
 raiden-contracts==0.4.1
-raiden-libs==0.1.6
+raiden-libs==0.1.7
 requests==2.19.1
 rlp==1.0.2
 semantic-version==2.6.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :feature:`2699` Add ``/channels/<token_address>`` REST-API endpoint to query all node's channels for a specific token
+* :release:`0.12.0 <2018-10-05>`
+* :feature:`2699` Add ``/channels/<token_address>`` REST-API endpoint to query all node's channels for a specific token.
 * :feature:`2568` Validate the state changes for the Delivered and Processed sender.
 * :bug:`2567` Increase default channel reveal timeout to 50 blocks.
 * :bug:`2676` Return an error if an invalid ``joinable_funds_target`` value is provided to the connect endpoint.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ master_doc = 'index'
 project = 'Raiden Network'
 author = 'Raiden Project'
 
-version_string = '0.11.0'
+version_string = '0.12.0'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -5,7 +5,6 @@ from eth_utils import is_binary_address, to_checksum_address
 
 import raiden.blockchain.events as blockchain_events
 from raiden import waiting
-from raiden.constants import NetworkType
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     ChannelNotFound,
@@ -30,6 +29,7 @@ from raiden.transfer.state import NettingChannelState
 from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils import pex, typing
 from raiden.utils.gas_reserve import has_enough_gas_reserve
+from raiden_contracts.constants import NetworkType
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -47,7 +47,6 @@ from raiden.api.v1.resources import (
     TokensResource,
     create_blueprint,
 )
-from raiden.constants import NetworkType
 from raiden.exceptions import (
     AddressWithoutCode,
     AlreadyRegisteredTokenAddress,
@@ -83,6 +82,7 @@ from raiden.utils import (
     typing,
 )
 from raiden.utils.runnable import Runnable
+from raiden_contracts.constants import NetworkType
 
 log = structlog.get_logger(__name__)
 

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -22,7 +22,9 @@ from raiden_contracts.constants import (
     EVENT_TOKEN_NETWORK_CREATED,
     ChannelEvent,
 )
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
+
+CONTRACT_MANAGER = ContractManager(CONTRACTS_PRECOMPILED_PATH)
 
 EventListener = namedtuple(
     'EventListener',

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -8,7 +8,6 @@ from gevent.lock import Semaphore
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
-from raiden.constants import NetworkType
 from raiden.exceptions import (
     DepositMismatch,
     DepositOverLimit,
@@ -23,6 +22,7 @@ from raiden.exceptions import (
 from raiden.transfer import views
 from raiden.utils import pex, typing
 from raiden.utils.typing import Address
+from raiden_contracts.constants import NetworkType
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -2,8 +2,6 @@ from enum import Enum
 
 from eth_utils import to_checksum_address
 
-from raiden_contracts.constants import ID_TO_NETWORKNAME
-
 SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
 
 UINT64_MAX = 2 ** 64 - 1
@@ -41,11 +39,6 @@ EMPTY_HASH = bytes(32)
 EMPTY_SIGNATURE = bytes(65)
 
 START_QUERY_BLOCK_KEY = 'DefaultStartBlock'
-
-NETWORKNAME_TO_ID = {
-    name: id
-    for id, name in ID_TO_NETWORKNAME.items()
-}
 
 MIN_REQUIRED_SOLC = 'v0.4.23'
 NULL_ADDRESS_BYTES = bytes(20)

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,12 +1,8 @@
 from enum import Enum
 
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_checksum_address
 
-from raiden_contracts.constants import (
-    CONTRACT_ENDPOINT_REGISTRY,
-    CONTRACT_SECRET_REGISTRY,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
-)
+from raiden_contracts.constants import ID_TO_NETWORKNAME
 
 SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
 
@@ -30,17 +26,6 @@ class NetworkType(Enum):
     TEST = 2
 
 
-# Deployed to Ropsten revival on 2018-09-03 from
-# raiden-contracts@fc1c79329a165c738fc55c3505cf801cc79872e4
-ROPSTEN_REGISTRY_ADDRESS = '0xf2a175A52Bd3c815eD7500c765bA19652AB89B30'
-ROPSTEN_DISCOVERY_ADDRESS = '0xEEADDC1667B6EBc7784721B123a6F669B69Eb9bD'
-ROPSTEN_SECRET_REGISTRY_ADDRESS = '0x16a25511A92C5ebfc6C30ad98F754e4c820c6822'
-# Deployed to Ropsten revival on 2018-09-21 from
-# raiden-contracts@bfb24fed3ebda2799e4d11ad1bb5a6de116bd12d
-ROPSTEN_LIMITS_REGISTRY_ADDRESS = '0x6cC27CBF184B4177CD3c5D1a39a875aD07345eEb'
-ROPSTEN_LIMITS_DISCOVERY_ADDRESS = '0xcF47EDF0D951c862ED9825F47075c15BEAf5Db1B'
-ROPSTEN_LIMITS_SECRET_REGISTRY_ADDRESS = '0x8167a262Fa3Be92F05420675c3b409c64Be3d348'
-
 DISCOVERY_TX_GAS_LIMIT = 76000
 
 
@@ -61,50 +46,6 @@ EMPTY_HASH = bytes(32)
 EMPTY_SIGNATURE = bytes(65)
 
 START_QUERY_BLOCK_KEY = 'DefaultStartBlock'
-
-MAINNET = 'mainnet'
-ROPSTEN = 'ropsten'
-RINKEBY = 'rinkeby'
-KOVAN = 'kovan'
-SMOKETEST = 'smoketest'
-RAIDENTEST_CHAINID = 627
-
-ID_TO_NETWORKNAME = {
-    1: MAINNET,
-    3: ROPSTEN,
-    4: RINKEBY,
-    42: KOVAN,
-    RAIDENTEST_CHAINID: SMOKETEST,
-}
-
-ID_TO_NETWORK_CONFIG = {
-    3: {
-        NetworkType.TEST: {
-            'network_type': NetworkType.TEST,
-            'contract_addresses': {
-                CONTRACT_ENDPOINT_REGISTRY: to_canonical_address(ROPSTEN_DISCOVERY_ADDRESS),
-                CONTRACT_SECRET_REGISTRY: to_canonical_address(ROPSTEN_SECRET_REGISTRY_ADDRESS),
-                CONTRACT_TOKEN_NETWORK_REGISTRY: to_canonical_address(ROPSTEN_REGISTRY_ADDRESS),
-            },
-            # 924 blocks before token network registry deployment
-            START_QUERY_BLOCK_KEY: 3604000,
-        },
-        NetworkType.MAIN: {
-            'network_type': NetworkType.MAIN,
-            'contract_addresses': {
-                CONTRACT_ENDPOINT_REGISTRY: to_canonical_address(ROPSTEN_LIMITS_DISCOVERY_ADDRESS),
-                CONTRACT_SECRET_REGISTRY: to_canonical_address(
-                    ROPSTEN_LIMITS_SECRET_REGISTRY_ADDRESS,
-                ),
-                CONTRACT_TOKEN_NETWORK_REGISTRY: to_canonical_address(
-                    ROPSTEN_LIMITS_REGISTRY_ADDRESS,
-                ),
-            },
-            # 153 blocks before token network registry deployment
-            START_QUERY_BLOCK_KEY: 4084000,
-        },
-    },
-}
 
 NETWORKNAME_TO_ID = {
     name: id

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -21,11 +21,6 @@ class EthClient(Enum):
     TESTER = 3
 
 
-class NetworkType(Enum):
-    MAIN = 1
-    TEST = 2
-
-
 DISCOVERY_TX_GAS_LIMIT = 76000
 
 

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -15,7 +15,7 @@ from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import EXPECTED_CONTRACTS_VERSION
 from raiden.utils import compare_versions, pex, privatekey_to_address
 from raiden_contracts.constants import CONTRACT_ENDPOINT_REGISTRY
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -31,8 +31,9 @@ class Discovery:
             jsonrpc_client,
             discovery_address,
     ):
+        contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
         contract = jsonrpc_client.new_contract(
-            CONTRACT_MANAGER.get_contract_abi(CONTRACT_ENDPOINT_REGISTRY),
+            contract_manager.get_contract_abi(CONTRACT_ENDPOINT_REGISTRY),
             to_normalized_address(discovery_address),
         )
         proxy = ContractProxy(jsonrpc_client, contract)

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -10,7 +10,7 @@ from raiden.network.proxies.token_network import ChannelDetails
 from raiden.utils import typing
 from raiden.utils.filters import decode_event, get_filter_args_for_specific_event_from_channel
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 
 class PaymentChannel:
@@ -20,6 +20,7 @@ class PaymentChannel:
             channel_identifier: typing.ChannelID,
     ):
 
+        self.contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
         if channel_identifier < 0 or channel_identifier > UINT256_MAX:
             raise ValueError('channel_identifier {} is not a uint256'.format(channel_identifier))
 
@@ -33,7 +34,10 @@ class PaymentChannel:
         if not len(events) > 0:
             raise ValueError('Channel is non-existing.')
 
-        event = decode_event(CONTRACT_MANAGER.get_contract_abi(CONTRACT_TOKEN_NETWORK), events[-1])
+        event = decode_event(
+            self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+            events[-1],
+        )
         participant1 = decode_hex(event['args']['participant1'])
         participant2 = decode_hex(event['args']['participant2'])
 
@@ -81,7 +85,10 @@ class PaymentChannel:
         assert len(events) > 0, 'No matching ChannelOpen event found.'
 
         # we want the latest event here, there might have been multiple channels
-        event = decode_event(CONTRACT_MANAGER.get_contract_abi(CONTRACT_TOKEN_NETWORK), events[-1])
+        event = decode_event(
+            self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+            events[-1],
+        )
         return event['args']['settle_timeout']
 
     def close_block_number(self) -> typing.Optional[int]:
@@ -100,7 +107,10 @@ class PaymentChannel:
             return None
 
         assert len(events) == 1
-        event = decode_event(CONTRACT_MANAGER.get_contract_abi(CONTRACT_TOKEN_NETWORK), events[0])
+        event = decode_event(
+            self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+            events[0],
+        )
         return event['blockNumber']
 
     def opened(self) -> bool:

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -16,7 +16,7 @@ from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import EXPECTED_CONTRACTS_VERSION
 from raiden.utils import compare_versions, pex, privatekey_to_address, sha3, typing
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, EVENT_SECRET_REVEALED
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -30,10 +30,11 @@ class SecretRegistry:
         if not is_binary_address(secret_registry_address):
             raise InvalidAddress('Expected binary address format for secret registry')
 
+        self.contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
         check_address_has_code(jsonrpc_client, secret_registry_address, CONTRACT_SECRET_REGISTRY)
 
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_contract_abi(CONTRACT_SECRET_REGISTRY),
+            self.contract_manager.get_contract_abi(CONTRACT_SECRET_REGISTRY),
             to_normalized_address(secret_registry_address),
         )
 
@@ -122,7 +123,7 @@ class SecretRegistry:
             from_block: typing.BlockSpecification = 0,
             to_block: typing.BlockSpecification = 'latest',
     ) -> StatelessFilter:
-        event_abi = CONTRACT_MANAGER.get_event_abi(
+        event_abi = self.contract_manager.get_event_abi(
             CONTRACT_SECRET_REGISTRY,
             EVENT_SECRET_REVEALED,
         )

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -7,7 +7,7 @@ from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.utils import pex, privatekey_to_address
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -18,8 +18,9 @@ class Token:
             jsonrpc_client,
             token_address,
     ):
+        contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
         contract = jsonrpc_client.new_contract(
-            CONTRACT_MANAGER.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
+            contract_manager.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN),
             to_normalized_address(token_address),
         )
         proxy = ContractProxy(jsonrpc_client, contract)

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -36,7 +36,7 @@ from raiden_contracts.constants import (
     ChannelState,
     ParticipantInfoIndex,
 )
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -80,8 +80,9 @@ class TokenNetwork:
 
         check_address_has_code(jsonrpc_client, manager_address, CONTRACT_TOKEN_NETWORK)
 
+        contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+            contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
             to_normalized_address(manager_address),
         )
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -25,7 +25,7 @@ from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.settings import EXPECTED_CONTRACTS_VERSION
 from raiden.utils import compare_versions, pex, privatekey_to_address, typing
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -41,8 +41,9 @@ class TokenNetworkRegistry:
 
         check_address_has_code(jsonrpc_client, registry_address, CONTRACT_TOKEN_NETWORK_REGISTRY)
 
+        self.contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
         proxy = jsonrpc_client.new_contract_proxy(
-            CONTRACT_MANAGER.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
+            self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
             to_normalized_address(registry_address),
         )
 
@@ -128,7 +129,7 @@ class TokenNetworkRegistry:
             from_block: typing.BlockSpecification = 0,
             to_block: typing.BlockSpecification = 'latest',
     ) -> StatelessFilter:
-        event_abi = CONTRACT_MANAGER.get_event_abi(
+        event_abi = self.contract_manager.get_event_abi(
             CONTRACT_TOKEN_NETWORK_REGISTRY,
             EVENT_TOKEN_NETWORK_CREATED,
         )

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -53,7 +53,7 @@ from raiden.transfer.state import (
     QueueIdsToQueues,
 )
 from raiden.transfer.state_change import ActionChangeNodeNetworkState
-from raiden.utils import pex
+from raiden.utils import networkid_is_known, pex
 from raiden.utils.runnable import Runnable
 from raiden.utils.typing import (
     Address,
@@ -68,6 +68,7 @@ from raiden.utils.typing import (
     Tuple,
     Union,
 )
+from raiden_contracts.constants import ChainId
 from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.network.matrix import GMatrixClient, Room
 from raiden_libs.utils.signing import eth_recover, eth_sign
@@ -309,10 +310,9 @@ class MatrixTransport(Runnable):
 
     @property
     def _network_name(self) -> str:
-        return ID_TO_NETWORKNAME.get(
-            self._raiden_service.chain.network_id,
-            str(self._raiden_service.chain.network_id),
-        )
+        netid = self._raiden_service.chain.network_id
+        netid_known = networkid_is_known(netid)
+        return ID_TO_NETWORKNAME[ChainId(netid)] if netid_known else str(netid)
 
     @property
     def _private_rooms(self) -> bool:

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -22,7 +22,6 @@ from gevent.lock import Semaphore
 from matrix_client.errors import MatrixError, MatrixRequestError
 from matrix_client.user import User
 
-from raiden.constants import ID_TO_NETWORKNAME
 from raiden.exceptions import (
     InvalidAddress,
     InvalidProtocolMessage,
@@ -68,7 +67,7 @@ from raiden.utils.typing import (
     Tuple,
     Union,
 )
-from raiden_contracts.constants import ChainId
+from raiden_contracts.constants import ID_TO_NETWORKNAME, ChainId
 from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.network.matrix import GMatrixClient, Room
 from raiden_libs.utils.signing import eth_recover, eth_sign

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -14,7 +14,7 @@ from raiden import constants, routing, waiting
 from raiden.blockchain.events import BlockchainEvents
 from raiden.blockchain_events_handler import on_blockchain_event
 from raiden.connection_manager import ConnectionManager
-from raiden.constants import SNAPSHOT_STATE_CHANGES_COUNT, NetworkType
+from raiden.constants import SNAPSHOT_STATE_CHANGES_COUNT
 from raiden.exceptions import (
     InvalidAddress,
     InvalidDBData,
@@ -55,6 +55,7 @@ from raiden.utils import (
     typing,
 )
 from raiden.utils.runnable import Runnable
+from raiden_contracts.constants import NetworkType
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -1,5 +1,6 @@
 from eth_utils import denoms, to_hex
-from raiden.constants import NetworkType
+
+from raiden_contracts.constants import NetworkType
 
 INITIAL_PORT = 38647
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 5
+RAIDEN_DB_VERSION = 6
 
 
 class EventRecord(typing.NamedTuple):

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -5,7 +5,6 @@ import random
 import pytest
 from eth_utils import denoms, remove_0x_prefix, to_normalized_address
 
-from raiden.constants import NetworkType
 from raiden.network.utils import get_free_port
 from raiden.settings import (
     DEFAULT_RETRY_TIMEOUT,
@@ -14,7 +13,11 @@ from raiden.settings import (
 )
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.utils import privatekey_to_address, sha3
-from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
+from raiden_contracts.constants import (
+    TEST_SETTLE_TIMEOUT_MAX,
+    TEST_SETTLE_TIMEOUT_MIN,
+    NetworkType,
+)
 
 # we need to use fixture for the default values otherwise
 # pytest.mark.parametrize won't work (pytest 2.9.2)

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -7,7 +7,6 @@ from eth_utils import is_checksum_address, to_canonical_address, to_checksum_add
 from flask import url_for
 
 from raiden.api.v1.encoding import AddressField, HexAddressConverter
-from raiden.constants import NetworkType
 from raiden.tests.fixtures.variables import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
 from raiden.tests.integration.api.utils import create_api_server
 from raiden.tests.utils import assert_dicts_are_equal
@@ -20,6 +19,7 @@ from raiden_contracts.constants import (
     CONTRACT_HUMAN_STANDARD_TOKEN,
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
+    NetworkType,
 )
 
 # pylint: disable=too-many-locals,unused-argument,too-many-lines

--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -12,7 +12,9 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
+
+CONTRACT_MANAGER = ContractManager(CONTRACTS_PRECOMPILED_PATH)
 
 
 @pytest.fixture

--- a/raiden/tests/integration/test_integration_events.py
+++ b/raiden/tests/integration/test_integration_events.py
@@ -31,7 +31,9 @@ from raiden_contracts.constants import (
     EVENT_TOKEN_NETWORK_CREATED,
     ChannelEvent,
 )
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
+
+CONTRACT_MANAGER = ContractManager(CONTRACTS_PRECOMPILED_PATH)
 
 
 def get_netting_channel_closed_events(

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -4,7 +4,7 @@ from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import typing
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 
 def deploy_tokens_and_fund_accounts(
@@ -56,8 +56,9 @@ def deploy_contract_web3(
         num_confirmations: int = None,
         constructor_arguments: typing.Tuple[typing.Any, ...] = (),
 ) -> typing.Address:
+    contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
     compiled = {
-        contract_name: CONTRACT_MANAGER.get_contract(contract_name),
+        contract_name: contract_manager.get_contract(contract_name),
     }
     contract_proxy = deploy_client.deploy_solidity_contract(
         contract_name,

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -14,7 +14,6 @@ from web3.middleware import geth_poa_middleware
 
 from raiden.accounts import AccountManager
 from raiden.connection_manager import ConnectionManager
-from raiden.constants import RAIDENTEST_CHAINID
 from raiden.network.proxies import TokenNetworkRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.utils import get_free_port
@@ -39,6 +38,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
+    ChainId,
 )
 
 # the smoketest will assert that a different endpoint got successfully registered
@@ -230,7 +230,7 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step):
         nodes_configuration=nodes_configuration,
         base_datadir=base_datadir,
         genesis_file=os.path.join(get_project_root(), 'smoketest_genesis.json'),
-        chain_id=RAIDENTEST_CHAINID,
+        chain_id=ChainId.SMOKETEST.value,
         verbosity=0,
         logdir=logdir,
     )
@@ -256,7 +256,7 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step):
     print_step('Deploying Raiden contracts')
 
     client = JSONRPCClient(web3, get_private_key(keystore))
-    contract_addresses = deploy_smoketest_contracts(client, RAIDENTEST_CHAINID)
+    contract_addresses = deploy_smoketest_contracts(client, ChainId.SMOKETEST.value)
     token_contract = deploy_token(client)
     token = token_contract(1000, 0, 'TKN', 'TKN')
     registry = TokenNetworkRegistry(client, contract_addresses[CONTRACT_TOKEN_NETWORK_REGISTRY])
@@ -285,7 +285,7 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step):
             'gas_price': 'fast',
             'keystore_path': keystore,
             'matrix_server': matrix_server,
-            'network_id': str(RAIDENTEST_CHAINID),
+            'network_id': str(ChainId.SMOKETEST.value),
             'password_file': click.File()(os.path.join(base_datadir, 'pw')),
             'registry_contract_address': registry_contract_address,
             'secret_registry_contract_address': secret_registry_contract_address,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -701,8 +701,8 @@ def run_app(
     if node_numeric_network_id != given_numeric_network_id:
         if known_given_network_id and known_node_network_id:
             click.secho(
-                f"The chosen ethereum network '{ID_TO_NETWORKNAME[given_network_id]}' "
-                f"differs from the ethereum client '{ID_TO_NETWORKNAME[node_network_id]}'. "
+                f"The chosen ethereum network '{given_network_id.name.lower()}' "
+                f"differs from the ethereum client '{node_network_id.name.lower()}'. "
                 "Please update your settings.",
                 fg='red',
             )
@@ -761,7 +761,7 @@ def run_app(
     if not contract_addresses_given and not contract_addresses_known:
         click.secho(
             f"There are no known contract addresses for network id '{given_numeric_network_id}'. "
-            "Please provide them in the command line or in the configuration file.",
+            "Please provide them on the command line or in the configuration file.",
             fg='red',
         )
         sys.exit(1)
@@ -799,7 +799,7 @@ def run_app(
 
     print(
         '\nYou are connected to the \'{}\' network and the DB path is: {}'.format(
-            ID_TO_NETWORKNAME.get(given_network_id) or given_numeric_network_id,
+            ID_TO_NETWORKNAME.get(given_network_id, given_numeric_network_id),
             database_path,
         ),
     )

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -728,7 +728,7 @@ def run_app(
     chain_config = {}
     contract_addresses_known = False
     contract_addresses = dict()
-    if known_node_network_id:
+    if node_network_id in ID_TO_NETWORK_CONFIG:
         network_config = ID_TO_NETWORK_CONFIG[node_network_id]
         not_allowed = (
             NetworkType.TEST not in network_config and

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -1,21 +1,22 @@
-from binascii import hexlify, unhexlify
 import collections
 import os
+import random
 import re
 import sys
 import time
-import random
-from typing import Tuple, Union, List, Iterable
+from binascii import hexlify, unhexlify
 from itertools import zip_longest
+from typing import Iterable, List, Tuple, Union
 
 import gevent
 from coincurve import PrivateKey
-from eth_utils import remove_0x_prefix, is_checksum_address, to_checksum_address
+from eth_utils import is_checksum_address, remove_0x_prefix, to_checksum_address
 
 import raiden
 from raiden import constants
 from raiden.exceptions import InvalidAddress
 from raiden.utils import typing
+from raiden_contracts.constants import ChainId
 from raiden_libs.utils.signing import sha3
 
 
@@ -288,3 +289,7 @@ def optional_address_to_string(address: typing.Address = None) -> typing.Optiona
         return None
 
     return to_checksum_address(address)
+
+
+def networkid_is_known(netid: int) -> bool:
+    return netid in [item.value for item in ChainId]

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -16,9 +16,9 @@ from click.formatting import iter_rows, measure_table, wrap_text
 from pytoml import TomlError, load
 from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_price_strategy
 
-from raiden.constants import NETWORKNAME_TO_ID
 from raiden.exceptions import InvalidAddress
 from raiden.utils import address_checksum_and_decode
+from raiden_contracts.constants import NETWORKNAME_TO_ID
 
 LOG_CONFIG_OPTION_NAME = 'log_config'
 

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -8,7 +8,7 @@ from web3.utils.filters import LogFilter, construct_event_filter_params
 
 from raiden.utils.typing import Address, BlockSpecification, ChannelID, Dict
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 
 try:
     from eth_tester.exceptions import BlockNotFound
@@ -28,7 +28,8 @@ def get_filter_args_for_specific_event_from_channel(
     if not event_name:
         raise ValueError('Event name must be given')
 
-    event_abi = CONTRACT_MANAGER.get_event_abi(CONTRACT_TOKEN_NETWORK, event_name)
+    contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
+    event_abi = contract_manager.get_event_abi(CONTRACT_TOKEN_NETWORK, event_name)
 
     # Here the topics for a specific event are created
     # The first entry of the topics list is the event name, then the first parameter is encoded,

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ with open('constraints.txt') as req_file:
 
 test_requirements = []
 
-version = '0.11.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
+version = '0.12.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
 
 setup(
     name='raiden',

--- a/tools/pyinstaller_hooks/runtime_raiden_contracts.py
+++ b/tools/pyinstaller_hooks/runtime_raiden_contracts.py
@@ -7,7 +7,4 @@ from raiden_contracts import contract_manager
 base_path = Path(sys._MEIPASS)
 
 # Patch location of compiled contracts.
-contract_manager.CONTRACTS_PRECOMPILED_PATH = base_path.joinpath('contracts.json.gz')
-contract_manager.CONTRACT_MANAGER = contract_manager.ContractManager(
-    contract_manager.CONTRACTS_PRECOMPILED_PATH,
-)
+contract_manager.CONTRACTS_PRECOMPILED_PATH = base_path.joinpath('contracts.json')

--- a/tools/scenario-player/scenario_player/utils.py
+++ b/tools/scenario-player/scenario_player/utils.py
@@ -15,7 +15,7 @@ from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_p
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN
-from raiden_contracts.contract_manager import CONTRACT_MANAGER
+from raiden_contracts.contract_manager import CONTRACTS_PRECOMPILED_PATH, ContractManager
 from scenario_player.exceptions import ScenarioTxError
 
 log = structlog.get_logger(__name__)
@@ -87,7 +87,8 @@ def wait_for_txs(client, txhashes, timeout=360):
 
 def get_or_deploy_token(client: JSONRPCClient, scenario: dict) -> ContractProxy:
     """ Deploy or reuse  """
-    token_contract = CONTRACT_MANAGER.get_contract(CONTRACT_CUSTOM_TOKEN)
+    contract_manager = ContractManager(CONTRACTS_PRECOMPILED_PATH)
+    token_contract = contract_manager.get_contract(CONTRACT_CUSTOM_TOKEN)
 
     token_config = scenario.get('token', {})
     if not token_config:
@@ -115,7 +116,7 @@ def get_or_deploy_token(client: JSONRPCClient, scenario: dict) -> ContractProxy:
 
     token_ctr = client.deploy_solidity_contract(
         'CustomToken',
-        CONTRACT_MANAGER._contracts,
+        contract_manager._contracts,
         constructor_parameters=(0, decimals, name, symbol),
         confirmations=1,
 

--- a/tools/startcluster.py
+++ b/tools/startcluster.py
@@ -6,9 +6,9 @@ import tempfile
 from eth_utils import remove_0x_prefix
 from web3 import HTTPProvider, Web3
 
-from raiden.constants import RAIDENTEST_CHAINID
 from raiden.tests.utils.geth import GethNodeDescription, geth_run_private_blockchain
 from raiden.utils import privatekey_to_address, sha3
+from raiden_contracts.constants import ChainId
 
 NUM_GETH_NODES = 3
 NUM_RAIDEN_ACCOUNTS = 10
@@ -59,7 +59,7 @@ def main():
         DEFAULT_ACCOUNTS,
         geth_nodes,
         tmpdir,
-        RAIDENTEST_CHAINID,
+        ChainId.SMOKETEST.value,
         verbosity,
         random_marker,
     )


### PR DESCRIPTION
- Adjusts raiden client to use the new v0.4.1 raiden contracts
- Bumps raiden version tag to v0.12.0

Admittedly the usage of the chain id constants is a tiny bit ugly and may need some cleaning up, but that can happen next week.