### PR TITLE
Fix "Deposit amount decreased" crash in development mode

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`3135` In development mode if more than 100 * (10^18) tokens are deposited then raiden no longer crashes.
+
 * :release:`0.18.1 <2018-12-07>`
 * :bug:`2779` Fixes a long standing bug that could cause payments to hang indefinitely.
 * :bug:`3103` Fixes a bug in matrix which prevented retries of messages.

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -395,13 +395,19 @@ class RaidenAPI:
                 token_network_proxy.proxy.contract.functions.
                 channel_participant_deposit_limit().call()
             )
-            if total_deposit > deposit_limit:
-                raise DepositOverLimit(
-                    'The deposit of {} is bigger than the current limit of {}'.format(
-                        total_deposit,
-                        deposit_limit,
-                    ),
-                )
+        elif self.raiden.config['environment_type'] == Environment.DEVELOPMENT:
+            deposit_limit = (
+                token_network_proxy.proxy.contract.functions.
+                deposit_limit().call()
+            )
+
+        if total_deposit > deposit_limit:
+            raise DepositOverLimit(
+                'The deposit of {} is bigger than the current limit of {}'.format(
+                    total_deposit,
+                    deposit_limit,
+                ),
+            )
 
         addendum = total_deposit - channel_state.our_state.contract_balance
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1147,7 +1147,9 @@ class TokenNetwork:
                 'Channel is already closed',
             )
         elif participant_details.our_details.deposit < deposit_amount:
-            raise RaidenUnrecoverableError('Deposit amount decreased')
+            raise RaidenUnrecoverableError(
+                'Deposit amount did not increase after deposit transaction',
+            )
 
     def _check_channel_state_for_settle(self, participant1, participant2, channel_identifier):
         channel_data = self.detail_channel(participant1, participant2, channel_identifier)

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -12,9 +12,10 @@ def append_arg_if_existing(argname, initial_args, new_args):
 @pytest.fixture(scope='session')
 def blockchain_provider():
     result = setup_testchain_and_raiden(
-        'matrix',
-        'auto',
-        lambda x: None,
+        transport='matrix',
+        matrix_server='auto',
+        print_step=lambda x: None,
+        contracts_version=None,  # cli tests should work with production contracts
     )
     args = result['args']
     # The setup of the testchain returns a TextIOWrapper but

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -191,7 +191,7 @@ def get_private_key(keystore):
     return accmgr.get_privkey(addresses[0], DEFAULT_PASSPHRASE)
 
 
-def setup_testchain_and_raiden(transport, matrix_server, print_step):
+def setup_testchain_and_raiden(transport, matrix_server, print_step, contracts_version):
     print_step('Starting Ethereum node')
 
     ensure_executable('geth')
@@ -261,8 +261,9 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step):
     print_step('Deploying Raiden contracts')
 
     client = JSONRPCClient(web3, get_private_key(keystore))
-    # for smoketest use the precompiled contracts
-    contract_manager = ContractManager(contracts_precompiled_path())
+    contract_manager = ContractManager(
+        contracts_precompiled_path(contracts_version),
+    )
 
     contract_addresses = deploy_smoketest_contracts(
         client=client,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -297,12 +297,10 @@ def run_app(
     chain_config = {}
     contract_addresses_known = False
     contracts = dict()
-    config['contracts_path'] = contracts_precompiled_path()
-
+    contracts_version = 'pre_limits' if environment_type == Environment.DEVELOPMENT else None
+    config['contracts_path'] = contracts_precompiled_path(contracts_version)
     if node_network_id in ID_TO_NETWORKNAME and ID_TO_NETWORKNAME[node_network_id] != 'smoketest':
-        contracts_version = 'pre_limits' if environment_type == Environment.DEVELOPMENT else None
         deployment_data = get_contracts_deployed(node_network_id, contracts_version)
-        config['contracts_path'] = contracts_precompiled_path(contracts_version)
         not_allowed = (  # for now we only disallow mainnet with test configuration
             network_id == 1 and
             environment_type == Environment.DEVELOPMENT

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -516,6 +516,7 @@ def smoketest(ctx, debug, local_matrix, **kwargs):  # pylint: disable=unused-arg
         ctx.parent.params['transport'],
         ctx.parent.params['matrix_server'],
         print_step,
+        'pre_limits',  # smoke test should work with pre-limits contract version
     )
     args = result['args']
     contract_addresses = result['contract_addresses']


### PR DESCRIPTION
In development mode we unfortunately seem to still have limits as we can see from the code
[here](https://github.com/raiden-network/raiden-contracts/blob/7105cf818fc290107ad48df9497bddcdec5c540e/raiden_contracts/contracts/TokenNetwork.sol) of what is probably the pre_limits contracts.

The fix for now, is to also take that limit into account at development mode and not allow the client to send a transaction when the token amount is above the limit that development mode contracts have.

Fix #3135
