### PR TITLE
Remove unused state machine code and view function

### DIFF
--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -497,19 +497,7 @@ def handle_token_network_action(
             pseudo_random_generator,
             chain_state.block_number,
         )
-
-        if iteration.new_state is None:
-            payment_network_state = views.search_payment_network_by_token_network_id(
-                chain_state,
-                state_change.token_network_identifier,
-            )
-
-            del payment_network_state.tokenaddresses_to_tokenidentifiers[
-                token_network_state.token_address
-            ]
-            del payment_network_state.tokenidentifiers_to_tokennetworks[
-                token_network_state.address
-            ]
+        assert iteration.new_state, 'No token network state transition leads to None'
 
         events = iteration.events
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -519,23 +519,6 @@ def list_all_channelstate(chain_state: ChainState) -> typing.List[NettingChannel
     return result
 
 
-def search_payment_network_by_token_network_id(
-        chain_state: ChainState,
-        token_network_id: typing.Address,
-) -> typing.Optional['PaymentNetworkState']:
-
-    payment_network_state = None
-    for payment_network in chain_state.identifiers_to_paymentnetworks.values():
-        token_network_state = payment_network.tokenidentifiers_to_tokennetworks.get(
-            token_network_id,
-        )
-
-        if token_network_state:
-            return payment_network_state
-
-    return payment_network_state
-
-
 def filter_channels_by_partneraddress(
         chain_state: ChainState,
         payment_network_id: typing.PaymentNetworkID,


### PR DESCRIPTION
Fix #2991

There is no state [transition](https://github.com/raiden-network/raiden/blob/761bedfee2ee326401ad5ec95d55b1ab458a5213/raiden/transfer/token_network.py#L338) that can lead to a `None` new state for the token network state machine.

With that in mind I removed the part of the `handle_token_network_action()` which does that and deletes a token network from the payment network state.

Incidentally this was also the only place `search_payment_network_by_token_network_id` was used so I also deleted that function. As pointed out in #2991 the function is wrong.

There is another function which does the same thing and does it correctly. It's [get_token_network_registry_by_token_network_identifier()](https://github.com/raiden-network/raiden/blob/761bedfee2ee326401ad5ec95d55b1ab458a5213/raiden/transfer/views.py#L140).