### PR TITLE
Properly recognize environment type from cli

### DIFF
--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -9,7 +9,7 @@ from eth_utils import to_checksum_address
 from raiden.constants import Environment
 from raiden.ui.cli import run
 
-EXPECTED_DEFAULT_ENVIRONMENT_VALUE = Environment.PRODUCTION.value.lower()
+EXPECTED_DEFAULT_ENVIRONMENT_VALUE = Environment.PRODUCTION.value
 
 
 def spawn_raiden(args):
@@ -179,13 +179,13 @@ def test_cli_registry_address_without_deployed_contract(cli_args):
 
 @pytest.mark.timeout(65)
 @pytest.mark.parametrize('changed_args', [{
-    'environment_type': Environment.DEVELOPMENT.value.lower(),
+    'environment_type': Environment.DEVELOPMENT.value,
 }])
 def test_cli_change_environment_type(cli_args):
     child = spawn_raiden(cli_args)
     try:
         # expect the provided mode
-        expect_cli_normal_startup(child, Environment.DEVELOPMENT.value.lower())
+        expect_cli_normal_startup(child, Environment.DEVELOPMENT.value)
     except pexpect.TIMEOUT as e:
         print('Timed out at', e)
     finally:

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -6,9 +6,10 @@ import pytest
 from click.testing import CliRunner
 from eth_utils import to_checksum_address
 
+from raiden.constants import Environment
 from raiden.ui.cli import run
 
-EXPECTED_DEFAULT_ENVIRONMENT_VALUE = 'production'
+EXPECTED_DEFAULT_ENVIRONMENT_VALUE = Environment.PRODUCTION.value.lower()
 
 
 def spawn_raiden(args):
@@ -178,13 +179,13 @@ def test_cli_registry_address_without_deployed_contract(cli_args):
 
 @pytest.mark.timeout(65)
 @pytest.mark.parametrize('changed_args', [{
-    'environment_type': 'development'
+    'environment_type': Environment.DEVELOPMENT.value.lower(),
 }])
 def test_cli_change_environment_type(cli_args):
     child = spawn_raiden(cli_args)
     try:
         # expect the provided mode
-        expect_cli_normal_startup(child, 'development')
+        expect_cli_normal_startup(child, Environment.DEVELOPMENT.value.lower())
     except pexpect.TIMEOUT as e:
         print('Timed out at', e)
     finally:

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -265,7 +265,7 @@ def run_app(
     config['chain_id'] = given_network_id
 
     # interpret the provided string argument
-    if environment_type == 'production':
+    if environment_type == Environment.PRODUCTION:
         # Safe configuration: restrictions for mainnet apply and matrix rooms have to be private
         config['environment_type'] = Environment.PRODUCTION
         config['transport']['matrix']['private_rooms'] = True

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -264,8 +264,8 @@ def run_app(
 
     config['chain_id'] = given_network_id
 
-    log.debug('Environment setting', type=environment_type)
-    if environment_type == Environment.PRODUCTION:
+    # interpret the provided string argument
+    if environment_type == 'production':
         # Safe configuration: restrictions for mainnet apply and matrix rooms have to be private
         config['environment_type'] = Environment.PRODUCTION
         config['transport']['matrix']['private_rooms'] = True
@@ -273,6 +273,10 @@ def run_app(
         config['environment_type'] = Environment.DEVELOPMENT
 
     environment_type = config['environment_type']
+    click.secho(
+        f'Raiden is running in {environment_type.value.lower()} mode',
+        fg='green'
+    )
     chain_config = {}
     contract_addresses_known = False
     contracts = dict()

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -273,10 +273,8 @@ def run_app(
         config['environment_type'] = Environment.DEVELOPMENT
 
     environment_type = config['environment_type']
-    click.secho(
-        f'Raiden is running in {environment_type.value.lower()} mode',
-        fg='green'
-    )
+    print(f'Raiden is running in {environment_type.value.lower()} mode')
+
     chain_config = {}
     contract_addresses_known = False
     contracts = dict()

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -158,7 +158,7 @@ def options(func):
                 'for running Raiden on the mainnet.\n'
             ),
             type=click.Choice([e.value for e in Environment]),
-            default=Environment.DEVELOPMENT.value,
+            default=Environment.PRODUCTION.value,
             show_default=True,
         ),
         option(

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -26,6 +26,7 @@ from raiden.utils import get_system_spec, merge_dict, split_endpoint
 from raiden.utils.cli import (
     ADDRESS_TYPE,
     LOG_LEVEL_CONFIG_TYPE,
+    EnvironmentChoiceType,
     GasPriceChoiceType,
     MatrixServerType,
     NATChoiceType,
@@ -157,7 +158,7 @@ def options(func):
                 'The "production" setting adds some safety measures and is mainly intended '
                 'for running Raiden on the mainnet.\n'
             ),
-            type=click.Choice([e.value for e in Environment]),
+            type=EnvironmentChoiceType([e.value for e in Environment]),
             default=Environment.PRODUCTION.value,
             show_default=True,
         ),

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -16,6 +16,7 @@ from click.formatting import iter_rows, measure_table, wrap_text
 from pytoml import TomlError, load
 from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_price_strategy
 
+from raiden.constants import Environment
 from raiden.exceptions import InvalidAddress
 from raiden.utils import address_checksum_and_decode
 from raiden_contracts.constants import NETWORKNAME_TO_ID
@@ -270,6 +271,14 @@ class NetworkChoiceType(click.Choice):
         else:
             network_name = super().convert(value, param, ctx)
             return NETWORKNAME_TO_ID[network_name]
+
+
+class EnvironmentChoiceType(click.Choice):
+    def convert(self, value, param, ctx):
+        try:
+            return Environment(value)
+        except ValueError:
+            self.fail(f"'{value}' is not a valid environment type", param, ctx)
 
 
 class GasPriceChoiceType(click.Choice):


### PR DESCRIPTION
- Fixes a tiny bug in recognition of the environment type CLI argument.
- Makes production the default environment type
- Adds CLI tests to check that the `--environment-type` argument changes the expected readout of the client at startup. 