### PR TITLE
Handle transaction execution error for parity

### DIFF
--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -45,10 +45,11 @@ def inspect_client_error(val_err: ValueError, eth_node: str) -> ClientErrorInspe
                 return ClientErrorInspectResult.TRANSACTION_PENDING
 
     elif eth_node == EthClient.PARITY:
-        if error['code'] == -32010 and 'insufficient funds' in error['message']:
-            return ClientErrorInspectResult.INSUFFICIENT_FUNDS
-        elif error['code'] == -32010 and 'another transaction with same nonce in the queue':
-            return ClientErrorInspectResult.TRANSACTION_UNDERPRICED
+        if error['code'] == -32010:
+            if 'insufficient funds' in error['message']:
+                return ClientErrorInspectResult.INSUFFICIENT_FUNDS
+            elif 'another transaction with same nonce in the queue' in error['message']:
+                return ClientErrorInspectResult.TRANSACTION_UNDERPRICED
         elif error['code'] == -32015 and 'Transaction execution error' in error['message']:
             return ClientErrorInspectResult.ALWAYS_FAIL
 

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -49,6 +49,8 @@ def inspect_client_error(val_err: ValueError, eth_node: str) -> ClientErrorInspe
             return ClientErrorInspectResult.INSUFFICIENT_FUNDS
         elif error['code'] == -32010 and 'another transaction with same nonce in the queue':
             return ClientErrorInspectResult.TRANSACTION_UNDERPRICED
+        elif error['code'] == -32015 and 'Transaction execution error' in error['message']:
+            return ClientErrorInspectResult.ALWAYS_FAIL
 
     return ClientErrorInspectResult.PROPAGATE_ERROR
 


### PR DESCRIPTION
Triggered by https://github.com/raiden-network/raiden/issues/2984

- We now recognize when parity's estimate gas tells us the transaction will always fail
- Fixed a bug where we were not detecting the `TRANSACTION_UNDERPRICED` case for parity