### PR TITLE
Fix pytestwarning for deploytoken dontcall fixture

### DIFF
--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -3,9 +3,8 @@ from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.network.proxies import SecretRegistry, Token, TokenNetwork, TokenNetworkRegistry
 from raiden.tests.utils import factories
-from raiden.tests.utils.smartcontracts import deploy_contract_web3
+from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import (
-    CONTRACT_HUMAN_STANDARD_TOKEN,
     CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -98,8 +97,15 @@ def token_network_proxy(deploy_client, token_network_contract, contract_manager)
 
 
 @pytest.fixture
-def token_contract(deploy_token):
-    return deploy_token(10000, 0, 'TKN', 'TKN')
+def token_contract(deploy_client, contract_manager):
+    return deploy_token(
+        deploy_client=deploy_client,
+        contract_manager=contract_manager,
+        initial_amount=10000,
+        decimals=0,
+        token_name='TKN',
+        token_symbol='TKN',
+    )
 
 
 @pytest.fixture
@@ -109,27 +115,3 @@ def token_proxy(deploy_client, token_contract, contract_manager):
         token_address=to_canonical_address(token_contract.contract.address),
         contract_manager=contract_manager,
     )
-
-
-@pytest.fixture
-def deploy_token(deploy_client, contract_manager):
-    def f(initial_amount, decimals, token_name, token_symbol):
-        token_address = deploy_contract_web3(
-            contract_name=CONTRACT_HUMAN_STANDARD_TOKEN,
-            deploy_client=deploy_client,
-            contract_manager=contract_manager,
-            constructor_arguments=(
-                initial_amount,
-                decimals,
-                token_name,
-                token_symbol,
-            ),
-        )
-
-        contract_abi = contract_manager.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN)
-        return deploy_client.new_contract_proxy(
-            contract_interface=contract_abi,
-            contract_address=token_address,
-        )
-
-    return f

--- a/raiden/tests/integration/contracts/test_network_registry.py
+++ b/raiden/tests/integration/contracts/test_network_registry.py
@@ -4,10 +4,15 @@ from eth_utils import is_same_address, to_canonical_address
 from raiden.exceptions import RaidenRecoverableError, TransactionThrew
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.tests.utils.factories import make_address
+from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
 
-def test_network_registry(token_network_registry_proxy: TokenNetworkRegistry, deploy_token):
+def test_network_registry(
+        deploy_client,
+        contract_manager,
+        token_network_registry_proxy: TokenNetworkRegistry,
+):
 
     assert token_network_registry_proxy.settlement_timeout_min() == TEST_SETTLE_TIMEOUT_MIN
     assert token_network_registry_proxy.settlement_timeout_max() == TEST_SETTLE_TIMEOUT_MAX
@@ -17,7 +22,14 @@ def test_network_registry(token_network_registry_proxy: TokenNetworkRegistry, de
     with pytest.raises(TransactionThrew):
         token_network_registry_proxy.add_token(bad_token_address)
     # create token network & register it
-    test_token = deploy_token(1000, 0, 'TKN', 'TKN')
+    test_token = deploy_token(
+        deploy_client=deploy_client,
+        contract_manager=contract_manager,
+        initial_amount=1000,
+        decimals=0,
+        token_name='TKN',
+        token_symbol='TKN',
+    )
     test_token_address = to_canonical_address(test_token.contract.address)
     event_filter = token_network_registry_proxy.tokenadded_filter()
     token_network_address = token_network_registry_proxy.add_token(

--- a/raiden/tests/integration/contracts/test_token_network_registry.py
+++ b/raiden/tests/integration/contracts/test_token_network_registry.py
@@ -8,7 +8,7 @@ from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
 
-def test_network_registry(
+def test_token_network_registry(
         deploy_client,
         contract_manager,
         token_network_registry_proxy: TokenNetworkRegistry,

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -2,9 +2,37 @@ from eth_utils import to_canonical_address
 
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils import typing
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
+
+
+def deploy_token(
+        deploy_client: JSONRPCClient,
+        contract_manager: ContractManager,
+        initial_amount: typing.TokenAmount,
+        decimals: int,
+        token_name: str,
+        token_symbol: str,
+)-> ContractProxy:
+    token_address = deploy_contract_web3(
+        contract_name=CONTRACT_HUMAN_STANDARD_TOKEN,
+        deploy_client=deploy_client,
+        contract_manager=contract_manager,
+        constructor_arguments=(
+            initial_amount,
+            decimals,
+            token_name,
+            token_symbol,
+        ),
+    )
+
+    contract_abi = contract_manager.get_contract_abi(CONTRACT_HUMAN_STANDARD_TOKEN)
+    return deploy_client.new_contract_proxy(
+        contract_interface=contract_abi,
+        contract_address=token_address,
+    )
 
 
 def deploy_tokens_and_fund_accounts(

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -24,7 +24,6 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.utils import get_free_port
 from raiden.raiden_service import RaidenService
 from raiden.tests.fixtures.variables import DEFAULT_PASSPHRASE
-from raiden.tests.integration.contracts.fixtures.contracts import deploy_token
 from raiden.tests.utils.geth import (
     GethNodeDescription,
     geth_node_config,
@@ -33,7 +32,7 @@ from raiden.tests.utils.geth import (
     geth_run_nodes,
     geth_wait_and_check,
 )
-from raiden.tests.utils.smartcontracts import deploy_contract_web3
+from raiden.tests.utils.smartcontracts import deploy_contract_web3, deploy_token
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED
 from raiden.utils import get_project_root, privatekey_to_address
@@ -270,8 +269,14 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step):
         chain_id=NETWORKNAME_TO_ID['smoketest'],
         contract_manager=contract_manager,
     )
-    token_contract = deploy_token(client, contract_manager)
-    token = token_contract(1000, 0, 'TKN', 'TKN')
+    token = deploy_token(
+        deploy_client=client,
+        contract_manager=contract_manager,
+        initial_amount=1000,
+        decimals=0,
+        token_name='TKN',
+        token_symbol='TKN',
+    )
     registry = TokenNetworkRegistry(
         jsonrpc_client=client,
         registry_address=contract_addresses[CONTRACT_TOKEN_NETWORK_REGISTRY],


### PR DESCRIPTION
pytest was giving a warning that the `deploytoken()` fixture was being called directly and that this should be avoided.

- Ended up removing it as it was never really used as a fixture and turned it into a utility test function.
- Also gave proper name to a file testing the token network registry contract