### PR TITLE
tests: fixed logging path

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -4,6 +4,7 @@ from gevent import monkey
 monkey.patch_all()
 
 if True:
+    import datetime
     import os
     import re
     import sys
@@ -147,11 +148,17 @@ def logging_level(request):
     else:
         logging_levels = {'': level}
 
+    time = datetime.datetime.utcnow().isoformat()
+    debug_path = os.path.join(
+        tempfile.gettempdir(),
+        f'raiden-debug_{time}.log',
+    )
     configure_logging(
         logging_levels,
         colorize=not request.config.option.plain_log,
         log_file=request.config.option.log_file,
         cache_logger_on_first_use=False,
+        debug_log_file_name=debug_path,
     )
 
 

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -102,8 +102,12 @@ def test_log_filter():
 @pytest.mark.parametrize('level', ['DEBUG', 'WARNING'])
 @pytest.mark.parametrize('logger', ['test', 'raiden', 'raiden.network'])
 @pytest.mark.parametrize('disabled_debug', [True, False])
-def test_basic_logging(capsys, module, level, logger, disabled_debug):
-    configure_logging({module: level}, disable_debug_logfile=disabled_debug)
+def test_basic_logging(capsys, module, level, logger, disabled_debug, tmpdir):
+    configure_logging(
+        {module: level},
+        disable_debug_logfile=disabled_debug,
+        debug_log_file_name=str(tmpdir / 'raiden-debug.log'),
+    )
     log = structlog.get_logger(logger).bind(foo='bar')
     log.debug('test event', key='value')
 
@@ -118,8 +122,11 @@ def test_basic_logging(capsys, module, level, logger, disabled_debug):
         assert 'foo=bar' in captured.err
 
 
-def test_redacted_request(capsys):
-    configure_logging({'': 'DEBUG'})
+def test_redacted_request(capsys, tmpdir):
+    configure_logging(
+        {'': 'DEBUG'},
+        debug_log_file_name=str(tmpdir / 'raiden-debug.log'),
+    )
     token = 'my_access_token123'
 
     # use logging, as 'urllib3/requests'
@@ -133,8 +140,11 @@ def test_redacted_request(capsys):
     assert 'access_token=<redacted>' in captured.err
 
 
-def test_redacted_traceback(capsys):
-    configure_logging({'': 'DEBUG'})
+def test_redacted_traceback(capsys, tmpdir):
+    configure_logging(
+        {'': 'DEBUG'},
+        debug_log_file_name=str(tmpdir / 'raiden-debug.log'),
+    )
 
     token = 'my_access_token123'
 


### PR DESCRIPTION
The tests for the configure_logging produced two dozens of files for
each run, in the diretory where the pytest was executed. This
unecessarily cluterred the file system and gets annoying really quick.

This commit moves all the log files to a temp directory.