### PR TITLE
Detect and fix mypy errors about Address type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,10 @@ mypy:
 	# whole codebase soon.
 	mypy raiden/transfer/mediated_transfer/target.py --ignore-missing-imports | grep error > mypy-out.txt || true
 	# Expecting status code 1 from `grep`, which indicates no match.
-	# Again, we are starting small, detecting only 'BlockNumber' related errors,
-	# but all mypy errors should be detected soon.
+	# Again, we are starting small, detecting only 'BlockNumber' and 'Address'
+	# related errors, but all mypy errors should be detected soon.
 	grep BlockNumber mypy-out.txt; [ $$? -eq 1 ]
+	grep Address mypy-out.txt; [ $$? -eq 1 ]
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1255,8 +1255,8 @@ def create_sendlockedtransfer(
         token,
         balance_proof,
         lock,
-        initiator,
-        target,
+        typing.Address(initiator),
+        typing.Address(target),
     )
 
     lockedtransfer = SendLockedTransfer(
@@ -1632,7 +1632,7 @@ def handle_send_directtransfer(
 
     amount = state_change.amount
     payment_identifier = state_change.payment_identifier
-    target_address = state_change.receiver_address
+    target_address = typing.TargetAddress(state_change.receiver_address)
     distributable_amount = get_distributable(channel_state.our_state, channel_state.partner_state)
 
     (
@@ -1747,7 +1747,7 @@ def handle_receive_directtransfer(
             token_network_identifier=channel_state.token_network_identifier,
             identifier=direct_transfer.payment_identifier,
             amount=transfer_amount,
-            initiator=channel_state.partner_state.address,
+            initiator=typing.InitiatorAddress(channel_state.partner_state.address),
         )
 
         send_processed = SendProcessed(
@@ -1936,7 +1936,7 @@ def handle_block(
             )
             event = ContractSendChannelSettle(
                 channel_state.identifier,
-                channel_state.token_network_identifier,
+                typing.TokenNetworkAddress(channel_state.token_network_identifier),
             )
             events.append(event)
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -99,7 +99,7 @@ def handle_inittarget(
             message_identifier = message_identifier_from_prng(pseudo_random_generator)
             recipient = transfer.initiator
             secret_request = SendSecretRequest(
-                recipient=recipient,
+                recipient=typing.Address(recipient),
                 channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
                 message_identifier=message_identifier,
                 payment_identifier=transfer.payment_identifier,

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -80,9 +80,9 @@ def address_checksum_and_decode(addr: str) -> typing.Address:
     if not is_checksum_address(addr):
         raise InvalidAddress('Address must be EIP55 checksummed')
 
-    addr = decode_hex(addr)
-    assert len(addr) in (20, 0)
-    return addr
+    addr_bytes = decode_hex(addr)
+    assert len(addr_bytes) in (20, 0)
+    return typing.Address(addr_bytes)
 
 
 def data_encoder(data: bytes, length: int = 0) -> str:
@@ -133,8 +133,8 @@ def privatekey_to_publickey(private_key_bin: bytes) -> bytes:
     return private_key.public_key.format(compressed=False)
 
 
-def publickey_to_address(publickey: bytes) -> bytes:
-    return sha3(publickey[1:])[12:]
+def publickey_to_address(publickey: bytes) -> typing.Address:
+    return typing.Address(sha3(publickey[1:])[12:])
 
 
 def privatekey_to_address(private_key_bin: bytes) -> typing.Address:


### PR DESCRIPTION
This PR is a part of #3040, and also a preparation for #3051 .

#3040 is about removing mypy errors in `target.py`.  This PR does that for the `Address` type.

#3051 is about a better type system.  Before introducing the change, I wanted to clean up the existing error messages around the `Address` type.