### PR TITLE
Fix bug at _initialize_queues

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -558,9 +558,10 @@ class RaidenService(Runnable):
                         payment_done=AsyncResult(),
                     )
                 elif is_initiator:
-                    self.identifiers_to_statuses[event.payment_identifier] = PaymentStatus(
+                    payment_identifier = event.transfer.payment_identifier
+                    self.identifiers_to_statuses[payment_identifier] = PaymentStatus(
                         payment_type=PaymentType.MEDIATED,
-                        payment_identifier=event.payment_identifier,
+                        payment_identifier=payment_identifier,
                         payment_done=AsyncResult(),
                     )
 


### PR DESCRIPTION
Should fix the stress test failure.

If it's a mediated transfer the event is a `SendLockedTransfer` which contains the `payment_id` inside its `transfer` attribute.

This was introduced at https://github.com/raiden-network/raiden/pull/2743.

~~But what I don't understand is how come the tests there did not catch it.~~

Thinking about it, it’s flaky. The test shuts down the nodes and restarts them. They would not always have a `LockedTransfer` stuck at the queue every time they restart. Some times they would have already sent it so it would never go inside the `else` of `_initialize_queues`