### PR TITLE
Add monitoring message

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -19,7 +19,7 @@ from raiden.exceptions import (
     TokenNotRegistered,
     UnknownTokenAddress,
 )
-from raiden.messages import RequestMonitoring, SignedBlindedBalanceProof
+from raiden.messages import RequestMonitoring
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
 from raiden.transfer import architecture, views
 from raiden.transfer.events import (
@@ -839,17 +839,9 @@ class RaidenAPI:
         for the `balance_proof` that we received from a channel partner.
         - claim the `reward_amount` from the UDC.
         """
-        assert isinstance(balance_proof, BalanceProofSignedState)
-
-        # create submessage `SignedBlindedBalanceProof` and create the `non_closing_signature`
-        onchain_balance_proof = SignedBlindedBalanceProof.from_balance_proof_signed_state(
-            balance_proof,
-        )
-        onchain_balance_proof.sign(self.raiden.signer)
-
         # create RequestMonitoring message from the above + `reward_amount`
-        monitor_request = RequestMonitoring(
-            onchain_balance_proof=onchain_balance_proof,
+        monitor_request = RequestMonitoring.from_balance_proof_signed_state(
+            balance_proof=balance_proof,
             reward_amount=reward_amount,
         )
         # sign RequestMonitoring and return

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -49,6 +49,7 @@ channel_identifier = make_field('channel_identifier', 32, '32s', integer(0, UINT
 locksroot = make_field('locksroot', 32, '32s')
 secrethash = make_field('secrethash', 32, '32s')
 balance_hash = make_field('balance_hash', 32, '32s')
+additional_hash = make_field('additional_hash', 32, '32s')
 secret = make_field('secret', 32, '32s')
 transferred_amount = make_field('transferred_amount', 32, '32s', integer(0, UINT256_MAX))
 locked_amount = make_field('locked_amount', 32, '32s', integer(0, UINT256_MAX))
@@ -237,6 +238,7 @@ RequestMonitoring = namedbuffer(
         token_network_address,
         channel_identifier,
         balance_hash,
+        additional_hash,
         signature,
         non_closing_signature,
         reward_amount,

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -19,6 +19,7 @@ REFUNDTRANSFER = 8
 REVEALSECRET = 11
 DELIVERED = 12
 LOCKEXPIRED = 13
+REQUESTMONITORING = 20
 
 
 # pylint: disable=invalid-name
@@ -47,13 +48,17 @@ channel_identifier = make_field('channel_identifier', 32, '32s', integer(0, UINT
 
 locksroot = make_field('locksroot', 32, '32s')
 secrethash = make_field('secrethash', 32, '32s')
+balance_hash = make_field('balance_hash', 32, '32s')
 secret = make_field('secret', 32, '32s')
 transferred_amount = make_field('transferred_amount', 32, '32s', integer(0, UINT256_MAX))
 locked_amount = make_field('locked_amount', 32, '32s', integer(0, UINT256_MAX))
 amount = make_field('amount', 32, '32s', integer(0, UINT256_MAX))
+reward_amount = make_field('reward_amount', 32, '32s', integer(0, UINT256_MAX))
 fee = make_field('fee', 32, '32s', integer(0, UINT256_MAX))
 
 signature = make_field('signature', 65, '65s')
+non_closing_signature = make_field('non_closing_signature', 65, '65s')
+reward_proof_signature = make_field('reward_proof_signature', 65, '65s')
 
 Processed = namedbuffer(
     'processed',
@@ -222,6 +227,23 @@ Lock = namedbuffer(
 )
 
 
+RequestMonitoring = namedbuffer(
+    'request_monitoring',
+    [
+        cmdid(REQUESTMONITORING),
+        pad(3),
+        nonce,
+        chain_id,
+        token_network_address,
+        channel_identifier,
+        balance_hash,
+        signature,
+        non_closing_signature,
+        reward_amount,
+        reward_proof_signature,
+    ],
+)
+
 CMDID_MESSAGE = {
     PROCESSED: Processed,
     PING: Ping,
@@ -233,6 +255,7 @@ CMDID_MESSAGE = {
     REFUNDTRANSFER: RefundTransfer,
     DELIVERED: Delivered,
     LOCKEXPIRED: LockExpired,
+    REQUESTMONITORING: RequestMonitoring,
 }
 
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1604,6 +1604,10 @@ class RequestMonitoring(SignedMessage):
         self.signature = signer.sign(data=message_data)
 
     def pack(self, packed: bytes) -> bytes:
+        if self.non_closing_signature is None:
+            raise ValueError('non_closing_signature missing, did you forget to sign()?')
+        if self.reward_proof_signature is None:
+            raise ValueError('reward_proof_signature missing, did you forget to sign()?')
         packed.nonce = self.balance_proof.nonce
         packed.chain_id = self.balance_proof.chain_id
         packed.token_network_address = self.balance_proof.token_network_address

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -14,7 +14,11 @@ from raiden.encoding import messages
 from raiden.encoding.format import buffer_for
 from raiden.exceptions import InvalidProtocolMessage, InvalidSignature
 from raiden.transfer.architecture import SendMessageEvent
-from raiden.transfer.balance_proof import pack_balance_proof, pack_balance_proof_update
+from raiden.transfer.balance_proof import (
+    pack_balance_proof,
+    pack_balance_proof_update,
+    pack_reward_proof,
+)
 from raiden.transfer.events import SendProcessed
 from raiden.transfer.mediated_transfer.events import (
     SendBalanceProof,
@@ -28,7 +32,6 @@ from raiden.transfer.state import BalanceProofSignedState, HashTimeLockState
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import ishash, pex, sha3, typing
 from raiden.utils.signer import Signer, recover
-from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
     Address,
     BlockExpiration,
@@ -1594,19 +1597,13 @@ class RequestMonitoring(SignedMessage):
 
     def _data_to_sign(self) -> bytes:
         """ Return the binary data to be/which was signed """
-        packed = pack_data([
-            'uint256',
-            'uint256',
-            'address',
-            'uint256',
-            'uint256',
-        ], [
+        packed = pack_reward_proof(
             self.balance_proof.channel_identifier,
             self.reward_amount,
             self.balance_proof.token_network_address,
             self.balance_proof.chain_id,
             self.balance_proof.nonce,
-        ])
+        )
         return packed
 
     def sign(self, signer: Signer):

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1542,6 +1542,21 @@ class RequestMonitoring(SignedMessage):
         else:
             self.signature = None
 
+    @classmethod
+    def from_balance_proof_signed_state(
+            cls: typing.Type[typing.T_SignedBlindedBalanceProof],
+            balance_proof: BalanceProofSignedState,
+            reward_amount: typing.TokenAmount,
+    ) -> typing.T_RequestMonitoring:
+        assert isinstance(balance_proof, BalanceProofSignedState)
+        onchain_balance_proof = SignedBlindedBalanceProof.from_balance_proof_signed_state(
+            balance_proof=balance_proof,
+        )
+        return cls(
+            onchain_balance_proof=onchain_balance_proof,
+            reward_amount=reward_amount,
+        )
+
     @property
     def reward_proof_signature(self) -> typing.Signature:
         return self.signature

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -49,21 +49,20 @@ def test_amount_out_of_bounds(amount, make):
 
 
 def test_request_monitoring():
-    balance_proof = make_balance_proof(signer=signer, amount=1)
+    partner_signer = LocalSigner(PARTNER_PRIVKEY)
+    balance_proof = make_balance_proof(signer=partner_signer, amount=1)
     partner_signed_balance_proof = SignedBlindedBalanceProof.from_balance_proof_signed_state(
         balance_proof,
     )
-    with pytest.raises(ValueError):
-        request_monitoring = RequestMonitoring(
-            onchain_balance_proof=partner_signed_balance_proof,
-            reward_amount=55,
-        )
-    partner_signer = LocalSigner(PARTNER_PRIVKEY)
-    partner_signed_balance_proof.sign(partner_signer)
     request_monitoring = RequestMonitoring(
         onchain_balance_proof=partner_signed_balance_proof,
         reward_amount=55,
     )
     assert request_monitoring
-    request_monitoring.sign(partner_signer)
-    assert RequestMonitoring.from_dict(request_monitoring.to_dict()) == request_monitoring
+    with pytest.raises(ValueError):
+        request_monitoring.to_dict()
+    request_monitoring.sign(signer)
+    as_dict = request_monitoring.to_dict()
+    assert RequestMonitoring.from_dict(as_dict) == request_monitoring
+    packed = request_monitoring.pack(request_monitoring.packed())
+    assert RequestMonitoring.unpack(packed) == request_monitoring

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -66,3 +66,23 @@ def test_request_monitoring():
     assert RequestMonitoring.from_dict(as_dict) == request_monitoring
     packed = request_monitoring.pack(request_monitoring.packed())
     assert RequestMonitoring.unpack(packed) == request_monitoring
+    # RequestMonitoring can be created directly from BalanceProofSignedState
+    direct_created = RequestMonitoring.from_balance_proof_signed_state(
+        balance_proof,
+        reward_amount=55,
+    )
+    with pytest.raises(ValueError):
+        # equality test uses `validated` packed format
+        assert direct_created == request_monitoring
+
+    direct_created.sign(signer)
+    # Instances created from same balance proof are equal
+    assert direct_created == request_monitoring
+    other_balance_proof = make_balance_proof(signer=partner_signer, amount=2)
+    other_instance = RequestMonitoring.from_balance_proof_signed_state(
+        other_balance_proof,
+        reward_amount=55,
+    )
+    other_instance.sign(signer)
+    # different balance proof ==> non-equality
+    assert other_instance != request_monitoring

--- a/raiden/tests/utils/messages.py
+++ b/raiden/tests/utils/messages.py
@@ -6,8 +6,9 @@ from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.messages import Lock, LockedTransfer, RefundTransfer
 from raiden.tests.utils.factories import UNIT_CHAIN_ID, UNIT_CHANNEL_ID, make_privkey_address
 from raiden.tests.utils.tests import fixture_all_combinations
-from raiden.transfer.state import EMPTY_MERKLE_ROOT
+from raiden.transfer.state import EMPTY_MERKLE_ROOT, balanceproof_from_envelope
 from raiden.utils import sha3
+from raiden.utils.signer import Signer
 
 PRIVKEY, ADDRESS = make_privkey_address()
 INVALID_ADDRESSES = [
@@ -159,3 +160,43 @@ def make_mediated_transfer(
         initiator=initiator,
         fee=fee,
     )
+
+
+def make_balance_proof(
+        signer: Signer = None,
+        message_identifier=None,
+        payment_identifier=0,
+        nonce=1,
+        token_network_addresss=ADDRESS,
+        token=ADDRESS,
+        channel_identifier=UNIT_CHANNEL_ID,
+        transferred_amount=0,
+        locked_amount=None,
+        amount=1,
+        expiration=1,
+        locksroot=EMPTY_MERKLE_ROOT,
+        recipient=ADDRESS,
+        target=ADDRESS,
+        initiator=ADDRESS,
+        fee=0,
+):
+    mediated_transfer = make_mediated_transfer(
+        message_identifier=message_identifier,
+        payment_identifier=payment_identifier,
+        nonce=nonce,
+        token_network_addresss=token_network_addresss,
+        token=token,
+        channel_identifier=channel_identifier,
+        transferred_amount=transferred_amount,
+        locked_amount=locked_amount,
+        amount=amount,
+        expiration=expiration,
+        locksroot=locksroot,
+        recipient=recipient,
+        target=target,
+        initiator=initiator,
+        fee=fee,
+    )
+    mediated_transfer.sign(signer)
+    balance_proof = balanceproof_from_envelope(mediated_transfer)
+    return balance_proof

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -6,6 +6,7 @@ from raiden.utils.typing import (
     ChannelID,
     Nonce,
     Signature,
+    TokenAmount,
     TokenNetworkID,
 )
 from raiden_contracts.constants import MessageTypeId
@@ -67,3 +68,25 @@ def pack_balance_proof_update(
         chain_id=chain_id,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
     ) + partner_signature
+
+
+def pack_reward_proof(
+        channel_identifier: ChannelID,
+        reward_amount: TokenAmount,
+        token_network_address: TokenNetworkID,
+        chain_id: ChainID,
+        nonce: Nonce,
+) -> bytes:
+    return pack_data([
+        'uint256',
+        'uint256',
+        'address',
+        'uint256',
+        'uint256',
+    ], [
+        channel_identifier,
+        reward_amount,
+        token_network_address,
+        chain_id,
+        nonce,
+    ])

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -121,8 +121,15 @@ SecretRegistryAddress = NewType('SecretRegistryAddress', T_SecretRegistryAddress
 T_Signature = bytes
 Signature = NewType('Signature', T_Signature)
 
-SignedBlindedBalanceProof = TypeVar('SignedBlindedBalanceProof', bound='SignedBlindedBalanceProof')
-RequestMonitoring = TypeVar('RequestMonitoring', bound='RequestMonitoring')
+T_SignedBlindedBalanceProof = TypeVar(
+    'T_SignedBlindedBalanceProof',
+    bound='raiden.messages.SignedBlindedBalanceProof',
+)
+
+T_RequestMonitoring = TypeVar(
+    'T_RequestMonitoring',
+    bound='raiden.messages.RequestMonitoring',
+)
 
 T_TransactionHash = bytes
 TransactionHash = NewType('TransactionHash', T_TransactionHash)

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -1,5 +1,5 @@
 from typing import *  # NOQA pylint:disable=wildcard-import,unused-wildcard-import
-from typing import Dict, List, NewType, Optional, Tuple, Union
+from typing import Dict, List, NewType, Optional, Tuple, TypeVar, Union
 
 MYPY_ANNOTATION = (
     'This assert is used to tell mypy what is the type of the variable'
@@ -120,6 +120,9 @@ SecretRegistryAddress = NewType('SecretRegistryAddress', T_SecretRegistryAddress
 
 T_Signature = bytes
 Signature = NewType('Signature', T_Signature)
+
+SignedBlindedBalanceProof = TypeVar('SignedBlindedBalanceProof', bound='SignedBlindedBalanceProof')
+RequestMonitoring = TypeVar('RequestMonitoring', bound='RequestMonitoring')
 
 T_TransactionHash = bytes
 TransactionHash = NewType('TransactionHash', T_TransactionHash)


### PR DESCRIPTION
This
- adds an encoding spec for `RequestMonitoring` messages
- the message `RequestMonitoring`
- and finally a **python** API endpoint                                                                
                                                                                                      
        create_monitoring_request(                                                                    
            balance_proof,                                                                       
            reward_amount,                                                                            
        )                                                                                             
                                                                                                      
that will create a signed `RequestMonitoring` message from the (signed) partner's `balance_proof` and the given `reward_amount`.   
 
Bundling the message creation in `RaidenAPI` allows for flexible integration of the actual monitoring requests throughout the client, or even for external services, client plugins, etc...
                                                                                              
This implements the **only** first bullet point of #1432, unit tests are missing still, but an integration test ensures                                         
- basic (de-)serialization works                                                                      
- creation of the message from minimal input (see API above) works

**Edit Note**: an earlier draft of this PR, the API method tried to identify the balance proof by `payment_identifier`, [which does not work.](https://github.com/raiden-network/raiden/pull/3374#discussion_r253424042) This version tries to create only the most minimal interface for creating `RequestMonitoring` messages, without making any assumptions about the client integration.

Since this is a prerequisite for the MS team to proceed, I'd like to ask for review and (potential) merging, without the added unit tests ASAP. 
We will keep #1432 open, until comprehensive tests for the message are added.