### PR TITLE
disabled file logging in the unit tests

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -143,6 +143,7 @@ def logging_level(request):
         colorize=not request.config.option.plain_log,
         log_file=request.config.option.log_file,
         cache_logger_on_first_use=False,
+        disable_debug_logfile=True,
     )
 
 

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -101,7 +101,7 @@ def test_log_filter():
 @pytest.mark.parametrize('module', ['', 'raiden', 'raiden.network'])
 @pytest.mark.parametrize('level', ['DEBUG', 'WARNING'])
 @pytest.mark.parametrize('logger', ['test', 'raiden', 'raiden.network'])
-@pytest.mark.parametrize('disabled_debug', [True, False])
+@pytest.mark.parametrize('disabled_debug', [True])
 def test_basic_logging(capsys, module, level, logger, disabled_debug):
     configure_logging({module: level}, disable_debug_logfile=disabled_debug)
     log = structlog.get_logger(logger).bind(foo='bar')
@@ -119,7 +119,7 @@ def test_basic_logging(capsys, module, level, logger, disabled_debug):
 
 
 def test_redacted_request(capsys):
-    configure_logging({'': 'DEBUG'})
+    configure_logging({'': 'DEBUG'}, disable_debug_logfile=True)
     token = 'my_access_token123'
 
     # use logging, as 'urllib3/requests'
@@ -134,7 +134,7 @@ def test_redacted_request(capsys):
 
 
 def test_redacted_traceback(capsys):
-    configure_logging({'': 'DEBUG'})
+    configure_logging({'': 'DEBUG'}, disable_debug_logfile=True)
 
     token = 'my_access_token123'
 


### PR DESCRIPTION
Each run of the unit tests is creating 21 files. An alternative is too keep the files but move it to `tmpdir`