### PR TITLE
Report problematic versions at contract version mismatch

### DIFF
--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -43,12 +43,18 @@ class Discovery:
         check_address_has_code(jsonrpc_client, discovery_address, 'Discovery')
 
         try:
+            deployed_version = proxy.contract.functions.contract_version().call()
+            expected_version = contract_manager.contracts_version
             is_valid_version = compare_versions(
-                proxy.contract.functions.contract_version().call(),
-                contract_manager.contracts_version,
+                deployed_version=deployed_version,
+                expected_version=expected_version,
             )
             if not is_valid_version:
-                raise ContractVersionMismatch('Incompatible ABI for Discovery')
+                raise ContractVersionMismatch(
+                    f'Provided EndpointRegistry contract ({pex(discovery_address)}) '
+                    f'version mismatch. Expected: {expected_version} Got: {deployed_version}.'
+                )
+
         except BadFunctionCallOutput:
             raise AddressWrongContract('')
 

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -1,18 +1,13 @@
 import structlog
 from eth_utils import is_binary_address, to_checksum_address, to_normalized_address
-from web3.exceptions import BadFunctionCallOutput
 
 from raiden.constants import NULL_ADDRESS
-from raiden.exceptions import (
-    AddressWrongContract,
-    ContractVersionMismatch,
-    TransactionThrew,
-    UnknownAddress,
-)
+from raiden.exceptions import TransactionThrew, UnknownAddress
+from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import compare_versions, pex, privatekey_to_address
+from raiden.utils import pex, privatekey_to_address
 from raiden_contracts.constants import CONTRACT_ENDPOINT_REGISTRY
 from raiden_contracts.contract_manager import ContractManager
 
@@ -42,21 +37,12 @@ class Discovery:
 
         check_address_has_code(jsonrpc_client, discovery_address, 'Discovery')
 
-        try:
-            deployed_version = proxy.contract.functions.contract_version().call()
-            expected_version = contract_manager.contracts_version
-            is_valid_version = compare_versions(
-                deployed_version=deployed_version,
-                expected_version=expected_version,
-            )
-            if not is_valid_version:
-                raise ContractVersionMismatch(
-                    f'Provided EndpointRegistry contract ({pex(discovery_address)}) '
-                    f'version mismatch. Expected: {expected_version} Got: {deployed_version}.'
-                )
-
-        except BadFunctionCallOutput:
-            raise AddressWrongContract('')
+        compare_contract_versions(
+            proxy=proxy,
+            expected_version=contract_manager.contracts_version,
+            contract_name=CONTRACT_ENDPOINT_REGISTRY,
+            address=discovery_address,
+        )
 
         self.address = discovery_address
         self.node_address = privatekey_to_address(jsonrpc_client.privkey)

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -3,18 +3,13 @@ from typing import List
 import structlog
 from eth_utils import encode_hex, event_abi_to_log_topic, is_binary_address, to_normalized_address
 from gevent.event import AsyncResult
-from web3.exceptions import BadFunctionCallOutput
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
-from raiden.exceptions import (
-    AddressWrongContract,
-    ContractVersionMismatch,
-    InvalidAddress,
-    TransactionThrew,
-)
+from raiden.exceptions import InvalidAddress, TransactionThrew
+from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import compare_versions, pex, privatekey_to_address, sha3, typing
+from raiden.utils import pex, privatekey_to_address, sha3, typing
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, EVENT_SECRET_REVEALED
 from raiden_contracts.contract_manager import ContractManager
 
@@ -39,21 +34,12 @@ class SecretRegistry:
             to_normalized_address(secret_registry_address),
         )
 
-        try:
-            deployed_version = proxy.contract.functions.contract_version().call()
-            expected_version = contract_manager.contracts_version
-            is_valid_version = compare_versions(
-                deployed_version=deployed_version,
-                expected_version=expected_version,
-            )
-            if not is_valid_version:
-                raise ContractVersionMismatch(
-                    f'Provided SecretRegistry contract ({pex(secret_registry_address)}) '
-                    f'version mismatch. Expected: {expected_version} Got: {deployed_version}.'
-                )
-
-        except BadFunctionCallOutput:
-            raise AddressWrongContract('')
+        compare_contract_versions(
+            proxy=proxy,
+            expected_version=contract_manager.contracts_version,
+            contract_name=CONTRACT_SECRET_REGISTRY,
+            address=secret_registry_address,
+        )
 
         self.address = secret_registry_address
         self.proxy = proxy

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -40,11 +40,18 @@ class SecretRegistry:
         )
 
         try:
-            if not compare_versions(
-                    proxy.contract.functions.contract_version().call(),
-                    contract_manager.contracts_version,
-            ):
-                raise ContractVersionMismatch('Incompatible ABI for SecretRegistry')
+            deployed_version = proxy.contract.functions.contract_version().call()
+            expected_version = contract_manager.contracts_version
+            is_valid_version = compare_versions(
+                deployed_version=deployed_version,
+                expected_version=expected_version,
+            )
+            if not is_valid_version:
+                raise ContractVersionMismatch(
+                    f'Provided SecretRegistry contract ({pex(secret_registry_address)}) '
+                    f'version mismatch. Expected: {expected_version} Got: {deployed_version}.'
+                )
+
         except BadFunctionCallOutput:
             raise AddressWrongContract('')
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -89,12 +89,17 @@ class TokenNetwork:
             to_normalized_address(manager_address),
         )
 
+        deployed_version = proxy.contract.functions.contract_version().call()
+        expected_version = contract_manager.contracts_version
         is_good_version = compare_versions(
-            proxy.contract.functions.contract_version().call(),
-            contract_manager.contracts_version,
+            deployed_version=deployed_version,
+            expected_version=expected_version,
         )
         if not is_good_version:
-            raise ContractVersionMismatch('Incompatible ABI for TokenNetwork')
+            raise ContractVersionMismatch(
+                f'Provided TokenNetwork contract ({pex(manager_address)}) '
+                f'version mismatch. Expected: {expected_version} Got: {deployed_version}.'
+            )
 
         self.address = manager_address
         self.proxy = proxy

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -48,14 +48,20 @@ class TokenNetworkRegistry:
         )
 
         try:
+            deployed_version = proxy.contract.functions.contract_version().call()
+            expected_version = contract_manager.contracts_version
             is_valid_version = compare_versions(
-                proxy.contract.functions.contract_version().call(),
-                contract_manager.contracts_version,
+                deployed_version=deployed_version,
+                expected_version=expected_version,
             )
+            if not is_valid_version:
+                raise ContractVersionMismatch(
+                    f'Provided TokenNetworkRegistry contract ({pex(registry_address)}) '
+                    f'version mismatch. Expected: {expected_version} Got: {deployed_version}.'
+                )
+
         except BadFunctionCallOutput:
             raise AddressWrongContract('')
-        if not is_valid_version:
-            raise ContractVersionMismatch('Incompatible ABI for TokenNetworkRegistry')
 
         self.address = registry_address
         self.proxy = proxy

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -1,0 +1,35 @@
+from eth_utils import to_normalized_address
+from web3.exceptions import BadFunctionCallOutput
+
+from raiden.exceptions import AddressWrongContract, ContractVersionMismatch
+from raiden.network.rpc.smartcontract_proxy import ContractProxy
+from raiden.utils.typing import Address
+
+
+def compare_contract_versions(
+        proxy: ContractProxy,
+        expected_version: str,
+        contract_name: str,
+        address: Address,
+) -> None:
+    """Compare version strings of a contract.
+
+    If not matching raise ContractVersionMismatch. Also may raise AddressWrongContract
+    if the contract contains no code."""
+    assert isinstance(expected_version, str)
+    try:
+        deployed_version = proxy.contract.functions.contract_version().call()
+    except BadFunctionCallOutput:
+        raise AddressWrongContract('')
+
+    deployed_version = deployed_version.replace('_', '0')
+    expected_version = expected_version.replace('_', '0')
+
+    deployed = [int(x) for x in deployed_version.split('.')]
+    expected = [int(x) for x in expected_version.split('.')]
+
+    if deployed != expected:
+        raise ContractVersionMismatch(
+            f'Provided {contract_name} contract ({to_normalized_address(address)}) '
+            f'version mismatch. Expected: {expected_version} Got: {deployed_version}',
+        )

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -52,7 +52,7 @@ log = structlog.get_logger(__name__)
 
 def handle_contract_version_mismatch(mismatch_exception: ContractVersionMismatch) -> None:
     click.secho(
-        f'{str(mismatch_exception)} Please update your Raiden installation.',
+        f'{str(mismatch_exception)}. Please update your Raiden installation.',
         fg='red',
     )
     sys.exit(1)

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -50,11 +50,9 @@ from .sync import check_discovery_registration_gas, check_synced
 log = structlog.get_logger(__name__)
 
 
-def handle_contract_version_mismatch(name: str, address: typing.Address) -> None:
-    hex_addr = to_checksum_address(address)
+def handle_contract_version_mismatch(mismatch_exception: ContractVersionMismatch) -> None:
     click.secho(
-        f'Error: Provided {name} {hex_addr} contract version mismatch. '
-        'Please update your Raiden installation.',
+        f'{str(mismatch_exception)} Please update your Raiden installation.',
         fg='red',
     )
     sys.exit(1)
@@ -120,8 +118,8 @@ def _setup_udp(
             blockchain_service.node_address,
             dicovery_proxy,
         )
-    except ContractVersionMismatch:
-        handle_contract_version_mismatch('Endpoint Registry', endpoint_registry_contract_address)
+    except ContractVersionMismatch as e:
+        handle_contract_version_mismatch(e)
     except AddressWithoutCode:
         handle_contract_no_code('Endpoint Registry', endpoint_registry_contract_address)
     except AddressWrongContract:
@@ -325,11 +323,8 @@ def run_app(
                 contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]['address'],
             ),
         )
-    except ContractVersionMismatch:
-        handle_contract_version_mismatch(
-            'token network registry',
-            tokennetwork_registry_contract_address,
-        )
+    except ContractVersionMismatch as e:
+        handle_contract_version_mismatch(e)
     except AddressWithoutCode:
         handle_contract_no_code('token network registry', tokennetwork_registry_contract_address)
     except AddressWrongContract:
@@ -344,8 +339,8 @@ def run_app(
                 contracts[CONTRACT_SECRET_REGISTRY]['address'],
             ),
         )
-    except ContractVersionMismatch:
-        handle_contract_version_mismatch('secret registry', secret_registry_contract_address)
+    except ContractVersionMismatch as e:
+        handle_contract_version_mismatch(e)
     except AddressWithoutCode:
         handle_contract_no_code('secret registry', secret_registry_contract_address)
     except AddressWrongContract:

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -237,22 +237,22 @@ def split_in_pairs(arg: Iterable) -> Iterable[Tuple]:
     return zip_longest(iterator, iterator)
 
 
-def compare_versions(deployed_version, current_version):
+def compare_versions(deployed_version, expected_version):
     """Compare version strings of a contract"""
     assert isinstance(deployed_version, str)
-    assert isinstance(current_version, str)
+    assert isinstance(expected_version, str)
 
     deployed_version = deployed_version.replace('_', '0')
-    current_version = current_version.replace('_', '0')
+    expected_version = expected_version.replace('_', '0')
 
     deployed = [int(x) for x in deployed_version.split('.')]
-    current = [int(x) for x in current_version.split('.')]
+    expected = [int(x) for x in expected_version.split('.')]
 
-    if deployed[0] != current[0]:
+    if deployed[0] != expected[0]:
         return False
-    if deployed[1] != current[1]:
+    if deployed[1] != expected[1]:
         return False
-    if deployed[2] != current[2]:
+    if deployed[2] != expected[2]:
         return False
 
     return True

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -237,27 +237,6 @@ def split_in_pairs(arg: Iterable) -> Iterable[Tuple]:
     return zip_longest(iterator, iterator)
 
 
-def compare_versions(deployed_version, expected_version):
-    """Compare version strings of a contract"""
-    assert isinstance(deployed_version, str)
-    assert isinstance(expected_version, str)
-
-    deployed_version = deployed_version.replace('_', '0')
-    expected_version = expected_version.replace('_', '0')
-
-    deployed = [int(x) for x in deployed_version.split('.')]
-    expected = [int(x) for x in expected_version.split('.')]
-
-    if deployed[0] != expected[0]:
-        return False
-    if deployed[1] != expected[1]:
-        return False
-    if deployed[2] != expected[2]:
-        return False
-
-    return True
-
-
 def create_default_identifier():
     """ Generates a random identifier. """
     return random.randint(0, constants.UINT64_MAX)


### PR DESCRIPTION
As seen by a user in [gitter](https://gitter.im/raiden-network/raiden?at=5bcb2de1ab17df2631c0fa6e), if a contract version mismatch is encountered we currently do not get any useful error describing expected/found version.

This PR addresses that by making sure that if there is a version mismatch the expected/deployed versions are included in the error.