### PR TITLE
 Protect targets_to_identifiers_to_statuses with a lock 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :feature:`3217` If channel is already updated onchain don't call updateNonClosingBalanceProof.
 * :bug:`3216` If coming online after partner closed channel don't try to send updateNonClosingBalanceProof twice and crash Raiden.
 * :bug:`3211` If using parity and getting the already imported error, attempt to handle it and not crash the client.
+* :bug:`3121` If the same payment identifier is reused avoid a specific race condition that can crash Raiden.
 * :bug:`3201` Workaround for gas price strategy crashing Raiden with an Infura ethereum node.
 
 * :release:`0.100.1 <2018-12-21>`

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -453,15 +453,6 @@ class RaidenService(Runnable):
     def get_block_number(self):
         return views.block_number(self.wal.state_manager.current_state)
 
-    def pop_payment_status(
-            self,
-            target: typing.TargetAddress,
-            payment_identifier: typing.PaymentID,
-    ) -> typing.Optional[PaymentStatus]:
-        with self.payment_identifier_lock:
-            status = self.targets_to_identifiers_to_statuses[target].pop(payment_identifier, None)
-        return status
-
     def on_message(self, message: Message):
         self.message_handler.on_message(self, message)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -261,6 +261,7 @@ class RaidenService(Runnable):
 
         self.event_poll_lock = gevent.lock.Semaphore()
         self.gas_reserve_lock = gevent.lock.Semaphore()
+        self.payment_identifier_lock = gevent.lock.Semaphore()
 
     def start(self):
         """ Start the node synchronously. Raises directly if anything went wrong on startup """
@@ -452,6 +453,15 @@ class RaidenService(Runnable):
     def get_block_number(self):
         return views.block_number(self.wal.state_manager.current_state)
 
+    def pop_payment_status(
+            self,
+            target: typing.TargetAddress,
+            payment_identifier: typing.PaymentID,
+    ) -> typing.Optional[PaymentStatus]:
+        with self.payment_identifier_lock:
+            status = self.targets_to_identifiers_to_statuses[target].pop(payment_identifier, None)
+        return status
+
     def on_message(self, message: Message):
         self.message_handler.on_message(self, message)
 
@@ -573,13 +583,14 @@ class RaidenService(Runnable):
             payment_type: PaymentType,
             balance_proof: BalanceProofUnsignedState,
     ):
-        self.targets_to_identifiers_to_statuses[target][identifier] = PaymentStatus(
-            payment_type=payment_type,
-            payment_identifier=identifier,
-            amount=balance_proof.transferred_amount,
-            token_network_identifier=balance_proof.token_network_identifier,
-            payment_done=AsyncResult(),
-        )
+        with self.payment_identifier_lock:
+            self.targets_to_identifiers_to_statuses[target][identifier] = PaymentStatus(
+                payment_type=payment_type,
+                payment_identifier=identifier,
+                amount=balance_proof.transferred_amount,
+                token_network_identifier=balance_proof.token_network_identifier,
+                payment_done=AsyncResult(),
+            )
 
     def _initialize_transactions_queues(self, chain_state):
         pending_transactions = views.get_pending_transactions(chain_state)
@@ -782,23 +793,29 @@ class RaidenService(Runnable):
         if identifier is None:
             identifier = create_default_identifier()
 
-        payment_status = self.targets_to_identifiers_to_statuses[target].get(identifier)
-        if payment_status:
-            if not payment_status.matches(PaymentType.MEDIATED, token_network_identifier, amount):
-                raise PaymentConflict(
-                    'Another payment with the same id is in flight',
+        with self.payment_identifier_lock:
+            payment_status = self.targets_to_identifiers_to_statuses[target].get(identifier)
+            if payment_status:
+                payment_status_matches = payment_status.matches(
+                    PaymentType.MEDIATED,
+                    token_network_identifier,
+                    amount,
                 )
+                if not payment_status_matches:
+                    raise PaymentConflict(
+                        'Another payment with the same id is in flight',
+                    )
 
-            return payment_status.payment_done
+                return payment_status.payment_done
 
-        payment_status = PaymentStatus(
-            payment_type=PaymentType.MEDIATED,
-            payment_identifier=identifier,
-            amount=amount,
-            token_network_identifier=token_network_identifier,
-            payment_done=AsyncResult(),
-        )
-        self.targets_to_identifiers_to_statuses[target][identifier] = payment_status
+            payment_status = PaymentStatus(
+                payment_type=PaymentType.MEDIATED,
+                payment_identifier=identifier,
+                amount=amount,
+                token_network_identifier=token_network_identifier,
+                payment_done=AsyncResult(),
+            )
+            self.targets_to_identifiers_to_statuses[target][identifier] = payment_status
 
         init_initiator_statechange = initiator_init(
             raiden=self,


### PR DESCRIPTION
Also remove unnecessary assert.

Fixes a race condition of using the same payment identifier and the
first transfer succeeding while the second one is just beginning.
For more details check: #3121 (comment)

Fix #3121