### PR TITLE
Fix TokenAddres into TokenAddress

### DIFF
--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -357,7 +357,7 @@ class LockedTransferUnsignedState(State):
     def __init__(
             self,
             payment_identifier: typing.PaymentID,
-            token: typing.Address,
+            token: typing.TokenAddress,
             balance_proof: BalanceProofUnsignedState,
             lock: HashTimeLockState,
             initiator: typing.Address,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1434,7 +1434,7 @@ class NettingChannelState(State):
             self,
             identifier: typing.ChannelID,
             chain_id: typing.ChainID,
-            token_address: typing.Address,
+            token_address: typing.TokenAddress,
             payment_network_identifier: typing.PaymentNetworkID,
             token_network_identifier: typing.TokenNetworkID,
             reveal_timeout: typing.BlockTimeout,

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -88,7 +88,7 @@ T_TargetAddress = bytes
 TargetAddress = NewType('TargetAddress', T_TargetAddress)
 
 T_TokenAddress = bytes
-TokenAddress = NewType('TokenAddres', T_TokenAddress)
+TokenAddress = NewType('TokenAddress', T_TokenAddress)
 
 T_TokenNetworkAddress = bytes
 TokenNetworkAddress = NewType('TokenNetworkAddress', T_TokenNetworkAddress)


### PR DESCRIPTION
As part of #3040, I saw an error from mypy, saying
```
raiden/utils/typing.py:89: error: String argument 1 'TokenAddres' to NewType(...) does not match variable name 'TokenAddress'
```
So I added a missing `s`.

Then I saw four new errors from mypy.  I fixed all new errors in this PR.