### PR TITLE
docs: geth --fast is now called "--syncmode fast"

### DIFF
--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -137,7 +137,7 @@ Using geth
 
 Run the Ethereum client and let it sync::
 
-    geth --fast --rpc --rpcapi eth,net,web3,txpool
+    geth --syncmode fast --rpc --rpcapi eth,net,web3,txpool
 
 .. note::
     When you want to use a testnet add the ``--testnet`` or ``--rinkeby`` flags or set the network id with ``--networkid`` directly.


### PR DESCRIPTION
`--fast` was just a shortcut for `--syncmode fast` and was removed in geth 1.8.15.

[no ci integration]