### PR TITLE
Nonce did not change sequentially

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -65,8 +65,8 @@ pystun-patched-for-raiden==0.1.0
 pytest==3.10.1
 pytoml==0.1.19
 pytz==2018.5
-raiden-contracts==0.6.0
-raiden-libs==0.1.11
+raiden-contracts==0.8.0
+raiden-libs==0.1.14
 requests==2.20.0
 rlp==1.0.2
 semantic-version==2.6.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`3054` Client will now reject any signatures with ``v`` not in (0, 1, 27, 28)
+* :bug:`3046` Sync with the matrix server using the last known sync token. This solves the issue of missing messages during restart as previously only the last 10 were fetched.
 
 * :release:`0.17.0 <2018-11-16>`
 * :bug:`3035` Registering a token twice should now return a proper error.

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -519,7 +519,7 @@ class MatrixTransport(Runnable):
 
             try:
                 self._client.sync_token = None
-                self._client.login(username, password)
+                self._client.login(username, password, sync=False)
                 self.log.debug(
                     'Login',
                     homeserver=self._server_name,

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -337,12 +337,16 @@ class MatrixTransport(Runnable):
         self,
         raiden_service: RaidenService,
         message_handler: MessageHandler,
+        fetch_since: str,
     ):
         if not self._stop_event.ready():
             raise RuntimeError(f'{self!r} already started')
         self._stop_event.clear()
         self._raiden_service = raiden_service
         self._message_handler = message_handler
+
+        # Initialize the point from which the client will sync messages
+        self._client.sync_token = fetch_since
 
         self._login_or_register()
         self.log = log.bind(current_user=self._user_id, node=pex(self._raiden_service.address))

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -198,14 +198,15 @@ class UDPTransport(Runnable):
 
     def start(
             self,
-            raiden: RaidenService,
+            raiden_service: RaidenService,
             message_handler: MessageHandler,
+            fetch_since_token: str,
     ):
         if not self.event_stop.ready():
             raise RuntimeError('UDPTransport started while running')
 
         self.event_stop.clear()
-        self.raiden = raiden
+        self.raiden = raiden_service
         self.log = log.bind(node=pex(self.raiden.address))
         self.log_healthcheck = log_healthcheck.bind(node=pex(self.raiden.address))
         self.message_handler = message_handler

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -378,9 +378,9 @@ class RaidenService(Runnable):
         # is closed on-chain new messages must be rejected, which will not be the
         # case if the node is not synchronized)
         self.transport.start(
-            self,
-            self.message_handler,
-            chain_state.last_transport_timestamp,
+            raiden_service=self,
+            message_handler=self.message_handler,
+            fetch_since_token=chain_state.last_transport_synctoken,
         )
 
         # First run has been called above!

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -377,7 +377,11 @@ class RaidenService(Runnable):
         # node with the blockchain, including the channel's state (if the channel
         # is closed on-chain new messages must be rejected, which will not be the
         # case if the node is not synchronized)
-        self.transport.start(self, self.message_handler)
+        self.transport.start(
+            self,
+            self.message_handler,
+            chain_state.last_transport_timestamp,
+        )
 
         # First run has been called above!
         self.alarm.start()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import get_system_spec, typing
 
 # The latest DB version
-RAIDEN_DB_VERSION = 14
+RAIDEN_DB_VERSION = 15
 
 
 class EventRecord(typing.NamedTuple):

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -1,7 +1,26 @@
-class MockRaidenService(object):
+from raiden.tests.utils import factories
 
-    def __init__(self, address):
-        self.address = address
+
+class MockChain:
+    def __init__(self):
+        self.network_id = 17
+
+
+class MockRaidenService:
+    def __init__(self, message_handler=None):
+        self.chain = MockChain()
+        self.private_key, self.address = factories.make_privatekey_address()
+        self.message_handler = message_handler
+
+    def on_message(self, message):
+        if self.message_handler:
+            self.message_handler.on_message(self, message)
+
+    def handle_state_change(self, state_change):
+        pass
+
+    def sign(self, message):
+        message.sign(self.private_key)
 
 
 class MockDiscovery(object):

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -44,6 +44,7 @@ from raiden.transfer.state_change import (
     ActionLeaveAllNetworks,
     ActionNewTokenNetwork,
     ActionTransferDirect,
+    ActionUpdateTransportTimestamp,
     Block,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -744,6 +745,14 @@ def handle_receive_unlock(
     return subdispatch_to_paymenttask(chain_state, state_change, secrethash)
 
 
+def handle_update_transport_timestamp(
+        chain_state: ChainState,
+        state_change: StateChange,
+) -> TransitionResult:
+    chain_state.last_transport_timestamp = state_change.timestamp
+    return TransitionResult(chain_state, list())
+
+
 def handle_state_change(chain_state: ChainState, state_change: StateChange) -> TransitionResult:
     if type(state_change) == Block:
         iteration = handle_block(
@@ -791,6 +800,11 @@ def handle_state_change(chain_state: ChainState, state_change: StateChange) -> T
         )
     elif type(state_change) == ActionInitTarget:
         iteration = handle_init_target(
+            chain_state,
+            state_change,
+        )
+    elif type(state_change) == ActionUpdateTransportTimestamp:
+        iteration = handle_update_transport_timestamp(
             chain_state,
             state_change,
         )

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -44,7 +44,7 @@ from raiden.transfer.state_change import (
     ActionLeaveAllNetworks,
     ActionNewTokenNetwork,
     ActionTransferDirect,
-    ActionUpdateTransportTimestamp,
+    ActionUpdateTransportSyncToken,
     Block,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -745,11 +745,11 @@ def handle_receive_unlock(
     return subdispatch_to_paymenttask(chain_state, state_change, secrethash)
 
 
-def handle_update_transport_timestamp(
+def handle_update_transport_synctoken(
         chain_state: ChainState,
-        state_change: StateChange,
+        state_change: ActionUpdateTransportSyncToken,
 ) -> TransitionResult:
-    chain_state.last_transport_timestamp = state_change.timestamp
+    chain_state.last_transport_synctoken = state_change.sync_token
     return TransitionResult(chain_state, list())
 
 
@@ -803,8 +803,8 @@ def handle_state_change(chain_state: ChainState, state_change: StateChange) -> T
             chain_state,
             state_change,
         )
-    elif type(state_change) == ActionUpdateTransportTimestamp:
-        iteration = handle_update_transport_timestamp(
+    elif type(state_change) == ActionUpdateTransportSyncToken:
+        iteration = handle_update_transport_synctoken(
             chain_state,
             state_change,
         )

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -244,7 +244,7 @@ class ChainState(State):
         'pending_transactions',
         'pseudo_random_generator',
         'queueids_to_queues',
-        'last_transport_timestamp',
+        'last_transport_synctoken',
     )
 
     def __init__(
@@ -269,7 +269,7 @@ class ChainState(State):
         self.pending_transactions = list()
         self.pseudo_random_generator = pseudo_random_generator
         self.queueids_to_queues: QueueIdsToQueues = dict()
-        self.last_transport_timestamp = None
+        self.last_transport_synctoken = None
 
     def __repr__(self):
         return '<ChainState block:{} networks:{} qty_transfers:{} chain_id:{}>'.format(
@@ -289,7 +289,7 @@ class ChainState(State):
             self.nodeaddresses_to_networkstates == other.nodeaddresses_to_networkstates and
             self.payment_mapping == other.payment_mapping and
             self.chain_id == other.chain_id and
-            self.last_transport_timestamp == other.last_transport_timestamp
+            self.last_transport_synctoken == other.last_transport_synctoken
         )
 
     def __ne__(self, other):
@@ -316,7 +316,7 @@ class ChainState(State):
             'queueids_to_queues': serialization.serialize_queueid_to_queue(
                 self.queueids_to_queues,
             ),
-            'last_transport_timestamp': self.last_transport_timestamp,
+            'last_transport_synctoken': self.last_transport_synctoken,
         }
 
     @classmethod
@@ -345,7 +345,7 @@ class ChainState(State):
         restored.queueids_to_queues = serialization.deserialize_queueid_to_queue(
             data['queueids_to_queues'],
         )
-        restored.last_transport_timestamp = data['last_transport_timestamp']
+        restored.last_transport_synctoken = data['last_transport_synctoken']
 
         return restored
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -244,6 +244,7 @@ class ChainState(State):
         'pending_transactions',
         'pseudo_random_generator',
         'queueids_to_queues',
+        'last_transport_timestamp',
     )
 
     def __init__(
@@ -268,6 +269,7 @@ class ChainState(State):
         self.pending_transactions = list()
         self.pseudo_random_generator = pseudo_random_generator
         self.queueids_to_queues: QueueIdsToQueues = dict()
+        self.last_transport_timestamp = None
 
     def __repr__(self):
         return '<ChainState block:{} networks:{} qty_transfers:{} chain_id:{}>'.format(
@@ -286,7 +288,8 @@ class ChainState(State):
             self.identifiers_to_paymentnetworks == other.identifiers_to_paymentnetworks and
             self.nodeaddresses_to_networkstates == other.nodeaddresses_to_networkstates and
             self.payment_mapping == other.payment_mapping and
-            self.chain_id == other.chain_id
+            self.chain_id == other.chain_id and
+            self.last_transport_timestamp == other.last_transport_timestamp
         )
 
     def __ne__(self, other):
@@ -313,6 +316,7 @@ class ChainState(State):
             'queueids_to_queues': serialization.serialize_queueid_to_queue(
                 self.queueids_to_queues,
             ),
+            'last_transport_timestamp': self.last_transport_timestamp,
         }
 
     @classmethod
@@ -341,6 +345,7 @@ class ChainState(State):
         restored.queueids_to_queues = serialization.deserialize_queueid_to_queue(
             data['queueids_to_queues'],
         )
+        restored.last_transport_timestamp = data['last_transport_timestamp']
 
         return restored
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -73,37 +73,38 @@ class Block(StateChange):
         )
 
 
-class ActionUpdateTransportTimestamp(StateChange):
+class ActionUpdateTransportSyncToken(StateChange):
     """ Holds the last "timestamp" at which we synced
-    with the transport. Can be used later to filter
-    the messages which have not been processed.
+    with the transport. The timestamp could be a date/time value
+    or any other value provided by the transport backend.
+    Can be used later to filter the messages which have not been processed.
     """
-    def __init__(self, timestamp: str):
-        self.timestamp = timestamp
+    def __init__(self, sync_token: str):
+        self.sync_token = sync_token
 
-    def __repr__(self):
-        return '<ActionUpdateTransportTimestamp timestamp:{}>'.format(
-            self.timestamp,
+    def __repr__(self) -> str:
+        return '<ActionUpdateTransportSyncToken value:{}>'.format(
+            self.sync_token,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'ActionUpdateTransportSyncToken') -> bool:
         return (
-            isinstance(other, ActionUpdateTransportTimestamp) and
-            self.timestamp == other.timestamp
+            isinstance(other, ActionUpdateTransportSyncToken) and
+            self.sync_token == other.sync_token
         )
 
-    def __ne__(self, other):
+    def __ne__(self, other: 'ActionUpdateTransportSyncToken') -> bool:
         return not self.__eq__(other)
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
-            'timestamp': str(self.timestamp),
+            'sync_token': str(self.sync_token),
         }
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ActionUpdateTransportTimestamp':
+    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ActionUpdateTransportSyncToken':
         return cls(
-            timestamp=data['timestamp'],
+            sync_token=data['sync_token'],
         )
 
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -73,6 +73,40 @@ class Block(StateChange):
         )
 
 
+class ActionUpdateTransportTimestamp(StateChange):
+    """ Holds the last "timestamp" at which we synced
+    with the transport. Can be used later to filter
+    the messages which have not been processed.
+    """
+    def __init__(self, timestamp: str):
+        self.timestamp = timestamp
+
+    def __repr__(self):
+        return '<ActionUpdateTransportTimestamp timestamp:{}>'.format(
+            self.timestamp,
+        )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ActionUpdateTransportTimestamp) and
+            self.timestamp == other.timestamp
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'timestamp': str(self.timestamp),
+        }
+
+    @classmethod
+    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'ActionUpdateTransportTimestamp':
+        return cls(
+            timestamp=data['timestamp'],
+        )
+
+
 class ActionCancelPayment(StateChange):
     """ The user requests the transfer to be cancelled.
     This state change can fail, it depends on the node's role and the current


### PR DESCRIPTION
## Problem

The current issue we're facing related to the "Nonce did not sequentially change" is the fact that upon restart, the node performs a login operation with the matrix server with a default value of `sync=True` and `sync_filter_limit=10`.

The above means that upon login, we will call the sync endpoint of the matrix API with a maximum number of messages to fetch set to 10. However, this was apparently an issue when we noticed that while a node is shutting down, some messages might have already been sent to the matrix server but have not been delivered to the shutting down node. As soon as this node comes back up, it will request a maximum of 10 messages which is what causes it sometimes to not receive important messages (nonce-updating kind of messages).

## Proposed solution

The solution is to basically prevent the implementation from relying on any limit. We need to fetch ALL messages from the last time we performed the sync with the matrix server. Which means that we need to keep storing the last timestamp (next_batch in the API response) and pass it to the matrix client upon starting for the client to start fetching all messages from point until the latest message.

## What changed?

This PR changes things in 2 repos:

1. [Introduce post-sync hook](https://github.com/raiden-network/raiden-libs/pull/147) which basically allows the raiden matrix implementation to register a hook function which is called after each sync is completed.

2. Raiden changes:
A. Disable sync on login
B. Introduce a state change `ActionUpdateTransportTimestamp` which holds the "last time" value at which the node synced with the matrix protocol. This value is called "SyncToken" in the raiden-libs repo but i wanted to give it a more generic name because this timestamp could apply to other transports.
C. Upon a callback for the hook function, we trigger the state change created in point B.
D. Update chain_state to store the last timestamp
E. When restarting, the raiden service should provide the transport with the value stored from the latest known chain_state.

Resolve #3046 

## TODO
- [x] Write a test