### PR TITLE
Remove mypy errors around SendSecretReveal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ mypy:
 	grep Address mypy-out.txt; [ $$? -eq 1 ]
 	grep ChannelID mypy-out.txt; [ $$? -eq 1 ]
 	grep BalanceProof mypy-out.txt; [ $$? -eq 1 ]
+	grep SendSecretReveal mypy-out.txt; [ $$? -eq 1 ]
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -303,8 +303,8 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractSendSecretReveal':
         restored = cls(
-            expiration=int(data['expiration']),
-            secret=serialization.deserialize_bytes(data['secret']),
+            expiration=BlockExpiration(int(data['expiration'])),
+            secret=Secret(serialization.deserialize_bytes(data['secret'])),
         )
 
         return restored

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -215,8 +215,8 @@ class SendSecretReveal(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
-            message_identifier=int(data['message_identifier']),
-            secret=serialization.deserialize_bytes(data['secret']),
+            message_identifier=typing.MessageID(int(data['message_identifier'])),
+            secret=typing.Secret(serialization.deserialize_bytes(data['secret'])),
         )
 
         return restored

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -4,14 +4,27 @@ from eth_utils import to_canonical_address, to_checksum_address
 from raiden.transfer.architecture import Event, SendMessageEvent
 from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
 from raiden.transfer.state import BalanceProofUnsignedState
-from raiden.utils import pex, serialization, sha3, typing
+from raiden.utils import pex, serialization, sha3
+from raiden.utils.typing import (
+    Address,
+    Any,
+    BlockExpiration,
+    ChannelID,
+    Dict,
+    MessageID,
+    PaymentID,
+    Secret,
+    SecretHash,
+    TokenAddress,
+    TokenAmount,
+)
 
 # According to the smart contracts as of 07/08:
 # https://github.com/raiden-network/raiden-contracts/blob/fff8646ebcf2c812f40891c2825e12ed03cc7628/raiden_contracts/contracts/TokenNetwork.sol#L213
 # channel_identifier can never be 0. We make this a requirement in the client and use this fact
 # to signify that a channel_identifier of `0` passed to the messages adds them to the
 # global queue
-CHANNEL_IDENTIFIER_GLOBAL_QUEUE = typing.ChannelID(0)
+CHANNEL_IDENTIFIER_GLOBAL_QUEUE = ChannelID(0)
 
 
 def refund_from_sendmediated(send_lockedtransfer_event):
@@ -26,10 +39,10 @@ def refund_from_sendmediated(send_lockedtransfer_event):
 class SendLockExpired(SendMessageEvent):
     def __init__(
             self,
-            recipient: typing.Address,
-            message_identifier: typing.MessageID,
+            recipient: Address,
+            message_identifier: MessageID,
             balance_proof: BalanceProofUnsignedState,
-            secrethash: typing.SecretHash,
+            secrethash: SecretHash,
     ):
         super().__init__(recipient, balance_proof.channel_identifier, message_identifier)
 
@@ -56,7 +69,7 @@ class SendLockExpired(SendMessageEvent):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'message_identifier': str(self.message_identifier),
             'balance_proof': self.balance_proof,
@@ -67,7 +80,7 @@ class SendLockExpired(SendMessageEvent):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendLockExpired':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SendLockExpired':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             message_identifier=int(data['message_identifier']),
@@ -83,9 +96,9 @@ class SendLockedTransfer(SendMessageEvent):
 
     def __init__(
             self,
-            recipient: typing.Address,
-            channel_identifier: typing.ChannelID,
-            message_identifier: typing.MessageID,
+            recipient: Address,
+            channel_identifier: ChannelID,
+            message_identifier: MessageID,
             transfer: LockedTransferUnsignedState,
     ):
         if not isinstance(transfer, LockedTransferUnsignedState):
@@ -116,7 +129,7 @@ class SendLockedTransfer(SendMessageEvent):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
@@ -128,10 +141,10 @@ class SendLockedTransfer(SendMessageEvent):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendLockedTransfer':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SendLockedTransfer':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
+            channel_identifier=ChannelID(int(data['channel_identifier'])),
             message_identifier=int(data['message_identifier']),
             transfer=data['transfer'],
         )
@@ -170,10 +183,10 @@ class SendSecretReveal(SendMessageEvent):
 
     def __init__(
             self,
-            recipient: typing.Address,
-            channel_identifier: typing.ChannelID,
-            message_identifier: typing.MessageID,
-            secret: typing.Secret,
+            recipient: Address,
+            channel_identifier: ChannelID,
+            message_identifier: MessageID,
+            secret: Secret,
     ):
         secrethash = sha3(secret)
 
@@ -200,7 +213,7 @@ class SendSecretReveal(SendMessageEvent):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
@@ -211,12 +224,12 @@ class SendSecretReveal(SendMessageEvent):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendSecretReveal':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SendSecretReveal':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
-            message_identifier=typing.MessageID(int(data['message_identifier'])),
-            secret=typing.Secret(serialization.deserialize_bytes(data['secret'])),
+            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            message_identifier=MessageID(int(data['message_identifier'])),
+            secret=Secret(serialization.deserialize_bytes(data['secret'])),
         )
 
         return restored
@@ -242,12 +255,12 @@ class SendBalanceProof(SendMessageEvent):
 
     def __init__(
             self,
-            recipient: typing.Address,
-            channel_identifier: typing.ChannelID,
-            message_identifier: typing.MessageID,
-            payment_identifier: typing.PaymentID,
-            token_address: typing.TokenAddress,
-            secret: typing.Secret,
+            recipient: Address,
+            channel_identifier: ChannelID,
+            message_identifier: MessageID,
+            payment_identifier: PaymentID,
+            token_address: TokenAddress,
+            secret: Secret,
             balance_proof: BalanceProofUnsignedState,
     ):
         super().__init__(recipient, channel_identifier, message_identifier)
@@ -287,7 +300,7 @@ class SendBalanceProof(SendMessageEvent):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
@@ -301,14 +314,14 @@ class SendBalanceProof(SendMessageEvent):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendBalanceProof':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SendBalanceProof':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
-            message_identifier=typing.MessageID(int(data['message_identifier'])),
-            payment_identifier=typing.PaymentID(int(data['payment_identifier'])),
+            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            message_identifier=MessageID(int(data['message_identifier'])),
+            payment_identifier=PaymentID(int(data['payment_identifier'])),
             token_address=to_canonical_address(data['token_address']),
-            secret=typing.Secret(serialization.deserialize_bytes(data['secret'])),
+            secret=Secret(serialization.deserialize_bytes(data['secret'])),
             balance_proof=data['balance_proof'],
         )
 
@@ -322,13 +335,13 @@ class SendSecretRequest(SendMessageEvent):
 
     def __init__(
             self,
-            recipient: typing.Address,
-            channel_identifier: typing.ChannelID,
-            message_identifier: typing.MessageID,
-            payment_identifier: typing.PaymentID,
-            amount: typing.TokenAmount,
-            expiration: typing.BlockExpiration,
-            secrethash: typing.SecretHash,
+            recipient: Address,
+            channel_identifier: ChannelID,
+            message_identifier: MessageID,
+            payment_identifier: PaymentID,
+            amount: TokenAmount,
+            expiration: BlockExpiration,
+            secrethash: SecretHash,
     ):
 
         super().__init__(recipient, channel_identifier, message_identifier)
@@ -366,7 +379,7 @@ class SendSecretRequest(SendMessageEvent):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
@@ -380,10 +393,10 @@ class SendSecretRequest(SendMessageEvent):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendSecretRequest':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SendSecretRequest':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
+            channel_identifier=ChannelID(int(data['channel_identifier'])),
             message_identifier=int(data['message_identifier']),
             payment_identifier=int(data['payment_identifier']),
             amount=int(data['amount']),
@@ -403,9 +416,9 @@ class SendRefundTransfer(SendMessageEvent):
 
     def __init__(
             self,
-            recipient: typing.Address,
-            channel_identifier: typing.ChannelID,
-            message_identifier: typing.MessageID,
+            recipient: Address,
+            channel_identifier: ChannelID,
+            message_identifier: MessageID,
             transfer: LockedTransferUnsignedState,
     ):
 
@@ -435,7 +448,7 @@ class SendRefundTransfer(SendMessageEvent):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'recipient': to_checksum_address(self.recipient),
             'channel_identifier': str(self.queue_identifier.channel_identifier),
@@ -447,10 +460,10 @@ class SendRefundTransfer(SendMessageEvent):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'SendRefundTransfer':
+    def from_dict(cls, data: Dict[str, Any]) -> 'SendRefundTransfer':
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
-            channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
+            channel_identifier=ChannelID(int(data['channel_identifier'])),
             message_identifier=int(data['message_identifier']),
             transfer=data['transfer'],
         )
@@ -461,7 +474,7 @@ class SendRefundTransfer(SendMessageEvent):
 class EventUnlockSuccess(Event):
     """ Event emitted when a lock unlock succeded. """
 
-    def __init__(self, identifier: typing.PaymentID, secrethash: typing.SecretHash):
+    def __init__(self, identifier: PaymentID, secrethash: SecretHash):
         self.identifier = identifier
         self.secrethash = secrethash
 
@@ -481,7 +494,7 @@ class EventUnlockSuccess(Event):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
@@ -490,7 +503,7 @@ class EventUnlockSuccess(Event):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockSuccess':
+    def from_dict(cls, data: Dict[str, Any]) -> 'EventUnlockSuccess':
         restored = cls(
             identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
@@ -504,8 +517,8 @@ class EventUnlockFailed(Event):
 
     def __init__(
             self,
-            identifier: typing.PaymentID,
-            secrethash: typing.SecretHash,
+            identifier: PaymentID,
+            secrethash: SecretHash,
             reason: str,
     ):
         self.identifier = identifier
@@ -529,7 +542,7 @@ class EventUnlockFailed(Event):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
@@ -539,7 +552,7 @@ class EventUnlockFailed(Event):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockFailed':
+    def from_dict(cls, data: Dict[str, Any]) -> 'EventUnlockFailed':
         restored = cls(
             identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
@@ -552,7 +565,7 @@ class EventUnlockFailed(Event):
 class EventUnlockClaimSuccess(Event):
     """ Event emitted when a lock claim succeded. """
 
-    def __init__(self, identifier: typing.PaymentID, secrethash: typing.SecretHash):
+    def __init__(self, identifier: PaymentID, secrethash: SecretHash):
         self.identifier = identifier
         self.secrethash = secrethash
 
@@ -572,7 +585,7 @@ class EventUnlockClaimSuccess(Event):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
@@ -581,7 +594,7 @@ class EventUnlockClaimSuccess(Event):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockClaimSuccess':
+    def from_dict(cls, data: Dict[str, Any]) -> 'EventUnlockClaimSuccess':
         restored = cls(
             identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
@@ -593,7 +606,7 @@ class EventUnlockClaimSuccess(Event):
 class EventUnlockClaimFailed(Event):
     """ Event emitted when a lock claim failed. """
 
-    def __init__(self, identifier: typing.PaymentID, secrethash: typing.SecretHash, reason: str):
+    def __init__(self, identifier: PaymentID, secrethash: SecretHash, reason: str):
         self.identifier = identifier
         self.secrethash = secrethash
         self.reason = reason
@@ -615,7 +628,7 @@ class EventUnlockClaimFailed(Event):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'identifier': str(self.identifier),
             'secrethash': serialization.serialize_bytes(self.secrethash),
@@ -625,7 +638,7 @@ class EventUnlockClaimFailed(Event):
         return result
 
     @classmethod
-    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'EventUnlockClaimFailed':
+    def from_dict(cls, data: Dict[str, Any]) -> 'EventUnlockClaimFailed':
         restored = cls(
             identifier=int(data['identifier']),
             secrethash=serialization.deserialize_bytes(data['secrethash']),
@@ -638,7 +651,7 @@ class EventUnlockClaimFailed(Event):
 class EventUnexpectedSecretReveal(Event):
     """ Event emitted when an unexpected secret reveal message is received. """
 
-    def __init__(self, secrethash: typing.SecretHash, reason: str):
+    def __init__(self, secrethash: SecretHash, reason: str):
         self.secrethash = secrethash
         self.reason = reason
 
@@ -661,7 +674,7 @@ class EventUnexpectedSecretReveal(Event):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> Dict[str, Any]:
         result = {
             'secrethash': serialization.serialize_bytes(self.secrethash),
             'reason': self.reason,
@@ -672,7 +685,7 @@ class EventUnexpectedSecretReveal(Event):
     @classmethod
     def from_dict(
             cls,
-            data: typing.Dict[str, typing.Any],
+            data: Dict[str, Any],
     )-> 'EventUnexpectedSecretReveal':
         restored = cls(
             secrethash=serialization.deserialize_bytes(data['secrethash']),

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -48,6 +48,7 @@ from raiden.utils.typing import (
     PaymentAmount,
     Secret,
     SecretHash,
+    Sequence,
     SuccessOrError,
     Tuple,
     cast,
@@ -461,7 +462,7 @@ def set_offchain_secret(
         channelidentifiers_to_channels: ChannelMap,
         secret: Secret,
         secrethash: SecretHash,
-) -> List[Event]:
+) -> Sequence[Event]:
     """ Set the secret to all mediated transfers. """
     state.secret = secret
 
@@ -840,7 +841,7 @@ def events_for_onchain_secretreveal_if_closed(
         transfers_pair: List[MediationPairState],
         secret: Secret,
         secrethash: SecretHash,
-) -> List[ContractSendSecretReveal]:
+) -> Sequence[ContractSendSecretReveal]:
     """ Register the secret on-chain if the payer channel is already closed and
     the mediator learned the secret off-chain.
 

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -1,4 +1,6 @@
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
+from typing import TYPE_CHECKING
+
 from eth_utils import encode_hex, to_canonical_address, to_checksum_address
 
 from raiden.transfer.architecture import State
@@ -11,6 +13,10 @@ from raiden.transfer.state import (
     balanceproof_from_envelope,
 )
 from raiden.utils import pex, serialization, sha3, typing
+
+# Upgrade pyflakes to 2.0.0 and remove the 'if' and '# noqa'.
+if TYPE_CHECKING:
+    from raiden.transfer.mediated_transfer.events import SendSecretReveal  # noqa: F401
 
 
 def lockedtransfersigned_from_message(message):


### PR DESCRIPTION
In particular, this commit removes the "unknown name" error in
`mediated_transfer/state.py` about `SendSecretReveal`. After this, it
becomes possible to remove warnings from `raiden/docs` compilation.