### PR TITLE
Disable coverage on long running integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ jobs:
       env:
         - TEST='raiden/tests/integration/long_running'
         - TRANSPORT_OPTIONS='--transport=udp'
+        - RUN_COVERAGE=no_coverage
 
     - stage: integration
       <<: *job-template-integration
@@ -133,6 +134,7 @@ jobs:
         - TEST='raiden/tests/integration/long_running'
         - TRANSPORT_OPTIONS='--transport=matrix --local-matrix=${HOME}/.bin/run_synapse.sh'
         - RUN_SYNAPSE=1
+        - RUN_COVERAGE=no_coverage
 
     - stage: integration
       <<: *job-template-integration


### PR DESCRIPTION
Running with `coverage` leads to frequent timeouts in the `long_running`
integration tests. In scope of the nightly coverage runs #3020 I now
selectively disable `coverage` for the two long running tests we have.
The goal is, to have any coverage results before switching CI platforms,
even if this will now underestimate our coverage (due to the two test
sets not being "covered").