### PR TITLE
Change argument order and add regression test

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -588,11 +588,11 @@ def events_for_balanceproof(
 
             message_identifier = message_identifier_from_prng(pseudo_random_generator)
             unlock_lock = channel.send_unlock(
-                payee_channel,
-                pair.payee_transfer.payment_identifier,
-                message_identifier,
-                secret,
-                secrethash,
+                channel_state=payee_channel,
+                message_identifier=message_identifier,
+                payment_identifier=pair.payee_transfer.payment_identifier,
+                secret=secret,
+                secrethash=secrethash,
             )
 
             unlock_success = EventUnlockSuccess(


### PR DESCRIPTION
The arguments of message identifier and payment identifier were mixed up. I fixed the order and use named keyword arguments.