### PR TITLE
Bump to v0.100.2-rc2

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.100.2-rc1
+current_version = 0.100.2-rc2
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-
+* :release:`0.100.2-rc2 <2019-01-11>`
 * :feature:`-` Update WebUI to version 0.7.1 https://github.com/raiden-network/webui/releases/tag/v0.7.1
 * :bug:`3257` Requesting the channel list with a token address and not a partner address via the API should no longer cause a 500 server error.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ master_doc = 'index'
 project = 'Raiden Network'
 author = 'Raiden Project'
 
-version_string = '0.100.2-rc1'
+version_string = '0.100.2-rc2'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open('constraints.txt') as req_file:
 test_requirements = []
 
 # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
-version = '0.100.2-rc1'
+version = '0.100.2-rc2'
 
 setup(
     name='raiden',


### PR DESCRIPTION
Only real changes added on top of rc1 are:

```
* :feature:`-` Update WebUI to version 0.7.1 https://github.com/raiden-network/webui/releases/tag/v0.7.1
* :bug:`3257` Requesting the channel list with a token address and not a partner address via the API should no longer cause a 500 server error.
```

Since rc1 testing did not really start yet we can start by testing rc2 directly.