### PR TITLE
Note about safe usage of close [skip ci]

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -898,6 +898,12 @@ class TokenNetwork:
     ):
         """ Close the channel using the provided balance proof.
 
+        Note:
+            This method must *not* be called without updating the application
+            state, otherwise the node may accept new transfers which cannot be
+            used, because the closer is not allowed to update the balance proof
+            sent.
+
         Raises:
             RaidenRecoverableError: If the channel is already closed.
             RaidenUnrecoverableError: If the channel does not exist or is settled.

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -902,7 +902,7 @@ class TokenNetwork:
             This method must *not* be called without updating the application
             state, otherwise the node may accept new transfers which cannot be
             used, because the closer is not allowed to update the balance proof
-            sent.
+            submitted on chain after closing
 
         Raises:
             RaidenRecoverableError: If the channel is already closed.


### PR DESCRIPTION
Added a note to remind that this is a bad idea: https://github.com/raiden-network/raiden/pull/2985/files#r250980431