### PR TITLE
Fix join dialog overflow

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug'`2963` Fixes an overflow issue with the hint of the join network dialog.
 * :bug:`2973` Introduce special handling of infura endpoints so that the old getTransactionCount is used.
 * :feature:`2946` Do not show full block information in the INFO logging message.
 * :bug:`2921` Properly estimate gas cost of transactions so that we have a more reasonable minimal amount of ETH required to run Raiden.

--- a/raiden/ui/web/src/app/components/token-input/token-input.component.css
+++ b/raiden/ui/web/src/app/components/token-input/token-input.component.css
@@ -1,3 +1,7 @@
 .checkbox {
-    padding-bottom: 0.8em;
+    padding-bottom: 1.1rem;
+}
+
+.form {
+    min-height: 5rem;
 }

--- a/raiden/ui/web/src/app/components/token-input/token-input.component.html
+++ b/raiden/ui/web/src/app/components/token-input/token-input.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="row" [formGroup]="form">
+<div fxLayout="row" [formGroup]="form" class="form">
     <mat-form-field fxLayout="column" fxFlex="1 1 auto" [hideRequiredMarker]="true">
         <input matInput type="number"
                [placeholder]="placeholder"

--- a/raiden/ui/web/src/app/components/token-network/token-network.component.ts
+++ b/raiden/ui/web/src/app/components/token-network/token-network.component.ts
@@ -156,7 +156,7 @@ export class TokenNetworkComponent implements OnInit, OnDestroy {
         };
 
         const joinDialogRef = this.dialog.open(JoinDialogComponent, {
-            width: '400px',
+            width: '480px',
             data: payload
         });
 


### PR DESCRIPTION
* Increased the height of the for container so that the second line of the hint doesn't have to overflow.

![image](https://user-images.githubusercontent.com/2269732/48258387-46519d00-e415-11e8-9b49-fcf825a36335.png)



Closes #2963