### PR TITLE
Force node to v10 on macOS builds

### DIFF
--- a/.travis/prepare_os_osx.sh
+++ b/.travis/prepare_os_osx.sh
@@ -4,6 +4,7 @@ set -e
 set -x
 
 PYTHON_36_FORMULA=https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb
+NODE_10_URL=https://nodejs.org/download/release/v10.12.0/node-v10.12.0-darwin-x64.tar.xz
 
 # Don't spam logs
 brew update > /dev/null
@@ -11,7 +12,7 @@ brew update > /dev/null
 # Remove to prevent a slow update cascade
 brew uninstall postgis
 
-for tool in automake gmp leveldb libffi libtool node openssl pkg-config sqlite3; do
+for tool in automake gmp leveldb libffi libtool openssl pkg-config sqlite3; do
     brew install ${tool} || brew upgrade ${tool} || true
 done
 
@@ -22,6 +23,16 @@ brew install ${PYTHON_36_FORMULA} || brew unlink python && brew install --force 
 # create links so python 3 tools get used
 ln -sf /usr/local/bin/pip3 $HOME/.bin/pip
 ln -sf /usr/local/bin/python3 $HOME/.bin/python
+
+# Download node
+wget ${NODE_10_URL}
+node_dl_file=$(basename ${NODE_10_URL})
+tar xvf $(basename ${NODE_10_URL})
+rm ${node_dl_file}
+ln -sf ${node_dl_file%.tar.xz}/bin/node /usr/local/bin/
+ln -sf ${node_dl_file%.tar.xz}/bin/npm /usr/local/bin/
+ln -sf ${node_dl_file%.tar.xz}/bin/npx /usr/local/bin/
+
 
 # some debug info
 ls -la $HOME/.bin


### PR DESCRIPTION
Brew recently updated node to v11.
Apparently there aren't pre-built binaries of some packages
(`fsevents` was the one that came up) for node v11 yet. This
causes our compile_webui task to try building those from source which
requires node-gyp which in turn requires Python 2 which isn't available
on our macOS environment.

Fixes #2907

[ci nightly]