### PR TITLE
Remove install_synapse.sh from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,6 @@ isolate the python dependencies used by Raiden from your system:
 Install the development dependencies:
 
     pip install -r requirements-dev.txt -c constraints.txt
-    ./tools/install_synapse.sh
 
 ## Development Guidelines
 


### PR DESCRIPTION
Since 66c86686722dcc528f9d20f8a95a5bf31d6e972e no separate steps for installing Synapse are required.