### PR TITLE
Rename Secret message into Unlock

### DIFF
--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -13,7 +13,7 @@ PROCESSED = 0
 PING = 1
 PONG = 2
 SECRETREQUEST = 3
-SECRET = 4
+UNLOCK = 4
 LOCKEDTRANSFER = 7
 REFUNDTRANSFER = 8
 REVEALSECRET = 11
@@ -110,10 +110,10 @@ SecretRequest = namedbuffer(
     ],
 )
 
-Secret = namedbuffer(
-    'secret',
+Unlock = namedbuffer(
+    'unlock',
     [
-        cmdid(SECRET),
+        cmdid(UNLOCK),
         pad(3),
         chain_id,
         message_identifier,
@@ -227,7 +227,7 @@ CMDID_MESSAGE = {
     PING: Ping,
     PONG: Pong,
     SECRETREQUEST: SecretRequest,
-    SECRET: Secret,
+    UNLOCK: Unlock,
     REVEALSECRET: RevealSecret,
     LOCKEDTRANSFER: LockedTransfer,
     REFUNDTRANSFER: RefundTransfer,

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -40,7 +40,7 @@ class MessageHandler:
         elif type(message) == RevealSecret:
             self.handle_message_revealsecret(raiden, message)
         elif type(message) == Unlock:
-            self.handle_message_secret(raiden, message)
+            self.handle_message_unlock(raiden, message)
         elif type(message) == LockExpired:
             self.handle_message_lockexpired(raiden, message)
         elif type(message) == RefundTransfer:
@@ -71,7 +71,7 @@ class MessageHandler:
         )
         raiden.handle_state_change(state_change)
 
-    def handle_message_secret(self, raiden: RaidenService, message: Unlock):
+    def handle_message_unlock(self, raiden: RaidenService, message: Unlock):
         balance_proof = balanceproof_from_envelope(message)
         state_change = ReceiveUnlock(
             message_identifier=message.message_identifier,

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -8,8 +8,8 @@ from raiden.messages import (
     Processed,
     RefundTransfer,
     RevealSecret,
-    Secret,
     SecretRequest,
+    Unlock,
 )
 from raiden.raiden_service import RaidenService
 from raiden.routing import get_best_routes
@@ -39,7 +39,7 @@ class MessageHandler:
             self.handle_message_secretrequest(raiden, message)
         elif type(message) == RevealSecret:
             self.handle_message_revealsecret(raiden, message)
-        elif type(message) == Secret:
+        elif type(message) == Unlock:
             self.handle_message_secret(raiden, message)
         elif type(message) == LockExpired:
             self.handle_message_lockexpired(raiden, message)
@@ -71,7 +71,7 @@ class MessageHandler:
         )
         raiden.handle_state_change(state_change)
 
-    def handle_message_secret(self, raiden: RaidenService, message: Secret):
+    def handle_message_secret(self, raiden: RaidenService, message: Unlock):
         balance_proof = balanceproof_from_envelope(message)
         state_change = ReceiveUnlock(
             message_identifier=message.message_identifier,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -52,7 +52,7 @@ __all__ = (
     'Ping',
     'Processed',
     'RefundTransfer',
-    'Secret',
+    'Unlock',
     'SecretRequest',
     'SignedMessage',
     'decode',
@@ -142,7 +142,7 @@ def message_from_sendevent(send_event: SendMessageEvent, our_address: Address) -
     elif type(send_event) == SendSecretReveal:
         message = RevealSecret.from_event(send_event)
     elif type(send_event) == SendBalanceProof:
-        message = Secret.from_event(send_event)
+        message = Unlock.from_event(send_event)
     elif type(send_event) == SendSecretRequest:
         message = SecretRequest.from_event(send_event)
     elif type(send_event) == SendRefundTransfer:
@@ -551,14 +551,14 @@ class SecretRequest(SignedMessage):
         return secret_request
 
 
-class Secret(EnvelopeMessage):
+class Unlock(EnvelopeMessage):
     """ Message used to do state changes on a partner Raiden Channel.
 
     Locksroot changes need to be synchronized among both participants, the
     protocol is for only the side unlocking to send the Secret message allowing
     the other party to claim the unlocked lock.
     """
-    cmdid = messages.SECRET
+    cmdid = messages.UNLOCK
 
     def __init__(
             self,
@@ -1424,7 +1424,7 @@ CMDID_TO_CLASS = {
     messages.PROCESSED: Processed,
     messages.REFUNDTRANSFER: RefundTransfer,
     messages.REVEALSECRET: RevealSecret,
-    messages.SECRET: Secret,
+    messages.UNLOCK: Unlock,
     messages.SECRETREQUEST: SecretRequest,
     messages.LOCKEXPIRED: LockExpired,
 }

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -671,7 +671,7 @@ class Unlock(EnvelopeMessage):
 
     def to_dict(self):
         return {
-            'type': self.__class__.__name__,
+            'type': 'Secret',
             'chain_id': self.chain_id,
             'message_identifier': self.message_identifier,
             'payment_identifier': self.payment_identifier,
@@ -687,7 +687,7 @@ class Unlock(EnvelopeMessage):
 
     @classmethod
     def from_dict(cls, data):
-        assert data['type'] == cls.__name__
+        assert data['type'] == 'Secret'
         message = cls(
             chain_id=data['chain_id'],
             message_identifier=data['message_identifier'],

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1430,3 +1430,4 @@ CMDID_TO_CLASS = {
 }
 
 CLASSNAME_TO_CLASS = {klass.__name__: klass for klass in CMDID_TO_CLASS.values()}
+CLASSNAME_TO_CLASS['Secret'] = Unlock

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -555,7 +555,7 @@ class Unlock(EnvelopeMessage):
     """ Message used to do state changes on a partner Raiden Channel.
 
     Locksroot changes need to be synchronized among both participants, the
-    protocol is for only the side unlocking to send the Secret message allowing
+    protocol is for only the side unlocking to send the Unlock message allowing
     the other party to claim the unlocked lock.
     """
     cmdid = messages.UNLOCK

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -147,11 +147,11 @@ class RaidenEventHandler:
             raiden: RaidenService,
             balance_proof_event: SendBalanceProof,
     ):
-        secret_message = message_from_sendevent(balance_proof_event, raiden.address)
-        raiden.sign(secret_message)
+        unlock_message = message_from_sendevent(balance_proof_event, raiden.address)
+        raiden.sign(unlock_message)
         raiden.transport.send_async(
             balance_proof_event.queue_identifier,
-            secret_message,
+            unlock_message,
         )
 
     def handle_send_secretrequest(

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -5,7 +5,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.app import App
 from raiden.message_handler import MessageHandler
-from raiden.messages import Secret
+from raiden.messages import Unlock
 from raiden.network.transport import UDPTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.utils.events import must_contain_entry
@@ -116,7 +116,7 @@ def test_recovery_happy_case(
     )
 
     identifier = create_default_identifier()
-    wait_for_payment = app2_wait_for.wait_for_message(Secret, {'payment_identifier': identifier})
+    wait_for_payment = app2_wait_for.wait_for_message(Unlock, {'payment_identifier': identifier})
 
     mediated_transfer(
         app2,

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -208,7 +208,7 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
     app0.raiden.sign(reveal_secret)
 
     token_network_identifier = channelstate_0_1.token_network_identifier
-    secret = Unlock(
+    unlock = Unlock(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=random.randint(0, UINT64_MAX),
         payment_identifier=payment_identifier,
@@ -220,11 +220,11 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
         locksroot=EMPTY_MERKLE_ROOT,
         secret=secret,
     )
-    app0.raiden.sign(secret)
+    app0.raiden.sign(unlock)
 
     if transport_protocol is TransportProtocol.UDP:
         messages = [
-            secret.encode(),
+            unlock.encode(),
             reveal_secret.encode(),
         ]
         host_port = None
@@ -240,7 +240,7 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
         ]
     elif transport_protocol is TransportProtocol.MATRIX:
         messages = [
-            secret,
+            unlock,
             reveal_secret,
         ]
         receive_method = app1.raiden.transport._receive_message

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -4,7 +4,7 @@ import gevent
 import pytest
 
 from raiden.constants import UINT64_MAX
-from raiden.messages import Lock, LockedTransfer, RevealSecret, Secret
+from raiden.messages import Lock, LockedTransfer, RevealSecret, Unlock
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.integration.fixtures.raiden_network import CHAIN, wait_for_channels
 from raiden.tests.utils.events import must_contain_entry
@@ -87,7 +87,7 @@ def test_regression_unfiltered_routes(
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_regression_revealsecret_after_secret(raiden_network, token_addresses, transport_protocol):
-    """ A RevealSecret message received after a Secret message must be cleanly
+    """ A RevealSecret message received after a Unlock message must be cleanly
     handled.
     """
     app0, app1, app2 = raiden_network
@@ -138,9 +138,9 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
     """ Multiple RevealSecret messages arriving at the same time must be
     handled properly.
 
-    Secret handling followed these steps:
+    Unlock handling followed these steps:
 
-        The Secret message arrives
+        The Unlock message arrives
         The secret is registered
         The channel is updated and the correspoding lock is removed
         * A balance proof for the new channel state is created and sent to the
@@ -148,7 +148,7 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
         The channel is unregistered for the given secrethash
 
     The step marked with an asterisk above introduced a context-switch. This
-    allowed a second Reveal Secret message to be handled before the channel was
+    allowed a second Reveal Unlock message to be handled before the channel was
     unregistered. And because the channel was already updated an exception was raised
     for an unknown secret.
     """
@@ -208,7 +208,7 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
     app0.raiden.sign(reveal_secret)
 
     token_network_identifier = channelstate_0_1.token_network_identifier
-    secret = Secret(
+    secret = Unlock(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=random.randint(0, UINT64_MAX),
         payment_identifier=payment_identifier,

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -48,7 +48,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     )
     sign_and_inject(refund_transfer_message, other_key, other_address, app0)
 
-    secret = Unlock(
+    unlock = Unlock(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=random.randint(0, UINT64_MAX),
         payment_identifier=1,
@@ -60,7 +60,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
         locksroot=UNIT_SECRETHASH,
         secret=UNIT_SECRET,
     )
-    sign_and_inject(secret, other_key, other_address, app0)
+    sign_and_inject(unlock, other_key, other_address, app0)
 
     secret_request_message = SecretRequest(
         message_identifier=random.randint(0, UINT64_MAX),

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -3,7 +3,7 @@ import random
 import pytest
 
 from raiden.constants import UINT64_MAX
-from raiden.messages import RevealSecret, Secret, SecretRequest
+from raiden.messages import RevealSecret, SecretRequest, Unlock
 from raiden.tests.utils.factories import (
     HOP1,
     HOP1_KEY,
@@ -48,7 +48,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     )
     sign_and_inject(refund_transfer_message, other_key, other_address, app0)
 
-    secret = Secret(
+    secret = Unlock(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=random.randint(0, UINT64_MAX),
         payment_identifier=1,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -505,7 +505,7 @@ def test_channelstate_receive_lockedtransfer():
     transferred_amount = 0
     message_identifier = random.randint(0, UINT64_MAX)
     token_network_identifier = channel_state.token_network_identifier
-    secret_message = Unlock(
+    unlock_message = Unlock(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=message_identifier,
         payment_identifier=1,
@@ -517,9 +517,9 @@ def test_channelstate_receive_lockedtransfer():
         locksroot=EMPTY_MERKLE_ROOT,
         secret=lock_secret,
     )
-    secret_message.sign(privkey2)
+    unlock_message.sign(privkey2)
     # Let's also create an invalid secret to test unlock with invalid chain id
-    invalid_secret_message = Unlock(
+    invalid_unlock_message = Unlock(
         chain_id=UNIT_CHAIN_ID + 1,
         message_identifier=message_identifier,
         payment_identifier=1,
@@ -531,9 +531,9 @@ def test_channelstate_receive_lockedtransfer():
         locksroot=EMPTY_MERKLE_ROOT,
         secret=lock_secret,
     )
-    invalid_secret_message.sign(privkey2)
+    invalid_unlock_message.sign(privkey2)
 
-    balance_proof = balanceproof_from_envelope(secret_message)
+    balance_proof = balanceproof_from_envelope(unlock_message)
     unlock_state_change = ReceiveUnlock(
         message_identifier=random.randint(0, UINT64_MAX),
         secret=lock_secret,
@@ -541,7 +541,7 @@ def test_channelstate_receive_lockedtransfer():
     )
 
     # First test that unlock with invalid chain_id fails
-    invalid_balance_proof = balanceproof_from_envelope(invalid_secret_message)
+    invalid_balance_proof = balanceproof_from_envelope(invalid_unlock_message)
     invalid_unlock_state_change = ReceiveUnlock(
         message_identifier=random.randint(0, UINT64_MAX),
         secret=lock_secret,
@@ -918,7 +918,7 @@ def test_interwoven_transfers():
             )
 
             message_identifier = random.randint(0, UINT64_MAX)
-            secret_message = Unlock(
+            unlock_message = Unlock(
                 chain_id=UNIT_CHAIN_ID,
                 message_identifier=message_identifier,
                 payment_identifier=nonce,
@@ -930,9 +930,9 @@ def test_interwoven_transfers():
                 locksroot=locksroot,
                 secret=lock_secret,
             )
-            secret_message.sign(privkey2)
+            unlock_message.sign(privkey2)
 
-            balance_proof = balanceproof_from_envelope(secret_message)
+            balance_proof = balanceproof_from_envelope(unlock_message)
             unlock_state_change = ReceiveUnlock(
                 message_identifier=random.randint(0, UINT64_MAX),
                 secret=lock_secret,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -7,7 +7,7 @@ from itertools import cycle
 import pytest
 
 from raiden.constants import UINT64_MAX
-from raiden.messages import Secret
+from raiden.messages import Unlock
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils import factories
 from raiden.tests.utils.events import must_contain_entry
@@ -505,7 +505,7 @@ def test_channelstate_receive_lockedtransfer():
     transferred_amount = 0
     message_identifier = random.randint(0, UINT64_MAX)
     token_network_identifier = channel_state.token_network_identifier
-    secret_message = Secret(
+    secret_message = Unlock(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=message_identifier,
         payment_identifier=1,
@@ -519,7 +519,7 @@ def test_channelstate_receive_lockedtransfer():
     )
     secret_message.sign(privkey2)
     # Let's also create an invalid secret to test unlock with invalid chain id
-    invalid_secret_message = Secret(
+    invalid_secret_message = Unlock(
         chain_id=UNIT_CHAIN_ID + 1,
         message_identifier=message_identifier,
         payment_identifier=1,
@@ -918,7 +918,7 @@ def test_interwoven_transfers():
             )
 
             message_identifier = random.randint(0, UINT64_MAX)
-            secret_message = Secret(
+            secret_message = Unlock(
                 chain_id=UNIT_CHAIN_ID,
                 message_identifier=message_identifier,
                 payment_identifier=nonce,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -766,7 +766,7 @@ def is_valid_unlock(
         result = (False, msg, None)
 
     elif received_balance_proof.locksroot != locksroot_without_lock:
-        # Secret messages remove a known lock, the new locksroot must have only
+        # Unlock messages remove a known lock, the new locksroot must have only
         # that lock removed, otherwise the sender may be trying to remove
         # additional locks.
         msg = (
@@ -780,7 +780,7 @@ def is_valid_unlock(
         result = (False, msg, None)
 
     elif received_balance_proof.transferred_amount != expected_transferred_amount:
-        # Secret messages must increase the transferred_amount by lock amount,
+        # Unlock messages must increase the transferred_amount by lock amount,
         # otherwise the sender is trying to play the protocol and steal token.
         msg = (
             "Invalid Unlock message. "
@@ -793,7 +793,7 @@ def is_valid_unlock(
         result = (False, msg, None)
 
     elif received_balance_proof.locked_amount != expected_locked_amount:
-        # Secret messages must increase the transferred_amount by lock amount,
+        # Unlock messages must increase the transferred_amount by lock amount,
         # otherwise the sender is trying to play the protocol and steal token.
         msg = (
             "Invalid Unlock message. "


### PR DESCRIPTION
Renaming Secret messages into Unlock messages.  The name Secret was chosen for historical reasons but not descriptive anymore.  Fixes #3132.