### PR TITLE
Save time and version in sqlite on startup

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Tuple
 from raiden.constants import SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
-from raiden.utils import typing
+from raiden.utils import typing, get_system_spec
 
 # The latest DB version
 RAIDEN_DB_VERSION = 12
@@ -30,7 +30,7 @@ def assert_sqlite_version() -> bool:
 
 class SQLiteStorage:
     def __init__(self, database_path, serializer):
-        conn = sqlite3.connect(database_path)
+        conn = sqlite3.connect(database_path, detect_types=sqlite3.PARSE_DECLTYPES)
         conn.text_factory = str
         conn.execute('PRAGMA foreign_keys=ON')
         self.conn = conn
@@ -45,6 +45,7 @@ class SQLiteStorage:
                 )
 
         self._run_updates()
+        self._log_raiden_run()
 
         # When writting to a table where the primary key is the identifier and we want
         # to return said identifier we use cursor.lastrowid, which uses sqlite's last_insert_rowid
@@ -71,6 +72,13 @@ class SQLiteStorage:
             'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
             ('version', str(RAIDEN_DB_VERSION)),
         )
+        self.conn.commit()
+
+    def _log_raiden_run(self):
+        """ Log timestamp and raiden version to help with debugging """
+        version = get_system_spec()['raiden']
+        cursor = self.conn.cursor()
+        cursor.execute('INSERT INTO runs(raiden_version) VALUES (?)', [version])
         self.conn.commit()
 
     def get_version(self) -> int:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Tuple
 from raiden.constants import SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
-from raiden.utils import typing, get_system_spec
+from raiden.utils import get_system_spec, typing
 
 # The latest DB version
 RAIDEN_DB_VERSION = 12

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -40,10 +40,17 @@ CREATE TABLE IF NOT EXISTS state_events (
 );
 '''
 
+DB_CREATE_RUNS = '''
+CREATE TABLE IF NOT EXISTS runs (
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP PRIMARY KEY,
+    raiden_version TEXT NOT NULL
+);
+'''
+
 DB_SCRIPT_CREATE_TABLES = """
 PRAGMA foreign_keys=off;
 BEGIN TRANSACTION;
-{}{}{}{}
+{}{}{}{}{}
 COMMIT;
 PRAGMA foreign_keys=on;
 """.format(
@@ -51,4 +58,5 @@ PRAGMA foreign_keys=on;
     DB_CREATE_STATE_CHANGES,
     DB_CREATE_SNAPSHOT,
     DB_CREATE_STATE_EVENTS,
+    DB_CREATE_RUNS,
 )

--- a/raiden/tests/unit/test_sqlitestorage.py
+++ b/raiden/tests/unit/test_sqlitestorage.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from raiden.storage.sqlite import SQLiteStorage
+
+
+def test_log_raiden_run():
+    with patch('raiden.storage.sqlite.get_system_spec') as get_speck_mock:
+        get_speck_mock.return_value = dict(raiden='1.2.3')
+        store = SQLiteStorage(':memory:', None)
+    cursor = store.conn.cursor()
+    cursor.execute('SELECT started_at, raiden_version FROM runs')
+    run = cursor.fetchone()
+    now = datetime.utcnow()
+    assert now - timedelta(seconds=2) <= run[0] <= now, f'{run[0]} not right before {now}'
+    assert run[1] == '1.2.3'

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -1,7 +1,5 @@
 import os
 import sqlite3
-from datetime import datetime, timedelta
-from unittest.mock import patch
 
 import pytest
 
@@ -263,15 +261,3 @@ def test_get_snapshot_closest_to_state_change():
 
     _, snapshot = wal.storage.get_snapshot_closest_to_state_change('latest')
     assert snapshot.state_changes == [block1, block2, block3]
-
-
-def test_log_raiden_run():
-    with patch('raiden.storage.sqlite.get_system_spec') as get_speck_mock:
-        get_speck_mock.return_value = dict(raiden='1.2.3')
-        store = SQLiteStorage(':memory:', None)
-    cursor = store.conn.cursor()
-    cursor.execute('SELECT started_at, raiden_version FROM runs')
-    run = cursor.fetchone()
-    now = datetime.utcnow()
-    assert now - timedelta(seconds=2) <= run[0] <= now, f'{run[0]} not right before {now}'
-    assert run[1] == '1.2.3'


### PR DESCRIPTION
This help reproducing problems related to upgrades and debugging in
general (closes #3006).

Adding detect_types=sqlite3.PARSE_DECLTYPES to sqlite3.connect might
affect other parts of the code, but makes using timestamp columns more
pleasant. The unit tests run fine and failures should be obvious, so I
don't think it brakes anything.

I'm not sure where to put the test, see https://github.com/raiden-network/raiden/issues/3006#issuecomment-438962908 .