### PR TITLE
Fix race condition with new blocks and filters

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -362,7 +362,7 @@ class RaidenService(Runnable):
         # - The alarm must complete its first run before the transport is started,
         #   to reject messages for closed/settled channels.
         self.alarm.register_callback(self._callback_new_block)
-        self.alarm.first_run()
+        self.alarm.first_run(last_log_block_number)
 
         # The transport must not ever be started before the alarm task's first
         # run, because it's this method which synchronizes the node with the

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -195,7 +195,7 @@ class AlarmTask(Runnable):
             if missed_blocks > 2:
                 log.info(
                     'Missed block(s)',
-                    missed_blocks=missed_blocks,
+                    missed_blocks=missed_blocks - 1,
                     latest_block=latest_block,
                 )
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -427,7 +427,7 @@ def wait_for_alarm_start(raiden_apps, retry_timeout=DEFAULT_RETRY_TIMEOUT):
     while apps:
         app = apps[-1]
 
-        if app.raiden.alarm.last_block_number is None:
+        if app.raiden.alarm.known_block_number is None:
             gevent.sleep(retry_timeout)
         else:
             apps.pop()


### PR DESCRIPTION
The race happened under this circunstance:

- A node learns about a new block, updates its state, then crashes
- On restart, the block number is recovered, the filters are
  installed with the latest known block.
- The race: The node finishes the above before a new block is mined
- The bug: The filter is polled during start of the RaidenService, by
  calling the AlarmTask.first_run, which always executes the
  callbacks, eventually using the StateFilter's to poll for new events
  from a block in the future.

The fix was to give the latest known block number to the alarm task in
the as an argument for first_run, and only execute the callbacks if
there is a new block.

fixes #2838