### PR TITLE
Matrix: handle E500 on join_room

### DIFF
--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -631,7 +631,7 @@ class MatrixTransport(Runnable):
             try:
                 discovery_room = self._client.join_room(discovery_room_alias_full)
             except MatrixRequestError as ex:
-                if ex.code not in (404, 403):
+                if ex.code not in (403, 404, 500):
                     raise
                 self.log.debug(
                     'Could not join discovery room',


### PR DESCRIPTION
`_join_discovery_room` raised an exception if we tried to `join_room` on a foreign server which couldn't be contacted by our current transport server.
This PR adds a test for that, and handles the returned E500, moving on and eventually creating a discovery room on our current server if none could be found (usually happens only on private chains, as discovery rooms for all known test and main blockchains are already present on all servers).
Fixes #3171 and #3081 