### PR TITLE
Fix flaky test_batch_unlock

### DIFF
--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -8,6 +8,7 @@ from eth_utils import denoms, remove_0x_prefix, to_normalized_address
 from raiden.constants import Environment
 from raiden.network.utils import get_free_port
 from raiden.settings import (
+    DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     DEFAULT_RETRY_TIMEOUT,
     DEFAULT_TRANSPORT_THROTTLE_CAPACITY,
     DEFAULT_TRANSPORT_THROTTLE_FILL_RATE,
@@ -70,7 +71,7 @@ def reveal_timeout(number_of_nodes):
     # Because the lock expiration is fixed, and it's computed based on the
     # reveal timeout value, we need to make it large enough to accomodate for
     # the room creation and invite, the formula below is used for that:
-    return number_of_nodes * 4
+    return number_of_nodes * 4 + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 
 
 @pytest.fixture


### PR DESCRIPTION
Only in Travis test_batch_unlock failed some times flakily with the following [logs](https://gist.github.com/LefterisJP/61827579badbc759a6e25bea28a70f6c).

What happens is that the attempted transfer:
```
[<HashTimeLockState amount:10 expiration:55 secrethash:88b432dc>]
0x88b432dc032ca2fdcc6b98a9bc0cb539f68f40971523e5698aa2f5fc28804097
```

has a lock expiration of `55`.

But according to the logs:
```
2018-10-26 23:05:21 [debug    ] Received new block             [raiden.tasks] block_hash=0x875b1450d0ca06114aafaba0f3f85a90a874ad5133ad58d8b28cf9bee33a5681 gas_limit=9492431 number=55
2018-10-26 23:05:21 [debug    ] State change                   [raiden.raiden_service] node=03ced6e8 state_change={"block_number": 50, "gas_limit": 9538911, "block_hash": "0xc3058ae034198402d893837f70c04a7c2bd2e0758cfcd894ce9b3bc601cecbbe", "_type": "raiden.transfer.state_change.Block", "_version": 0}
2018-10-26 23:05:21 [info     ] registerSecretBatch successful [raiden.network.proxies.secret_registry] contract=eda9cc0e node=03ced6e8 secrethashes=['0x88b432dc032ca2fdcc6b98a9bc0cb539f68f40971523e5698aa2f5fc28804097'] secrethashes_not_sent=[]
2018-10-26 23:05:22 [debug ] Received new block [raiden.tasks]
block_hash=0x5bb88b56572c1180987a74bc9e835dade0b82342f48d70c13486e1c0588573ed
gas_limit=9483231 number=56
```

the client seems to be 1 block late to send the register secret transaction. So in the end after batch unlock the initiator gets the tokens back instead of the target.

Since this started right after the change to [confirmed block emitting](https://github.com/raiden-network/raiden/pull/2895/commits/2691264dbe5d3ec3b59aa22db887bfd183f335f4) it's safe to assume that this happens because there is an introduced delay of 5 blocks for all actions when it comes to the blockchain. This should be properly addressed when #2885 is implemented.

Until then the tests had a reveal timeout pretty close to the default number of confirmation blocks which lead to this flaky test failing some times.

So the fix is to change the reveal timeout for tests to adjust for the default number of confirmation blocks.

**Important note:** This can't happen in production due to the larger number of reveal timeout blocks we use there. But the delay in acting is still there.