### PR TITLE
correct ip of geth client listening is '::' (any)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,10 +449,7 @@ workflows:
           requires:
             - prepare-python-3.6
           filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              only: /.*/
+            <<: *filter-version-regex
 
       - smoketest:
           name: smoketest-udp-3.6
@@ -503,11 +500,11 @@ workflows:
       - test:
           name: test-integration-udp-3.6
           py-version: "3.6"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-udp-3.6
           filters:
@@ -517,12 +514,12 @@ workflows:
       - test:
           name: test-integration-matrix-3.6
           py-version: "3.6"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-matrix-3.6
           filters:
@@ -542,10 +539,7 @@ workflows:
           requires:
             - prepare-python-3.7
           filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
-            branches:
-              only: /.*/
+            <<: *filter-version-regex
 
       - smoketest:
           name: smoketest-udp-3.7
@@ -580,12 +574,12 @@ workflows:
 
       - test:
           name: test-integration-udp-3.7
-          resource: "xlarge"
+          resource: "large"
           py-version: "3.7"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-udp-3.7
           filters:
@@ -594,12 +588,12 @@ workflows:
       - test:
           name: test-integration-matrix-3.7
           py-version: "3.7"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-matrix-3.7
           filters:
@@ -698,7 +692,7 @@ workflows:
       - finalize:
           requires:
             - lint-3.6
-            - mypy-3.7
+            - mypy-3.6
             - test-unit-3.6
             - test-integration-udp-3.6
             - test-integration-matrix-3.6
@@ -711,23 +705,23 @@ workflows:
       - test:
           name: test-integration-udp-3.6
           py-version: "3.6"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-udp-3.6
 
       - test:
           name: test-integration-matrix-3.6
           py-version: "3.6"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-matrix-3.6
 
@@ -771,23 +765,23 @@ workflows:
       - test:
           name: test-integration-udp-3.7
           py-version: "3.7"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-udp-3.7
 
       - test:
           name: test-integration-matrix-3.7
           py-version: "3.7"
-          resource: "xlarge"
+          resource: "large"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 8
+          parallelism: 4
           requires:
             - smoketest-matrix-3.7
 

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -44,8 +44,7 @@ def cli_args(blockchain_provider, removed_args, changed_args):
 
     if changed_args is not None:
         for k, v in changed_args.items():
-            if k in initial_args:
-                initial_args[k] = v
+            initial_args[k] = v
 
     args = [
         '--no-sync-check',

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -179,7 +179,7 @@ def test_cli_registry_address_without_deployed_contract(cli_args):
 
 @pytest.mark.timeout(65)
 @pytest.mark.parametrize('changed_args', [{
-    'environment-type': Environment.DEVELOPMENT.value,
+    'environment_type': Environment.DEVELOPMENT.value,
 }])
 def test_cli_change_environment_type(cli_args):
     child = spawn_raiden(cli_args)

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -179,7 +179,7 @@ def test_cli_registry_address_without_deployed_contract(cli_args):
 
 @pytest.mark.timeout(65)
 @pytest.mark.parametrize('changed_args', [{
-    'environment_type': Environment.DEVELOPMENT.value,
+    'environment-type': Environment.DEVELOPMENT.value,
 }])
 def test_cli_change_environment_type(cli_args):
     child = spawn_raiden(cli_args)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -196,7 +196,7 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step):
 
     ensure_executable('geth')
 
-    free_port = get_free_port('127.0.0.1', 27854)
+    free_port = get_free_port('::', 27854)
     rpc_port = next(free_port)
     p2p_port = next(free_port)
     base_datadir = os.environ['RST_DATADIR']


### PR DESCRIPTION
fixes #3098 

Actual ip address of geth client is '::' (any) and not 127.0.0.1 at least what psutils is showing. Now it finds the connection and thus gives the next free available port. 