### PR TITLE
Try to handle estimateGas predicting that a call will fail

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -13,7 +13,13 @@ from raiden.network.proxies import (
 )
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import privatekey_to_address
-from raiden.utils.typing import Address, ChannelID, T_ChannelID, TokenNetworkAddress
+from raiden.utils.typing import (
+    Address,
+    ChannelID,
+    PaymentNetworkID,
+    T_ChannelID,
+    TokenNetworkAddress,
+)
 from raiden_contracts.contract_manager import ContractManager
 
 
@@ -143,7 +149,7 @@ class BlockChainService:
             if address not in self.address_to_token_network_registry:
                 self.address_to_token_network_registry[address] = TokenNetworkRegistry(
                     jsonrpc_client=self.client,
-                    registry_address=address,
+                    registry_address=PaymentNetworkID(address),
                     contract_manager=self.contract_manager,
                 )
 

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -6,8 +6,18 @@ from web3.utils.filters import Filter
 from raiden.constants import UINT256_MAX
 from raiden.network.proxies import TokenNetwork
 from raiden.network.proxies.token_network import ChannelDetails
-from raiden.utils import typing
 from raiden.utils.filters import decode_event, get_filter_args_for_specific_event_from_channel
+from raiden.utils.typing import (
+    AdditionalHash,
+    Address,
+    BalanceHash,
+    BlockSpecification,
+    ChannelID,
+    Locksroot,
+    Nonce,
+    Signature,
+    TokenAmount,
+)
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
 from raiden_contracts.contract_manager import ContractManager
 
@@ -16,7 +26,7 @@ class PaymentChannel:
     def __init__(
             self,
             token_network: TokenNetwork,
-            channel_identifier: typing.ChannelID,
+            channel_identifier: ChannelID,
             contract_manager: ContractManager,
     ):
 
@@ -53,7 +63,7 @@ class PaymentChannel:
         self.participant2 = participant2
         self.token_network = token_network
 
-    def token_address(self) -> typing.Address:
+    def token_address(self) -> Address:
         """ Returns the address of the token for the channel. """
         return self.token_network.token_address()
 
@@ -87,7 +97,7 @@ class PaymentChannel:
         )
         return event['args']['settle_timeout']
 
-    def close_block_number(self) -> typing.Optional[int]:
+    def close_block_number(self) -> Optional[int]:
         """ Returns the channel's closed block number. """
 
         # The closed block number is not in the smart contract storage to save
@@ -134,7 +144,7 @@ class PaymentChannel:
             channel_identifier=self.channel_identifier,
         )
 
-    def closing_address(self) -> Optional[typing.Address]:
+    def closing_address(self) -> Optional[Address]:
         """ Returns the address of the closer of the channel. """
         return self.token_network.closing_address(
             participant1=self.participant1,
@@ -150,7 +160,7 @@ class PaymentChannel:
             channel_identifier=self.channel_identifier,
         )
 
-    def set_total_deposit(self, total_deposit: typing.TokenAmount):
+    def set_total_deposit(self, total_deposit: TokenAmount):
         self.token_network.set_total_deposit(
             channel_identifier=self.channel_identifier,
             total_deposit=total_deposit,
@@ -159,10 +169,10 @@ class PaymentChannel:
 
     def close(
             self,
-            nonce: typing.Nonce,
-            balance_hash: typing.BalanceHash,
-            additional_hash: typing.AdditionalHash,
-            signature: typing.Signature,
+            nonce: Nonce,
+            balance_hash: BalanceHash,
+            additional_hash: AdditionalHash,
+            signature: Signature,
     ):
         """ Closes the channel using the provided balance proof. """
         self.token_network.close(
@@ -176,11 +186,11 @@ class PaymentChannel:
 
     def update_transfer(
             self,
-            nonce: typing.Nonce,
-            balance_hash: typing.BalanceHash,
-            additional_hash: typing.AdditionalHash,
-            partner_signature: typing.Signature,
-            signature: typing.Signature,
+            nonce: Nonce,
+            balance_hash: BalanceHash,
+            additional_hash: AdditionalHash,
+            partner_signature: Signature,
+            signature: Signature,
     ):
         """ Updates the channel using the provided balance proof. """
         self.token_network.update_transfer(
@@ -204,10 +214,10 @@ class PaymentChannel:
             self,
             transferred_amount: int,
             locked_amount: int,
-            locksroot: typing.Locksroot,
+            locksroot: Locksroot,
             partner_transferred_amount: int,
             partner_locked_amount: int,
-            partner_locksroot: typing.Locksroot,
+            partner_locksroot: Locksroot,
     ):
         """ Settles the channel. """
         self.token_network.settle(
@@ -223,8 +233,8 @@ class PaymentChannel:
 
     def all_events_filter(
             self,
-            from_block: typing.BlockSpecification = None,
-            to_block: typing.BlockSpecification = None,
+            from_block: BlockSpecification = None,
+            to_block: BlockSpecification = None,
     ) -> Filter:
 
         channel_topics = [

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -142,6 +142,7 @@ class PaymentChannel:
             participant1=self.participant1,
             participant2=self.participant2,
             channel_identifier=self.channel_identifier,
+            block_identifier='latest',
         )
 
     def closing_address(self) -> Optional[Address]:

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -82,7 +82,7 @@ class SecretRegistry:
             log.debug('registerSecretBatch skipped', **log_details)
             return
 
-        gas_limit = self.proxy.estimate_gas('latest', 'registerSecretBatch', secrets)
+        gas_limit = self.proxy.estimate_gas('pending', 'registerSecretBatch', secrets)
         if not gas_limit:
             log.critical(
                 'Call to registerSecretBatch will fail. Out of funds?',

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -82,7 +82,7 @@ class SecretRegistry:
             log.debug('registerSecretBatch skipped', **log_details)
             return
 
-        gas_limit = self.proxy.estimate_gas('registerSecretBatch', secrets)
+        gas_limit = self.proxy.estimate_gas('latest', 'registerSecretBatch', secrets)
         if not gas_limit:
             log.critical(
                 'Call to registerSecretBatch will fail. Out of funds?',

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -106,6 +106,17 @@ class SecretRegistry:
 
         transaction_executed = gas_limit is not None
         if not transaction_executed or receipt_or_none:
+            if transaction_executed:
+                block = receipt_or_none['blockNumber']
+            else:
+                block = 'pending'
+
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='registerSecretBatch',
+                transaction_executed=transaction_executed,
+                required_gas=len(secrets) * GAS_REQUIRED_PER_SECRET_IN_BATCH,
+                block_identifier=block,
+            )
             error_msg = f'{error_prefix}. {msg}'
             log.critical(error_msg, **log_details)
             raise RaidenUnrecoverableError(error_msg)

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -9,7 +9,8 @@ from raiden.exceptions import InvalidAddress, RaidenUnrecoverableError
 from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit, sha3, typing
+from raiden.utils import pex, privatekey_to_address, safe_gas_limit, sha3
+from raiden.utils.typing import BlockSpecification, Keccak256, Secret
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, EVENT_SECRET_REVEALED
 from raiden_contracts.contract_manager import ContractManager
 
@@ -47,10 +48,10 @@ class SecretRegistry:
         self.node_address = privatekey_to_address(self.client.privkey)
         self.open_secret_transactions = dict()
 
-    def register_secret(self, secret: typing.Secret):
+    def register_secret(self, secret: Secret):
         self.register_secret_batch([secret])
 
-    def register_secret_batch(self, secrets: List[typing.Secret]):
+    def register_secret_batch(self, secrets: List[Secret]):
         secrets_to_register = list()
         secrethashes_to_register = list()
         secrethashes_not_sent = list()
@@ -111,16 +112,16 @@ class SecretRegistry:
 
         log.info('registerSecretBatch successful', **log_details)
 
-    def get_register_block_for_secrethash(self, secrethash: typing.Keccak256) -> int:
+    def get_register_block_for_secrethash(self, secrethash: Keccak256) -> int:
         return self.proxy.contract.functions.getSecretRevealBlockHeight(secrethash).call()
 
-    def check_registered(self, secrethash: typing.Keccak256) -> bool:
+    def check_registered(self, secrethash: Keccak256) -> bool:
         return self.get_register_block_for_secrethash(secrethash) > 0
 
     def secret_registered_filter(
             self,
-            from_block: typing.BlockSpecification = GENESIS_BLOCK_NUMBER,
-            to_block: typing.BlockSpecification = 'latest',
+            from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
+            to_block: BlockSpecification = 'latest',
     ) -> StatelessFilter:
         event_abi = self.contract_manager.get_event_abi(
             CONTRACT_SECRET_REGISTRY,

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -85,10 +85,10 @@ class SecretRegistry:
         gas_limit = self.proxy.estimate_gas('registerSecretBatch', secrets)
         if not gas_limit:
             log.critical(
-                'registerSecretBatch will always fail',
+                'Call to registerSecretBatch will fail. Out of funds?',
                 **log_details,
             )
-            raise RaidenUnrecoverableError('RegisterSecretBatch transaction will always fail')
+            raise RaidenUnrecoverableError('Call to registerSecretBatch will fail. Out of funds?')
 
         try:
             log.debug('registerSecretBatch called', **log_details)

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -13,6 +13,9 @@ from raiden_contracts.contract_manager import ContractManager
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
+# Determined by safe_gas_limit(estimateGas(approve)) on 17/01/19 with geth 1.8.20
+GAS_REQUIRED_FOR_APPROVE = 58792
+
 
 class Token:
     def __init__(
@@ -86,6 +89,13 @@ class Token:
                 block = receipt_or_none['blockNumber']
             else:
                 block = 'pending'
+
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='approve',
+                transaction_executed=transaction_executed,
+                required_gas=GAS_REQUIRED_FOR_APPROVE,
+                block_identifier=block,
+            )
 
             msg = self._check_why_approved_failed(allowance, block)
             error_msg = f'{error_prefix}. {msg}'

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -59,6 +59,7 @@ class Token:
         }
 
         startgas = self.proxy.estimate_gas(
+            'latest',
             'approve',
             to_checksum_address(allowed_address),
             allowance,

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -42,7 +42,7 @@ class Token:
             to_checksum_address(spender),
         ).call()
 
-    def approve(self, allowed_address: typing.AddressHex, allowance: typing.TokenAmount):
+    def approve(self, allowed_address: typing.Address, allowance: typing.TokenAmount):
         """ Aprove `allowed_address` to transfer up to `deposit` amount of token.
 
         Note:

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -66,10 +66,11 @@ class Token:
         if not startgas:
             msg = self._check_why_approved_failed(allowance)
             log.critical(
-                f'approve transaction will always fail due to,  {msg}',
+                'Call to approve transaction will fail',
+                msg=msg,
                 **log_details,
             )
-            raise RaidenUnrecoverableError('Approve transaction will always fail')
+            raise RaidenUnrecoverableError('Call to approve transaction will fail')
 
         log.debug('approve called', **log_details)
         transaction_hash = self.proxy.transact(
@@ -107,22 +108,23 @@ class Token:
         # allowance, which is not necessarily the case)
         elif user_balance < allowance:
             msg = (
-                'Approve failed. \n'
-                'Your account balance is {}, nevertheless the call to '
-                'approve failed. Please make sure the corresponding smart '
-                'contract is a valid ERC20 token.'
-            ).format(user_balance)
+                f'Approve failed. \n'
+                f'Your account balance is {user_balance}. '
+                f'The requested allowance is {allowance}. '
+                f'The smart contract may be rejecting your request due to the '
+                f'lack of balance.'
+            )
 
         # If the user has enough balance, warn the user the smart contract
         # may not have the approve function.
         else:
             msg = (
                 f'Approve failed. \n'
-                f'Your account balance is {user_balance}, '
-                f'the request allowance is {allowance}. '
-                f'The smart contract may be rejecting your request for the '
-                f'lack of balance.'
-            )
+                f'Your account balance is {user_balance}. Nevertheless the call to'
+                f'approve failed. Please make sure the corresponding smart '
+                f'contract is a valid ERC20 token.'
+            ).format(user_balance)
+
         return msg
 
     def balance_of(self, address):

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -59,7 +59,7 @@ class Token:
         }
 
         startgas = self.proxy.estimate_gas(
-            'latest',
+            'pending',
             'approve',
             to_checksum_address(allowed_address),
             allowance,

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -6,7 +6,8 @@ from raiden.exceptions import RaidenUnrecoverableError, TransactionThrew
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit, typing
+from raiden.utils import pex, privatekey_to_address, safe_gas_limit
+from raiden.utils.typing import Address, BlockSpecification, TokenAmount
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
 
@@ -42,7 +43,7 @@ class Token:
             to_checksum_address(spender),
         ).call(block_identifier=block_identifier)
 
-    def approve(self, allowed_address: typing.Address, allowance: typing.TokenAmount):
+    def approve(self, allowed_address: Address, allowance: TokenAmount):
         """ Aprove `allowed_address` to transfer up to `deposit` amount of token.
 
         Note:
@@ -95,8 +96,8 @@ class Token:
 
     def _check_why_approved_failed(
             self,
-            allowance: typing.TokenAmount,
-            block_identifier: typing.BlockSpecification,
+            allowance: TokenAmount,
+            block_identifier: BlockSpecification,
     ) -> str:
         user_balance = self.balance_of(
             address=self.client.address,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -622,7 +622,7 @@ class TokenNetwork:
             # in which case  the second `approve` will overwrite the first,
             # and the first `setTotalDeposit` will consume the allowance,
             #  making the second deposit fail.
-            token.approve(self.address, amount_to_deposit)
+            token.approve(typing.Address(self.address), amount_to_deposit)
 
             gas_limit = self.proxy.estimate_gas(
                 'setTotalDeposit',

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1025,9 +1025,6 @@ class TokenNetwork:
                     locksroot,
                 )
                 if not gas_limit:
-                    # Context switch before we check the channel data in
-                    # case the partner already settled and this is why settle would fail
-                    gevent.sleep(1)
                     self._check_channel_state_before_settle(
                         participant1=self.node_address,
                         participant2=partner,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -168,6 +168,7 @@ class TokenNetwork:
             'peer2': pex(partner),
         }
         gas_limit = self.proxy.estimate_gas(
+            'latest',
             'openChannel',
             self.node_address,
             partner,
@@ -626,6 +627,7 @@ class TokenNetwork:
             token.approve(typing.Address(self.address), amount_to_deposit)
 
             gas_limit = self.proxy.estimate_gas(
+                'latest',
                 'setTotalDeposit',
                 channel_identifier,
                 self.node_address,
@@ -929,6 +931,7 @@ class TokenNetwork:
         leaves_packed = b''.join(lock.encoded for lock in merkle_tree_leaves)
 
         gas_limit = self.proxy.estimate_gas(
+            'latest',
             'unlock',
             channel_identifier,
             self.node_address,
@@ -1013,6 +1016,7 @@ class TokenNetwork:
 
             if our_bp_is_larger:
                 gas_limit = self.proxy.estimate_gas(
+                    'latest',
                     'settleChannel',
                     channel_identifier,
                     partner,
@@ -1050,6 +1054,7 @@ class TokenNetwork:
                 )
             else:
                 gas_limit = self.proxy.estimate_gas(
+                    'latest',
                     'settleChannel',
                     channel_identifier,
                     self.node_address,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -177,8 +177,9 @@ class TokenNetwork:
             channel_exists = self.channel_exists_and_not_settled(self.node_address, partner)
             if channel_exists:
                 raise DuplicatedChannelError('Duplicated channel')
-            log.critical('openChannel will always fail', **log_details)
-            raise RaidenUnrecoverableError('creating new channel failed')
+
+            log.critical('Call to openChannel will fail', **log_details)
+            raise RaidenUnrecoverableError('Call to openChannel will fail')
 
         log.debug('new_netting_channel called', **log_details)
 
@@ -680,9 +681,9 @@ class TokenNetwork:
             log_details: typing.Dict,
     ):
         latest_deposit = self.detail_participant(
-            channel_identifier,
-            self.node_address,
-            partner,
+            channel_identifier=channel_identifier,
+            participant=self.node_address,
+            partner=partner,
         ).deposit
 
         if token.allowance(self.node_address, self.address) < amount_to_deposit:
@@ -701,10 +702,10 @@ class TokenNetwork:
         log.critical(log_msg, **log_details)
 
         self._check_channel_state_for_deposit(
-            self.node_address,
-            partner,
-            channel_identifier,
-            total_deposit,
+            participant1=self.node_address,
+            participant2=partner,
+            channel_identifier=channel_identifier,
+            deposit_amount=total_deposit,
         )
 
     def close(

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1247,12 +1247,12 @@ class TokenNetwork:
     def _settle_preconditions(
             self,
             channel_identifier: ChannelID,
-            transferred_amount: int,
-            locked_amount: int,
+            transferred_amount: TokenAmount,
+            locked_amount: TokenAmount,
             locksroot: Locksroot,
             partner: Address,
-            partner_transferred_amount: int,
-            partner_locked_amount: int,
+            partner_transferred_amount: TokenAmount,
+            partner_locked_amount: TokenAmount,
             partner_locksroot: Locksroot,
             block_identifier: BlockSpecification,
     ):
@@ -1295,12 +1295,12 @@ class TokenNetwork:
     def settle(
             self,
             channel_identifier: ChannelID,
-            transferred_amount: int,
-            locked_amount: int,
+            transferred_amount: TokenAmount,
+            locked_amount: TokenAmount,
             locksroot: Locksroot,
             partner: Address,
-            partner_transferred_amount: int,
-            partner_locked_amount: int,
+            partner_transferred_amount: TokenAmount,
+            partner_locked_amount: TokenAmount,
             partner_locksroot: Locksroot,
     ):
         """ Settle the channel. """
@@ -1539,7 +1539,7 @@ class TokenNetwork:
             channel_identifier: ChannelID,
             block_identifier: BlockSpecification,
     ) -> str:
-        str = ''
+        msg = ''
         channel_data = self._check_channel_state_before_settle(
             participant1=participant1,
             participant2=participant2,
@@ -1547,11 +1547,11 @@ class TokenNetwork:
             block_identifier=block_identifier,
         )
         if channel_data.state == ChannelState.CLOSED:
-            str = (
+            msg = (
                 "Settling this channel failed although the channel's current state "
                 "is closed.",
             )
-        return str
+        return msg
 
     def _check_channel_state_for_update(
             self,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -168,7 +168,7 @@ class TokenNetwork:
             'peer2': pex(partner),
         }
         gas_limit = self.proxy.estimate_gas(
-            'latest',
+            'pending',
             'openChannel',
             self.node_address,
             partner,
@@ -627,7 +627,7 @@ class TokenNetwork:
             token.approve(typing.Address(self.address), amount_to_deposit)
 
             gas_limit = self.proxy.estimate_gas(
-                'latest',
+                'pending',
                 'setTotalDeposit',
                 channel_identifier,
                 self.node_address,
@@ -931,7 +931,7 @@ class TokenNetwork:
         leaves_packed = b''.join(lock.encoded for lock in merkle_tree_leaves)
 
         gas_limit = self.proxy.estimate_gas(
-            'latest',
+            'pending',
             'unlock',
             channel_identifier,
             self.node_address,
@@ -1016,7 +1016,7 @@ class TokenNetwork:
 
             if our_bp_is_larger:
                 gas_limit = self.proxy.estimate_gas(
-                    'latest',
+                    'pending',
                     'settleChannel',
                     channel_identifier,
                     partner,
@@ -1054,7 +1054,7 @@ class TokenNetwork:
                 )
             else:
                 gas_limit = self.proxy.estimate_gas(
-                    'latest',
+                    'pending',
                     'settleChannel',
                     channel_identifier,
                     self.node_address,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -277,6 +277,12 @@ class TokenNetwork:
             self.open_channel_transactions[partner].get()
 
         if not gas_limit:
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='openChannel',
+                transaction_executed=False,
+                required_gas=GAS_REQUIRED_FOR_OPEN_CHANNEL,
+                block_identifier='pending',
+            )
             known_race, msg = self._new_channel_postconditions(
                 partner=partner,
                 block='pending',
@@ -769,6 +775,13 @@ class TokenNetwork:
                     block = receipt_or_none['blockNumber']
                 else:
                     block = 'pending'
+
+                self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                    transaction_name='setTotalDeposit',
+                    transaction_executed=transaction_executed,
+                    required_gas=GAS_REQUIRED_FOR_SET_TOTAL_DEPOSIT,
+                    block_identifier=block,
+                )
                 error_type, msg = self._check_why_deposit_failed(
                     channel_identifier=channel_identifier,
                     partner=partner,
@@ -940,6 +953,12 @@ class TokenNetwork:
             else:
                 block = 'pending'
 
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='closeChannel',
+                transaction_executed=transaction_executed,
+                required_gas=GAS_REQUIRED_FOR_CLOSE_CHANNEL,
+                block_identifier=block,
+            )
             error_type, msg = self._check_channel_state_for_close(
                 participant1=self.node_address,
                 participant2=partner,
@@ -1101,6 +1120,12 @@ class TokenNetwork:
                 block = 'pending'
                 to_compare_block = self.client.block_number()
 
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='updateNonClosingBalanceProof',
+                transaction_executed=transaction_executed,
+                required_gas=GAS_REQUIRED_FOR_UPDATE_BALANCE_PROOF,
+                block_identifier=block,
+            )
             detail = self.detail_channel(
                 participant1=self.node_address,
                 participant2=partner,
@@ -1197,6 +1222,12 @@ class TokenNetwork:
             else:
                 block = 'pending'
 
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='unlock',
+                transaction_executed=transaction_executed,
+                required_gas=UNLOCK_TX_GAS_LIMIT,
+                block_identifier=block,
+            )
             channel_settled = self.channel_is_settled(
                 participant1=self.node_address,
                 participant2=partner,
@@ -1328,6 +1359,12 @@ class TokenNetwork:
             else:
                 block = 'pending'
 
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='settleChannel',
+                transaction_executed=transaction_executed,
+                required_gas=GAS_REQUIRED_FOR_SETTLE_CHANNEL,
+                block_identifier=block,
+            )
             msg = self._check_channel_state_after_settle(
                 participant1=self.node_address,
                 participant2=partner,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -302,7 +302,7 @@ class TokenNetwork:
             participant2: Address,
             called_by_fn: str,
             channel_identifier: ChannelID = None,
-            block_identifier: BlockSpecification ='pending',
+            block_identifier: BlockSpecification = 'pending',
     ) -> ChannelID:
         if not channel_identifier:
             channel_identifier = self._call_and_check_result(
@@ -544,7 +544,7 @@ class TokenNetwork:
             participant1: Address,
             participant2: Address,
             channel_identifier: ChannelID = None,
-            block_identifier: BlockSpecification = 'pending',
+            block_identifier: BlockSpecification = 'latest',
     ) -> Optional[Address]:
         """ Returns the address of the closer, if the channel is closed and not settled. None
         otherwise. """

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -126,10 +126,11 @@ class TokenNetworkRegistry:
             else:
                 block = 'pending'
 
+            required_gas = gas_limit if gas_limit else GAS_REQUIRED_FOR_CREATE_ERC20_TOKEN_NETWORK
             self.proxy.jsonrpc_client.check_for_insufficient_eth(
                 transaction_name='createERC20TokenNetwork',
                 transaction_executed=transaction_executed,
-                required_gas=GAS_REQUIRED_FOR_CREATE_ERC20_TOKEN_NETWORK,
+                required_gas=required_gas,
                 block_identifier=block,
             )
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -126,6 +126,13 @@ class TokenNetworkRegistry:
             else:
                 block = 'pending'
 
+            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                transaction_name='createERC20TokenNetwork',
+                transaction_executed=transaction_executed,
+                required_gas=GAS_REQUIRED_FOR_CREATE_ERC20_TOKEN_NETWORK,
+                block_identifier=block,
+            )
+
             msg = ''
             if self.get_token_network(token_address, block):
                 msg = 'Token already registered'

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -20,8 +20,8 @@ from web3.eth import Eth
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 from web3.utils.contracts import prepare_transaction
+from web3.utils.empty import empty
 from web3.utils.toolz import assoc
-from web3.utls.empty import empty
 
 from raiden import constants
 from raiden.exceptions import AddressWithoutCode, EthNodeCommunicationError, EthNodeInterfaceError
@@ -304,13 +304,13 @@ def patched_contractfunction_estimateGas(self, transaction=None, block_identifie
             )
 
     return estimate_gas_for_function(
-        address=self.address,
-        web3=self.web3,
-        fn_identifier=self.function_identifier,
-        transaction=estimate_gas_transaction,
-        contract_abi=self.contract_abi,
-        fn_abi=self.abi,
-        block_identifier=block_identifier,
+        self.address,
+        self.web3,
+        self.function_identifier,
+        estimate_gas_transaction,
+        self.contract_abi,
+        self.abi,
+        block_identifier,
         *self.args,
         **self.kwargs,
     )

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -257,21 +257,21 @@ def patched_web3_eth_estimate_gas(self, transaction, block_identifier=None):
         params = [transaction, block_identifier]
 
     return self.web3.manager.request_blocking(
-        "eth_estimateGas",
+        'eth_estimateGas',
         params,
     )
 
 
 def estimate_gas_for_function(
-    address,
-    web3,
-    fn_identifier=None,
-    transaction=None,
-    contract_abi=None,
-    fn_abi=None,
-    block_identifier=None,
-    *args,
-    **kwargs,
+        address,
+        web3,
+        fn_identifier=None,
+        transaction=None,
+        contract_abi=None,
+        fn_abi=None,
+        block_identifier=None,
+        *args,
+        **kwargs,
 ):
     """Temporary workaround until next web3.py release (5.X.X)"""
     estimate_transaction = prepare_transaction(
@@ -292,7 +292,7 @@ def estimate_gas_for_function(
 def patched_contractfunction_estimateGas(self, transaction=None, block_identifier=None):
     """Temporary workaround until next web3.py release (5.X.X)"""
     if transaction is None:
-            estimate_gas_transaction = {}
+        estimate_gas_transaction = {}
     else:
         estimate_gas_transaction = dict(**transaction)
 

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -186,6 +186,11 @@ class ContractProxy:
         """Returns a gas estimate for the function with the given arguments or
         None if the function call will fail due to Insufficient funds or
         the logic in the called function."""
+        msg = (
+            'At the moment since geth only accepts pending block for estimateGas '
+            'we enforce the same behaviour for all clients. Please use "pending".'
+        )
+        assert block_identifier == 'pending', msg
         fn = getattr(self.contract.functions, function)
         address = to_checksum_address(self.jsonrpc_client.address)
         if self.jsonrpc_client.eth_node == constants.EthClient.GETH:

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -193,6 +193,10 @@ class ContractProxy:
             # does not accept a block identifier argument for eth_estimateGas
             # parity and py-evm (trinity) do.
             #
+            # Geth only runs estimateGas on the pending block and that's why we
+            # should also enforce parity, py-evm and others to do the same since
+            # we can't customize geth.
+            #
             # Spec: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas
             # Geth Issue: https://github.com/ethereum/go-ethereum/issues/2586
             # Relevant web3 PR: https://github.com/ethereum/web3.py/pull/1046

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -181,15 +181,17 @@ class ContractProxy:
     def encode_function_call(self, function: str, args: List = None):
         return self.get_transaction_data(self.contract.abi, function, args)
 
-    def estimate_gas(self, function: str, *args) -> typing.Optional[int]:
+    def estimate_gas(self, block_identifier, function: str, *args) -> typing.Optional[int]:
         """Returns a gas estimate for the function with the given arguments or
         None if the function call will fail due to Insufficient funds or
         the logic in the called function."""
         fn = getattr(self.contract.functions, function)
+        address = to_checksum_address(self.jsonrpc_client.address)
         try:
-            return fn(*args).estimateGas({
-                'from': to_checksum_address(self.jsonrpc_client.address),
-            })
+            return fn(*args).estimateGas(
+                transaction={'from': address},
+                block_identifier=block_identifier,
+            )
         except ValueError as err:
             action = inspect_client_error(err, self.jsonrpc_client.eth_node)
             will_fail = action in (

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -183,7 +183,7 @@ class ContractProxy:
 
     def estimate_gas(self, function: str, *args) -> typing.Optional[int]:
         """Returns a gas estimate for the function with the given arguments or
-        None if the function call will always fail due to Insufficient funds or
+        None if the function call will fail due to Insufficient funds or
         the logic in the called function."""
         fn = getattr(self.contract.functions, function)
         try:

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -181,7 +181,10 @@ class ContractProxy:
     def encode_function_call(self, function: str, args: List = None):
         return self.get_transaction_data(self.contract.abi, function, args)
 
-    def estimate_gas(self, function: str, *args):
+    def estimate_gas(self, function: str, *args) -> typing.Optional[int]:
+        """Returns a gas estimate for the function with the given arguments or
+        None if the function call will always fail due to Insufficient funds or
+        the logic in the called function."""
         fn = getattr(self.contract.functions, function)
         try:
             return fn(*args).estimateGas({

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -55,12 +55,12 @@ def secret_registry_proxy_patched(secret_registry_proxy, contract_manager):
     )
     _register_secret_batch = secret_registry_patched._register_secret_batch
 
-    def register_secret_batch_patched(self, secrets):
+    def register_secret_batch_patched(self, secrets, gas_limit):
         """Make sure the transaction is sent only once per secret"""
         for secret in secrets:
             assert secret not in self.trigger
             self.trigger[secret] = True
-        return _register_secret_batch(secrets)
+        return _register_secret_batch(secrets, gas_limit)
 
     secret_registry_patched._register_secret_batch = types.MethodType(
         register_secret_batch_patched,

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -53,14 +53,14 @@ def secret_registry_proxy_patched(secret_registry_proxy, contract_manager):
         secret_registry_address=secret_registry_proxy.address,
         contract_manager=contract_manager,
     )
-    _register_secret_batch = secret_registry_patched._register_secret_batch
+    register_secret_batch = secret_registry_patched.register_secret_batch
 
-    def register_secret_batch_patched(self, secrets, gas_limit):
+    def register_secret_batch_patched(self, secrets):
         """Make sure the transaction is sent only once per secret"""
         for secret in secrets:
             assert secret not in self.trigger
             self.trigger[secret] = True
-        return _register_secret_batch(secrets, gas_limit)
+        return register_secret_batch(secrets)
 
     secret_registry_patched._register_secret_batch = types.MethodType(
         register_secret_batch_patched,

--- a/raiden/tests/integration/contracts/test_token.py
+++ b/raiden/tests/integration/contracts/test_token.py
@@ -31,6 +31,6 @@ def test_token(
     assert allow_funds == token_proxy.proxy.contract.functions.allowance(
         to_checksum_address(deploy_client.address),
         to_checksum_address(address),
-    ).call()
+    ).call(block_identifier='latest')
     other_token_proxy.transfer(deploy_client.address, transfer_funds)
     assert token_proxy.balance_of(address) == 0

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -9,7 +9,6 @@ from raiden.exceptions import (
     RaidenRecoverableError,
     RaidenUnrecoverableError,
     SamePeerAddress,
-    TransactionThrew,
 )
 from raiden.network.proxies import TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
@@ -104,6 +103,7 @@ def test_token_network_proxy_basics(
     ) is False
 
     channel_identifier = c1_token_network_proxy._call_and_check_result(
+        'latest',
         'getChannelIdentifier',
         to_checksum_address(c1_client.address),
         to_checksum_address(c2_client.address),
@@ -219,7 +219,7 @@ def test_token_network_proxy_basics(
         data=balance_proof.serialize_bin(),
     ))
     # close with invalid signature
-    with pytest.raises(TransactionThrew):
+    with pytest.raises(RaidenUnrecoverableError):
         c2_token_network_proxy.close(
             channel_identifier=channel_identifier,
             partner=c1_client.address,
@@ -436,7 +436,7 @@ def test_token_network_proxy_update_transfer(
         privkey=encode_hex(c2_client.privkey),
         data=non_closing_data,
     )
-    with pytest.raises(TransactionThrew):
+    with pytest.raises(RaidenUnrecoverableError):
         c2_token_network_proxy.update_transfer(
             channel_identifier,
             c1_client.address,

--- a/raiden/tests/integration/contracts/test_token_network_registry.py
+++ b/raiden/tests/integration/contracts/test_token_network_registry.py
@@ -1,7 +1,7 @@
 import pytest
 from eth_utils import is_same_address, to_canonical_address
 
-from raiden.exceptions import RaidenRecoverableError, TransactionThrew
+from raiden.exceptions import RaidenRecoverableError, RaidenUnrecoverableError
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.smartcontracts import deploy_token
@@ -19,7 +19,7 @@ def test_token_network_registry(
 
     bad_token_address = make_address()
     # try to register non-existing token network
-    with pytest.raises(TransactionThrew):
+    with pytest.raises(RaidenUnrecoverableError):
         token_network_registry_proxy.add_token(bad_token_address)
     # create token network & register it
     test_token = deploy_token(

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -109,7 +109,7 @@ def test_estimate_gas_fail(deploy_client):
     address = contract_proxy.contract_address
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
-    assert not contract_proxy.estimate_gas('fail')
+    assert not contract_proxy.estimate_gas('latest', 'fail')
 
 
 def test_duplicated_transaction_same_gas_price_raises(deploy_client):
@@ -132,7 +132,7 @@ def test_duplicated_transaction_same_gas_price_raises(deploy_client):
         contract_proxy.contract_address,
     )
 
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('ret'))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'ret'))
 
     with pytest.raises(TransactionAlreadyPending):
         second_proxy.transact('ret', startgas)
@@ -158,7 +158,7 @@ def test_duplicated_transaction_different_gas_price_raises(deploy_client):
         contract_proxy.contract_address,
     )
 
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('ret'))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'ret'))
 
     with pytest.raises(ReplacementTransactionUnderpriced):
         second_proxy.transact('ret', startgas)
@@ -172,7 +172,7 @@ def test_transact_opcode(deploy_client):
     address = contract_proxy.contract_address
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
-    startgas = contract_proxy.estimate_gas('ret') * 2
+    startgas = contract_proxy.estimate_gas('latest', 'ret') * 2
 
     transaction = contract_proxy.transact('ret', startgas)
     deploy_client.poll(transaction)
@@ -204,7 +204,7 @@ def test_transact_opcode_oog(deploy_client):
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     # divide the estimate by 2 to run into out-of-gas
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('loop', 1000)) // 2
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'loop', 1000)) // 2
 
     transaction = contract_proxy.transact('loop', startgas, 1000)
     deploy_client.poll(transaction)
@@ -217,7 +217,7 @@ def test_filter_start_block_inclusive(deploy_client):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     # call the create event function twice and wait for confirmation each time
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('createEvent', 1))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'createEvent', 1))
     transaction_1 = contract_proxy.transact('createEvent', startgas, 1)
     deploy_client.poll(transaction_1)
     transaction_2 = contract_proxy.transact('createEvent', startgas, 2)
@@ -249,7 +249,7 @@ def test_filter_end_block_inclusive(deploy_client):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     # call the create event function twice and wait for confirmation each time
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('createEvent', 1))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'createEvent', 1))
     transaction_1 = contract_proxy.transact('createEvent', startgas, 1)
     deploy_client.poll(transaction_1)
     transaction_2 = contract_proxy.transact('createEvent', startgas, 2)

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -109,7 +109,7 @@ def test_estimate_gas_fail(deploy_client):
     address = contract_proxy.contract_address
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
-    assert not contract_proxy.estimate_gas('latest', 'fail')
+    assert not contract_proxy.estimate_gas('pending', 'fail')
 
 
 def test_duplicated_transaction_same_gas_price_raises(deploy_client):
@@ -132,7 +132,7 @@ def test_duplicated_transaction_same_gas_price_raises(deploy_client):
         contract_proxy.contract_address,
     )
 
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'ret'))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('pending', 'ret'))
 
     with pytest.raises(TransactionAlreadyPending):
         second_proxy.transact('ret', startgas)
@@ -158,7 +158,7 @@ def test_duplicated_transaction_different_gas_price_raises(deploy_client):
         contract_proxy.contract_address,
     )
 
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'ret'))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('pending', 'ret'))
 
     with pytest.raises(ReplacementTransactionUnderpriced):
         second_proxy.transact('ret', startgas)
@@ -172,7 +172,7 @@ def test_transact_opcode(deploy_client):
     address = contract_proxy.contract_address
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
-    startgas = contract_proxy.estimate_gas('latest', 'ret') * 2
+    startgas = contract_proxy.estimate_gas('pending', 'ret') * 2
 
     transaction = contract_proxy.transact('ret', startgas)
     deploy_client.poll(transaction)
@@ -204,7 +204,7 @@ def test_transact_opcode_oog(deploy_client):
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     # divide the estimate by 2 to run into out-of-gas
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'loop', 1000)) // 2
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('pending', 'loop', 1000)) // 2
 
     transaction = contract_proxy.transact('loop', startgas, 1000)
     deploy_client.poll(transaction)
@@ -217,7 +217,7 @@ def test_filter_start_block_inclusive(deploy_client):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     # call the create event function twice and wait for confirmation each time
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'createEvent', 1))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('pending', 'createEvent', 1))
     transaction_1 = contract_proxy.transact('createEvent', startgas, 1)
     deploy_client.poll(transaction_1)
     transaction_2 = contract_proxy.transact('createEvent', startgas, 2)
@@ -249,7 +249,7 @@ def test_filter_end_block_inclusive(deploy_client):
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
     # call the create event function twice and wait for confirmation each time
-    startgas = safe_gas_limit(contract_proxy.estimate_gas('latest', 'createEvent', 1))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas('pending', 'createEvent', 1))
     transaction_1 = contract_proxy.transact('createEvent', startgas, 1)
     deploy_client.poll(transaction_1)
     transaction_2 = contract_proxy.transact('createEvent', startgas, 2)

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -9,9 +9,9 @@ from raiden.constants import Environment
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     DepositOverLimit,
-    InsufficientFunds,
     InsufficientGasReserve,
     InvalidAddress,
+    RaidenUnrecoverableError,
 )
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.events import must_have_event, wait_for_state_change
@@ -111,8 +111,8 @@ def test_register_token_insufficient_eth(raiden_network, token_amount, contract_
     # app1.raiden loses all its ETH because it has been naughty
     burn_eth(app1.raiden)
 
-    # At this point we should get the InsufficientFunds exception
-    with pytest.raises(InsufficientFunds):
+    # At this point we should get an UnrecoverableError due to InsufficientFunds
+    with pytest.raises(RaidenUnrecoverableError):
         api1.token_network_register(registry_address, token_address)
 
 

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -9,9 +9,9 @@ from raiden.constants import Environment
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     DepositOverLimit,
+    InsufficientFunds,
     InsufficientGasReserve,
     InvalidAddress,
-    RaidenUnrecoverableError,
 )
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.events import must_have_event, wait_for_state_change
@@ -112,7 +112,7 @@ def test_register_token_insufficient_eth(raiden_network, token_amount, contract_
     burn_eth(app1.raiden)
 
     # At this point we should get an UnrecoverableError due to InsufficientFunds
-    with pytest.raises(RaidenUnrecoverableError):
+    with pytest.raises(InsufficientFunds):
         api1.token_network_register(registry_address, token_address)
 
 

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -280,11 +280,10 @@ def optional_address_to_string(
     return to_checksum_address(address)
 
 
-def safe_gas_limit(*estimates) -> int:
-    """ Calculates a safe gas limit for a number of estimates.
-
-    Even though it's not documented, it does happen that estimate_gas returns `None`.
-    This function takes care of this and adds a security margin as well.
+def safe_gas_limit(*estimates: int) -> int:
+    """ Calculates a safe gas limit for a number of gas estimates
+    including a security margin
     """
-    calculated_limit = max(gas or 0 for gas in estimates)
+    assert None not in estimates, 'if estimateGas returned None it should not reach here'
+    calculated_limit = max(estimates)
     return int(calculated_limit * constants.GAS_FACTOR)


### PR DESCRIPTION
After the changes introduced by https://github.com/raiden-network/raiden/pull/2623/ we again rely on gas estimation for the gas limit to provide to an onchain call which is great since it reduces our overall ETH balance requirements.

But we don't take into account the fact that if estimateGas returns `None` it's
because the transaction will fail, either due to our account not having enough
funds or because the call will just revert somewhere down the line due to the
contract logic (e.g. calling settle before closing).

With that in mind we can now detect those bad cases a bit earlier and handle
them without sending an onchain transaction. This is what this PR is trying to achieve.

Admittedly all those cases are bad ones. Since all the checks should have stopped us from getting into that part of the code in the first place, unless we expected that sending an onchain transaction will succeed.