### PR TITLE
Generalized HoldOffChainSecretRequest to any event

### DIFF
--- a/raiden/tests/utils/protocol.py
+++ b/raiden/tests/utils/protocol.py
@@ -2,14 +2,14 @@ from collections import defaultdict
 from unittest.mock import patch
 
 import structlog
-from gevent.event import Event
+from gevent.event import AsyncResult, Event as GeventEvent
 
 from raiden.message_handler import MessageHandler
 from raiden.messages import Message
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.raiden_service import RaidenService
 from raiden.tests.utils.events import check_nested_attrs
-from raiden.transfer.architecture import TransitionResult
+from raiden.transfer.architecture import Event as RaidenEvent, TransitionResult
 from raiden.transfer.mediated_transfer.events import SendBalanceProof, SendSecretRequest
 from raiden.utils import pex, typing
 
@@ -18,19 +18,14 @@ log = structlog.get_logger(__name__)
 
 class MessageWaiting(typing.NamedTuple):
     attributes: dict
-    message_received_event: Event
+    message_received_event: GeventEvent
 
 
-class SendSecretRequestState(typing.NamedTuple):
-    secrethash: bytes
-    secret_request_available: Event
-    secret_request_event: typing.Optional[SendSecretRequest]
-
-
-class SendBalanceProofState(typing.NamedTuple):
-    secrethash: bytes
-    secret_request_available: Event
-    balance_proof_event: typing.Optional[SendBalanceProof]
+class Hold(typing.NamedTuple):
+    event: RaidenEvent
+    event_type: type
+    async_result: AsyncResult
+    attributes: typing.Dict
 
 
 class WaitForMessage(MessageHandler):
@@ -39,7 +34,7 @@ class WaitForMessage(MessageHandler):
 
     def wait_for_message(self, message_type: Message, attributes: dict):
         assert not any(attributes == waiting.attributes for waiting in self.waiting[message_type])
-        event = Event()
+        event = GeventEvent()
         self.waiting[message_type].append(MessageWaiting(attributes, event))
         return event
 
@@ -53,105 +48,91 @@ class WaitForMessage(MessageHandler):
                 waiting.message_received_event.set()
 
 
-class HoldOffChainSecretRequest(RaidenEventHandler):
-    """ Use this handler to stop the target from requesting the secret.
+class HoldRaidenEvent(RaidenEventHandler):
+    """ Use this handler to stop the node from processing an event.
 
-    This is used to simulate network communication problems. The message
-    SecretRequest is used because the participants state can be expected to be
-    consistent.
+    This is useful:
+    - Simulate network communication problems, by delaying when protocol
+      messages are sent.
+    - Simulate blockchain congestion, by delaying transactions.
+    - Wait for a given state of the protocol, by waiting for an event to be
+      available.
     """
 
     def __init__(self):
-        self.secrethashes_to_holdsecretrequest = dict()
-        self.secrethashes_to_holdbalanceproof = dict()
+        self.eventtype_to_holds = defaultdict(list)
 
-    def hold_secretrequest_for(self, secrethash: typing.SecretHash):
-        assert secrethash not in self.secrethashes_to_holdsecretrequest
+    def on_raiden_event(self, raiden: RaidenService, event: RaidenEvent):
+        holds = self.eventtype_to_holds[type(event)]
+        found = None
 
-        waiting_event = Event()
-        self.secrethashes_to_holdsecretrequest[secrethash] = SendSecretRequestState(
-            secrethash=secrethash,
-            secret_request_available=waiting_event,
-            secret_request_event=None,
+        for pos, hold in enumerate(holds):
+            if check_nested_attrs(event, hold.attributes):
+                msg = (
+                    'Same event emitted twice, should not happen. '
+                    'Either there is a bug in the state machine or '
+                    'the hold.attributes is too generic and multiple '
+                    'different events are matching.'
+                )
+                assert hold.event is None, msg
+
+                newhold = hold._replace(event=event)
+                found = (pos, newhold)
+                break
+
+        if found is not None:
+            hold = found[1]
+            holds[found[0]] = found[1]
+            hold.async_result.set(event)
+        else:
+            super().on_raiden_event(raiden, event)
+
+    def hold(self, event_type: type, attributes: typing.Dict) -> AsyncResult:
+        hold = Hold(
+            event=None,
+            event_type=event_type,
+            async_result=AsyncResult(),
+            attributes=attributes,
         )
+        self.eventtype_to_holds[event_type].append(hold)
+        log.debug(f'Hold for {event_type.__name__} with {attributes} created.')
+        return hold.async_result
 
-        return waiting_event
+    def release(self, raiden: RaidenService, event: RaidenEvent):
+        holds = self.eventtype_to_holds[type(event)]
+        found = None
+
+        for pos, hold in enumerate(holds):
+            if hold.event == event:
+                found = (pos, hold)
+                break
+
+        msg = (
+            'Cannot release unknown event. '
+            'Either it was never held, the event was not emited yet, '
+            'or it was released twice.'
+        )
+        assert found is not None, msg
+
+        hold = holds.pop(found[0])
+        super().on_raiden_event(raiden, event)
+        log.debug(f'{event} released.', node=pex(raiden.address))
+
+    def hold_secretrequest_for(self, secrethash: typing.SecretHash) -> AsyncResult:
+        return self.hold(SendSecretRequest, {'secrethash': secrethash})
 
     def hold_unlock_for(self, secrethash: typing.SecretHash):
-        assert secrethash not in self.secrethashes_to_holdbalanceproof
-
-        waiting_event = Event()
-        self.secrethashes_to_holdbalanceproof[secrethash] = SendBalanceProofState(
-            secrethash=secrethash,
-            secret_request_available=waiting_event,
-            balance_proof_event=None,
-        )
-
-        return waiting_event
+        return self.hold(SendBalanceProof, {'secrethash': secrethash})
 
     def release_secretrequest_for(self, raiden: RaidenService, secrethash: typing.SecretHash):
-        hold_state = self.secrethashes_to_holdsecretrequest.get(secrethash)
-
-        if hold_state and hold_state.secret_request_available.is_set():
-            secret_request_event = hold_state.secret_request_event
-            assert secret_request_event
-            del self.secrethashes_to_holdsecretrequest[secrethash]
-
-            super().handle_send_secretrequest(raiden, secret_request_event)
-            log.info(
-                f'SecretRequest for {pex(secret_request_event.secrethash)} released.',
-                node=pex(raiden.address),
-            )
+        for hold in self.eventtype_to_holds[SendSecretRequest]:
+            if hold.attributes['secrethash'] == secrethash:
+                self.release(raiden, hold.event)
 
     def release_unlock_for(self, raiden: RaidenService, secrethash: typing.SecretHash):
-        hold_state = self.secrethashes_to_holdbalanceproof.get(secrethash)
-
-        if hold_state and hold_state.secret_request_available.is_set():
-            secret_request_event = hold_state.secret_request_event
-            assert secret_request_event
-            del self.secrethashes_to_holdbalanceproof[secrethash]
-
-            super().handle_send_secretrequest(raiden, secret_request_event)
-            log.info(
-                f'SecretRequest for {pex(secret_request_event.secrethash)} released.',
-                node=pex(raiden.address),
-            )
-
-    def handle_send_secretrequest(
-            self,
-            raiden: RaidenService,
-            secret_request_event: SendSecretRequest,
-    ):
-        hold_state = self.secrethashes_to_holdsecretrequest.get(secret_request_event.secrethash)
-        if hold_state is None:
-            super().handle_send_secretrequest(raiden, secret_request_event)
-        else:
-            new_hold_state = hold_state._replace(secret_request_event=secret_request_event)
-            new_hold_state.secret_request_available.set()
-            self.secrethashes_to_holdsecretrequest[
-                secret_request_event.secrethash
-            ] = new_hold_state
-            log.info(
-                f'SendSecretRequest for {pex(secret_request_event.secrethash)} held.',
-                node=pex(raiden.address),
-            )
-
-    def handle_send_balanceproof(
-            self,
-            raiden: RaidenService,
-            balance_proof_event: SendBalanceProof,
-    ):
-        hold_state = self.secrethashes_to_holdbalanceproof.get(balance_proof_event.secrethash)
-        if hold_state is None:
-            super().handle_send_secretrequest(raiden, balance_proof_event)
-        else:
-            new_hold_state = hold_state._replace(balance_proof_event=balance_proof_event)
-            new_hold_state.secret_request_available.set()
-            self.secrethashes_to_holdbalanceproof[balance_proof_event.secrethash] = new_hold_state
-            log.info(
-                f'SendBalanceProof for {pex(balance_proof_event.secrethash)} held.',
-                node=pex(raiden.address),
-            )
+        for hold in self.eventtype_to_holds[SendBalanceProof]:
+            if hold.attributes['secrethash'] == secrethash:
+                self.release(raiden, hold.event)
 
 
 def dont_handle_secret_request_mock(app):
@@ -203,3 +184,7 @@ def dont_handle_node_change_network_state():
         'raiden.transfer.node.handle_node_change_network_state',
         empty_state_transition,
     )
+
+
+# backwards compatibility
+HoldOffChainSecretRequest = HoldRaidenEvent


### PR DESCRIPTION
This commit makes the testing tool HoldOffChainSecretRequest more
generic, so that it can be used with any raiden event.