### PR TITLE
Fix high CPU usage when idle.

### DIFF
--- a/.circleci/conditional_skip.sh
+++ b/.circleci/conditional_skip.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Seems that circle calls this script with -e and we don't want
+# grep failure to stop the build
+set +e
+
 SKIP_TAG="\[skip tests\]"
 
 if [[ -a ~/.local/BASE_COMMIT ]]; then
@@ -16,3 +20,4 @@ if [[ ${PIPESTATUS[1]} == 0 ]]; then
     echo Skip tag found - skipping build
     circleci step halt
 fi
+set -e

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3369` Fix high CPU usage when the raiden node is idle.
 * :feature:`-` Set python 3.7 as a minimum python version requirement to run Raiden.
 
 * :release:`0.100.2-rc3 <2019-01-25>`

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -102,7 +102,6 @@ class AlarmTask(Runnable):
         self.chain = chain
         self.chain_id = None
         self.known_block_number = None
-        self._stop_event = AsyncResult()
 
         # TODO: Start with a larger sleep_time and decrease it as the
         # probability of a new block increases.
@@ -110,7 +109,7 @@ class AlarmTask(Runnable):
 
     def start(self):
         log.debug('Alarm task started', node=pex(self.chain.node_address))
-        self._stop_event.set(False)
+        self._stop_event = AsyncResult()
         super().start()
 
     def _run(self):  # pylint: disable=method-hidden


### PR DESCRIPTION

Merge after #3371

----

Fix #3369

The commit which introduced this problem was
7e6dd0f

That commit had tried to fix the restart tests by resetting the alarm task's
`_stop_event` to `False` whenever a new alarm task is started during
tests.

The problem with this approach is that setting an `AsyncResult()` to
`False` at the very beginning, gives it a value. So by having a value
here:

https://github.com/raiden-network/raiden/blob/e76687c5d4dc8c6dd8888719ea60243f37c9a945/raiden/tasks.py#L151-L158

`self._stop_event.wait(sleep_time)` does not actually do any
sleeping. That's because the `AsyncResult` already has a value as we
can also see in the documentation
[here](http://www.gevent.org/api/gevent.event.html#gevent.event.AsyncResult.wait).

> If this instance already holds a value, it is returned immediately. If this instance already holds an exception, None is returned immediately.