### PR TITLE
Reject secret reveal

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -503,35 +503,6 @@ def test_regression_mediator_not_update_payer_state_twice():
     transfer = send_transfer.transfer
     block_expiration_number = transfer.lock.expiration + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS * 2
 
-    # # Playing with also receiving a lock expired message from the initiator
-    # send_lock_expired, _ = channel.create_sendexpiredlock(
-    #     sender_end_state=payer_channel.partner_state,
-    #     locked_lock=transfer.lock,
-    #     pseudo_random_generator=pseudo_random_generator,
-    #     chain_id=payer_channel.chain_id,
-    #     token_network_identifier=payer_channel.token_network_identifier,
-    #     channel_identifier=payer_channel.identifier,
-    #     recipient=payer_channel.our_state.address,
-    # )
-    # assert send_lock_expired
-    # lock_expired_message = message_from_sendevent(send_lock_expired, HOP1)
-    # lock_expired_message.sign(initiator_key)
-    # balance_proof = balanceproof_from_envelope(lock_expired_message)
-
-    # message_identifier = message_identifier_from_prng(pseudo_random_generator)
-    # iteration = mediator.state_transition(
-    #     current_state,
-    #     ReceiveLockExpired(
-    #         balance_proof=balance_proof,
-    #         secrethash=payer_transfer.lock.secrethash,
-    #         message_identifier=message_identifier,
-    #     ),
-    #     channel_map,
-    #     pseudo_random_generator,
-    #     block_expiration_number,
-    # )
-    # current_state = iteration.new_state
-
     block = Block(
         block_number=block_expiration_number,
         gas_limit=1,

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -407,7 +407,7 @@ def make_signed_transfer_for(
         sender: typing.Address = EMPTY,
         compute_locksroot: typing.Locksroot = EMPTY,
         allow_invalid: bool = EMPTY,
-):
+) -> LockedTransferSignedState:
 
     channel_state = if_empty(channel_state, make_channel_state())
     amount = if_empty(amount, 0)
@@ -435,8 +435,12 @@ def make_signed_transfer_for(
     assert sender in (channel_state.our_state.address, channel_state.partner_state.address)
     if sender == channel_state.our_state.address:
         recipient = channel_state.partner_state.address
+        # sender_state = channel_state.our_state
+        # receiver_state = channel_state.partner_state
     else:
         recipient = channel_state.our_state.address
+        # sender_state = channel_state.partner_state
+        # receiver_state = channel_state.our_state
 
     channel_identifier = channel_state.identifier
     token_address = channel_state.token_address
@@ -471,10 +475,12 @@ def make_signed_transfer_for(
     # Do *not* register the transfer here
     if not allow_invalid:
         is_valid, msg, _ = channel.is_valid_lockedtransfer(
-            mediated_transfer,
-            channel_state,
-            channel_state.partner_state,
-            channel_state.our_state,
+            transfer_state=mediated_transfer,
+            channel_state=channel_state,
+            sender_state=channel_state.partner_state,
+            receiver_state=channel_state.our_state,
+            # sender_state=sender_state,
+            # receiver_state=receiver_state,
         )
         assert is_valid, msg
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -435,12 +435,8 @@ def make_signed_transfer_for(
     assert sender in (channel_state.our_state.address, channel_state.partner_state.address)
     if sender == channel_state.our_state.address:
         recipient = channel_state.partner_state.address
-        # sender_state = channel_state.our_state
-        # receiver_state = channel_state.partner_state
     else:
         recipient = channel_state.our_state.address
-        # sender_state = channel_state.partner_state
-        # receiver_state = channel_state.our_state
 
     channel_identifier = channel_state.identifier
     token_address = channel_state.token_address
@@ -479,8 +475,6 @@ def make_signed_transfer_for(
             channel_state=channel_state,
             sender_state=channel_state.partner_state,
             receiver_state=channel_state.our_state,
-            # sender_state=sender_state,
-            # receiver_state=receiver_state,
         )
         assert is_valid, msg
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -74,7 +74,7 @@ def is_safe_to_wait(
         reveal_timeout: typing.BlockTimeout,
         block_number: typing.BlockNumber,
 ) -> typing.SuccessOrError:
-    """ True if waiting safe, i.e. there are more than enough blocks to safely
+    """ True if waiting is safe, i.e. there are more than enough blocks to safely
     unlock on chain.
     """
     # reveal timeout will not ever be larger than the lock_expiration otherwise
@@ -188,6 +188,28 @@ def filter_used_routes(
             del channelid_to_route[channelid]
 
     return list(channelid_to_route.values())
+
+
+def payer_transfer_expired(
+        payer_channel: NettingChannelState,
+        pair: MediationPairState,
+        block_number: typing.BlockNumber,
+) -> bool:
+    payer_lock_expiration_threshold = typing.BlockNumber(
+        pair.payer_transfer.lock.expiration +
+        DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS * 2,
+    )
+    has_payer_lock_expired, _ = channel.is_lock_expired(
+        end_state=payer_channel.our_state,
+        lock=pair.payer_transfer.lock,
+        block_number=block_number,
+        lock_expiration_threshold=payer_lock_expiration_threshold,
+    )
+    has_payer_transfer_expired = (
+        has_payer_lock_expired and
+        pair.payer_state != 'payer_expired'
+    )
+    return has_payer_transfer_expired
 
 
 def get_payee_channel(
@@ -584,19 +606,10 @@ def events_for_expired_pairs(
         if not payer_channel:
             continue
 
-        payer_lock_expiration_threshold = typing.BlockNumber(
-            pair.payer_transfer.lock.expiration +
-            DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS * 2,
-        )
-        has_payer_lock_expired, _ = channel.is_lock_expired(
-            end_state=payer_channel.our_state,
-            lock=pair.payer_transfer.lock,
+        has_payer_transfer_expired = payer_transfer_expired(
+            payer_channel=payer_channel,
+            pair=pair,
             block_number=block_number,
-            lock_expiration_threshold=payer_lock_expiration_threshold,
-        )
-        has_payer_transfer_expired = (
-            has_payer_lock_expired and
-            pair.payer_state != 'payer_expired'
         )
 
         if has_payer_transfer_expired:
@@ -736,10 +749,12 @@ def events_for_balanceproof(
         )
 
         if should_send_balanceproof_to_payee:
-            # At this point we are sure that payee_channel due to the
+            # At this point we are sure that payee_channel exists due to the
             # payee_channel_open check above. So let mypy know about this
             assert payee_channel
             payee_channel = cast(NettingChannelState, payee_channel)
+            # import pdb
+            # pdb.set_trace()
             pair.payee_state = 'payee_balance_proof'
 
             message_identifier = message_identifier_from_prng(pseudo_random_generator)
@@ -923,6 +938,8 @@ def events_to_remove_expired_locks(
             )
 
             if has_lock_expired:
+                import pdb
+                pdb.set_trace()
                 transfer_pair.payee_state = 'payee_expired'
                 expired_lock_events = channel.events_for_expired_lock(
                     channel_state=channel_state,
@@ -1331,6 +1348,8 @@ def handle_lock_expired(
         if not channel_state:
             return TransitionResult(mediator_state, list())
 
+        import pdb
+        pdb.set_trace()
         result = channel.handle_receive_lock_expired(
             channel_state=channel_state,
             state_change=state_change,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -205,11 +205,7 @@ def payer_transfer_expired(
         block_number=block_number,
         lock_expiration_threshold=payer_lock_expiration_threshold,
     )
-    has_payer_transfer_expired = (
-        has_payer_lock_expired and
-        pair.payer_state != 'payer_expired'
-    )
-    return has_payer_transfer_expired
+    return has_payer_lock_expired
 
 
 def get_payee_channel(

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -749,8 +749,6 @@ def events_for_balanceproof(
             # payee_channel_open check above. So let mypy know about this
             assert payee_channel
             payee_channel = cast(NettingChannelState, payee_channel)
-            # import pdb
-            # pdb.set_trace()
             pair.payee_state = 'payee_balance_proof'
 
             message_identifier = message_identifier_from_prng(pseudo_random_generator)

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -934,8 +934,6 @@ def events_to_remove_expired_locks(
             )
 
             if has_lock_expired:
-                import pdb
-                pdb.set_trace()
                 transfer_pair.payee_state = 'payee_expired'
                 expired_lock_events = channel.events_for_expired_lock(
                     channel_state=channel_state,
@@ -1230,7 +1228,23 @@ def handle_offchain_secretreveal(
     is_valid_reveal = mediator_state_change.secrethash == mediator_state.secrethash
     is_secret_unknown = mediator_state.secret is None
 
-    if is_secret_unknown and is_valid_reveal:
+    # a SecretReveal should be rejected if the payer transfer
+    # has expired. To check for this, we use the last
+    # transfer pair.
+    transfer_pair = mediator_state.transfers_pair[-1]
+    payer_transfer = transfer_pair.payer_transfer
+    channel_identifier = payer_transfer.balance_proof.channel_identifier
+    payer_channel = channelidentifiers_to_channels.get(channel_identifier)
+    if not payer_channel:
+        return TransitionResult(mediator_state, list())
+
+    has_payer_transfer_expired = payer_transfer_expired(
+        payer_channel=payer_channel,
+        pair=transfer_pair,
+        block_number=block_number,
+    )
+
+    if is_secret_unknown and is_valid_reveal and not has_payer_transfer_expired:
         iteration = secret_learned(
             mediator_state,
             channelidentifiers_to_channels,
@@ -1344,8 +1358,6 @@ def handle_lock_expired(
         if not channel_state:
             return TransitionResult(mediator_state, list())
 
-        import pdb
-        pdb.set_trace()
         result = channel.handle_receive_lock_expired(
             channel_state=channel_state,
             state_change=state_change,


### PR DESCRIPTION
### Problem
The mediator will accept `SecretReveal` messages after having expired the transfer's lock. Which means that claiming the locked amount will always fail and therefore will cause emitting `EventUnlockClaimFailed`.

### Solution in this PR
Check if the payer transfer's lock has expired before accepting `SecretReveal` messages.

Resolves #3086 