### PR TITLE
Fixed folder mixup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,7 @@ ARG RAIDENVERSION=master
 ADD https://api.github.com/repos/${REPO}/commits/${RAIDENVERSION} /dev/null
 
 # clone raiden repo + install dependencies
-RUN git clone -b ${RAIDENVERSION} https://github.com/${REPO}
-RUN git fetch --tags
+RUN git clone -b ${RAIDENVERSION} https://github.com/${REPO} /app/raiden
 
 RUN python3 -m venv /opt/venv
 


### PR DESCRIPTION
I mixed up my Dockerfile versions in PR #3247... 
Obviously, the repo needs to get cloned in `/app/raiden` and the git fetch is not needed.