### PR TITLE
Use pylint's builtin-redefine check

### DIFF
--- a/.pylint.rc
+++ b/.pylint.rc
@@ -26,7 +26,7 @@ logging-modules=logging,structlog
 [MESSAGES CONTROL]
 
 disable=all
-enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order
+enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order, redefined-builtin
 
 [REPORTS]
 

--- a/.pylint.rc
+++ b/.pylint.rc
@@ -26,7 +26,7 @@ logging-modules=logging,structlog
 [MESSAGES CONTROL]
 
 disable=all
-enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order, redefined-builtin
+enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin
 
 [REPORTS]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,10 @@ Flake8 will warn you for 99 characters which is the hard limit on the max
 length. Try not to go above it. We also have a soft limit on 80 characters but
 that is not enforced and is there just to encourage short lines.
 
+**Shadowing built-ins**
+
+Shadowing built-in names is not allowed. Pylint will also warn you about it. If you want to use a built-in name then add a trailing underscore and not a leading one. Leading ones are reserved for private attributes. For example `type` -> `type_`.
+
 **Function definitions formatting**
 
 The line length must be [smaller than 100 characters](#python), so the

--- a/raiden/encoding/format.py
+++ b/raiden/encoding/format.py
@@ -28,10 +28,10 @@ def make_field(name, size_bytes, format_string, encoder=None):
     )
 
 
-def pad(bytes):
+def pad(bytes_):
     return Pad(
-        bytes,
-        '{}x'.format(bytes),
+        bytes_,
+        '{}x'.format(bytes_),
     )
 
 

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -89,18 +89,18 @@ def enable_greenlet_debugger(request):
         enabled = False
         hub = gevent.get_hub()
 
-        def debugger(context, type, value, tb):
+        def debugger(context, type_, value, tb):
             # Always print the exception, because once the pdb REPL is started
             # we cannot retrieve it with `sys.exc_info()`.
             #
             # Using gevent's hub print_exception because it properly handles
             # corner cases.
-            hub.print_exception(context, type, value, tb)
+            hub.print_exception(context, type_, value, tb)
 
             # Don't enter nested sessions
             # Ignore exceptions used to quit the debugger / interpreter
             nonlocal enabled
-            if not enabled and type not in (bdb.BdbQuit, KeyboardInterrupt):
+            if not enabled and type_ not in (bdb.BdbQuit, KeyboardInterrupt):
                 enabled = True
                 pdb.post_mortem()  # pylint: disable=no-member
                 enabled = False

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -9,53 +9,53 @@ from raiden.log_config import LogFilter, configure_logging
 
 def test_log_filter():
     rules = {'': 'INFO'}
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('test', 'DEBUG') is False
-    assert filter.should_log('test', 'INFO') is True
-    assert filter.should_log('raiden', 'DEBUG') is False
-    assert filter.should_log('raiden', 'INFO') is True
-    assert filter.should_log('raiden.cli', 'DEBUG') is False
-    assert filter.should_log('raiden.cli', 'INFO') is True
+    assert filter_.should_log('test', 'DEBUG') is False
+    assert filter_.should_log('test', 'INFO') is True
+    assert filter_.should_log('raiden', 'DEBUG') is False
+    assert filter_.should_log('raiden', 'INFO') is True
+    assert filter_.should_log('raiden.cli', 'DEBUG') is False
+    assert filter_.should_log('raiden.cli', 'INFO') is True
 
     rules = {'': 'WARN'}
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('test', 'INFO') is False
-    assert filter.should_log('test', 'WARN') is True
-    assert filter.should_log('raiden', 'INFO') is False
-    assert filter.should_log('raiden', 'WARN') is True
-    assert filter.should_log('raiden.cli', 'INFO') is False
-    assert filter.should_log('raiden.cli', 'WARN') is True
+    assert filter_.should_log('test', 'INFO') is False
+    assert filter_.should_log('test', 'WARN') is True
+    assert filter_.should_log('raiden', 'INFO') is False
+    assert filter_.should_log('raiden', 'WARN') is True
+    assert filter_.should_log('raiden.cli', 'INFO') is False
+    assert filter_.should_log('raiden.cli', 'WARN') is True
 
     rules = {'test': 'WARN'}
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('test', 'INFO') is False
-    assert filter.should_log('test', 'WARN') is True
-    assert filter.should_log('raiden', 'DEBUG') is False
-    assert filter.should_log('raiden', 'INFO') is True
-    assert filter.should_log('raiden', 'WARN') is True
-    assert filter.should_log('raiden.cli', 'DEBUG') is False
-    assert filter.should_log('raiden.cli', 'INFO') is True
-    assert filter.should_log('raiden.cli', 'WARN') is True
+    assert filter_.should_log('test', 'INFO') is False
+    assert filter_.should_log('test', 'WARN') is True
+    assert filter_.should_log('raiden', 'DEBUG') is False
+    assert filter_.should_log('raiden', 'INFO') is True
+    assert filter_.should_log('raiden', 'WARN') is True
+    assert filter_.should_log('raiden.cli', 'DEBUG') is False
+    assert filter_.should_log('raiden.cli', 'INFO') is True
+    assert filter_.should_log('raiden.cli', 'WARN') is True
 
     rules = {'raiden': 'DEBUG'}
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('test', 'DEBUG') is False
-    assert filter.should_log('test', 'INFO') is True
-    assert filter.should_log('raiden', 'DEBUG') is True
-    assert filter.should_log('raiden.cli', 'DEBUG') is True
+    assert filter_.should_log('test', 'DEBUG') is False
+    assert filter_.should_log('test', 'INFO') is True
+    assert filter_.should_log('raiden', 'DEBUG') is True
+    assert filter_.should_log('raiden.cli', 'DEBUG') is True
 
     rules = {'raiden.network': 'DEBUG'}
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('test', 'DEBUG') is False
-    assert filter.should_log('test', 'INFO') is True
-    assert filter.should_log('raiden', 'DEBUG') is False
-    assert filter.should_log('raiden', 'INFO') is True
-    assert filter.should_log('raiden.network', 'DEBUG') is True
+    assert filter_.should_log('test', 'DEBUG') is False
+    assert filter_.should_log('test', 'INFO') is True
+    assert filter_.should_log('raiden', 'DEBUG') is False
+    assert filter_.should_log('raiden', 'INFO') is True
+    assert filter_.should_log('raiden.network', 'DEBUG') is True
 
     rules = {
         '': 'WARN',
@@ -63,39 +63,39 @@ def test_log_filter():
         'raiden.network': 'INFO',
         'raiden.network.transport': 'DEBUG',
     }
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('raiden.network.transport.matrix', 'DEBUG') is True
-    assert filter.should_log('raiden.network.transport', 'DEBUG') is True
-    assert filter.should_log('raiden.network', 'DEBUG') is False
-    assert filter.should_log('raiden.network', 'INFO') is True
-    assert filter.should_log('raiden.network', 'INFO') is True
-    assert filter.should_log('raiden', 'DEBUG') is True
-    assert filter.should_log('', 'DEBUG') is False
-    assert filter.should_log('', 'INFO') is False
-    assert filter.should_log('', 'WARN') is True
-    assert filter.should_log('other', 'DEBUG') is False
-    assert filter.should_log('other', 'WARN') is True
+    assert filter_.should_log('raiden.network.transport.matrix', 'DEBUG') is True
+    assert filter_.should_log('raiden.network.transport', 'DEBUG') is True
+    assert filter_.should_log('raiden.network', 'DEBUG') is False
+    assert filter_.should_log('raiden.network', 'INFO') is True
+    assert filter_.should_log('raiden.network', 'INFO') is True
+    assert filter_.should_log('raiden', 'DEBUG') is True
+    assert filter_.should_log('', 'DEBUG') is False
+    assert filter_.should_log('', 'INFO') is False
+    assert filter_.should_log('', 'WARN') is True
+    assert filter_.should_log('other', 'DEBUG') is False
+    assert filter_.should_log('other', 'WARN') is True
 
     rules = {
         'raiden': 'DEBUG',
         'raiden.network': 'INFO',
         'raiden.network.transport': 'DEBUG',
     }
-    filter = LogFilter(rules, default_level='INFO')
+    filter_ = LogFilter(rules, default_level='INFO')
 
-    assert filter.should_log('raiden.network.transport.matrix', 'DEBUG') is True
-    assert filter.should_log('raiden.network.transport', 'DEBUG') is True
-    assert filter.should_log('raiden.network', 'DEBUG') is False
-    assert filter.should_log('raiden.network', 'INFO') is True
-    assert filter.should_log('raiden.network', 'INFO') is True
-    assert filter.should_log('raiden', 'DEBUG') is True
-    assert filter.should_log('', 'DEBUG') is False
-    assert filter.should_log('', 'INFO') is True
-    assert filter.should_log('', 'WARN') is True
-    assert filter.should_log('other', 'DEBUG') is False
-    assert filter.should_log('other', 'INFO') is True
-    assert filter.should_log('other', 'WARN') is True
+    assert filter_.should_log('raiden.network.transport.matrix', 'DEBUG') is True
+    assert filter_.should_log('raiden.network.transport', 'DEBUG') is True
+    assert filter_.should_log('raiden.network', 'DEBUG') is False
+    assert filter_.should_log('raiden.network', 'INFO') is True
+    assert filter_.should_log('raiden.network', 'INFO') is True
+    assert filter_.should_log('raiden', 'DEBUG') is True
+    assert filter_.should_log('', 'DEBUG') is False
+    assert filter_.should_log('', 'INFO') is True
+    assert filter_.should_log('', 'WARN') is True
+    assert filter_.should_log('other', 'DEBUG') is False
+    assert filter_.should_log('other', 'INFO') is True
+    assert filter_.should_log('other', 'WARN') is True
 
 
 @pytest.mark.parametrize('module', ['', 'raiden', 'raiden.network'])

--- a/raiden/tests/utils/geth.py
+++ b/raiden/tests/utils/geth.py
@@ -9,9 +9,9 @@ import time
 from collections import namedtuple
 
 import gevent
+import requests
 import structlog
 from eth_utils import encode_hex, remove_0x_prefix, to_checksum_address, to_normalized_address
-from requests import ConnectionError
 from web3 import Web3
 
 from raiden.tests.fixtures.variables import DEFAULT_BALANCE_BIN, DEFAULT_PASSPHRASE
@@ -209,7 +209,7 @@ def geth_wait_and_check(web3, accounts_addresses, random_marker):
                 'eth_getBlockByNumber',
                 ['0x0', False],
             )
-        except ConnectionError:
+        except requests.exceptions.ConnectionError:
             gevent.sleep(0.5)
             tries -= 1
         else:

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -114,8 +114,6 @@ class GroupableOption(click.Option):
             multiple=False,
             count=False,
             allow_from_autoenv=True,
-            type=None,
-            help=None,
             option_group=None,
             **attrs,
     ):
@@ -130,8 +128,6 @@ class GroupableOption(click.Option):
             multiple,
             count,
             allow_from_autoenv,
-            type,
-            help,
             **attrs,
         )
         self.option_group = option_group

--- a/raiden/utils/serialization.py
+++ b/raiden/utils/serialization.py
@@ -14,21 +14,21 @@ def identity(val):
 def map_dict(
     key_func: typing.Callable,
     value_func: typing.Callable,
-    dict: typing.Dict,
+    dict_: typing.Dict,
 ) -> typing.Dict[str, typing.Any]:
     return {
         key_func(k): value_func(v)
-        for k, v in dict.items()
+        for k, v in dict_.items()
     }
 
 
 def map_list(
     value_func: typing.Callable,
-    list: typing.List,
+    list_: typing.List,
 ) -> typing.List[typing.Any]:
     return [
         value_func(v)
-        for v in list
+        for v in list_
     ]
 
 


### PR DESCRIPTION
There are cases where we mistakenly redefine python built-ins in the code. Pylint allows us to add a check to avoid this.