### PR TITLE
Add pytest option for gevent monitoring signal

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -66,6 +66,31 @@ def pytest_addoption(parser):
         help="Host name of local matrix server if used, default: 'http://localhost:8008'",
     )
 
+    parser.addoption(
+        '--gevent-monitoring-signal',
+        action='store_true',
+        dest='gevent_monitoring_signal',
+        default=False,
+        help='Install a SIGUSR1 signal handler to print gevent run_info.',
+    )
+
+
+@pytest.fixture(scope='session', autouse=True)
+def enable_gevent_monitoring_signal(request):
+    """ Install a signal handler for SIGUSR1 that executes gevent.util.print_run_info().
+    This can help evaluating the gevent greenlet tree.
+    See http://www.gevent.org/monitoring.html for more information.
+
+    Usage:
+        pytest [...] --gevent-monitoring-signal
+        # while test is running (or stopped in a pdb session):
+        kill -SIGUSR1 $(pidof -x pytest)
+    """
+    if request.config.option.gevent_monitoring_signal:
+        import gevent.util
+        import signal
+        signal.signal(signal.SIGUSR1, gevent.util.print_run_info)
+
 
 @pytest.fixture(scope='session', autouse=True)
 def enable_greenlet_debugger(request):


### PR DESCRIPTION
This adds the option `--gevent-monitoring-signal` to the pytest
configuration. This option allows to inspect the gevent state when
sending
    kill -SIGUSR1 $(pidof -x pytest)
to a running pytest session.