### PR TITLE
Target must register secret onchain once only

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -144,9 +144,12 @@ def test_events_for_onchain_secretreveal():
     assert not events
 
     events = target.events_for_onchain_secretreveal(state, channels[0], unsafe_to_wait)
-    assert events
-    assert isinstance(events[0], ContractSendSecretReveal)
-    assert events[0].secret == UNIT_SECRET
+
+    msg = 'when its not safe to wait, the contract send must be emitted'
+    assert must_contain_entry(events, ContractSendSecretReveal, {'secret': UNIT_SECRET}), msg
+
+    msg = 'second call must not emit ContractSendSecretReveal again'
+    assert not target.events_for_onchain_secretreveal(state, channels[0], unsafe_to_wait), msg
 
 
 def test_handle_inittarget():

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -283,10 +283,18 @@ class TargetTransferState(State):
         'state',
     )
 
+    EXPIRED = 'expired'
+    OFFCHAIN_SECRET_REVEAL = 'reveal_secret'
+    ONCHAIN_SECRET_REVEAL = 'onchain_secret_reveal'
+    ONCHAIN_UNLOCK = 'onchain_unlock'
+    SECRET_REQUEST = 'secret_request'
+
     valid_states = (
-        'secret_request',
-        'reveal_secret',
-        'expired',
+        EXPIRED,
+        OFFCHAIN_SECRET_REVEAL,
+        ONCHAIN_SECRET_REVEAL,
+        ONCHAIN_UNLOCK,
+        SECRET_REQUEST,
     )
 
     def __init__(

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -68,10 +68,12 @@ def events_for_onchain_secretreveal(
         channel_state.partner_state,
         transfer.lock.secrethash,
     )
-    has_onchain_reveal_started = target_state.state == 'onchain_reveal_secret'
+    has_onchain_reveal_started = (
+        target_state.state == TargetTransferState.ONCHAIN_SECRET_REVEAL
+    )
 
     if not safe_to_wait and secret_known_offchain and not has_onchain_reveal_started:
-        target_state.state = 'onchain_reveal_secret'
+        target_state.state = TargetTransferState.ONCHAIN_SECRET_REVEAL
         secret = channel.get_secret(
             channel_state.partner_state,
             transfer.lock.secrethash,
@@ -179,7 +181,7 @@ def handle_offchain_secretreveal(
 
         route = target_state.route
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
-        target_state.state = 'reveal_secret'
+        target_state.state = TargetTransferState.OFFCHAIN_SECRET_REVEAL
         target_state.secret = state_change.secret
         recipient = route.node_address
 
@@ -219,7 +221,7 @@ def handle_onchain_secretreveal(
             secret_reveal_block_number=state_change.block_number,
         )
 
-        target_state.state = 'onchain_unlock'
+        target_state.state = TargetTransferState.ONCHAIN_UNLOCK
         target_state.secret = state_change.secret
 
     return TransitionResult(target_state, list())
@@ -296,7 +298,7 @@ def handle_block(
             secrethash=transfer.lock.secrethash,
             reason=f'lock expired',
         )
-        target_state.state = 'expired'
+        target_state.state = TargetTransferState.EXPIRED
         events = [failed]
     elif secret_known:
         events = events_for_onchain_secretreveal(

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -68,8 +68,10 @@ def events_for_onchain_secretreveal(
         channel_state.partner_state,
         transfer.lock.secrethash,
     )
+    has_onchain_reveal_started = target_state.state == 'onchain_reveal_secret'
 
-    if not safe_to_wait and secret_known_offchain:
+    if not safe_to_wait and secret_known_offchain and not has_onchain_reveal_started:
+        target_state.state = 'onchain_reveal_secret'
         secret = channel.get_secret(
             channel_state.partner_state,
             transfer.lock.secrethash,
@@ -217,7 +219,7 @@ def handle_onchain_secretreveal(
             secret_reveal_block_number=state_change.block_number,
         )
 
-        target_state.state = 'reveal_secret'
+        target_state.state = 'onchain_unlock'
         target_state.secret = state_change.secret
 
     return TransitionResult(target_state, list())


### PR DESCRIPTION
The target state machine had no chek for a in-flight secret transaction,
resulting in a new transaction after each new block.