### PR TITLE
Specified Python Version Fixes #2996

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Raiden Network
 ==============
 
+.. image:: https://img.shields.io/pypi/pyversions/raiden.svg
+    :target: https://raiden-network.readthedocs.io/en/stable/)
+    :alt: Python 3.6
 .. image:: https://badges.gitter.im/Join%20Chat.svg
     :target: https://gitter.im/raiden-network/raiden?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
     :alt: Chat on Gitter

--- a/docs/macos_install_guide.rst
+++ b/docs/macos_install_guide.rst
@@ -34,9 +34,9 @@ checkout of raiden.
 
     $ sudo pip install virtualenv
 
-#. Create a virtualenv for raiden::
+#. Create a virtualenv for raiden (requires python3.6)::
 
-    $ virtualenv venv-raiden
+    $ virtualenv --python=python3.6 venv-raiden
 
 #. "Activate" the virtualenv::
 

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -89,7 +89,7 @@ Navigate to the directory::
 
     cd raiden
 
-It's advised to create a `virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_ for Raiden and install all python dependencies there.
+It's advised to create a `virtualenv <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_ for Raiden (requires python3.6) and install all python dependencies there.
 
 After you have done that you can proceed to install the dependencies::
 


### PR DESCRIPTION
Added Python3.6 shield to README and specified python3.6 in macos_install_guide and overview_and_guide docs. Fixes #2996

Related to previous PR #3061