### PR TITLE
Fix shortened variable names

### DIFF
--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -391,10 +391,10 @@ def maybe_add_tokennetwork(
 
     if token_network_state_previous is None:
         ids_to_tokens = payment_network_state.tokenidentifiers_to_tokennetworks
-        addrs_to_ids = payment_network_state.tokenaddresses_to_tokenidentifiers
+        addresses_to_ids = payment_network_state.tokenaddresses_to_tokenidentifiers
 
         ids_to_tokens[token_network_identifier] = token_network_state
-        addrs_to_ids[token_address] = token_network_identifier
+        addresses_to_ids[token_address] = token_network_identifier
 
 
 def sanity_check(iteration: TransitionResult):

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -89,8 +89,8 @@ def handle_channelnew(token_network_state, state_change):
     # the ethereum node
     if channel_identifier not in token_network_state.channelidentifiers_to_channels:
         token_network_state.channelidentifiers_to_channels[channel_identifier] = channel_state
-        addrs_to_ids = token_network_state.partneraddresses_to_channelidentifiers
-        addrs_to_ids[partner_address].append(channel_identifier)
+        addresses_to_ids = token_network_state.partneraddresses_to_channelidentifiers
+        addresses_to_ids[partner_address].append(channel_identifier)
 
     return TransitionResult(token_network_state, events)
 


### PR DESCRIPTION
Small improvement for #2968 , as pointed out by @LefterisJP in the review.