### PR TITLE
Remove compile_webui from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -233,8 +233,7 @@ jobs:
         # pdbpp interferes with pyinstaller, uninstall it
         - pip uninstall -y pdbpp
       before_script:
-        - python setup.py build
-        - RAIDEN_NPM_MISSING_FATAL=1 python setup.py compile_webui
+        - python setup.py build      
       script:
         - source .travis/set_tag.sh
         - mkdir -p dist/archive

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.6
 # these are defined in .travis.yml and passed here in the makefile
 ARG SOLC_URL_LINUX
 ARG GETH_URL_LINUX
-ARG NODE_DOWNLOAD_URL=https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-x64.tar.xz
 
 # install dependencies
 RUN apt-get update


### PR DESCRIPTION
macOS binary generation failed due to leftover line that used to compile the webui.