### PR TITLE
Fixed a param option

### DIFF
--- a/tools/scenario-player/scenario_player/node_support.py
+++ b/tools/scenario-player/scenario_player/node_support.py
@@ -251,7 +251,7 @@ class NodeRunner:
             self._password_file,
             '--network-id',
             self._runner.chain_id,
-            '--network-type',
+            '--environment-type',
             self._runner.chain_type.name.lower(),
             '--sync-check',  # FIXME: Disable sync check for private chains
             '--gas-price',

--- a/tools/scenario-player/scenario_player/node_support.py
+++ b/tools/scenario-player/scenario_player/node_support.py
@@ -252,7 +252,7 @@ class NodeRunner:
             '--network-id',
             self._runner.chain_id,
             '--environment-type',
-            self._runner.chain_type.name.lower(),
+            self._runner.environment_type.name.lower(),
             '--sync-check',  # FIXME: Disable sync check for private chains
             '--gas-price',
             self._options.get('gas-price', 'normal'),

--- a/tools/scenario-player/scenario_player/runner.py
+++ b/tools/scenario-player/scenario_player/runner.py
@@ -143,7 +143,9 @@ class ScenarioRunner(object):
 
         self.chain_id = self.client.web3.net.version
         # FIXME: Support main net type for test chains
-        self.chain_type = Environment.PRODUCTION if self.chain_id == 1 else Environment.DEVELOPMENT
+        self.environment_type = (
+            Environment.PRODUCTION if self.chain_id == 1 else Environment.DEVELOPMENT
+        )
 
         balance = self.client.balance(account.address)
         if balance < OWN_ACCOUNT_BALANCE_MIN:


### PR DESCRIPTION
The `--network-type` option name was changed to `--environment-type`
but there is this place where we forgot to change it.
