### PR TITLE
Some SP improvements

### DIFF
--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -13,7 +13,7 @@ settings:
   #chain: any
   ## Other examples
   #chain: ropsten
-  #chain: kovan
+  chain: kovan
   #chain: rinkeby
   #chain: raiden_clique
   #chain: raiden_aura
@@ -80,7 +80,7 @@ scenario:
       - parallel:
           name: "Open channels"
           tasks:
-            - open_channel: {from: 0, to: 1, total_deposit: 10, expected_http_status: "[234].."}
+            - open_channel: {from: 0, to: 1, total_deposit: 10, settle_timeout: 100}
             - open_channel: {from: 1, to: 2, total_deposit: 10, expected_http_status: "(2..|409)"}
       - parallel:
           name: "Assert after open"

--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -13,7 +13,7 @@ settings:
   #chain: any
   ## Other examples
   #chain: ropsten
-  chain: kovan
+  #chain: kovan
   #chain: rinkeby
   #chain: raiden_clique
   #chain: raiden_aura

--- a/tools/scenario-player/scenario_player/tasks/channels.py
+++ b/tools/scenario-player/scenario_player/tasks/channels.py
@@ -26,6 +26,9 @@ class OpenChannelTask(RaidenAPIActionTask):
         total_deposit = self._config.get('total_deposit')
         if total_deposit is not None:
             params['total_deposit'] = total_deposit
+        settle_timeout = self._config.get('settle_timeout')
+        if settle_timeout:
+            params['settle_timeout'] = settle_timeout
         return params
 
 


### PR DESCRIPTION
Some improvements that collected over the last week.

- Add `settle_timeout` parameter to `open_channel`
- Use random ports for the raiden nodes to allow running multiple scenarios in parallel
- Add `reclaim-eth` CLI subcommand to reclaim eth of no longer used scenarios

Usage of `reclaim-eth`:

It will reclaim eth for the given `--chain`s from all node accounts that haven't been used to run scenarios in the last `--min-age` hours.
The eth will be transferred into the account of the given `--keystore-file`.

Example:
```
python -m scenario_player \
        --keystore-file <...> \
        --password <...> \
        --chain kovan:<...> \
        --chain rinkeby:<...> \
        [--chain <...>:<...>] \
        - \
        reclaim-eth \
        --min-age <hours>
```
(The dash before `reclaim-eth` is required as a placeholder for the not used scenario file parameter)
