### PR TITLE
Fixed a attribute that was renamed

### DIFF
--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -68,7 +68,7 @@ class Token:
         receipt_or_none = check_transaction_threw(self.client, transaction_hash)
 
         if receipt_or_none:
-            user_balance = self.balance_of(self.client.sender)
+            user_balance = self.balance_of(self.client.address)
 
             # If the balance is zero, either the smart contract doesnt have a
             # balanceOf function or the actual balance is zero

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -30,7 +30,7 @@ def main(keystore_file, password, rpc_url, eth_amount, targets_file):
     )
 
     targets = [t.strip() for t in targets_file]
-    balance = client.balance(client.sender)
+    balance = client.balance(client.address)
 
     balance_needed = len(targets) * eth_amount
     if balance_needed * WEI_TO_ETH > balance:


### PR DESCRIPTION
If we take a look in the JSONRPCClient we can see that the
sender attribute became [address](https://github.com/raiden-network/raiden/blob/master/raiden/network/rpc/client.py#L172), and this was not changed on this
[transfer_eth.py](https://github.com/raiden-network/raiden/blob/master/tools/transfer_eth.py#L33) from tools.