### PR TITLE
pylint: added bad-continuation check

### DIFF
--- a/.pylint.rc
+++ b/.pylint.rc
@@ -26,7 +26,7 @@ logging-modules=logging,structlog
 [MESSAGES CONTROL]
 
 disable=all
-enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin
+enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin,bad-continuation
 
 [REPORTS]
 

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -100,11 +100,11 @@ class AccountManager:
                             address = add_0x_prefix(str(data['address']).lower())
                             self.accounts[address] = str(fullpath)
                     except (
-                        IOError,
-                        json.JSONDecodeError,
-                        KeyError,
-                        OSError,
-                        UnicodeDecodeError,
+                            IOError,
+                            json.JSONDecodeError,
+                            KeyError,
+                            OSError,
+                            UnicodeDecodeError,
                     ) as ex:
                         # Invalid file - skip
                         if f.startswith('UTC--'):

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -52,9 +52,9 @@ class LogFilter:
         ]
 
     def _match_list(
-        self,
-        module_rule: Tuple[List[str], str],
-        logger_name: str,
+            self,
+            module_rule: Tuple[List[str], str],
+            logger_name: str,
     ) -> Tuple[int, str]:
         logger_modules_split = logger_name.split('.') if logger_name else []
 

--- a/raiden/network/stunsock.py
+++ b/raiden/network/stunsock.py
@@ -7,11 +7,11 @@ log = structlog.get_logger(__name__)
 
 
 def stun_socket(
-    socket,
-    source_ip='0.0.0.0',
-    source_port=4200,
-    stun_host=None,
-    stun_port=3478,
+        socket,
+        source_ip='0.0.0.0',
+        source_port=4200,
+        stun_host=None,
+        stun_port=3478,
 ):
     timeout = socket.gettimeout()
     socket.settimeout(2)

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -339,10 +339,10 @@ class MatrixTransport(Runnable):
         self._account_data_lock = Semaphore()
 
     def start(
-        self,
-        raiden_service: RaidenService,
-        message_handler: MessageHandler,
-        prev_auth_data: str,
+            self,
+            raiden_service: RaidenService,
+            message_handler: MessageHandler,
+            prev_auth_data: str,
     ):
         if not self._stop_event.ready():
             raise RuntimeError(f'{self!r} already started')
@@ -486,9 +486,9 @@ class MatrixTransport(Runnable):
             self._update_address_presence(node_address)
 
     def send_async(
-        self,
-        queue_identifier: QueueIdentifier,
-        message: Message,
+            self,
+            queue_identifier: QueueIdentifier,
+            message: Message,
     ):
         """Queue the message for sending to recipient in the queue_identifier
 
@@ -997,9 +997,9 @@ class MatrixTransport(Runnable):
         return self._address_to_retrier[receiver]
 
     def _send_with_retry(
-        self,
-        queue_identifier: QueueIdentifier,
-        message: Message,
+            self,
+            queue_identifier: QueueIdentifier,
+            message: Message,
     ):
         retrier = self._get_retrier(queue_identifier.recipient)
         retrier.enqueue(queue_identifier=queue_identifier, message=message)
@@ -1022,9 +1022,9 @@ class MatrixTransport(Runnable):
         room.send_text(data)
 
     def _get_room_for_address(
-        self,
-        address: Address,
-        allow_missing_peers=False,
+            self,
+            address: Address,
+            allow_missing_peers=False,
     ) -> Optional[Room]:
         if self._stop_event.ready():
             return
@@ -1339,11 +1339,11 @@ class MatrixTransport(Runnable):
             if not (address and recovered and recovered == address):
                 return None
         except (
-            DecodeError,
-            TypeError,
-            InvalidSignature,
-            MatrixRequestError,
-            json.decoder.JSONDecodeError,
+                DecodeError,
+                TypeError,
+                InvalidSignature,
+                MatrixRequestError,
+                json.decoder.JSONDecodeError,
         ):
             return None
         return address

--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -10,9 +10,9 @@ from requests import RequestException
 
 
 def get_free_port(
-    bind_address: str = '127.0.0.1',
-    initial_port: int = 0,
-    socket_kind: SocketKind = SocketKind.SOCK_STREAM,
+        bind_address: str = '127.0.0.1',
+        initial_port: int = 0,
+        socket_kind: SocketKind = SocketKind.SOCK_STREAM,
 ):
     """
     Find an unused TCP port.
@@ -45,10 +45,10 @@ def get_free_port(
 
 
 def get_http_rtt(
-    url: str,
-    samples: int = 3,
-    method: str = 'head',
-    timeout: int = 1,
+        url: str,
+        samples: int = 3,
+        method: str = 'head',
+        timeout: int = 1,
 ) -> Optional[float]:
     """
     Determine the average HTTP RTT to `url` over the number of `samples`.

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -71,7 +71,7 @@ def secret_registry_proxy_patched(secret_registry_proxy, contract_manager):
 
 
 def test_concurrent_access(
-    secret_registry_proxy_patched,
+        secret_registry_proxy_patched,
 ):
     """Test if multiple greenlets actually send only one transaction
     when registering a secret.

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -25,10 +25,10 @@ def matrix_server_count():
 
 @pytest.fixture
 def local_matrix_servers(
-    request,
-    transport_protocol,
-    matrix_server_count,
-    synapse_config_generator,
+        request,
+        transport_protocol,
+        matrix_server_count,
+        synapse_config_generator,
 ):
     if transport_protocol is not TransportProtocol.MATRIX:
         yield [None]

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -10,10 +10,10 @@ from raiden.transfer.state import CHANNEL_STATE_OPENED
 
 
 def wait_for_transaction(
-    receiver,
-    registry_address,
-    token_address,
-    sender_address,
+        receiver,
+        registry_address,
+        token_address,
+        sender_address,
 ):
     """Wait until a first transaction in a channel is received"""
     while True:
@@ -136,10 +136,8 @@ def test_participant_selection(raiden_network, token_addresses):
     ]
 
     unsaturated_connection_managers = connection_managers[:]
-    with gevent.Timeout(
-        120,
-        AssertionError('Unsaturated connection managers', unsaturated_connection_managers),
-    ):
+    exception = AssertionError('Unsaturated connection managers', unsaturated_connection_managers)
+    with gevent.Timeout(120, exception):
         while unsaturated_connection_managers:
             for manager in unsaturated_connection_managers:
                 if is_manager_saturated(manager, registry_address, token_address):

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -307,10 +307,10 @@ def test_matrix_message_sync(
 
 
 def test_matrix_message_retry(
-    local_matrix_servers,
-    private_rooms,
-    retry_interval,
-    retries_before_backoff,
+        local_matrix_servers,
+        private_rooms,
+        retry_interval,
+        retries_before_backoff,
 ):
     """ Test the retry mechanism implemented into the matrix client.
     The test creates a transport and sends a message. Given that the
@@ -390,10 +390,10 @@ def test_matrix_message_retry(
 
 
 def test_join_invalid_discovery(
-    local_matrix_servers,
-    private_rooms,
-    retry_interval,
-    retries_before_backoff,
+        local_matrix_servers,
+        private_rooms,
+        retry_interval,
+        retries_before_backoff,
 ):
     """_join_discovery_room tries to join on all servers on available_servers config
 
@@ -469,10 +469,10 @@ def test_matrix_cross_server(matrix_transports, retry_interval):
 
 
 def test_matrix_discovery_room_offline_server(
-    local_matrix_servers,
-    retries_before_backoff,
-    retry_interval,
-    private_rooms,
+        local_matrix_servers,
+        retries_before_backoff,
+        retry_interval,
+        private_rooms,
 ):
 
     transport = MatrixTransport({

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -81,12 +81,20 @@ def test_account_manager_invalid_files(test_keystore, caplog):
     with caplog.at_level(logging.DEBUG):
         AccountManager(test_keystore)
 
-    for msg, file_name, reason in [
-        ('The account file is not valid JSON format',
-         KEYFILE_INVALID,
-         'Expecting value: line 1 column 1 (char 0)'),
-        ('Can not read account file (errno=13)', KEYFILE_INACCESSIBLE, 'Permission denied'),
-    ]:
+    logs = [
+        (
+            'The account file is not valid JSON format',
+            KEYFILE_INVALID,
+            'Expecting value: line 1 column 1 (char 0)',
+        ),
+        (
+            'Can not read account file (errno=13)',
+            KEYFILE_INACCESSIBLE,
+            'Permission denied',
+        ),
+    ]
+
+    for msg, file_name, reason in logs:
         for record in caplog.records:
             message = record.getMessage()
             if msg in message and file_name in message and reason in message:
@@ -100,9 +108,15 @@ def test_account_manager_invalid_directory(caplog):
         mock_listdir.side_effect = OSError
         AccountManager('/some/path')
 
-    for msg, path, reason in [
-        ('Unable to list the specified directory', '/some/path', ''),
-    ]:
+    logs = [
+        (
+            'Unable to list the specified directory',
+            '/some/path',
+            '',
+        ),
+    ]
+
+    for msg, path, reason in logs:
         for record in caplog.records:
             message = record.getMessage()
             if msg in message and path in message and reason in message:

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -789,12 +789,12 @@ SIGNED_TRANSFER_FOR_CHANNEL_DEFAULTS = create_properties(LockedTransferSignedSta
 
 
 def make_signed_transfer_for(
-    channel_state: NettingChannelState = EMPTY,
-    properties: LockedTransferSignedStateProperties = None,
-    defaults: LockedTransferSignedStateProperties = None,
-    compute_locksroot: bool = False,
-    allow_invalid: bool = False,
-    only_transfer: bool = True,
+        channel_state: NettingChannelState = EMPTY,
+        properties: LockedTransferSignedStateProperties = None,
+        defaults: LockedTransferSignedStateProperties = None,
+        compute_locksroot: bool = False,
+        allow_invalid: bool = False,
+        only_transfer: bool = True,
 ) -> LockedTransferSignedState:
     properties: LockedTransferSignedStateProperties = create_properties(
         properties or LockedTransferSignedStateProperties(),
@@ -921,9 +921,9 @@ class ChannelSet:
 
 
 def make_channel_set(
-    properties: typing.List[NettingChannelStateProperties] = None,
-    defaults: NettingChannelStateProperties = NETTING_CHANNEL_STATE_DEFAULTS,
-    number_of_channels: int = None,
+        properties: typing.List[NettingChannelStateProperties] = None,
+        defaults: NettingChannelStateProperties = NETTING_CHANNEL_STATE_DEFAULTS,
+        number_of_channels: int = None,
 ) -> ChannelSet:
 
     if number_of_channels is None:

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -176,10 +176,10 @@ def generate_synapse_config() -> ContextManager:
 
 @contextmanager
 def matrix_server_starter(
-    *,
-    count: int = 1,
-    config_generator: ContextManager = None,
-    log_context: str = None,
+        *,
+        count: int = 1,
+        config_generator: ContextManager = None,
+        log_context: str = None,
 ) -> ContextManager:
     with ExitStack() as exit_stack:
         if config_generator is None:

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -183,12 +183,13 @@ class NodeRunner:
         except RaidenError as ex:
             click.secho(f'FATAL: {ex}', fg='red')
         except Exception as ex:
-            with NamedTemporaryFile(
+            file = NamedTemporaryFile(
                 'w',
                 prefix=f'raiden-exception-{datetime.utcnow():%Y-%m-%dT%H-%M}',
                 suffix='.txt',
                 delete=False,
-            ) as traceback_file:
+            )
+            with file as traceback_file:
                 traceback.print_exc(file=traceback_file)
                 click.secho(
                     f'FATAL: An unexpected exception occured. '
@@ -223,9 +224,12 @@ class UDPRunner(NodeRunner):
 
         (listen_host, listen_port) = split_endpoint(self._options['listen_address'])
         try:
-            with SocketFactory(
-                listen_host, listen_port, strategy=self._options['nat'],
-            ) as mapped_socket:
+            factory = SocketFactory(
+                listen_host,
+                listen_port,
+                strategy=self._options['nat'],
+            )
+            with factory as mapped_socket:
                 self._options['mapped_socket'] = mapped_socket
                 app = self._start_services()
 

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -29,6 +29,7 @@ class HelpFormatter(click.HelpFormatter):
     Subclass that allows multiple (option) sections to be formatted with pre-determined
     widths.
     """
+
     def write_dl(self, rows, col_max=30, col_spacing=2, widths=None):
         """Writes a definition list into the buffer.  This is how options
         and commands are usually formatted.
@@ -76,6 +77,7 @@ class Context(click.Context):
 
 class CustomContextMixin:
     """ Use above context class instead of the click default """
+
     def make_context(self, info_name, args, parent=None, **extra):
         """
         This function when given an info name and arguments will kick
@@ -279,6 +281,7 @@ class EnvironmentChoiceType(click.Choice):
 
 class GasPriceChoiceType(click.Choice):
     """ Returns a GasPriceStrategy for the choice """
+
     def convert(self, value, param, ctx):
         if isinstance(value, str) and value.isnumeric():
             try:
@@ -340,10 +343,10 @@ class PathRelativePath(click.Path):
 
 
 def apply_config_file(
-    command_function: Union[click.Command, click.Group],
-    cli_params: Dict[str, Any],
-    ctx,
-    config_file_option_name='config_file',
+        command_function: Union[click.Command, click.Group],
+        cli_params: Dict[str, Any],
+        ctx,
+        config_file_option_name='config_file',
 ):
     """ Applies all options set in the config file to `cli_params` """
     paramname_to_param = {param.name: param for param in command_function.params}

--- a/raiden/utils/gas_reserve.py
+++ b/raiden/utils/gas_reserve.py
@@ -28,13 +28,13 @@ GAS_RESERVE_ESTIMATE_SECURITY_FACTOR = 1.1
 
 
 def _get_required_gas_estimate(
-    new_channels: int = 0,
-    opening_channels: int = 0,
-    opened_channels: int = 0,
-    closing_channels: int = 0,
-    closed_channels: int = 0,
-    settling_channels: int = 0,
-    settled_channels: int = 0,
+        new_channels: int = 0,
+        opening_channels: int = 0,
+        opened_channels: int = 0,
+        closing_channels: int = 0,
+        closed_channels: int = 0,
+        settling_channels: int = 0,
+        settled_channels: int = 0,
 ) -> int:
     estimate = 0
 

--- a/raiden/utils/serialization.py
+++ b/raiden/utils/serialization.py
@@ -12,9 +12,9 @@ def identity(val):
 
 
 def map_dict(
-    key_func: typing.Callable,
-    value_func: typing.Callable,
-    dict_: typing.Dict,
+        key_func: typing.Callable,
+        value_func: typing.Callable,
+        dict_: typing.Dict,
 ) -> typing.Dict[str, typing.Any]:
     return {
         key_func(k): value_func(v)
@@ -23,8 +23,8 @@ def map_dict(
 
 
 def map_list(
-    value_func: typing.Callable,
-    list_: typing.List,
+        value_func: typing.Callable,
+        list_: typing.List,
 ) -> typing.List[typing.Any]:
     return [
         value_func(v)
@@ -57,7 +57,7 @@ def deserialize_networkx_graph(data: str) -> networkx.Graph:
 
 
 def serialize_participants_tuple(
-    participants: typing.Tuple[typing.Address, typing.Address],
+        participants: typing.Tuple[typing.Address, typing.Address],
 ) -> typing.List[str]:
     return [
         to_checksum_address(participants[0]),
@@ -66,7 +66,7 @@ def serialize_participants_tuple(
 
 
 def deserialize_participants_tuple(
-    data: typing.List[str],
+        data: typing.List[str],
 ) -> typing.Tuple[typing.Address, typing.Address]:
     assert len(data) == 2
     return (


### PR DESCRIPTION
this check enforces our rule for 8 spaces:

> When splitting the function arguments, each must go into its own line, followed by the argument type and a comma, and indented with 8 spaces.