### PR TITLE
Don't delete payment task when receiving invalid secret request

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`3001` Don't delete payment task when receiving invalid secret request.
+
 * :release:`0.16.0 <2018-11-09>`
 * :bug'`2963` Fixes an overflow issue with the hint of the join network dialog.
 * :bug:`2973` Introduce special handling of infura endpoints so that the old getTransactionCount is used.

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 11
+RAIDEN_DB_VERSION = 12
 
 
 class EventRecord(typing.NamedTuple):

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -241,6 +241,25 @@ def test_state_wait_secretrequest_valid():
 
     assert len(iteration.events) == 1
     assert isinstance(iteration.events[0], SendSecretReveal)
+    assert iteration.new_state.initiator.received_secret_request is True
+
+    state_change_2 = ReceiveSecretRequest(
+        UNIT_TRANSFER_IDENTIFIER,
+        lock.amount,
+        lock.expiration,
+        lock.secrethash,
+        UNIT_TRANSFER_TARGET,
+    )
+
+    iteration2 = initiator_manager.state_transition(
+        iteration.new_state,
+        state_change_2,
+        channel_map,
+        pseudo_random_generator,
+        block_number,
+    )
+
+    assert len(iteration2.events) == 0
 
 
 def test_state_wait_secretrequest_invalid_amount():
@@ -286,6 +305,25 @@ def test_state_wait_secretrequest_invalid_amount():
 
     assert len(iteration.events) == 1
     assert isinstance(iteration.events[0], EventPaymentSentFailed)
+    assert iteration.new_state.initiator.received_secret_request is True
+
+    state_change_2 = ReceiveSecretRequest(
+        UNIT_TRANSFER_IDENTIFIER,
+        lock.amount,
+        lock.expiration,
+        lock.secrethash,
+        UNIT_TRANSFER_TARGET,
+    )
+
+    iteration2 = initiator_manager.state_transition(
+        iteration.new_state,
+        state_change_2,
+        channel_map,
+        pseudo_random_generator,
+        block_number,
+    )
+
+    assert len(iteration2.events) == 0
 
 
 def test_state_wait_secretrequest_invalid_amount_and_sender():
@@ -330,6 +368,27 @@ def test_state_wait_secretrequest_invalid_amount_and_sender():
     )
 
     assert len(iteration.events) == 0
+    assert iteration.new_state.initiator.received_secret_request is False
+
+    # Now the proper target sends the message, this should be applied
+    state_change_2 = ReceiveSecretRequest(
+        UNIT_TRANSFER_IDENTIFIER,
+        lock.amount,
+        lock.expiration,
+        lock.secrethash,
+        UNIT_TRANSFER_TARGET,
+    )
+
+    iteration2 = initiator_manager.state_transition(
+        iteration.new_state,
+        state_change_2,
+        channel_map,
+        pseudo_random_generator,
+        block_number,
+    )
+
+    assert iteration2.new_state.initiator.received_secret_request is True
+    assert isinstance(iteration2.events[0], SendSecretReveal)
 
 
 def test_state_wait_unlock_valid():

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -91,6 +91,7 @@ class InitiatorTransferState(State):
         'channel_identifier',
         'transfer',
         'revealsecret',
+        'received_secret_request',
     )
 
     def __init__(
@@ -99,6 +100,7 @@ class InitiatorTransferState(State):
             channel_identifier: typing.ChannelID,
             transfer: 'LockedTransferUnsignedState',
             revealsecret: typing.Optional['SendSecretReveal'],
+            received_secret_request: bool = False,
     ):
 
         if not isinstance(transfer_description, TransferDescriptionWithSecretState):
@@ -114,6 +116,7 @@ class InitiatorTransferState(State):
         self.channel_identifier = channel_identifier
         self.transfer = transfer
         self.revealsecret = revealsecret
+        self.received_secret_request = received_secret_request
 
     def __repr__(self):
         return '<InitiatorTransferState transfer:{} channel:{}>'.format(
@@ -127,7 +130,8 @@ class InitiatorTransferState(State):
             self.transfer_description == other.transfer_description and
             self.channel_identifier == other.channel_identifier and
             self.transfer == other.transfer and
-            self.revealsecret == other.revealsecret
+            self.revealsecret == other.revealsecret and
+            self.received_secret_request == other.received_secret_request
         )
 
     def __ne__(self, other):
@@ -139,6 +143,7 @@ class InitiatorTransferState(State):
             'channel_identifier': self.channel_identifier,
             'transfer': self.transfer,
             'revealsecret': self.revealsecret,
+            'received_secret_request': self.received_secret_request,
         }
 
         return result
@@ -150,6 +155,7 @@ class InitiatorTransferState(State):
             channel_identifier=data['channel_identifier'],
             transfer=data['transfer'],
             revealsecret=data['revealsecret'],
+            received_secret_request=data['received_secret_request'],
         )
 
         return restored


### PR DESCRIPTION
Deleting the payment task will lead to problems when unlocking locks related to the task.

@hackaugusto Can you have a look and see if this goes in the right direction? I'll work on a test in the meantime.

Fixes #3001 