### PR TITLE
Added MessageHandler class

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -72,6 +72,7 @@ class App:  # pylint: disable=too-few-public-methods
             default_secret_registry: SecretRegistry,
             transport,
             raiden_event_handler,
+            message_handler,
             discovery: Discovery = None,
     ):
         raiden = RaidenService(
@@ -82,6 +83,7 @@ class App:  # pylint: disable=too-few-public-methods
             private_key_bin=unhexlify(config['privatekey_hex']),
             transport=transport,
             raiden_event_handler=raiden_event_handler,
+            message_handler=message_handler,
             config=config,
             discovery=discovery,
         )

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -35,138 +35,128 @@ from raiden.utils import random_secret
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
-def handle_message_secretrequest(raiden: RaidenService, message: SecretRequest):
-    secret_request = ReceiveSecretRequest(
-        message.payment_identifier,
-        message.amount,
-        message.expiration,
-        message.secrethash,
-        message.sender,
-    )
-    raiden.handle_state_change(secret_request)
+class MessageHandler:
+    # pylint: disable=no-self-use
 
+    def on_message(self, raiden: RaidenService, message: Message):
+        # pylint: disable=unidiomatic-typecheck
 
-def handle_message_revealsecret(raiden: RaidenService, message: RevealSecret):
-    state_change = ReceiveSecretReveal(
-        message.secret,
-        message.sender,
-    )
-    raiden.handle_state_change(state_change)
+        if type(message) == SecretRequest:
+            self.handle_message_secretrequest(raiden, message)
+        elif type(message) == RevealSecret:
+            self.handle_message_revealsecret(raiden, message)
+        elif type(message) == Secret:
+            self.handle_message_secret(raiden, message)
+        elif type(message) == LockExpired:
+            self.handle_message_lockexpired(raiden, message)
+        elif type(message) == DirectTransfer:
+            self.handle_message_directtransfer(raiden, message)
+        elif type(message) == RefundTransfer:
+            self.handle_message_refundtransfer(raiden, message)
+        elif type(message) == LockedTransfer:
+            self.handle_message_lockedtransfer(raiden, message)
+        elif type(message) == Delivered:
+            self.handle_message_delivered(raiden, message)
+        elif type(message) == Processed:
+            self.handle_message_processed(raiden, message)
+        else:
+            log.error('Unknown message cmdid {}'.format(message.cmdid))
 
-
-def handle_message_secret(raiden: RaidenService, message: Secret):
-    balance_proof = balanceproof_from_envelope(message)
-    state_change = ReceiveUnlock(
-        message_identifier=message.message_identifier,
-        secret=message.secret,
-        balance_proof=balance_proof,
-    )
-    raiden.handle_state_change(state_change)
-
-
-def handle_message_lockexpired(raiden: RaidenService, message: LockExpired):
-    balance_proof = balanceproof_from_envelope(message)
-    state_change = ReceiveLockExpired(
-        message.sender,
-        balance_proof,
-        message.secrethash,
-        message.message_identifier,
-    )
-    raiden.handle_state_change(state_change)
-
-
-def handle_message_refundtransfer(raiden: RaidenService, message: RefundTransfer):
-    token_network_address = message.token_network_address
-    from_transfer = lockedtransfersigned_from_message(message)
-    chain_state = views.state_from_raiden(raiden)
-
-    routes = get_best_routes(
-        chain_state,
-        token_network_address,
-        raiden.address,
-        from_transfer.target,
-        from_transfer.lock.amount,
-        message.sender,
-    )
-
-    role = views.get_transfer_role(
-        chain_state,
-        from_transfer.lock.secrethash,
-    )
-
-    if role == 'initiator':
-        secret = random_secret()
-        state_change = ReceiveTransferRefundCancelRoute(
+    def handle_message_secretrequest(self, raiden: RaidenService, message: SecretRequest):
+        secret_request = ReceiveSecretRequest(
+            message.payment_identifier,
+            message.amount,
+            message.expiration,
+            message.secrethash,
             message.sender,
-            routes,
-            from_transfer,
-            secret,
         )
-    else:
-        state_change = ReceiveTransferRefund(
+        raiden.handle_state_change(secret_request)
+
+    def handle_message_revealsecret(self, raiden: RaidenService, message: RevealSecret):
+        state_change = ReceiveSecretReveal(
+            message.secret,
             message.sender,
-            from_transfer,
-            routes,
+        )
+        raiden.handle_state_change(state_change)
+
+    def handle_message_secret(self, raiden: RaidenService, message: Secret):
+        balance_proof = balanceproof_from_envelope(message)
+        state_change = ReceiveUnlock(
+            message_identifier=message.message_identifier,
+            secret=message.secret,
+            balance_proof=balance_proof,
+        )
+        raiden.handle_state_change(state_change)
+
+    def handle_message_lockexpired(self, raiden: RaidenService, message: LockExpired):
+        balance_proof = balanceproof_from_envelope(message)
+        state_change = ReceiveLockExpired(
+            message.sender,
+            balance_proof,
+            message.secrethash,
+            message.message_identifier,
+        )
+        raiden.handle_state_change(state_change)
+
+    def handle_message_refundtransfer(self, raiden: RaidenService, message: RefundTransfer):
+        token_network_address = message.token_network_address
+        from_transfer = lockedtransfersigned_from_message(message)
+        chain_state = views.state_from_raiden(raiden)
+
+        routes = get_best_routes(
+            chain_state,
+            token_network_address,
+            raiden.address,
+            from_transfer.target,
+            from_transfer.lock.amount,
+            message.sender,
         )
 
-    raiden.handle_state_change(state_change)
+        role = views.get_transfer_role(
+            chain_state,
+            from_transfer.lock.secrethash,
+        )
 
+        if role == 'initiator':
+            secret = random_secret()
+            state_change = ReceiveTransferRefundCancelRoute(
+                message.sender,
+                routes,
+                from_transfer,
+                secret,
+            )
+        else:
+            state_change = ReceiveTransferRefund(
+                message.sender,
+                from_transfer,
+                routes,
+            )
 
-def handle_message_directtransfer(raiden: RaidenService, message: DirectTransfer):
-    token_network_identifier = message.token_network_address
-    balance_proof = balanceproof_from_envelope(message)
+        raiden.handle_state_change(state_change)
 
-    direct_transfer = ReceiveTransferDirect(
-        token_network_identifier,
-        message.message_identifier,
-        message.payment_identifier,
-        balance_proof,
-    )
+    def handle_message_directtransfer(self, raiden: RaidenService, message: DirectTransfer):
+        token_network_identifier = message.token_network_address
+        balance_proof = balanceproof_from_envelope(message)
 
-    raiden.handle_state_change(direct_transfer)
+        direct_transfer = ReceiveTransferDirect(
+            token_network_identifier,
+            message.message_identifier,
+            message.payment_identifier,
+            balance_proof,
+        )
 
+        raiden.handle_state_change(direct_transfer)
 
-def handle_message_lockedtransfer(raiden: RaidenService, message: LockedTransfer):
-    if message.target == raiden.address:
-        raiden.target_mediated_transfer(message)
-    else:
-        raiden.mediate_mediated_transfer(message)
+    def handle_message_lockedtransfer(self, raiden: RaidenService, message: LockedTransfer):
+        if message.target == raiden.address:
+            raiden.target_mediated_transfer(message)
+        else:
+            raiden.mediate_mediated_transfer(message)
 
+    def handle_message_processed(self, raiden: RaidenService, message: Processed):
+        processed = ReceiveProcessed(message.sender, message.message_identifier)
+        raiden.handle_state_change(processed)
 
-def handle_message_processed(raiden: RaidenService, message: Processed):
-    processed = ReceiveProcessed(message.sender, message.message_identifier)
-    raiden.handle_state_change(processed)
-
-
-def handle_message_delivered(raiden: RaidenService, message: Delivered):
-    delivered = ReceiveDelivered(message.sender, message.delivered_message_identifier)
-    raiden.handle_state_change(delivered)
-
-
-def on_message(raiden: RaidenService, message: Message):
-    """ Return True if the message is known. """
-    # pylint: disable=unidiomatic-typecheck
-    if type(message) == SecretRequest:
-        handle_message_secretrequest(raiden, message)
-    elif type(message) == RevealSecret:
-        handle_message_revealsecret(raiden, message)
-    elif type(message) == Secret:
-        handle_message_secret(raiden, message)
-    elif type(message) == LockExpired:
-        handle_message_lockexpired(raiden, message)
-    elif type(message) == DirectTransfer:
-        handle_message_directtransfer(raiden, message)
-    elif type(message) == RefundTransfer:
-        handle_message_refundtransfer(raiden, message)
-    elif type(message) == LockedTransfer:
-        handle_message_lockedtransfer(raiden, message)
-    elif type(message) == Delivered:
-        handle_message_delivered(raiden, message)
-    elif type(message) == Processed:
-        handle_message_processed(raiden, message)
-    else:
-        log.error('Unknown message cmdid {}'.format(message.cmdid))
-        return False
-
-    # Inform the transport that it's okay to send a Delivered message
-    return True
+    def handle_message_delivered(self, raiden: RaidenService, message: Delivered):
+        delivered = ReceiveDelivered(message.sender, message.delivered_message_identifier)
+        raiden.handle_state_change(delivered)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -178,6 +178,7 @@ class RaidenService(Runnable):
             private_key_bin,
             transport,
             raiden_event_handler,
+            message_handler,
             config,
             discovery=None,
     ):
@@ -207,6 +208,7 @@ class RaidenService(Runnable):
         self.blockchain_events = BlockchainEvents()
         self.alarm = AlarmTask(chain)
         self.raiden_event_handler = raiden_event_handler
+        self.message_handler = message_handler
 
         self.stop_event = Event()
         self.stop_event.set()  # inits as stopped
@@ -342,7 +344,10 @@ class RaidenService(Runnable):
 
         # alarm.first_run may process some new channel, which would start_health_check_for
         # a partner, that's why transport needs to be already started at this point
-        self.transport.start(self)
+        self.transport.start(
+            self,
+            self.message_handler,
+        )
 
         self.alarm.first_run()
 

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -4,6 +4,7 @@ from gevent import server
 from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.app import App
+from raiden.message_handler import MessageHandler
 from raiden.network.transport import UDPTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.utils.events import must_contain_entry
@@ -64,6 +65,7 @@ def test_recovery_happy_case(
     )
 
     raiden_event_handler = RaidenEventHandler()
+    message_handler = MessageHandler()
 
     app0_restart = App(
         config=app0.config,
@@ -73,6 +75,7 @@ def test_recovery_happy_case(
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
         raiden_event_handler=raiden_event_handler,
+        message_handler=message_handler,
         discovery=app0.raiden.discovery,
     )
 
@@ -203,6 +206,7 @@ def test_recovery_unhappy_case(
     )
 
     raiden_event_handler = RaidenEventHandler()
+    message_handler = MessageHandler()
 
     app0_restart = App(
         config=app0.config,
@@ -212,6 +216,7 @@ def test_recovery_unhappy_case(
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
         raiden_event_handler=raiden_event_handler,
+        message_handler=message_handler,
         discovery=app0.raiden.discovery,
     )
     del app0  # from here on the app0_restart should be used
@@ -273,6 +278,7 @@ def test_recovery_blockchain_events(
     gevent.sleep(1)
 
     raiden_event_handler = RaidenEventHandler()
+    message_handler = MessageHandler()
 
     app0_restart = App(
         config=app0.config,
@@ -282,6 +288,7 @@ def test_recovery_blockchain_events(
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
         raiden_event_handler=raiden_event_handler,
+        message_handler=message_handler,
         discovery=app0.raiden.discovery,
     )
 

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -3,6 +3,7 @@ import pytest
 
 from raiden import waiting
 from raiden.app import App
+from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.utils.network import CHAIN
@@ -55,6 +56,7 @@ def test_send_queued_messages(
     )
 
     raiden_event_handler = RaidenEventHandler()
+    message_handler = MessageHandler()
 
     app0_restart = App(
         config=app0.config,
@@ -64,6 +66,7 @@ def test_send_queued_messages(
         default_secret_registry=app0.raiden.default_secret_registry,
         transport=new_transport,
         raiden_event_handler=raiden_event_handler,
+        message_handler=message_handler,
         discovery=app0.raiden.discovery,
     )
 

--- a/raiden/tests/integration/test_settlement.py
+++ b/raiden/tests/integration/test_settlement.py
@@ -515,7 +515,7 @@ def test_automatic_secret_registration(raiden_chain, token_addresses):
         secret,
     )
     app0.raiden.sign(reveal_secret)
-    message_handler.on_message(app1.raiden, reveal_secret)
+    message_handler.MessageHandler().on_message(app1.raiden, reveal_secret)
 
     chain_state = views.state_from_app(app1)
 

--- a/raiden/tests/integration/test_stress.py
+++ b/raiden/tests/integration/test_stress.py
@@ -14,6 +14,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.api.rest import APIServer, RestAPI
 from raiden.app import App
+from raiden.message_handler import MessageHandler
 from raiden.network.transport import UDPTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.integration.api.utils import wait_for_listening_port
@@ -122,6 +123,7 @@ def restart_app(app):
         default_secret_registry=app.raiden.default_secret_registry,
         transport=new_transport,
         raiden_event_handler=RaidenEventHandler(),
+        message_handler=MessageHandler(),
         discovery=app.raiden.discovery,
     )
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -7,6 +7,7 @@ from gevent import server
 
 from raiden import waiting
 from raiden.app import App
+from raiden.message_handler import MessageHandler
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
@@ -342,6 +343,7 @@ def create_apps(
             )
 
         raiden_event_handler = RaidenEventHandler()
+        message_handler = MessageHandler()
 
         app = App(
             config=config_copy,
@@ -351,6 +353,7 @@ def create_apps(
             default_secret_registry=secret_registry,
             transport=transport,
             raiden_event_handler=raiden_event_handler,
+            message_handler=message_handler,
             discovery=discovery,
         )
         apps.append(app)

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -5,7 +5,7 @@ import gevent
 from coincurve import PrivateKey
 
 from raiden.constants import UINT64_MAX
-from raiden.message_handler import on_message
+from raiden.message_handler import MessageHandler
 from raiden.messages import LockedTransfer, Secret
 from raiden.tests.utils.factories import make_address
 from raiden.transfer import channel, views
@@ -28,7 +28,7 @@ from raiden.utils import privatekey_to_address, sha3
 def sign_and_inject(message, key, address, app):
     """Sign the message with key and inject it directly in the app transport layer."""
     message.sign(key)
-    on_message(app.raiden, message)
+    MessageHandler().on_message(app.raiden, message)
 
 
 def get_channelstate(app0, app1, token_network_identifier) -> NettingChannelState:

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -18,6 +18,7 @@ from raiden.exceptions import (
     EthNodeCommunicationError,
     RaidenError,
 )
+from raiden.message_handler import MessageHandler
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.discovery import ContractDiscovery
 from raiden.network.rpc.client import JSONRPCClient
@@ -361,6 +362,7 @@ def run_app(
         raise RuntimeError(f'Unknown transport type "{transport}" given')
 
     raiden_event_handler = RaidenEventHandler()
+    message_handler = MessageHandler()
 
     try:
         start_block = chain_config.get(START_QUERY_BLOCK_KEY, 0)
@@ -372,6 +374,7 @@ def run_app(
             default_secret_registry=secret_registry,
             transport=transport,
             raiden_event_handler=raiden_event_handler,
+            message_handler=message_handler,
             discovery=discovery,
         )
     except RaidenError as e:


### PR DESCRIPTION
Adding a class to provide late binding, the previous code relied on the
free standing functions from the message_handler module to handle
messages. Although this worked it didn't provide for a mechanism to
extend the message handling, which is desirable for testing (waiting for
a message to be received before proceeding).

Note: an alternative would to just use the module as an object instead
of introducing the class, this however makes extending the behavior a
bit more burdensome, since alternative implementations would have to
reimplement the dispatching code.