### PR TITLE
tests: removed pending_mediated_transfer

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -625,11 +625,13 @@ class RaidenService(Runnable):
               expire.
         """
 
-        async_result = self.start_mediated_transfer(
+        secret = random_secret()
+        async_result = self.start_mediated_transfer_with_secret(
             token_network_identifier,
             amount,
             target,
             identifier,
+            secret,
         )
 
         return async_result
@@ -673,12 +675,13 @@ class RaidenService(Runnable):
 
         self.handle_state_change(direct_transfer)
 
-    def start_mediated_transfer(
+    def start_mediated_transfer_with_secret(
             self,
             token_network_identifier: typing.TokenNetworkID,
             amount: typing.TokenAmount,
             target: typing.Address,
             identifier: typing.PaymentID,
+            secret: typing.Secret,
     ):
 
         self.start_health_check_for(target)
@@ -692,7 +695,6 @@ class RaidenService(Runnable):
         async_result = AsyncResult()
         self.identifier_to_results[identifier] = async_result
 
-        secret = random_secret()
         init_initiator_statechange = initiator_init(
             self,
             identifier,

--- a/raiden/tests/utils/protocol.py
+++ b/raiden/tests/utils/protocol.py
@@ -1,0 +1,34 @@
+import logging
+
+from raiden.raiden_event_handler import RaidenEventHandler
+from raiden.raiden_service import RaidenService
+from raiden.transfer.mediated_transfer.events import SendSecretRequest
+from raiden.utils import pex
+
+log = logging.getLogger(__name__)
+
+
+class HoldOffChainSecretRequest(RaidenEventHandler):
+    """ Use this handler to stop the target from requesting the secret.
+
+    This is used to simulate network communication problems. The message
+    SecretRequest is used because the participants state can be expected to be
+    consistent.
+    """
+
+    def __init__(self):
+        self.secrethashes_to_hold = list()
+
+    def hold_secret_for(self, secrethash):
+        if secrethash not in self.secrethashes_to_hold:
+            self.secrethashes_to_hold.append(secrethash)
+
+    def handle_send_secretrequest(
+            self,
+            raiden: RaidenService,
+            secret_request_event: SendSecretRequest,
+    ):
+        if secret_request_event.secrethash not in self.secrethashes_to_hold:
+            super().handle_send_secretrequest(raiden, secret_request_event)
+        else:
+            log.info(f'SecretRequest for {pex(secret_request_event.secrethash)} held.')


### PR DESCRIPTION
The pending_mediated_transfer utility was going around the RaidenService
api and injecting state changes directly in the write-ahead-log. This
approach does produce correct results in the state logic, but not in the
RaidenService, since the AsyncResults are not properly set.

This change removed the pending_mediated_transfer in favor of a special
event handler, which allows the tests to decide which secret requests
are sent. Having the same end effect of pending_mediated_transfer while
properly setting up the RaidenService state.