### PR TITLE
State change handling of alarm task's first run should generate no events

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -379,7 +379,8 @@ class RaidenService(Runnable):
         # - The alarm must complete its first run before the transport is started,
         #   to reject messages for closed/settled channels.
         self.alarm.register_callback(self._callback_new_block)
-        self.alarm.first_run(last_log_block_number)
+        with self.dispatch_events_lock:
+            self.alarm.first_run(last_log_block_number)
 
         chain_state = views.state_from_raiden(self)
         self._initialize_transactions_queues(chain_state)

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -176,13 +176,6 @@ class AlarmTask(Runnable):
         self.chain_id = chain_id
         self._maybe_run_callbacks(latest_block)
 
-        # Run the alarm task block callback once more to possibly
-        # clear pending transactions after the chain syncing during
-        # the first run of the alarm task.
-        # https://github.com/raiden-network/raiden/issues/3216
-        latest_block = self.chain.get_block(block_identifier='latest')
-        self._maybe_run_callbacks(latest_block)
-
     def _maybe_run_callbacks(self, latest_block):
         """ Run the callbacks if there is at least one new block.
 

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -432,8 +432,18 @@ def test_different_view_of_last_bp_during_unlock(
             partner_address=app1.raiden.address,
         )
 
+    count = 0
+    original_update = app1.raiden.raiden_event_handler.handle_contract_send_channelupdate
+
+    def patched_update(raiden, event):
+        nonlocal count
+        count += 1
+        original_update(raiden, event)
+
+    app1.raiden.raiden_event_handler.handle_contract_send_channelupdate = patched_update
     # and now app1 comes back online
     app1.raiden.start()
+    assert count == 1
     channel_identifier = get_channelstate(app0, app1, token_network_identifier).identifier
 
     # and we wait for settlement


### PR DESCRIPTION
Proper fix for #3216.

Check [this](https://github.com/raiden-network/raiden/issues/3216#issuecomment-451548798) and [this](https://github.com/raiden-network/raiden/issues/3216#issuecomment-451595735) comments for context.

The issue where the alarm task's events may cause blockchain transactions to be sent twice was [fixed](https://github.com/raiden-network/raiden/pull/3218/commits/59c2ae665542e836ce06c8319be2334d62a43d3c) for the test where I first noticed the problem but the fix was not covering all potential edge cases. This PR makes sure that the alarm task's first run does not generate any events which should fix all cases of the problem seen in #3216.

Also adds a check for the situation described in the discussion in #3216's comments making sure the `handle_contract_send_channelupdate` function is not called twice at startup for the test where this problem was originally seen.

Note to self:

The test failed when I tried to use `unittest.mock.patch` to count the times `handle_contract_send_channelupdate`. The counting itself was successful but the test failed with a timeout at the following location:

```
        with gevent.Timeout(10):
            unlock_app1 = wait_for_state_change(
                app1.raiden,
                ContractReceiveChannelBatchUnlock,
                {'participant': app1.raiden.address},
>               retry_timeout,                                         
            )     
```

This is what I had used in the test when it failed (the red part). Find out why.

```diff
diff --git a/raiden/tests/integration/transfer/test_refundtransfer.py b/raiden/tests/integration/transfer/test_refundtransfer.py
index bcad2dc8..1fa7774d 100644
--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import gevent
 import pytest
 
@@ -435,14 +433,18 @@ def test_different_view_of_last_bp_during_unlock(
             partner_address=app1.raiden.address,
         )
 
-    update = patch.object(app1.raiden.raiden_event_handler, 'handle_contract_send_channelupdate')
-    with update as patched_obj:
-        # and now app1 comes back online
-        app1.raiden.start()
-        # Make sure that send_channel_update is called only once
-        # https://github.com/raiden-network/raiden/issues/3216
-        assert patched_obj.call_count == 1
+    count = 0
+    original_update = app1.raiden.raiden_event_handler.handle_contract_send_channelupdate
+
+    def patched_update(raiden, event):
+        nonlocal count
+        count += 1
+        original_update(raiden, event)
 
+    app1.raiden.raiden_event_handler.handle_contract_send_channelupdate = patched_update
+    # and now app1 comes back online
+    app1.raiden.start()
+    assert count == 1
     channel_identifier = get_channelstate(app0, app1, token_network_identifier).identifier
 
     # and we wait for settlement
```