### PR TITLE
New factories for unit tests part 2

### DIFF
--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-locals,too-many-statements,too-many-lines
+# pylint: disable=too-many-locals,too-many-statements,too-many-lines,no-member
 import random
 from collections import namedtuple
 from copy import deepcopy
@@ -18,6 +18,10 @@ from raiden.tests.utils.factories import (
     UNIT_TRANSFER_INITIATOR,
     UNIT_TRANSFER_SENDER,
     UNIT_TRANSFER_TARGET,
+    NettingChannelEndStateProperties,
+    NettingChannelStateProperties,
+    TransactionExecutionStatusProperties,
+    create,
     make_secret,
 )
 from raiden.tests.utils.transfer import make_receive_expired_lock, make_receive_transfer_mediated
@@ -103,21 +107,21 @@ def create_model(balance, merkletree_width=0):
 
 def create_channel_from_models(our_model, partner_model):
     """Utility to instantiate state objects used throughout the tests."""
-    channel_state = factories.make_netting_channel_state(
+    channel_state = create(NettingChannelStateProperties(
         reveal_timeout=10,
         settle_timeout=100,
-        our_state=factories.make_netting_channel_end_state_record(
+        our_state=NettingChannelEndStateProperties(
             address=our_model.participant_address,
             balance=our_model.balance,
             merkletree_leaves=our_model.merkletree_leaves,
         ),
-        partner_state=factories.make_netting_channel_end_state_record(
+        partner_state=NettingChannelEndStateProperties(
             address=partner_model.participant_address,
             balance=partner_model.balance,
             merkletree_leaves=partner_model.merkletree_leaves,
         ),
-        open_transaction=factories.make_transaction_execution_status(finished_block_number=1),
-    )
+        open_transaction=TransactionExecutionStatusProperties(finished_block_number=1),
+    ))
 
     assert channel_state.our_total_deposit == our_model.contract_balance
     assert channel_state.partner_total_deposit == partner_model.contract_balance

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-locals,too-many-statements,too-many-lines,no-member
+# pylint: disable=too-many-locals,too-many-statements,too-many-lines
 import random
 from collections import namedtuple
 from copy import deepcopy

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -18,6 +18,9 @@ from raiden.tests.utils.factories import (
     UNIT_TRANSFER_IDENTIFIER,
     UNIT_TRANSFER_INITIATOR,
     UNIT_TRANSFER_TARGET,
+    NettingChannelEndStateProperties,
+    NettingChannelStateProperties,
+    make_channel_set,
 )
 from raiden.transfer import channel
 from raiden.transfer.mediated_transfer import mediator
@@ -267,14 +270,11 @@ def test_regression_mediator_task_no_routes():
     """
     pseudo_random_generator = random.Random()
 
-    channels = factories.make_channel_set([
-        {
-            'our_state': {'balance': 0},
-            'partner_state': {'balance': 10, 'address': HOP2},
-            'open_transaction': factories.make_transaction_execution_status(
-                finished_block_number=10,
-            ),
-        },
+    channels = make_channel_set([
+        NettingChannelStateProperties(
+            our_state=NettingChannelEndStateProperties(balance=0),
+            partner_state=NettingChannelEndStateProperties(balance=10, address=HOP2),
+        ),
     ])
 
     payer_transfer = factories.make_default_signed_transfer_for(

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-arguments,no-member
+# pylint: disable=too-many-arguments
 import random
 import string
 from functools import singledispatch
@@ -573,20 +573,26 @@ def make_merkletree_leaves(width: int) -> typing.List[typing.Secret]:
 
 
 @singledispatch
-def create(properties: typing.Any, defaults=None) -> typing.Any:
+def create(properties, defaults=None):
     """Create objects from their associated property class.
 
     E. g. a NettingChannelState from NettingChannelStateProperties. For any field in
     properties set to EMPTY a default will be used. The default values can be changed
     by giving another object of the same property type as the defaults argument.
     """
-    return properties
+    return None
 
 
-def _args_from_properties(properties: NamedTuple, defaults: NamedTuple):
+# the default implementation of create() must return None to not confuse pylint.
+def _create_or_echo(properties, defaults=None):
+    created = create(properties, defaults)
+    return created if created is not None else properties
+
+
+def _args_from_properties(properties: NamedTuple, defaults: NamedTuple) -> typing.Dict:
     defaults_dict = defaults._asdict()
     return {
-        key: create(if_empty(value, defaults_dict[key]))
+        key: _create_or_echo(if_empty(value, defaults_dict[key]))
         for key, value in properties._asdict().items()
     }
 


### PR DESCRIPTION
- refactoring of new factories using property classes
- refactoring of all tests using the `make_transfers_pair` fixture 