### PR TITLE
Gas reserve check was a no-op

### DIFF
--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -72,7 +72,7 @@ def check_gas_reserve(raiden):
     while True:
         has_enough_balance, estimated_required_balance = gas_reserve.has_enough_gas_reserve(
             raiden,
-            channels_to_open=0,
+            channels_to_open=1,
         )
         estimated_required_balance_eth = Web3.fromWei(estimated_required_balance, 'ether')
 


### PR DESCRIPTION
The periodical gas reserve check was checking if we have enough gas to
open `0` channels which was boiling down to a check `<= 0`. This commit
changes it to be checking for at least 1 channel