### PR TITLE
geth: added more checks for the cluster startup

### DIFF
--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -243,14 +243,13 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step, contracts_v
     try:
         # the marker is hardcoded in the genesis file
         random_marker = remove_0x_prefix(encode_hex(b'raiden'))
-        geth_wait_and_check(web3, [], random_marker)
-
-        for process in processes_list:
-            process.poll()
-
-            if process.returncode is not None:
-                raise ValueError(f'geth process failed with exit code {process.returncode}')
-
+        geth_wait_and_check(
+            web3=web3,
+            accounts_addresses=[],
+            random_marker=random_marker,
+            rpc_port=rpc_port,
+            processes_list=processes_list,
+        )
     except (ValueError, RuntimeError) as e:
         # If geth_wait_and_check or the above loop throw an exception make sure
         # we don't end up with a rogue geth process running in the background

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -247,7 +247,6 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step, contracts_v
             web3=web3,
             accounts_addresses=[],
             random_marker=random_marker,
-            rpc_port=rpc_port,
             processes_list=processes_list,
         )
     except (ValueError, RuntimeError) as e:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,3 +35,4 @@ bump2version==0.5.8
 
 # Test support
 matrix-synapse==0.33.9
+psutil==5.4.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,4 +35,3 @@ bump2version==0.5.8
 
 # Test support
 matrix-synapse==0.33.9
-psutil==5.4.7


### PR DESCRIPTION
- Moved the check for the process status inside the geth_wait_and_check,
otherwise that would be deadcode
- Added a check for the process name using the expected rpc port, this
should help with debugging in case there is no app using it, or
something besides geth