### PR TITLE
Split tests on Circle CI by test function instead of file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,8 @@ templates:
     transport-layer:
       description: "transmission protocol used, udp or matrix"
       default: "udp"
-      type: string
+      type: enum
+      enum: ["udp", "matrix"]
     additional-args:
       description: "additional arguments to run smoketest if needed"
       default: ""
@@ -152,9 +153,8 @@ jobs:
         command: |
           . ${VENV_PATH}/bin/activate
           pip install -U pip wheel
-          pip install readme_renderer pyinstaller s3cmd
-          pip install -c constraints.txt -r requirements-dev.txt
-          pip install -e .
+          pip install -c constraints.txt readme_renderer pyinstaller s3cmd
+          pip install -c constraints.txt -r requirements-dev.txt -e .
     - save_cache:
         key: python-deps-<< parameters.py-version >>-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
         paths:
@@ -256,13 +256,9 @@ jobs:
       resource: << parameters.resource >>
 
     environment:
-      TEST_TYPE: << parameters.test-type >>
-      BLOCKCHAIN_TYPE: << parameters.blockchain-type >>
-      BLOCKCHAIN_TYPE_ARG: "--blockchain-type=<< parameters.blockchain-type >>"
-      TRANSPORT_OPTION: << parameters.transport-layer >>
-      TRANSPORT_OPTION_ARG: "--transport=<< parameters.transport-layer >>"
       RAIDEN_TESTS_SYNAPSE_BASE_DIR: /home/circleci/.cache/synapse
       RAIDEN_TESTS_SYNAPSE_LOGS_DIR: /tmp/synapse-logs
+      COVERAGE_DIR: /home/circleci/raiden/coverage
 
     parallelism: << parameters.parallelism >>
 
@@ -276,22 +272,53 @@ jobs:
         keys:
           - synapse-keys-v1
           - synapse-keys-
+    # Remove any existing .coverage files so we don't persist them again, causing a conflict.
     - run:
-        name: Running tests
+        name: Prepare coverage
         command: |
-          mkdir -p ~/raiden/coverage
-          export COVERAGE_FILE=~/raiden/coverage/.coverage
-          mkdir -p test-reports/test-${TEST_TYPE}-<< parameters.transport-layer >>-<< parameters.py-version >>
-          circleci tests glob raiden/tests/${TEST_TYPE}/test_*.py raiden/tests/${TEST_TYPE}/*/test_*.py | \
-          circleci tests split --split-by=timings | \
-          xargs --no-run-if-empty coverage run --include="~/raiden/**/*" --parallel-mode --module pytest \
+          mkdir -p ${COVERAGE_DIR}
+          rm ${COVERAGE_DIR}/.coverage* || true
+    - run:
+        name: Select tests
+        command: |
+          pytest \
+            raiden/tests/<< parameters.test-type >> \
+            --collect-only \
+            --quiet \
+            --blockchain-type=<< parameters.blockchain-type >> \
+            --transport=<< parameters.transport-layer >> \
+            << parameters.additional-args >> \
+            | \
+          grep '::' | \
+          circleci tests split --split-by=timings --timings-type=testname | \
+          grep '::' > selected-tests.txt
+
+          cat selected-tests.txt
+
+    - run:
+        name: Run tests
+        command: |
+          mkdir -p test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>
+          coverage run \
+            --include="~/raiden/**/*" \
+            --parallel-mode \
+            --module pytest \
+            raiden/tests \
             -vvvvvv \
             --log-config='raiden:DEBUG' \
             --random \
-            --junit-xml=test-reports/test-${TEST_TYPE}-<< parameters.transport-layer >>-<< parameters.py-version >>/results.xml \
-            $BLOCKCHAIN_TYPE_ARG \
-            $TRANSPORT_OPTION_ARG \
+            --junit-xml=test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>/results.xml \
+            --blockchain-type=<< parameters.blockchain-type >> \
+            --transport=<< parameters.transport-layer >> \
+            --select-fail-on-missing \
+            --select-from-file selected-tests.txt \
             << parameters.additional-args >>
+
+    - run:
+        name: Store coverage
+        command: |
+          mv .coverage* ${COVERAGE_DIR}
+
     - persist_to_workspace:
         root: "~"
         paths:
@@ -482,13 +509,11 @@ workflows:
           requires:
             - lint-3.6
             - mypy-3.6
-            - test-unit-3.6
             - test-fuzz-3.6
             - test-integration-udp-3.6
             - test-integration-matrix-3.6
             - lint-3.7
             - mypy-3.7
-            - test-unit-3.7
             - test-fuzz-3.7
             - test-integration-udp-3.7
             - test-integration-matrix-3.7
@@ -496,22 +521,26 @@ workflows:
       - test:
           name: test-integration-udp-3.6
           py-version: "3.6"
+          resource: "medium"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 16
+          parallelism: 25
           requires:
             - smoketest-udp-3.6
+            - test-unit-3.6
 
       - test:
           name: test-integration-matrix-3.6
           py-version: "3.6"
+          resource: "medium"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"
-          parallelism: 16
+          parallelism: 25
           requires:
             - smoketest-matrix-3.6
+            - test-unit-3.6
 
       - lint:
           name: lint-3.7
@@ -558,23 +587,27 @@ workflows:
 
       - test:
           name: test-integration-udp-3.7
+          resource: "medium"
           py-version: "3.7"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 16
+          parallelism: 25
           requires:
             - smoketest-udp-3.7
+            - test-unit-3.7
 
       - test:
           name: test-integration-matrix-3.7
           py-version: "3.7"
+          resource: "medium"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"
-          parallelism: 16
+          parallelism: 25
           requires:
             - smoketest-matrix-3.7
+            - test-unit-3.7
 
   deploy-release:
 
@@ -682,13 +715,11 @@ workflows:
           requires:
             - lint-3.6
             - mypy-3.7
-            - test-unit-3.6
             - test-fuzz-3.6
             - test-integration-udp-3.6
             - test-integration-matrix-3.6
             - lint-3.7
             - mypy-3.7
-            - test-unit-3.7
             - test-fuzz-3.7
             - test-integration-udp-3.7
             - test-integration-matrix-3.7
@@ -702,6 +733,7 @@ workflows:
           parallelism: 16
           requires:
             - smoketest-udp-3.6
+            - test-unit-3.6
 
       - test:
           name: test-integration-matrix-3.6
@@ -712,6 +744,7 @@ workflows:
           parallelism: 16
           requires:
             - smoketest-matrix-3.6
+            - test-unit-3.6
 
       - lint:
           name: lint-3.7
@@ -765,6 +798,7 @@ workflows:
           parallelism: 16
           requires:
             - smoketest-udp-3.7
+            - test-unit-3.7
 
       - test:
           name: test-integration-matrix-3.7
@@ -775,6 +809,7 @@ workflows:
           parallelism: 16
           requires:
             - smoketest-matrix-3.7
+            - test-unit-3.7
 
       - build-dist:
           requires:

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -489,7 +489,8 @@ def test_query_events(
     assert must_have_event(all_netting_channel_events, settled_event)
 
 
-@pytest.mark.xfail(reason='out-of-gas for unlock and settle')
+# @pytest.mark.xfail(reason='out-of-gas for unlock and settle')
+@pytest.mark.skip(reason='out-of-gas for unlock and settle')
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_secret_revealed(raiden_chain, deposit, settle_timeout, token_addresses):

--- a/raiden/tests/utils/geth.py
+++ b/raiden/tests/utils/geth.py
@@ -274,7 +274,8 @@ def geth_node_to_datadir(node_config, base_datadir):
 
 def geth_prepare_datadir(datadir, genesis_file):
     node_genesis_path = os.path.join(datadir, 'custom_genesis.json')
-    assert len(datadir + '/geth.ipc') <= 104, 'geth data path is too large'
+    ipc_path = datadir + '/geth.ipc'
+    assert len(ipc_path) <= 104, f'geth data path "{ipc_path}" is too large'
 
     os.makedirs(datadir)
     shutil.copy(genesis_file, node_genesis_path)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@
 pytest-cov==2.5.1
 pytest-random==0.02
 pytest-timeout==1.2.1
+pytest-select==0.1.2
 grequests==0.3.0
 pexpect==4.6.0
 


### PR DESCRIPTION
Previously we used file level timing based test splitting on Circle CI.
The problem with that approach is that it limits the minimum achievable runtime to the one of the longest single test file.

This PR introduces splitting the tests at the test function level instead of by file. This allows us to utilize more workers and thereby reduce the test suite runtime.

Currently it takes about 9 minutes for the entire run, but this should improve a bit more over time as more timing data is gathered and the distribution will become more even.