### PR TITLE
Fix CircleCI timeout with parallelism=1 by increasing to 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,7 +507,7 @@ workflows:
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-udp-3.6
           filters:
@@ -522,7 +522,7 @@ workflows:
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-matrix-3.6
           filters:
@@ -585,7 +585,7 @@ workflows:
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-udp-3.7
           filters:
@@ -599,7 +599,7 @@ workflows:
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-matrix-3.7
           filters:
@@ -715,7 +715,7 @@ workflows:
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-udp-3.6
 
@@ -727,7 +727,7 @@ workflows:
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-matrix-3.6
 
@@ -775,7 +775,7 @@ workflows:
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-udp-3.7
 
@@ -787,7 +787,7 @@ workflows:
           blockchain-type: "geth"
           transport-layer: "matrix"
           additional-args: "--local-matrix='~/raiden/.synapse/run_synapse.sh'"
-          parallelism: 1
+          parallelism: 2
           requires:
             - smoketest-matrix-3.7
 


### PR DESCRIPTION
CircleCI parallelism was decreased to 1 on f34ab26bd5dbd4989dffdb1a134c909ee1e5c0b6 to avoid hitting the limit of 4 on the smaller plan and allow all 4 sets of integration tests running together, but it pushed the time required to run a single set of tests to more than 1 hour, which made it timeout and not complete successfuly even if no test errored.
This PR increase it to 2, to decrease the time of running a single set of test to less than 1hr, but preventing all 4 sets of tests of running parallely, running 2 then 2 at a time.