### PR TITLE
remove exceptions from state machines

### DIFF
--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -257,11 +257,7 @@ def send_lockedtransfer(
         message_identifier: MessageID,
         block_number: BlockNumber,
 ) -> SendLockedTransfer:
-    """ Create a mediated transfer using channel.
-
-    Raises:
-        AssertionError: If the channel does not have enough capacity.
-    """
+    """ Create a mediated transfer using channel. """
     assert channel_state.token_network_identifier == transfer_description.token_network_identifier
 
     lock_expiration = get_initial_lock_expiration(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -881,8 +881,6 @@ def handle_state_change(chain_state: ChainState, state_change: StateChange) -> T
             chain_state,
             state_change,
         )
-    else:
-        raise ValueError(f'Unknown state change: {state_change!r}')
 
     return iteration
 

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -335,7 +335,5 @@ def state_transition(
             token_network_state,
             state_change,
         )
-    else:
-        raise RuntimeError(state_change)
 
     return iteration


### PR DESCRIPTION
This is open to discussion. I think we should either remove them and let the unknown state changes fall through, or make sure that all transition functions raise a runtime error