### PR TITLE
[SP] Fix send_transaction gaslimit argument

### DIFF
--- a/tools/scenario-player/scenario_player/node_support.py
+++ b/tools/scenario-player/scenario_player/node_support.py
@@ -289,7 +289,7 @@ class NodeRunner:
             '--eth-rpc-endpoint',
             self.eth_rpc_endpoint,
             '--log-config',
-            ':info,raiden:debug',
+            ':info,raiden:debug,raiden.api.rest.pywsgi:warning',
             '--log-file',
             self._log_file,
             '--disable-debug-logfile',

--- a/tools/scenario-player/scenario_player/runner.py
+++ b/tools/scenario-player/scenario_player/runner.py
@@ -194,7 +194,11 @@ class ScenarioRunner(object):
             if low_balances:
                 log.info('Funding nodes', nodes=low_balances.keys())
                 fund_tx = [
-                    self.client.send_transaction(address, NODE_ACCOUNT_BALANCE_FUND - balance)
+                    self.client.send_transaction(
+                        to=address,
+                        startgas=21000,
+                        value=NODE_ACCOUNT_BALANCE_FUND - balance,
+                    )
                     for address, balance in low_balances.items()
                 ]
             node_starter = self.node_controller.start(wait=False)

--- a/tools/scenario-player/scenario_player/tasks/base.py
+++ b/tools/scenario-player/scenario_player/tasks/base.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import pkgutil
 import time
+from copy import copy
 from datetime import timedelta
 from enum import Enum
 from typing import Any, TypeVar
@@ -48,7 +49,7 @@ class Task:
         _TASK_ID = _TASK_ID + 1
         self.id = str(_TASK_ID)
         self._runner = runner
-        self._config = config
+        self._config = copy(config)
         self._parent = parent
         self._abort_on_fail = abort_on_fail
         self.state = TaskState.INITIALIZED

--- a/tools/scenario-player/scenario_player/utils.py
+++ b/tools/scenario-player/scenario_player/utils.py
@@ -330,8 +330,8 @@ def reclaim_eth(account: Account, chain_rpc_urls: dict, data_path: str, min_age_
                 client = JSONRPCClient(web3, privkey)
                 txs[chain_name].append(
                     client.send_transaction(
-                        account.address,
-                        drain_amount,
+                        to=account.address,
+                        value=drain_amount,
                         startgas=VALUE_TX_GAS_COST,
                     ),
                 )


### PR DESCRIPTION
Fix breakage introduced by the changed `send_transaction()` signature. 
Also includes some other small improvements:
- Hide rest api `GET`, `POST` etc. log lines in managed Raiden node logs
- Allow scenarios to specify payment identifiers or to autogenerate deterministic ones.