### PR TITLE
Fix Matrix Transport retry mechanism

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3103` Fixes a bug in matrix which prevented retries of messages.
 * :bug:`3093` Getting raiden payment history will no longer crash raiden for failed sent payment events.
 
 * :release:`0.18.0 <2018-11-30>`

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -221,7 +221,7 @@ class _RetryQueue(Runnable):
         # clean after composing, so any queued messages (e.g. Delivered) are sent at least once
         for msg_data in self._message_queue[:]:
             remove = False
-            if not hasattr(msg_data.message, 'message_identifier'):
+            if isinstance(msg_data.message, (Delivered, Ping, Pong)):
                 # e.g. Delivered, send only once and then clear
                 # TODO: Is this correct? Will a missed Delivered be 'fixed' by the
                 #       later `Processed` message?

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -221,7 +221,7 @@ class _RetryQueue(Runnable):
         # clean after composing, so any queued messages (e.g. Delivered) are sent at least once
         for msg_data in self._message_queue[:]:
             remove = False
-            if not hasattr(msg_data, 'message_identifier'):
+            if not hasattr(msg_data.message, 'message_identifier'):
                 # e.g. Delivered, send only once and then clear
                 # TODO: Is this correct? Will a missed Delivered be 'fixed' by the
                 #       later `Processed` message?

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -382,7 +382,7 @@ def test_matrix_message_retry(
     # Retrier did not call send_raw given that the receiver is still offline
     assert transport._send_raw.call_count == 1
 
-    # Receiver goes offline
+    # Receiver comes back online
     transport._address_to_presence[partner_address] = UserPresence.ONLINE
 
     gevent.sleep(retry_interval)

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -1,4 +1,12 @@
+import random
+
+from raiden.storage.serialize import JSONSerializer
+from raiden.storage.sqlite import SQLiteStorage
+from raiden.storage.wal import WriteAheadLog
 from raiden.tests.utils import factories
+from raiden.transfer import node
+from raiden.transfer.architecture import StateManager
+from raiden.transfer.state_change import ActionInitChain
 
 
 class MockChain:
@@ -7,10 +15,29 @@ class MockChain:
 
 
 class MockRaidenService:
-    def __init__(self, message_handler=None):
+    def __init__(self, message_handler=None, state_transition=None):
         self.chain = MockChain()
         self.private_key, self.address = factories.make_privatekey_address()
+
+        self.chain.node_address = self.address
         self.message_handler = message_handler
+
+        if state_transition is None:
+            state_transition = node.state_transition
+
+        serializer = JSONSerializer
+        state_manager = StateManager(state_transition, None)
+        storage = SQLiteStorage(':memory:', serializer)
+        self.wal = WriteAheadLog(state_manager, storage)
+
+        state_change = ActionInitChain(
+            random.Random(),
+            0,
+            self.chain.node_address,
+            self.chain.network_id,
+        )
+
+        self.wal.log_and_dispatch(state_change)
 
     def on_message(self, message):
         if self.message_handler:


### PR DESCRIPTION
### Introduction
Issue #3103 was created as a follow up to issue #3046 because we assumed that as soon as the receiver node came back online, the sending node would trigger the retry mechanism and resend the messages which were not responded to.

### Cause
The discovered issue was in the following line:
https://github.com/raiden-network/raiden/blob/85652fc89e35b9f47e950b5753bd4bcc05cd201c/raiden/network/transport/matrix.py#L224-L228

Where `msg_data` is an instance of `_MessageData` inner class of the `_RetryQueue`. And according to the declarations, `message_identifier` is never a member of the `_MessageData` class which triggered the line on 228 to remove the message. This meant that messages were never retried because of this bug.

### Solution
- The if statement should simply check for the existence of `message_identifier` in `msg_data.message` rather than in `msg_data` itself.
- Added tests to make sure the retry happens.

Resolve #3103 