### PR TITLE
Change batch_unlock on settlement logic

### DIFF
--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -204,10 +204,16 @@ class PaymentChannel:
             non_closing_signature=signature,
         )
 
-    def unlock(self, merkle_tree_leaves: bytes):
+    def unlock(
+        self,
+        merkle_tree_leaves: bytes,
+        participant: Address,
+        partner: Address,
+    ):
         self.token_network.unlock(
             channel_identifier=self.channel_identifier,
-            partner=self.participant2,
+            participant=participant,
+            partner=partner,
             merkle_tree_leaves=merkle_tree_leaves,
         )
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1164,6 +1164,7 @@ class TokenNetwork:
     def unlock(
             self,
             channel_identifier: ChannelID,
+            participant: Address,
             partner: Address,
             merkle_tree_leaves: MerkleTreeLeaves,
     ):
@@ -1171,6 +1172,7 @@ class TokenNetwork:
             'token_network': pex(self.address),
             'node': pex(self.node_address),
             'partner': pex(partner),
+            'participant': pex(participant),
             'merkle_tree_leaves': merkle_tree_leaves,
         }
 
@@ -1185,7 +1187,7 @@ class TokenNetwork:
             'pending',
             'unlock',
             channel_identifier,
-            self.node_address,
+            participant,
             partner,
             leaves_packed,
         )
@@ -1198,7 +1200,7 @@ class TokenNetwork:
                 'unlock',
                 gas_limit,
                 channel_identifier,
-                self.node_address,
+                participant,
                 partner,
                 leaves_packed,
             )
@@ -1220,7 +1222,7 @@ class TokenNetwork:
                 block_identifier=block,
             )
             channel_settled = self.channel_is_settled(
-                participant1=self.node_address,
+                participant1=participant,
                 participant2=partner,
                 channel_identifier=channel_identifier,
                 block_identifier=block,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -324,47 +324,70 @@ class RaidenEventHandler:
             token_network_address=token_network_identifier,
             channel_id=channel_identifier,
         )
+
+        our_address = raiden.address
+        partner_address = (
+            payment_channel.participant2 if payment_channel.participant1 == our_address
+            else payment_channel.participant1
+        )
         token_network: TokenNetwork = payment_channel.token_network
 
-        participants_details = token_network.detail_participants(
-            participant1=raiden.address,
-            participant2=participant,
-            channel_identifier=channel_identifier,
-        )
+        (
+            _, _, _, _,
+            our_nonce,
+            our_locksroot,
+            our_locked_amount,
+        ) = token_network.proxy.contract.functions.getChannelParticipantInfo(
+            channel_identifier,
+            to_checksum_address(our_address),
+            to_checksum_address(partner_address),
+        ).call()
 
-        our_details = participants_details.our_details
-        our_locksroot = our_details.locksroot
+        (
+            _, _, _, _,
+            partner_nonce,
+            partner_locksroot,
+            partner_locked_amount,
+        ) = token_network.proxy.contract.functions.getChannelParticipantInfo(
+            channel_identifier,
+            to_checksum_address(partner_address),
+            to_checksum_address(our_address),
+        ).call()
 
-        partner_details = participants_details.partner_details
-        partner_locksroot = partner_details.locksroot
-
-        is_partner_unlock = (
-            partner_details.address == participant and
+        # we want to unlock because there are on-chain unlocked locks
+        is_unlock_receiving = (
+            our_address == participant and
             partner_locksroot != EMPTY_HASH
         )
-        is_our_unlock = (
-            our_details.address == participant and
+        # we want to unlock, because there are expired, not revealed locks
+        is_unlock_sending = (
+            partner_address == participant and
             our_locksroot != EMPTY_HASH
         )
 
-        if is_partner_unlock:
+        if is_unlock_receiving:
             state_change_record = get_state_change_with_balance_proof_by_locksroot(
                 storage=raiden.wal.storage,
                 chain_id=raiden.chain.network_id,
                 token_network_identifier=token_network_identifier,
                 channel_identifier=channel_identifier,
                 locksroot=partner_locksroot,
-                sender=participants_details.partner_details.address,
+                sender=partner_address,
             )
+            participant = our_address
+            partner = partner_address
             state_change_identifier = state_change_record.state_change_identifier
-        elif is_our_unlock:
+        elif is_unlock_sending:
             event_record = get_event_with_balance_proof_by_locksroot(
                 storage=raiden.wal.storage,
                 chain_id=raiden.chain.network_id,
                 token_network_identifier=token_network_identifier,
                 channel_identifier=channel_identifier,
-                locksroot=our_locksroot.balance_hash,
+                locksroot=our_locksroot,
             )
+            assert our_locked_amount > 0
+            participant = partner_address
+            partner = our_address
             state_change_identifier = event_record.state_change_identifier
         else:
             # In the case that someone else sent the unlock we do nothing
@@ -387,9 +410,7 @@ class RaidenEventHandler:
                 f'channel:{channel_identifier} '
                 f'participant:{to_checksum_address(participant)} '
                 f'our_locksroot:{to_hex(our_locksroot)} '
-                f'our_balance_hash:{to_hex(our_details.balance_hash)} '
-                f'partner_locksroot:{to_hex(partner_locksroot)} '
-                f'partner_balancehash:{to_hex(partner_details.balance_hash)} ',
+                f'partner_locksroot:{to_hex(partner_locksroot)} ',
             )
 
         # Replay state changes until a channel state is reached where
@@ -405,12 +426,16 @@ class RaidenEventHandler:
         our_state = restored_channel_state.our_state
         partner_state = restored_channel_state.partner_state
         if partner_state.address == participant:
-            merkle_tree_leaves = get_batch_unlock(partner_state)
-        elif our_state.address == participant:
             merkle_tree_leaves = get_batch_unlock(our_state)
+        elif our_state.address == participant:
+            merkle_tree_leaves = get_batch_unlock(partner_state)
 
         try:
-            payment_channel.unlock(merkle_tree_leaves)
+            payment_channel.unlock(
+                participant=participant,
+                partner=partner,
+                merkle_tree_leaves=merkle_tree_leaves,
+            )
         except ChannelOutdatedError as e:
             log.error(
                 str(e),

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -206,7 +206,7 @@ class SQLiteStorage:
             self,
             filters: typing.Dict[str, typing.Any],
     ) -> EventRecord:
-        """ Return all state changes filtered by a named field and value."""
+        """ Return latest event filtered by named fields and values."""
         cursor = self.conn.cursor()
 
         where_clauses = []
@@ -250,7 +250,7 @@ class SQLiteStorage:
             self,
             filters: typing.Dict[str, str],
     ) -> StateChangeRecord:
-        """ Return all state changes filtered by a named field and value."""
+        """ Return latest state change filtered by named fields and values."""
         cursor = self.conn.cursor()
 
         where_clauses = []

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -8,7 +8,7 @@ from raiden.api.python import RaidenAPI
 from raiden.constants import UINT64_MAX
 from raiden.messages import LockedTransfer, LockExpired, RevealSecret
 from raiden.tests.utils import factories
-from raiden.tests.utils.events import search_for_item
+from raiden.tests.utils.events import search_for_item, wait_for_batch_unlock
 from raiden.tests.utils.geth import wait_until_block
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldOffChainSecretRequest, WaitForMessage
@@ -20,29 +20,11 @@ from raiden.tests.utils.transfer import (
 from raiden.transfer import channel, views
 from raiden.transfer.state import UnlockProofState
 from raiden.transfer.state_change import (
-    ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
     ContractReceiveChannelSettled,
     ContractReceiveSecretReveal,
 )
 from raiden.utils import encode_hex, sha3
-
-
-def wait_for_batch_unlock(app, token_network_id, participant, partner):
-    unlock_event = None
-    while not unlock_event:
-        gevent.sleep(1)
-
-        state_changes = app.raiden.wal.storage.get_statechanges_by_identifier(
-            from_identifier=0,
-            to_identifier='latest',
-        )
-
-        unlock_event = search_for_item(state_changes, ContractReceiveChannelBatchUnlock, {
-            'token_network_identifier': token_network_id,
-            'participant': participant,
-            'partner': partner,
-        })
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from raiden.constants import EMPTY_HASH
 from raiden.network.proxies.token_network import ParticipantDetails, ParticipantsDetails
 from raiden.raiden_event_handler import RaidenEventHandler
@@ -7,7 +9,7 @@ from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.utils import hash_balance_data
 
 
-def test_handle_contract_send_channelunlock_already_unlocked():
+def test_handle_contract_send_channelunlock_already_unlocked(monkeypatch):
     """This is a test for the scenario where the onchain unlock has
     already happened when we get to handle our own send unlock
     transaction.
@@ -55,6 +57,15 @@ def test_handle_contract_send_channelunlock_already_unlocked():
 
     # make sure detail_participants returns partner data with a locksroot of 0x0
     raiden.chain.token_network.detail_participants = detail_participants
+    # ensure, there are some fields set
+    raiden.chain.payment_channel(
+        token_network_identifier,
+        channel_identifier,
+    ).participant1 = participant
+    raiden.chain.token_network.configure_mock(**{
+        'proxy.contract.functions.getChannelParticipantInfo.return_value':
+        Mock(call=lambda: (0, 0, 0, 0, 1, EMPTY_HASH, 1)),
+    })
 
     event = ContractSendChannelBatchUnlock(
         token_address=token_address,

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -32,7 +32,7 @@ def test_is_transaction_effect_satisfied(
     # now call normally with us being the partner and not the participant
     state_change.partner = netting_channel_state.our_state.address
     state_change.participant = netting_channel_state.partner_state.address
-    assert not is_transaction_effect_satisfied(chain_state, transaction, state_change)
+    assert is_transaction_effect_satisfied(chain_state, transaction, state_change)
     # finally call with us being the participant and not the partner which should check out
     state_change.participant = netting_channel_state.our_state.address
     state_change.partner = netting_channel_state.partner_state.address

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -1,4 +1,5 @@
 import random
+from unittest.mock import Mock
 
 from raiden.storage.serialize import JSONSerializer
 from raiden.storage.sqlite import SQLiteStorage
@@ -9,60 +10,76 @@ from raiden.transfer.architecture import StateManager
 from raiden.transfer.state_change import ActionInitChain
 
 
-class MockTokenNetwork:
-
-    def detail_participants(self, participant1, participant2, channel_identifier):
-        # To be changed by each test
-        return None
-
-
-class MockPaymentChannel:
-
-    def __init__(self, token_network, channel_id):
-        self.token_network = token_network
+def MockTokenNetwork():
+    """ Tests might want to `.configure_mock(participant_details.return_value=ParticipantDetails..`
+    """
+    return Mock()
 
 
-class MockChain:
-    def __init__(self):
-        self.network_id = 17
+def MockPaymentChannel(token_network, channel_id):
+    return Mock(
+        name='MockPaymentChannel',
+        token_network=token_network,
+        channel_id=channel_id,
+    )
+
+
+def MockChain():
+    mock = Mock()
+
+    def payment_channel(token_network_address, channel_id):
+        if not (token_network_address, channel_id) in mock._payment_channels:
+            mock._payment_channels[(
+                token_network_address,
+                channel_id,
+            )] = MockPaymentChannel(mock.token_network, channel_id)
+        return mock._payment_channels[(token_network_address, channel_id)]
+    mock.configure_mock(**dict(
+        network_id=17,
         # let's make a single mock token network for testing
-        self.token_network = MockTokenNetwork()
+        token_network=MockTokenNetwork(),
+        payment_channel=payment_channel,
+    ))
+    mock._payment_channels = dict()
+    return mock
 
-    def payment_channel(self, token_network_address, channel_id):
-        return MockPaymentChannel(self.token_network, channel_id)
 
+def MockRaidenService(message_handler=None, state_transition=None):
+    mock = Mock()
+    mock.chain = MockChain()
+    mock.private_key, mock.address = factories.make_privatekey_address()
 
-class MockRaidenService:
-    def __init__(self, message_handler=None, state_transition=None):
-        self.chain = MockChain()
-        self.private_key, self.address = factories.make_privatekey_address()
+    mock.chain.node_address = mock.address
+    mock.message_handler = message_handler
 
-        self.chain.node_address = self.address
-        self.message_handler = message_handler
+    if state_transition is None:
+        state_transition = node.state_transition
 
-        if state_transition is None:
-            state_transition = node.state_transition
+    serializer = JSONSerializer
+    state_manager = StateManager(state_transition, None)
+    storage = SQLiteStorage(':memory:', serializer)
+    mock.wal = WriteAheadLog(state_manager, storage)
 
-        serializer = JSONSerializer
-        state_manager = StateManager(state_transition, None)
-        storage = SQLiteStorage(':memory:', serializer)
-        self.wal = WriteAheadLog(state_manager, storage)
+    state_change = ActionInitChain(
+        random.Random(),
+        0,
+        mock.chain.node_address,
+        mock.chain.network_id,
+    )
 
-        state_change = ActionInitChain(
-            random.Random(),
-            0,
-            self.chain.node_address,
-            self.chain.network_id,
-        )
+    mock.wal.log_and_dispatch(state_change)
 
-        self.wal.log_and_dispatch(state_change)
+    def on_message(message):
+        if mock.message_handler:
+            mock.message_handler.on_message(mock, message)
 
-    def on_message(self, message):
-        if self.message_handler:
-            self.message_handler.on_message(self, message)
-
-    def handle_state_change(self, state_change):
+    def handle_state_change(state_change):
         pass
 
-    def sign(self, message):
-        message.sign(self.private_key)
+    def sign(message):
+        message.sign(mock.private_key)
+
+    mock.on_message = on_message
+    mock.handle_state_change = handle_state_change
+    mock.sign = sign
+    return mock

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -2,7 +2,6 @@
 import random
 
 import gevent
-from coincurve import PrivateKey
 
 from raiden.constants import UINT64_MAX
 from raiden.message_handler import MessageHandler
@@ -231,12 +230,11 @@ def make_mediated_transfer(
     )
     mediated_transfer_msg = LockedTransfer.from_event(lockedtransfer)
 
-    sign_key = PrivateKey(pkey)
-    mediated_transfer_msg.sign(sign_key)
+    mediated_transfer_msg.sign(pkey)
 
     # compute the signature
     balance_proof = balanceproof_from_envelope(mediated_transfer_msg)
-    lockedtransfer.balance_proof = balance_proof
+    lockedtransfer.transfer.balance_proof = balance_proof
 
     # if this fails it's not the right key for the current `from_channel`
     assert mediated_transfer_msg.sender == from_channel.our_state.address

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1839,7 +1839,7 @@ def handle_channel_settled(
     if state_change.channel_identifier == channel_state.identifier:
         set_settled(channel_state, state_change.block_number)
 
-        # Decide which sides of the channel to unlock. Depending on the difference between
+        # Decide which sides of the channel to unlock. Depending on the
         # the expired sent, and the on-chain revealed token amounts,
         # we decide for both sides, if it is in our favor to unlock.
         receiving_side, sending_side = get_batch_unlock_values(channel_state)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1017,7 +1017,11 @@ def is_transaction_effect_satisfied(
                     state_change.participant == our_address and
                     state_change.token_network_identifier == transaction.token_network_identifier
                 )
-                if is_our_batch_unlock:
+                is_partner_batch_unlock = (
+                    state_change.partner == our_address and
+                    state_change.token_network_identifier == transaction.token_network_identifier
+                )
+                if is_our_batch_unlock or is_partner_batch_unlock:
                     return True
 
     return False

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1480,6 +1480,7 @@ class NettingChannelState(State):
         'settle_transaction',
         'update_transaction',
         'our_unlock_transaction',
+        'partner_unlock_transaction',
     )
 
     def __init__(
@@ -1553,6 +1554,7 @@ class NettingChannelState(State):
         self.settle_transaction = settle_transaction
         self.update_transaction = update_transaction
         self.our_unlock_transaction: TransactionExecutionStatus = None
+        self.partner_unlock_transaction: TransactionExecutionStatus = None
 
     def __repr__(self):
         return '<NettingChannelState id:{} opened:{} closed:{} settled:{} updated:{}>'.format(


### PR DESCRIPTION
This changes the unlock logic during settlement:
- we now calculate the net gain for either channel side to unlock
- if we are to receive tokens by calling unlock for either side, we will
do it

I adjusted some tests that looked at unlock logic, so that they contain more
expired locks than unlocked locks, in order for the channel unlock events still being generated.

This improves the logic for unlock as described in #3151 -- we will
unlock both sides, if it is in our "economic interest", and, when there
is nothing to gain for us from unlock, we will remove the channel
immediately.

Fixes #3151