### PR TITLE
Update scenario player

### DIFF
--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -68,6 +68,7 @@ nodes:
 ## - stop_node
 ## - kill_node
 ## - start_node
+## - update_node_options
 ## - assert
 ## - assert_all
 ## - wait
@@ -125,6 +126,12 @@ scenario:
             - assert: {from: 2, to: 1, total_deposit: 10, balance: 12, state: "opened"}
 
 # More examples:
+#      ## All Raiden API tasks take a `timeout` parameter. If the timeout passes without the request returning successfully the task will fail.
+#      - transfer: {from: 0, to: 1, amount: 1, timeout: 30}
+#      ## Node options can be updated during a scenario run (but only while nodes are stopped):
+#      - stop_node: 0
+#      - update_node_options: {node: 0, options: {matrix-server: "https://..."}}
+#      - start_node: 0
 #      ## Assert on multiple channels without knowing the explicit peers
 #      - assert_all: {from: 0, count: 2, balances: [10, 10], total_deposits: [10, 10], states: ['opened', 'opened']}
 #      ## Open channel to arbitrary address

--- a/tools/scenario-player/scenario_player/main.py
+++ b/tools/scenario-player/scenario_player/main.py
@@ -16,7 +16,7 @@ from urwid import ExitMainLoop
 from web3.utils.transactions import TRANSACTION_DEFAULTS
 
 from raiden.accounts import Account
-from raiden.log_config import configure_logging
+from raiden.log_config import _FIRST_PARTY_PACKAGES, configure_logging
 from scenario_player import tasks
 from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.runner import ScenarioRunner
@@ -85,7 +85,7 @@ def main(
     configure_logging(
         {'': 'INFO', 'raiden': 'DEBUG', 'scenario_player': 'DEBUG'},
         debug_log_file_name=log_file_name,
-        _first_party_packages=frozenset(['raiden', 'scenario_player']),
+        _first_party_packages=_FIRST_PARTY_PACKAGES | frozenset(['scenario_player']),
     )
 
     log_buffer = None
@@ -143,7 +143,7 @@ def main(
                 str(ex),
                 mailgun_api_key,
             )
-        except ScenarioError as ex:
+        except ScenarioError:
             log.exception('Run finished', result='scenario error')
             send_notification_mail(
                 runner.notification_email,

--- a/tools/scenario-player/scenario_player/node_support.py
+++ b/tools/scenario-player/scenario_player/node_support.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from enum import Enum
 from pathlib import Path
 from tarfile import TarFile
+from typing import Any, Dict
 from zipfile import ZipFile
 
 import gevent
@@ -170,22 +171,7 @@ class NodeRunner:
         if options.pop('_clean', False):
             shutil.rmtree(self._datadir)
         self._datadir.mkdir(parents=True, exist_ok=True)
-
-        for option_name, option_value in options.items():
-            if option_name.startswith('no-'):
-                option_name = option_name.replace('no-', '')
-            if option_name in MANAGED_CONFIG_OPTIONS:
-                raise ScenarioError(
-                    f'Raiden node option "{option_name}" is managed by the scenario player '
-                    f'and cannot be changed.',
-                )
-            if option_name in MANAGED_CONFIG_OPTIONS_OVERRIDABLE:
-                log.warning(
-                    'Overriding managed option',
-                    option_name=option_name,
-                    option_value=option_value,
-                    node=self._index,
-                )
+        self._validate_options(options)
 
     def initialize(self):
         # Access properties to ensure they're initialized
@@ -239,6 +225,13 @@ class NodeRunner:
         self.state = NodeState.STOPPED
         return self.executor.kill()
 
+    def update_options(self, new_options: Dict[str, Any]):
+        if self.state is not NodeState.STOPPED:
+            raise ScenarioError("Can't update node options while node is running.")
+        self._validate_options(new_options)
+        self._options.update(new_options)
+        self._executor = None
+
     @property
     def address(self):
         if not self._address:
@@ -289,7 +282,14 @@ class NodeRunner:
             '--eth-rpc-endpoint',
             self.eth_rpc_endpoint,
             '--log-config',
-            ':info,raiden:debug,raiden.api.rest.pywsgi:warning',
+            (
+                ':info,'
+                'raiden:debug,'
+                'raiden_libs:debug,'
+                'raiden_contracts:debug,'
+                'raiden.api.rest.pywsgi:warning'
+            ),
+            '--log-json',
             '--log-file',
             self._log_file,
             '--disable-debug-logfile',
@@ -360,6 +360,23 @@ class NodeRunner:
     @property
     def _stderr_file(self):
         return self._datadir.joinpath(f'run-{self._runner.run_number:03d}.stderr')
+
+    def _validate_options(self, options: Dict[str, Any]):
+        for option_name, option_value in options.items():
+            if option_name.startswith('no-'):
+                option_name = option_name.replace('no-', '')
+            if option_name in MANAGED_CONFIG_OPTIONS:
+                raise ScenarioError(
+                    f'Raiden node option "{option_name}" is managed by the scenario player '
+                    f'and cannot be changed.',
+                )
+            if option_name in MANAGED_CONFIG_OPTIONS_OVERRIDABLE:
+                log.warning(
+                    'Overriding managed option',
+                    option_name=option_name,
+                    option_value=option_value,
+                    node=self._index,
+                )
 
 
 class NodeController:

--- a/tools/scenario-player/scenario_player/tasks/base.py
+++ b/tools/scenario-player/scenario_player/tasks/base.py
@@ -60,7 +60,6 @@ class Task:
 
         runner.task_cache[self.id] = self
         runner.task_count += 1
-        log.debug('Task initialized', task=self)
 
     def __call__(self, *args, **kwargs):
         log.info('Starting task', task=self)
@@ -153,7 +152,6 @@ def get_task_class_for_type(task_type) -> T_Task:
 
 def register_task(task_name, task):
     global NAME_TO_TASK
-    log.debug(f'Registered task: {task_name}')
     NAME_TO_TASK[task_name] = task
 
 

--- a/tools/scenario-player/scenario_player/tasks/raiden_node.py
+++ b/tools/scenario-player/scenario_player/tasks/raiden_node.py
@@ -53,3 +53,12 @@ class StopNodeTask(ProcessTask):
 class KillNodeTask(ProcessTask):
     _name = 'kill_node'
     _command = 'kill'
+
+
+class UpdateNodeOptionsTask(Task):
+    _name = 'update_node_options'
+
+    def _run(self, *args, **kwargs):
+        if not self._runner.is_managed:
+            raise ScenarioError("Can't update node options in 'external' mode.")
+        self._runner.node_controller[self._config['node']].update_options(self._config['options'])


### PR DESCRIPTION
Useful features I needed while debugging the hanging transfers:

- Add `timeout` parameter to Raiden API tasks
- Add a `update_node_options` tasks to update node start options during a running scenario
