### PR TITLE
Fix UnlockPartialProofState lockhash attribute

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+:bug:`2794` UnlockPartialProofState does no longer raise AttributeError when accessing lockhash.
+
 * :release:`0.13.1 <2018-10-15>`
 * :bug:`2784` Raiden node is no longer left with a partial update if it crashes during polling.
 * :bug:`2776` Properly include per chain contract json data in the created binaries

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1083,6 +1083,10 @@ class UnlockPartialProofState(State):
             'secret': serialization.serialize_bytes(self.secret),
         }
 
+    @property
+    def lockhash(self):
+        return self.lock.lockhash
+
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'UnlockPartialProofState':
         restored = cls(


### PR DESCRIPTION
This class was missing the `lockhash` attribute in order to be used like
any other lock state object.

Fixes #2794