### PR TITLE
More new factories for unit tests

### DIFF
--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -109,7 +109,7 @@ def make_from_route_from_counter(counter):
 
     expiration = factories.UNIT_REVEAL_TIMEOUT + 1
 
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         from_channel,
         factories.LockedTransferSignedStateProperties(
             transfer=factories.LockedTransferProperties(

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -109,18 +109,24 @@ def make_from_route_from_counter(counter):
 
     expiration = factories.UNIT_REVEAL_TIMEOUT + 1
 
-    from_transfer = factories.make_signed_transfer_for(
-        channel_state=from_channel,
-        amount=1,
-        initiator=factories.make_address(),
-        target=factories.make_address(),
-        expiration=expiration,
-        secret=sha3(factories.make_secret(next(counter))),
-        identifier=next(counter),
-        nonce=1,
-        transferred_amount=0,
-        pkey=factories.HOP1_KEY,
-        sender=factories.HOP1,
+    from_transfer = factories.make_signed_transfer_for2(
+        from_channel,
+        factories.LockedTransferSignedStateProperties(
+            transfer=factories.LockedTransferProperties(
+                balance_proof=factories.BalanceProofProperties(
+                    transferred_amount=0,
+                    token_network_identifier=from_channel.token_network_identifier,
+                ),
+                amount=1,
+                expiration=expiration,
+                secret=sha3(factories.make_secret(next(counter))),
+                initiator=factories.make_address(),
+                target=factories.make_address(),
+                payment_identifier=next(counter),
+            ),
+            sender=factories.HOP1,
+            pkey=factories.HOP1_KEY,
+        ),
     )
     return from_route, from_transfer
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -62,7 +62,6 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.state import (
     CHANNEL_STATE_CLOSED,
     CHANNEL_STATE_SETTLED,
-    EMPTY_MERKLE_ROOT,
     message_identifier_from_prng,
 )
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal
@@ -329,8 +328,8 @@ def test_events_for_refund():
             balance_proof=BalanceProofProperties(
                 channel_identifier=refund_channel.identifier,
                 token_network_identifier=refund_channel.token_network_identifier,
-                transferred_amount=0,   # TODO decent defaults
-                locked_amount=10,   # TODO decent defaults
+                transferred_amount=0,
+                locked_amount=10,
             ),
         ),
     )
@@ -1328,8 +1327,8 @@ def test_mediate_transfer_with_maximum_pending_transfers_exceeded():
                     balance_proof=BalanceProofProperties(
                         nonce=index,
                         locked_amount=index * UNIT_TRANSFER_AMOUNT,
-                        channel_identifier=2,  # TODO defaults
-                        transferred_amount=0,  # TODO defaults
+                        channel_identifier=2,
+                        transferred_amount=0,
                     ),
                 ),
                 message_identifier=index,
@@ -1460,7 +1459,6 @@ def test_mediator_lock_expired_with_receive_lock_expired():
             transferred_amount=transfer.balance_proof.transferred_amount,
             token_network_identifier=transfer.balance_proof.token_network_identifier,
             channel_identifier=channels[0].identifier,
-            locksroot=EMPTY_MERKLE_ROOT,  # TODO default?
         ),
         message_hash=transfer.lock.secrethash,
     )
@@ -1553,10 +1551,8 @@ def test_mediator_receive_lock_expired_after_secret_reveal():
         balance_proof=BalanceProofProperties(
             nonce=2,
             transferred_amount=transfer.balance_proof.transferred_amount,
-            locked_amount=0,
             token_network_identifier=transfer.balance_proof.token_network_identifier,
             channel_identifier=channels[0].identifier,
-            locksroot=EMPTY_MERKLE_ROOT,  # TODO set as default?
         ),
         message_hash=transfer.lock.secrethash,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -731,7 +731,7 @@ def test_secret_learned():
 
     channels = mediator_make_channel_pair()
 
-    from_transfer = factories.make_signed_transfer_for2(channels[0])
+    from_transfer = factories.make_signed_transfer_for(channels[0])
 
     iteration = mediator.state_transition(
         mediator_state=None,
@@ -806,7 +806,7 @@ def test_mediate_transfer():
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
-    payer_transfer = factories.make_signed_transfer_for2(
+    payer_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(transfer=LockedTransferProperties(expiration=30)),
     )
@@ -839,7 +839,7 @@ def test_mediate_transfer():
 
 def test_init_mediator():
     channels = mediator_make_channel_pair()
-    from_transfer = factories.make_signed_transfer_for2(channels[0])
+    from_transfer = factories.make_signed_transfer_for(channels[0])
 
     iteration = mediator.state_transition(
         mediator_state=None,
@@ -865,7 +865,7 @@ def test_init_mediator():
 
 def test_mediator_reject_keccak_empty_hash():
     channels = mediator_make_channel_pair()
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(initiator=HOP1, secret=EMPTY_HASH),
@@ -888,7 +888,7 @@ def test_mediator_secret_reveal_empty_hash():
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(transfer=LockedTransferProperties(initiator=HOP1)),
     )
@@ -953,7 +953,7 @@ def test_no_valid_routes():
             our_state=NettingChannelEndStateProperties(balance=0),
         ),
     ])
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(transfer=LockedTransferProperties(initiator=HOP1)),
     )
@@ -1012,7 +1012,7 @@ def test_lock_timeout_larger_than_settlement_period_must_be_ignored():
     )
 
     channels = mediator_make_channel_pair(defaults=channel_defaults)
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(initiator=HOP1, expiration=high_expiration),
@@ -1082,7 +1082,7 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
     )
     from_route = factories.route_from_channel(bc_channel)
 
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         bc_channel,
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(
@@ -1226,7 +1226,7 @@ def test_payee_timeout_must_be_equal_to_payer_timeout():
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
-    payer_transfer = factories.make_signed_transfer_for2(
+    payer_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(expiration=30),
@@ -1317,7 +1317,7 @@ def test_mediate_transfer_with_maximum_pending_transfers_exceeded():
 
     iterations = []
     for index in range(1, MAXIMUM_PENDING_TRANSFERS + 2):
-        from_transfer = factories.make_signed_transfer_for2(
+        from_transfer = factories.make_signed_transfer_for(
             channels[0],
             LockedTransferSignedStateProperties(
                 transfer=LockedTransferProperties(
@@ -1367,7 +1367,7 @@ def test_mediator_lock_expired_with_new_block():
 
     channels = mediator_make_channel_pair()
 
-    payer_transfer = factories.make_signed_transfer_for2(
+    payer_transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(
@@ -1423,7 +1423,7 @@ def test_mediator_lock_expired_with_receive_lock_expired():
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
-    transfer = factories.make_signed_transfer_for2(
+    transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(expiration=expiration),
@@ -1513,7 +1513,7 @@ def test_mediator_receive_lock_expired_after_secret_reveal():
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
-    transfer = factories.make_signed_transfer_for2(
+    transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(expiration=expiration),
@@ -1597,7 +1597,7 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
-    transfer = factories.make_signed_transfer_for2(
+    transfer = factories.make_signed_transfer_for(
         channels[0],
         LockedTransferSignedStateProperties(
             transfer=LockedTransferProperties(expiration=30),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -57,8 +57,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     pseudo_random_generator = random.Random()
 
     channels = factories.mediator_make_channel_pair()
-
-    payer_transfer = factories.make_signed_transfer_for2(channels[0], LONG_EXPIRATION)
+    payer_transfer = factories.make_signed_transfer_for(channels[0], LONG_EXPIRATION)
 
     initial_iteration = mediator.state_transition(
         mediator_state=None,
@@ -228,7 +227,7 @@ def test_regression_mediator_send_lock_expired_with_new_block():
     pseudo_random_generator = random.Random()
 
     channels = factories.mediator_make_channel_pair()
-    payer_transfer = factories.make_signed_transfer_for2(channels[0], LONG_EXPIRATION)
+    payer_transfer = factories.make_signed_transfer_for(channels[0], LONG_EXPIRATION)
 
     init_iteration = mediator.state_transition(
         mediator_state=None,
@@ -295,7 +294,7 @@ def test_regression_mediator_task_no_routes():
         ),
     ])
 
-    payer_transfer = factories.make_signed_transfer_for2(
+    payer_transfer = factories.make_signed_transfer_for(
         channels[0],
         factories.LockedTransferSignedStateProperties(
             sender=HOP2,
@@ -385,7 +384,7 @@ def test_regression_mediator_not_update_payer_state_twice():
     pair = factories.mediator_make_channel_pair()
     payer_channel, payee_channel = pair.channels
     payer_route = factories.route_from_channel(payer_channel)
-    payer_transfer = factories.make_signed_transfer_for2(payer_channel, LONG_EXPIRATION)
+    payer_transfer = factories.make_signed_transfer_for(payer_channel, LONG_EXPIRATION)
 
     available_routes = [factories.route_from_channel(payee_channel)]
     init_state_change = ActionInitMediator(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -45,7 +45,7 @@ from raiden.utils import typing
 def make_target_transfer(channel, amount=None, expiration=None, initiator=None, block_number=1):
     default_expiration = block_number + channel.settle_timeout - channel.reveal_timeout
 
-    return factories.make_signed_transfer_for2(
+    return factories.make_signed_transfer_for(
         channel,
         factories.LockedTransferSignedStateProperties(
             transfer=factories.LockedTransferProperties(
@@ -518,7 +518,7 @@ def test_target_reject_keccak_empty_hash():
     channels = make_channel_set([channel_properties2])
     expiration = block_number + channels[0].settle_timeout - channels[0].reveal_timeout
 
-    from_transfer = factories.make_signed_transfer_for2(
+    from_transfer = factories.make_signed_transfer_for(
         channels[0],
         factories.LockedTransferSignedStateProperties(
             transfer=factories.LockedTransferProperties(

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -497,21 +497,6 @@ def make_signed_transfer_for(
     return mediated_transfer
 
 
-def make_default_signed_transfer_for(
-        channel_state: NettingChannelState,
-        **kwargs,
-) -> LockedTransferSignedState:
-    parameters = {
-        'amount': UNIT_TRANSFER_AMOUNT,
-        'initiator': UNIT_TRANSFER_SENDER,
-        'target': HOP2,
-        'expiration': UNIT_SETTLE_TIMEOUT - UNIT_REVEAL_TIMEOUT,
-        'secret': UNIT_SECRET,
-    }
-    parameters.update(kwargs)
-    return make_signed_transfer_for(channel_state, **parameters)
-
-
 # ALIASES
 make_channel = make_channel_state
 route_from_channel = make_route_from_channel

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -819,15 +819,14 @@ def make_signed_transfer_for(
         assert False, 'Given sender does not participate in given channel.'
 
     if compute_locksroot:
+        lock = Lock(
+            amount=properties.transfer.amount,
+            expiration=properties.transfer.expiration,
+            secrethash=sha3(properties.transfer.secret),
+        )
         locksroot = merkleroot(channel.compute_merkletree_with(
-            channel_state.partner_state.merkletree,
-            sha3(
-                Lock(
-                    properties.transfer.amount,
-                    properties.transfer.expiration,
-                    sha3(properties.transfer.secret),
-                ).as_bytes,
-            ),
+            merkletree=channel_state.partner_state.merkletree,
+            lockhash=sha3(lock.as_bytes),
         ))
     else:
         locksroot = properties.transfer.balance_proof.locksroot


### PR DESCRIPTION
- more property classes
-  refactorings of tests in `raiden/unit/test/transfer/mediated_transfer`

There will be a followup pr with:
- replacement of the old factories (`make_signed_transfer`, `make_channel` etc) where they are still used
- removal of the old factories
- introduction of randomness in the new factories, where the old factories had them