### PR TITLE
Remove mypy errors: re.search() might return None

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -42,14 +42,20 @@ def is_supported_client(
         client_version: str,
 ) -> typing.Tuple[bool, typing.Optional[constants.EthClient]]:
     if client_version.startswith('Parity'):
+        matches = re.search(r'//v(\d+)\.(\d+)\.(\d+)', client_version)
+        if matches is None:
+            return False, None
         major, minor, patch = [
-            int(x) for x in re.search(r'//v(\d+)\.(\d+)\.(\d+)', client_version).groups()
+            int(x) for x in matches.groups()
         ]
         if (major, minor, patch) >= (1, 7, 6):
             return True, constants.EthClient.PARITY
     elif client_version.startswith('Geth'):
+        matches = re.search(r'/v(\d+)\.(\d+)\.(\d+)', client_version)
+        if matches is None:
+            return False, None
         major, minor, patch = [
-            int(x) for x in re.search(r'/v(\d+)\.(\d+)\.(\d+)', client_version).groups()
+            int(x) for x in matches.groups()
         ]
         if (major, minor, patch) >= (1, 7, 2):
             return True, constants.EthClient.GETH


### PR DESCRIPTION
Before this commit, `mypy raiden/transfer/mediated_transfer/target.py
--ignore-missing-imports` returned error messages:

```
raiden/utils/__init__.py:46: error: Item "None" of "Optional[Match[str]]" has no attribute "groups"
raiden/utils/__init__.py:52: error: Item "None" of "Optional[Match[str]]" has no attribute "groups"
```

This commit removes these errors.

This change is one step for
https://github.com/raiden-network/raiden/issues/3040.