### PR TITLE
Put raiden/api and raiden/transfer under mypy checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ lint:
 	python setup.py check --restructuredtext --strict
 
 mypy:
-	# We are starting small with a few files here, but mypy should run on the
-	# whole codebase soon.
-	mypy raiden/transfer/mediated_transfer/target.py raiden/messages.py \
+	# We are starting small with a few files and directories here,
+	# but mypy should run on the whole codebase soon.
+	mypy raiden/transfer raiden/messages.py \
 	--ignore-missing-imports | grep error > mypy-out.txt || true
 	# Expecting status code 1 from `grep`, which indicates no match.
 	# Again, we are starting small, detecting only 'BlockNumber' and 'Address'

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ lint:
 mypy:
 	# We are starting small with a few files and directories here,
 	# but mypy should run on the whole codebase soon.
-	mypy raiden/transfer raiden/messages.py \
+	mypy raiden/transfer raiden/api raiden/messages.py \
 	--ignore-missing-imports | grep error > mypy-out.txt || true
 	# Expecting status code 1 from `grep`, which indicates no match.
 	# Again, we are starting small, detecting only 'BlockNumber' and 'Address'

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -736,7 +736,7 @@ class RaidenAPI:
 
     def get_blockchain_events_network(
             self,
-            registry_address: typing.PaymentNetworkID,
+            registry_address: typing.Address,
             from_block: typing.BlockSpecification = GENESIS_BLOCK_NUMBER,
             to_block: typing.BlockSpecification = 'latest',
     ):

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -736,7 +736,7 @@ class RaidenAPI:
 
     def get_blockchain_events_network(
             self,
-            registry_address: typing.Address,
+            registry_address: typing.PaymentNetworkID,
             from_block: typing.BlockSpecification = GENESIS_BLOCK_NUMBER,
             to_block: typing.BlockSpecification = 'latest',
     ):

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -13,7 +13,7 @@ from raiden.utils.filters import (
     decode_event,
     get_filter_args_for_all_events_from_channel,
 )
-from raiden.utils.typing import Address, BlockSpecification, ChannelID
+from raiden.utils.typing import Address, BlockSpecification, ChannelID, PaymentNetworkID
 from raiden_contracts.constants import (
     CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK,
@@ -74,7 +74,7 @@ def get_contract_events(
 
 def get_token_network_registry_events(
         chain: BlockChainService,
-        token_network_registry_address: Address,
+        token_network_registry_address: PaymentNetworkID,
         contract_manager: ContractManager,
         events: List[str] = ALL_EVENTS,
         from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
@@ -84,7 +84,7 @@ def get_token_network_registry_events(
     return get_contract_events(
         chain,
         contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
-        token_network_registry_address,
+        Address(token_network_registry_address),
         events,
         from_block,
         to_block,

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Optional
 
 from eth_utils import decode_hex
 from gevent.lock import RLock
@@ -141,7 +142,7 @@ class PaymentChannel:
             channel_identifier=self.channel_identifier,
         )
 
-    def closing_address(self) -> typing.Address:
+    def closing_address(self) -> Optional[typing.Address]:
         """ Returns the address of the closer of the channel. """
         return self.token_network.closing_address(
             participant1=self.participant1,

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -152,7 +152,7 @@ def get_token_network_identifier_by_token_address(
         chain_state: ChainState,
         payment_network_id: typing.PaymentNetworkID,
         token_address: typing.TokenAddress,
-) -> typing.Address:
+) -> typing.TokenNetworkID:
     token_network = get_token_network_by_token_address(
         chain_state,
         payment_network_id,

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -150,8 +150,8 @@ def get_token_network_registry_by_token_network_identifier(
 
 def get_token_network_identifier_by_token_address(
         chain_state: ChainState,
-        payment_network_id: typing.Address,
-        token_address: typing.Address,
+        payment_network_id: typing.PaymentNetworkID,
+        token_address: typing.TokenAddress,
 ) -> typing.Address:
     token_network = get_token_network_by_token_address(
         chain_state,
@@ -234,7 +234,7 @@ def total_token_network_channels(
 def get_token_network_by_token_address(
         chain_state: ChainState,
         payment_network_id: typing.PaymentNetworkID,
-        token_address: typing.Address,
+        token_address: typing.TokenAddress,
 ) -> typing.Optional[TokenNetworkState]:
 
     payment_network = chain_state.identifiers_to_paymentnetworks.get(payment_network_id)
@@ -251,7 +251,7 @@ def get_token_network_by_token_address(
 
 def get_token_network_by_identifier(
         chain_state: ChainState,
-        token_network_id: typing.TokenAddress,
+        token_network_id: typing.TokenNetworkID,
 ) -> typing.Optional[TokenNetworkState]:
 
     token_network_state = None
@@ -297,7 +297,7 @@ def get_channelstate_for(
 
 def get_channelstate_by_token_network_and_partner(
         chain_state: ChainState,
-        token_network_id: typing.Address,
+        token_network_id: typing.TokenNetworkID,
         partner_address: typing.Address,
 ) -> typing.Optional[NettingChannelState]:
     """ Return the NettingChannelState if it exists, None otherwise. """
@@ -324,7 +324,7 @@ def get_channelstate_by_token_network_and_partner(
 
 def get_channelstate_by_token_network_identifier(
         chain_state: ChainState,
-        token_network_id: typing.Address,
+        token_network_id: typing.TokenNetworkID,
         channel_id: typing.ChannelID,
 ) -> typing.Optional[NettingChannelState]:
     """ Return the NettingChannelState if it exists, None otherwise. """

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -5,7 +5,7 @@ import re
 import sys
 import time
 from itertools import zip_longest
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union
 
 import gevent
 from coincurve import PrivateKey
@@ -271,7 +271,9 @@ def merge_dict(to_update: dict, other_dict: dict):
             to_update[key] = value
 
 
-def optional_address_to_string(address: typing.Address = None) -> typing.Optional[str]:
+def optional_address_to_string(
+        address: Optional[Union[typing.Address, typing.TokenAddress]] = None,
+) -> typing.Optional[str]:
     if address is None:
         return None
 

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -146,7 +146,7 @@ def wait_for_payment_balance(
 def wait_for_close(
         raiden: RaidenService,
         payment_network_id: typing.PaymentNetworkID,
-        token_address: typing.Address,
+        token_address: typing.TokenAddress,
         channel_ids: typing.List[typing.ChannelID],
         retry_timeout: float,
 ) -> None:


### PR DESCRIPTION
This PR puts `raiden/api` and `raiden/transfer` under mypy checks.  The focus is still on `Address` related errors https://github.com/raiden-network/raiden/issues/3120.

When I solve all `Address` related mypy errors, the integration of the new type system https://github.com/raiden-network/raiden/issues/3051 will be much easier.