### PR TITLE
bugfix: Mediator task must wait for expired lock

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -303,7 +303,7 @@ def test_regression_mediator_send_lock_expired_with_new_block():
 
     msg = (
         "The payer's lock has also expired, "
-        "but it must not be touched locally (without a Expired lock)"
+        "but it must not be removed locally (without an Expired lock)"
     )
     assert transfer.lock.secrethash in payer_channel.partner_state.secrethashes_to_lockedlocks, msg
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -1,20 +1,37 @@
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
 import random
 
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils import factories
 from raiden.tests.utils.events import must_contain_entry
 from raiden.tests.utils.factories import (
     HOP1,
     HOP2,
+    HOP2_KEY,
+    HOP3_KEY,
+    HOP4,
+    HOP4_KEY,
     UNIT_SECRET,
     UNIT_SECRETHASH,
     UNIT_TOKEN_ADDRESS,
+    UNIT_TRANSFER_IDENTIFIER,
+    UNIT_TRANSFER_INITIATOR,
     UNIT_TRANSFER_SENDER,
+    UNIT_TRANSFER_TARGET,
 )
+from raiden.transfer import channel
 from raiden.transfer.mediated_transfer import mediator
-from raiden.transfer.mediated_transfer.events import SendLockedTransfer
+from raiden.transfer.mediated_transfer.events import (
+    SendLockedTransfer,
+    SendLockExpired,
+    SendRefundTransfer,
+)
 from raiden.transfer.mediated_transfer.state import MediatorTransferState
-from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
+from raiden.transfer.mediated_transfer.state_change import (
+    ActionInitMediator,
+    ReceiveSecretReveal,
+    ReceiveTransferRefund,
+)
 from raiden.transfer.state_change import Block
 
 
@@ -38,6 +55,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         partner_address=UNIT_TRANSFER_SENDER,
         token_address=UNIT_TOKEN_ADDRESS,
     )
+    payer_route = factories.route_from_channel(payer_channel)
 
     payer_transfer = factories.make_signed_transfer_for(
         payer_channel,
@@ -58,14 +76,17 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     }
     possible_routes = [factories.route_from_channel(channel1)]
 
-    mediator_state = MediatorTransferState(UNIT_SECRETHASH)
-    initial_iteration = mediator.mediate_transfer(
-        mediator_state,
+    init_state_change = ActionInitMediator(
         possible_routes,
-        payer_channel,
+        payer_route,
+        payer_transfer,
+    )
+    initial_state = None
+    initial_iteration = mediator.state_transition(
+        initial_state,
+        init_state_change,
         channel_map,
         pseudo_random_generator,
-        payer_transfer,
         block_number,
     )
 
@@ -120,3 +141,176 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         channel_map,
         pseudo_random_generator,
     )
+
+
+def test_regression_send_refund():
+    """Regression test for discarded refund transfer.
+
+    The handle_refundtransfer used to discard events from the channel state
+    machine, which led to the state being updated but the message to the
+    partner was never sent.
+    """
+    amount = 10
+    privatekeys = [HOP2_KEY, HOP3_KEY, HOP4_KEY]
+    pseudo_random_generator = random.Random()
+    block_number = 5
+
+    channel_map, transfers_pair = factories.make_transfers_pair(
+        privatekeys,
+        amount,
+        block_number,
+    )
+
+    mediator_state = MediatorTransferState(UNIT_SECRETHASH)
+    mediator_state.transfers_pair = transfers_pair
+
+    last_pair = transfers_pair[-1]
+    channel_identifier = last_pair.payee_transfer.balance_proof.channel_identifier
+    lock_expiration = last_pair.payee_transfer.lock.expiration
+
+    received_transfer = factories.make_signed_transfer(
+        amount=amount,
+        initiator=UNIT_TRANSFER_INITIATOR,
+        target=UNIT_TRANSFER_TARGET,
+        expiration=lock_expiration,
+        secret=UNIT_SECRET,
+        payment_identifier=UNIT_TRANSFER_IDENTIFIER,
+        channel_identifier=channel_identifier,
+        pkey=HOP4_KEY,
+        sender=HOP4,
+    )
+
+    # All three channels have been used
+    routes = []
+
+    refund_state_change = ReceiveTransferRefund(
+        HOP4,
+        received_transfer,
+        routes,
+    )
+
+    iteration = mediator.handle_refundtransfer(
+        mediator_state,
+        refund_state_change,
+        channel_map,
+        pseudo_random_generator,
+        block_number,
+    )
+
+    first_pair = transfers_pair[0]
+    first_payer_transfer = first_pair.payer_transfer
+    payer_channel = mediator.get_payer_channel(channel_map, first_pair)
+    lock = channel.get_lock(
+        end_state=payer_channel.partner_state,
+        secrethash=UNIT_SECRETHASH,
+    )
+    token_network_identifier = first_payer_transfer.balance_proof.token_network_identifier
+    assert must_contain_entry(iteration.events, SendRefundTransfer, {
+        'recipient': HOP2,
+        'queue_identifier': {
+            'recipient': HOP2,
+            'channel_identifier': first_payer_transfer.balance_proof.channel_identifier,
+        },
+        'payment_identifier': UNIT_TRANSFER_IDENTIFIER,
+        'token': UNIT_TOKEN_ADDRESS,
+        'balance_proof': {
+            # 'nonce': ,
+            'transferred_amount': 0,
+            'locked_amount': 10,
+            'locksroot': lock.lockhash,
+            'token_network_identifier': token_network_identifier,
+            'channel_identifier': first_payer_transfer.balance_proof.channel_identifier,
+            'chain_id': first_payer_transfer.balance_proof.chain_id,
+        },
+        'lock': {
+            'amount': lock.amount,
+            'expiration': lock.expiration,
+            'secrethash': lock.secrethash,
+        },
+        'initiator': UNIT_TRANSFER_INITIATOR,
+        'target': UNIT_TRANSFER_TARGET,
+    })
+
+
+def test_regression_mediator_send_lock_expired_with_new_block():
+    """ The mediator must send the lock expired, but it must **not** clear
+    itself if it has not **received** the corresponding message.
+    """
+    amount = 10
+    block_number = 5
+    target = HOP2
+    expiration = 30
+    pseudo_random_generator = random.Random()
+
+    payer_channel = factories.make_channel(
+        partner_balance=amount,
+        partner_address=UNIT_TRANSFER_SENDER,
+        token_address=UNIT_TOKEN_ADDRESS,
+    )
+    payer_route = factories.route_from_channel(payer_channel)
+
+    payer_transfer = factories.make_signed_transfer_for(
+        payer_channel,
+        amount,
+        HOP1,
+        target,
+        expiration,
+        UNIT_SECRET,
+    )
+
+    channel1 = factories.make_channel(
+        our_balance=amount,
+        token_address=UNIT_TOKEN_ADDRESS,
+    )
+    available_routes = [factories.route_from_channel(channel1)]
+    channel_map = {
+        channel1.identifier: channel1,
+        payer_channel.identifier: payer_channel,
+    }
+
+    init_state_change = ActionInitMediator(
+        available_routes,
+        payer_route,
+        payer_transfer,
+    )
+    initial_state = None
+    init_iteration = mediator.state_transition(
+        initial_state,
+        init_state_change,
+        channel_map,
+        pseudo_random_generator,
+        block_number,
+    )
+    assert init_iteration.new_state is not None
+    send_transfer = must_contain_entry(init_iteration.events, SendLockedTransfer, {})
+    assert send_transfer
+
+    transfer = send_transfer.transfer
+
+    block_expiration_number = transfer.lock.expiration + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS * 2
+    block = Block(
+        block_number=block_expiration_number,
+        gas_limit=1,
+        block_hash=factories.make_transaction_hash(),
+    )
+    iteration = mediator.state_transition(
+        init_iteration.new_state,
+        block,
+        channel_map,
+        pseudo_random_generator,
+        block_expiration_number,
+    )
+
+    msg = (
+        "The payer's lock has also expired, "
+        "but it must not be touched locally (without a Expired lock)"
+    )
+    assert transfer.lock.secrethash in payer_channel.partner_state.secrethashes_to_lockedlocks, msg
+
+    msg = 'The payer has not yet sent an expired lock, the task can not be cleared yet'
+    assert iteration.new_state is not None, msg
+
+    assert must_contain_entry(iteration.events, SendLockExpired, {
+        'secrethash': transfer.lock.secrethash,
+    })
+    assert transfer.lock.secrethash not in channel1.our_state.secrethashes_to_lockedlocks

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -241,7 +241,7 @@ def clear_if_finalized(iteration, channelidentifiers_to_channels):
     if state is None:
         return iteration
 
-    # Only clear the taks if all channels have the lock cleared.
+    # Only clear the task if all channels have the lock cleared.
     secrethash = state.secrethash
     for pair in state.transfers_pair:
         payer_channel = get_payer_channel(channelidentifiers_to_channels, pair)


### PR DESCRIPTION
The mediator task definition of finalized was wrong. The task was
considered final the lock expired, which happens once the corresponding
block was mined.

The consequence is that during a run where the lock expired, the
mediator would send the remove expire lock message, and set the status
of the task as finalized, leading the task to be cleared. The problem is
that the mediator task is also responsible to handle the remove expired
lock messages, and if is clered these messages are not handled, leading
to synchronization problems among the participants.