### PR TITLE
Start describing the state machines

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Contents
   webui_tutorial
   config_file
   onboarding
+  state_machines
   changelog
   glossary
   trademarks

--- a/docs/state_machines.rst
+++ b/docs/state_machines.rst
@@ -1,0 +1,58 @@
+Raiden Guide on State Machines
+##############################
+.. toctree::
+   :maxdepth: 2
+
+Introduction
+============
+
+The current Raiden prototype chose to use hierarchical state machines to represent the internal state of the node. The state of the whole node is a tree that can be serialized on and recovered from the disk. Moreover, whenever the state changes, the change is triggered by a state change object, which can also be serialized on the disk. A snapshot of the state and the subsequent state change objects are enough to compute the current state of the node. That's how a node recovers from crashes.
+
+Kinds of State Machines
+=======================
+
+The state of the whole node is represented as a ``ChainState`` object. The ``ChainState`` object contains many other different kinds of objects. This section describes them in a bottom-to-top manner.
+
+This section is very early in construction with the simplest state machines.
+
+HashTimeLockState
+*****************
+
+A ``HashTimeLockState`` represents a hash time lock.
+
+Attributes of a HashTimeLockState
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``amount`` is the amount of tokens locked in the hash time lock.
+* ``expiration`` is the block number when the hash time lock expires.
+* ``secrethash`` is the hash value of the secret that can unlock the hash time lock.
+* ``encoded`` is the serialization of the above fields.
+* ``lockhash`` is the hash of ``encoded``, which is useful for the Merkle tree formation.
+
+State Changes on a HashTimeLockState
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No state changes operate on a ``HashTimeLockState``. A ``HashTimeLockState`` is just added to and removed from :ref:`netting-channel-end-state`.
+
+Other State Machines that Contain a HashTimeLockState
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* A :ref:`netting-channel-end-state` contains zero-to-many ``HashTimeLockState``.
+
+.. _netting-channel-end-state:
+
+NettingChannelEndState
+**********************
+
+(TODO: describe)
+
+Other State Machines to be Added
+********************************
+
+* ``NettingChannelEndState``
+* ``NettingChannelState``
+* ...
+* ``TokenNetworkState``
+* ``PaymentMappingState``
+* ``PaymentNetworkState``
+* ``ChainState``

--- a/docs/state_machines.rst
+++ b/docs/state_machines.rst
@@ -23,11 +23,7 @@ A ``HashTimeLockState`` represents a hash time lock.
 Attributes of a HashTimeLockState
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ``amount`` is the amount of tokens locked in the hash time lock.
-* ``expiration`` is the block number when the hash time lock expires.
-* ``secrethash`` is the hash value of the secret that can unlock the hash time lock.
-* ``encoded`` is the serialization of the above fields.
-* ``lockhash`` is the hash of ``encoded``, which is useful for the Merkle tree formation.
+See `the code <https://github.com/raiden-network/raiden/blob/f5d48172931ce60c820253e81708acc2a2f49941/raiden/transfer/state.py#L998>`__.
 
 State Changes on a HashTimeLockState
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/state_machines.rst
+++ b/docs/state_machines.rst
@@ -1,5 +1,5 @@
-Raiden Guide on State Machines
-##############################
+Description of the Raiden State Machines
+########################################
 .. toctree::
    :maxdepth: 2
 
@@ -13,7 +13,7 @@ Kinds of State Machines
 
 The state of the whole node is represented as a ``ChainState`` object. The ``ChainState`` object contains many other different kinds of objects. This section describes them in a bottom-to-top manner.
 
-This section is very early in construction with the simplest state machines.
+This section is still in construction. It contains only the simplest of the state machines.
 
 HashTimeLockState
 *****************

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -997,10 +997,10 @@ class HashTimeLockState(State):
 
     __slots__ = (
         'amount',
-        'expiration',
+        'expiration',   # latest block number when the secret has to be revealed
         'secrethash',
-        'encoded',
-        'lockhash',
+        'encoded',      # serialization of the above fields
+        'lockhash',     # hash of 'encoded'
     )
 
     def __init__(


### PR DESCRIPTION
This commit adds a file that describes state machines.  As a start, I tried to describe the ``HashTimeLockState``.

This is the first bite on https://github.com/raiden-network/raiden/issues/3160

[no ci integration]