### PR TITLE
Added asserts on balance proofs

### DIFF
--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1283,6 +1283,9 @@ def send_refundtransfer(
     msg = 'Refunds are only valid for *known and pending* transfers'
     assert secrethash in channel_state.partner_state.secrethashes_to_lockedlocks, msg
 
+    msg = 'caller must make sure the channel is open'
+    assert get_status(channel_state) == CHANNEL_STATE_OPENED, msg
+
     send_mediated_transfer, merkletree = create_sendlockedtransfer(
         channel_state,
         initiator,
@@ -1409,6 +1412,9 @@ def events_for_expired_lock(
         locked_lock: HashTimeLockState,
         pseudo_random_generator: random.Random,
 ) -> List[SendLockExpired]:
+    msg = 'caller must make sure the channel is open'
+    assert get_status(channel_state) == CHANNEL_STATE_OPENED, msg
+
     send_lock_expired, merkletree = create_sendexpiredlock(
         sender_end_state=channel_state.our_state,
         locked_lock=locked_lock,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -929,7 +929,9 @@ def events_to_remove_expired_locks(
                 lock_expiration_threshold=lock_expiration_threshold,
             )
 
-            if has_lock_expired:
+            is_channel_open = channel.get_status(channel_state) == CHANNEL_STATE_OPENED
+
+            if has_lock_expired and is_channel_open:
                 transfer_pair.payee_state = 'payee_expired'
                 expired_lock_events = channel.events_for_expired_lock(
                     channel_state=channel_state,


### PR DESCRIPTION
A node should not send a balance proof for a closed channel, added
missing checks for the refund and removed expired lock BPs.