### PR TITLE
Providing a partner address without a token address is not allowed

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -540,8 +540,13 @@ class RaidenAPI:
         if token_address and not is_binary_address(token_address):
             raise InvalidAddress('Expected binary address format for token in get_channel_list')
 
-        if partner_address and not is_binary_address(partner_address):
-            raise InvalidAddress('Expected binary address format for partner in get_channel_list')
+        if partner_address:
+            if not is_binary_address(partner_address):
+                raise InvalidAddress(
+                    'Expected binary address format for partner in get_channel_list',
+                )
+            if not token_address:
+                raise UnknownTokenAddress('Provided a partner address but no token address')
 
         if token_address and partner_address:
             channel_state = views.get_channelstate_for(
@@ -558,21 +563,14 @@ class RaidenAPI:
 
         elif token_address:
             result = views.list_channelstate_for_tokennetwork(
-                views.state_from_raiden(self.raiden),
-                registry_address,
-                token_address,
-            )
-
-        elif partner_address:
-            result = views.list_channelstate_for_tokennetwork(
-                views.state_from_raiden(self.raiden),
-                registry_address,
-                partner_address,
+                chain_state=views.state_from_raiden(self.raiden),
+                payment_network_id=registry_address,
+                token_address=token_address,
             )
 
         else:
             result = views.list_all_channelstate(
-                views.state_from_raiden(self.raiden),
+                chain_state=views.state_from_raiden(self.raiden),
             )
 
         return result

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -2,7 +2,7 @@ import pytest
 from eth_utils import is_same_address, to_normalized_address
 
 from raiden.api.python import RaidenAPI
-from raiden.exceptions import DepositMismatch
+from raiden.exceptions import DepositMismatch, UnknownTokenAddress
 from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.geth import wait_until_block
 from raiden.tests.utils.transfer import get_channelstate
@@ -46,6 +46,14 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_c
     assert api1.get_node_network_state(api2.address) == NODE_NETWORK_UNKNOWN
     assert api2.get_node_network_state(api1.address) == NODE_NETWORK_UNKNOWN
     assert not api1.get_channel_list(registry_address, token_address, api2.address)
+
+    # Make sure invalid arguments to get_channel_list are caught
+    with pytest.raises(UnknownTokenAddress):
+        api1.get_channel_list(
+            registry_address=registry_address,
+            token_address=None,
+            partner_address=api2.address,
+        )
 
     # open is a synchronous api
     api1.channel_open(node1.raiden.default_registry.address, token_address, api2.address)


### PR DESCRIPTION
I don't catch it in the rest api since it's not even possible to do it there

Fix #2723