### PR TITLE
Forbid invalid upgrades

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -22,7 +22,7 @@ from raiden.settings import (
     DEFAULT_TRANSPORT_UDP_RETRY_INTERVAL,
     INITIAL_PORT,
 )
-from raiden.storage.versions import older_db_files_exist
+from raiden.storage.versions import older_db_file
 from raiden.utils import pex, typing
 from raiden_contracts.contract_manager import contracts_precompiled_path
 
@@ -95,20 +95,20 @@ class App:  # pylint: disable=too-few-public-methods
 
         # Check if files with older versions of the DB exist, emit a warning
         db_base_path = os.path.dirname(config['database_path'])
-        old_version_path = older_db_files_exist(db_base_path)
+        old_version_path = older_db_file(db_base_path)
         if old_version_path:
             old_version_file = os.path.basename(old_version_path)
             raise RuntimeError(
                 f'A database file for a previous version of Raiden exists '
                 f'{old_version_path}. Because the new version of Raiden '
-                f'introduces changes which breaks compatibility with the old '
+                f'introduces changes which break compatibility with the old '
                 f'database, a new database is necessary. The new database '
                 f'file will be created automatically for you, but as a side effect all '
                 f'previous data will be unavailable. The only way to proceed '
                 f'without the risk of losing funds is to leave all token networks '
                 f'and *make a backup* of the existing database. Please, *after* all the '
                 f'existing channels have been settled, make sure to make a backup by '
-                f'renaming {old_version_file} to {old_version_file}_backup, and the new '
+                f'renaming {old_version_file} to {old_version_file}_backup. Then the new '
                 f'version of Raiden can be used.',
             )
 

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -95,12 +95,21 @@ class App:  # pylint: disable=too-few-public-methods
 
         # Check if files with older versions of the DB exist, emit a warning
         db_base_path = os.path.dirname(config['database_path'])
-        if older_db_files_exist(db_base_path):
-            log.warning(
-                'Older versions of the database exist in '
-                f'{db_base_path}. Since a newer breaking version is introduced, '
-                'it is advised that you leave all token networks before upgrading and '
-                'then proceed with the upgrade.',
+        old_version_path = older_db_files_exist(db_base_path)
+        if old_version_path:
+            old_version_file = os.path.basename(old_version_path)
+            raise RuntimeError(
+                f'A database file for a previous version of Raiden exists '
+                f'{old_version_path}. Because the new version of Raiden '
+                f'introduces changes which breaks compatibility with the old '
+                f'database, a new database is necessary. The new database '
+                f'file will be created automatically for you, but as a side effect all '
+                f'previous data will be unavailable. The only way to proceed '
+                f'without the risk of losing funds is to leave all token networks '
+                f'and *make a backup* of the existing database. Please, *after* all the '
+                f'existing channels have been settled, make sure to make a backup by '
+                f'renaming {old_version_file} to {old_version_file}_backup, and the new '
+                f'version of Raiden can be used.',
             )
 
         # check that the settlement timeout fits the limits of the contract

--- a/raiden/storage/versions.py
+++ b/raiden/storage/versions.py
@@ -2,18 +2,21 @@ import os
 import re
 from glob import glob
 
+from raiden.utils import typing
+
 from .sqlite import RAIDEN_DB_VERSION
 
 VERSION_RE = re.compile("^v(\d+).*")
 
 
-def older_db_files_exist(database_base_path: str):
+def older_db_files_exist(database_base_path: str) -> typing.Optional[str]:
     """ Check if the directory contains database files that
     belong to the previous version of the schema. """
     database_base_path = os.path.expanduser(database_base_path)
     db_files = glob(f'{database_base_path}/**/*.db', recursive=True)
     for db_file in db_files:
-        matches = VERSION_RE.search(os.path.basename(db_file))
+        expanded_name = os.path.basename(db_file)
+        matches = VERSION_RE.search(expanded_name)
         if not matches:
             continue
         try:
@@ -22,6 +25,6 @@ def older_db_files_exist(database_base_path: str):
             continue
 
         if version < RAIDEN_DB_VERSION:
-            return True
+            return expanded_name
 
-    return False
+    return None

--- a/raiden/storage/versions.py
+++ b/raiden/storage/versions.py
@@ -9,9 +9,10 @@ from .sqlite import RAIDEN_DB_VERSION
 VERSION_RE = re.compile("^v(\d+).*")
 
 
-def older_db_files_exist(database_base_path: str) -> typing.Optional[str]:
-    """ Check if the directory contains database files that
-    belong to the previous version of the schema. """
+def older_db_file(database_base_path: str) -> typing.Optional[str]:
+    """ Returns the path to a database file that belong to the previous version
+    of the schema.
+    """
     database_base_path = os.path.expanduser(database_base_path)
     db_files = glob(f'{database_base_path}/**/*.db', recursive=True)
     for db_file in db_files:

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -97,6 +97,9 @@ class NodeRunner:
         except (EthNodeCommunicationError, RequestsConnectionError):
             print(ETHEREUM_NODE_COMMUNICATION_ERROR)
             sys.exit(1)
+        except RuntimeError as e:
+            click.secho(str(e), fg='red')
+            sys.exit(1)
         except EthNodeInterfaceError as e:
             click.secho(str(e), fg='red')
             sys.exit(1)


### PR DESCRIPTION
When a database version upgrade happens, the user must take action and
exit all the token networks and rename the existing database file. This
should not happen often, as the database format is choosen to be
upgradable, but to avoid problems with testing realeases and possible
future breaking changes a check was added.

This should help to prevent problems like #2931
Edit: This does **not** prevent #2931 , it's another problem.