### PR TITLE
Grab bag of CircleCI / deployment fixes

### DIFF
--- a/.circleci/conditional_skip.sh
+++ b/.circleci/conditional_skip.sh
@@ -2,13 +2,9 @@
 
 SKIP_TAG="\[skip tests\]"
 
-if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
-    # If this is a PR get the base commit from the GitHub API
-    BASE_COMMIT=$(curl \
-        -H "Authorization: token ${GITHUB_TOKEN_RO}" \
-        https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} \
-        | jq -r .base.sha)
-    LOG_RANGE="${BASE_COMMIT}..${CIRCLE_SHA1}"
+if [[ -a ~/.local/BASE_COMMIT ]]; then
+    # The is a PR and we know the base commit (see fetch_pr_base_commit.sh)
+    LOG_RANGE="$(cat ~/.local/BASE_COMMIT)..${CIRCLE_SHA1}"
 else
     # Otherwise just look at the HEAD commit
     LOG_RANGE="-1"

--- a/.circleci/conditional_skip.sh
+++ b/.circleci/conditional_skip.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SKIP_TAG="\[skip tests\]"
+
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+    # If this is a PR get the base commit from the GitHub API
+    BASE_COMMIT=$(curl \
+        -H "Authorization: token ${GITHUB_TOKEN_RO}" \
+        https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} \
+        | jq -r .base.sha)
+    LOG_RANGE="${BASE_COMMIT}..${CIRCLE_SHA1}"
+else
+    # Otherwise just look at the HEAD commit
+    LOG_RANGE="-1"
+fi
+
+git log --pretty="- %h %B" ${LOG_RANGE} | grep "${SKIP_TAG}"
+
+if [[ ${PIPESTATUS[1]} == 0 ]]; then
+    echo Skip tag found - skipping build
+    circleci step halt
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,14 @@ templates:
 
   parameter-templates: &parameter-templates
     py-version: &py-version-template
-        description: "python version to be used in the executor"
-        default: "3.7"
-        type: string
+      description: "python version to be used in the executor"
+      default: "3.7"
+      type: string
     resource:
-        description: "resource type for underlying VM"
-        default: "medium"
-        type: enum
-        enum: ["small", "medium", "medium+", "large", "xlarge"]
+      description: "resource type for underlying VM"
+      default: "medium"
+      type: enum
+      enum: ["small", "medium", "medium+", "large", "xlarge"]
     transport-layer:
       description: "transmission protocol used, udp or matrix"
       default: "udp"
@@ -85,6 +85,62 @@ commands:
             echo 'export PATH=~/venv-${PYTHON_VERSION_SHORT}/bin:~/.local/bin:${PATH}' >> ${BASH_ENV}
             echo 'export RAIDEN_VERSION=$(python setup.py --version)' >> ${BASH_ENV}
 
+  prepare-system:
+    steps:
+      - run:
+          name: Preparing environment
+          command: |
+            echo "export OS_NAME=$(uname -s | sed s/Darwin/macos/ | tr '[:lower:]' '[:upper:]')" >> ${BASH_ENV}
+            echo ${GETH_VERSION} > /tmp/geth-version
+            echo ${SOLC_VERSION} > /tmp/solc-version
+            echo "SHA: ${CIRCLE_SHA1}"
+            echo "TAG: ${CIRCLE_TAG}"
+
+      - checkout
+
+      # This needs to be done here in order for the .egg-info directory to be included in the
+      # workspace. Luckily we don't need a virtualenv for this step.
+      - run:
+          name: Generate .egg-info
+          command: python setup.py egg_info
+
+
+      - restore_cache:
+          key: system-deps-geth-{{ checksum "/tmp/geth-version" }}-solc-{{ checksum "/tmp/solc-version" }}
+
+      - run:
+          name: Installing system dependencies
+          command: |
+            GETH_PATH="${HOME}/.local/bin/geth-${OS_NAME}-${GETH_VERSION}"
+            if [ ! -x ${GETH_PATH} ]; then
+              mkdir -p ${HOME}/.local/bin
+              TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'gethtmp')
+              pushd ${TEMP}
+              GETH_URL_VAR="GETH_URL_${OS_NAME}"
+              wget -O geth.tar.gz ${!GETH_URL_VAR}
+              tar xzf geth.tar.gz
+              cd geth*/
+              install -m 755 geth ${GETH_PATH}
+            fi
+            ln -sf ${GETH_PATH} ${HOME}/.local/bin/geth
+            SOLC_PATH="${HOME}/.local/bin/solc-${OS_NAME}-${SOLC_VERSION}"
+            if [ ! -x ${SOLC_PATH} ]; then
+              mkdir -p ${HOME}/.local/bin
+              SOLC_URL_VAR="SOLC_URL_${OS_NAME}"
+              curl -L ${!SOLC_URL_VAR} > ${SOLC_PATH}
+              chmod 775 ${SOLC_PATH}
+            fi
+            ln -sf ${SOLC_PATH} ${HOME}/.local/bin/solc
+      - save_cache:
+          key: system-deps-geth-{{ checksum "/tmp/geth-version" }}-solc-{{ checksum "/tmp/solc-version" }}
+          paths:
+          - "~/.local"
+      - persist_to_workspace:
+          root: "~"
+          paths:
+          - .local
+          - raiden
+
   prepare-python:
     parameters:
       py-version:
@@ -128,65 +184,15 @@ commands:
           - venv-<< parameters.py-version >>
 
 jobs:
-  prepare-system:
-    parameters:
-      py-version:
-        <<: *py-version-template
-    executor:
-      name: docker
-      py-version: << parameters.py-version >>
-
+  prepare-system-linux:
+    executor: docker
     steps:
-      - run:
-          name: Preparing environment
+      - prepare-system
 
-          command: |
-            echo "export OS_NAME=$(uname -s)" >> ${BASH_ENV}
-            echo "SHA: ${CIRCLE_SHA1}"
-            echo "TAG: ${CIRCLE_TAG}"
-      - checkout
-
-      # This needs to be done here in order for the .egg-info directory to be included in the
-      # workspace. Luckily we don't need a virtualenv for this step.
-      - run:
-          name: Generate .egg-info
-          command: python setup.py egg_info
-
-
-      # Get Geth and Solc -> Versions defined in Project Environment Variables accessible via circleci webUI
-      - restore_cache:
-          key: system-deps-geth-{{ .Environment.GETH_VERSION }}-solc-{{ .Environment.SOLC_VERSION }}
-
-      - run:
-          name: Installing system dependencies
-          command: |
-            GETH_PATH="${HOME}/.local/bin/geth-${OS_NAME}-${GETH_VERSION}"
-            if [ ! -x ${GETH_PATH} ]; then
-              mkdir -p ${HOME}/.local/bin
-              TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'gethtmp')
-              pushd ${TEMP}
-              wget -O geth.tar.gz ${GETH_URL_LINUX}
-              tar xzf geth.tar.gz
-              cd geth*/
-              install -m 755 geth ${GETH_PATH}
-            fi
-            ln -sf ${GETH_PATH} ${HOME}/.local/bin/geth
-            SOLC_PATH="${HOME}/.local/bin/solc-${OS_NAME}-${SOLC_VERSION}"
-            if [ ! -x ${SOLC_PATH} ]; then
-              mkdir -p ${HOME}/.local/bin
-              curl -L ${SOLC_URL_LINUX} > ${SOLC_PATH}
-              chmod 775 ${SOLC_PATH}
-            fi
-            ln -sf ${SOLC_PATH} ${HOME}/.local/bin/solc
-      - save_cache:
-          key: system-deps-geth-{{ .Environment.GETH_VERSION }}-solc-{{ .Environment.SOLC_VERSION }}
-          paths:
-            - "~/.local"
-      - persist_to_workspace:
-          root: "~"
-          paths:
-            - .local
-            - raiden
+  prepare-system-macos:
+    executor: macos
+    steps:
+      - prepare-system
 
   prepare-python-linux:
     parameters:
@@ -553,13 +559,13 @@ jobs:
 workflows:
   raiden-default:
     jobs:
-      - prepare-system
+      - prepare-system-linux
 
       - prepare-python-linux:
           name: prepare-python-linux-3.7
           py-version: '3.7'
           requires:
-            - prepare-system
+            - prepare-system-linux
 
       - lint:
           name: lint-3.7
@@ -639,19 +645,25 @@ workflows:
 
   deploy-release:
     jobs:
-      - prepare-system:
+      - prepare-system-linux:
+          filters:
+            <<: *only-tagged-version-filter
+
+      - prepare-system-macos:
           filters:
             <<: *only-tagged-version-filter
 
       - prepare-python-linux:
           py-version: '3.7'
           requires:
-            - prepare-system
+            - prepare-system-linux
           filters:
             <<: *only-tagged-version-filter
 
       - prepare-python-macos:
           py-version: '3.7'
+          requires:
+            - prepare-system-macos
           filters:
             <<: *only-tagged-version-filter
 
@@ -698,13 +710,13 @@ workflows:
 
   nightly:
     jobs:
-      - prepare-system
+      - prepare-system-linux
 
       - prepare-python-linux:
           name: prepare-python-linux-3.7
           py-version: '3.7'
           requires:
-          - prepare-system
+          - prepare-system-linux
 
       - lint:
           name: lint-3.7
@@ -786,9 +798,18 @@ workflows:
             requires:
               - finalize
 
+      - prepare-system-macos
+
+      - prepare-python-macos:
+          name: prepare-python-macos-3.7
+          py-version: '3.7'
+          requires:
+            - prepare-system-macos
+
       - build-binary-macos:
           requires:
             - finalize
+            - prepare-python-macos-3.7
 
       - deploy-digitalocean:
           context: "Raiden Context"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,33 +104,12 @@ commands:
           name: Generate .egg-info
           command: python setup.py egg_info
 
-
       - restore_cache:
           key: system-deps-geth-{{ checksum "/tmp/geth-version" }}-solc-{{ checksum "/tmp/solc-version" }}
 
       - run:
-          name: Installing system dependencies
-          command: |
-            GETH_PATH="${HOME}/.local/bin/geth-${OS_NAME}-${GETH_VERSION}"
-            if [ ! -x ${GETH_PATH} ]; then
-              mkdir -p ${HOME}/.local/bin
-              TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'gethtmp')
-              pushd ${TEMP}
-              GETH_URL_VAR="GETH_URL_${OS_NAME}"
-              wget -O geth.tar.gz ${!GETH_URL_VAR}
-              tar xzf geth.tar.gz
-              cd geth*/
-              install -m 755 geth ${GETH_PATH}
-            fi
-            ln -sf ${GETH_PATH} ${HOME}/.local/bin/geth
-            SOLC_PATH="${HOME}/.local/bin/solc-${OS_NAME}-${SOLC_VERSION}"
-            if [ ! -x ${SOLC_PATH} ]; then
-              mkdir -p ${HOME}/.local/bin
-              SOLC_URL_VAR="SOLC_URL_${OS_NAME}"
-              curl -L ${!SOLC_URL_VAR} > ${SOLC_PATH}
-              chmod 775 ${SOLC_PATH}
-            fi
-            ln -sf ${SOLC_PATH} ${HOME}/.local/bin/solc
+          name: Installing System Dependencies
+          command: .circleci/fetch_geth_solc.sh
       - save_cache:
           key: system-deps-geth-{{ checksum "/tmp/geth-version" }}-solc-{{ checksum "/tmp/solc-version" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,9 @@ commands:
           key: system-deps-geth-{{ checksum "/tmp/geth-version" }}-solc-{{ checksum "/tmp/solc-version" }}
           paths:
           - "~/.local"
+      - run:
+          name: Fetch PR Base Commit
+          command: source .circleci/fetch_pr_base_commit.sh
       - persist_to_workspace:
           root: "~"
           paths:
@@ -401,6 +404,7 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
       - config-path
       - run:
           name: Report to Codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,13 @@ executors:
 
 
 commands:
+  conditional-skip:
+    description: "Check commit message for skip tag and skip job if found"
+    steps:
+      - run:
+          name: Skip Tag Check
+          command: source .circleci/conditional_skip.sh
+
   config-path:
     description: "set environment variables and change path to use venv"
     steps:
@@ -85,6 +92,7 @@ commands:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
       - config-path
       - restore_cache:
           key: pip-cache-<< parameters.py-version >>
@@ -215,12 +223,13 @@ jobs:
     steps:
     - attach_workspace:
         at: "~"
+    - conditional-skip
     - config-path
     - run:
         name: Validate CircleCI Config
         command: python tools/check_circleci_config.py
     - run:
-        name: lint test
+        name: Run Lint
         command: make lint
 
   mypy:
@@ -235,13 +244,8 @@ jobs:
     steps:
     - attach_workspace:
         at: "~"
+    - conditional-skip
     - config-path
-    - run:
-        name: install requirements for mypy check
-        command: pip install -r requirements-lint.txt
-    - run:
-        name: ""
-        command: git rev-parse HEAD
     - run:
         name: mypy test
         command: make mypy
@@ -257,6 +261,7 @@ jobs:
     steps:
     - attach_workspace:
         at: "~"
+    - conditional-skip
     - config-path
     - run:
         name: Set Options
@@ -298,6 +303,7 @@ jobs:
     steps:
     - attach_workspace:
         at: "~"
+    - conditional-skip
     - config-path
     - restore_cache:
         key: ethash-{{ checksum "~/.local/bin/geth" }}
@@ -406,6 +412,8 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
+      - config-path
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -427,6 +435,8 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
+      - config-path
       - run:
           name: Prepare build
           command: |
@@ -452,6 +462,8 @@ jobs:
             - "46:b3:a5:c3:d8:21:63:cd:de:6d:07:5d:0c:5d:ba:73"
       - attach_workspace:
           at: "~"
+      - conditional-skip
+      - config-path
       - run:
           name: Configure Git
           command: |
@@ -489,6 +501,7 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
       - config-path
       - run:
           name: upload-to-digitalocean
@@ -501,6 +514,7 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
       - when:
           condition: ${CIRCLE_TAG} && ${GITHUB_TOKEN}
           steps:
@@ -519,6 +533,7 @@ jobs:
     steps:
       - attach_workspace:
           at: "~"
+      - conditional-skip
       - config-path
       - run:
           name: "install twine"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,11 +217,8 @@ jobs:
         at: "~"
     - config-path
     - run:
-        name: install requirements for lint check
-        command: pip install -r requirements-lint.txt
-    - run:
-        name: ""
-        command: git rev-parse HEAD
+        name: Validate CircleCI Config
+        command: python tools/check_circleci_config.py
     - run:
         name: lint test
         command: make lint
@@ -739,8 +736,8 @@ workflows:
 
       - test:
           name: test-integration-udp-3.7
-          resource: "medium"
           py-version: "3.7"
+          resource: "medium+"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "udp"
@@ -753,7 +750,7 @@ workflows:
       - test:
           name: test-integration-matrix-3.7
           py-version: "3.7"
-          resource: "medium"
+          resource: "medium+"
           test-type: "integration"
           blockchain-type: "geth"
           transport-layer: "matrix"

--- a/.circleci/fetch_geth_solc.sh
+++ b/.circleci/fetch_geth_solc.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+GETH_PATH="${HOME}/.local/bin/geth-${OS_NAME}-${GETH_VERSION}"
+if [[ ! -x ${GETH_PATH} ]]; then
+  mkdir -p ${HOME}/.local/bin
+  TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'gethtmp')
+  pushd ${TEMP}
+  GETH_URL_VAR="GETH_URL_${OS_NAME}"
+  wget -O geth.tar.gz ${!GETH_URL_VAR}
+  tar xzf geth.tar.gz
+  cd geth*/
+  install -m 755 geth ${GETH_PATH}
+fi
+ln -sf ${GETH_PATH} ${HOME}/.local/bin/geth
+
+SOLC_PATH="${HOME}/.local/bin/solc-${OS_NAME}-${SOLC_VERSION}"
+if [[ ! -x ${SOLC_PATH} ]]; then
+  mkdir -p ${HOME}/.local/bin
+  SOLC_URL_VAR="SOLC_URL_${OS_NAME}"
+  curl -L ${!SOLC_URL_VAR} > ${SOLC_PATH}
+  chmod 775 ${SOLC_PATH}
+fi
+ln -sf ${SOLC_PATH} ${HOME}/.local/bin/solc

--- a/.circleci/fetch_pr_base_commit.sh
+++ b/.circleci/fetch_pr_base_commit.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+    # If this is a PR get the base commit from the GitHub API
+    PR_DETAILS_URL="https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}"
+    BASE_COMMIT=$(curl ${PR_DETAILS_URL} | jq -r .base.sha)
+    if [[ ${BASE_COMMIT} =~ ^[0-9a-zA-Z]{40}$ ]]; then
+        echo ${BASE_COMMIT} > ~/.local/BASE_COMMIT
+    fi
+fi

--- a/raiden.spec
+++ b/raiden.spec
@@ -63,7 +63,7 @@ def Entrypoint(dist, group, name, scripts=None, pathex=None, hiddenimports=None,
 if hasattr(pdb, 'pdb'):
     # pdbpp moves the stdlib pdb to the `pdb` attribute of it's own patched pdb module
     raise RuntimeError(
-        'pdbpp is installed with causes broken PyInstaller builds. Please uninstall it.',
+        'pdbpp is installed which causes broken PyInstaller builds. Please uninstall it.',
     )
 
 

--- a/raiden.spec
+++ b/raiden.spec
@@ -1,8 +1,8 @@
 # -*- mode: python -*-
 from __future__ import print_function
 import sys
+import pdb
 import platform
-from distutils.spawn import find_executable
 
 from raiden.utils import get_system_spec
 
@@ -57,6 +57,13 @@ def Entrypoint(dist, group, name, scripts=None, pathex=None, hiddenimports=None,
         excludes=excludes,
         runtime_hooks=runtime_hooks,
         datas=datas
+    )
+
+
+if hasattr(pdb, 'pdb'):
+    # pdbpp moves the stdlib pdb to the `pdb` attribute of it's own patched pdb module
+    raise RuntimeError(
+        'pdbpp is installed with causes broken PyInstaller builds. Please uninstall it.',
     )
 
 

--- a/tools/check_circleci_config.py
+++ b/tools/check_circleci_config.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+"""
+Utility to ensure correctness of the CircleCI workflow
+"""
+import sys
+from difflib import unified_diff
+
+import click
+import yaml
+from yaml.parser import ParserError
+
+
+def _red(string):
+    return click.style(string, fg='red')
+
+
+def _green(string):
+    return click.style(string, fg='green')
+
+
+def _yellow(string):
+    return click.style(string, fg='yellow')
+
+
+def _check_workflows_align(config):
+    """
+    Ensure that the common shared jobs in the `raiden-default` and `nightly` workflows are
+    identical.
+    """
+
+    jobs_default = config['workflows']['raiden-default']['jobs']
+    jobs_nightly = config['workflows']['nightly']['jobs']
+
+    if jobs_default == jobs_nightly[:len(jobs_default)]:
+        return True, []
+
+    job_diff = unified_diff(
+        [f"{line}\n" for line in jobs_default],
+        [f"{line}\n" for line in jobs_nightly[:len(jobs_default)]],
+        'raiden-default',
+        'nightly',
+    )
+    message = [
+        _yellow(
+            "Mismatch in common items of workflow definitions 'raiden-default' and "
+            "'nightly':\n",
+        ),
+    ]
+    for line in job_diff:
+        if line.startswith('-'):
+            message.append(_red(line))
+        elif line.startswith('+'):
+            message.append(_green(line))
+        else:
+            message.append(line)
+
+    return False, ''.join(message)
+
+
+@click.command()
+@click.argument('circle-config-file', type=click.File('rt'), default='.circleci/config.yml')
+def main(circle_config_file):
+    try:
+        config = yaml.safe_load(circle_config_file)
+    except ParserError as ex:
+        click.secho(f'Invalid yaml file: {ex}', fg='red')
+        sys.exit(1)
+
+    result, message = _check_workflows_align(config)
+    if result is False:
+        click.echo(message)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This includes a few fixes / improvements for CircleCI and deployment:

- Add check for consistent CircleCI workflows
  Prevents the `raiden-default` and `nightly` workflows from diverging
- Allow skipping tests via commit message tag `[skip tests]`
  Other than the builtin `[skip ci]` tag this prevents the tests from running but will still report a valid commit status back to GitHub
- Fix missing job dependency for CircleCI macOS deployment
  The nightly macOS deploy job was missing a dependency
- Prevent PyInstaller from creating broken binaries 
  When `pdbpp` is installed PyInstaller creates broken binaries due to import path hacking performed by pdbpp