### PR TITLE
Disable pytest captured logs

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -13,6 +13,7 @@ py.test \
     -Wd \
     --travis-fold=always \
     --log-config='raiden:DEBUG' \
+    --no-print-logs \
     --random \
     -v \
     --showlocals \


### PR DESCRIPTION
It seems like pytest ignores `showcapture` and `capture` options when it prints the report for failed tests.
The problem that we're having right now is the fact that when we log stuff, pytest hooks it's own handlers into the test session to capture logs... in our code, our structured log instance prints the logs to stdout which makes the pytest also capture this output and therefore, resulting in two duplicate log lines being printed on failed tests (stdout + captured log record)

Resolves #3012 