### PR TITLE
Remove mypy errors around SendSecretRequest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ mypy:
 	grep Address mypy-out.txt; [ $$? -eq 1 ]
 	grep ChannelID mypy-out.txt; [ $$? -eq 1 ]
 	grep BalanceProof mypy-out.txt; [ $$? -eq 1 ]
-	grep SendSecretReveal mypy-out.txt; [ $$? -eq 1 ]
+	grep SendSecret mypy-out.txt; [ $$? -eq 1 ]
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -397,11 +397,11 @@ class SendSecretRequest(SendMessageEvent):
         restored = cls(
             recipient=to_canonical_address(data['recipient']),
             channel_identifier=ChannelID(int(data['channel_identifier'])),
-            message_identifier=int(data['message_identifier']),
-            payment_identifier=int(data['payment_identifier']),
-            amount=int(data['amount']),
-            expiration=int(data['expiration']),
-            secrethash=serialization.deserialize_bytes(data['secrethash']),
+            message_identifier=MessageID(int(data['message_identifier'])),
+            payment_identifier=PaymentID(int(data['payment_identifier'])),
+            amount=TokenAmount(int(data['amount'])),
+            expiration=BlockExpiration(int(data['expiration'])),
+            secrethash=SecretHash(serialization.deserialize_bytes(data['secrethash'])),
         )
 
         return restored

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -30,7 +30,6 @@ from raiden.utils.typing import (
     LockHash,
     Locksroot,
     Optional,
-    PaymentAmount,
     PaymentNetworkID,
     Secret,
     SecretHash,
@@ -1037,7 +1036,7 @@ class HashTimeLockState(State):
 
     def __init__(
             self,
-            amount: PaymentAmount,
+            amount: TokenAmount,
             expiration: BlockExpiration,
             secrethash: SecretHash,
     ):

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -71,6 +71,7 @@ NetworkTimeout = NewType('NetworkTimeout', T_NetworkTimeout)
 T_PaymentID = int
 PaymentID = NewType('PaymentID', T_PaymentID)
 
+# PaymentAmount is for amounts of tokens paid end-to-end
 T_PaymentAmount = int
 PaymentAmount = NewType('PaymentAmount', T_PaymentAmount)
 


### PR DESCRIPTION
I chose `PaymentAmount` over `TokenAmount` because `Payment` sounded more specific.

---

but @LefterisJP pointed out that `PaymentAmount` is usually for end-to-end amounts so I changed my mind.