### PR TITLE
If initiator had a refund transfer dont remove payment task at lock expiration block

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3183` If as initiator our nodes receives a RefundTransfer then do not delete the payment task at the lock expiration block but wait for a LockExpired message. Solves one hanging transfer case.
 * :bug:`3179` Properly process a SendRefundTransfer event if it's the last one before settlement and not crash the client.
 * :bug:`3175` If Github checking of latest version returns unexpected response do not let Raiden crash.
 * :bug:`3170` If the same refund transfer is received multiple times, the mediator state machine will reject subsequent ones rather than clearing up the mediator task.

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -18,6 +18,7 @@ from raiden.transfer.mediated_transfer.events import (
 )
 from raiden.transfer.mediated_transfer.state_change import ReceiveLockExpired
 from raiden.transfer.state import lockstate_from_lock
+from raiden.transfer.state_change import ReceiveProcessed
 from raiden.transfer.views import state_from_raiden
 from raiden.waiting import wait_for_block
 
@@ -235,10 +236,17 @@ def test_refund_transfer(
 
     # Out of the handicapped app0 transport.
     # Now wait till app0 receives and processes LockExpired
-    wait_for_state_change(
+    receive_lock_expired = wait_for_state_change(
         app0.raiden,
         ReceiveLockExpired,
         {'secrethash': secrethash},
+        retry_timeout,
+    )
+    # And also till app1 received the processed
+    wait_for_state_change(
+        app1.raiden,
+        ReceiveProcessed,
+        {'message_identifier': receive_lock_expired.message_identifier},
         retry_timeout,
     )
 

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -261,6 +261,13 @@ def test_refund_transfer(
     ]
     assert not result
 
+    # and now wait for 1 more block so that the payment task can be deleted
+    wait_for_block(
+        raiden=app0.raiden,
+        block_number=app0.raiden.get_block_number() + 1,
+        retry_timeout=retry_timeout,
+    )
+
     # and since the lock expired message has been sent and processed then the
     # payment task should have been deleted from both nodes
     # https://github.com/raiden-network/raiden/issues/3183

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -123,3 +123,5 @@ def wait_for_state_change(
             break
 
         gevent.sleep(retry_timeout)
+
+    return found

--- a/raiden/tests/utils/protocol.py
+++ b/raiden/tests/utils/protocol.py
@@ -128,6 +128,19 @@ def dont_handle_secret_request_mock(app):
     )
 
 
+def dont_handle_locked_expired_mock(app):
+    """Takes in a raiden app and returns a mock context where locke expired is not processed
+    """
+    def do_nothing(raiden, message):
+        pass
+
+    return patch.object(
+        app.raiden.message_handler,
+        'handle_message_lockexpired',
+        side_effect=do_nothing,
+    )
+
+
 def dont_handle_node_change_network_state():
     """Returns a mock context where ActionChangeNodeNetworkState is not processed
     """

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -881,7 +881,7 @@ def get_batch_unlock(
 def get_lock(
         end_state: NettingChannelEndState,
         secrethash: typing.SecretHash,
-) -> HashTimeLockState:
+) -> typing.Optional[HashTimeLockState]:
     """Return the lock correspoding to `secrethash` or None if the lock is
     unknown.
     """
@@ -898,6 +898,17 @@ def get_lock(
 
     assert isinstance(lock, HashTimeLockState) or lock is None
     return lock
+
+
+def lock_exists_in_either_channel_side(
+        channel_state: NettingChannelState,
+        secrethash: typing.SecretHash,
+) -> bool:
+    """Check if the lock with `secrethash` exists in either our state or the partner's state"""
+    lock = get_lock(channel_state.our_state, secrethash)
+    if not lock:
+        lock = get_lock(channel_state.partner_state, secrethash)
+    return lock is not None
 
 
 def get_next_nonce(end_state: NettingChannelEndState) -> typing.Nonce:

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -68,6 +68,7 @@ def events_for_unlock_lock(
 
 def handle_block(
         initiator_state: InitiatorTransferState,
+        had_canceled_payments: bool,
         state_change: Block,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
@@ -109,7 +110,10 @@ def handle_block(
         )
         expired_lock_events.append(transfer_failed)
         return TransitionResult(
-            None,
+            # If there were any refund transfers we need to keep the payment
+            # task around to wait for the LockExpired message.
+            # Check https://github.com/raiden-network/raiden/issues/3183
+            initiator_state if had_canceled_payments else None,
             typing.cast(typing.List[Event], expired_lock_events),
         )
     else:

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -92,7 +92,6 @@ def handle_block(
 
     sub_iteration = initiator.handle_block(
         initiator_state=payment_state.initiator,
-        had_canceled_payments=len(payment_state.cancelled_channels) != 0,
         state_change=state_change,
         channel_state=channel_state,
         pseudo_random_generator=pseudo_random_generator,
@@ -255,7 +254,7 @@ def handle_transferrefundcancelroute(
 
 def handle_lock_expired(
         payment_state: InitiatorPaymentState,
-        state_change: ReceiveSecretReveal,
+        state_change: ReceiveLockExpired,
         channelidentifiers_to_channels: typing.ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: typing.BlockNumber,
@@ -289,7 +288,6 @@ def handle_lock_expired(
             reason='Lock expired',
         )
         result.events.append(unlock_failed)
-        return TransitionResult(None, result.events)
 
     return TransitionResult(payment_state, result.events)
 


### PR DESCRIPTION
- If the initiator has the lock with the transfer's secrethash also pending in the partner state (iow had a refund transfer) then don't remove the payment task at the lock expiration block but wait for a lock expire message to unlock the lock and then be free to remove it in the next block.

- As an initiator handle LockExpired messages. Your partner may send
  you one if you sent him a locked transfer, he had no capacity and
  sent you a refund transfer back.

Fix #3183