### PR TITLE
Matrix per-receiver retry message queue

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -430,21 +430,13 @@ class MatrixTransport(Runnable):
         queue_identifier: QueueIdentifier,
         message: Message,
     ):
-        # even if transport is not started, can run to enqueue messages to send when it starts
-        message_id = message.message_identifier
-        receiver_address = queue_identifier.recipient
+        """Queue the message for sending to recipient in the queue_identifier
 
-        assert queue_identifier in self._queueids_to_queues
-        message_in_queue = any(
-            message_id == event.message_identifier
-            for event in self._queueids_to_queues[queue_identifier]
-        )
-        if not message_in_queue:
-            self.log.warning(
-                'Message not in queue',
-                message=message,
-                queue=queue_identifier,
-            )
+        It may be called before transport is started, to initialize message queues
+        The actual sending is started only when the transport is started
+        """
+        # even if transport is not started, can run to enqueue messages to send when it starts
+        receiver_address = queue_identifier.recipient
 
         if not is_binary_address(receiver_address):
             raise ValueError('Invalid address {}'.format(pex(receiver_address)))

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -273,11 +273,23 @@ class UDPTransport(Runnable):
 
         return self.addresses_events[recipient]
 
+    def whitelist(self, address: typing.Address):
+        """Whitelist peer address to receive communications from
+
+        This may be called before transport is started, to ensure events generated during
+        start are handled properly.
+        PS: udp currently doesn't do whitelisting, method defined for compatibility with matrix
+        """
+        return
+
     def start_health_check(self, recipient):
         """ Starts a task for healthchecking `recipient` if there is not
         one yet.
+
+        It also whitelists the address
         """
         if recipient not in self.addresses_events:
+            self.whitelist(recipient)  # noop for now, for compatibility
             ping_nonce = self.nodeaddresses_to_nonces.setdefault(
                 recipient,
                 {'nonce': 0},  # HACK: Allows the task to mutate the object

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -371,13 +371,14 @@ class RaidenService(Runnable):
         # messages to be enqueued before these older ones
         self._initialize_messages_queues(chain_state)
 
-        # The transport must not ever be started before the alarm task's first
-        # run, because it's this method which synchronizes the node with the
-        # blockchain, including the channel's state (if the channel is closed
-        # on-chain new messages must be rejected, which will not be the case if
-        # the node is not synchronized)
+        # The transport must not ever be started before the alarm task's
+        # `first_run()` has been, because it's this method which synchronizes the
+        # node with the blockchain, including the channel's state (if the channel
+        # is closed on-chain new messages must be rejected, which will not be the
+        # case if the node is not synchronized)
         self.transport.start(self, self.message_handler)
 
+        # First run has been called above!
         self.alarm.start()
 
         # exceptions on these subtasks should crash the app and bubble up

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -306,7 +306,7 @@ def database_paths(tmpdir, private_keys):
 
 @pytest.fixture
 def private_rooms():
-    return True
+    return False
 
 
 @pytest.fixture

--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -18,6 +18,6 @@ def pytest_generate_tests(metafunc):
             if 'public_and_private_rooms' in metafunc.fixturenames:
                 transport_and_privacy.extend([('matrix', False), ('matrix', True)])
             else:
-                transport_and_privacy.append(('matrix', True))
+                transport_and_privacy.append(('matrix', False))
 
         metafunc.parametrize('transport,private_rooms', transport_and_privacy)


### PR DESCRIPTION
Previously, we spawned a greenlet to retry each message, and kept retrying them blindly every timeout, skipping if the user was offline but despite events such as the user coming online, until the event with same `message_identifier` was cleaned from the respective `queueids_to_queue` queue.

This PR changes that to one `Runnable` per **receiver** (as, with matrix, the messages for any channel goes in the same room), and use a notification system on the loop, to allow bursts of messages to be batched (going on the body of a single Matrix's `send_text`/HTTP request, and as well being fetched on the same `/sync` response), relying then on the natural ordering of the messages on the receiver to process them in-order as well, or (if any fails) be retried if not cleared on next notify/retry loop.

This also enables us to enqueue queued messages before starting the transport, but starting the actual sends only after transport is started.

Should fix #2893, although it was non-fatal and couldn't be reproduced to create a test for it. Despite that, this change **is internal to matrix**, and doesn't change the interface with Raiden, so it's tested by all current tests that test matrix (as per `CONTRIBUTING.md` about private/protected methods and implementation).
Built on top of #2889, as it requires the changes there to whitelist the partners before transport start.