### PR TITLE
Rename --network-type cli option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+:feature:`2752` Renamed ``--network-type`` cli option to ``--environment``.
 :bug:`2836` Contract version check now works for any deployed contract version.
 :bug:`2449` Only polling events from confirmed blocks to prevent conflicts with reorgs.
 :bug:`2827` Fixed a typo in the handle_secretrequest function.

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -38,3 +38,9 @@ SNAPSHOT_STATE_CHANGES_COUNT = 500
 # exceeded. The limit is inclusive.
 TRANSACTION_GAS_LIMIT = int(0.4 * 3141592)
 MAXIMUM_PENDING_TRANSFERS = 160
+
+
+class Environment(Enum):
+    """Environment configurations that can be chosen on the command line."""
+    PRODUCTION = 'production'
+    DEVELOPMENT = 'development'

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -41,7 +41,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ActionInitMediator,
     ActionInitTarget,
 )
-from raiden.transfer.state import PaymentNetworkState, RouteState
+from raiden.transfer.state import BalanceProofUnsignedState, PaymentNetworkState, RouteState
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
     ActionInitChain,
@@ -175,7 +175,12 @@ class PaymentStatus(typing.NamedTuple):
     token_network_identifier: typing.TokenNetworkID
     payment_done: AsyncResult
 
-    def matches(self, payment_type, token_network_identifier, amount):
+    def matches(
+            self,
+            payment_type: PaymentType,
+            token_network_identifier: typing.TokenNetworkID,
+            amount: typing.TokenAmount,
+    ):
         return (
             payment_type == self.payment_type and
             token_network_identifier == self.token_network_identifier and
@@ -183,7 +188,7 @@ class PaymentStatus(typing.NamedTuple):
         )
 
 
-StatusesDict = typing.Dict[typing.Address, typing.Dict[typing.PaymentID, PaymentStatus]]
+StatusesDict = typing.Dict[typing.TargetAddress, typing.Dict[typing.PaymentID, PaymentStatus]]
 
 
 class RaidenService(Runnable):
@@ -552,7 +557,13 @@ class RaidenService(Runnable):
             )
             self.handle_state_change(state_change)
 
-    def _register_payment_status(self, target, identifier, payment_type, balance_proof):
+    def _register_payment_status(
+            self,
+            target: typing.TargetAddress,
+            identifier: typing.PaymentID,
+            payment_type: PaymentType,
+            balance_proof: BalanceProofUnsignedState,
+    ):
         self.targets_to_identifiers_to_statuses[target][identifier] = PaymentStatus(
             payment_type=payment_type,
             payment_identifier=identifier,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -9,7 +9,7 @@ from eth_utils import encode_hex, to_canonical_address, to_checksum_address, to_
 from requests.exceptions import ConnectTimeout
 from web3 import HTTPProvider, Web3
 
-from raiden.constants import SQLITE_MIN_REQUIRED_VERSION
+from raiden.constants import SQLITE_MIN_REQUIRED_VERSION, Environment
 from raiden.exceptions import (
     AddressWithoutCode,
     AddressWrongContract,
@@ -181,7 +181,7 @@ def run_app(
         transport,
         matrix_server,
         network_id,
-        network_type,
+        environment,
         config=None,
         extra_config=None,
         **kwargs,
@@ -267,10 +267,10 @@ def run_app(
 
     config['chain_id'] = given_network_id
 
-    log.debug('Network type', type=network_type)
-    if network_type == 'main':
+    log.debug('Environment setting', type=environment)
+    if environment == Environment.PRODUCTION:
+        # Safe configuration: restrictions for mainnet apply and matrix rooms have to be private
         config['network_type'] = NetworkType.MAIN
-        # Forcing private rooms to true for the mainnet
         config['transport']['matrix']['private_rooms'] = True
     else:
         config['network_type'] = NetworkType.TEST

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -286,14 +286,14 @@ def run_app(
         config['contracts_path'] = contracts_precompiled_path(contracts_version)
         not_allowed = (  # for now we only disallow mainnet with test configuration
             network_id == 1 and
-            network_type == NetworkType.TEST
+            environment == Environment.DEVELOPMENT
         )
         if not_allowed:
             click.secho(
-                'The chosen network {} has no test configuration but a test network type '
-                'was given. This is not allowed.'.format(
-                    ID_TO_NETWORKNAME[node_network_id],
-                ),
+                f'The chosen network ({ID_TO_NETWORKNAME[node_network_id]}) is not a testnet, '
+                'but the "development" environment was selected.\n'
+                'This is not allowed. Please start again with a safe environment setting '
+                '(--environment production).',
                 fg='red',
             )
             sys.exit(1)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -16,6 +16,7 @@ from mirakuru import ProcessExitedWithError
 
 from raiden.api.rest import APIServer, RestAPI
 from raiden.app import App
+from raiden.constants import Environment
 from raiden.exceptions import ReplacementTransactionUnderpriced, TransactionAlreadyPending
 from raiden.log_config import configure_logging
 from raiden.network.sockfactory import SocketFactory
@@ -150,12 +151,14 @@ def options(func):
             show_default=True,
         ),
         option(
-            '--network-type',
+            '--environment',
             help=(
-                'Specify the network type (main or test).\n'
+                'Specify the environment (production or development).\n'
+                'The "production" setting adds some safety measures and is mainly intended '
+                'for running Raiden on the mainnet.\n'
             ),
-            type=click.Choice(['main', 'test']),
-            default='test',
+            type=click.Choice([e.value for e in Environment]),
+            default=Environment.DEVELOPMENT.value,
             show_default=True,
         ),
         option(


### PR DESCRIPTION
- As discussed, `--network-type main|test` will be changed to `--environment production|development`
- If we are on the mainnet, the `--environment` option will be overriden and set to `production`. We used to check for that and abort if the setting was wrong, but it is awkward to always have to specify both options to run on mainnet.
- also adds some missing type annotations in raiden_service.py (unrelated)

Fixes #2752 