### PR TITLE
Fix Refund transfer serialization

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`3022` Reject REST API channel opening with an error if there is not enough token balance for the initial deposit.
 * :bug:`2932` Node will no longer crash if it mediated a transfer and the channel cycle for mediation has completed.
 * :bug:`3001` Don't delete payment task when receiving invalid secret request.
+* :bug:`2931` Fixes serialization of state changes for refund transfers, allowing it to be used for unlocks.
 
 * :release:`0.16.0 <2018-11-09>`
 * :bug:`2963` Fixes an overflow issue with the hint of the join network dialog.

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -91,10 +91,9 @@ class MessageHandler:
     def handle_message_lockexpired(self, raiden: RaidenService, message: LockExpired):
         balance_proof = balanceproof_from_envelope(message)
         state_change = ReceiveLockExpired(
-            message.sender,
-            balance_proof,
-            message.secrethash,
-            message.message_identifier,
+            balance_proof=balance_proof,
+            secrethash=message.secrethash,
+            message_identifier=message.message_identifier,
         )
         raiden.handle_state_change(state_change)
 
@@ -120,16 +119,14 @@ class MessageHandler:
         if role == 'initiator':
             secret = random_secret()
             state_change = ReceiveTransferRefundCancelRoute(
-                message.sender,
-                routes,
-                from_transfer,
-                secret,
+                routes=routes,
+                transfer=from_transfer,
+                secret=secret,
             )
         else:
             state_change = ReceiveTransferRefund(
-                message.sender,
-                from_transfer,
-                routes,
+                transfer=from_transfer,
+                routes=routes,
             )
 
         raiden.handle_state_change(state_change)

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -921,6 +921,7 @@ class TokenNetwork:
             ChannelBusyError: If the channel is busy with another operation
         """
         log_details = {
+            'channel_identifier': channel_identifier,
             'token_network': pex(self.address),
             'node': pex(self.node_address),
             'partner': pex(partner),

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 12
+RAIDEN_DB_VERSION = 13
 
 
 class EventRecord(typing.NamedTuple):

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -252,12 +252,15 @@ class SQLiteStorage:
             args.append(f'$.{field}')
             args.append(value)
 
-        cursor.execute(
-            "SELECT identifier, data FROM state_changes WHERE "
-            f"{' AND '.join(where_clauses)}"
-            "ORDER BY identifier DESC LIMIT 1",
-            args,
+        where = ' AND '.join(where_clauses)
+        sql = (
+            f'SELECT identifier, data '
+            f'FROM state_changes '
+            f'WHERE {where} '
+            f'ORDER BY identifier '
+            f'DESC LIMIT 1'
         )
+        cursor.execute(sql, args)
 
         result = StateChangeRecord(state_change_identifier=0, data=None)
         try:

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1300,10 +1300,9 @@ def test_regression_must_update_balanceproof_remove_expired_lock():
     )
 
     lock_expired = ReceiveLockExpired(
-        channel_state.partner_state.address,
-        receive_lockedtransfer.balance_proof,
-        lock_secrethash,
-        1,
+        balance_proof=receive_lockedtransfer.balance_proof,
+        secrethash=lock_secrethash,
+        message_identifier=1,
     )
 
     is_valid, _, _ = channel.is_valid_lock_expired(
@@ -2000,10 +1999,9 @@ def test_valid_lock_expired_for_unlocked_lock():
     )
 
     lock_expired = ReceiveLockExpired(
-        channel_state.partner_state.address,
-        receive_lockedtransfer.balance_proof,
-        lock_secrethash,
-        1,
+        balance_proof=receive_lockedtransfer.balance_proof,
+        secrethash=lock_secrethash,
+        message_identifier=1,
     )
 
     is_valid, _, _ = channel.is_valid_lock_expired(

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -193,7 +193,6 @@ def test_get_state_change_with_balance_proof():
             token_network_identifier=balance_proof.token_network_identifier,
             channel_identifier=balance_proof.channel_identifier,
             sender=balance_proof.sender,
-            locksroot=balance_proof.locksroot,
             balance_hash=balance_proof.balance_hash,
         )
         assert state_change_record.data == state_change
@@ -270,7 +269,6 @@ def test_get_event_with_balance_proof():
             chain_id=balance_proof.chain_id,
             token_network_identifier=balance_proof.token_network_identifier,
             channel_identifier=balance_proof.channel_identifier,
-            locksroot=balance_proof.locksroot,
             balance_hash=balance_proof.balance_hash,
         )
         assert event_record.data == event

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -1,0 +1,130 @@
+import itertools
+from datetime import datetime
+
+from eth_utils import to_checksum_address
+
+from raiden.messages import Lock
+from raiden.storage.serialize import JSONSerializer
+from raiden.storage.sqlite import SQLiteStorage
+from raiden.tests.utils import factories
+from raiden.transfer.mediated_transfer.state_change import (
+    ReceiveLockExpired,
+    ReceiveTransferRefund,
+    ReceiveTransferRefundCancelRoute,
+)
+from raiden.transfer.state_change import ReceiveTransferDirect, ReceiveUnlock
+from raiden.utils import sha3
+from raiden.utils.serialization import serialize_bytes
+
+
+def make_signed_balance_proof_from_counter(counter):
+    lock = Lock(
+        amount=next(counter),
+        expiration=next(counter),
+        secrethash=sha3(factories.make_secret(next(counter))),
+    )
+    lock_expired_balance_proof = factories.make_signed_balance_proof(
+        nonce=next(counter),
+        transferred_amount=next(counter),
+        locked_amount=next(counter),
+        token_network_address=factories.make_address(),
+        channel_identifier=next(counter),
+        locksroot=sha3(lock.as_bytes),
+        extra_hash=sha3(b''),
+        private_key=factories.HOP1_KEY,
+        sender_address=factories.HOP1,
+    )
+
+    return lock_expired_balance_proof
+
+
+def make_signed_transfer_from_counter(counter):
+    lock = Lock(
+        amount=next(counter),
+        expiration=next(counter),
+        secrethash=sha3(factories.make_secret(next(counter))),
+    )
+
+    signed_transfer = factories.make_signed_transfer(
+        amount=next(counter),
+        initiator=factories.make_address(),
+        target=factories.make_address(),
+        expiration=next(counter),
+        secret=sha3(factories.make_secret(next(counter))),
+        payment_identifier=next(counter),
+        message_identifier=next(counter),
+        nonce=next(counter),
+        transferred_amount=next(counter),
+        locked_amount=next(counter),
+        locksroot=sha3(lock.as_bytes),
+        recipient=factories.make_address(),
+        channel_identifier=next(counter),
+        token_network_address=factories.make_address(),
+        token=factories.make_address(),
+        pkey=factories.HOP1_KEY,
+        sender=factories.HOP1,
+    )
+
+    return signed_transfer
+
+
+def test_get_latest_state_change_by_data_field():
+    """ All state changes which contain a balance proof must be found by when
+    querying the database.
+    """
+    serializer = JSONSerializer
+    storage = SQLiteStorage(':memory:', serializer)
+    counter = itertools.count()
+
+    lock_expired = ReceiveLockExpired(
+        balance_proof=make_signed_balance_proof_from_counter(counter),
+        secrethash=sha3(factories.make_secret(next(counter))),
+        message_identifier=next(counter),
+    )
+    transfer_direct = ReceiveTransferDirect(
+        token_network_identifier=factories.make_address(),
+        message_identifier=next(counter),
+        payment_identifier=next(counter),
+        balance_proof=make_signed_balance_proof_from_counter(counter),
+    )
+    unlock = ReceiveUnlock(
+        message_identifier=next(counter),
+        secret=sha3(factories.make_secret(next(counter))),
+        balance_proof=make_signed_balance_proof_from_counter(counter),
+    )
+    transfer_refund = ReceiveTransferRefund(
+        transfer=make_signed_transfer_from_counter(counter),
+        routes=list(),
+    )
+    transfer_refund_cancel_route = ReceiveTransferRefundCancelRoute(
+        routes=list(),
+        transfer=make_signed_transfer_from_counter(counter),
+        secret=sha3(factories.make_secret(next(counter))),
+    )
+
+    statechange_balanceproof = [
+        (lock_expired, lock_expired.balance_proof),
+        (transfer_direct, transfer_direct.balance_proof),
+        (unlock, unlock.balance_proof),
+        (transfer_refund, transfer_refund.transfer.balance_proof),
+        (transfer_refund_cancel_route, transfer_refund_cancel_route.transfer.balance_proof),
+    ]
+
+    timestamp = datetime.utcnow().isoformat(timespec='milliseconds')
+    storage.write_state_change(lock_expired, timestamp)
+    storage.write_state_change(transfer_refund, timestamp)
+    storage.write_state_change(transfer_refund_cancel_route, timestamp)
+    storage.write_state_change(transfer_direct, timestamp)
+    storage.write_state_change(unlock, timestamp)
+
+    for state_change, balance_proof in statechange_balanceproof:
+        result = storage.get_latest_state_change_by_data_field({
+            'balance_proof.chain_id': balance_proof.chain_id,
+            'balance_proof.token_network_identifier': to_checksum_address(
+                balance_proof.token_network_identifier,
+            ),
+            'balance_proof.channel_identifier': balance_proof.channel_identifier,
+            'balance_proof.sender': to_checksum_address(balance_proof.sender),
+            'balance_proof.locksroot': serialize_bytes(balance_proof.locksroot),
+        })
+        assert result.data == state_change

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -119,7 +119,6 @@ def make_from_route_from_counter(counter):
         identifier=next(counter),
         nonce=1,
         transferred_amount=0,
-        locked_amount=None,
         pkey=factories.HOP1_KEY,
         sender=factories.HOP1,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -552,7 +552,7 @@ def test_refund_transfer_next_route():
         pkey=refund_pkey,
         sender=refund_address,
     )
-    assert channel_state.partner_state.address == refund_address
+    assert channel1.partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
         routes=available_routes,
@@ -605,8 +605,6 @@ def test_refund_transfer_no_more_routes():
     )
 
     original_transfer = current_state.initiator.transfer
-    channel_identifier = current_state.initiator.channel_identifier
-    channel_state = channel_map[channel_identifier]
 
     refund_transfer = factories.make_signed_transfer(
         amount,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -806,7 +806,6 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
     mediator.state_transition(
         mediator_state,
         ReceiveLockExpired(
-            sender=payer_channel.partner_state.address,
             balance_proof=balance_proof,
             secrethash=secrethash,
             message_identifier=message_identifier,
@@ -1845,7 +1844,6 @@ def test_mediator_lock_expired_with_receive_lock_expired():
     )
 
     lock_expired_state_change = ReceiveLockExpired(
-        sender=HOP1,
         balance_proof=balance_proof,
         secrethash=transfer.lock.secrethash,
         message_identifier=1,
@@ -1969,10 +1967,9 @@ def test_mediator_receive_lock_expired_after_secret_reveal():
     )
 
     lock_expired_state_change = ReceiveLockExpired(
-        HOP1,
-        balance_proof,
-        transfer.lock.secrethash,
-        1,
+        balance_proof=balance_proof,
+        secrethash=transfer.lock.secrethash,
+        message_identifier=1,
     )
 
     iteration = mediator.state_transition(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -187,9 +187,8 @@ def test_regression_send_refund():
     routes = []
 
     refund_state_change = ReceiveTransferRefund(
-        HOP4,
-        received_transfer,
-        routes,
+        transfer=received_transfer,
+        routes=routes,
     )
 
     iteration = mediator.handle_refundtransfer(
@@ -418,7 +417,6 @@ def test_regression_mediator_task_no_routes():
     receive_expired_iteration = mediator.state_transition(
         expire_block_iteration.new_state,
         ReceiveLockExpired(
-            sender=payer_channel.partner_state.address,
             balance_proof=balance_proof,
             secrethash=secrethash,
             message_identifier=message_identifier,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -566,10 +566,9 @@ def test_target_receive_lock_expired():
     )
 
     lock_expired_state_change = ReceiveLockExpired(
-        HOP1,
-        balance_proof,
-        from_transfer.lock.secrethash,
-        1,
+        balance_proof=balance_proof,
+        secrethash=from_transfer.lock.secrethash,
+        message_identifier=1,
     )
 
     block_before_confirmed_expiration = expiration + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS - 1

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -426,7 +426,7 @@ def make_signed_transfer_for(
     if not allow_invalid:
         msg = 'expiration must be lower than settle_timeout'
         assert expiration < channel_state.settle_timeout, msg
-        msg = 'expiration must be larger than settle_timeout'
+        msg = 'expiration must be larger than reveal_timeout'
         assert expiration > channel_state.reveal_timeout, msg
 
     pubkey = pkey.public_key.format(compressed=False)

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -396,10 +396,9 @@ def make_receive_expired_lock(
     balance_proof = balanceproof_from_envelope(lock_expired_msg)
 
     receive_lockedtransfer = ReceiveLockExpired(
-        channel_state.partner_state.address,
-        balance_proof,
-        lock.secrethash,
-        random.randint(0, UINT64_MAX),
+        balance_proof=balance_proof,
+        secrethash=lock.secrethash,
+        message_identifier=random.randint(0, UINT64_MAX),
     )
 
     return receive_lockedtransfer

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -143,7 +143,28 @@ class AuthenticatedSenderStateChange(StateChange):
         self.sender = sender
 
     def __eq__(self, other):
-        return self.sender == other.sender
+        return (
+            isinstance(other, AuthenticatedSenderStateChange) and
+            self.sender == other.sender
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class BalanceProofStateChange(AuthenticatedSenderStateChange):
+    """ Marker used for state changes which contain a balance proof. """
+
+    def __init__(self, balance_proof):
+        super().__init__(sender=balance_proof.sender)
+        self.balance_proof = balance_proof
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, BalanceProofStateChange) and
+            super().__eq__(other) and
+            self.balance_proof == other.balance_proof
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -61,14 +61,6 @@ class ContractSendChannelClose(ContractSendEvent):
             'balance_proof': self.balance_proof,
 
         }
-        if self.balance_proof:
-            # This was added to enable query for the balance hash from the Sqlite storage
-            # on the 1st nested level.
-            # Example: json_extract(data, '$.balance_proof') == XYZ
-            # Because in some cases, the balance hash might be nested 2 levels
-            # deep into the stored JSON and this is only to unify the level among
-            # queried state changes and events.
-            result['balance_hash'] = serialization.serialize_bytes(self.balance_proof.balance_hash)
         return result
 
     @classmethod
@@ -179,8 +171,6 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
         }
-        if self.balance_proof:
-            result['balance_hash'] = serialization.serialize_bytes(self.balance_proof.balance_hash)
 
         return result
 
@@ -831,8 +821,6 @@ class SendDirectTransfer(SendMessageEvent):
             'balance_proof': self.balance_proof,
             'token_address': to_checksum_address(self.token),
         }
-        if self.balance_proof:
-            result['balance_hash'] = serialization.serialize_bytes(self.balance_proof.balance_hash)
 
         return result
 

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -60,7 +60,6 @@ class SendLockExpired(SendMessageEvent):
         result = {
             'message_identifier': self.message_identifier,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
             'secrethash': serialization.serialize_bytes(self.secrethash),
             'recipient': to_checksum_address(self.recipient),
         }
@@ -124,9 +123,6 @@ class SendLockedTransfer(SendMessageEvent):
             'message_identifier': self.message_identifier,
             'transfer': self.transfer,
             'balance_proof': self.transfer.balance_proof,
-            'balance_hash': serialization.serialize_bytes(
-                self.transfer.balance_proof.balance_hash,
-            ),
         }
 
         return result
@@ -300,7 +296,6 @@ class SendBalanceProof(SendMessageEvent):
             'token_address': to_checksum_address(self.token),
             'secret': serialization.serialize_bytes(self.secret),
             'balance_proof': self.balance_proof,
-            'balance_hash': serialization.serialize_bytes(self.balance_proof.balance_hash),
         }
 
         return result
@@ -443,9 +438,6 @@ class SendRefundTransfer(SendMessageEvent):
             'message_identifier': self.message_identifier,
             'transfer': self.transfer,
             'balance_proof': self.transfer.balance_proof,
-            'balance_hash': serialization.serialize_bytes(
-                self.transfer.balance_proof.balance_hash,
-            ),
         }
 
         return result

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -119,7 +119,6 @@ class ActionInitMediator(BalanceProofStateChange):
             'from_route': self.from_route,
             'from_transfer': self.from_transfer,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -175,7 +174,6 @@ class ActionInitTarget(BalanceProofStateChange):
             'route': self.route,
             'transfer': self.transfer,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -268,7 +266,6 @@ class ReceiveLockExpired(BalanceProofStateChange):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
             'secrethash': serialize_bytes(self.secrethash),
             'message_identifier': self.message_identifier,
         }
@@ -441,7 +438,6 @@ class ReceiveTransferRefundCancelRoute(BalanceProofStateChange):
             'routes': self.routes,
             'transfer': self.transfer,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -491,7 +487,6 @@ class ReceiveTransferRefund(BalanceProofStateChange):
             'routes': self.routes,
             'transfer': self.transfer,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -69,7 +69,7 @@ class ActionInitInitiator(StateChange):
         )
 
 
-class ActionInitMediator(StateChange):
+class ActionInitMediator(BalanceProofStateChange):
     """ Initial state for a new mediator.
 
     Args:
@@ -91,6 +91,7 @@ class ActionInitMediator(StateChange):
         if not isinstance(from_transfer, LockedTransferSignedState):
             raise ValueError('from_transfer must be a LockedTransferSignedState instance')
 
+        super().__init__(from_transfer.balance_proof)
         self.routes = routes
         self.from_route = from_route
         self.from_transfer = from_transfer
@@ -112,10 +113,6 @@ class ActionInitMediator(StateChange):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    @property
-    def balance_proof(self):
-        return self.from_transfer.balance_proof
-
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'routes': self.routes,
@@ -134,7 +131,7 @@ class ActionInitMediator(StateChange):
         )
 
 
-class ActionInitTarget(StateChange):
+class ActionInitTarget(BalanceProofStateChange):
     """ Initial state for a new target.
 
     Args:
@@ -153,6 +150,7 @@ class ActionInitTarget(StateChange):
         if not isinstance(transfer, LockedTransferSignedState):
             raise ValueError('transfer must be a LockedTransferSignedState instance')
 
+        super().__init__(transfer.balance_proof)
         self.route = route
         self.transfer = transfer
 
@@ -171,10 +169,6 @@ class ActionInitTarget(StateChange):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-    @property
-    def balance_proof(self):
-        return self.transfer.balance_proof
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -14,7 +14,7 @@ from raiden.transfer.merkle_tree import merkleroot
 from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.transfer.utils import hash_balance_data, pseudo_random_generator_from_json
 from raiden.utils import lpex, pex, serialization, sha3, typing
-from raiden.utils.serialization import map_dict, map_list
+from raiden.utils.serialization import map_dict, map_list, serialize_bytes
 
 SecretHashToLock = typing.Dict[typing.SecretHash, 'HashTimeLockState']
 SecretHashToPartialUnlockProof = typing.Dict[typing.SecretHash, 'UnlockPartialProofState']
@@ -960,6 +960,8 @@ class BalanceProofSignedState(State):
             'signature': serialization.serialize_bytes(self.signature),
             'sender': to_checksum_address(self.sender),
             'chain_id': self.chain_id,
+            # Makes the balance hash available to query
+            'balance_hash': serialize_bytes(self.balance_hash),
         }
 
     @classmethod

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -789,6 +789,8 @@ class BalanceProofUnsignedState(State):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': self.channel_identifier,
             'chain_id': self.chain_id,
+            # Makes the balance hash available to query
+            'balance_hash': serialize_bytes(self.balance_hash),
         }
 
     @classmethod

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -3,6 +3,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.transfer.architecture import (
     AuthenticatedSenderStateChange,
+    BalanceProofStateChange,
     ContractReceiveStateChange,
     StateChange,
 )
@@ -1065,7 +1066,7 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
         )
 
 
-class ReceiveTransferDirect(AuthenticatedSenderStateChange):
+class ReceiveTransferDirect(BalanceProofStateChange):
     def __init__(
             self,
             token_network_identifier: typing.TokenNetworkID,
@@ -1076,12 +1077,11 @@ class ReceiveTransferDirect(AuthenticatedSenderStateChange):
         if not isinstance(balance_proof, BalanceProofSignedState):
             raise ValueError('balance_proof must be a BalanceProofSignedState instance')
 
-        super().__init__(balance_proof.sender)
+        super().__init__(balance_proof)
 
         self.token_network_identifier = token_network_identifier
         self.message_identifier = message_identifier
         self.payment_identifier = payment_identifier
-        self.balance_proof = balance_proof
 
     def __repr__(self):
         return (
@@ -1101,7 +1101,6 @@ class ReceiveTransferDirect(AuthenticatedSenderStateChange):
             self.token_network_identifier == other.token_network_identifier and
             self.message_identifier == other.message_identifier and
             self.payment_identifier == other.payment_identifier and
-            self.balance_proof == other.balance_proof and
             super().__eq__(other)
         )
 
@@ -1127,7 +1126,7 @@ class ReceiveTransferDirect(AuthenticatedSenderStateChange):
         )
 
 
-class ReceiveUnlock(AuthenticatedSenderStateChange):
+class ReceiveUnlock(BalanceProofStateChange):
     def __init__(
             self,
             message_identifier: typing.MessageID,
@@ -1137,14 +1136,13 @@ class ReceiveUnlock(AuthenticatedSenderStateChange):
         if not isinstance(balance_proof, BalanceProofSignedState):
             raise ValueError('balance_proof must be an instance of BalanceProofSignedState')
 
-        super().__init__(balance_proof.sender)
+        super().__init__(balance_proof)
 
         secrethash: typing.SecretHash = typing.SecretHash(sha3(secret))
 
         self.message_identifier = message_identifier
         self.secret = secret
         self.secrethash = secrethash
-        self.balance_proof = balance_proof
 
     def __repr__(self):
         return '<ReceiveUnlock msgid:{} secrethash:{} balance_proof:{}>'.format(
@@ -1159,7 +1157,6 @@ class ReceiveUnlock(AuthenticatedSenderStateChange):
             self.message_identifier == other.message_identifier and
             self.secret == other.secret and
             self.secrethash == other.secrethash and
-            self.balance_proof == other.balance_proof and
             super().__eq__(other)
         )
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1113,7 +1113,6 @@ class ReceiveTransferDirect(BalanceProofStateChange):
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod
@@ -1168,7 +1167,6 @@ class ReceiveUnlock(BalanceProofStateChange):
             'message_identifier': self.message_identifier,
             'secret': serialize_bytes(self.secret),
             'balance_proof': self.balance_proof,
-            'balance_hash': serialize_bytes(self.balance_proof.balance_hash),
         }
 
     @classmethod

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -44,7 +44,7 @@ def get_latest_known_balance_proof_from_events(
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_id),
         'balance_proof.channel_identifier': channel_identifier,
-        'balance_hash': serialize_bytes(balance_hash),
+        'balance_proof.balance_hash': serialize_bytes(balance_hash),
     })
     if event_record.data:
         return event_record.data.balance_proof

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -14,7 +14,6 @@ def get_state_change_with_balance_proof(
         chain_id: typing.ChainID,
         token_network_identifier: typing.TokenNetworkID,
         channel_identifier: typing.ChannelID,
-        locksroot: typing.Locksroot,
         balance_hash: typing.BalanceHash,
         sender: typing.Address,
 ) -> sqlite.StateChangeRecord:
@@ -25,7 +24,6 @@ def get_state_change_with_balance_proof(
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
         'balance_proof.channel_identifier': channel_identifier,
-        'balance_proof.locksroot': serialize_bytes(locksroot),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
         'balance_proof.sender': to_checksum_address(sender),
     })
@@ -36,7 +34,6 @@ def get_event_with_balance_proof(
         chain_id: typing.ChainID,
         token_network_identifier: typing.TokenNetworkID,
         channel_identifier: typing.ChannelID,
-        locksroot: typing.Locksroot,
         balance_hash: typing.BalanceHash,
 ) -> sqlite.EventRecord:
     """ Returns the event which contains the corresponding balance
@@ -46,7 +43,6 @@ def get_event_with_balance_proof(
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
         'balance_proof.channel_identifier': channel_identifier,
-        'balance_proof.locksroot': serialize_bytes(locksroot),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
     })
 

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -4,52 +4,51 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 
 from raiden.constants import EMPTY_HASH
-from raiden.storage.sqlite import SQLiteStorage
+from raiden.storage import sqlite
 from raiden.utils import typing
 from raiden.utils.serialization import serialize_bytes
 
 
-def get_latest_known_balance_proof_from_state_changes(
-        storage: SQLiteStorage,
+def get_state_change_with_balance_proof(
+        storage: sqlite.SQLiteStorage,
         chain_id: typing.ChainID,
-        token_network_id: typing.TokenNetworkID,
+        token_network_identifier: typing.TokenNetworkID,
         channel_identifier: typing.ChannelID,
+        locksroot: typing.Locksroot,
         balance_hash: typing.BalanceHash,
         sender: typing.Address,
-) -> typing.Optional['BalanceProofSignedState']:
-    """ Tries to find the balance proof with the provided balance hash
-    in stored state changes. """
-    state_change_record = storage.get_latest_state_change_by_data_field({
+) -> sqlite.StateChangeRecord:
+    """ Returns the state change which contains the corresponding balance
+    proof.
+    """
+    return storage.get_latest_state_change_by_data_field({
         'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_identifier': to_checksum_address(token_network_id),
+        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
         'balance_proof.channel_identifier': channel_identifier,
+        'balance_proof.locksroot': serialize_bytes(locksroot),
+        'balance_proof.balance_hash': serialize_bytes(balance_hash),
         'balance_proof.sender': to_checksum_address(sender),
-        'balance_hash': serialize_bytes(balance_hash),
     })
-    if state_change_record.data:
-        return state_change_record.data.balance_proof
-    return None
 
 
-def get_latest_known_balance_proof_from_events(
-        storage: SQLiteStorage,
+def get_event_with_balance_proof(
+        storage: sqlite.SQLiteStorage,
         chain_id: typing.ChainID,
-        token_network_id: typing.TokenNetworkID,
+        token_network_identifier: typing.TokenNetworkID,
         channel_identifier: typing.ChannelID,
+        locksroot: typing.Locksroot,
         balance_hash: typing.BalanceHash,
-) -> typing.Optional['BalanceProofSignedState']:
-    """ Tries to find the balance proof with the provided balance hash
-    in stored events. """
-    event_record = storage.get_latest_event_by_data_field({
+) -> sqlite.EventRecord:
+    """ Returns the event which contains the corresponding balance
+    proof.
+    """
+    return storage.get_latest_event_by_data_field({
         'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_identifier': to_checksum_address(token_network_id),
+        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
         'balance_proof.channel_identifier': channel_identifier,
+        'balance_proof.locksroot': serialize_bytes(locksroot),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
     })
-    if event_record.data:
-        return event_record.data.balance_proof
-
-    return None
 
 
 def hash_balance_data(


### PR DESCRIPTION
The shape of messages which balance proofs changes depending if it
contains a lock or not. Messages like Unlock, LockExpired and
DirectTransfer have a balance proof directly in the object itself, while
messages like LockedTransfer and RefundTransfer have their balance proof
inside a transfer object, which also contains the lock.

This difference in the shape of the objects would also require different
queries to the database. In order to not have such queries, the
serialization of the objects duplicates information, and copies the
balance proofs from the inner transfer object to the top level, allowing
a single query to work with all the above messages and their state
changes counter part.

However, such strategy is error prone, and we indeed forgot to properly
serialize two state changes, namely ReceiveTransferRefundCancelRoute and
ReceiveTransferRefund which are used for refund transfers. In this case,
if a refund transfer was the last transfer received for a given channel,
and this channel was closed, the call to settlement fails, because the
corresponding balance proof cannot be found.

This commit adds a new marker for the state changes which have a balance
proof, fixes the serialization of the refund state changes, and adds a
unit test for the current state changes which have a balance proof.

fix #2931