### PR TITLE
Finish test_different_view_of_last_bp_during_unlock and address related issues

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`3217` If channel is already updated onchain don't call updateNonClosingBalanceProof.
+* :bug:`3216` If coming online after partner closed channel don't try to send updateNonClosingBalanceProof twice and crash Raiden.
 * :bug:`3211` If using parity and getting the already imported error, attempt to handle it and not crash the client.
 * :bug:`3201` Workaround for gas price strategy crashing Raiden with an Infura ethereum node.
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -361,8 +361,14 @@ class RaidenService(Runnable):
         self.alarm.register_callback(self._callback_new_block)
         self.alarm.first_run(last_log_block_number)
 
-        chain_state = views.state_from_raiden(self)
+        # Run the alarm task block callback once more to possibly
+        # clear pending transactions after the chain syncing during
+        # the first run of the alarm task.
+        # https://github.com/raiden-network/raiden/issues/3216
+        latest_block = self.chain.get_block(block_identifier='latest')
+        self._callback_new_block(latest_block)
 
+        chain_state = views.state_from_raiden(self)
         self._initialize_transactions_queues(chain_state)
         self._initialize_whitelists(chain_state)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -361,13 +361,6 @@ class RaidenService(Runnable):
         self.alarm.register_callback(self._callback_new_block)
         self.alarm.first_run(last_log_block_number)
 
-        # Run the alarm task block callback once more to possibly
-        # clear pending transactions after the chain syncing during
-        # the first run of the alarm task.
-        # https://github.com/raiden-network/raiden/issues/3216
-        latest_block = self.chain.get_block(block_identifier='latest')
-        self._callback_new_block(latest_block)
-
         chain_state = views.state_from_raiden(self)
         self._initialize_transactions_queues(chain_state)
         self._initialize_whitelists(chain_state)

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -108,6 +108,7 @@ class AlarmTask(Runnable):
 
     def start(self):
         log.debug('Alarm task started', node=pex(self.chain.node_address))
+        self._stop_event.set(False)
         super().start()
 
     def _run(self):  # pylint: disable=method-hidden
@@ -224,5 +225,6 @@ class AlarmTask(Runnable):
 
     def stop(self):
         self._stop_event.set(True)
+        self.callbacks = []
         log.debug('Alarm task stopped', node=pex(self.chain.node_address))
         return self.join()

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -232,6 +232,8 @@ class AlarmTask(Runnable):
 
     def stop(self):
         self._stop_event.set(True)
-        self.callbacks = []
         log.debug('Alarm task stopped', node=pex(self.chain.node_address))
-        return self.join()
+        result = self.join()
+        # Callbacks should be cleaned after join
+        self.callbacks = []
+        return result

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -176,6 +176,13 @@ class AlarmTask(Runnable):
         self.chain_id = chain_id
         self._maybe_run_callbacks(latest_block)
 
+        # Run the alarm task block callback once more to possibly
+        # clear pending transactions after the chain syncing during
+        # the first run of the alarm task.
+        # https://github.com/raiden-network/raiden/issues/3216
+        latest_block = self.chain.get_block(block_identifier='latest')
+        self._maybe_run_callbacks(latest_block)
+
     def _maybe_run_callbacks(self, latest_block):
         """ Run the callbacks if there is at least one new block.
 


### PR DESCRIPTION
Fix #3217 Fix #3216 

This PR does the following:

- Finishes the test left skipped after PR #3197. This tests all the other bullet points.
- During testing we `stop()` and `start()` raiden again. This will also
  stop and start the alarm task. After the initial stop of the alarm
  task the `stop_event` was never set to False again so it never ran
  after a restart.  Fixed by https://github.com/raiden-network/raiden/commit/4bb56d2de98d9b53c5bee74af85f3c21d19e4254
  This may be a cause for other failing integration/stress tests that deal with node restarts.
-  (#3217) If when we are handling `ContractSendChannelUpdateTransfer` we see
  that the onchain state has already been updated with the nonce we were
  about to send then don't send the transaction. Also if
  updateNonClossingBalanceProof throws and the on chain state is already
  up to date fail in a recoverable way.
- (#3216) In some cases there can be a pending transaction left in the
  transaction queues after the first run of the alarm task that would
  have been invalidated if we get the events generated by all the
  transactions sent during the first run of the alarm task. We address this by
 adding a poll of the new   block events between the first run of the alarm task
 and the initialization of the transaction queues.