### PR TITLE
simplified lock acquision in the python api

### DIFF
--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -1,8 +1,6 @@
-from contextlib import contextmanager
 from typing import Optional
 
 from eth_utils import decode_hex
-from gevent.lock import RLock
 from web3.utils.filters import Filter
 
 from raiden.constants import UINT256_MAX
@@ -51,15 +49,9 @@ class PaymentChannel:
             participant1, participant2 = participant2, participant1
 
         self.channel_identifier = channel_identifier
-        self.channel_operations_lock = RLock()
         self.participant1 = participant1
         self.participant2 = participant2
         self.token_network = token_network
-
-    @contextmanager
-    def lock_or_raise(self):
-        with self.token_network.channel_operations_lock[self.participant2]:
-            yield
 
     def token_address(self) -> typing.Address:
         """ Returns the address of the token for the channel. """


### PR DESCRIPTION
- removed locks from the payment_channel proxy, since the token network
already has locks in place.
- Channel operations are no longer raising a ChannelBusy exception if
there is another concurrent operation. The new transaction will just
wait for the pending one to finish, and once the lock is held the
preconditions checks if the transaction is still valid.
    - This means that if a user request for a close and there is a
    deposit in flight, the close will not raise an error but wait for
    the deposit and then execute.
    - The same happens for the deposit waiting for a close, but the
    deposit is not sent once the lock is acquired because of the
    preconditions checks.

The above means we no longer need to acquire the locks for all channels
before doing a batch close, we can just dispatch the action close and
wait for the locks to be freed, and eventually the channels will close.