### PR TITLE
Workaround for Infura and gas price strategy issue

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`3201` Workaround for gas price strategy crashing Raiden with an Infura ethereum node.
+
 * :release:`0.100.1 <2018-12-21>`
 * :bug:`3171` Do not crash raiden if the Matrix server is offline when joining a discovery room.
 * :bug:`3196` If our partner updates onchain with earlier balance proof find the event in the DB and properly perform the unlock onchain.

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -339,11 +339,19 @@ class JSONRPCClient:
         return self.web3.eth.getBalance(to_checksum_address(account), 'pending')
 
     def gas_price(self) -> int:
-        # generateGasPrice takes the transaction to be send as an optional argument
-        # but both strategies that we are using (time-based and rpc-based) don't make
-        # use of this argument. It is therefore safe to not provide it at the moment.
-        # This needs to be reevaluated if we use different gas price strategies
-        return int(self.web3.eth.generateGasPrice())
+        try:
+            # generateGasPrice takes the transaction to be send as an optional argument
+            # but both strategies that we are using (time-based and rpc-based) don't make
+            # use of this argument. It is therefore safe to not provide it at the moment.
+            # This needs to be reevaluated if we use different gas price strategies
+            price = int(self.web3.eth.generateGasPrice())
+        except AttributeError:  # workaround for Infura gas strategy key error
+            # As per https://github.com/raiden-network/raiden/issues/3201
+            # we can sporadically get an AtttributeError here. If that happens
+            # use latest gas price
+            price = int(self.web3.eth.gasPrice)
+
+        return price
 
     def new_contract_proxy(self, contract_interface, contract_address: typing.Address):
         """ Return a proxy for interacting with a smart contract.


### PR DESCRIPTION
Handle https://github.com/raiden-network/raiden/issues/3201 issue for Infura by essentially reverting back to `eth_gasPrice` RPC call whenever Infura + web3 cause the attribute error.

This is just a workaround that can be made on our side. The real fix should be done either upstream in web3 or Infura.