### PR TITLE
Signer

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -8,7 +8,7 @@ import structlog
 from eth_keyfile import decode_keyfile_json
 from eth_utils import add_0x_prefix, decode_hex, encode_hex, remove_0x_prefix, to_checksum_address
 
-from raiden.utils import privatekey_to_address, privtopub
+from raiden.utils import privatekey_to_address, privatekey_to_publickey
 from raiden.utils.typing import AddressHex
 
 log = structlog.get_logger(__name__)
@@ -252,7 +252,7 @@ class Account:
     def pubkey(self):
         """The account's public key or `None` if the account is locked"""
         if not self.locked:
-            return privtopub(self.privkey)
+            return privatekey_to_publickey(self.privkey)
 
         return None
 

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,5 +1,5 @@
 import structlog
-from eth_utils import decode_hex, to_checksum_address
+from eth_utils import to_checksum_address
 
 from raiden.exceptions import InvalidSettleTimeout
 from raiden.network.blockchain_service import BlockChainService
@@ -28,7 +28,6 @@ log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 class App:  # pylint: disable=too-few-public-methods
     DEFAULT_CONFIG = {
-        'privatekey_hex': '',
         'reveal_timeout': DEFAULT_REVEAL_TIMEOUT,
         'settle_timeout': DEFAULT_SETTLE_TIMEOUT,
         'contracts_path': contracts_precompiled_path(),
@@ -86,7 +85,6 @@ class App:  # pylint: disable=too-few-public-methods
             query_start_block=query_start_block,
             default_registry=default_registry,
             default_secret_registry=default_secret_registry,
-            private_key_bin=decode_hex(config['privatekey_hex']),
             transport=transport,
             raiden_event_handler=raiden_event_handler,
             message_handler=message_handler,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -27,7 +27,7 @@ from raiden.transfer.mediated_transfer.events import (
 from raiden.transfer.state import HashTimeLockState
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import ishash, pex, sha3, typing
-from raiden.utils.signing import eth_recover, eth_sign
+from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import (
     Address,
     BlockExpiration,
@@ -232,10 +232,10 @@ class SignedMessage(Message):
         # this slice must be from the end of the buffer
         return packed.data[:-field.size_bytes]
 
-    def sign(self, private_key):
-        """ Sign message using `private_key`. """
+    def sign(self, signer: Signer):
+        """ Sign message using signer. """
         message_data = self._data_to_sign()
-        self.signature = eth_sign(privkey=private_key, data=message_data)
+        self.signature = signer.sign(data=message_data)
 
     @property
     @cached(_senders_cache, key=attrgetter('signature'))
@@ -246,7 +246,7 @@ class SignedMessage(Message):
         message_signature = self.signature
 
         try:
-            address: Optional[Address] = eth_recover(
+            address: Optional[Address] = recover(
                 data=data_that_was_signed,
                 signature=message_signature,
             )

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -12,7 +12,6 @@ from raiden.network.proxies import (
     TokenNetworkRegistry,
 )
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.utils import privatekey_to_address
 from raiden.utils.typing import (
     Address,
     ChannelID,
@@ -29,7 +28,6 @@ class BlockChainService:
 
     def __init__(
             self,
-            privatekey_bin: bytes,
             jsonrpc_client: JSONRPCClient,
             contract_manager: ContractManager = None,
     ):
@@ -41,8 +39,6 @@ class BlockChainService:
         self.identifier_to_payment_channel = dict()
 
         self.client = jsonrpc_client
-        self.private_key = privatekey_bin
-        self.node_address = privatekey_to_address(privatekey_bin)
         self.contract_manager = contract_manager
 
         self._token_creation_lock = Semaphore()
@@ -51,6 +47,10 @@ class BlockChainService:
         self._token_network_registry_creation_lock = Semaphore()
         self._secret_registry_creation_lock = Semaphore()
         self._payment_channel_creation_lock = Semaphore()
+
+    @property
+    def node_address(self) -> Address:
+        return self.client.address
 
     def block_number(self) -> int:
         return self.client.block_number()

--- a/raiden/network/proxies/discovery.py
+++ b/raiden/network/proxies/discovery.py
@@ -7,7 +7,7 @@ from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit
+from raiden.utils import pex, safe_gas_limit
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
     GAS_REQUIRED_FOR_ENDPOINT_REGISTER,
@@ -48,7 +48,7 @@ class Discovery:
         )
 
         self.address = discovery_address
-        self.node_address = privatekey_to_address(jsonrpc_client.privkey)
+        self.node_address = jsonrpc_client.address
         self.client = jsonrpc_client
         self.not_found_address = NULL_ADDRESS
         self.proxy = proxy

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -9,7 +9,7 @@ from raiden.exceptions import InvalidAddress, RaidenUnrecoverableError
 from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit, sha3
+from raiden.utils import pex, safe_gas_limit, sha3
 from raiden.utils.typing import BlockSpecification, Keccak256, Secret
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, EVENT_SECRET_REVEALED
 from raiden_contracts.contract_manager import ContractManager
@@ -45,7 +45,7 @@ class SecretRegistry:
         self.address = secret_registry_address
         self.proxy = proxy
         self.client = jsonrpc_client
-        self.node_address = privatekey_to_address(self.client.privkey)
+        self.node_address = self.client.address
         self.open_secret_transactions = dict()
 
     def register_secret(self, secret: Secret):

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -6,7 +6,7 @@ from raiden.exceptions import RaidenUnrecoverableError, TransactionThrew
 from raiden.network.rpc.client import check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit
+from raiden.utils import pex, safe_gas_limit
 from raiden.utils.typing import Address, BlockSpecification, TokenAmount
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
@@ -37,7 +37,7 @@ class Token:
 
         self.address = token_address
         self.client = jsonrpc_client
-        self.node_address = privatekey_to_address(jsonrpc_client.privkey)
+        self.node_address = jsonrpc_client.address
         self.proxy = proxy
 
     def allowance(self, owner, spender, block_identifier):

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -28,7 +28,7 @@ from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.transfer.balance_proof import pack_balance_proof
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit
+from raiden.utils import pex, safe_gas_limit
 from raiden.utils.signer import recover
 from raiden.utils.typing import (
     AdditionalHash,
@@ -124,7 +124,7 @@ class TokenNetwork:
         self.address = token_network_address
         self.proxy = proxy
         self.client = jsonrpc_client
-        self.node_address = privatekey_to_address(self.client.privkey)
+        self.node_address = self.client.address
         self.open_channel_transactions = dict()
 
         # Forbids concurrent operations on the same channel

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -29,7 +29,7 @@ from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.utils import pex, privatekey_to_address, safe_gas_limit
-from raiden.utils.signing import eth_recover
+from raiden.utils.signer import recover
 from raiden.utils.typing import (
     AdditionalHash,
     Address,
@@ -1004,12 +1004,12 @@ class TokenNetwork:
         )
 
         try:
-            signer_address = eth_recover(
+            signer_address = recover(
                 data=data_that_was_signed,
                 signature=closing_signature,
             )
 
-            # InvalidSignature is raised by eth_utils.eth_recover if signature
+            # InvalidSignature is raised by raiden.utils.signer.recover if signature
             # is not bytes or has the incorrect length
             #
             # ValueError is raised if the PublicKey instantiation failed, let it

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -20,7 +20,7 @@ from raiden.exceptions import InvalidAddress, RaidenRecoverableError, RaidenUnre
 from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import pex, privatekey_to_address, safe_gas_limit
+from raiden.utils import pex, safe_gas_limit
 from raiden.utils.typing import (
     Address,
     BlockSpecification,
@@ -66,7 +66,7 @@ class TokenNetworkRegistry:
         self.address = registry_address
         self.proxy = proxy
         self.client = jsonrpc_client
-        self.node_address = privatekey_to_address(self.client.privkey)
+        self.node_address = self.client.address
 
     def get_token_network(
             self,

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -59,8 +59,10 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils import pex
 from raiden.utils.runnable import Runnable
+from raiden.utils.signer import recover
 from raiden.utils.typing import (
     Address,
+
     AddressHex,
     Callable,
     Dict,
@@ -1308,9 +1310,10 @@ class MatrixTransport(Runnable):
         """ Use eth_sign compatible hasher to sign matrix data """
         return self._raiden_service.signer.sign(data=data)
 
-    def _recover(self, data: bytes, signature: bytes) -> Address:
+    @staticmethod
+    def _recover(data: bytes, signature: bytes) -> Address:
         """ Use eth_sign compatible hasher to recover address from signed data """
-        return self._raiden_service.signer.recover(data=data, signature=signature)
+        return recover(data=data, signature=signature)
 
     def _validate_userid_signature(self, user: User) -> Optional[Address]:
         """ Validate a userId format and signature on displayName, and return its address"""

--- a/raiden/network/transport/matrix.py
+++ b/raiden/network/transport/matrix.py
@@ -59,7 +59,6 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils import pex
 from raiden.utils.runnable import Runnable
-from raiden.utils.signing import eth_recover, eth_sign
 from raiden.utils.typing import (
     Address,
     AddressHex,
@@ -1307,18 +1306,11 @@ class MatrixTransport(Runnable):
 
     def _sign(self, data: bytes) -> bytes:
         """ Use eth_sign compatible hasher to sign matrix data """
-        return eth_sign(
-            privkey=self._raiden_service.private_key,
-            data=data,
-        )
+        return self._raiden_service.signer.sign(data=data)
 
-    @staticmethod
-    def _recover(data: bytes, signature: bytes) -> Address:
+    def _recover(self, data: bytes, signature: bytes) -> Address:
         """ Use eth_sign compatible hasher to recover address from signed data """
-        return eth_recover(
-            data=data,
-            signature=signature,
-        )
+        return self._raiden_service.signer.recover(data=data, signature=signature)
 
     def _validate_userid_signature(self, user: User) -> Optional[Address]:
         """ Validate a userId format and signature on displayName, and return its address"""

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -43,7 +43,6 @@ from raiden.transfer.utils import (
     get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.utils import pex
-from raiden.utils.signing import eth_sign
 
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
@@ -297,7 +296,7 @@ class RaidenEventHandler:
                 chain_id=balance_proof.chain_id,
                 partner_signature=balance_proof.signature,
             )
-            our_signature = eth_sign(privkey=raiden.privkey, data=non_closing_data)
+            our_signature = raiden.signer.sign(data=non_closing_data)
 
             try:
                 channel.update_transfer(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -209,7 +209,6 @@ class RaidenService(Runnable):
             query_start_block: BlockNumber,
             default_registry: TokenNetworkRegistry,
             default_secret_registry: SecretRegistry,
-            private_key_bin,
             transport,
             raiden_event_handler,
             message_handler,
@@ -217,9 +216,6 @@ class RaidenService(Runnable):
             discovery=None,
     ):
         super().__init__()
-        if not isinstance(private_key_bin, bytes) or len(private_key_bin) != 32:
-            raise ValueError('invalid private_key')
-
         self.tokennetworkids_to_connectionmanagers = dict()
         self.targets_to_identifiers_to_statuses: StatusesDict = defaultdict(dict)
 
@@ -229,12 +225,12 @@ class RaidenService(Runnable):
         self.default_secret_registry = default_secret_registry
         self.config = config
 
-        self.signer: Signer = LocalSigner(private_key_bin)
-        self.privkey = private_key_bin
+        self.privkey = self.chain.client.privkey
+        self.signer: Signer = LocalSigner(self.privkey)
         self.address = self.signer.address
         self.discovery = discovery
 
-        self.private_key = PrivateKey(private_key_bin)
+        self.private_key = PrivateKey(self.privkey)
         self.transport = transport
 
         self.blockchain_events = BlockchainEvents()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -7,7 +7,6 @@ from typing import Dict, List, NamedTuple, Union
 import filelock
 import gevent
 import structlog
-from coincurve import PrivateKey
 from eth_utils import is_binary_address
 from gevent.event import AsyncResult, Event
 from gevent.lock import Semaphore
@@ -225,12 +224,9 @@ class RaidenService(Runnable):
         self.default_secret_registry = default_secret_registry
         self.config = config
 
-        self.privkey = self.chain.client.privkey
-        self.signer: Signer = LocalSigner(self.privkey)
+        self.signer: Signer = LocalSigner(self.chain.client.privkey)
         self.address = self.signer.address
         self.discovery = discovery
-
-        self.private_key = PrivateKey(self.privkey)
         self.transport = transport
 
         self.blockchain_events = BlockchainEvents()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -53,15 +53,9 @@ from raiden.transfer.state_change import (
     Block,
     ContractReceiveNewPaymentNetwork,
 )
-from raiden.utils import (
-    create_default_identifier,
-    lpex,
-    pex,
-    privatekey_to_address,
-    random_secret,
-    sha3,
-)
+from raiden.utils import create_default_identifier, lpex, pex, random_secret, sha3
 from raiden.utils.runnable import Runnable
+from raiden.utils.signer import LocalSigner, Signer
 from raiden.utils.typing import (
     Address,
     BlockNumber,
@@ -234,12 +228,13 @@ class RaidenService(Runnable):
         self.query_start_block = query_start_block
         self.default_secret_registry = default_secret_registry
         self.config = config
+
+        self.signer: Signer = LocalSigner(private_key_bin)
         self.privkey = private_key_bin
-        self.address = privatekey_to_address(private_key_bin)
+        self.address = self.signer.address
         self.discovery = discovery
 
         self.private_key = PrivateKey(private_key_bin)
-        self.pubkey = self.private_key.public_key.format(compressed=False)
         self.transport = transport
 
         self.blockchain_events = BlockchainEvents()
@@ -678,7 +673,7 @@ class RaidenService(Runnable):
         if not isinstance(message, SignedMessage):
             raise ValueError('{} is not signable.'.format(repr(message)))
 
-        message.sign(self.private_key)
+        message.sign(self.signer)
 
     def install_all_blockchain_filters(
             self,

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -7,7 +7,7 @@ from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies import PaymentChannel, TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils import privatekey_to_address
-from raiden.utils.signing import eth_sign
+from raiden.utils.signer import LocalSigner
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
 from raiden_libs.messages import BalanceProof
 
@@ -98,10 +98,11 @@ def test_payment_channel_proxy_basics(
         chain_id=chain_id,
         transferred_amount=transferred_amount,
     )
-    balance_proof.signature = encode_hex(eth_sign(
-        privkey=encode_hex(private_keys[1]),
-        data=balance_proof.serialize_bin(),
-    ))
+    balance_proof.signature = encode_hex(
+        LocalSigner(private_keys[1]).sign(
+            data=balance_proof.serialize_bin(),
+        ),
+    )
     # correct close
     c2_token_network_proxy.close(
         channel_identifier=channel_identifier,
@@ -195,10 +196,11 @@ def test_payment_channel_outdated_channel_close(
         chain_id=chain_id,
         transferred_amount=0,
     )
-    balance_proof.signature = encode_hex(eth_sign(
-        privkey=encode_hex(private_keys[0]),
-        data=balance_proof.serialize_bin(),
-    ))
+    balance_proof.signature = encode_hex(
+        LocalSigner(private_keys[0]).sign(
+            data=balance_proof.serialize_bin(),
+        ),
+    )
     # correct close
     token_network_proxy.close(
         channel_identifier=channel_identifier,

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -23,7 +23,7 @@ def test_payment_channel_proxy_basics(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(private_keys[1], c1_client)
+    c1_chain = BlockChainService(c1_client)
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
@@ -157,7 +157,7 @@ def test_payment_channel_outdated_channel_close(
     partner = privatekey_to_address(private_keys[0])
 
     client = JSONRPCClient(web3, private_keys[1])
-    chain = BlockChainService(private_keys[1], client)
+    chain = BlockChainService(client)
     token_network_proxy = TokenNetwork(
         jsonrpc_client=client,
         token_network_address=token_network_address,

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -13,7 +13,7 @@ from raiden.exceptions import (
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies import TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.utils.signing import eth_sign
+from raiden.utils.signer import LocalSigner
 from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
@@ -217,10 +217,11 @@ def test_token_network_proxy_basics(
         chain_id=chain_id,
         transferred_amount=transferred_amount,
     )
-    balance_proof.signature = encode_hex(eth_sign(
-        privkey=encode_hex(private_keys[1]),
-        data=balance_proof.serialize_bin(),
-    ))
+    balance_proof.signature = encode_hex(
+        LocalSigner(private_keys[1]).sign(
+            data=balance_proof.serialize_bin(),
+        ),
+    )
     # close with invalid signature
     with pytest.raises(RaidenUnrecoverableError):
         c2_token_network_proxy.close(
@@ -389,10 +390,11 @@ def test_token_network_proxy_update_transfer(
         chain_id=chain_id,
         transferred_amount=transferred_amount_c1,
     )
-    balance_proof_c1.signature = encode_hex(eth_sign(
-        privkey=encode_hex(private_keys[1]),
-        data=balance_proof_c1.serialize_bin(),
-    ))
+    balance_proof_c1.signature = encode_hex(
+        LocalSigner(private_keys[1]).sign(
+            data=balance_proof_c1.serialize_bin(),
+        ),
+    )
     # balance proof signed by c2
     balance_proof_c2 = BalanceProof(
         channel_identifier=channel_identifier,
@@ -401,16 +403,16 @@ def test_token_network_proxy_update_transfer(
         chain_id=chain_id,
         transferred_amount=transferred_amount_c2,
     )
-    balance_proof_c2.signature = encode_hex(eth_sign(
-        privkey=encode_hex(private_keys[2]),
-        data=balance_proof_c2.serialize_bin(),
-    ))
+    balance_proof_c2.signature = encode_hex(
+        LocalSigner(private_keys[2]).sign(
+            data=balance_proof_c2.serialize_bin(),
+        ),
+    )
 
     non_closing_data = balance_proof_c1.serialize_bin(
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
     ) + decode_hex(balance_proof_c1.signature)
-    non_closing_signature = eth_sign(
-        privkey=encode_hex(c2_client.privkey),
+    non_closing_signature = LocalSigner(c2_client.privkey).sign(
         data=non_closing_data,
     )
 
@@ -453,8 +455,7 @@ def test_token_network_proxy_update_transfer(
     # using invalid non-closing signature
     # Usual mistake when calling update Transfer - balance proof signature is missing in the data
     non_closing_data = balance_proof_c1.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
-    non_closing_signature = eth_sign(
-        privkey=encode_hex(c2_client.privkey),
+    non_closing_signature = LocalSigner(c2_client.privkey).sign(
         data=non_closing_data,
     )
     with pytest.raises(RaidenUnrecoverableError):
@@ -471,8 +472,7 @@ def test_token_network_proxy_update_transfer(
     non_closing_data = balance_proof_c1.serialize_bin(
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
     ) + decode_hex(balance_proof_c1.signature)
-    non_closing_signature = eth_sign(
-        privkey=encode_hex(c2_client.privkey),
+    non_closing_signature = LocalSigner(c2_client.privkey).sign(
         data=non_closing_data,
     )
     c2_token_network_proxy.update_transfer(

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -76,7 +76,7 @@ def test_token_network_proxy_basics(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(private_keys[1], c1_client)
+    c1_chain = BlockChainService(c1_client)
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
@@ -345,7 +345,7 @@ def test_token_network_proxy_update_transfer(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(private_keys[1], c1_client)
+    c1_chain = BlockChainService(c1_client)
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -122,7 +122,6 @@ def contract_manager(environment_type):
 @pytest.fixture
 def deploy_service(deploy_key, deploy_client, contract_manager):
     return BlockChainService(
-        privatekey_bin=deploy_key,
         jsonrpc_client=deploy_client,
         contract_manager=contract_manager,
     )

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -16,6 +16,7 @@ from raiden.transfer.mediated_transfer.events import CHANNEL_IDENTIFIER_GLOBAL_Q
 from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.transfer.state_change import ActionUpdateTransportAuthData
 from raiden.utils import pex
+from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address, List, Optional, Union
 from raiden_libs.network.matrix import Room
 
@@ -113,7 +114,7 @@ def make_message(convert_to_hex: bool = False, overwrite_data=None):
             amount=1,
             expiration=10,
         )
-        message.sign(HOP1_KEY)
+        message.sign(LocalSigner(HOP1_KEY))
         data = message.encode()
         if convert_to_hex:
             data = '0x' + data.hex()
@@ -258,7 +259,7 @@ def test_matrix_message_sync(
 
     for i in range(5):
         message = Processed(i)
-        message.sign(transport0._raiden_service.private_key)
+        transport0._raiden_service.sign(message)
         transport0.send_async(
             queue_identifier,
             message,
@@ -277,7 +278,7 @@ def test_matrix_message_sync(
     # Send more messages while the other end is offline
     for i in range(10, 15):
         message = Processed(i)
-        message.sign(transport0._raiden_service.private_key)
+        transport0._raiden_service.sign(message)
         transport0.send_async(
             queue_identifier,
             message,
@@ -351,7 +352,7 @@ def test_matrix_message_retry(
 
     # Send the initial message
     message = Processed(0)
-    message.sign(transport._raiden_service.private_key)
+    transport._raiden_service.sign(message)
     chain_state.queueids_to_queues[queueid] = [message]
     retry_queue.enqueue_global(message)
 
@@ -462,7 +463,7 @@ def test_matrix_cross_server_with_load_balance(matrix_transports, retry_interval
         channel_identifier=CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
     )
     message = Processed(0)
-    message.sign(raiden_service0.private_key)
+    raiden_service0.sign(message)
 
     transport0.send_async(queueid1, message)
     transport0.send_async(queueid2, message)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -21,6 +21,7 @@ from raiden.tests.utils.transfer import (
     wait_assert,
 )
 from raiden.transfer import views
+from raiden.utils.signer import LocalSigner
 
 
 @pytest.mark.parametrize('channels_per_node', [1])
@@ -133,8 +134,7 @@ def test_receive_lockedtransfer_invalidnonce(
 
     sign_and_inject(
         mediated_transfer_message,
-        app0.raiden.private_key,
-        app0.raiden.address,
+        app0.raiden.signer,
         app1,
     )
 
@@ -188,8 +188,7 @@ def test_receive_lockedtransfer_invalidsender(
 
     sign_and_inject(
         mediated_transfer_message,
-        other_key,
-        other_address,
+        LocalSigner(other_key),
         app0,
     )
 
@@ -242,8 +241,7 @@ def test_receive_lockedtransfer_invalidrecipient(
 
     sign_and_inject(
         mediated_transfer_message,
-        app0.raiden.private_key,
-        app0.raiden.address,
+        app0.raiden.signer,
         app1,
     )
 
@@ -308,8 +306,7 @@ def test_received_lockedtransfer_closedchannel(
 
     sign_and_inject(
         mediated_transfer_message,
-        app0.raiden.private_key,
-        app0.raiden.address,
+        app0.raiden.signer,
         app1,
     )
 

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -5,7 +5,6 @@ import pytest
 from raiden.constants import UINT64_MAX
 from raiden.messages import RevealSecret, SecretRequest, Unlock
 from raiden.tests.utils.factories import (
-    HOP1,
     HOP1_KEY,
     UNIT_CHAIN_ID,
     UNIT_SECRET,
@@ -15,6 +14,7 @@ from raiden.tests.utils.factories import (
 from raiden.tests.utils.messages import make_refund_transfer
 from raiden.tests.utils.transfer import sign_and_inject
 from raiden.transfer import views
+from raiden.utils.signer import LocalSigner
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
@@ -30,7 +30,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     )
 
     other_key = HOP1_KEY
-    other_address = HOP1
+    other_signer = LocalSigner(other_key)
     channel_identifier = make_channel_identifier()
 
     amount = 10
@@ -46,7 +46,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
         amount=amount,
         secrethash=UNIT_SECRETHASH,
     )
-    sign_and_inject(refund_transfer_message, other_key, other_address, app0)
+    sign_and_inject(refund_transfer_message, other_signer, app0)
 
     unlock = Unlock(
         chain_id=UNIT_CHAIN_ID,
@@ -60,7 +60,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
         locksroot=UNIT_SECRETHASH,
         secret=UNIT_SECRET,
     )
-    sign_and_inject(unlock, other_key, other_address, app0)
+    sign_and_inject(unlock, other_signer, app0)
 
     secret_request_message = SecretRequest(
         message_identifier=random.randint(0, UINT64_MAX),
@@ -69,10 +69,10 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
         amount=1,
         expiration=refund_transfer_message.lock.expiration,
     )
-    sign_and_inject(secret_request_message, other_key, other_address, app0)
+    sign_and_inject(secret_request_message, other_signer, app0)
 
     reveal_secret_message = RevealSecret(
         message_identifier=random.randint(0, UINT64_MAX),
         secret=UNIT_SECRET,
     )
-    sign_and_inject(reveal_secret_message, other_key, other_address, app0)
+    sign_and_inject(reveal_secret_message, other_signer, app0)

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -8,7 +8,7 @@ from raiden.messages import Ping, Processed, decode
 from raiden.tests.utils.factories import make_privkey_address
 from raiden.tests.utils.messages import make_mediated_transfer, make_refund_transfer
 from raiden.utils import sha3
-from raiden.utils.signer import LocalSigner
+from raiden.utils.signer import LocalSigner, recover
 
 PRIVKEY, ADDRESS = make_privkey_address()
 signer = LocalSigner(PRIVKEY)
@@ -23,21 +23,21 @@ def test_signature():
     message_data = ping._data_to_sign()
     # This signature will sometimes end up with v being 0, sometimes 1
     signature = signer.sign(data=message_data, v=0)
-    assert ADDRESS == signer.recover(message_data, signature)
+    assert ADDRESS == recover(message_data, signature)
     # This signature will sometimes end up with v being 27, sometimes 28
     signature = signer.sign(data=message_data, v=27)
-    assert ADDRESS == signer.recover(message_data, signature)
+    assert ADDRESS == recover(message_data, signature)
 
     # test that other v values are rejected
     signature = signature[:-1] + bytes([29])
     with pytest.raises(InvalidSignature):
-        signer.recover(message_data, signature)
+        recover(message_data, signature)
     signature = signature[:-1] + bytes([37])
     with pytest.raises(InvalidSignature):
-        signer.recover(message_data, signature)
+        recover(message_data, signature)
     signature = signature[:-1] + bytes([38])
     with pytest.raises(InvalidSignature):
-        signer.recover(message_data, signature)
+        recover(message_data, signature)
 
 
 def test_encoding():

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -61,6 +61,7 @@ from raiden.transfer.state_change import (
     ReceiveUnlock,
 )
 from raiden.utils import random_secret, sha3
+from raiden.utils.signer import LocalSigner
 
 PartnerStateModel = namedtuple(
     'PartnerStateModel',
@@ -452,6 +453,7 @@ def test_channelstate_receive_lockedtransfer():
     """
     our_model1, _ = create_model(70)
     partner_model1, privkey2 = create_model(100)
+    signer2 = LocalSigner(privkey2)
     channel_state = create_channel_from_models(our_model1, partner_model1)
 
     # Step 1: Simulate receiving a transfer
@@ -517,7 +519,7 @@ def test_channelstate_receive_lockedtransfer():
         locksroot=EMPTY_MERKLE_ROOT,
         secret=lock_secret,
     )
-    unlock_message.sign(privkey2)
+    unlock_message.sign(signer2)
     # Let's also create an invalid secret to test unlock with invalid chain id
     invalid_unlock_message = Unlock(
         chain_id=UNIT_CHAIN_ID + 1,
@@ -531,7 +533,7 @@ def test_channelstate_receive_lockedtransfer():
         locksroot=EMPTY_MERKLE_ROOT,
         secret=lock_secret,
     )
-    invalid_unlock_message.sign(privkey2)
+    invalid_unlock_message.sign(signer2)
 
     balance_proof = balanceproof_from_envelope(unlock_message)
     unlock_state_change = ReceiveUnlock(
@@ -825,6 +827,7 @@ def test_interwoven_transfers():
 
     our_model, _ = create_model(70)
     partner_model, privkey2 = create_model(balance_for_all_transfers)
+    signer2 = LocalSigner(privkey2)
     channel_state = create_channel_from_models(our_model, partner_model)
 
     block_number = 1000
@@ -930,7 +933,7 @@ def test_interwoven_transfers():
                 locksroot=locksroot,
                 secret=lock_secret,
             )
-            unlock_message.sign(privkey2)
+            unlock_message.sign(signer2)
 
             balance_proof = balanceproof_from_envelope(unlock_message)
             unlock_state_change = ReceiveUnlock(

--- a/raiden/tests/unit/test_dict_encoding.py
+++ b/raiden/tests/unit/test_dict_encoding.py
@@ -4,8 +4,10 @@ from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.messages import LockedTransfer, RefundTransfer
 from raiden.tests.utils.factories import make_privkey_address
 from raiden.tests.utils.messages import make_mediated_transfer, make_refund_transfer
+from raiden.utils.signer import LocalSigner
 
 PRIVKEY, ADDRESS = make_privkey_address()
+signer = LocalSigner(PRIVKEY)
 
 
 @pytest.mark.parametrize('amount', [0, UINT256_MAX])
@@ -22,7 +24,7 @@ def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, trans
         transferred_amount=transferred_amount,
     )
 
-    mediated_transfer.sign(PRIVKEY)
+    mediated_transfer.sign(signer)
     assert LockedTransfer.from_dict(mediated_transfer.to_dict()) == mediated_transfer
 
 
@@ -38,5 +40,5 @@ def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_
         transferred_amount=transferred_amount,
     )
 
-    refund_transfer.sign(PRIVKEY)
+    refund_transfer.sign(signer)
     assert RefundTransfer.from_dict(refund_transfer.to_dict()) == refund_transfer

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -9,13 +9,15 @@ from raiden.tests.utils.messages import (
     make_mediated_transfer,
     make_refund_transfer,
 )
+from raiden.utils.signer import LocalSigner
 
 PRIVKEY, ADDRESS = make_privkey_address()
+signer = LocalSigner(PRIVKEY)
 
 
 def test_signature():
     ping = Ping(nonce=0, current_protocol_version=0)
-    ping.sign(PRIVKEY)
+    ping.sign(signer)
     assert ping.sender == ADDRESS
 
 

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -16,8 +16,10 @@ def test_signer_sign():
     privkey = sha3(b'secret')  # 0x38e959391dD8598aE80d5d6D114a7822A09d313A
     message = b'message'
     # generated with Metamask's web3.personal.sign
-    signature = decode_hex('0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
-                           '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c')
+    signature = decode_hex(
+        '0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
+        '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c',
+    )
 
     signer: Signer = LocalSigner(privkey)
 
@@ -28,7 +30,9 @@ def test_recover():
     account = to_canonical_address('0x38e959391dD8598aE80d5d6D114a7822A09d313A')
     message = b'message'
     # generated with Metamask's web3.personal.sign
-    signature = decode_hex('0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
-                           '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c')
+    signature = decode_hex(
+        '0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
+        '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c',
+    )
 
     assert recover(data=message, signature=signature) == account

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -1,9 +1,9 @@
-from raiden.utils import privtopub, sha3
+from raiden.utils import privatekey_to_publickey, sha3
 
 
-def test_privtopub():
+def test_privatekey_to_publickey():
     privkey = sha3(b'secret')
     pubkey = ('c283b0507c4ec6903a49fac84a5aead951f3c38b2c72b69da8a70a5bac91e9c'
               '705f70c7554b26e82b90d2d1bbbaf711b10c6c8b807077f4070200a8fb4c6b771')
 
-    assert pubkey == privtopub(privkey).hex()
+    assert pubkey == privatekey_to_publickey(privkey).hex()

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -24,18 +24,7 @@ def test_signer_sign():
     assert signer.sign(message) == signature
 
 
-def test_signer_recover():
-    account = to_canonical_address('0x38e959391dD8598aE80d5d6D114a7822A09d313A')
-    message = b'message'
-    # generated with Metamask's web3.personal.sign
-    signature = decode_hex('0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
-                           '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c')
-    signer: Signer = LocalSigner(sha3(b'deadbeef'))
-
-    assert signer.recover(data=message, signature=signature) == account
-
-
-def test_standalone_recover():
+def test_recover():
     account = to_canonical_address('0x38e959391dD8598aE80d5d6D114a7822A09d313A')
     message = b'message'
     # generated with Metamask's web3.personal.sign

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -1,4 +1,7 @@
+from eth_utils import decode_hex, to_canonical_address
+
 from raiden.utils import privatekey_to_publickey, sha3
+from raiden.utils.signer import LocalSigner, Signer, recover
 
 
 def test_privatekey_to_publickey():
@@ -7,3 +10,36 @@ def test_privatekey_to_publickey():
               '705f70c7554b26e82b90d2d1bbbaf711b10c6c8b807077f4070200a8fb4c6b771')
 
     assert pubkey == privatekey_to_publickey(privkey).hex()
+
+
+def test_signer_sign():
+    privkey = sha3(b'secret')  # 0x38e959391dD8598aE80d5d6D114a7822A09d313A
+    message = b'message'
+    # generated with Metamask's web3.personal.sign
+    signature = decode_hex('0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
+                           '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c')
+
+    signer: Signer = LocalSigner(privkey)
+
+    assert signer.sign(message) == signature
+
+
+def test_signer_recover():
+    account = to_canonical_address('0x38e959391dD8598aE80d5d6D114a7822A09d313A')
+    message = b'message'
+    # generated with Metamask's web3.personal.sign
+    signature = decode_hex('0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
+                           '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c')
+    signer: Signer = LocalSigner(sha3(b'deadbeef'))
+
+    assert signer.recover(data=message, signature=signature) == account
+
+
+def test_standalone_recover():
+    account = to_canonical_address('0x38e959391dD8598aE80d5d6D114a7822A09d313A')
+    message = b'message'
+    # generated with Metamask's web3.personal.sign
+    signature = decode_hex('0x1eff8317c59ab169037f5063a5129bb1bab0299fef0b5621d866b07be59e2c0a'
+                           '6a404e88d3360fb58bd13daf577807c2cf9b6b26d80fc929c52e952769a460981c')
+
+    assert recover(data=message, signature=signature) == account

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -36,6 +36,7 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state import balanceproof_from_envelope, message_identifier_from_prng
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal
+from raiden.utils.signer import LocalSigner
 
 LONG_EXPIRATION = factories.create_properties(factories.LockedTransferSignedStateProperties(
     transfer=factories.LockedTransferProperties(expiration=30),
@@ -334,7 +335,7 @@ def test_regression_mediator_task_no_routes():
     )
     assert send_lock_expired
     lock_expired_message = message_from_sendevent(send_lock_expired, HOP1)
-    lock_expired_message.sign(channels.partner_privatekeys[0])
+    lock_expired_message.sign(LocalSigner(channels.partner_privatekeys[0]))
     balance_proof = balanceproof_from_envelope(lock_expired_message)
 
     message_identifier = message_identifier_from_prng(pseudo_random_generator)
@@ -522,7 +523,7 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
     )
     assert send_lock_expired
     expired_message = message_from_sendevent(send_lock_expired, setup.channels.our_address(0))
-    expired_message.sign(setup.channels.partner_privatekeys[0])
+    expired_message.sign(LocalSigner(setup.channels.partner_privatekeys[0]))
     balance_proof = balanceproof_from_envelope(expired_message)
 
     message_identifier = message_identifier_from_prng(pseudo_random_generator)

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -32,7 +32,7 @@ from raiden.transfer.state import (
     message_identifier_from_prng,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import privatekey_to_address, publickey_to_address, random_secret, sha3, typing
+from raiden.utils import privatekey_to_address, random_secret, sha3, typing
 from raiden.utils.signer import LocalSigner
 
 EMPTY = object()
@@ -114,8 +114,7 @@ def make_privatekey_address(
         privatekey: PrivateKey = EMPTY,
 ) -> typing.Tuple[PrivateKey, typing.Address]:
     privatekey = if_empty(privatekey, make_privatekey())
-    publickey = privatekey.public_key.format(compressed=False)
-    address = publickey_to_address(publickey)
+    address = LocalSigner(privatekey).address
     return privatekey, address
 
 
@@ -812,8 +811,7 @@ def make_signed_transfer_for(
         valid = channel_state.reveal_timeout < expiration < channel_state.settle_timeout
         assert valid, 'Expiration must be between reveal_timeout and settle_timeout.'
 
-    pubkey = properties.pkey.public_key.format(compressed=False)
-    assert publickey_to_address(pubkey) == properties.sender
+    assert privatekey_to_address(properties.pkey.secret) == properties.sender
 
     if properties.sender == channel_state.our_state.address:
         recipient = channel_state.partner_state.address

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -4,8 +4,6 @@ import string
 from functools import singledispatch
 from typing import NamedTuple
 
-from coincurve import PrivateKey
-
 from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.messages import Lock, LockedTransfer
 from raiden.transfer import balance_proof, channel
@@ -105,16 +103,15 @@ def make_secret(i: int = EMPTY) -> bytes:
         return make_32bytes()
 
 
-def make_privatekey(privatekey_bin: bytes = EMPTY) -> PrivateKey:
-    privatekey_bin = if_empty(privatekey_bin, make_privatekey_bin())
-    return PrivateKey(privatekey_bin)
+def make_privatekey(privatekey_bin: bytes = EMPTY) -> bytes:
+    return if_empty(privatekey_bin, make_privatekey_bin())
 
 
 def make_privatekey_address(
-        privatekey: PrivateKey = EMPTY,
-) -> typing.Tuple[PrivateKey, typing.Address]:
+        privatekey: bytes = EMPTY,
+) -> typing.Tuple[bytes, typing.Address]:
     privatekey = if_empty(privatekey, make_privatekey())
-    address = LocalSigner(privatekey).address
+    address = privatekey_to_address(privatekey)
     return privatekey, address
 
 
@@ -299,7 +296,7 @@ def make_signed_transfer(
         channel_identifier: typing.ChannelID = EMPTY,
         token_network_address: typing.TokenNetworkID = EMPTY,
         token: typing.TargetAddress = EMPTY,
-        pkey: PrivateKey = EMPTY,
+        pkey: bytes = EMPTY,
         sender: typing.Address = EMPTY,
 ) -> LockedTransferSignedState:
 
@@ -364,7 +361,7 @@ def make_signed_balance_proof(
         channel_identifier: typing.ChannelID = EMPTY,
         locksroot: typing.Locksroot = EMPTY,
         extra_hash: typing.Keccak256 = EMPTY,
-        private_key: PrivateKey = EMPTY,
+        private_key: bytes = EMPTY,
         sender_address: typing.Address = EMPTY,
 ) -> BalanceProofSignedState:
 
@@ -433,20 +430,20 @@ UNIT_TRANSFER_IDENTIFIER = 37
 UNIT_TRANSFER_INITIATOR = b'initiatorinitiatorin'
 UNIT_TRANSFER_TARGET = b'targettargettargetta'
 UNIT_TRANSFER_PKEY_BIN = sha3(b'transfer pkey')
-UNIT_TRANSFER_PKEY = PrivateKey(UNIT_TRANSFER_PKEY_BIN)
+UNIT_TRANSFER_PKEY = UNIT_TRANSFER_PKEY_BIN
 UNIT_TRANSFER_SENDER = privatekey_to_address(sha3(b'transfer pkey'))
-HOP1_KEY = PrivateKey(b'11111111111111111111111111111111')
-HOP2_KEY = PrivateKey(b'22222222222222222222222222222222')
-HOP3_KEY = PrivateKey(b'33333333333333333333333333333333')
-HOP4_KEY = PrivateKey(b'44444444444444444444444444444444')
-HOP5_KEY = PrivateKey(b'55555555555555555555555555555555')
-HOP6_KEY = PrivateKey(b'66666666666666666666666666666666')
-HOP1 = privatekey_to_address(b'11111111111111111111111111111111')
-HOP2 = privatekey_to_address(b'22222222222222222222222222222222')
-HOP3 = privatekey_to_address(b'33333333333333333333333333333333')
-HOP4 = privatekey_to_address(b'44444444444444444444444444444444')
-HOP5 = privatekey_to_address(b'55555555555555555555555555555555')
-HOP6 = privatekey_to_address(b'66666666666666666666666666666666')
+HOP1_KEY = b'11111111111111111111111111111111'
+HOP2_KEY = b'22222222222222222222222222222222'
+HOP3_KEY = b'33333333333333333333333333333333'
+HOP4_KEY = b'44444444444444444444444444444444'
+HOP5_KEY = b'55555555555555555555555555555555'
+HOP6_KEY = b'66666666666666666666666666666666'
+HOP1 = privatekey_to_address(HOP1_KEY)
+HOP2 = privatekey_to_address(HOP2_KEY)
+HOP3 = privatekey_to_address(HOP3_KEY)
+HOP4 = privatekey_to_address(HOP4_KEY)
+HOP5 = privatekey_to_address(HOP5_KEY)
+HOP6 = privatekey_to_address(HOP6_KEY)
 UNIT_CHAIN_ID = 337
 ADDR = b'addraddraddraddraddr'
 UNIT_TRANSFER_DESCRIPTION = make_transfer_description(secret=UNIT_SECRET)
@@ -528,7 +525,7 @@ def _(properties, defaults=None) -> TransactionExecutionStatus:
 
 class NettingChannelEndStateProperties(NamedTuple):
     address: typing.Address = EMPTY
-    privatekey: PrivateKey = EMPTY
+    privatekey: bytes = EMPTY
     balance: typing.TokenAmount = EMPTY
     merkletree_leaves: typing.MerkleTreeLeaves = EMPTY
     merkletree_width: int = EMPTY
@@ -633,7 +630,7 @@ class BalanceProofSignedStateProperties(NamedTuple):
     message_hash: typing.AdditionalHash = EMPTY
     signature: typing.Signature = EMPTY
     sender: typing.Address = EMPTY
-    pkey: PrivateKey = EMPTY
+    pkey: bytes = EMPTY
 
 
 BALANCE_PROOF_SIGNED_STATE_DEFAULTS = BalanceProofSignedStateProperties(
@@ -718,7 +715,7 @@ class LockedTransferSignedStateProperties(NamedTuple):
     transfer: LockedTransferProperties = EMPTY
     sender: typing.Address = EMPTY
     recipient: typing.Address = EMPTY
-    pkey: PrivateKey = EMPTY
+    pkey: bytes = EMPTY
     message_identifier: typing.MessageID = EMPTY
 
 
@@ -811,7 +808,7 @@ def make_signed_transfer_for(
         valid = channel_state.reveal_timeout < expiration < channel_state.settle_timeout
         assert valid, 'Expiration must be between reveal_timeout and settle_timeout.'
 
-    assert privatekey_to_address(properties.pkey.secret) == properties.sender
+    assert privatekey_to_address(properties.pkey) == properties.sender
 
     if properties.sender == channel_state.our_state.address:
         recipient = channel_state.partner_state.address
@@ -870,7 +867,7 @@ def make_signed_transfer_for(
 def pkeys_from_channel_state(
         properties: NettingChannelStateProperties,
         defaults: NettingChannelStateProperties = NETTING_CHANNEL_STATE_DEFAULTS,
-) -> typing.Tuple[typing.Optional[PrivateKey], typing.Optional[PrivateKey]]:
+) -> typing.Tuple[typing.Optional[bytes], typing.Optional[bytes]]:
 
     our_key = None
     if properties.our_state is not EMPTY:
@@ -895,8 +892,8 @@ class ChannelSet:
     def __init__(
             self,
             channels: typing.List[NettingChannelState],
-            our_privatekeys: typing.List[PrivateKey],
-            partner_privatekeys: typing.List[PrivateKey],
+            our_privatekeys: typing.List[bytes],
+            partner_privatekeys: typing.List[bytes],
     ):
         self.channels = channels
         self.our_privatekeys = our_privatekeys

--- a/raiden/tests/utils/geth.py
+++ b/raiden/tests/utils/geth.py
@@ -16,7 +16,7 @@ from web3 import Web3
 
 from raiden.tests.fixtures.variables import DEFAULT_BALANCE_BIN, DEFAULT_PASSPHRASE
 from raiden.tests.utils.genesis import GENESIS_STUB
-from raiden.utils import privatekey_to_address, privtopub, typing
+from raiden.utils import privatekey_to_address, privatekey_to_publickey, typing
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -248,7 +248,7 @@ def geth_wait_and_check(
 
 def geth_node_config(miner_pkey, p2p_port, rpc_port):
     address = privatekey_to_address(miner_pkey)
-    pub = remove_0x_prefix(encode_hex(privtopub(miner_pkey)))
+    pub = privatekey_to_publickey(miner_pkey).hex()
 
     config = {
         'nodekey': miner_pkey,

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -7,6 +7,7 @@ from raiden.tests.utils import factories
 from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
 from raiden.transfer.state_change import ActionInitChain
+from raiden.utils.signer import LocalSigner
 
 
 class MockTokenNetwork:
@@ -42,6 +43,7 @@ class MockRaidenService:
     def __init__(self, message_handler=None, state_transition=None):
         self.chain = MockChain()
         self.private_key, self.address = factories.make_privatekey_address()
+        self.signer = LocalSigner(self.private_key)
 
         self.chain.node_address = self.address
         self.message_handler = message_handler
@@ -71,4 +73,4 @@ class MockRaidenService:
         pass
 
     def sign(self, message):
-        message.sign(self.private_key)
+        message.sign(self.signer)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -2,7 +2,6 @@
 from collections import namedtuple
 
 import gevent
-from eth_utils import encode_hex
 from gevent import server
 
 from raiden import waiting
@@ -294,7 +293,6 @@ def create_apps(
 
     apps = []
     for idx, (blockchain, discovery, port) in enumerate(services):
-        private_key = blockchain.client.privkey
         address = blockchain.client.address
 
         host = '127.0.0.1'
@@ -303,7 +301,6 @@ def create_apps(
             'chain_id': chain_id,
             'environment_type': environment_type,
             'unrecoverable_error_should_crash': unrecoverable_error_should_crash,
-            'privatekey_hex': encode_hex(private_key),
             'reveal_timeout': reveal_timeout,
             'settle_timeout': settle_timeout,
             'database_path': database_paths[idx],

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -15,7 +15,7 @@ from raiden.network.transport import MatrixTransport, UDPTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, DEFAULT_RETRY_TIMEOUT
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
-from raiden.utils import merge_dict, privatekey_to_address
+from raiden.utils import merge_dict
 from raiden.waiting import wait_for_payment_network
 
 CHAIN = object()  # Flag used by create a network does make a loop with the channels
@@ -290,13 +290,12 @@ def create_apps(
 ):
     """ Create the apps."""
     # pylint: disable=too-many-locals
-    services = zip(blockchain_services, endpoint_discovery_services)
+    services = zip(blockchain_services, endpoint_discovery_services, raiden_udp_ports)
 
     apps = []
-    for idx, (blockchain, discovery) in enumerate(services):
-        port = raiden_udp_ports[idx]
-        private_key = blockchain.private_key
-        address = privatekey_to_address(private_key)
+    for idx, (blockchain, discovery, port) in enumerate(services):
+        private_key = blockchain.client.privkey
+        address = blockchain.client.address
 
         host = '127.0.0.1'
 
@@ -406,7 +405,6 @@ def jsonrpc_services(
     for privkey in private_keys:
         rpc_client = JSONRPCClient(web3, privkey)
         blockchain = BlockChainService(
-            privatekey_bin=privkey,
             jsonrpc_client=rpc_client,
             contract_manager=contract_manager,
         )

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -17,7 +17,7 @@ from twisted.internet import defer
 
 from raiden.network.utils import get_free_port
 from raiden.utils.http import HTTPExecutor
-from raiden.utils.signing import eth_recover
+from raiden.utils.signer import recover
 
 _SYNAPSE_BASE_DIR_VAR_NAME = 'RAIDEN_TESTS_SYNAPSE_BASE_DIR'
 _SYNAPSE_LOGS_PATH = os.environ.get('RAIDEN_TESTS_SYNAPSE_LOGS_DIR', False)
@@ -91,7 +91,7 @@ class EthAuthProvider(object):
         user_addr_hex = user_match.group(1)
         user_addr = unhexlify(user_addr_hex[2:])
 
-        rec_addr = eth_recover(data=self.hs_hostname.encode(), signature=signature)
+        rec_addr = recover(data=self.hs_hostname.encode(), signature=signature)
         if not rec_addr or rec_addr != user_addr:
             self.log.error(
                 'invalid account password/signature. user=%r, signer=%r',

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -72,7 +72,7 @@ from raiden.transfer.state_change import (
 )
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import pex
-from raiden.utils.signing import eth_recover
+from raiden.utils.signer import recover
 from raiden.utils.typing import (
     Address,
     Any,
@@ -320,11 +320,11 @@ def is_valid_signature(
     )
 
     try:
-        signer_address = eth_recover(
+        signer_address = recover(
             data=data_that_was_signed,
             signature=balance_proof.signature,
         )
-        # InvalidSignature is raised by eth_utils.eth_recover if signature
+        # InvalidSignature is raised by raiden.utils.signer.recover if signature
         # is not bytes or has the incorrect length
         #
         # ValueError is raised if the PublicKey instantiation failed, let it

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -249,7 +249,6 @@ def run_app(
     )
 
     blockchain_service = BlockChainService(
-        privatekey_bin=privatekey_bin,
         jsonrpc_client=rpc_client,
         # Not giving the contract manager here, but injecting it later
         # since we first need blockchain service to calculate the network id

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 import click
 import filelock
 import structlog
-from eth_utils import encode_hex, to_canonical_address, to_checksum_address, to_normalized_address
+from eth_utils import to_canonical_address, to_checksum_address, to_normalized_address
 from requests.exceptions import ConnectTimeout
 from web3 import HTTPProvider, Web3
 
@@ -229,7 +229,6 @@ def run_app(
     config['transport']['udp']['nat_keepalive_retries'] = DEFAULT_NAT_KEEPALIVE_RETRIES
     timeout = max_unresponsive_time / DEFAULT_NAT_KEEPALIVE_RETRIES
     config['transport']['udp']['nat_keepalive_timeout'] = timeout
-    config['privatekey_hex'] = encode_hex(privatekey_bin)
     config['unrecoverable_error_should_crash'] = unrecoverable_error_should_crash
     config['services']['pathfinding_service_address'] = pathfinding_service_address
     config['services']['pathfinding_max_paths'] = pathfinding_max_paths

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -8,7 +8,7 @@ from itertools import zip_longest
 from typing import Iterable, List, Optional, Tuple, Union
 
 import gevent
-from coincurve import PrivateKey
+from eth_keys import keys
 from eth_utils import (
     add_0x_prefix,
     decode_hex,
@@ -23,7 +23,7 @@ import raiden
 from raiden import constants
 from raiden.exceptions import InvalidAddress
 from raiden.utils import typing
-from raiden.utils.signing import sha3
+from raiden.utils.signing import sha3  # noqa
 
 
 def random_secret():
@@ -129,23 +129,11 @@ def privatekey_to_publickey(private_key_bin: bytes) -> bytes:
     """ Returns public key in bitcoins 'bin' encoding. """
     if not ishash(private_key_bin):
         raise ValueError('private_key_bin format mismatch. maybe hex encoded?')
-    private_key = PrivateKey(private_key_bin)
-    return private_key.public_key.format(compressed=False)
-
-
-def publickey_to_address(publickey: bytes) -> typing.Address:
-    return typing.Address(sha3(publickey[1:])[12:])
+    return keys.PrivateKey(private_key_bin).public_key.to_bytes()
 
 
 def privatekey_to_address(private_key_bin: bytes) -> typing.Address:
-    return publickey_to_address(privatekey_to_publickey(private_key_bin))
-
-
-def privtopub(private_key_bin: bytes) -> bytes:
-    """ Returns public key in bitcoins 'bin_electrum' encoding. """
-    raw_pubkey = privatekey_to_publickey(private_key_bin)
-    assert raw_pubkey.startswith(b'\x04')
-    return raw_pubkey[1:]
+    return keys.PrivateKey(private_key_bin).public_key.to_canonical_address()
 
 
 def get_project_root() -> str:

--- a/raiden/utils/signer.py
+++ b/raiden/utils/signer.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Union
+from typing import Callable
 
-from coincurve import PrivateKey
 from eth_keys import keys
 from eth_keys.exceptions import BadSignature
 from eth_utils import keccak, to_checksum_address
@@ -81,12 +80,10 @@ class Signer(ABC):
 
 
 class LocalSigner(Signer):
-    """ Concrete Signer implementation using a local raw or coincurve private key """
+    """ Concrete Signer implementation using a local private key """
     private_key: keys.PrivateKey
 
-    def __init__(self, private_key: Union[bytes, PrivateKey]) -> None:
-        if isinstance(private_key, PrivateKey):
-            private_key = private_key.secret
+    def __init__(self, private_key: bytes) -> None:
         self.private_key = keys.PrivateKey(private_key)
         self.address = self.private_key.public_key.to_canonical_address()
 

--- a/raiden/utils/signer.py
+++ b/raiden/utils/signer.py
@@ -1,0 +1,99 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Union
+
+from coincurve import PrivateKey
+from eth_keys import keys
+from eth_keys.exceptions import BadSignature
+from eth_utils import keccak, to_checksum_address
+
+from raiden.exceptions import InvalidSignature
+from raiden.utils.typing import Address, AddressHex
+
+
+def eth_sign_sha3(data: bytes) -> bytes:
+    """
+    eth_sign/recover compatible hasher
+    Prefixes data with "\x19Ethereum Signed Message:\n<len(data)>"
+    """
+    prefix = b'\x19Ethereum Signed Message:\n'
+    if not data.startswith(prefix):
+        data = prefix + b'%d%s' % (len(data), data)
+    return keccak(data)
+
+
+def recover(
+        data: bytes,
+        signature: bytes,
+        hasher: Callable[[bytes], bytes] = eth_sign_sha3,
+) -> Address:
+    """ eth_recover address from data hash and signature """
+    _hash = hasher(data)
+
+    if signature[-1] >= 27:  # support (0,1,27,28) v values
+        signature = signature[:-1] + bytes([signature[-1] - 27])
+
+    try:
+        sig = keys.Signature(signature_bytes=signature)
+        public_key = keys.ecdsa_recover(message_hash=_hash, signature=sig)
+    except BadSignature as e:
+        raise InvalidSignature from e
+    return public_key.to_canonical_address()
+
+
+class Signer(ABC):
+    """ ABC for Signer interface """
+    # attribute or cached property which represents the address of the account of this Signer
+    address: Address
+
+    # hasher used for this Signer to sign and recover hash
+    # must be kept in sync with sign implementation, which may or may not allow changing it
+    # (e.g. privatekey local signing may use it, but eth_sign rpc always use \x19-prefixed-hasher)
+    # default hasher is eth_sign/personal_sign/eip191 compatible
+    hasher: Callable[[bytes], bytes] = staticmethod(eth_sign_sha3)
+
+    @abstractmethod
+    def sign(self, data: bytes, v: int = 27) -> bytes:
+        """ Sign data hash (from hasher) with this Signer's account """
+        pass
+
+    # TODO: signTransaction (replace privkey on JSONRPCClient)
+    # @abstractmethod
+    # def signTransaction(self, transaction: dict) -> bytes:
+    #     """ Allows Signers to sign transactions with account """
+    #     pass
+
+    # TODO: signTypedData (one can dream)
+    # @abstractmethod
+    # def signTypedData(self, data: dict) -> bytes:
+    #     """ Allows Signers to sign typed/structured data from EIP-712 with account """
+    #     pass
+
+    @property
+    def address_hex(self) -> AddressHex:
+        return to_checksum_address(self.address)
+
+    def recover(self, data: bytes, signature: bytes) -> Address:
+        """ Use instance hasher to recover address from data hash and signature """
+        return recover(data=data, signature=signature, hasher=self.hasher)
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} for {self.address_hex}>'
+
+
+class LocalSigner(Signer):
+    """ Concrete Signer implementation using a local raw or coincurve private key """
+    private_key: keys.PrivateKey
+
+    def __init__(self, private_key: Union[bytes, PrivateKey]) -> None:
+        if isinstance(private_key, PrivateKey):
+            private_key = private_key.secret
+        self.private_key = keys.PrivateKey(private_key)
+        self.address = self.private_key.public_key.to_canonical_address()
+
+    def sign(self, data: bytes, v: int = 27) -> bytes:
+        assert v in (0, 27), 'Raiden is only signing messages with v in (0, 27)'
+        _hash = self.hasher(data)
+        signature = self.private_key.sign_msg_hash(message_hash=_hash)
+        sig_bytes = signature.to_bytes()
+        # adjust last byte to v
+        return sig_bytes[:-1] + bytes([sig_bytes[-1] + v])

--- a/raiden/utils/signer.py
+++ b/raiden/utils/signer.py
@@ -28,6 +28,8 @@ def recover(
     """ eth_recover address from data hash and signature """
     _hash = hasher(data)
 
+    # ecdsa_recover accepts only standard [0,1] v's so we add support also for [27,28] here
+    # anything else will raise BadSignature
     if signature[-1] >= 27:  # support (0,1,27,28) v values
         signature = signature[:-1] + bytes([signature[-1] - 27])
 
@@ -50,6 +52,7 @@ class Signer(ABC):
         pass
 
     # TODO: signTransaction (replace privkey on JSONRPCClient)
+    # issue: https://github.com/raiden-network/raiden/issues/3390
     # @abstractmethod
     # def signTransaction(self, transaction: dict) -> bytes:
     #     """ Allows Signers to sign transactions with account """

--- a/raiden/utils/signing.py
+++ b/raiden/utils/signing.py
@@ -1,83 +1,9 @@
-from coincurve import PrivateKey, PublicKey
-from eth_utils import decode_hex, keccak, remove_0x_prefix, to_bytes
+from eth_utils import decode_hex, keccak, remove_0x_prefix
 from web3.utils.abi import map_abi_data
 from web3.utils.encoding import hex_encode_abi_type
 from web3.utils.normalizers import abi_address_to_hex
 
-from raiden.exceptions import InvalidSignature
-from raiden.utils.typing import Address, Callable, Optional, Union
-
 sha3 = keccak
-Hasher = Optional[Callable[[bytes], bytes]]
-
-
-def eth_sign_sha3(data: bytes) -> bytes:
-    """
-    eth_sign/recover compatible hasher
-    Prefixes data with "\x19Ethereum Signed Message:\n<len(data)>"
-    """
-    prefix = b'\x19Ethereum Signed Message:\n'
-    if not data.startswith(prefix):
-        data = prefix + b'%d%s' % (len(data), data)
-    return sha3(data)
-
-
-def public_key_to_address(public_key: Union[PublicKey, bytes]) -> Address:
-    """ Converts a public key to an Ethereum address. """
-    if isinstance(public_key, PublicKey):
-        public_key = public_key.format(compressed=False)
-    assert isinstance(public_key, bytes)
-    return sha3(public_key[1:])[-20:]
-
-
-def address_from_signature(data: bytes, signature: bytes, hasher: Hasher = sha3) -> Address:
-    """Convert an EC signature into an ethereum address"""
-    if not isinstance(signature, bytes) or len(signature) != 65:
-        raise InvalidSignature('Invalid signature, must be 65 bytes')
-    v = signature[-1]
-    # Support Ethereum's EC v value of 27,28 but also 0,1 to be in
-    # sync with the values accepted by the contracts:
-    # https://github.com/raiden-network/raiden-contracts/blob/aea36ce403605670edc23fe0d14cf422e2b8e69b/raiden_contracts/contracts/lib/ECVerify.sol#L27
-    if v in (27, 28):
-        signature = signature[:-1] + bytes([signature[-1] - 27])
-    elif v not in (0, 1):
-        raise InvalidSignature(f'Invalid signature. v value of {v} is illegal.')
-
-    try:
-        signer_pubkey = PublicKey.from_signature_and_message(signature, data, hasher=hasher)
-        return public_key_to_address(signer_pubkey)
-    except Exception as e:  # pylint: disable=broad-except
-        # coincurve raises bare exception on verify error
-        raise InvalidSignature('Invalid signature') from e
-
-
-def eth_recover(data: bytes, signature: bytes, hasher: Hasher = eth_sign_sha3) -> Address:
-    """ Recover an address (hex encoded) from an eth_sign data and signature """
-    return address_from_signature(data=data, signature=signature, hasher=hasher)
-
-
-def sign(
-        privkey: Union[str, bytes, PrivateKey],
-        data: bytes,
-        v: int = 27,
-        hasher: Hasher = sha3,
-) -> bytes:
-    if isinstance(privkey, str):
-        privkey = to_bytes(hexstr=privkey)
-    if isinstance(privkey, bytes):
-        privkey = PrivateKey(privkey)
-    sig = privkey.sign_recoverable(data, hasher=hasher)
-    assert v in (0, 27), 'Raiden is only signing messages with v in (0, 27)'
-    return sig[:-1] + bytes([sig[-1] + v])
-
-
-def eth_sign(
-        privkey: Union[str, bytes, PrivateKey],
-        data: bytes,
-        v: int = 27,
-        hasher: Hasher = eth_sign_sha3,
-) -> bytes:
-    return sign(privkey, data, v=v, hasher=hasher)
 
 
 def pack_data(abi_types, values) -> bytes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cachetools
 coincurve
 colorama
+eth-keys
 eth-keyfile
 eth-utils
 filelock

--- a/tools/gas_cost_measures.py
+++ b/tools/gas_cost_measures.py
@@ -2,7 +2,6 @@ from os import urandom
 
 # increase block gas limit
 import eth_tester.backends.pyevm.main as pyevm_main
-from coincurve import PrivateKey
 from eth_tester import EthereumTester, PyEVMBackend
 from eth_utils import encode_hex
 from web3 import EthereumTesterProvider, Web3
@@ -22,11 +21,10 @@ class ContractTester:
         self.tester = EthereumTester(PyEVMBackend())
         self.web3 = Web3(EthereumTesterProvider(self.tester))
         if generate_keys > 0:
-            generated_keys = [urandom(32) for _ in range(generate_keys)]
-            self.private_keys = [PrivateKey(key) for key in generated_keys]
+            self.private_keys = [urandom(32) for _ in range(generate_keys)]
             self.accounts = [
-                self.tester.add_account(f'{encode_hex(key)}')
-                for key in generated_keys
+                self.tester.add_account(encode_hex(key))
+                for key in self.private_keys
             ]
             for account in self.accounts:
                 self.tester.send_transaction({

--- a/tools/gas_cost_measures.py
+++ b/tools/gas_cost_measures.py
@@ -10,7 +10,7 @@ from web3 import EthereumTesterProvider, Web3
 from raiden.constants import TRANSACTION_GAS_LIMIT
 from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils.signing import eth_sign
+from raiden.utils.signer import LocalSigner
 from raiden_contracts.contract_manager import CONTRACTS_SOURCE_DIRS, ContractManager
 from raiden_contracts.utils.utils import get_pending_transfers_tree
 
@@ -171,7 +171,7 @@ def find_max_pending_transfers(gas_limit):
             token_network_identifier=token_network_identifier,
             chain_id=1,
         )
-        signature = eth_sign(privkey=tester.private_keys[1], data=data_to_sign)
+        signature = LocalSigner(tester.private_keys[1]).sign(data=data_to_sign)
 
         tester.call_transaction(
             'TokenNetwork',


### PR DESCRIPTION
Replace direct usage of private keys with a class complying with a small interface:
right now, the `Signer` interface requires only an `address: Address` property/attribute to be set, and a `sign(data: bytes) -> bytes` to sign and return data in a `eth_sign`/eip-191 compatible manner.

This minimum interface will allow for easier sharing of code that needs signing without exposing how it's done (e.g. for matrix transport and MS), and will allow easily changing backend, e.g. by implementing e `RemoteSigner` which uses `eth_sign` rpc call to sign data with a remotely-held key.

- Implements last bullet-point of #3252
- Pave the way for #1402 and related issues
- Required for #3291 (for splitting away from transport/raiden essential functions which require signing)