### PR TITLE
Feature:  Return the secretHash and the Secret as part of payment reponse

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`3317` Return the secretHash and the Secret as part of payment response
 * :bug:`3380` Connection manager no longer attempts deposit if per partner funds are zero.
 * :bug:`3369` Fix high CPU usage when the raiden node is idle.
 * :feature:`-` Set python 3.7 as a minimum python version requirement to run Raiden.

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1038,7 +1038,7 @@ class RestAPI:
                 status_code=HTTPStatus.PAYMENT_REQUIRED,
             )
 
-        if transfer_result is None:
+        if transfer_result is False:
             return api_error(
                 errors="Payment couldn't be completed "
                 "(insufficient funds, no route to target or target offline).",

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1038,7 +1038,7 @@ class RestAPI:
                 status_code=HTTPStatus.PAYMENT_REQUIRED,
             )
 
-        if transfer_result is False:
+        if transfer_result is None:
             return api_error(
                 errors="Payment couldn't be completed "
                 "(insufficient funds, no route to target or target offline).",
@@ -1052,6 +1052,8 @@ class RestAPI:
             'target_address': target_address,
             'amount': amount,
             'identifier': identifier,
+            'secret': transfer_result.get('secret').hex(),
+            'secret_hash': transfer_result.get('secret_hash').hex(),
         }
         result = self.payment_schema.dump(payment)
         return api_response(result=result.data)

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -243,6 +243,8 @@ class PaymentSchema(BaseSchema):
     token_address = AddressField(missing=None)
     amount = fields.Integer(required=True)
     identifier = fields.Integer(missing=None)
+    secret = fields.String(missing=None)
+    secret_hash = fields.String(missing=None)
 
     class Meta:
         strict = True

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -202,7 +202,10 @@ class RaidenEventHandler:
         # With the introduction of the lock we should always get
         # here only once per identifier so payment_status should always exist
         # see: https://github.com/raiden-network/raiden/pull/3191
-        payment_status.payment_done.set(True)
+        payment_status.payment_done.set({
+            'secret': payment_status.secret,
+            'secret_hash': payment_status.secret_hash,
+        })
 
     def handle_paymentsentfailed(
             self,
@@ -219,7 +222,7 @@ class RaidenEventHandler:
         # but the lock expiration will generate a second
         # EventPaymentSentFailed message which we can ignore here
         if payment_status:
-            payment_status.payment_done.set(False)
+            payment_status.payment_done.set(None)
 
     def handle_unlockfailed(
             self,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -222,7 +222,7 @@ class RaidenEventHandler:
         # but the lock expiration will generate a second
         # EventPaymentSentFailed message which we can ignore here
         if payment_status:
-            payment_status.payment_done.set(None)
+            payment_status.payment_done.set(False)
 
     def handle_unlockfailed(
             self,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -69,6 +69,7 @@ from raiden.utils.typing import (
     PaymentAmount,
     PaymentID,
     Secret,
+    SecretHash,
     TargetAddress,
     TokenAmount,
     TokenNetworkAddress,
@@ -188,6 +189,8 @@ class PaymentStatus(NamedTuple):
     amount: TokenAmount
     token_network_identifier: TokenNetworkID
     payment_done: AsyncResult
+    secret: Secret
+    secret_hash: SecretHash
 
     def matches(
             self,
@@ -803,6 +806,8 @@ class RaidenService(Runnable):
                 amount=amount,
                 token_network_identifier=token_network_identifier,
                 payment_done=AsyncResult(),
+                secret=secret,
+                secret_hash=secret_hash,
             )
             self.targets_to_identifiers_to_statuses[target][identifier] = payment_status
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -189,8 +189,8 @@ class PaymentStatus(NamedTuple):
     amount: TokenAmount
     token_network_identifier: TokenNetworkID
     payment_done: AsyncResult
-    secret: Secret
-    secret_hash: SecretHash
+    secret: Secret = None
+    secret_hash: SecretHash = None
 
     def matches(
             self,

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -15,13 +15,13 @@ from raiden.tests.utils.events import check_dict_nested_attrs, must_have_event, 
 from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.smartcontracts import deploy_contract_web3
 from raiden.transfer.state import CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPENED
+from raiden.utils import sha3
 from raiden.waiting import wait_for_transfer_success
 from raiden_contracts.constants import (
     CONTRACT_HUMAN_STANDARD_TOKEN,
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-from raiden.utils import sha3
 
 # pylint: disable=too-many-locals,unused-argument,too-many-lines
 

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -21,6 +21,7 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
+from raiden.utils import sha3
 
 # pylint: disable=too-many-locals,unused-argument,too-many-lines
 
@@ -926,7 +927,13 @@ def test_api_payments(api_server_test_instance, raiden_network, token_addresses)
     response = request.send().response
     assert_proper_response(response)
     response = response.json()
-    assert response == payment
+    # make sure that payment key/values are part of the response.
+    assert response.items() >= payment.items()
+    assert 'secret' in response
+    assert 'secret_hash' in response
+    assert len(response['secret']) == 64
+    assert len(response['secret_hash']) == 64
+    assert sha3(bytes.fromhex(response['secret'])).hex() == response['secret_hash']
 
 
 def assert_payment_conflict(responses):


### PR DESCRIPTION
allow the payment API caller to know the Secret and the SecretHash used for the payment. The secret and the hash are kept as part of the payment_status object and return to the caller as asyncresults data.

Fixes #3317 