### PR TITLE
bugfix: conficting payments

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -30,6 +30,13 @@ class ChannelNotFound(RaidenError):
     pass
 
 
+class PaymentConflict(RaidenRecoverableError):
+    """ Raised when there is another payment with the same identifier but the
+    attributes of the payment don't match.
+    """
+    pass
+
+
 class InsufficientFunds(RaidenError):
     """ Raised when provided account doesn't have token funds to complete the
     requested deposit.

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -439,7 +439,7 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
     claim_lock(raiden_network, identifier, token_network_identifier, secret)
 
     # Make a new transfer
-    direct_transfer(app0, app1, token_network_identifier, amount, identifier=1)
+    direct_transfer(app0, app1, token_network_identifier, amount, identifier=2)
     RaidenAPI(app1.raiden).channel_close(
         registry_address,
         token_address,


### PR DESCRIPTION
This commit fixes two bugs:
- Previously a direct transfer was overwritting the async result for a
mediated transfer which led to crashes. The crash happened because 
when the first transfer was confirmed the async result was set and
cleared from the mapping, once the second transfer confirmed the mapping
was empty and the assertion was hit. The fix is to forbid conflicting
direct/mediated transfers.
- The async result mapping must be restored on restarts, the previous
logic was only resetting it for direct transfers and not mediated
transfers.

Fixes #2744 and fixes #2745 