### PR TITLE
Fix restore_to_state_change logging

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -332,16 +332,16 @@ class RaidenEventHandler:
         token_address = channel_unlock_event.token_address
 
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
-            token_network_identifier,
-            channel_identifier,
+            token_network_address=token_network_identifier,
+            channel_id=channel_identifier,
         )
         token_network: TokenNetwork = payment_channel.token_network
 
         # Fetch on-chain balance hashes for both participants
         participants_details = token_network.detail_participants(
-            raiden.address,
-            participant,
-            channel_identifier,
+            participant1=raiden.address,
+            participant2=participant,
+            channel_identifier=channel_identifier,
         )
 
         our_details = participants_details.our_details

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -14,12 +14,14 @@ def channel_state_until_state_change(
         state_change_identifier: int,
 ) -> typing.Optional[NettingChannelState]:
     """ Go through WAL state changes until a certain balance hash is found. """
-    # Restore state from the latest snapshot
     wal = restore_to_state_change(
-        node.state_transition,
-        raiden.wal.storage,
-        state_change_identifier,
+        transition_function=node.state_transition,
+        storage=raiden.wal.storage,
+        state_change_identifier=state_change_identifier,
     )
+
+    msg = 'There is a state change, therefore the state must not be None'
+    assert wal.state_manager.current_state is not None, msg
 
     channel_state = views.get_channelstate_by_id(
         chain_state=wal.state_manager.current_state,

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -347,9 +347,9 @@ def get_channelstate_by_id(
         channel_id: typing.ChannelID,
 ) -> typing.Optional[NettingChannelState]:
     token_network = get_token_network_by_token_address(
-        chain_state,
-        payment_network_id,
-        token_address,
+        chain_state=chain_state,
+        payment_network_id=payment_network_id,
+        token_address=token_address,
     )
 
     channel_state = None


### PR DESCRIPTION
The function `get_snapshot_closest_to_state_change` always returns a
tuple, which may be `(None, 0)`. In the previous code this return value
would be check for truthiness, which even though the values in the tuple
evaluate to False, the tuple itself evaluate to True because it has
elements. The end result was just improper logging.

This also improves the logging and adds assertions to easy debugging.

These are the changes I used to figure out part of https://github.com/raiden-network/raiden/issues/2931