### PR TITLE
Fixed log message

### DIFF
--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -241,7 +241,7 @@ def handle_block(
         channel_state.partner_state,
         lock.secrethash,
     )
-    lock_has_expired, lock_expired_msg = channel.is_lock_expired(
+    lock_has_expired, _ = channel.is_lock_expired(
         end_state=channel_state.our_state,
         lock=lock,
         block_number=block_number,
@@ -252,7 +252,7 @@ def handle_block(
         failed = EventUnlockClaimFailed(
             identifier=transfer.payment_identifier,
             secrethash=transfer.lock.secrethash,
-            reason=f'lock expired {lock_expired_msg}',
+            reason=f'lock expired',
         )
         target_state.state = 'expired'
         events = [failed]


### PR DESCRIPTION
When the lock has expired the message is None, appending it to the event
will result in the string `lock expired None`.