### PR TITLE
replay_wal.py: changed command line arguments

### DIFF
--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -169,13 +169,11 @@ def replay_wal(storage, token_network_identifier, partner_address, translator=No
     'db-file',
     type=click.Path(exists=True),
 )
-@click.option(
-    '-n',
-    '--token-network-identifier',
+@click.argument(
+    'token-network-identifier',
 )
-@click.option(
-    '-p',
-    '--partner-address',
+@click.argument(
+    'partner-address',
 )
 @click.option(
     '-x',


### PR DESCRIPTION
If either the `token_network_identifier` or `partner_address` parameters
weren't given the utility would fail at lines 150 or 151. This change
the values from optional to required.