### PR TITLE
Improve matrix_transports fixture to allow generating an arbitrary number of transports #3290

### DIFF
--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -44,9 +44,16 @@ def local_matrix_servers(
 
 
 @pytest.fixture
-def matrix_transports(local_matrix_servers, retries_before_backoff, retry_interval, private_rooms):
+def matrix_transports(
+        local_matrix_servers,
+        retries_before_backoff,
+        retry_interval,
+        private_rooms,
+        number_of_transports,
+):
     transports = []
-    for server in local_matrix_servers:
+    for transport_index in range(number_of_transports):
+        server = local_matrix_servers[transport_index % len(local_matrix_servers)]
         transports.append(
             MatrixTransport({
                 'discovery_room': 'discovery',


### PR DESCRIPTION
Adds round-robin scheme to `matrix_transports` fixture to support load balancing when `number_of_transports > #local_matrix_servers`. Extends `test_matrix_cross_server` to test the round-robin scheme.  Closes #3290