### PR TITLE
Reject any signatures with v not in (0, 1, 27, 28)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`3054` Client will now reject any signatures with ``v`` not in (0, 1, 27, 28)
+
 * :release:`0.17.0 <2018-11-16>`
 * :bug:`3035` Registering a token twice should now return a proper error.
 * :bug:`3013` Encode all integers before saving to the sqlite database

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -83,6 +83,11 @@ class InvalidSettleTimeout(RaidenError):
     pass
 
 
+class InvalidSignature(RaidenError):
+    """Raised on invalid signature recover/verify"""
+    pass
+
+
 class SamePeerAddress(RaidenError):
     """ Raised when a user tries to create a channel where the address of both
     peers is the same.

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -248,10 +248,10 @@ class SignedMessage(Message):
         message_signature = self.signature
 
         try:
-            address = to_canonical_address(eth_recover(
+            address = eth_recover(
                 data=data_that_was_signed,
                 signature=message_signature,
-            ))
+            )
         except InvalidSignature:
             address = None
         return address

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -27,6 +27,7 @@ from raiden.transfer.mediated_transfer.events import (
 from raiden.transfer.state import HashTimeLockState
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import ishash, pex, sha3, typing
+from raiden.utils.signing import eth_recover, eth_sign
 from raiden.utils.typing import (
     Address,
     BlockExpiration,
@@ -42,7 +43,6 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
 )
 from raiden_libs.exceptions import InvalidSignature
-from raiden_libs.utils.signing import eth_recover, eth_sign
 
 __all__ = (
     'Delivered',

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -12,7 +12,7 @@ from eth_utils import (
 from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.encoding import messages
 from raiden.encoding.format import buffer_for
-from raiden.exceptions import InvalidProtocolMessage
+from raiden.exceptions import InvalidProtocolMessage, InvalidSignature
 from raiden.transfer.architecture import SendMessageEvent
 from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.transfer.events import SendDirectTransfer, SendProcessed
@@ -42,7 +42,6 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
 )
-from raiden_libs.exceptions import InvalidSignature
 
 __all__ = (
     'Delivered',

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -30,6 +30,7 @@ from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.utils import pex, privatekey_to_address, safe_gas_limit, typing
+from raiden.utils.signing import eth_recover
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
     GAS_REQUIRED_FOR_CLOSE_CHANNEL,
@@ -42,7 +43,6 @@ from raiden_contracts.constants import (
     ParticipantInfoIndex,
 )
 from raiden_contracts.contract_manager import ContractManager
-from raiden_libs.utils.signing import eth_recover
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -755,10 +755,10 @@ class TokenNetwork:
         )
 
         try:
-            signer_address = to_canonical_address(eth_recover(
+            signer_address = eth_recover(
                 data=data_that_was_signed,
                 signature=closing_signature,
-            ))
+            )
 
             # InvalidSignature is raised by eth_utils.eth_recover if signature
             # is not bytes or has the incorrect length

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -26,6 +26,7 @@ from matrix_client.user import User
 from raiden.exceptions import (
     InvalidAddress,
     InvalidProtocolMessage,
+    InvalidSignature,
     TransportError,
     UnknownAddress,
     UnknownTokenAddress,
@@ -73,7 +74,6 @@ from raiden.utils.typing import (
     Union,
 )
 from raiden_contracts.constants import ID_TO_NETWORKNAME
-from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.network.matrix import GMatrixClient, Room
 
 log = structlog.get_logger(__name__)

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -56,6 +56,7 @@ from raiden.transfer.state import (
 from raiden.transfer.state_change import ActionChangeNodeNetworkState
 from raiden.utils import pex
 from raiden.utils.runnable import Runnable
+from raiden.utils.signing import eth_recover, eth_sign
 from raiden.utils.typing import (
     Address,
     AddressHex,
@@ -74,7 +75,6 @@ from raiden.utils.typing import (
 from raiden_contracts.constants import ID_TO_NETWORKNAME
 from raiden_libs.exceptions import InvalidSignature
 from raiden_libs.network.matrix import GMatrixClient, Room
-from raiden_libs.utils.signing import eth_recover, eth_sign
 
 log = structlog.get_logger(__name__)
 

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -1239,10 +1239,10 @@ class MatrixTransport(Runnable):
     @staticmethod
     def _recover(data: bytes, signature: bytes) -> Address:
         """ Use eth_sign compatible hasher to recover address from signed data """
-        return to_canonical_address(eth_recover(
+        return eth_recover(
             data=data,
             signature=signature,
-        ))
+        )
 
     @cached(_addresses_cache, key=lambda _, user: (user.user_id, user.displayname))
     def _validate_userid_signature(self, user: User) -> Optional[Address]:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -40,7 +40,7 @@ from raiden.transfer.mediated_transfer.events import (
 )
 from raiden.transfer.utils import get_event_with_balance_proof, get_state_change_with_balance_proof
 from raiden.utils import pex
-from raiden_libs.utils.signing import eth_sign
+from raiden.utils.signing import eth_sign
 
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -7,9 +7,9 @@ from raiden.network.proxies import PaymentChannel, TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils import wait_blocks
 from raiden.utils import privatekey_to_address
+from raiden.utils.signing import eth_sign
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
 from raiden_libs.messages import BalanceProof
-from raiden_libs.utils.signing import eth_sign
 
 
 def test_payment_channel_proxy_basics(

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -14,13 +14,13 @@ from raiden.exceptions import (
 from raiden.network.proxies import TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils import wait_blocks
+from raiden.utils.signing import eth_sign
 from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
     MessageTypeId,
 )
 from raiden_libs.messages import BalanceProof
-from raiden_libs.utils.signing import eth_sign
 
 
 def test_token_network_deposit_race(

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -1,7 +1,6 @@
 import random
 
 import pytest
-from eth_utils import to_canonical_address
 
 from raiden import constants
 from raiden.exceptions import InvalidSignature
@@ -27,10 +26,10 @@ def test_signature():
     message_data = ping._data_to_sign()
     # This signature will sometimes end up with v being 0, sometimes 1
     signature = eth_sign(privkey=PRIVKEY, data=message_data, v=0)
-    assert ADDRESS == to_canonical_address(eth_recover(message_data, signature))
+    assert ADDRESS == eth_recover(message_data, signature)
     # This signature will sometimes end up with v being 27, sometimes 28
     signature = eth_sign(privkey=PRIVKEY, data=message_data, v=27)
-    assert ADDRESS == to_canonical_address(eth_recover(message_data, signature))
+    assert ADDRESS == eth_recover(message_data, signature)
 
     # test that other v values are rejected
     signature = signature[:-1] + bytes([29])

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -29,7 +29,7 @@ from raiden.transfer.state import (
 )
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import privatekey_to_address, publickey_to_address, random_secret, sha3, typing
-from raiden_libs.utils.signing import eth_sign
+from raiden.utils.signing import eth_sign
 
 EMPTY = object()
 

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -1,6 +1,6 @@
 from raiden.utils import typing
+from raiden.utils.signing import pack_data
 from raiden_contracts.constants import MessageTypeId
-from raiden_libs.utils.signing import pack_data
 
 
 def pack_balance_proof(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -78,7 +78,7 @@ from raiden.transfer.state_change import (
 )
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import pex, typing
-from raiden_libs.utils.signing import eth_recover
+from raiden.utils.signing import eth_recover
 
 # This should be changed to `Union[str, MerkleTreeState]`
 MerkletreeOrError = typing.Tuple[bool, typing.Optional[str], typing.Optional[typing.Any]]

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -2,7 +2,7 @@
 import heapq
 import random
 
-from eth_utils import encode_hex, to_canonical_address
+from eth_utils import encode_hex
 
 from raiden.constants import MAXIMUM_PENDING_TRANSFERS, UINT256_MAX
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
@@ -261,10 +261,10 @@ def is_valid_signature(
     )
 
     try:
-        signer_address = to_canonical_address(eth_recover(
+        signer_address = eth_recover(
             data=data_that_was_signed,
             signature=balance_proof.signature,
-        ))
+        )
         # InvalidSignature is raised by eth_utils.eth_recover if signature
         # is not bytes or has the incorrect length
         #

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -23,7 +23,7 @@ import raiden
 from raiden import constants
 from raiden.exceptions import InvalidAddress
 from raiden.utils import typing
-from raiden_libs.utils.signing import sha3
+from raiden.utils.signing import sha3
 
 
 def random_secret():

--- a/raiden/utils/signing.py
+++ b/raiden/utils/signing.py
@@ -1,5 +1,5 @@
 from coincurve import PrivateKey, PublicKey
-from eth_utils import decode_hex, keccak, remove_0x_prefix, to_bytes, to_checksum_address
+from eth_utils import decode_hex, keccak, remove_0x_prefix, to_bytes
 from web3.utils.abi import map_abi_data
 from web3.utils.encoding import hex_encode_abi_type
 from web3.utils.normalizers import abi_address_to_hex
@@ -27,7 +27,7 @@ def public_key_to_address(public_key: Union[PublicKey, bytes]) -> Address:
     if isinstance(public_key, PublicKey):
         public_key = public_key.format(compressed=False)
     assert isinstance(public_key, bytes)
-    return to_checksum_address(sha3(public_key[1:])[-20:])
+    return sha3(public_key[1:])[-20:]
 
 
 def address_from_signature(data: bytes, signature: bytes, hasher: Hasher = sha3) -> Address:

--- a/raiden/utils/signing.py
+++ b/raiden/utils/signing.py
@@ -1,0 +1,94 @@
+from coincurve import PrivateKey, PublicKey
+from eth_utils import decode_hex, keccak, remove_0x_prefix, to_bytes, to_checksum_address
+from web3.utils.abi import map_abi_data
+from web3.utils.encoding import hex_encode_abi_type
+from web3.utils.normalizers import abi_address_to_hex
+
+from raiden.exceptions import InvalidSignature
+from raiden.utils.typing import Address, Callable, Optional, Union
+
+sha3 = keccak
+Hasher = Optional[Callable[[bytes], bytes]]
+
+
+def eth_sign_sha3(data: bytes) -> bytes:
+    """
+    eth_sign/recover compatible hasher
+    Prefixes data with "\x19Ethereum Signed Message:\n<len(data)>"
+    """
+    prefix = b'\x19Ethereum Signed Message:\n'
+    if not data.startswith(prefix):
+        data = prefix + b'%d%s' % (len(data), data)
+    return sha3(data)
+
+
+def public_key_to_address(public_key: Union[PublicKey, bytes]) -> Address:
+    """ Converts a public key to an Ethereum address. """
+    if isinstance(public_key, PublicKey):
+        public_key = public_key.format(compressed=False)
+    assert isinstance(public_key, bytes)
+    return to_checksum_address(sha3(public_key[1:])[-20:])
+
+
+def address_from_signature(data: bytes, signature: bytes, hasher: Hasher = sha3) -> Address:
+    """Convert an EC signature into an ethereum address"""
+    if not isinstance(signature, bytes) or len(signature) != 65:
+        raise InvalidSignature('Invalid signature, must be 65 bytes')
+    # Support Ethereum's EC v value of 27 and EIP 155 values of > 35.
+    if signature[-1] >= 35:
+        network_id = (signature[-1] - 35) // 2
+        signature = signature[:-1] + bytes([signature[-1] - 35 - 2 * network_id])
+    elif signature[-1] >= 27:
+        signature = signature[:-1] + bytes([signature[-1] - 27])
+
+    try:
+        signer_pubkey = PublicKey.from_signature_and_message(signature, data, hasher=hasher)
+        return public_key_to_address(signer_pubkey)
+    except Exception as e:  # pylint: disable=broad-except
+        # coincurve raises bare exception on verify error
+        raise InvalidSignature('Invalid signature') from e
+
+
+def eth_recover(data: bytes, signature: bytes, hasher: Hasher = eth_sign_sha3) -> Address:
+    """ Recover an address (hex encoded) from a eth_sign data and signature """
+    return address_from_signature(data=data, signature=signature, hasher=hasher)
+
+
+def sign(
+        privkey: Union[str, bytes, PrivateKey],
+        data: bytes,
+        v: int = 27,
+        hasher: Hasher = sha3,
+) -> bytes:
+    if isinstance(privkey, str):
+        privkey = to_bytes(hexstr=privkey)
+    if isinstance(privkey, bytes):
+        privkey = PrivateKey(privkey)
+    sig = privkey.sign_recoverable(data, hasher=hasher)
+    return sig[:-1] + bytes([sig[-1] + v])
+
+
+def eth_sign(
+        privkey: Union[str, bytes, PrivateKey],
+        data: bytes,
+        v: int = 27,
+        hasher: Hasher = eth_sign_sha3,
+) -> bytes:
+    return sign(privkey, data, v=v, hasher=hasher)
+
+
+def pack_data(abi_types, values) -> bytes:
+    """Normalize data and pack them into a byte array"""
+    if len(abi_types) != len(values):
+        raise ValueError(
+            "Length mismatch between provided abi types and values.  Got "
+            "{0} types and {1} values.".format(len(abi_types), len(values)),
+        )
+
+    normalized_values = map_abi_data([abi_address_to_hex], abi_types, values)
+
+    return decode_hex(''.join(
+        remove_0x_prefix(hex_encode_abi_type(abi_type, value))
+        for abi_type, value
+        in zip(abi_types, normalized_values)
+    ))

--- a/tools/gas_cost_measures.py
+++ b/tools/gas_cost_measures.py
@@ -10,9 +10,9 @@ from web3 import EthereumTesterProvider, Web3
 from raiden.constants import TRANSACTION_GAS_LIMIT
 from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.transfer.utils import hash_balance_data
+from raiden.utils.signing import eth_sign
 from raiden_contracts.contract_manager import CONTRACTS_SOURCE_DIRS, ContractManager
 from raiden_contracts.utils.utils import get_pending_transfers_tree
-from raiden_libs.utils.signing import eth_sign
 
 pyevm_main.GENESIS_GAS_LIMIT = 6 * 10 ** 6
 


### PR DESCRIPTION
Should fix #3054 

- Moves the signing code from raiden libs to the client as discussed in our talks of moving stuff out of raiden libs. Will also make a PR to the libs to deprecate the calls.
- When trying to process a signature to recover sender address we now reject all `v` values not in `(0, 1, 27. 28)` to be in sync with the [contracts implementation](https://github.com/raiden-network/raiden-contracts/blob/aea36ce403605670edc23fe0d14cf422e2b8e69b/raiden_contracts/contracts/lib/ECVerify.sol#L27).
- Tests for the above.

