### PR TITLE
Explicit check for queue length in inplace_delete_message_queue

### DIFF
--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -411,7 +411,7 @@ def inplace_delete_message_queue(
         state_change,
     )
 
-    if not queue:
+    if len(queue) == 0:
         del chain_state.queueids_to_queues[queueid]
     else:
         chain_state.queueids_to_queues[queueid] = queue


### PR DESCRIPTION
I know this may be considered "unpythonic" but frankly I prefer more readable code over purism.

I spent 2-3 mins (before coffee!) looking at the code being confused why the same function checks again if the list is `None` in two different parts of the code. The second check seemed unreachable until I realized the list is modified in place and the second check is a length check.

Made it a bit more explicit.