### PR TITLE
Proper fix for 3196

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -36,7 +36,12 @@ from raiden.transfer.mediated_transfer.events import (
     SendSecretRequest,
     SendSecretReveal,
 )
-from raiden.transfer.utils import get_event_with_balance_proof, get_state_change_with_balance_proof
+from raiden.transfer.utils import (
+    get_event_with_balance_proof_by_balance_hash,
+    get_event_with_balance_proof_by_locksroot,
+    get_state_change_with_balance_proof_by_balance_hash,
+    get_state_change_with_balance_proof_by_locksroot,
+)
 from raiden.utils import pex
 from raiden.utils.signing import eth_sign
 
@@ -343,22 +348,22 @@ class RaidenEventHandler:
         )
 
         if is_partner_unlock:
-            state_change_record = get_state_change_with_balance_proof(
+            state_change_record = get_state_change_with_balance_proof_by_locksroot(
                 storage=raiden.wal.storage,
                 chain_id=raiden.chain.network_id,
                 token_network_identifier=token_network_identifier,
                 channel_identifier=channel_identifier,
-                balance_hash=partner_details.balance_hash,
+                locksroot=partner_locksroot,
                 sender=participants_details.partner_details.address,
             )
             state_change_identifier = state_change_record.state_change_identifier
         elif is_our_unlock:
-            event_record = get_event_with_balance_proof(
+            event_record = get_event_with_balance_proof_by_locksroot(
                 storage=raiden.wal.storage,
                 chain_id=raiden.chain.network_id,
                 token_network_identifier=token_network_identifier,
                 channel_identifier=channel_identifier,
-                balance_hash=our_details.balance_hash,
+                locksroot=our_locksroot.balance_hash,
             )
             state_change_identifier = event_record.state_change_identifier
         else:
@@ -459,7 +464,7 @@ class RaidenEventHandler:
         }
 
         if our_details.balance_hash != EMPTY_HASH:
-            event_record = get_event_with_balance_proof(
+            event_record = get_event_with_balance_proof_by_balance_hash(
                 storage=raiden.wal.storage,
                 chain_id=chain_id,
                 token_network_identifier=token_network_identifier,
@@ -486,7 +491,7 @@ class RaidenEventHandler:
             our_locksroot = EMPTY_HASH
 
         if partner_details.balance_hash != EMPTY_HASH:
-            state_change_record = get_state_change_with_balance_proof(
+            state_change_record = get_state_change_with_balance_proof_by_balance_hash(
                 storage=raiden.wal.storage,
                 chain_id=chain_id,
                 token_network_identifier=token_network_identifier,

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -11,18 +11,13 @@ from raiden.utils import get_system_spec, typing
 RAIDEN_DB_VERSION = 16
 
 
-class Record(typing.NamedTuple):
-    state_change_identifier: int
-    data: typing.Any
-
-
-class StateChangeRecord(Record):
-    state_change_identifier: int
-    data: typing.Any
-
-
 class EventRecord(typing.NamedTuple):
     event_identifier: int
+    state_change_identifier: int
+    data: typing.Any
+
+
+class StateChangeRecord(typing.NamedTuple):
     state_change_identifier: int
     data: typing.Any
 

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -21,7 +21,10 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state import BalanceProofUnsignedState
 from raiden.transfer.state_change import ReceiveUnlock
-from raiden.transfer.utils import get_event_with_balance_proof, get_state_change_with_balance_proof
+from raiden.transfer.utils import (
+    get_event_with_balance_proof_by_balance_hash,
+    get_state_change_with_balance_proof_by_balance_hash,
+)
 from raiden.utils import sha3
 
 
@@ -199,7 +202,7 @@ def test_get_state_change_with_balance_proof():
     assert isinstance(stored_statechanges[1], ReceiveUnlock)
 
     for state_change, balance_proof in statechanges_balanceproofs:
-        state_change_record = get_state_change_with_balance_proof(
+        state_change_record = get_state_change_with_balance_proof_by_balance_hash(
             storage=storage,
             chain_id=balance_proof.chain_id,
             token_network_identifier=balance_proof.token_network_identifier,
@@ -267,7 +270,7 @@ def test_get_event_with_balance_proof():
         )
 
     for event, balance_proof in events_balanceproofs:
-        event_record = get_event_with_balance_proof(
+        event_record = get_event_with_balance_proof_by_balance_hash(
             storage=storage,
             chain_id=balance_proof.chain_id,
             token_network_identifier=balance_proof.token_network_identifier,

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -17,69 +17,6 @@ from raiden.utils.typing import (
 )
 
 
-def get_state_change_or_event_with_balance_proof(
-        storage: sqlite.SQLiteStorage,
-        chain_id: ChainID,
-        token_network_identifier: TokenNetworkID,
-        channel_identifier: ChannelID,
-        is_our_unlock: bool,
-        is_partner_unlock: bool,
-        our_balance_hash: BalanceHash,
-        partner_balance_hash: BalanceHash,
-        sender: Address,
-) -> sqlite.Record:
-    """ Returns the state change or event which contains the corresponding balance
-    proof depending on who's balance hash we're looking for.
-    """
-    if is_partner_unlock:
-        state_change_record = get_state_change_with_balance_proof(
-            storage=storage,
-            chain_id=chain_id,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
-            balance_hash=partner_balance_hash,
-            sender=sender,
-        )
-        state_change_identifier = state_change_record.state_change_identifier
-
-        if state_change_identifier:
-            return state_change_record
-
-        event_record = get_event_with_balance_proof(
-            storage=storage,
-            chain_id=chain_id,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
-            balance_hash=partner_balance_hash,
-        )
-
-        return event_record
-    elif is_our_unlock:
-        event_record = get_event_with_balance_proof(
-            storage=storage,
-            chain_id=chain_id,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
-            balance_hash=our_balance_hash,
-        )
-        state_change_identifier = event_record.state_change_identifier
-
-        if state_change_identifier:
-            return event_record
-
-        state_change_record = get_state_change_with_balance_proof(
-            storage=storage,
-            chain_id=chain_id,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
-            balance_hash=our_balance_hash,
-            sender=sender,
-        )
-
-        return state_change_record
-    return 0
-
-
 def get_state_change_with_balance_proof(
         storage: sqlite.SQLiteStorage,
         chain_id: ChainID,

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -17,7 +17,7 @@ from raiden.utils.typing import (
 )
 
 
-def get_state_change_with_balance_proof(
+def get_state_change_with_balance_proof_by_balance_hash(
         storage: sqlite.SQLiteStorage,
         chain_id: ChainID,
         token_network_identifier: TokenNetworkID,
@@ -27,6 +27,9 @@ def get_state_change_with_balance_proof(
 ) -> sqlite.StateChangeRecord:
     """ Returns the state change which contains the corresponding balance
     proof.
+
+    Use this function to find a balance proof for a call to settle, which only
+    have the blinded balance proof data.
     """
     return storage.get_latest_state_change_by_data_field({
         'balance_proof.chain_id': chain_id,
@@ -37,7 +40,31 @@ def get_state_change_with_balance_proof(
     })
 
 
-def get_event_with_balance_proof(
+def get_state_change_with_balance_proof_by_locksroot(
+        storage: sqlite.SQLiteStorage,
+        chain_id: ChainID,
+        token_network_identifier: TokenNetworkID,
+        channel_identifier: ChannelID,
+        locksroot: Locksroot,
+        sender: Address,
+) -> sqlite.StateChangeRecord:
+    """ Returns the state change which contains the corresponding balance
+    proof.
+
+    Use this function to find a balance proof for a call to unlock, which only
+    happens after settle, so the channel has the unblinded of the balance
+    proof.
+    """
+    return storage.get_latest_state_change_by_data_field({
+        'balance_proof.chain_id': chain_id,
+        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
+        'balance_proof.channel_identifier': str(channel_identifier),
+        'balance_proof.locksroot': serialize_bytes(locksroot),
+        'balance_proof.sender': to_checksum_address(sender),
+    })
+
+
+def get_event_with_balance_proof_by_balance_hash(
         storage: sqlite.SQLiteStorage,
         chain_id: ChainID,
         token_network_identifier: TokenNetworkID,
@@ -46,12 +73,36 @@ def get_event_with_balance_proof(
 ) -> sqlite.EventRecord:
     """ Returns the event which contains the corresponding balance
     proof.
+
+    Use this function to find a balance proof for a call to settle, which only
+    have the blinded balance proof data.
     """
     return storage.get_latest_event_by_data_field({
         'balance_proof.chain_id': chain_id,
         'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
         'balance_proof.channel_identifier': str(channel_identifier),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
+    })
+
+
+def get_event_with_balance_proof_by_locksroot(
+        storage: sqlite.SQLiteStorage,
+        chain_id: ChainID,
+        token_network_identifier: TokenNetworkID,
+        channel_identifier: ChannelID,
+        locksroot: Locksroot,
+) -> sqlite.EventRecord:
+    """ Returns the event which contains the corresponding balance proof.
+
+    Use this function to find a balance proof for a call to unlock, which only
+    happens after settle, so the channel has the unblinded of the balance
+    proof.
+    """
+    return storage.get_latest_event_by_data_field({
+        'balance_proof.chain_id': chain_id,
+        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
+        'balance_proof.channel_identifier': str(channel_identifier),
+        'balance_proof.locksroot': serialize_bytes(locksroot),
     })
 
 


### PR DESCRIPTION
    fix unlock calls

    The token network smart contract has a few optimizations, one of these
    optimizations is to remove storage data as soon as possible, to reduce
    gas usage.

    Because of that, once the channel is settled the channel structs and
    their corresponding participant structs are removed. This removes the
    following data from the smart contract:

    participant.deposit
    participant.withdraw
    participant.is_the_closer
    participant.balance_hash
    participant.nonce

    and

    channel.settle_block_number
    channel.state

    Meaning the processing of unlock requests cannot rely on the
    availability of the balance_hash and nonce data to find the
    corresponding merkle tree. For a proper unlock the locksroot must be
    used.

    In the other hand, because of privacy concerns, the data provided to the
    functions closed and updateTransfer is blinded, this is done to avoid
    sharing the all the details with the monitoring service. Therefore the
    event which request the call to settle, which has to find the complete
    balance proof can not rely on the locksroot for the search, it must use
    the balance_hash.

    Because of the above, now we have four functions to search for the
    channel data, two for our data, two for the partner data, one of each
    for the call to settle and unlock.