### PR TITLE
Add whitelisting of users before transport starts

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -234,7 +234,19 @@ class MatrixTransport(Runnable):
         self.greenlets.append(greenlet)
         return greenlet
 
+    def whitelist(self, address: Address):
+        """Whitelist peer address to receive communications from
+
+        This may be called before transport is started, to ensure events generated during
+        start are handled properly.
+        """
+        self._address_to_userids.setdefault(address, set())
+
     def start_health_check(self, node_address):
+        """Start healthcheck (status monitoring) for a peer
+
+        It also whitelists the address to answer invites and listen for messages
+        """
         if self._stop_event.ready():
             return
 
@@ -254,6 +266,7 @@ class MatrixTransport(Runnable):
                 for user in candidates
                 if self._validate_userid_signature(user) == node_address
             }
+            self.whitelist(node_address)
             self._address_to_userids[node_address].update(user_ids)
 
             # Ensure network state is updated in case we already know about the user presences
@@ -442,7 +455,7 @@ class MatrixTransport(Runnable):
             )
 
     def _handle_invite(self, room_id: _RoomID, state: dict):
-        """ Join rooms invited by healthchecked partners """
+        """ Join rooms invited by whitelisted partners """
         if self._stop_event.ready():
             return
 
@@ -482,7 +495,7 @@ class MatrixTransport(Runnable):
 
         if peer_address not in self._address_to_userids:
             self.log.debug(
-                'Got invited by a non-healthchecked user - ignoring',
+                'Got invited by a non-whitelisted user - ignoring',
                 room_id=room_id,
                 user=user,
             )
@@ -549,11 +562,11 @@ class MatrixTransport(Runnable):
             )
             return False
 
-        # don't proceed if user isn't healthchecked (yet)
+        # don't proceed if user isn't whitelisted (yet)
         if peer_address not in self._address_to_userids:
             # user not start_health_check'ed
             self.log.debug(
-                'Message from non-healthchecked peer - ignoring',
+                'Message from non-whitelisted peer - ignoring',
                 sender=user,
                 sender_address=pex(peer_address),
                 room=room,
@@ -934,7 +947,7 @@ class MatrixTransport(Runnable):
             # Malformed address - skip
             return
 
-        # not a user we've started healthcheck, skip
+        # not a user we've whitelisted, skip
         if address not in self._address_to_userids:
             return
         self._address_to_userids[address].add(user_id)
@@ -1186,8 +1199,8 @@ class MatrixTransport(Runnable):
 
     def _leave_unused_rooms(self, _address_to_room_ids: Dict[AddressHex, List[_RoomID]] = None):
         """ Checks for rooms we've joined and which partner isn't health-checked and leave"""
-        # cache in a set all healthchecked addresses
-        healthchecked_hex_addresses: Set[AddressHex] = {
+        # cache in a set all whitelisted addresses
+        whitelisted_hex_addresses: Set[AddressHex] = {
             to_checksum_address(address)
             for address in self._address_to_userids
         }
@@ -1210,7 +1223,7 @@ class MatrixTransport(Runnable):
             if not isinstance(room_ids, list):  # old version, single room
                 room_ids = [room_ids]
 
-            if address_hex not in healthchecked_hex_addresses:
+            if address_hex not in whitelisted_hex_addresses:
                 _address_to_room_ids.pop(address_hex)
                 changed = True
                 continue

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -273,11 +273,23 @@ class UDPTransport(Runnable):
 
         return self.addresses_events[recipient]
 
+    def whitelist(self, address: typing.Address):
+        """Whitelist peer address to receive communications from
+
+        This may be called before transport is started, to ensure events generated during
+        start are handled properly.
+        PS: udp currently doesn't do whitelisting, method defined for compatibility with matrix
+        """
+        return
+
     def start_health_check(self, recipient):
         """ Starts a task for healthchecking `recipient` if there is not
         one yet.
+
+        It also whitelists the address
         """
         if recipient not in self.addresses_events:
+            self.whitelist(recipient)  # noop for now, for compatibility
             ping_nonce = self.nodeaddresses_to_nonces.setdefault(
                 recipient,
                 {'nonce': 0},  # HACK: Allows the task to mutate the object

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -363,6 +363,11 @@ class RaidenService(Runnable):
         self.alarm.register_callback(self._callback_new_block)
         self.alarm.first_run()
 
+        chain_state = views.state_from_raiden(self)
+
+        self._initialize_transactions_queues(chain_state)
+        self._initialize_whitelists(chain_state)
+
         # The transport must not ever be started before the alarm task's first
         # run, because it's this method which synchronizes the node with the
         # blockchain, including the channel's state (if the channel is closed
@@ -370,22 +375,17 @@ class RaidenService(Runnable):
         # the node is not synchronized)
         self.transport.start(self, self.message_handler)
 
-        chain_state = views.state_from_raiden(self)
-
-        self._initialize_transactions_queues(chain_state)
-
         self.alarm.start()
 
         # after transport and alarm is started, send queued messages
-        events_queues = views.get_all_messagequeues(chain_state)
-        self._initialize_messages_queues(events_queues)
+        self._initialize_messages_queues(chain_state)
 
         # exceptions on these subtasks should crash the app and bubble up
         self.alarm.link_exception(self.on_error)
         self.transport.link_exception(self.on_error)
 
         # Health check needs the transport layer
-        self.start_neighbours_healthcheck()
+        self.start_neighbours_healthcheck(chain_state)
 
         if self.config['transport_type'] == 'udp':
             endpoint_registration_greenlet.get()  # re-raise if exception occurred
@@ -439,8 +439,8 @@ class RaidenService(Runnable):
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, pex(self.address))
 
-    def start_neighbours_healthcheck(self):
-        for neighbour in views.all_neighbour_nodes(self.wal.state_manager.current_state):
+    def start_neighbours_healthcheck(self, chain_state):
+        for neighbour in views.all_neighbour_nodes(chain_state):
             if neighbour != ConnectionManager.BOOTSTRAP_ADDR:
                 self.start_health_check_for(neighbour)
 
@@ -603,10 +603,11 @@ class RaidenService(Runnable):
                     else:
                         raise
 
-    def _initialize_messages_queues(self, events_queues):
+    def _initialize_messages_queues(self, chain_state):
         """ Push the queues to the transport and populate
         targets_to_identifiers_to_statuses.
         """
+        events_queues = views.get_all_messagequeues(chain_state)
 
         for queue_identifier, event_queue in events_queues.items():
             self.start_health_check_for(queue_identifier.recipient)
@@ -635,6 +636,25 @@ class RaidenService(Runnable):
                 message = message_from_sendevent(event, self.address)
                 self.sign(message)
                 self.transport.send_async(queue_identifier, message)
+
+    def _initialize_whitelists(self, chain_state):
+        """ Whitelist neighbors and mediated transfer targets on transport """
+
+        for neighbour in views.all_neighbour_nodes(chain_state):
+            if neighbour == ConnectionManager.BOOTSTRAP_ADDR:
+                continue
+            self.transport.whitelist(neighbour)
+
+        events_queues = views.get_all_messagequeues(chain_state)
+
+        for event_queue in events_queues.values():
+            for event in event_queue:
+                is_initiator = (
+                    type(event) == SendLockedTransfer and
+                    event.transfer.initiator == self.address
+                )
+                if is_initiator:
+                    self.transport.whitelist(address=event.transfer.target)
 
     def sign(self, message):
         """ Sign message inplace. """


### PR DESCRIPTION
UDP is noop for now, but for matrix, ensure invites sent while offline are properly handled
Fix #2779 , as per 2. of https://github.com/raiden-network/raiden/issues/2779#issuecomment-432992109