### PR TITLE
Remove raiden/tests/smart_contracts from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     -rrequirements-dev.txt
 commands =
     coverage erase
-    pytest --cov-append --exitfirst {posargs:./raiden/tests/unit ./raiden/tests/smart_contracts ./raiden/tests/integration/api ./raiden/tests/integration}
+    pytest --cov-append --exitfirst {posargs:./raiden/tests/unit ./raiden/tests/integration/api ./raiden/tests/integration}
 
 [testenv:flake8]
 deps =
@@ -25,9 +25,6 @@ usedevelop = True
 deps =
     -rrequirements-dev.txt
 commands = pytest --cov-append --exitfirst {posargs:./raiden/}
-
-[testenv:smart_contracts]
-commands = pytest --cov-append --initial-port=2000 --exitfirst ./raiden/tests/smart_contracts {posargs}
 
 [testenv:integration]
 commands = pytest --cov-append --initial-port=3000 --exitfirst ./raiden/tests/integration {posargs}


### PR DESCRIPTION
Before this commit, `tox` gave an error message about a missing directory `raiden/tests/smart_contracts`. This directory existed in the past but not anymore.

After this commit `tox` seems to work for me.