### PR TITLE
Serialize integers for sqlite

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`3035` Registering a token twice should now return a proper error.
+* :bug:`3013` Encode all integers before saving to the sqlite database
 * :bug:`3022` Reject REST API channel opening with an error if there is not enough token balance for the initial deposit.
 * :bug:`2932` Node will no longer crash if it mediated a transfer and the channel cycle for mediation has completed.
 * :bug:`3001` Don't delete payment task when receiving invalid secret request.

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -387,7 +387,7 @@ class UDPTransport(Runnable):
     def send_async(
             self,
             queue_identifier: QueueIdentifier,
-            message: 'Message',
+            message: Message,
     ):
         """ Send a new ordered message to recipient.
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 13
+RAIDEN_DB_VERSION = 14
 
 
 class EventRecord(typing.NamedTuple):

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -55,7 +55,7 @@ class ContractSendChannelClose(ContractSendEvent):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
@@ -66,7 +66,7 @@ class ContractSendChannelClose(ContractSendEvent):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendChannelClose':
         restored = cls(
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             token_address=to_canonical_address(data['token_address']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             balance_proof=data['balance_proof'],
@@ -111,7 +111,7 @@ class ContractSendChannelSettle(ContractSendEvent):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
         }
 
@@ -120,7 +120,7 @@ class ContractSendChannelSettle(ContractSendEvent):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendChannelSettle':
         restored = cls(
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
         )
 
@@ -166,8 +166,8 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'expiration': self.expiration,
-            'channel_identifier': self.channel_identifier,
+            'expiration': str(self.expiration),
+            'channel_identifier': str(self.channel_identifier),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'balance_proof': self.balance_proof,
         }
@@ -177,8 +177,8 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendChannelUpdateTransfer':
         restored = cls(
-            expiration=data['expiration'],
-            channel_identifier=data['channel_identifier'],
+            expiration=int(data['expiration']),
+            channel_identifier=int(data['channel_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             balance_proof=data['balance_proof'],
         )
@@ -229,7 +229,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
         result = {
             'token_address': to_checksum_address(self.token_address),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'participant': to_checksum_address(self.participant),
         }
 
@@ -240,7 +240,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
         restored = cls(
             token_address=to_canonical_address(data['token_address']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             participant=to_canonical_address(data['participant']),
         )
 
@@ -273,7 +273,7 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'expiration': self.expiration,
+            'expiration': str(self.expiration),
             'secret': serialization.serialize_bytes(self.secret),
         }
 
@@ -282,7 +282,7 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ContractSendSecretReveal':
         restored = cls(
-            expiration=data['expiration'],
+            expiration=int(data['expiration']),
             secret=serialization.deserialize_bytes(data['secret']),
         )
 
@@ -359,8 +359,8 @@ class EventPaymentSentSuccess(Event):
         result = {
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'identifier': self.identifier,
-            'amount': self.amount,
+            'identifier': str(self.identifier),
+            'amount': str(self.amount),
             'target': to_checksum_address(self.target),
         }
 
@@ -371,8 +371,8 @@ class EventPaymentSentSuccess(Event):
         restored = cls(
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            identifier=data['identifier'],
-            amount=data['amount'],
+            identifier=int(data['identifier']),
+            amount=int(data['amount']),
             target=to_canonical_address(data['target']),
         )
 
@@ -433,7 +433,7 @@ class EventPaymentSentFailed(Event):
         result = {
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'target': to_checksum_address(self.target),
             'reason': self.reason,
         }
@@ -445,7 +445,7 @@ class EventPaymentSentFailed(Event):
         restored = cls(
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             target=to_canonical_address(data['target']),
             reason=data['reason'],
         )
@@ -515,8 +515,8 @@ class EventPaymentReceivedSuccess(Event):
         result = {
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'identifier': self.identifier,
-            'amount': self.amount,
+            'identifier': str(self.identifier),
+            'amount': str(self.amount),
             'initiator': to_checksum_address(self.initiator),
         }
 
@@ -527,8 +527,8 @@ class EventPaymentReceivedSuccess(Event):
         restored = cls(
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            identifier=data['identifier'],
-            amount=data['amount'],
+            identifier=int(data['identifier']),
+            amount=int(data['amount']),
             initiator=to_canonical_address(data['initiator']),
         )
 
@@ -560,7 +560,7 @@ class EventTransferReceivedInvalidDirectTransfer(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'reason': self.reason,
         }
 
@@ -572,7 +572,7 @@ class EventTransferReceivedInvalidDirectTransfer(Event):
             data: typing.Dict[str, typing.Any],
     )-> 'EventTransferReceivedInvalidDirectTransfer':
         restored = cls(
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             reason=data['reason'],
         )
 
@@ -607,7 +607,7 @@ class EventInvalidReceivedTransferRefund(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'payment_identifier': self.payment_identifier,
+            'payment_identifier': str(self.payment_identifier),
             'reason': self.reason,
         }
 
@@ -619,7 +619,7 @@ class EventInvalidReceivedTransferRefund(Event):
             data: typing.Dict[str, typing.Any],
     )-> 'EventInvalidReceivedTransferRefund':
         restored = cls(
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
             reason=data['reason'],
         )
 
@@ -701,7 +701,7 @@ class EventInvalidReceivedLockedTransfer(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'payment_identifier': self.payment_identifier,
+            'payment_identifier': str(self.payment_identifier),
             'reason': self.reason,
         }
 
@@ -713,7 +713,7 @@ class EventInvalidReceivedLockedTransfer(Event):
             data: typing.Dict[str, typing.Any],
     )-> 'EventInvalidReceivedLockedTransfer':
         restored = cls(
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
             reason=data['reason'],
         )
 
@@ -815,9 +815,9 @@ class SendDirectTransfer(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
-            'payment_identifier': self.payment_identifier,
+            'payment_identifier': str(self.payment_identifier),
             'balance_proof': self.balance_proof,
             'token_address': to_checksum_address(self.token),
         }
@@ -828,9 +828,9 @@ class SendDirectTransfer(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendDirectTransfer':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
             balance_proof=data['balance_proof'],
             token_address=to_canonical_address(data['token_address']),
         )
@@ -859,7 +859,7 @@ class SendProcessed(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
         }
 
@@ -869,7 +869,7 @@ class SendProcessed(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendProcessed':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
         )
 

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -816,7 +816,7 @@ class SendDirectTransfer(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'payment_identifier': str(self.payment_identifier),
             'balance_proof': self.balance_proof,
             'token_address': to_checksum_address(self.token),
@@ -829,7 +829,7 @@ class SendDirectTransfer(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             payment_identifier=int(data['payment_identifier']),
             balance_proof=data['balance_proof'],
             token_address=to_canonical_address(data['token_address']),
@@ -860,7 +860,7 @@ class SendProcessed(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
         }
 
         return result
@@ -870,7 +870,7 @@ class SendProcessed(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
         )
 
         return restored

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -58,7 +58,7 @@ class SendLockExpired(SendMessageEvent):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'balance_proof': self.balance_proof,
             'secrethash': serialization.serialize_bytes(self.secrethash),
             'recipient': to_checksum_address(self.recipient),
@@ -70,7 +70,7 @@ class SendLockExpired(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendLockExpired':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             balance_proof=data['balance_proof'],
             secrethash=serialization.deserialize_bytes(data['secrethash']),
         )
@@ -120,7 +120,7 @@ class SendLockedTransfer(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'transfer': self.transfer,
             'balance_proof': self.transfer.balance_proof,
         }
@@ -132,7 +132,7 @@ class SendLockedTransfer(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             transfer=data['transfer'],
         )
 
@@ -204,7 +204,7 @@ class SendSecretReveal(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'secret': serialization.serialize_bytes(self.secret),
         }
 
@@ -215,7 +215,7 @@ class SendSecretReveal(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             secret=serialization.deserialize_bytes(data['secret']),
         )
 
@@ -291,7 +291,7 @@ class SendBalanceProof(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'payment_identifier': str(self.payment_identifier),
             'token_address': to_checksum_address(self.token),
             'secret': serialization.serialize_bytes(self.secret),
@@ -305,7 +305,7 @@ class SendBalanceProof(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             payment_identifier=int(data['payment_identifier']),
             token_address=to_canonical_address(data['token_address']),
             secret=serialization.deserialize_bytes(data['secret']),
@@ -370,7 +370,7 @@ class SendSecretRequest(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'payment_identifier': str(self.payment_identifier),
             'amount': str(self.amount),
             'expiration': str(self.expiration),
@@ -384,7 +384,7 @@ class SendSecretRequest(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             payment_identifier=int(data['payment_identifier']),
             amount=int(data['amount']),
             expiration=int(data['expiration']),
@@ -435,7 +435,7 @@ class SendRefundTransfer(SendMessageEvent):
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'transfer': self.transfer,
             'balance_proof': self.transfer.balance_proof,
         }
@@ -447,7 +447,7 @@ class SendRefundTransfer(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=int(data['channel_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             transfer=data['transfer'],
         )
 

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -119,7 +119,7 @@ class SendLockedTransfer(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
             'transfer': self.transfer,
             'balance_proof': self.transfer.balance_proof,
@@ -131,7 +131,7 @@ class SendLockedTransfer(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendLockedTransfer':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
             transfer=data['transfer'],
         )
@@ -203,7 +203,7 @@ class SendSecretReveal(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
             'secret': serialization.serialize_bytes(self.secret),
         }
@@ -214,7 +214,7 @@ class SendSecretReveal(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendSecretReveal':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
             secret=serialization.deserialize_bytes(data['secret']),
         )
@@ -290,9 +290,9 @@ class SendBalanceProof(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
-            'payment_identifier': self.payment_identifier,
+            'payment_identifier': str(self.payment_identifier),
             'token_address': to_checksum_address(self.token),
             'secret': serialization.serialize_bytes(self.secret),
             'balance_proof': self.balance_proof,
@@ -304,9 +304,9 @@ class SendBalanceProof(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendBalanceProof':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
             token_address=to_canonical_address(data['token_address']),
             secret=serialization.deserialize_bytes(data['secret']),
             balance_proof=data['balance_proof'],
@@ -369,11 +369,11 @@ class SendSecretRequest(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
-            'payment_identifier': self.payment_identifier,
-            'amount': self.amount,
-            'expiration': self.expiration,
+            'payment_identifier': str(self.payment_identifier),
+            'amount': str(self.amount),
+            'expiration': str(self.expiration),
             'secrethash': serialization.serialize_bytes(self.secrethash),
         }
 
@@ -383,11 +383,11 @@ class SendSecretRequest(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendSecretRequest':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
-            payment_identifier=data['payment_identifier'],
-            amount=data['amount'],
-            expiration=data['expiration'],
+            payment_identifier=int(data['payment_identifier']),
+            amount=int(data['amount']),
+            expiration=int(data['expiration']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
         )
 
@@ -434,7 +434,7 @@ class SendRefundTransfer(SendMessageEvent):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
-            'channel_identifier': self.queue_identifier.channel_identifier,
+            'channel_identifier': str(self.queue_identifier.channel_identifier),
             'message_identifier': self.message_identifier,
             'transfer': self.transfer,
             'balance_proof': self.transfer.balance_proof,
@@ -446,7 +446,7 @@ class SendRefundTransfer(SendMessageEvent):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendRefundTransfer':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_identifier=data['message_identifier'],
             transfer=data['transfer'],
         )
@@ -479,7 +479,7 @@ class EventUnlockSuccess(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
         }
 
@@ -488,7 +488,7 @@ class EventUnlockSuccess(Event):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockSuccess':
         restored = cls(
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
         )
 
@@ -527,7 +527,7 @@ class EventUnlockFailed(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
             'reason': self.reason,
         }
@@ -537,7 +537,7 @@ class EventUnlockFailed(Event):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockFailed':
         restored = cls(
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
             reason=data['reason'],
         )
@@ -570,7 +570,7 @@ class EventUnlockClaimSuccess(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
         }
 
@@ -579,7 +579,7 @@ class EventUnlockClaimSuccess(Event):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockClaimSuccess':
         restored = cls(
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
         )
 
@@ -613,7 +613,7 @@ class EventUnlockClaimFailed(Event):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
             'reason': self.reason,
         }
@@ -623,7 +623,7 @@ class EventUnlockClaimFailed(Event):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockClaimFailed':
         restored = cls(
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
             reason=data['reason'],
         )

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -140,7 +140,7 @@ class InitiatorTransferState(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'transfer_description': self.transfer_description,
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'transfer': self.transfer,
             'revealsecret': self.revealsecret,
             'received_secret_request': self.received_secret_request,
@@ -152,7 +152,7 @@ class InitiatorTransferState(State):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'InitiatorTransferState':
         restored = cls(
             transfer_description=data['transfer_description'],
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             transfer=data['transfer'],
             revealsecret=data['revealsecret'],
             received_secret_request=data['received_secret_request'],
@@ -411,7 +411,7 @@ class LockedTransferUnsignedState(State):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'payment_identifier': self.payment_identifier,
+            'payment_identifier': str(self.payment_identifier),
             'token': to_checksum_address(self.token),
             'balance_proof': self.balance_proof,
             'lock': self.lock,
@@ -422,7 +422,7 @@ class LockedTransferUnsignedState(State):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'LockedTransferUnsignedState':
         restored = cls(
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
             token=to_canonical_address(data['token']),
             balance_proof=data['balance_proof'],
             lock=data['lock'],
@@ -512,8 +512,8 @@ class LockedTransferSignedState(State):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'message_identifier': self.message_identifier,
-            'payment_identifier': self.payment_identifier,
+            'message_identifier': str(self.message_identifier),
+            'payment_identifier': str(self.payment_identifier),
             'token': to_checksum_address(self.token),
             'balance_proof': self.balance_proof,
             'lock': self.lock,
@@ -524,8 +524,8 @@ class LockedTransferSignedState(State):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'LockedTransferSignedState':
         restored = cls(
-            message_identifier=data['message_identifier'],
-            payment_identifier=data['payment_identifier'],
+            message_identifier=int(data['message_identifier']),
+            payment_identifier=int(data['payment_identifier']),
             token=to_canonical_address(data['token']),
             balance_proof=data['balance_proof'],
             lock=data['lock'],
@@ -604,8 +604,8 @@ class TransferDescriptionWithSecretState(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
-            'payment_identifier': self.payment_identifier,
-            'amount': self.amount,
+            'payment_identifier': str(self.payment_identifier),
+            'amount': str(self.amount),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'initiator': to_checksum_address(self.initiator),
             'target': to_checksum_address(self.target),
@@ -616,8 +616,8 @@ class TransferDescriptionWithSecretState(State):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'TransferDescriptionWithSecretState':
         restored = cls(
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
-            payment_identifier=data['payment_identifier'],
-            amount=data['amount'],
+            payment_identifier=int(data['payment_identifier']),
+            amount=int(data['amount']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             initiator=to_canonical_address(data['initiator']),
             target=to_canonical_address(data['target']),

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -267,7 +267,7 @@ class ReceiveLockExpired(BalanceProofStateChange):
         return {
             'balance_proof': self.balance_proof,
             'secrethash': serialize_bytes(self.secrethash),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
         }
 
     @classmethod
@@ -275,7 +275,7 @@ class ReceiveLockExpired(BalanceProofStateChange):
         return cls(
             balance_proof=data['balance_proof'],
             secrethash=deserialize_bytes(data['secrethash']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
         )
 
 

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -220,7 +220,7 @@ class ActionCancelRoute(StateChange):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'registry_address': to_checksum_address(self.registry_address),
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'routes': self.routes,
         }
 
@@ -228,7 +228,7 @@ class ActionCancelRoute(StateChange):
     def from_dict(cls, data) -> 'ActionInitTarget':
         return cls(
             registry_address=to_canonical_address(data['registry_address']),
-            channel_identifier=data['identifier'],
+            channel_identifier=int(data['identifier']),
             routes=data['routes'],
         )
 
@@ -321,9 +321,9 @@ class ReceiveSecretRequest(AuthenticatedSenderStateChange):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'payment_identifier': self.payment_identifier,
-            'amount': self.amount,
-            'expiration': self.expiration,
+            'payment_identifier': str(self.payment_identifier),
+            'amount': str(self.amount),
+            'expiration': str(self.expiration),
             'secrethash': serialize_bytes(self.secrethash),
             'sender': to_checksum_address(self.sender),
             'revealsecret': self.revealsecret,
@@ -332,9 +332,9 @@ class ReceiveSecretRequest(AuthenticatedSenderStateChange):
     @classmethod
     def from_dict(cls, data) -> 'ReceiveSecretRequest':
         instance = cls(
-            payment_identifier=data['payment_identifier'],
-            amount=data['amount'],
-            expiration=data['expiration'],
+            payment_identifier=int(data['payment_identifier']),
+            amount=int(data['amount']),
+            expiration=int(data['expiration']),
             secrethash=deserialize_bytes(data['secrethash']),
             sender=to_canonical_address(data['sender']),
         )

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -211,7 +211,7 @@ class TargetTask(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'target_state': self.target_state,
         }
 
@@ -219,7 +219,7 @@ class TargetTask(State):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'TargetTask':
         restored = cls(
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             target_state=data['target_state'],
         )
 
@@ -294,7 +294,7 @@ class ChainState(State):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
             'chain_id': self.chain_id,
             'pseudo_random_generator': self.pseudo_random_generator.getstate(),
             'identifiers_to_paymentnetworks': map_dict(
@@ -321,7 +321,7 @@ class ChainState(State):
 
         restored = cls(
             pseudo_random_generator=pseudo_random_generator,
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
             our_address=to_canonical_address(data['our_address']),
             chain_id=data['chain_id'],
         )
@@ -661,14 +661,14 @@ class RouteState(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'node_address': to_checksum_address(self.node_address),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
         }
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'RouteState':
         restored = cls(
-            to_canonical_address(data['node_address']),
-            data['channel_identifier'],
+            node_address=to_canonical_address(data['node_address']),
+            channel_identifier=int(data['channel_identifier']),
         )
 
         return restored
@@ -783,11 +783,11 @@ class BalanceProofUnsignedState(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'nonce': self.nonce,
-            'transferred_amount': self.transferred_amount,
-            'locked_amount': self.locked_amount,
+            'transferred_amount': str(self.transferred_amount),
+            'locked_amount': str(self.locked_amount),
             'locksroot': serialization.serialize_bytes(self.locksroot),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'chain_id': self.chain_id,
             # Makes the balance hash available to query
             'balance_hash': serialize_bytes(self.balance_hash),
@@ -797,11 +797,11 @@ class BalanceProofUnsignedState(State):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'BalanceProofUnsignedState':
         restored = cls(
             nonce=data['nonce'],
-            transferred_amount=data['transferred_amount'],
-            locked_amount=data['locked_amount'],
+            transferred_amount=int(data['transferred_amount']),
+            locked_amount=int(data['locked_amount']),
             locksroot=serialization.deserialize_bytes(data['locksroot']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             chain_id=data['chain_id'],
         )
 
@@ -953,11 +953,11 @@ class BalanceProofSignedState(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'nonce': self.nonce,
-            'transferred_amount': self.transferred_amount,
-            'locked_amount': self.locked_amount,
+            'transferred_amount': str(self.transferred_amount),
+            'locked_amount': str(self.locked_amount),
             'locksroot': serialization.serialize_bytes(self.locksroot),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'message_hash': serialization.serialize_bytes(self.message_hash),
             'signature': serialization.serialize_bytes(self.signature),
             'sender': to_checksum_address(self.sender),
@@ -970,11 +970,11 @@ class BalanceProofSignedState(State):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'BalanceProofSignedState':
         restored = cls(
             nonce=data['nonce'],
-            transferred_amount=data['transferred_amount'],
-            locked_amount=data['locked_amount'],
+            transferred_amount=int(data['transferred_amount']),
+            locked_amount=int(data['locked_amount']),
             locksroot=serialization.deserialize_bytes(data['locksroot']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             message_hash=serialization.deserialize_bytes(data['message_hash']),
             signature=serialization.deserialize_bytes(data['signature']),
             sender=to_canonical_address(data['sender']),
@@ -1239,9 +1239,9 @@ class TransactionExecutionStatus(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result: typing.Dict[str, typing.Any] = {}
         if self.started_block_number is not None:
-            result['started_block_number'] = self.started_block_number
+            result['started_block_number'] = str(self.started_block_number)
         if self.finished_block_number is not None:
-            result['finished_block_number'] = self.finished_block_number
+            result['finished_block_number'] = str(self.finished_block_number)
         if self.result is not None:
             result['result'] = self.result
 
@@ -1249,9 +1249,14 @@ class TransactionExecutionStatus(State):
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'TransactionExecutionStatus':
+        started_optional = data.get('started_block_number')
+        started_block_number = int(started_optional) if started_optional else None
+        finished_optional = data.get('finished_block_number')
+        finished_block_number = int(finished_optional) if finished_optional else None
+
         restored = cls(
-            started_block_number=data.get('started_block_number'),
-            finished_block_number=data.get('finished_block_number'),
+            started_block_number=started_block_number,
+            finished_block_number=finished_block_number,
             result=data.get('result'),
         )
 
@@ -1351,7 +1356,7 @@ class NettingChannelEndState(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
             'address': to_checksum_address(self.address),
-            'contract_balance': self.contract_balance,
+            'contract_balance': str(self.contract_balance),
             'secrethashes_to_lockedlocks': map_dict(
                 serialization.serialize_bytes,
                 serialization.identity,
@@ -1378,7 +1383,7 @@ class NettingChannelEndState(State):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'NettingChannelEndState':
         restored = cls(
             address=to_canonical_address(data['address']),
-            balance=data['contract_balance'],
+            balance=int(data['contract_balance']),
         )
         restored.secrethashes_to_lockedlocks = map_dict(
             serialization.deserialize_bytes,
@@ -1539,13 +1544,13 @@ class NettingChannelState(State):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            'identifier': self.identifier,
+            'identifier': str(self.identifier),
             'chain_id': self.chain_id,
             'token_address': to_checksum_address(self.token_address),
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'reveal_timeout': self.reveal_timeout,
-            'settle_timeout': self.settle_timeout,
+            'reveal_timeout': str(self.reveal_timeout),
+            'settle_timeout': str(self.settle_timeout),
             'our_state': self.our_state,
             'partner_state': self.partner_state,
             'open_transaction': self.open_transaction,
@@ -1566,13 +1571,13 @@ class NettingChannelState(State):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'NettingChannelState':
         restored = cls(
-            identifier=data['identifier'],
+            identifier=int(data['identifier']),
             chain_id=data['chain_id'],
             token_address=to_canonical_address(data['token_address']),
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            reveal_timeout=data['reveal_timeout'],
-            settle_timeout=data['settle_timeout'],
+            reveal_timeout=int(data['reveal_timeout']),
+            settle_timeout=int(data['settle_timeout']),
             our_state=data['our_state'],
             partner_state=data['partner_state'],
             open_transaction=data['open_transaction'],
@@ -1657,16 +1662,16 @@ class TransactionChannelNewBalance(State):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'participant_address': to_checksum_address(self.participant_address),
-            'contract_balance': self.contract_balance,
-            'deposit_block_number': self.deposit_block_number,
+            'contract_balance': str(self.contract_balance),
+            'deposit_block_number': str(self.deposit_block_number),
         }
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'TransactionChannelNewBalance':
         restored = cls(
             participant_address=to_canonical_address(data['participant_address']),
-            contract_balance=data['contract_balance'],
-            deposit_block_number=data['deposit_block_number'],
+            contract_balance=int(data['contract_balance']),
+            deposit_block_number=int(data['deposit_block_number']),
         )
 
         return restored
@@ -1708,14 +1713,14 @@ class TransactionOrder(State):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
             'transaction': self.transaction,
         }
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'TransactionOrder':
         restored = cls(
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
             transaction=data['transaction'],
         )
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1115,7 +1115,7 @@ class ReceiveTransferDirect(BalanceProofStateChange):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'payment_identifier': str(self.payment_identifier),
             'balance_proof': self.balance_proof,
         }
@@ -1124,7 +1124,7 @@ class ReceiveTransferDirect(BalanceProofStateChange):
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ReceiveTransferDirect':
         return cls(
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             payment_identifier=int(data['payment_identifier']),
             balance_proof=data['balance_proof'],
         )
@@ -1169,7 +1169,7 @@ class ReceiveUnlock(BalanceProofStateChange):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
             'secret': serialize_bytes(self.secret),
             'balance_proof': self.balance_proof,
         }
@@ -1177,7 +1177,7 @@ class ReceiveUnlock(BalanceProofStateChange):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ReceiveUnlock':
         return cls(
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
             secret=deserialize_bytes(data['secret']),
             balance_proof=data['balance_proof'],
         )
@@ -1208,14 +1208,14 @@ class ReceiveDelivered(AuthenticatedSenderStateChange):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'sender': to_checksum_address(self.sender),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
         }
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ReceiveDelivered':
         return cls(
             sender=to_canonical_address(data['sender']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
         )
 
 
@@ -1243,12 +1243,12 @@ class ReceiveProcessed(AuthenticatedSenderStateChange):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'sender': to_checksum_address(self.sender),
-            'message_identifier': self.message_identifier,
+            'message_identifier': str(self.message_identifier),
         }
 
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ReceiveProcessed':
         return cls(
             sender=to_canonical_address(data['sender']),
-            message_identifier=data['message_identifier'],
+            message_identifier=int(data['message_identifier']),
         )

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -59,7 +59,7 @@ class Block(StateChange):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
             'gas_limit': self.gas_limit,
             'block_hash': serialize_bytes(self.block_hash),
         }
@@ -67,7 +67,7 @@ class Block(StateChange):
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'Block':
         return cls(
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
             gas_limit=data['gas_limit'],
             block_hash=deserialize_bytes(data['block_hash']),
         )
@@ -96,10 +96,15 @@ class ActionCancelPayment(StateChange):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'payment_identifier': str(self.payment_identifier),
+        }
+
     @classmethod
     def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ActionCancelPayment':
         return cls(
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
         )
 
 
@@ -132,14 +137,14 @@ class ActionChannelClose(StateChange):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
         }
 
     @classmethod
     def from_dict(cls, data):
         return cls(
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
         )
 
 
@@ -216,8 +221,8 @@ class ActionTransferDirect(StateChange):
         return {
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'receiver_address': to_checksum_address(self.receiver_address),
-            'payment_identifier': self.payment_identifier,
-            'amount': self.amount,
+            'payment_identifier': str(self.payment_identifier),
+            'amount': str(self.amount),
         }
 
     @classmethod
@@ -225,8 +230,8 @@ class ActionTransferDirect(StateChange):
         return cls(
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             receiver_address=to_canonical_address(data['receiver_address']),
-            payment_identifier=data['payment_identifier'],
-            amount=data['amount'],
+            payment_identifier=int(data['payment_identifier']),
+            amount=int(data['amount']),
         )
 
 
@@ -269,7 +274,7 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_state': self.channel_state,
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -278,7 +283,7 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_state=data['channel_state'],
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
         )
 
 
@@ -328,8 +333,8 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'transaction_from': to_checksum_address(self.transaction_from),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
-            'block_number': self.block_number,
+            'channel_identifier': str(self.channel_identifier),
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -338,8 +343,8 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             transaction_from=to_canonical_address(data['transaction_from']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
-            block_number=data['block_number'],
+            channel_identifier=int(data['channel_identifier']),
+            block_number=int(data['block_number']),
         )
 
 
@@ -382,7 +387,7 @@ class ActionInitChain(StateChange):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
             'our_address': to_checksum_address(self.our_address),
             'chain_id': self.chain_id,
             'pseudo_random_generator': self.pseudo_random_generator.getstate(),
@@ -394,7 +399,7 @@ class ActionInitChain(StateChange):
 
         return cls(
             pseudo_random_generator=pseudo_random_generator,
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
             our_address=to_canonical_address(data['our_address']),
             chain_id=data['chain_id'],
         )
@@ -491,9 +496,9 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'deposit_transaction': self.deposit_transaction,
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -501,9 +506,9 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             deposit_transaction=data['deposit_transaction'],
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
         )
 
 
@@ -546,8 +551,8 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
-            'block_number': self.block_number,
+            'channel_identifier': str(self.channel_identifier),
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -555,8 +560,8 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
-            block_number=data['block_number'],
+            channel_identifier=int(data['channel_identifier']),
+            block_number=int(data['block_number']),
         )
 
 
@@ -573,7 +578,7 @@ class ActionLeaveAllNetworks(StateChange):
         return not self.__eq__(other)
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ActionLeaveAllNetworks':
+    def from_dict(cls, _data: typing.Dict[str, typing.Any]) -> 'ActionLeaveAllNetworks':
         return cls()
 
 
@@ -659,7 +664,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'payment_network': self.payment_network,
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -667,7 +672,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             payment_network=data['payment_network'],
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
         )
 
 
@@ -712,7 +717,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network': self.token_network,
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -721,7 +726,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network=data['token_network'],
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
         )
 
 
@@ -779,7 +784,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             'secret_registry_address': to_checksum_address(self.secret_registry_address),
             'secrethash': serialize_bytes(self.secrethash),
             'secret': serialize_bytes(self.secret),
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -789,7 +794,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             secret_registry_address=to_canonical_address(data['secret_registry_address']),
             secrethash=deserialize_bytes(data['secrethash']),
             secret=deserialize_bytes(data['secret']),
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
         )
 
 
@@ -872,9 +877,9 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             'participant': to_checksum_address(self.participant),
             'partner': to_checksum_address(self.partner),
             'locksroot': serialize_bytes(self.locksroot),
-            'unlocked_amount': self.unlocked_amount,
-            'returned_tokens': self.returned_tokens,
-            'block_number': self.block_number,
+            'unlocked_amount': str(self.unlocked_amount),
+            'returned_tokens': str(self.returned_tokens),
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -885,9 +890,9 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             participant=to_canonical_address(data['participant']),
             partner=to_canonical_address(data['partner']),
             locksroot=deserialize_bytes(data['locksroot']),
-            unlocked_amount=data['unlocked_amount'],
-            returned_tokens=data['returned_tokens'],
-            block_number=data['block_number'],
+            unlocked_amount=int(data['unlocked_amount']),
+            returned_tokens=int(data['returned_tokens']),
+            block_number=int(data['block_number']),
         )
 
 
@@ -947,10 +952,10 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
+            'channel_identifier': str(self.channel_identifier),
             'participant1': to_checksum_address(self.participant1),
             'participant2': to_checksum_address(self.participant2),
-            'block_number': self.block_number,
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -958,10 +963,10 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
+            channel_identifier=int(data['channel_identifier']),
             participant1=to_canonical_address(data['participant1']),
             participant2=to_canonical_address(data['participant2']),
-            block_number=data['block_number'],
+            block_number=int(data['block_number']),
         )
 
 
@@ -1002,8 +1007,8 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
-            'block_number': self.block_number,
+            'channel_identifier': str(self.channel_identifier),
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -1011,8 +1016,8 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
-            block_number=data['block_number'],
+            channel_identifier=int(data['channel_identifier']),
+            block_number=int(data['block_number']),
         )
 
 
@@ -1050,9 +1055,9 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
         return {
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
-            'channel_identifier': self.channel_identifier,
-            'nonce': self.nonce,
-            'block_number': self.block_number,
+            'channel_identifier': str(self.channel_identifier),
+            'nonce': str(self.nonce),
+            'block_number': str(self.block_number),
         }
 
     @classmethod
@@ -1060,9 +1065,9 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=data['channel_identifier'],
-            nonce=data['nonce'],
-            block_number=data['block_number'],
+            channel_identifier=int(data['channel_identifier']),
+            nonce=int(data['nonce']),
+            block_number=int(data['block_number']),
         )
 
 
@@ -1111,7 +1116,7 @@ class ReceiveTransferDirect(BalanceProofStateChange):
         return {
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'message_identifier': self.message_identifier,
-            'payment_identifier': self.payment_identifier,
+            'payment_identifier': str(self.payment_identifier),
             'balance_proof': self.balance_proof,
         }
 
@@ -1120,7 +1125,7 @@ class ReceiveTransferDirect(BalanceProofStateChange):
         return cls(
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             message_identifier=data['message_identifier'],
-            payment_identifier=data['payment_identifier'],
+            payment_identifier=int(data['payment_identifier']),
             balance_proof=data['balance_proof'],
         )
 

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -23,7 +23,7 @@ def get_state_change_with_balance_proof(
     return storage.get_latest_state_change_by_data_field({
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
-        'balance_proof.channel_identifier': channel_identifier,
+        'balance_proof.channel_identifier': str(channel_identifier),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
         'balance_proof.sender': to_checksum_address(sender),
     })

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -42,7 +42,7 @@ def get_event_with_balance_proof(
     return storage.get_latest_event_by_data_field({
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
-        'balance_proof.channel_identifier': channel_identifier,
+        'balance_proof.channel_identifier': str(channel_identifier),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
     })
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -10,6 +10,7 @@ Address = NewType('Address', T_Address)
 T_AddressHex = str
 AddressHex = NewType('AddressHex', T_AddressHex)
 
+# This is an absolute number of blocks
 T_BlockExpiration = int
 BlockExpiration = NewType('BlockExpiration', T_BlockExpiration)
 
@@ -31,6 +32,7 @@ BlockHash = NewType('BlockHash', T_BlockHash)
 T_BlockNumber = int
 BlockNumber = NewType('BlockNumber', T_BlockNumber)
 
+# This is a relative number of blocks
 T_BlockTimeout = int
 BlockTimeout = NewType('BlockTimeout', T_BlockTimeout)
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -10,7 +10,7 @@ Address = NewType('Address', T_Address)
 T_AddressHex = str
 AddressHex = NewType('AddressHex', T_AddressHex)
 
-# This is an absolute number of blocks
+# An absolute number of blocks
 T_BlockExpiration = int
 BlockExpiration = NewType('BlockExpiration', T_BlockExpiration)
 
@@ -32,7 +32,7 @@ BlockHash = NewType('BlockHash', T_BlockHash)
 T_BlockNumber = int
 BlockNumber = NewType('BlockNumber', T_BlockNumber)
 
-# This is a relative number of blocks
+# A relative number of blocks
 T_BlockTimeout = int
 BlockTimeout = NewType('BlockTimeout', T_BlockTimeout)
 
@@ -54,7 +54,7 @@ LockHash = NewType('LockHash', T_LockHash)
 T_MerkleTreeLeaves = List['HashTimeLockState']
 MerkleTreeLeaves = NewType('MerkleTreeLeaves', T_MerkleTreeLeaves)
 
-T_MessageID = Union[int, Tuple[str, int, bytes]]
+T_MessageID = int
 MessageID = NewType('MessageID', T_MessageID)
 
 T_Nonce = int


### PR DESCRIPTION
Fixes #3013 

Right now I explicitly convert IDs from channels and payments as well as absolute block numbers and token amounts as well as the message id.

Not converted are currently:
- chain id
- gas limit