### PR TITLE
Match the Merkle hash computation with the onchain computation

### DIFF
--- a/raiden/tests/unit/test_mtree.py
+++ b/raiden/tests/unit/test_mtree.py
@@ -5,6 +5,7 @@ from raiden.transfer.merkle_tree import (
     MERKLEROOT,
     compute_layers,
     compute_merkleproof_for,
+    hash_pair,
     merkleroot,
     validate_proof,
 )
@@ -43,6 +44,11 @@ def test_compute_layers_duplicated():
 
     with pytest.raises(ValueError):
         compute_layers([hash_0, hash_1, hash_0])
+
+
+def test_hash_pair_on_same_inputs():
+    hash = sha3(b'x')
+    assert hash == hash_pair(hash, hash)
 
 
 def test_compute_layers_single_entry():

--- a/raiden/transfer/merkle_tree.py
+++ b/raiden/transfer/merkle_tree.py
@@ -22,6 +22,9 @@ def hash_pair(first, second):
     if second is None:
         return first
 
+    if first == second:
+        return first
+
     if first > second:
         return sha3(second + first)
 


### PR DESCRIPTION
In the TokenNetwork contract, when two children have the same value x, the parent should be also `x`, not `sha3(x || x)`.
https://github.com/raiden-network/raiden-contracts/blob/fef7f5bd596d2a83f76714ef501d510b32b0964a/raiden_contracts/contracts/TokenNetwork.sol#L1595

Probably this is not a practical issue because offchain Merkle leaves do not contain duplicate elements.

This was found during #3070.