### PR TITLE
Fix API query for channel list without a partner address

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,10 @@
 Changelog
 =========
 
+
 * :feature:`-` Update WebUI to version 0.7.1 https://github.com/raiden-network/webui/releases/tag/v0.7.1
+* :bug:`3257` Requesting the channel list with a token address and not a partner address via the API should no longer cause a 500 server error.
+
 
 * :release:`0.100.2-rc1 <2019-01-04>`
 * :feature:`3217` If channel is already updated onchain don't call updateNonClosingBalanceProof.

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -1,0 +1,17 @@
+from raiden.transfer.views import list_channelstate_for_tokennetwork
+
+
+def test_list_channelstate_for_tokennetwork(
+        chain_state,
+        token_network_state,
+        payment_network_id,
+        token_id,
+):
+    """Regression test for https://github.com/raiden-network/raiden/issues/3257"""
+    token_address = token_id
+    result = list_channelstate_for_tokennetwork(
+        chain_state=chain_state,
+        payment_network_id=payment_network_id,
+        token_address=token_address,
+    )
+    assert isinstance(result, list)

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -493,7 +493,7 @@ def list_channelstate_for_tokennetwork(
     )
 
     if token_network:
-        result = token_network.channelidentifiers_to_channels.values()
+        result = list(token_network.channelidentifiers_to_channels.values())
     else:
         result = []
 


### PR DESCRIPTION
Fix #3257 