### PR TITLE
 SendRefundTransfer should have a balance_proof attribute

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3179` Properly process a SendRefundTransfer event if it's the last one before settlement and not crash the client.
 * :bug:`3175` If Github checking of latest version returns unexpected response do not let Raiden crash.
 * :bug:`3170` If the same refund transfer is received multiple times, the mediator state machine will reject subsequent ones rather than clearing up the mediator task.
 * :bug:`3146` If a refund transfer is received and there are no other routes, keep the payment task so that the channel does not hang when mediator sends a LockExpired.

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -269,6 +269,9 @@ def test_get_event_with_balance_proof():
             balance_hash=balance_proof.balance_hash,
         )
         assert event_record.data == event
+        # Checking that balance proof attribute can be accessed for all events.
+        # Issue https://github.com/raiden-network/raiden/issues/3179
+        assert event_record.data.balance_proof == event.balance_proof
 
 
 def test_log_raiden_run():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_events.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_events.py
@@ -1,0 +1,18 @@
+from raiden.tests.utils.factories import make_address, make_channel_identifier, make_transfer
+from raiden.transfer.mediated_transfer.events import SendRefundTransfer
+
+
+def test_send_refund_transfer_contains_balance_proof():
+    recipient = make_address()
+    transfer = make_transfer()
+    message_identifier = 1
+    channel_identifier = make_channel_identifier()
+    event = SendRefundTransfer(
+        recipient=recipient,
+        channel_identifier=channel_identifier,
+        message_identifier=message_identifier,
+        transfer=transfer,
+    )
+
+    assert hasattr(event, 'balance_proof')
+    assert SendRefundTransfer.from_dict(event.to_dict()) == event

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -413,6 +413,10 @@ class SendRefundTransfer(SendMessageEvent):
 
         self.transfer = transfer
 
+    @property
+    def balance_proof(self):
+        return self.transfer.balance_proof
+
     def __repr__(self):
         return (
             f'<'


### PR DESCRIPTION
Properly process a `SendRefundTransfer` event if it's the last one with a related balance proof before settlement and not crash the client.

Fix #3179 