### PR TITLE
Added protocol version to the Ping message

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -12,6 +12,8 @@ INT64_MIN = -(2 ** 63)
 
 UINT256_MAX = 2 ** 256 - 1
 
+PROTOCOL_VERSION = 1
+
 
 class EthClient(Enum):
     GETH = 1

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -30,6 +30,7 @@ nonce = make_field('nonce', 8, '8s', integer(0, UINT64_MAX))
 payment_identifier = make_field('payment_identifier', 8, '8s', integer(0, UINT64_MAX))
 chain_id = make_field('chain_id', 32, '32s', integer(0, UINT256_MAX))
 message_identifier = make_field('message_identifier', 8, '8s', integer(0, UINT64_MAX))
+current_protocol_version = make_field('current_protocol_version', 1, '1s', integer(0, 256))
 delivered_message_identifier = make_field(
     'delivered_message_identifier',
     8,
@@ -81,6 +82,7 @@ Ping = namedbuffer(
         cmdid(PING),
         pad(3),
         nonce,
+        current_protocol_version,
         signature,
     ],
 )

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -445,18 +445,23 @@ class Ping(SignedMessage):
     """ Healthcheck message. """
     cmdid = messages.PING
 
-    def __init__(self, nonce: int):
+    def __init__(self, nonce: int, current_protocol_version: typing.RaidenProtocolVersion):
         super().__init__()
         self.nonce = nonce
+        self.current_protocol_version = current_protocol_version
 
     @classmethod
     def unpack(cls, packed):
-        ping = cls(nonce=packed.nonce)
+        ping = cls(
+            nonce=packed.nonce,
+            current_protocol_version=packed.current_protocol_version,
+        )
         ping.signature = packed.signature
         return ping
 
     def pack(self, packed):
         packed.nonce = self.nonce
+        packed.current_protocol_version = self.current_protocol_version
         packed.signature = self.signature
 
 

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -8,6 +8,7 @@ from eth_utils import is_binary_address
 from gevent.event import AsyncResult, Event
 from gevent.server import DatagramServer
 
+from raiden import constants
 from raiden.exceptions import InvalidAddress, InvalidProtocolMessage, UnknownAddress
 from raiden.message_handler import on_message
 from raiden.messages import Delivered, Message, Ping, Pong, decode
@@ -608,7 +609,10 @@ class UDPTransport(Runnable):
         Note: Ping messages don't have an enforced ordering, so a Ping message
         with a higher nonce may be acknowledged first.
         """
-        message = Ping(nonce)
+        message = Ping(
+            nonce=nonce,
+            current_protocol_version=constants.PROTOCOL_VERSION,
+        )
         self.raiden.sign(message)
         message_data = message.encode()
 

--- a/raiden/tests/integration/test_service.py
+++ b/raiden/tests/integration/test_service.py
@@ -8,7 +8,7 @@ from raiden.transfer import state, views
 def test_udp_ping_pong(raiden_network, skip_if_not_udp):
     app0, app1 = raiden_network
 
-    ping_message = Ping(nonce=0)
+    ping_message = Ping(nonce=0, current_protocol_version=0)
     app0.raiden.sign(ping_message)
     ping_encoded = ping_message.encode()
 
@@ -33,7 +33,7 @@ def test_udp_ping_pong_unreachable_node(raiden_network, skip_if_not_udp):
 
     app1.raiden.transport.stop()
 
-    ping_message = Ping(nonce=0)
+    ping_message = Ping(nonce=0, current_protocol_version=0)
     app0.raiden.sign(ping_message)
     ping_encoded = ping_message.encode()
 

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 
-from raiden.constants import UINT64_MAX, UINT256_MAX
+from raiden import constants
 from raiden.messages import Ping, Processed, decode
 from raiden.tests.utils.factories import make_privkey_address
 from raiden.tests.utils.messages import (
@@ -16,13 +16,13 @@ PRIVKEY, ADDRESS = make_privkey_address()
 
 
 def test_signature():
-    ping = Ping(nonce=0)
+    ping = Ping(nonce=0, current_protocol_version=constants.PROTOCOL_VERSION)
     ping.sign(PRIVKEY)
     assert ping.sender == ADDRESS
 
 
 def test_encoding():
-    ping = Ping(nonce=0)
+    ping = Ping(nonce=0, current_protocol_version=constants.PROTOCOL_VERSION)
     ping.sign(PRIVKEY)
     decoded_ping = decode(ping.encode())
     assert isinstance(decoded_ping, Ping)
@@ -34,7 +34,7 @@ def test_encoding():
 
 
 def test_hash():
-    ping = Ping(nonce=0)
+    ping = Ping(nonce=0, current_protocol_version=constants.PROTOCOL_VERSION)
     ping.sign(PRIVKEY)
     data = ping.encode()
     msghash = sha3(data)
@@ -43,7 +43,7 @@ def test_hash():
 
 
 def test_processed():
-    message_identifier = random.randint(0, UINT64_MAX)
+    message_identifier = random.randint(0, constants.UINT64_MAX)
     processed_message = Processed(message_identifier)
     processed_message.sign(PRIVKEY)
     assert processed_message.sender == ADDRESS
@@ -59,9 +59,9 @@ def test_processed():
     assert sha3(decoded_processed_message.encode()) == sha3(data)
 
 
-@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
-@pytest.mark.parametrize('nonce', [1, UINT64_MAX])
-@pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, constants.UINT64_MAX])
+@pytest.mark.parametrize('nonce', [1, constants.UINT64_MAX])
+@pytest.mark.parametrize('transferred_amount', [0, constants.UINT256_MAX])
 def test_direct_transfer_min_max(payment_identifier, nonce, transferred_amount):
     direct_transfer = make_direct_transfer(
         payment_identifier=payment_identifier,
@@ -74,11 +74,11 @@ def test_direct_transfer_min_max(payment_identifier, nonce, transferred_amount):
     assert decode(direct_transfer.encode()) == direct_transfer
 
 
-@pytest.mark.parametrize('amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
-@pytest.mark.parametrize('nonce', [1, UINT64_MAX])
-@pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('fee', [0, UINT256_MAX])
+@pytest.mark.parametrize('amount', [0, constants.UINT256_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, constants.UINT64_MAX])
+@pytest.mark.parametrize('nonce', [1, constants.UINT64_MAX])
+@pytest.mark.parametrize('transferred_amount', [0, constants.UINT256_MAX])
+@pytest.mark.parametrize('fee', [0, constants.UINT256_MAX])
 def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, transferred_amount):
     mediated_transfer = make_mediated_transfer(
         amount=amount,
@@ -93,10 +93,10 @@ def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, trans
     assert decode(mediated_transfer.encode()) == mediated_transfer
 
 
-@pytest.mark.parametrize('amount', [0, UINT256_MAX])
-@pytest.mark.parametrize('payment_identifier', [0, UINT64_MAX])
-@pytest.mark.parametrize('nonce', [1, UINT64_MAX])
-@pytest.mark.parametrize('transferred_amount', [0, UINT256_MAX])
+@pytest.mark.parametrize('amount', [0, constants.UINT256_MAX])
+@pytest.mark.parametrize('payment_identifier', [0, constants.UINT64_MAX])
+@pytest.mark.parametrize('nonce', [1, constants.UINT64_MAX])
+@pytest.mark.parametrize('transferred_amount', [0, constants.UINT256_MAX])
 def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_amount):
     refund_transfer = make_refund_transfer(
         amount=amount,

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -16,7 +16,7 @@ PRIVKEY, ADDRESS = make_privkey_address()
 
 
 def test_signature():
-    ping = Ping(nonce=0)
+    ping = Ping(nonce=0, current_protocol_version=0)
     ping.sign(PRIVKEY)
     assert ping.sender == ADDRESS
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -70,6 +70,9 @@ PaymentAmount = NewType('PaymentAmount', T_PaymentAmount)
 T_PaymentNetworkID = bytes
 PaymentNetworkID = NewType('PaymentNetworkID', T_PaymentNetworkID)
 
+T_RaidenProtocolVersion = int
+RaidenProtocolVersion = NewType('RaidenProtocolVersion', T_RaidenProtocolVersion)
+
 T_ChainID = int
 ChainID = NewType('ChainID', T_ChainID)
 


### PR DESCRIPTION
Added protocol version to the Ping message

The protocol version handshake should be tied to the healthcheck in
order to avoid race conditions. Where a target is known to be online but
its protocol version is unknown.

Without the version in the Ping message the sender must assume the
lowest protocol version, otherwise a message unknown o the target could
be sent. Because the new message is not known to the target, it would
never be processed, and the message queue for that channel would stall.

Adding this field to the Ping message fixes the above problem. This is
being added now just to introduce the strategy of protocol handshake for
future releases.