### PR TITLE
Remove invalid check for onchain secret registration

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -582,62 +582,6 @@ def test_target_lock_is_expired_if_secret_is_not_registered_onchain():
     assert must_contain_entry(iteration.events, EventUnlockClaimFailed, {})
 
 
-def test_target_transfer_invalid_if_lock_registered_onchain():
-    lock_amount = 7
-    block_number = 1
-    initiator = factories.HOP6
-    pseudo_random_generator = random.Random()
-
-    our_balance = 100
-    our_address = factories.make_address()
-    partner_balance = 130
-
-    from_channel = factories.make_channel(
-        our_address=our_address,
-        our_balance=our_balance,
-        partner_address=UNIT_TRANSFER_SENDER,
-        partner_balance=partner_balance,
-    )
-    from_route = factories.route_from_channel(from_channel)
-    expiration = block_number + from_channel.settle_timeout - from_channel.reveal_timeout
-
-    from_transfer = factories.make_signed_transfer_for(
-        from_channel,
-        lock_amount,
-        initiator,
-        our_address,
-        expiration,
-        UNIT_SECRET,
-        identifier=1,
-        nonce=1,
-    )
-
-    init = ActionInitTarget(
-        from_route,
-        from_transfer,
-    )
-
-    secrethash = from_transfer.lock.secrethash
-    # mock register secret on-chain
-    from_channel.our_state.secrethashes_to_lockedlocks[secrethash] = from_transfer.lock
-    channel.register_onchain_secret(
-        channel_state=from_channel,
-        secret=UNIT_SECRET,
-        secrethash=secrethash,
-        secret_reveal_block_number=0,
-        delete_lock=True,
-    )
-
-    init_transition = target.state_transition(
-        None,
-        init,
-        from_channel,
-        pseudo_random_generator,
-        block_number,
-    )
-    assert init_transition.new_state is None
-
-
 @pytest.mark.xfail(reason='Not implemented #522')
 def test_transfer_successful_after_secret_learned():
     # TransferCompleted event must be used only after the secret is learned and

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -578,10 +578,6 @@ def valid_lockedtransfer_check(
         lock: HashTimeLockState,
 ) -> MerkletreeOrError:
 
-    lock_registered_on_chain = (
-        lock.secrethash in channel_state.our_state.secrethashes_to_onchain_unlockedlocks
-    )
-
     current_balance_proof = get_current_balanceproof(sender_state)
     merkletree = compute_merkletree_with(sender_state.merkletree, lock.lockhash)
 
@@ -595,11 +591,7 @@ def valid_lockedtransfer_check(
         sender_state=sender_state,
     )
 
-    if lock_registered_on_chain:
-        msg = f'Invalid {message_name} message. Secrethash is already registered on chain.'
-        result = (False, msg, None)
-
-    elif not is_balance_proof_usable:
+    if not is_balance_proof_usable:
         msg = f'Invalid {message_name} message. {invalid_balance_proof_msg}'
         result = (False, msg, None)
 


### PR DESCRIPTION
It's already checked
[here](https://github.com/raiden-network/raiden/blob/06cc18240422b042d87d05029f5a429be166cb59/raiden/message_handler.py#L151).

Also removing the relevant unit test which does not really test anything anymore.