### PR TITLE
Enforce proper development setup

### DIFF
--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -153,8 +153,7 @@ class NodeRunner:
 
         # spawn a greenlet to handle the version checking
         version = get_system_spec()['raiden']
-        if version is not None:
-            tasks.append(gevent.spawn(check_version, version))
+        tasks.append(gevent.spawn(check_version, version))
 
         # spawn a greenlet to handle the gas reserve check
         tasks.append(gevent.spawn(check_gas_reserve, app_.raiden))

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -181,7 +181,11 @@ def get_system_spec() -> typing.Dict[str, str]:
     try:
         version = pkg_resources.require(raiden.__name__)[0].version
     except (pkg_resources.ContextualVersionConflict, pkg_resources.DistributionNotFound):
-        version = 'unknown_raiden_version'
+        raise RuntimeError(
+            'Cannot detect Raiden version. Did you do python setup.py?  '
+            'Refer to https://raiden-network.readthedocs.io/en/latest/'
+            'overview_and_guide.html#for-developers',
+        )
 
     system_spec = {
         'raiden': version,


### PR DESCRIPTION
In the past if a user simply does
`pip install -c constraints.txt --upgrade -r requirements-dev.txt`
without a `python setup.py`
then a `None` version is returned. This is an incorrect usage of the
software so we should enforce it.