### PR TITLE
Don't install pyinstaller and s3cmd in jobs that don't need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,10 @@ jobs:
         - git fetch --unshallow
         - git pull --tags
         - .travis/before_install.sh
-      install: .travis/install.sh
+      install:
+        - .travis/install.sh
+        - pip install s3cmd
+        - pip install pyinstaller
       script:
         - source .travis/set_tag.sh
         - REPO=${TRAVIS_REPO_SLUG} RAIDENVERSION=${TRAVIS_COMMIT} make bundle-docker

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -11,8 +11,6 @@ fi
 
 pip install ${INSTALL_OPT} --upgrade pip wheel
 pip install ${INSTALL_OPT} pytest-travis-fold
-pip install ${INSTALL_OPT} s3cmd
-pip install ${INSTALL_OPT} pyinstaller
 pip install ${INSTALL_OPT} -c constraints.txt --upgrade --upgrade-strategy eager -r requirements-dev.txt
 pip install ${INSTALL_OPT} -c constraints.txt -e .
 


### PR DESCRIPTION
This will also probably circumvent the pip 19.0 pyinstaller
[bug](https://github.com/pypa/pip/issues/6163) that hit us in all
Travis jobs. Example: https://travis-ci.org/raiden-network/raiden/jobs/483407811