### PR TITLE
 If Rest API open() gets non-contract address don't crash the client

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3153` If a non-contract address is given for token_address in the channel open REST API call, the client no longer crashes.
 * :bug:`3135` In development mode if more than 100 * (10^18) tokens are deposited then raiden no longer crashes.
 
 * :release:`0.18.1 <2018-12-07>`

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -584,7 +584,8 @@ class RestAPI:
                 partner_address,
                 settle_timeout,
             )
-        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress, AddressWithoutCode, DuplicatedChannelError, TokenNotRegistered) as e:
+        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
+                AddressWithoutCode, DuplicatedChannelError, TokenNotRegistered) as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -557,7 +557,13 @@ class RestAPI:
             token_address=to_checksum_address(token_address),
             settle_timeout=settle_timeout,
         )
-        token = self.raiden_api.raiden.chain.token(token_address)
+        try:
+            token = self.raiden_api.raiden.chain.token(token_address)
+        except AddressWithoutCode as e:
+            return api_error(
+                errors=str(e),
+                status_code=HTTPStatus.CONFLICT,
+            )
         balance = token.balance_of(self.raiden_api.raiden.address)
 
         if total_deposit is not None and total_deposit > balance:
@@ -578,8 +584,7 @@ class RestAPI:
                 partner_address,
                 settle_timeout,
             )
-        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress,
-                AddressWithoutCode, DuplicatedChannelError, TokenNotRegistered) as e:
+        except (InvalidAddress, InvalidSettleTimeout, SamePeerAddress, AddressWithoutCode, DuplicatedChannelError, TokenNotRegistered) as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -13,6 +13,7 @@ from raiden.tests.integration.api.utils import create_api_server
 from raiden.tests.utils import assert_dicts_are_equal
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.events import must_have_event, must_have_events
+from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.smartcontracts import deploy_contract_web3
 from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED
 from raiden.waiting import wait_for_transfer_success
@@ -643,6 +644,18 @@ def test_api_open_channel_invalid_input(
     assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
     channel_data_obj['settle_timeout'] = TEST_SETTLE_TIMEOUT_MAX + 1
+    request = grequests.put(
+        api_url_for(
+            test_api_server,
+            'channelsresource',
+        ),
+        json=channel_data_obj,
+    )
+    response = request.send().response
+    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
+
+    channel_data_obj['settle_timeout'] = TEST_SETTLE_TIMEOUT_MAX - 1
+    channel_data_obj['token_address'] = to_checksum_address(make_address())
     request = grequests.put(
         api_url_for(
             test_api_server,


### PR DESCRIPTION
We are actually properly catching the `AddressWithoutCode` exception thrown out
of the `open_channel()` function but there was an instance before the
actual opening where a `Token()` object is instantiated and throws
that same exception which is left unhandled and crashes the client.

Fix #3153