### PR TITLE
Bump version: 0.100.0 → 0.100.1

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.100.0
+current_version = 0.100.1
 commit = True
 tag = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ master_doc = 'index'
 project = 'Raiden Network'
 author = 'Raiden Project'
 
-version_string = '0.100.0'
+version_string = '0.100.1'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('constraints.txt') as req_file:
 
 test_requirements = []
 
-version = '0.100.0'  # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
+version = '0.100.1'  # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
 
 setup(
     name='raiden',


### PR DESCRIPTION
[no ci integration]