### PR TITLE
removed duplicated call

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -226,14 +226,6 @@ class TokenNetwork:
             settle_timeout,
         )
         if not gas_limit:
-            channel_exists = self.channel_exists_and_not_settled(
-                participant1=self.node_address,
-                participant2=partner,
-                block_identifier='pending',
-            )
-            if channel_exists:
-                raise DuplicatedChannelError('Duplicated channel')
-
             log.critical('Call to openChannel will fail', **log_details)
             raise RaidenUnrecoverableError('Call to openChannel will fail')
 


### PR DESCRIPTION
The check channel_exists_and_not_settled is done by
_new_channel_preconditions just before, this second call is unecessary.