### PR TITLE
Temporarily skip version check

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -239,18 +239,18 @@ def split_in_pairs(arg: Iterable) -> Iterable[Tuple]:
 
 def compare_versions(deployed_version, current_version):
     """Compare version strings of a contract"""
-    assert isinstance(deployed_version, str)
-    assert isinstance(current_version, str)
+    # assert isinstance(deployed_version, str)
+    # assert isinstance(current_version, str)
 
-    deployed_version = deployed_version.replace('_', '0')
-    current_version = current_version.replace('_', '0')
-    deployed = [int(x) for x in deployed_version.split('.')]
-    current = [int(x) for x in current_version.split('.')]
+    # deployed_version = deployed_version.replace('_', '0')
+    # current_version = current_version.replace('_', '0')
+    # deployed = [int(x) for x in deployed_version.split('.')]
+    # current = [int(x) for x in current_version.split('.')]
 
-    if deployed[0] != current[0]:
-        return False
-    if deployed[1] != current[1]:
-        return False
+    # if deployed[0] != current[0]:
+    #     return False
+    # if deployed[1] != current[1]:
+    #     return False
     return True
 
 


### PR DESCRIPTION
This is only temporary so that testing in Rinkeby and Kovan can go on until new
contracts are re-deployed there.