### PR TITLE
Add --fix-missing in Dockerfile apt-get-update

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -5,7 +5,7 @@ ARG SOLC_URL_LINUX
 ARG GETH_URL_LINUX
 
 # install dependencies
-RUN apt-get update
+RUN apt-get update --fix-missing
 RUN apt-get install -y git-core wget xz-utils
 
 RUN wget -nv -O /usr/bin/solc ${SOLC_URL_LINUX} && \


### PR DESCRIPTION
This avoids errors like the following:

```
Err:1 http://deb.debian.org/debian stretch/main amd64 git-core all 1:2.11.0-3+deb9u3
  404  Not Found
Err:1 http://security.debian.org/debian-security stretch/updates/main amd64 git-core all 1:2.11.0-3+deb9u3
  404  Not Found
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/g/git/git-core_2.11.0-3+deb9u3_all.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
The command '/bin/sh -c apt-get install -y git-core wget xz-utils' returned a non-zero code: 100
make: *** [Makefile:95: bundle-docker] Error 100
```