### PR TITLE
Ignore a transfer if lock's secrethash is already registered onchain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2730` Refuse to send a transfer and ignore it during receiving, if its secret is already registered on-chain.
 * :feature:`2713` Added the protocol version in the Ping message.
 * :feature:`2708` Add `--showconfig` CLI flag which dumps all configuration values that will control Raiden behavior.
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -30,7 +30,7 @@ from raiden.transfer.state_change import (
     ReceiveTransferDirect,
     ReceiveUnlock,
 )
-from raiden.utils import random_secret
+from raiden.utils import pex, random_secret
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -151,8 +151,8 @@ class MessageHandler:
         secret_hash = message.lock.secrethash
         if raiden.default_secret_registry.check_registered(secret_hash):
             log.warning(
-                f'Ignoring received locked transfer with secrethash {secret_hash} '
-                f'since it is already registered in the secret registry'
+                f'Ignoring received locked transfer with secrethash {pex(secret_hash)} '
+                f'since it is already registered in the secret registry',
             )
             return
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -148,6 +148,14 @@ class MessageHandler:
         raiden.handle_state_change(direct_transfer)
 
     def handle_message_lockedtransfer(self, raiden: RaidenService, message: LockedTransfer):
+        secret_hash = message.lock.secrethash
+        if raiden.default_secret_registry.check_registered(secret_hash):
+            log.warning(
+                f'Ignoring received locked transfer with secrethash {secret_hash} '
+                f'since it is already registered in the secret registry'
+            )
+            return
+
         if message.target == raiden.address:
             raiden.target_mediated_transfer(message)
         else:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -55,6 +55,7 @@ from raiden.utils import (
     pex,
     privatekey_to_address,
     random_secret,
+    sha3,
     typing,
 )
 from raiden.utils.runnable import Runnable
@@ -738,6 +739,13 @@ class RaidenService(Runnable):
             identifier: typing.PaymentID,
             secret: typing.Secret,
     ):
+
+        secret_hash = sha3(secret)
+        if self.default_secret_registry.check_registered(secret_hash):
+            raise RaidenUnrecoverableError(
+                f'Attempted to initiate a locked transfer with secrethash {pex(secret_hash)}.'
+                f' That secret is already registered onchain.',
+            )
 
         self.start_health_check_for(target)
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -1,10 +1,16 @@
 import gevent
 import pytest
 
+from raiden.exceptions import RaidenUnrecoverableError
+from raiden.message_handler import MessageHandler
 from raiden.messages import LockedTransfer, RevealSecret
+from raiden.tests.utils.events import must_contain_entry
+from raiden.tests.utils.factories import UNIT_TRANSFER_INITIATOR, make_signed_transfer
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import assert_synced_channel_state, mediated_transfer, wait_assert
 from raiden.transfer import views
+from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
+from raiden.utils import sha3
 
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
@@ -50,6 +56,66 @@ def test_mediated_transfer(
             app1, deposit - amount, [],
             app2, deposit + amount, [],
         )
+
+
+@pytest.mark.parametrize('channels_per_node', [CHAIN])
+@pytest.mark.parametrize('number_of_nodes', [1])
+def test_locked_transfer_secret_registered_onchain(
+        raiden_network,
+        token_addresses,
+        secret_registry_address,
+):
+    app0 = raiden_network[0]
+    token_address = token_addresses[0]
+    chain_state = views.state_from_app(app0)
+    payment_network_id = app0.raiden.default_registry.address
+    token_network_identifier = views.get_token_network_identifier_by_token_address(
+        chain_state,
+        payment_network_id,
+        token_address,
+    )
+
+    amount = 1
+    target = UNIT_TRANSFER_INITIATOR
+    identifier = 1
+    transfer_secret = sha3(target + b'1')
+
+    secret_registry_proxy = app0.raiden.chain.secret_registry(
+        secret_registry_address,
+    )
+    secret_registry_proxy.register_secret(transfer_secret)
+
+    # Test that sending a transfer with a secret already registered on-chain fails
+    with pytest.raises(RaidenUnrecoverableError):
+        app0.raiden.start_mediated_transfer_with_secret(
+            token_network_identifier,
+            amount,
+            target,
+            identifier,
+            transfer_secret,
+        )
+
+    expiration = 9999
+    transfer = make_signed_transfer(
+        amount,
+        UNIT_TRANSFER_INITIATOR,
+        app0.raiden.address,
+        expiration,
+        transfer_secret,
+    )
+
+    message_handler = MessageHandler()
+    message_handler.handle_message_lockedtransfer(
+        app0.raiden,
+        transfer,
+    )
+
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(0, 'latest')
+    transfer_statechange_dispatched = (
+        must_contain_entry(state_changes, ActionInitMediator, {}) or
+        must_contain_entry(state_changes, ActionInitTarget, {})
+    )
+    assert not transfer_statechange_dispatched
 
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -538,7 +538,7 @@ def test_target_transfer_invalid_if_lock_registered_onchain():
         expiration,
         UNIT_SECRET,
         identifier=1,
-        nonce=1
+        nonce=1,
     )
 
     init = ActionInitTarget(

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -146,7 +146,7 @@ def make_channel(
         channel_identifier=None,
         reveal_timeout=UNIT_REVEAL_TIMEOUT,
         settle_timeout=UNIT_SETTLE_TIMEOUT,
-):
+) -> NettingChannelState:
 
     our_address = our_address or make_address()
     partner_address = partner_address or make_address()


### PR DESCRIPTION
Should fix https://github.com/raiden-network/raiden/issues/2730