### PR TITLE
Don't create logfile when --disable-debug-logfile (fixes #3003)

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -475,8 +475,10 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
 
     report_file = mktemp(suffix='.log')
     configure_logging(
-        {'': 'DEBUG'}, log_file=report_file,
-        disable_debug_logfile=ctx.parent.params['disable_debug_logfile'])
+        logger_level_config={'': 'DEBUG'},
+        log_file=report_file,
+        disable_debug_logfile=ctx.parent.params['disable_debug_logfile'],
+    )
     click.secho(
         f'Report file: {report_file}',
         fg='yellow',

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -474,7 +474,9 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
     )
 
     report_file = mktemp(suffix='.log')
-    configure_logging({'': 'DEBUG'}, log_file=report_file)
+    configure_logging(
+        {'': 'DEBUG'}, log_file=report_file,
+        disable_debug_logfile=ctx.parent.params['disable_debug_logfile'])
     click.secho(
         f'Report file: {report_file}',
         fg='yellow',


### PR DESCRIPTION
This is avoided by not configuring the log handler in that case. I
applied the same approach for the other handlers for consistency.

The --disable-debug-logfile flag also was not passed to
configure_logging when calling `raiden smoketest`, so I added it there.