### PR TITLE
Client will no longer accept 0x0 as secret or keccak(0x0) as secrethash

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3091` Client will no longer accept secret of 0x0 or secrethash keccak(0x0).
 * :bug:`3054` Client will now reject any signatures with ``v`` not in (0, 1, 27, 28)
 
 * :release:`0.17.0 <2018-11-16>`

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,7 +1,7 @@
 import math
 from enum import Enum
 
-from eth_utils import to_checksum_address
+from eth_utils import keccak, to_checksum_address
 
 SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
 PROTOCOL_VERSION = 1
@@ -17,6 +17,7 @@ NULL_ADDRESS_BYTES = bytes(20)
 NULL_ADDRESS = to_checksum_address(NULL_ADDRESS_BYTES)
 
 EMPTY_HASH = bytes(32)
+EMPTY_HASH_KECCAK = keccak(EMPTY_HASH)
 EMPTY_SIGNATURE = bytes(65)
 
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -89,14 +89,16 @@ def _redact_secret(data):
 
 
 def initiator_init(
-        raiden,
-        transfer_identifier,
-        transfer_amount,
-        transfer_secret,
-        token_network_identifier,
-        target_address,
+        raiden: 'RaidenService',
+        transfer_identifier: typing.PaymentID,
+        transfer_amount: typing.PaymentAmount,
+        transfer_secret: typing.Secret,
+        token_network_identifier: typing.TokenNetworkID,
+        target_address: typing.TargetAddress,
 ):
 
+    msg = 'Should never end up initiating transfer with Secret 0x0'
+    assert transfer_secret != constants.EMPTY_HASH, msg
     transfer_state = TransferDescriptionWithSecretState(
         raiden.default_registry.address,
         transfer_identifier,
@@ -859,12 +861,12 @@ class RaidenService(Runnable):
         self.targets_to_identifiers_to_statuses[target][identifier] = payment_status
 
         init_initiator_statechange = initiator_init(
-            self,
-            identifier,
-            amount,
-            secret,
-            token_network_identifier,
-            target,
+            raiden=self,
+            transfer_identifier=identifier,
+            transfer_amount=amount,
+            transfer_secret=secret,
+            token_network_identifier=token_network_identifier,
+            target_address=target,
         )
 
         # Dispatch the state change even if there are no routes to create the

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -868,11 +868,11 @@ def test_handle_offchain_emptyhash_secret():
     block_number = 10
 
     manager_state = make_initiator_manager_state(
-        available_routes,
-        factories.UNIT_TRANSFER_DESCRIPTION,
-        channel_map,
-        pseudo_random_generator,
-        block_number,
+        routes=available_routes,
+        transfer_description=factories.UNIT_TRANSFER_DESCRIPTION,
+        channel_map=channel_map,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
     )
 
     secret_reveal = ReceiveSecretReveal(
@@ -885,7 +885,10 @@ def test_handle_offchain_emptyhash_secret():
         channel_state=channel1,
         pseudo_random_generator=pseudo_random_generator,
     )
+    secrethash = factories.UNIT_TRANSFER_DESCRIPTION.secrethash
     assert len(iteration.events) == 0
+    # make sure the lock has not moved
+    assert secrethash in channel1.our_state.secrethashes_to_lockedlocks
 
 
 def test_initiator_lock_expired():
@@ -1104,6 +1107,8 @@ def test_initiator_handle_contract_receive_emptyhash_secret_reveal():
         pseudo_random_generator=pseudo_random_generator,
     )
     assert len(iteration.events) == 0
+    # make sure the original lock wasn't moved
+    assert transfer.lock.secrethash in channel1.our_state.secrethashes_to_lockedlocks
 
 
 def test_initiator_handle_contract_receive_secret_reveal_expired():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -534,6 +534,50 @@ def test_state_transition():
     assert proof_iteration.new_state is None
 
 
+def test_target_reject_keccak_empty_hash():
+    lock_amount = 7
+    block_number = 1
+    initiator = factories.HOP6
+    pseudo_random_generator = random.Random()
+
+    our_balance = 100
+    our_address = factories.make_address()
+    partner_balance = 130
+
+    from_channel = factories.make_channel(
+        our_address=our_address,
+        our_balance=our_balance,
+        partner_address=UNIT_TRANSFER_SENDER,
+        partner_balance=partner_balance,
+    )
+    from_route = factories.route_from_channel(from_channel)
+    expiration = block_number + from_channel.settle_timeout - from_channel.reveal_timeout
+
+    from_transfer = factories.make_signed_transfer_for(
+        channel_state=from_channel,
+        amount=lock_amount,
+        initiator=initiator,
+        target=our_address,
+        expiration=expiration,
+        secret=EMPTY_HASH,
+        allow_invalid=True,
+    )
+
+    init = ActionInitTarget(
+        route=from_route,
+        transfer=from_transfer,
+    )
+
+    init_transition = target.state_transition(
+        None,
+        init,
+        from_channel,
+        pseudo_random_generator,
+        block_number,
+    )
+    assert init_transition.new_state is None
+
+
 def test_target_receive_lock_expired():
     lock_amount = 7
     block_number = 1

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -4,7 +4,7 @@ import random
 
 from eth_utils import encode_hex
 
-from raiden.constants import MAXIMUM_PENDING_TRANSFERS, UINT256_MAX
+from raiden.constants import EMPTY_HASH_KECCAK, MAXIMUM_PENDING_TRANSFERS, UINT256_MAX
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.transfer.architecture import Event, StateChange, TransitionResult
 from raiden.transfer.balance_proof import pack_balance_proof
@@ -687,6 +687,15 @@ def valid_lockedtransfer_check(
                 distributable,
             )
 
+            result = (False, msg, None)
+
+        # if the message contains the keccak of the empty hash it will never be
+        # usable onchain https://github.com/raiden-network/raiden/issues/3091
+        elif lock.secrethash == EMPTY_HASH_KECCAK:
+            msg = (
+                f'Invalid {message_name} message. '
+                'The secrethash is the keccak of 0x0 and will not be usable onchain'
+            )
             result = (False, msg, None)
 
         else:

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -352,7 +352,7 @@ def handle_onchain_secretreveal(
     the current lock removed from the merkle tree and the transferred amount
     updated.
     """
-    valid_secret = is_valid_secret_reveal(
+    is_valid_secret = is_valid_secret_reveal(
         state_change=state_change,
         transfer_secrethash=initiator_state.transfer_description.secrethash,
         secret=state_change.secret,
@@ -361,7 +361,7 @@ def handle_onchain_secretreveal(
     is_lock_expired = state_change.block_number > initiator_state.transfer.lock.expiration
 
     is_lock_unlocked = (
-        valid_secret and
+        is_valid_secret and
         is_channel_open and
         not is_lock_expired
     )

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -36,6 +36,7 @@ from raiden.transfer.state import (
     message_identifier_from_prng,
 )
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, ReceiveUnlock
+from raiden.transfer.utils import is_valid_secret_reveal
 from raiden.utils import typing
 
 STATE_SECRET_KNOWN = (
@@ -1214,7 +1215,11 @@ def handle_offchain_secretreveal(
         block_number: typing.BlockNumber,
 ) -> TransitionResult:
     """ Handles the secret reveal and sends SendBalanceProof/RevealSecret if necessary. """
-    is_valid_reveal = mediator_state_change.secrethash == mediator_state.secrethash
+    is_valid_reveal = is_valid_secret_reveal(
+        state_change=mediator_state_change,
+        transfer_secrethash=mediator_state.secrethash,
+        secret=mediator_state_change.secret,
+    )
     is_secret_unknown = mediator_state.secret is None
 
     if is_secret_unknown and is_valid_reveal:
@@ -1245,7 +1250,11 @@ def handle_onchain_secretreveal(
     secret known.
     """
     secrethash = onchain_secret_reveal.secrethash
-    is_valid_reveal = secrethash == mediator_state.secrethash
+    is_valid_reveal = is_valid_secret_reveal(
+        state_change=onchain_secret_reveal,
+        transfer_secrethash=mediator_state.secrethash,
+        secret=onchain_secret_reveal.secret,
+    )
 
     if is_valid_reveal:
         secret = onchain_secret_reveal.secret
@@ -1253,20 +1262,20 @@ def handle_onchain_secretreveal(
         block_number = onchain_secret_reveal.block_number
 
         secret_reveal = set_onchain_secret(
-            mediator_state,
-            channelidentifiers_to_channels,
-            secret,
-            secrethash,
-            block_number,
+            state=mediator_state,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            secret=secret,
+            secrethash=secrethash,
+            block_number=block_number,
         )
 
         balance_proof = events_for_balanceproof(
-            channelidentifiers_to_channels,
-            mediator_state.transfers_pair,
-            pseudo_random_generator,
-            block_number,
-            secret,
-            secrethash,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            transfers_pair=mediator_state.transfers_pair,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+            secret=secret,
+            secrethash=secrethash,
         )
         iteration = TransitionResult(mediator_state, secret_reveal + balance_proof)
     else:

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -20,6 +20,7 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state import NettingChannelState, message_identifier_from_prng
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, ReceiveUnlock
+from raiden.transfer.utils import is_valid_secret_reveal
 from raiden.utils import typing
 
 
@@ -131,7 +132,11 @@ def handle_offchain_secretreveal(
         pseudo_random_generator: random.Random,
 ):
     """ Validates and handles a ReceiveSecretReveal state change. """
-    valid_secret = state_change.secrethash == target_state.transfer.lock.secrethash
+    valid_secret = is_valid_secret_reveal(
+        state_change=state_change,
+        transfer_secrethash=target_state.transfer.lock.secrethash,
+        secret=state_change.secret,
+    )
 
     if valid_secret:
         channel.register_offchain_secret(
@@ -168,7 +173,11 @@ def handle_onchain_secretreveal(
         channel_state: NettingChannelState,
 ):
     """ Validates and handles a ContractReceiveSecretReveal state change. """
-    valid_secret = state_change.secrethash == target_state.transfer.lock.secrethash
+    valid_secret = is_valid_secret_reveal(
+        state_change=state_change,
+        transfer_secrethash=target_state.transfer.lock.secrethash,
+        secret=state_change.secret,
+    )
 
     if valid_secret:
         channel.register_onchain_secret(

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -71,3 +71,7 @@ def pseudo_random_generator_from_json(data):
     pseudo_random_generator.setstate(tuple(state))
 
     return pseudo_random_generator
+
+
+def is_valid_secret_reveal(state_change, transfer_secrethash, secret):
+    return secret != EMPTY_HASH and state_change.secrethash == transfer_secrethash

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -27,7 +27,12 @@ from raiden.utils.signing import sha3
 
 
 def random_secret():
-    return os.urandom(32)
+    """ Return a random 32 byte secret except the 0 secret since it's not accepted in the contracts
+    """
+    while True:
+        secret = os.urandom(32)
+        if secret != constants.EMPTY_HASH:
+            return secret
 
 
 def ishash(data: bytes) -> bool:


### PR DESCRIPTION
Should fix #3091 

- [x] Make sure that we never generate a secret of `0x00000.000`
- [x] Reject any `RevealSecret` message with secret being `0x00000.000`
- [x] Calculate the keccak hash of `0x00000.000`and if we get a message with that hashlock reject it.