### PR TITLE
Connection manager no longer attempts to deposit if per partner funds are zero

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3380` Connection manager no longer attempts deposit if per partner funds are zero.
 * :bug:`3369` Fix high CPU usage when the raiden node is idle.
 * :feature:`-` Set python 3.7 as a minimum python version requirement to run Raiden.
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -7,6 +7,7 @@ from raiden.constants import GENESIS_BLOCK_NUMBER, Environment
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     ChannelNotFound,
+    DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
     InsufficientFunds,
@@ -406,6 +407,9 @@ class RaidenAPI:
                     deposit_limit,
                 ),
             )
+
+        if total_deposit == 0:
+            raise DepositMismatch('Attempted to deposit with total deposit being 0')
 
         addendum = total_deposit - channel_state.our_state.contract_balance
 

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -339,12 +339,16 @@ class ConnectionManager:
             # or it's nonfunded channel), continue to ensure it's funded
             pass
 
+        total_deposit = self._initial_funding_per_partner
+        if total_deposit == 0:
+            return
+
         try:
             self.api.set_total_channel_deposit(
-                self.registry_address,
-                self.token_address,
-                partner,
-                self._initial_funding_per_partner,
+                registry_address=self.registry_address,
+                token_address=self.token_address,
+                partner_address=partner,
+                total_deposit=total_deposit,
             )
         except InvalidDBData:
             raise

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -89,12 +89,20 @@ def test_channel_lifecycle(raiden_network, token_addresses, deposit, transport_p
     assert token_events[0]['event'] == ChannelEvent.OPENED
 
     registry_address = api1.raiden.default_registry.address
+    # Check that giving a 0 total deposit is not accepted
+    with pytest.raises(DepositMismatch):
+        api1.set_total_channel_deposit(
+            registry_address=registry_address,
+            token_address=token_address,
+            partner_address=api2.address,
+            total_deposit=0,
+        )
     # Load the new state with the deposit
     api1.set_total_channel_deposit(
-        registry_address,
-        token_address,
-        api2.address,
-        deposit,
+        registry_address=registry_address,
+        token_address=token_address,
+        partner_address=api2.address,
+        total_deposit=deposit,
     )
 
     # let's make sure it's idempotent. Same deposit should raise deposit mismatch limit


### PR DESCRIPTION
Fix #3380 

- The connection manager no longer attempts to deposit if per partner funds are zero.
- Invoking api's set total channel deposit with 0 funds is now rejected