### PR TITLE
Unlock using state change or event

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,8 +2,10 @@
 Changelog
 =========
 
-* :bug:`3193` Channel balance shown to the user now takes locked amount into account.
 * :bug:`3171` Do not crash raiden if the Matrix server is offline when joining a discovery room.
+* :bug:`3196` If our partner updates onchain with earlier balance proof find the event in the DB and properly perform the unlock onchain.
+* :bug:`3193` Channel balance shown to the user now takes locked amount into account.
+
 * :bug:`3183` If as initiator our nodes receives a RefundTransfer then do not delete the payment task at the lock expiration block but wait for a LockExpired message. Solves one hanging transfer case.
 * :bug:`3179` Properly process a SendRefundTransfer event if it's the last one before settlement and not crash the client.
 * :bug:`3175` If Github checking of latest version returns unexpected response do not let Raiden crash.

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -369,7 +369,8 @@ class RaidenEventHandler:
         )
 
         if not record.state_change_identifier:
-            raise RaidenUnrecoverableError(
+            log.warning(
+                f'Unlock not done',
                 f'Failed to find state/event that match current channel locksroots. '
                 f'token:{to_checksum_address(token_address)} '
                 f'token_network:{to_checksum_address(token_network_identifier)} '
@@ -378,6 +379,7 @@ class RaidenEventHandler:
                 f'our_locksroot:{to_hex(our_locksroot)} '
                 f'partner_locksroot:{to_hex(partner_locksroot)} ',
             )
+            return
 
         # Replay state changes until a channel state is reached where
         # this channel state has the participants balance hash.

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -36,7 +36,11 @@ from raiden.transfer.mediated_transfer.events import (
     SendSecretRequest,
     SendSecretReveal,
 )
-from raiden.transfer.utils import get_event_with_balance_proof, get_state_change_with_balance_proof
+from raiden.transfer.utils import (
+    get_event_with_balance_proof,
+    get_state_change_or_event_with_balance_proof,
+    get_state_change_with_balance_proof,
+)
 from raiden.utils import pex
 from raiden.utils.signing import eth_sign
 
@@ -340,26 +344,7 @@ class RaidenEventHandler:
             our_locksroot != EMPTY_HASH
         )
 
-        if is_partner_unlock:
-            state_change_record = get_state_change_with_balance_proof(
-                storage=raiden.wal.storage,
-                chain_id=raiden.chain.network_id,
-                token_network_identifier=token_network_identifier,
-                channel_identifier=channel_identifier,
-                balance_hash=partner_details.balance_hash,
-                sender=participants_details.partner_details.address,
-            )
-            state_change_identifier = state_change_record.state_change_identifier
-        elif is_our_unlock:
-            event_record = get_event_with_balance_proof(
-                storage=raiden.wal.storage,
-                chain_id=raiden.chain.network_id,
-                token_network_identifier=token_network_identifier,
-                channel_identifier=channel_identifier,
-                balance_hash=our_details.balance_hash,
-            )
-            state_change_identifier = event_record.state_change_identifier
-        else:
+        if not is_partner_unlock and not is_our_unlock:
             # In the case that someone else sent the unlock we do nothing
             # Check https://github.com/raiden-network/raiden/issues/3152
             # for more details
@@ -370,6 +355,18 @@ class RaidenEventHandler:
                 participant=participant,
             )
             return
+
+        state_change_identifier = get_state_change_or_event_with_balance_proof(
+            storage=raiden.wal.storage,
+            chain_id=raiden.chain.network_id,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            is_our_unlock=is_our_unlock,
+            is_partner_unlock=is_partner_unlock,
+            our_balance_hash=our_details.balance_hash,
+            partner_balance_hash=partner_details.balance_hash,
+            sender=participants_details.partner_details.address,
+        )
 
         if not state_change_identifier:
             raise RaidenUnrecoverableError(

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -356,7 +356,7 @@ class RaidenEventHandler:
             )
             return
 
-        state_change_identifier = get_state_change_or_event_with_balance_proof(
+        record = get_state_change_or_event_with_balance_proof(
             storage=raiden.wal.storage,
             chain_id=raiden.chain.network_id,
             token_network_identifier=token_network_identifier,
@@ -368,7 +368,7 @@ class RaidenEventHandler:
             sender=participants_details.partner_details.address,
         )
 
-        if not state_change_identifier:
+        if not record.state_change_identifier:
             raise RaidenUnrecoverableError(
                 f'Failed to find state/event that match current channel locksroots. '
                 f'token:{to_checksum_address(token_address)} '
@@ -386,7 +386,7 @@ class RaidenEventHandler:
             payment_network_identifier=raiden.default_registry.address,
             token_address=token_address,
             channel_identifier=channel_identifier,
-            state_change_identifier=state_change_identifier,
+            state_change_identifier=record.state_change_identifier,
         )
 
         our_state = restored_channel_state.our_state

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -11,13 +11,18 @@ from raiden.utils import get_system_spec, typing
 RAIDEN_DB_VERSION = 16
 
 
-class EventRecord(typing.NamedTuple):
-    event_identifier: int
+class Record(typing.NamedTuple):
     state_change_identifier: int
     data: typing.Any
 
 
-class StateChangeRecord(typing.NamedTuple):
+class StateChangeRecord(Record):
+    state_change_identifier: int
+    data: typing.Any
+
+
+class EventRecord(typing.NamedTuple):
+    event_identifier: int
     state_change_identifier: int
     data: typing.Any
 

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -81,7 +81,7 @@ def cancel_current_route(payment_state: InitiatorPaymentState) -> typing.List[Ev
 
 def handle_block(
         payment_state: InitiatorPaymentState,
-        state_change: ReceiveSecretReveal,
+        state_change: Block,
         channelidentifiers_to_channels: typing.ChannelMap,
         pseudo_random_generator: random.Random,
 ) -> TransitionResult:

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -9,6 +9,69 @@ from raiden.utils import typing
 from raiden.utils.serialization import serialize_bytes
 
 
+def get_state_change_or_event_with_balance_proof(
+        storage: sqlite.SQLiteStorage,
+        chain_id: typing.ChainID,
+        token_network_identifier: typing.TokenNetworkID,
+        channel_identifier: typing.ChannelID,
+        is_our_unlock: bool,
+        is_partner_unlock: bool,
+        our_balance_hash: typing.BalanceHash,
+        partner_balance_hash: typing.BalanceHash,
+        sender: typing.Address,
+) -> int:
+    """ Returns the state change or event which contains the corresponding balance
+    proof depending on who's balance hash we're looking for.
+    """
+    if is_partner_unlock:
+        state_change_record = get_state_change_with_balance_proof(
+            storage=storage,
+            chain_id=chain_id,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=partner_balance_hash,
+            sender=sender,
+        )
+        state_change_identifier = state_change_record.state_change_identifier
+
+        if state_change_identifier:
+            return state_change_identifier
+
+        event_record = get_event_with_balance_proof(
+            storage=storage,
+            chain_id=chain_id,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=partner_balance_hash,
+        )
+
+        return event_record.state_change_identifier
+    elif is_our_unlock:
+        event_record = get_event_with_balance_proof(
+            storage=storage,
+            chain_id=chain_id,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=our_balance_hash,
+        )
+        state_change_identifier = event_record.state_change_identifier
+
+        if state_change_identifier:
+            return state_change_identifier
+
+        state_change_record = get_state_change_with_balance_proof(
+            storage=storage,
+            chain_id=chain_id,
+            token_network_identifier=token_network_identifier,
+            channel_identifier=channel_identifier,
+            balance_hash=our_balance_hash,
+            sender=sender,
+        )
+
+        return state_change_record.state_change_identifier
+    return 0
+
+
 def get_state_change_with_balance_proof(
         storage: sqlite.SQLiteStorage,
         chain_id: typing.ChainID,

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -19,7 +19,7 @@ def get_state_change_or_event_with_balance_proof(
         our_balance_hash: typing.BalanceHash,
         partner_balance_hash: typing.BalanceHash,
         sender: typing.Address,
-) -> int:
+) -> sqlite.Record:
     """ Returns the state change or event which contains the corresponding balance
     proof depending on who's balance hash we're looking for.
     """
@@ -35,7 +35,7 @@ def get_state_change_or_event_with_balance_proof(
         state_change_identifier = state_change_record.state_change_identifier
 
         if state_change_identifier:
-            return state_change_identifier
+            return state_change_record
 
         event_record = get_event_with_balance_proof(
             storage=storage,
@@ -45,7 +45,7 @@ def get_state_change_or_event_with_balance_proof(
             balance_hash=partner_balance_hash,
         )
 
-        return event_record.state_change_identifier
+        return event_record
     elif is_our_unlock:
         event_record = get_event_with_balance_proof(
             storage=storage,
@@ -57,7 +57,7 @@ def get_state_change_or_event_with_balance_proof(
         state_change_identifier = event_record.state_change_identifier
 
         if state_change_identifier:
-            return state_change_identifier
+            return event_record
 
         state_change_record = get_state_change_with_balance_proof(
             storage=storage,
@@ -68,7 +68,7 @@ def get_state_change_or_event_with_balance_proof(
             sender=sender,
         )
 
-        return state_change_record.state_change_identifier
+        return state_change_record
     return 0
 
 


### PR DESCRIPTION
Fixes #3196 

This PR fixes the issue mentioned above by doing the following in the case the node is trying to unlock:

If the partner has locked amounts, then we search for the the balance hash in the state_changes table (which we already did before), but in case it doesn't find it, it searches events so that we find the event at which the partner's balance hash was updated due to a new balance proof we sent.

If the partner has no locked amounts but our side of the channel does, then we look for events (which we already did before) but in case it doesn't find it, it searches for state changes.

We tried the fix on a test-case that crashed the lock previously on mainnet and we confirm that the fix works and the following transactions on-chain were able to restore the locked amounts for both participants:
https://etherscan.io/tx/0x1dc402ca55614b83d68c4ef8a9eb749cdb53306f745a47390c95cd25d30082c4
https://etherscan.io/tx/0x620b4472ca1b7f4bac8eedd89a7d228de4eb90c339b6da88cdd383f65bbc59fa

Note: We will skip the test for now and merge the PR now and resume writing the test later.