### PR TITLE
Fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
         - TEST='raiden/tests/unit'
 
     - stage: test
-      << *job-template-test
+      <<: *job-template-test
       env:
         - TEST='raiden/tests/fuzz'
         - TRANSPORT_OPTIONS='--hypothesis-show-statistics'


### PR DESCRIPTION
There was a syntax error introduced by fa7ed417261c743ee6f5c6864f76a398930fbab4

Syntax errors in Travis can be seen in the requests page. Unfortunately they only tell you that they can't parse `.travis.yml`: https://travis-ci.org/raiden-network/raiden/requests

![2019-01-23-001833_1073x848_scrot](https://user-images.githubusercontent.com/1658405/51572161-d5167780-1ea4-11e9-8cd3-551ecb5e6b64.png)
