### PR TITLE
 Handle the Parity Transaction already imported error 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3211` If using parity and getting the already imported error, attempt to handle it and not crash the client.
 * :bug:`3201` Workaround for gas price strategy crashing Raiden with an Infura ethereum node.
 
 * :release:`0.100.1 <2018-12-21>`


### PR DESCRIPTION
Fix #3211 for parity.

What we do is:

1. When we get the transaction already imported error we get all the
pending transactions from the pool via `parity_allTransactions`.
2. Search these transactions for one originating from our node and
with the expected nonce.
3. i. If the transaction is found we get the hash and proceed as usual
with polling it.
   ii. If it's not found we handle this as the geth
   `TransactionAlreadyPending` error and crash raiden.

3-ii can only happen if the transaction gets out of the pool between
the time we get the already imported error and the time we query it.
The only reason that 3-ii does not handle the situation gracefully is
because at that point there will be no way to get the transaction hash.
The raiden client needs a transaction hash for blockchain transactions so we are left with no choice.

The crash generatedby `TransactionAlreadyPending` exception will not be fatal though. As soon as we restart assuming the transaction is mined, we will get all required state from the blockchain events and can keep on operating normally.