### PR TITLE
Convert QueueId keys to string before logging

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -749,7 +749,9 @@ class MatrixTransport(Runnable):
                         'Queue cleaned, stop retrying',
                         message=message,
                         queue=queue_identifier,
-                        queueids_to_queues=self._queueids_to_queues,
+                        queueids_to_queues={
+                            str(k): v for k, v in self._queueids_to_queues.items()
+                        },
                     )
                     break
                 # retry while the message is in queue


### PR DESCRIPTION
Fixes #2981 


I didn't find a nice way to generically convert keys to strings during serialization, so I think this is the best solution. 
There is a way like described in https://stackoverflow.com/a/28079487 , but this would come with a performance penalty for all log invocations.