### PR TITLE
Nightly coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ templates:
       - .travis/install.sh
     script:
       - .travis/run.sh
+    after_success:
+      - if [[ ${RUN_COVERAGE} = run_coverage ]]; then coveralls; else true; fi
     sudo: true
 
   job-template-integration: &job-template-integration
@@ -37,6 +39,7 @@ env:
   - SOLC_URL_LINUX='https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux'
   - SOLC_URL_MACOS='https://www.dropbox.com/s/4amq3on2ds1dq36/solc_0.4.23?dl=0'
   - SOLC_VERSION='v0.4.23'
+  - RUN_COVERAGE=$(.travis/coverage.sh)
   - COVERALLS_PARALLEL=true
   # `GITHUB_ACCESS_TOKEN` - read only access token to increase GitHub API rate limits
   # Format: `GITHUB_ACCESS_TOKEN=<username>:<token>`
@@ -54,6 +57,8 @@ notifications:
   webhooks:
   # Chat notification
   - secure: IXBsyQtH29Vkh+Pe2exrbE3L8FJMQFqJ8ZRxkACts7cQtB8Iz1vyjWg9nYE9ZuCj/JWEeMZd/09JvwwKUj8ZEzwj59gFwVQFwTAxJbiDLRsn7WpdI5Q2fQ9ZPZIAbPo/mJejeHC+z3d5UgY72hbhqWuPJAa4ApWWKE5mPFUIr9uxgs01ReWs/y5HaPawQkSQAKVWWsS5R52Oyr9CYQNbfqfWcoLvzdiIZpsBi2r4ZK3NGrBZPGo4b+PkDkWjuBhMJ0FVABFCJT/bT2ORFsmsCDwZ4I3vOrKtJGDybmwONZqr0ymfYo1lbcUp0mE0zJ0ApyRtLqEFiTzaQqenlAZmBAtpDZVvpxFuDwZgFxafpNutO3Aj3Xbfe+aaooPfHA7SoxmxG/3gWY+OyaME8EDePfBHM0c1gGsNHmbPLt8k0lmwYKlNTFtFFyRAbL3700j19utkGroOK6CUYbed9YD96UehQTj7HN8rpLTZzSMh39c1JHVyqxsUZKkhQgY4GPgx2RAIiCVrwc6wN3Ebtwft0hA2UhvDodsc/qBAyz/YnSp2oKZKagLy5747torZybtNOGKCaV2fT3mSTxV2UNwPJ/N94dlTquJNx3StHT0IqD3Kfo5HYKJKHeri6lttTDul3rjAs1xxB2aAMutsyg7dRbBMmuKlK9gAtoS3UKthQdk=
+  # coveralls 'parallel build done' trigger
+  - secure: "eFjTor3HH4OiMkBYJAbiri09AV86KbMoPi9khESCOTicM/AnofrAdObguxa4v/s1d2AXbpaEpvy59R2ZaocucwSnw2UoCa/VgTPZf8FOazShn001g0PN2LS6hQFxCTFDowOHZKx9P2jqoUf17rtUDDbGfin6L/aaykJ9MCXxJKY+jlf8roDGArbaXHqntkhphNYuFsmaHHqQqjuRUdCB+Ys8BAQavsePWpyJ0kjlPo4UuSasn6OpRnrz7E6K/3tziFJB0l4hTghU2wzDYF9V+eF9jIyoqoUkcgqTeyjjAO2Rf1If20gQerf09wC8xl965VLgzZ/oQCp4WpIFzorJielLwdE498N0S/gZ0GktqO3jPfS97JaH2+ZkSb2yUdTSLxTHCva9mgqpnQAK8AOEndjMUupbc0UXe440MJzX1wT6IaQ2IwibRwADWAgUqOu5XSaV+rWPvKbBl54NwO7yAVxV20PbKqJMFAYiuVKnRRqnLDhKsZpPxEf0nfrbu/VARKeVuWEg6LkaBFPA4r+EjCQFhT/hwB/DFjoYSCf5PpFcvwL1Tl2gpQcxFhDHKHAITLwYCVCiQHkG1MdQt4fTaBUEm+BcmIbZ4FVfTYbCdys7Hge6RTKxVl8Xe7jDgibHXF4wTPHR81crX9Xk3nUm6VwJzluaTUi1OKj8Nathqbk="
 
 jobs:
   include:

--- a/.travis/coverage.sh
+++ b/.travis/coverage.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Script to determine whether to run `coverage` or not. Its output is intended to be set to a global
+# env variable `RUN_COVERAGE`, that will be tested for in consecutive steps.
+
+set -e
+set -x
+
+PR_MSG="$(git log --format=%B -n 1 $(echo ${TRAVIS_COMMIT_RANGE} | cut -d '.' -f4))"
+
+# Conditions
+# - HEAD commit is tagged [ci coverage]
+# - master branch AND cron job
+
+if [[ "${PR_MSG}" =~ "[ci coverage]" || "${TRAVIS_EVENT_TYPE}" == "cron" && "${TRAVIS_BRANCH}" == "master" ]]; then
+    echo run_coverage
+else
+    echo no_coverage
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -16,4 +16,8 @@ pip install ${INSTALL_OPT} pyinstaller
 pip install ${INSTALL_OPT} -c constraints.txt --upgrade --upgrade-strategy eager -r requirements-dev.txt
 pip install ${INSTALL_OPT} -c constraints.txt -e .
 
+if [[ ${RUN_COVERAGE} = run_coverage ]]; then
+    pip install ${INSTALL_OPT} --upgrade coveralls
+fi
+
 pip list --outdated

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -9,7 +9,13 @@ elif [ -z ${BLOCKCHAIN_TYPE} ]; then
     BLOCKCHAIN_TYPE="geth"
 fi
 
-py.test \
+if [[ ${RUN_COVERAGE} = run_coverage ]]; then
+    TEST_RUNNER="coverage run -m py.test"
+elif [[ ${RUN_COVERAGE} = no_coverage ]]; then
+    TEST_RUNNER="py.test"
+fi
+
+${TEST_RUNNER} \
     -Wd \
     --travis-fold=always \
     --log-config='raiden:DEBUG' \


### PR DESCRIPTION
This enables `coverage` and `coveralls` reporting on every nightly cron build in travis.

I chose to export a conditional `env` variable `RUN_COVERAGE` in the ~`before_install`~ `env.GLOBAL` stage. This allows for a streamlined conditional checking in all affected later stages/scripts.

This fixes #3020