### PR TITLE
bugfix: flaky test_matrix_cross_server_with_load_balance

### DIFF
--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -468,16 +468,15 @@ def test_matrix_cross_server_with_load_balance(matrix_transports, retry_interval
     transport0.send_async(queueid2, message)
 
     with Timeout(retry_interval * 10, exception=False):
-        while not (
-                len(received_messages0) == 1 and
+        all_messages_received = False
+
+        while not all_messages_received:
+            all_messages_received = (
+                len(received_messages0) == 2 and
                 len(received_messages1) == 1 and
                 len(received_messages2) == 1
-        ):
+            )
             gevent.sleep(.1)
-
-    assert len(received_messages0) == 2
-    assert len(received_messages1) == 1
-    assert len(received_messages2) == 1
 
     transport0.stop()
     transport1.stop()


### PR DESCRIPTION
The test was waiting for a single message in the wait loop, however it
was asserting that two messages arrived, this caused flakyness.

This additionally remove the asserts, since the number of messages is
already tests as part of the wait loop, which will timeout if the
expected number of messages is not received.