### PR TITLE
add environment_type to args to spawn raiden

### DIFF
--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -44,8 +44,7 @@ def cli_args(blockchain_provider, removed_args, changed_args):
 
     if changed_args is not None:
         for k, v in changed_args.items():
-            if k in initial_args:
-                initial_args[k] = v
+            initial_args[k] = v
 
     args = [
         '--no-sync-check',
@@ -62,5 +61,6 @@ def cli_args(blockchain_provider, removed_args, changed_args):
     append_arg_if_existing('datadir', initial_args, args)
     append_arg_if_existing('network_id', initial_args, args)
     append_arg_if_existing('eth_rpc_endpoint', initial_args, args)
+    append_arg_if_existing('environment_type', initial_args, args)
 
     return args

--- a/raiden/tests/integration/cli/test_cli.py
+++ b/raiden/tests/integration/cli/test_cli.py
@@ -49,14 +49,16 @@ def expect_cli_until_account_selection(child):
     child.sendline('0')
 
 
-def expect_cli_normal_startup(child, mode):
-    expect_cli_until_acknowledgment(child)
-    child.expect('The following accounts were found in your machine:')
-    child.expect('Select one of them by index to continue: ')
-    child.sendline('0')
+def expect_cli_successful_connected(child, mode):
     child.expect(f'Raiden is running in {mode} mode')
     child.expect('You are connected')
     child.expect('The Raiden API RPC server is now running')
+
+
+def expect_cli_normal_startup(child, mode):
+    expect_cli_until_acknowledgment(child)
+    expect_cli_until_account_selection(child)
+    expect_cli_successful_connected(child, mode)
 
 
 @pytest.mark.timeout(65)
@@ -94,8 +96,7 @@ def test_cli_missing_password_file_enter_password(blockchain_provider, cli_args)
         with open(blockchain_provider['password_file'], 'r') as password_file:
             password = password_file.readline()
             child.sendline(password)
-        child.expect('You are connected')
-        child.expect('The Raiden API RPC server is now running')
+        expect_cli_successful_connected(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
     except pexpect.TIMEOUT as e:
         print('Timed out at', e)
     finally:


### PR DESCRIPTION
When spawning raiden through cli arguments get converted of the fixture to cli command like structure. every argument needs to be converted explicitly. environment_type was missing. Refactoring recommended to avoid future pain