### PR TITLE
Remove ChannelID type annotation on some other IDs

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -12,13 +12,13 @@ RAIDEN_DB_VERSION = 14
 
 
 class EventRecord(typing.NamedTuple):
-    event_identifier: typing.ChannelID
+    event_identifier: int
     state_change_identifier: typing.BlockNumber
     data: typing.Any
 
 
 class StateChangeRecord(typing.NamedTuple):
-    state_change_identifier: typing.ChannelID
+    state_change_identifier: int
     data: typing.Any
 
 


### PR DESCRIPTION
This commit removes error messages from
`mypy raiden/transfer/mediated_transfer/target.py --ignore-missing-imports`
namely,
```
> raiden/storage/sqlite.py:226: error: Argument "event_identifier" to "EventRecord" has incompatible type "int"; expected "ChannelID"
> raiden/storage/sqlite.py:273: error: Argument "state_change_identifier" to "StateChangeRecord" has incompatible type "int"; expected "ChannelID"
```