### PR TITLE
 Channel balance returned by API takes locked amount into account 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3193` Channel balance shown to the user now takes locked amount into account.
 * :bug:`3171` Do not crash raiden if the Matrix server is offline when joining a discovery room.
 * :bug:`3183` If as initiator our nodes receives a RefundTransfer then do not delete the payment task at the lock expiration block but wait for a LockExpired message. Solves one hanging transfer case.
 * :bug:`3179` Properly process a SendRefundTransfer event if it's the last one before settlement and not crash the client.

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -190,7 +190,7 @@ class ChannelStateSchema(BaseSchema):
         return to_checksum_address(channel_state.partner_state.address)
 
     def get_balance(self, channel_state):  # pylint: disable=no-self-use
-        return channel.get_balance(
+        return channel.get_distributable(
             channel_state.our_state,
             channel_state.partner_state,
         )


### PR DESCRIPTION
Use the `get_distributable()` instead of `get_balance()` channel
functions for the balance shown to the user.

Fix #3193