### PR TITLE
Fix deserialization of similar token networks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`2662` Fix wrong deserialization of snapshots in special cases.
 * :bug:`2730` Refuse to send a transfer and ignore it during receiving, if its secret is already registered on-chain.
 * :feature:`2713` Added the protocol version in the Ping message.
 * :feature:`2708` Add `--showconfig` CLI flag which dumps all configuration values that will control Raiden behavior.

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 6
+RAIDEN_DB_VERSION = 7
 
 
 class EventRecord(typing.NamedTuple):


### PR DESCRIPTION
So that turned out to be quite a bug, much more foundational than I initially thought.

From initial debugging with @CosminNechifor  we saw that there was a mismatch in the internal network graph which is part of the `TokenNetworkGraphState`. However all tries to reproduce this failed, the correct state changes were written to the WAL and when replaying the WAL everything was right. 
However, we finally found that we could reproduce this when we started with a snapshot. From here on the problem was easy to track down.

It turns out that that there was a problem during deserialization which made multiple `TokenNetworkState` objects reference the same `TokenNetworkGraphState`. This only happened in really special constrains, so it’s not surprising that we haven’t found this earlier:
A snapshot need to be deserialized when there are multiple token networks with the same topology and exactly the same channel participants at the time of the snapshot.
So thanks to the scenario player @CosminNechifor  was able to trigger that.


For the fix: It turns out that the `TokenNetworkGraphState` currently doesn’t know which token network it belongs to. We therefore need a breaking change and add the token network identifier to the `TokenNetworkGraphState`. With this the objects don’t compare to equal any more and proper instances for each token network are created during deserialization.

This is the easy and quick fix, but in the future we might want to move the `TokenNetworkGraphState` in the `TokenNetworkState` or remove it all together when the PFS gets introduced.


Fixes #2662 