### PR TITLE
[wip] Use the new sized Address class

### DIFF
--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -28,14 +28,7 @@ from raiden.transfer.state import (
     message_identifier_from_prng,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import (
-    privatekey_to_address,
-    publickey_to_address,
-    random_secret,
-    sha3,
-    sized,
-    typing,
-)
+from raiden.utils import privatekey_to_address, publickey_to_address, random_secret, sha3, typing
 from raiden.utils.signing import eth_sign
 
 EMPTY = object()
@@ -559,7 +552,7 @@ def make_transfers_pair(privatekeys, amount, block_number):
 
         pair = MediationPairState(
             received_transfer,
-            sized.Address(lockedtransfer_event.recipient),
+            lockedtransfer_event.recipient,
             sent_transfer,
         )
         transfers_pair.append(pair)

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -28,7 +28,14 @@ from raiden.transfer.state import (
     message_identifier_from_prng,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import privatekey_to_address, publickey_to_address, random_secret, sha3, typing
+from raiden.utils import (
+    privatekey_to_address,
+    publickey_to_address,
+    random_secret,
+    sha3,
+    sized,
+    typing,
+)
 from raiden.utils.signing import eth_sign
 
 EMPTY = object()
@@ -552,7 +559,7 @@ def make_transfers_pair(privatekeys, amount, block_number):
 
         pair = MediationPairState(
             received_transfer,
-            lockedtransfer_event.recipient,
+            sized.Address(lockedtransfer_event.recipient),
             sent_transfer,
         )
         transfers_pair.append(pair)

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -2,8 +2,8 @@
 from copy import deepcopy
 
 from raiden.transfer.queue_identifier import QueueIdentifier
+from raiden.utils import sized
 from raiden.utils.typing import (
-    Address,
     BlockExpiration,
     BlockNumber,
     ChannelID,
@@ -108,7 +108,7 @@ class SendMessageEvent(Event):
 
     def __init__(
             self,
-            recipient: Address,
+            recipient: sized.Address,
             channel_identifier: ChannelID,
             message_identifier: MessageID,
     ):

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -77,7 +77,7 @@ from raiden.transfer.state_change import (
     ReceiveUnlock,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import pex, typing
+from raiden.utils import pex, sized, typing
 from raiden.utils.signing import eth_recover
 
 # This should be changed to `Union[str, MerkleTreeState]`
@@ -1260,7 +1260,7 @@ def create_sendlockedtransfer(
     )
 
     lockedtransfer = SendLockedTransfer(
-        recipient=recipient,
+        recipient=sized.Address(recipient),
         channel_identifier=channel_state.identifier,
         message_identifier=message_identifier,
         transfer=locked_transfer,
@@ -1786,7 +1786,7 @@ def handle_refundtransfer(
         channel_state.partner_state.secrethashes_to_lockedlocks[lock.secrethash] = lock
 
         send_processed = SendProcessed(
-            recipient=refund.transfer.balance_proof.sender,
+            recipient=sized.Address(refund.transfer.balance_proof.sender),
             channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
             message_identifier=refund.transfer.message_identifier,
         )
@@ -1864,7 +1864,7 @@ def handle_receive_lockedtransfer(
         channel_state.partner_state.secrethashes_to_lockedlocks[lock.secrethash] = lock
 
         send_processed = SendProcessed(
-            recipient=mediated_transfer.balance_proof.sender,
+            recipient=sized.Address(mediated_transfer.balance_proof.sender),
             channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
             message_identifier=mediated_transfer.message_identifier,
         )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -8,7 +8,7 @@ from raiden.transfer.architecture import (
     SendMessageEvent,
 )
 from raiden.transfer.state import BalanceProofSignedState, BalanceProofUnsignedState
-from raiden.utils import pex, serialization, sha3, typing
+from raiden.utils import pex, serialization, sha3, sized, typing
 
 # pylint: disable=too-many-arguments,too-few-public-methods
 
@@ -780,7 +780,7 @@ class SendDirectTransfer(SendMessageEvent):
             token_address: typing.TokenAddress,
     ):
 
-        super().__init__(recipient, channel_identifier, message_identifier)
+        super().__init__(sized.Address(recipient), channel_identifier, message_identifier)
 
         self.payment_identifier = payment_identifier
         self.balance_proof = balance_proof

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -4,7 +4,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 from raiden.transfer.architecture import Event, SendMessageEvent
 from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
 from raiden.transfer.state import BalanceProofUnsignedState
-from raiden.utils import pex, serialization, sha3, typing
+from raiden.utils import pex, serialization, sha3, sized, typing
 
 # According to the smart contracts as of 07/08:
 # https://github.com/raiden-network/raiden-contracts/blob/fff8646ebcf2c812f40891c2825e12ed03cc7628/raiden_contracts/contracts/TokenNetwork.sol#L213
@@ -31,7 +31,11 @@ class SendLockExpired(SendMessageEvent):
             balance_proof: BalanceProofUnsignedState,
             secrethash: typing.SecretHash,
     ):
-        super().__init__(recipient, balance_proof.channel_identifier, message_identifier)
+        super().__init__(
+            sized.Address(recipient),
+            balance_proof.channel_identifier,
+            message_identifier,
+        )
 
         self.balance_proof = balance_proof
         self.secrethash = secrethash
@@ -83,7 +87,7 @@ class SendLockedTransfer(SendMessageEvent):
 
     def __init__(
             self,
-            recipient: typing.Address,
+            recipient: sized.Address,
             channel_identifier: typing.ChannelID,
             message_identifier: typing.MessageID,
             transfer: LockedTransferUnsignedState,
@@ -177,7 +181,7 @@ class SendSecretReveal(SendMessageEvent):
     ):
         secrethash = sha3(secret)
 
-        super().__init__(recipient, channel_identifier, message_identifier)
+        super().__init__(sized.Address(recipient), channel_identifier, message_identifier)
 
         self.secret = secret
         self.secrethash = secrethash
@@ -250,7 +254,7 @@ class SendBalanceProof(SendMessageEvent):
             secret: typing.Secret,
             balance_proof: BalanceProofUnsignedState,
     ):
-        super().__init__(recipient, channel_identifier, message_identifier)
+        super().__init__(sized.Address(recipient), channel_identifier, message_identifier)
 
         self.payment_identifier = payment_identifier
         self.token = token_address
@@ -331,7 +335,7 @@ class SendSecretRequest(SendMessageEvent):
             secrethash: typing.SecretHash,
     ):
 
-        super().__init__(recipient, channel_identifier, message_identifier)
+        super().__init__(sized.Address(recipient), channel_identifier, message_identifier)
 
         self.payment_identifier = payment_identifier
         self.amount = amount
@@ -409,7 +413,7 @@ class SendRefundTransfer(SendMessageEvent):
             transfer: LockedTransferUnsignedState,
     ):
 
-        super().__init__(recipient, channel_identifier, message_identifier)
+        super().__init__(sized.Address(recipient), channel_identifier, message_identifier)
 
         self.transfer = transfer
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -37,7 +37,7 @@ from raiden.transfer.state import (
 )
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, ReceiveUnlock
 from raiden.transfer.utils import is_valid_secret_reveal
-from raiden.utils import typing
+from raiden.utils import sized, typing
 
 STATE_SECRET_KNOWN = (
     'payee_secret_revealed',
@@ -375,7 +375,7 @@ def forward_transfer_pair(
 
         transfer_pair = MediationPairState(
             payer_transfer,
-            payee_channel.partner_state.address,
+            sized.Address(payee_channel.partner_state.address),
             lockedtransfer_event.transfer,
         )
 
@@ -433,7 +433,7 @@ def backward_transfer_pair(
 
         transfer_pair = MediationPairState(
             payer_transfer,
-            backward_channel.partner_state.address,
+            sized.Address(backward_channel.partner_state.address),
             refund_transfer.transfer,
         )
 

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -10,7 +10,7 @@ from raiden.transfer.state import (
     RouteState,
     balanceproof_from_envelope,
 )
-from raiden.utils import pex, serialization, sha3, typing
+from raiden.utils import pex, serialization, sha3, sized, typing
 
 
 def lockedtransfersigned_from_message(message):
@@ -678,14 +678,14 @@ class MediationPairState(State):
     def __init__(
             self,
             payer_transfer: LockedTransferSignedState,
-            payee_address: typing.Address,
+            payee_address: sized.Address,
             payee_transfer: LockedTransferUnsignedState,
     ):
         if not isinstance(payer_transfer, LockedTransferSignedState):
             raise ValueError('payer_transfer must be a LockedTransferSignedState instance')
 
-        if not isinstance(payee_address, typing.T_Address):
-            raise ValueError('payee_address must be an address')
+        if not isinstance(payee_address, sized.Address):
+            raise ValueError('payee_address must be a sized address')
 
         if not isinstance(payee_transfer, LockedTransferUnsignedState):
             raise ValueError('payee_transfer must be a LockedTransferUnsignedState instance')

--- a/raiden/transfer/queue_identifier.py
+++ b/raiden/transfer/queue_identifier.py
@@ -1,12 +1,12 @@
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.utils import pex, typing
+from raiden.utils import pex, sized, typing
 
 
 class QueueIdentifier:
     def __init__(
             self,
-            recipient: typing.Address,
+            recipient: sized.Address,
             channel_identifier: typing.ChannelID,
     ):
         self.recipient = recipient

--- a/raiden/utils/sized.py
+++ b/raiden/utils/sized.py
@@ -1,0 +1,108 @@
+from abc import ABCMeta
+from collections.abc import Sized
+from typing import Type, Union, _tp_cache
+from eth_utils import encode_hex, is_checksum_address, to_bytes, to_checksum_address
+
+
+class SizedMeta(Sized, ABCMeta):
+    @_tp_cache  # can be replaced by our own cache if someone doesn't like re-using typing's
+    def __getitem__(cls: Type, size: int) -> Type:
+        assert size > 0, 'Subclasses need a positive size'
+
+        class Meta(SizedMeta):
+            def __len__(cls):
+                return size
+
+        return Meta(
+            f'{cls.__name__}[{size}]',
+            (cls,),
+            {'__len__': lambda self: size},
+        )
+
+    def __len__(cls) -> int:
+        """ Type length (len of bytes representation) for introspection
+
+        len(type)==0 mean we're on the superclass. e.g. UInt
+        len(type)>0 mean we're on a sized subclass. e.g. UInt[8]
+        """
+        return 0
+
+
+class UInt(int, metaclass=SizedMeta):
+    """ Int subclass which supports size assignment and ranges validation (raises ValueError)
+
+    e.g. UInt[32] == 256bit uint
+    Supports smart cast to and from bytes, and from 0x-hex-encoded strings
+    """
+
+    def __new__(cls, v: Union[bytes, str, int]):
+        if isinstance(v, bytes):
+            # easy construction from bytes
+            v = int.from_bytes(v, byteorder='big', signed=False)
+        elif isinstance(v, str) and v.startswith('0x'):
+            # construct from hex-encoded strings
+            v = int(v, 16)
+        elif isinstance(v, str):
+            # compatibility with decimal-encoded strings
+            v = int(v)
+        size = len(cls)
+        if size:
+            # if on a sized subclass, verify range
+            m = 2 ** (size * 8)
+            if not 0 <= v < m:
+                raise ValueError(f'Invalid range. v={v}, max={m - 1}')
+        return super(UInt, cls).__new__(cls, v)
+
+    def __bytes__(self):
+        """ Support bytes() cast, respecting length """
+        return self.to_bytes(len(self), byteorder='big')
+
+    def __repr__(self) -> str:
+        """ Nice repr including class name and size, if present """
+        return f'{self.__class__.__name__}({int.__repr__(self)})'
+
+
+class Bytes(bytes, metaclass=SizedMeta):
+    """ Sized bytes subclass with nice hex-encoded repr. str() is hex-encoded """
+    def __new__(cls, v: Union[bytes, str]):
+        if isinstance(v, str):
+            v = to_bytes(hexstr=v)
+        size = len(cls)
+        if size and len(v) != size:
+            # if on a sized subclass, verify data size
+            raise ValueError(f'Invalid size. {v!r} should be of size {size}')
+        return super(Bytes, cls).__new__(cls, v)
+
+    def __repr__(self) -> str:
+        """ Repr including classname and size, and string representation """
+        return f'{self.__class__.__name__}({self!s})'
+
+    def __str__(self) -> str:
+        """ Standard str() cast is 0x-prefixed encoding, also supported by constructor """
+        return encode_hex(self)
+
+    def __add__(self, y: bytes) -> 'Bytes':
+        """ Support returning non-sized Bytes object when concatenating """
+        return Bytes(bytes.__add__(self, y))
+
+    def __getitem__(self, item) -> 'Bytes':
+        """ Support returning non-sized Bytes object when slicing """
+        return Bytes(bytes.__getitem__(self, item))
+
+
+class Address(Bytes[20]):
+    """ 20-byte address. str() is checksum """
+    def __new__(cls, v: Union[bytes, str]):
+        """ Add subclass-specific validations """
+        if isinstance(v, str) and not is_checksum_address(v):
+            # same checks as bytes, plus checksum validation when constructing from string
+            raise ValueError(f'Invalid checksum address: {v!r}')
+        return super(Address, cls).__new__(cls, v)
+
+    def __str__(self) -> str:
+        """ For addresses, str() cast gives checksummed encoding """
+        return to_checksum_address(self)
+
+
+class TargetAddress(Address):
+    pass

--- a/raiden/utils/sized.pyi
+++ b/raiden/utils/sized.pyi
@@ -1,0 +1,41 @@
+from abc import ABCMeta
+from collections.abc import Sized
+from typing import Union
+
+
+# helper classes
+class SizedMeta(Sized, ABCMeta):
+    def __len__(cls) -> int:
+        ...
+
+
+class UInt(int, Sized, metaclass=SizedMeta):
+    def __init__(self, v: Union[bytes, str, int]) -> None:
+        ...
+
+    def __len__(self) -> int:
+        ...
+
+    def __bytes__(self) -> bytes:
+        ...
+
+
+class Bytes(bytes, metaclass=SizedMeta):
+    def __init__(self, v: Union[bytes, str]) -> None:
+        ...
+
+    def __str__(self) -> str:
+        ...
+
+    def __add__(self, y: bytes) -> 'Bytes':
+        ...
+
+    def __getitem__(self, item):
+        ...
+
+
+# final classes
+class Address(Bytes): ...
+
+
+class TargetAddress(Address): ...


### PR DESCRIPTION
As a part of https://github.com/raiden-network/raiden/issues/3051, this PR introduces a new Address class. Any instance of the new Address class is a byte sequence of 20 bytes.

This commit uses the new Address class instead of typing.T_Address.  The `sized` module was written by @andrevmatos .

**work in progress: converting InitiatorAddress, TokenAddress etc.**