### PR TITLE
Bump version: 0.100.1 → 0.100.2-rc1

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.100.1
+current_version = 0.100.2-rc1
 commit = True
 tag = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ master_doc = 'index'
 project = 'Raiden Network'
 author = 'Raiden Project'
 
-version_string = '0.100.1'
+version_string = '0.100.2-rc1'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ with open('constraints.txt') as req_file:
 
 test_requirements = []
 
-version = '0.100.1'  # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
+# Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
+version = '0.100.2-rc1'
 
 setup(
     name='raiden',
@@ -61,7 +62,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     cmdclass={
-        'test': PyTest
+        'test': PyTest,
     },
     use_scm_version=True,
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
Just doing `bump2version --config-file .bumpversion_client.cfg --new-version 0.100.2-rc1 patch ` did not work. I manually changed 2/3 occurrences. Would have to either try some more customization + hacks as per the discussion [here](https://github.com/peritus/bumpversion/issues/128) or just use another tool.