### PR TITLE
fix: getChannelIdentifier cannot return empty

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -311,13 +311,14 @@ class TokenNetwork:
             block_identifier: BlockSpecification = 'pending',
     ) -> ChannelID:
         if not channel_identifier:
-            channel_identifier = self._call_and_check_result(
-                block_identifier,
-                'getChannelIdentifier',
+            channel_identifier = self.proxy.contract.functions.getChannelIdentifier(
                 to_checksum_address(participant1),
                 to_checksum_address(participant2),
-            )
-        assert isinstance(channel_identifier, T_ChannelID)
+            ).call(block_identifier=block_identifier)
+
+        if not isinstance(channel_identifier, T_ChannelID):
+            raise ValueError('channel_identifier must be of type T_ChannelID')
+
         if channel_identifier == 0:
             raise RaidenRecoverableError(
                 f'When calling {called_by_fn} either 0 value was given for the '
@@ -325,6 +326,7 @@ class TokenNetwork:
                 f'no channel currently exists between {pex(participant1)} and '
                 f'{pex(participant2)}',
             )
+
         return channel_identifier
 
     def channel_exists_and_not_settled(


### PR DESCRIPTION
The signature of getChannelIdentifier is:

    function (address, address) view public returns (uint256)

So the function will return 0 if the value exists, never the empty string