### PR TITLE
Fix rest api

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -436,7 +436,10 @@ class APIServer(Runnable):
 
     def _run(self):
         try:
-            self.wsgiserver.serve_forever()
+            # stop may have been executed before _run was scheduled, in this
+            # case wsgiserver will be None
+            if self.wsgiserver is not None:
+                self.wsgiserver.serve_forever()
         except gevent.GreenletExit:  # pylint: disable=try-except-raise
             raise
         except Exception:

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -6,6 +6,7 @@ from http import HTTPStatus
 from typing import Dict
 
 import gevent
+import gevent.pool
 import structlog
 from eth_utils import encode_hex, to_checksum_address
 from flask import Flask, make_response, request, send_from_directory, url_for
@@ -456,11 +457,16 @@ class APIServer(Runnable):
         # WSGI expects an stdlib logger. With structlog there's conflict of
         # method names. Rest unhandled exception will be re-raised here:
         wsgi_log = logging.getLogger(__name__ + '.pywsgi')
+
+        # server.stop() clears the handle and the pool, this is okay since a
+        # new WSGIServer is created on each start
+        pool = gevent.pool.Pool()
         wsgiserver = WSGIServer(
             (self.config['host'], self.config['port']),
             self.flask_app,
             log=wsgi_log,
             error_log=wsgi_log,
+            spawn=pool,
         )
 
         try:

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -2,6 +2,7 @@ import socket
 
 import cachetools
 import gevent
+import gevent.pool
 import structlog
 from eth_utils import encode_hex, is_binary_address
 from gevent.event import AsyncResult, Event
@@ -194,7 +195,12 @@ class UDPTransport(Runnable):
         self.get_host_port = cache_wrapper(discovery.get)
 
         self.throttle_policy = throttle_policy
-        self.server = DatagramServer(udpsocket, handle=self.receive)
+        pool = gevent.pool.Pool()
+        self.server = DatagramServer(
+            udpsocket,
+            handle=self.receive,
+            spawn=pool,
+        )
 
     def start(
             self,
@@ -211,9 +217,11 @@ class UDPTransport(Runnable):
         self.log_healthcheck = log_healthcheck.bind(node=pex(self.raiden.address))
         self.message_handler = message_handler
 
-        # server.stop() clears the handle. Since this may be a restart the
-        # handle must always be set
+        # server.stop() clears the handle and the pool. Since this may be a
+        # restart the handle must always be set
         self.server.set_handle(self.receive)
+        pool = gevent.pool.Pool()
+        self.server.set_spawn(pool)
 
         self.server.start()
         self.log.debug('UDP started')

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -160,7 +160,7 @@ class UDPTransport(Runnable):
     def __init__(self, address, discovery, udpsocket, throttle_policy, config):
         super().__init__()
         # these values are initialized by the start method
-        self.queueids_to_queues = dict()
+        self.queueids_to_queues: typing.Dict = dict()
         self.raiden: RaidenService
         self.message_handler: MessageHandler
 
@@ -219,6 +219,8 @@ class UDPTransport(Runnable):
         self.log.debug('UDP started')
         super().start()
 
+        log.debug('UDP transport started')
+
     def _run(self):
         """ Runnable main method, perform wait on long-running subtasks """
         try:
@@ -262,7 +264,7 @@ class UDPTransport(Runnable):
         for async_result in self.messageids_to_asyncresults.values():
             async_result.set(False)
 
-        self.log.debug('UDP stopped')
+        log.debug('UDP stopped', node=pex(self.raiden.address))
         del self.log_healthcheck
         del self.log
 

--- a/raiden/tests/integration/api/utils.py
+++ b/raiden/tests/integration/api/utils.py
@@ -31,9 +31,9 @@ def wait_for_listening_port(
 def create_api_server(raiden_app: App, port_number: int) -> APIServer:
     raiden_api = RaidenAPI(raiden_app.raiden)
     rest_api = RestAPI(raiden_api)
-    api_server = APIServer(rest_api)
+    api_server = APIServer(rest_api, config={'host': 'localhost', 'port': port_number})
     api_server.flask_app.config['SERVER_NAME'] = 'localhost:{}'.format(port_number)
-    api_server.start(port=port_number)
+    api_server.start()
 
     # Fixes flaky test, were requests are done prior to the server initializing
     # the listening socket.

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -87,9 +87,12 @@ def _trimmed_logging(logger_level_config):
 def start_apiserver(raiden_app, rest_api_port_number):
     raiden_api = RaidenAPI(raiden_app.raiden)
     rest_api = RestAPI(raiden_api)
-    api_server = APIServer(rest_api)
+    api_server = APIServer(rest_api, config={'host': 'localhost', 'port': rest_api_port_number})
+
+    # required for url_for
     api_server.flask_app.config['SERVER_NAME'] = 'localhost:{}'.format(rest_api_port_number)
-    api_server.start(port=rest_api_port_number)
+
+    api_server.start()
 
     wait_for_listening_port(rest_api_port_number)
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -558,9 +558,9 @@ def smoketest(ctx, debug):
 
                 raiden_api = RaidenAPI(app.raiden)
                 rest_api = RestAPI(raiden_api)
-                api_server = APIServer(rest_api)
                 (api_host, api_port) = split_endpoint(args['api_address'])
-                api_server.start(api_host, api_port)
+                api_server = APIServer(rest_api, config={'host': api_host, 'port': api_port})
+                api_server.start()
 
                 raiden_api.channel_open(
                     registry_address=contract_addresses[CONTRACT_TOKEN_NETWORK_REGISTRY],

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -118,16 +118,17 @@ class NodeRunner:
 
         if self._options['rpc']:
             rest_api = RestAPI(self._raiden_api)
+            (api_host, api_port) = split_endpoint(self._options['api_address'])
             api_server = APIServer(
                 rest_api,
+                config={'host': api_host, 'port': api_port},
                 cors_domain_list=domain_list,
                 web_ui=self._options['web_ui'],
                 eth_rpc_endpoint=self._options['eth_rpc_endpoint'],
             )
-            (api_host, api_port) = split_endpoint(self._options['api_address'])
 
             try:
-                api_server.start(api_host, api_port)
+                api_server.start()
             except APIServerPortInUseError:
                 click.secho(
                     f'ERROR: API Address {api_host}:{api_port} is in use. '


### PR DESCRIPTION
This is a cherry pick of the fixes for the REST API and UDP transport from the stress test with crashes.

There are two problems:

- The greenlets spawned to handle the incoming HTTP requests and UDP packets are not tracked if an explicit pool is not used. During normal usage this is not a problem, but for tests it means there can be a greenlet from a previous test waiting to be scheduled, resulting in *another* test failing because the RaidenService is not running anymore
- The interface with host and port in `start` was a bit error prone, so for the stress test it's just better to save that as a configuration for the REST API, so that it can be restarted and use the same port number.

This should fix the failure encountered here: https://circleci.com/gh/raiden-network/raiden/18129#tests/containers/17