### PR TITLE
bugfix: InitChain must use deployed blocknumber

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -288,11 +288,14 @@ class RaidenService(Runnable):
                 'No recoverable state available, created inital state',
                 node=pex(self.address),
             )
-            block_number = self.chain.block_number()
+            # On first run Raiden needs to fetch all events for the payment
+            # network, to reconstruct all token network graphs and find opened
+            # channels
+            last_log_block_number = self.query_start_block
 
             state_change = ActionInitChain(
                 random.Random(),
-                block_number,
+                last_log_block_number,
                 self.chain.node_address,
                 self.chain.network_id,
             )
@@ -304,14 +307,9 @@ class RaidenService(Runnable):
             state_change = ContractReceiveNewPaymentNetwork(
                 constants.EMPTY_HASH,
                 payment_network,
-                block_number,
+                last_log_block_number,
             )
             self.handle_state_change(state_change)
-
-            # On first run Raiden needs to fetch all events for the payment
-            # network, to reconstruct all token network graphs and find opened
-            # channels
-            last_log_block_number = 0
         else:
             # The `Block` state change is dispatched only after all the events
             # for that given block have been processed, filters can be safely


### PR DESCRIPTION
- During start Raiden uses the latest block number (as seen by the
  node's Ethereum node) to initialize the node's state, this value
  is dispatched and made recoverable by the WAL with the ActionInitChain
  state change.
- Then all events are polled starting from block 0 until the current
  block number, updating the node's view of the blockchain.
- Assuming the node crashes during polling. On restart it will use the
  block number set by ActionInitChain instead of 0, which is up the latest
  block number, effectively missing events not processed after the crash.

This also fixes the value 0, which should not be used. The correct value is
the block height at which the token network registry was deployed, which
is available in the RaidenService.query_start_block