### PR TITLE
Add block_identifier to all proxy functions that were missing it

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -144,8 +144,11 @@ class RaidenAPI:
 
         try:
             registry = self.raiden.chain.token_network_registry(registry_address)
-
-            return registry.add_token(token_address)
+            # LEFTODO: Supply a proper block id
+            return registry.add_token(
+                token_address=token_address,
+                given_block_identifier='latest',
+            )
         except RaidenRecoverableError as e:
             if 'Token already registered' in str(e):
                 raise AlreadyRegisteredTokenAddress('Token already registered')
@@ -427,7 +430,7 @@ class RaidenAPI:
             raise InsufficientFunds(msg)
 
         # set_total_deposit calls approve
-        # token.approve(netcontract_address, addendum)
+        # token.approve(netcontract_address, addendum, 'latest')
         # LEFTODO: Supply a proper block id
         channel_proxy.set_total_deposit(total_deposit, block_identifier='latest')
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -304,9 +304,11 @@ class RaidenAPI:
                 ))
 
             try:
+                # LEFTODO: Supply a proper block id
                 token_network.new_netting_channel(
                     partner=partner_address,
                     settle_timeout=settle_timeout,
+                    given_block_identifier='latest',
                 )
             except DuplicatedChannelError:
                 log.info('partner opened channel first')
@@ -426,7 +428,8 @@ class RaidenAPI:
 
         # set_total_deposit calls approve
         # token.approve(netcontract_address, addendum)
-        channel_proxy.set_total_deposit(total_deposit)
+        # LEFTODO: Supply a proper block id
+        channel_proxy.set_total_deposit(total_deposit, block_identifier='latest')
 
         target_address = self.raiden.address
         waiting.wait_for_participant_newbalance(

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -13,7 +13,8 @@ def get_channel_state(
         payment_channel_proxy,
         opened_block_number,
 ):
-    channel_details = payment_channel_proxy.detail()
+    # LEFTODO: Supply a proper block id
+    channel_details = payment_channel_proxy.detail('latest')
 
     our_state = NettingChannelEndState(
         channel_details.participants_data.our_details.address,

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -126,7 +126,12 @@ class MessageHandler:
 
     def handle_message_lockedtransfer(self, raiden: RaidenService, message: LockedTransfer):
         secret_hash = message.lock.secrethash
-        if raiden.default_secret_registry.check_registered(secret_hash):
+        # LEFTODO: Supply a proper block id
+        registered = raiden.default_secret_registry.check_registered(
+            secrethash=secret_hash,
+            block_identifier='latest',
+        )
+        if registered:
             log.warning(
                 f'Ignoring received locked transfer with secrethash {pex(secret_hash)} '
                 f'since it is already registered in the secret registry',

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -68,13 +68,12 @@ class PaymentChannel:
         """ Returns the address of the token for the channel. """
         return self.token_network.token_address()
 
-    def detail(self) -> ChannelDetails:
+    def detail(self, block_identifier: BlockSpecification) -> ChannelDetails:
         """ Returns the channel details. """
-        checking_block = self.client.get_checking_block()
         return self.token_network.detail(
             participant1=self.participant1,
             participant2=self.participant2,
-            block_identifier=checking_block,
+            block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
         )
 
@@ -123,50 +122,54 @@ class PaymentChannel:
         )
         return event['blockNumber']
 
-    def opened(self) -> bool:
+    def opened(self, block_identifier: BlockSpecification) -> bool:
         """ Returns if the channel is opened. """
         return self.token_network.channel_is_opened(
             participant1=self.participant1,
             participant2=self.participant2,
+            block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
         )
 
-    def closed(self) -> bool:
+    def closed(self, block_identifier: BlockSpecification) -> bool:
         """ Returns if the channel is closed. """
         return self.token_network.channel_is_closed(
             participant1=self.participant1,
             participant2=self.participant2,
+            block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
         )
 
-    def settled(self) -> bool:
+    def settled(self, block_identifier: BlockSpecification) -> bool:
         """ Returns if the channel is settled. """
         return self.token_network.channel_is_settled(
             participant1=self.participant1,
             participant2=self.participant2,
-            block_identifier='latest',
+            block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
         )
 
-    def closing_address(self) -> Optional[Address]:
+    def closing_address(self, block_identifier: BlockSpecification) -> Optional[Address]:
         """ Returns the address of the closer of the channel. """
         return self.token_network.closing_address(
             participant1=self.participant1,
             participant2=self.participant2,
-            block_identifier='latest',
+            block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
         )
 
-    def can_transfer(self) -> bool:
+    def can_transfer(self, block_identifier: BlockSpecification) -> bool:
         """ Returns True if the channel is opened and the node has deposit in it. """
         return self.token_network.can_transfer(
             participant1=self.participant1,
             participant2=self.participant2,
+            block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
         )
 
-    def set_total_deposit(self, total_deposit: TokenAmount):
+    def set_total_deposit(self, total_deposit: TokenAmount, block_identifier: BlockSpecification):
         self.token_network.set_total_deposit(
+            given_block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
             total_deposit=total_deposit,
             partner=self.participant2,
@@ -178,6 +181,7 @@ class PaymentChannel:
             balance_hash: BalanceHash,
             additional_hash: AdditionalHash,
             signature: Signature,
+            block_identifier: BlockSpecification,
     ):
         """ Closes the channel using the provided balance proof. """
         self.token_network.close(
@@ -187,6 +191,7 @@ class PaymentChannel:
             nonce=nonce,
             additional_hash=additional_hash,
             signature=signature,
+            given_block_identifier=block_identifier,
         )
 
     def update_transfer(
@@ -196,6 +201,7 @@ class PaymentChannel:
             additional_hash: AdditionalHash,
             partner_signature: Signature,
             signature: Signature,
+            block_identifier: BlockSpecification,
     ):
         """ Updates the channel using the provided balance proof. """
         self.token_network.update_transfer(
@@ -206,13 +212,15 @@ class PaymentChannel:
             additional_hash=additional_hash,
             closing_signature=partner_signature,
             non_closing_signature=signature,
+            given_block_identifier=block_identifier,
         )
 
-    def unlock(self, merkle_tree_leaves: bytes):
+    def unlock(self, merkle_tree_leaves: bytes, block_identifier: BlockSpecification):
         self.token_network.unlock(
             channel_identifier=self.channel_identifier,
             partner=self.participant2,
             merkle_tree_leaves=merkle_tree_leaves,
+            given_block_identifier=block_identifier,
         )
 
     def settle(
@@ -223,6 +231,7 @@ class PaymentChannel:
             partner_transferred_amount: int,
             partner_locked_amount: int,
             partner_locksroot: Locksroot,
+            block_identifier: BlockSpecification,
     ):
         """ Settles the channel. """
         self.token_network.settle(
@@ -234,6 +243,7 @@ class PaymentChannel:
             partner_transferred_amount=partner_transferred_amount,
             partner_locked_amount=partner_locked_amount,
             partner_locksroot=partner_locksroot,
+            given_block_identifier=block_identifier,
         )
 
     def all_events_filter(

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -40,13 +40,18 @@ class Token:
         self.node_address = jsonrpc_client.address
         self.proxy = proxy
 
-    def allowance(self, owner, spender, block_identifier):
+    def allowance(self, owner: Address, spender: Address, block_identifier: BlockSpecification):
         return self.proxy.contract.functions.allowance(
             to_checksum_address(owner),
             to_checksum_address(spender),
         ).call(block_identifier=block_identifier)
 
-    def approve(self, allowed_address: Address, allowance: TokenAmount):
+    def approve(
+            self,
+            allowed_address: Address,
+            allowance: TokenAmount,
+            given_block_identifier: BlockSpecification,
+    ):
         """ Aprove `allowed_address` to transfer up to `deposit` amount of token.
 
         Note:
@@ -54,6 +59,8 @@ class Token:
             For channel deposit please use the channel proxy, since it does
             additional validations.
         """
+        # Note that given_block_identifier is not used here as there
+        # are no preconditions to check before sending the transaction
 
         log_details = {
             'node': pex(self.node_address),
@@ -155,7 +162,14 @@ class Token:
             to_checksum_address(address),
         ).call(block_identifier=block_identifier)
 
-    def transfer(self, to_address, amount):
+    def transfer(
+            self,
+            to_address: Address,
+            amount: TokenAmount,
+            given_block_identifier: BlockSpecification,
+    ):
+        # Note that given_block_identifier is not used here as there
+        # are no preconditions to check before sending the transaction
         log_details = {
             'node': pex(self.node_address),
             'contract': pex(self.address),

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -719,7 +719,11 @@ class TokenNetwork:
         # in which case  the second `approve` will overwrite the first,
         # and the first `setTotalDeposit` will consume the allowance,
         #  making the second deposit fail.
-        token.approve(Address(self.address), amount_to_deposit)
+        token.approve(
+            allowed_address=Address(self.address),
+            allowance=amount_to_deposit,
+            given_block_identifier=block_identifier,
+        )
 
         return amount_to_deposit, log_details
 
@@ -832,7 +836,12 @@ class TokenNetwork:
             block_identifier=block_identifier,
         ).deposit
 
-        if token.allowance(self.node_address, self.address, block_identifier) < amount_to_deposit:
+        allowance = token.allowance(
+            owner=self.node_address,
+            spender=Address(self.address),
+            block_identifier=block_identifier,
+        )
+        if allowance < amount_to_deposit:
             msg = (
                 'The allowance is insufficient. Check concurrent deposits '
                 'for the same token network but different proxies.'

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -201,18 +201,21 @@ class TokenNetwork:
             self,
             partner: Address,
             settle_timeout: int,
+            given_block_identifier: BlockSpecification,
     ) -> ChannelID:
         """ Creates a new channel in the TokenNetwork contract.
 
         Args:
             partner: The peer to open the channel with.
             settle_timeout: The settle timeout to use for this channel.
+            given_block_identifier: The block identifier of the state change that
+                                    prompted this proxy action
 
         Returns:
             The ChannelID of the new netting channel.
         """
         checking_block = self.client.get_checking_block()
-        self._new_channel_preconditions(partner, settle_timeout, checking_block)
+        self._new_channel_preconditions(partner, settle_timeout, given_block_identifier)
         log_details = {
             'peer1': pex(self.node_address),
             'peer2': pex(partner),
@@ -490,15 +493,15 @@ class TokenNetwork:
             self,
             participant1: Address,
             participant2: Address,
+            block_identifier: BlockSpecification,
             channel_identifier: ChannelID,
     ) -> bool:
         """ Returns true if the channel is in an open state, false otherwise. """
-        checking_block = self.client.get_checking_block()
         try:
             channel_state = self._get_channel_state(
                 participant1=participant1,
                 participant2=participant2,
-                block_identifier=checking_block,
+                block_identifier=block_identifier,
                 channel_identifier=channel_identifier,
             )
         except RaidenRecoverableError:
@@ -509,15 +512,15 @@ class TokenNetwork:
             self,
             participant1: Address,
             participant2: Address,
+            block_identifier: BlockSpecification,
             channel_identifier: ChannelID,
     ) -> bool:
         """ Returns true if the channel is in a closed state, false otherwise. """
-        checking_block = self.client.get_checking_block()
         try:
             channel_state = self._get_channel_state(
                 participant1=participant1,
                 participant2=participant2,
-                block_identifier=checking_block,
+                block_identifier=block_identifier,
                 channel_identifier=channel_identifier,
             )
         except RaidenRecoverableError:
@@ -547,7 +550,7 @@ class TokenNetwork:
             self,
             participant1: Address,
             participant2: Address,
-            block_identifier: BlockSpecification = 'latest',
+            block_identifier: BlockSpecification,
             channel_identifier: ChannelID = None,
     ) -> Optional[Address]:
         """ Returns the address of the closer, if the channel is closed and not settled. None
@@ -584,6 +587,7 @@ class TokenNetwork:
             self,
             participant1: Address,
             participant2: Address,
+            block_identifier: BlockSpecification,
             channel_identifier: ChannelID,
     ) -> bool:
         """ Returns True if the channel is opened and the node has deposit in
@@ -591,7 +595,12 @@ class TokenNetwork:
 
         Note: Having a deposit does not imply having a balance for off-chain
         transfers. """
-        opened = self.channel_is_opened(participant1, participant2, channel_identifier)
+        opened = self.channel_is_opened(
+            participant1=participant1,
+            participant2=participant2,
+            block_identifier=block_identifier,
+            channel_identifier=channel_identifier,
+        )
 
         if opened is False:
             return False
@@ -600,7 +609,7 @@ class TokenNetwork:
             channel_identifier=channel_identifier,
             participant=participant1,
             partner=participant2,
-            block_identifier='latest',
+            block_identifier=block_identifier,
         ).deposit
         return deposit > 0
 
@@ -716,6 +725,7 @@ class TokenNetwork:
 
     def set_total_deposit(
             self,
+            given_block_identifier: BlockSpecification,
             channel_identifier: ChannelID,
             total_deposit: TokenAmount,
             partner: Address,
@@ -740,7 +750,7 @@ class TokenNetwork:
                 total_deposit=total_deposit,
                 partner=partner,
                 token=token,
-                block_identifier=checking_block,
+                block_identifier=given_block_identifier,
             )
 
             gas_limit = self.proxy.estimate_gas(
@@ -892,6 +902,7 @@ class TokenNetwork:
             nonce: Nonce,
             additional_hash: AdditionalHash,
             signature: Signature,
+            given_block_identifier: BlockSpecification,
     ):
         """ Close the channel using the provided balance proof.
 
@@ -921,7 +932,7 @@ class TokenNetwork:
         self._close_preconditions(
             channel_identifier,
             partner=partner,
-            block_identifier=checking_block,
+            block_identifier=given_block_identifier,
         )
 
         error_prefix = 'closeChannel call will fail'
@@ -1062,6 +1073,7 @@ class TokenNetwork:
             additional_hash: AdditionalHash,
             closing_signature: Signature,
             non_closing_signature: Signature,
+            given_block_identifier: BlockSpecification,
     ):
         log_details = {
             'token_network': pex(self.address),
@@ -1083,7 +1095,7 @@ class TokenNetwork:
             nonce=nonce,
             additional_hash=additional_hash,
             closing_signature=closing_signature,
-            block_identifier=checking_block,
+            block_identifier=given_block_identifier,
         )
 
         error_prefix = 'updateNonClosingBalanceProof call will fail'
@@ -1181,7 +1193,10 @@ class TokenNetwork:
             channel_identifier: ChannelID,
             partner: Address,
             merkle_tree_leaves: MerkleTreeLeaves,
+            given_block_identifier: BlockSpecification,
     ):
+        # Note: given_block_identifier
+        # is unused at the moment here
         log_details = {
             'token_network': pex(self.address),
             'node': pex(self.node_address),
@@ -1310,6 +1325,7 @@ class TokenNetwork:
             partner_transferred_amount: TokenAmount,
             partner_locked_amount: TokenAmount,
             partner_locksroot: Locksroot,
+            given_block_identifier: BlockSpecification,
     ):
         """ Settle the channel. """
         log_details = {
@@ -1336,7 +1352,7 @@ class TokenNetwork:
             partner_transferred_amount=partner_transferred_amount,
             partner_locked_amount=partner_locked_amount,
             partner_locksroot=partner_locksroot,
-            block_identifier=checking_block,
+            block_identifier=given_block_identifier,
         )
 
         with self.channel_operations_lock[partner]:

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -89,7 +89,9 @@ class TokenNetworkRegistry:
 
         return address
 
-    def add_token(self, token_address: TokenAddress):
+    def add_token(self, token_address: TokenAddress, given_block_identifier: BlockSpecification):
+        # given_block_identifier is not really used in this function yet as there
+        # are no preconditions to check with the given block
         if not is_binary_address(token_address):
             raise InvalidAddress('Expected binary address format for token')
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -241,7 +241,11 @@ class RaidenEventHandler:
             raiden: RaidenService,
             channel_reveal_secret_event: ContractSendSecretReveal,
     ):
-        raiden.default_secret_registry.register_secret(channel_reveal_secret_event.secret)
+        # LEFTODO: Supply a proper block id
+        raiden.default_secret_registry.register_secret(
+            secret=channel_reveal_secret_event.secret,
+            given_block_identifier='latest',
+        )
 
     def handle_contract_send_channelclose(
             self,
@@ -418,7 +422,10 @@ class RaidenEventHandler:
 
         try:
             # LEFTODO: Supply a proper block id
-            payment_channel.unlock(merkle_tree_leave=merkle_tree_leaves, block_identifier='latest')
+            payment_channel.unlock(
+                merkle_tree_leaves=merkle_tree_leaves,
+                block_identifier='latest',
+            )
         except ChannelOutdatedError as e:
             log.error(
                 str(e),

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -267,11 +267,13 @@ class RaidenEventHandler:
             channel_id=channel_close_event.channel_identifier,
         )
 
+        # LEFTODO: Supply a proper block id
         channel_proxy.close(
-            nonce,
-            balance_hash,
-            message_hash,
-            signature,
+            nonce=nonce,
+            balance_hash=balance_hash,
+            additional_hash=message_hash,
+            signature=signature,
+            block_identifier='latest',
         )
 
     def handle_contract_send_channelupdate(
@@ -299,12 +301,14 @@ class RaidenEventHandler:
             our_signature = raiden.signer.sign(data=non_closing_data)
 
             try:
+                # LEFTODO: Supply a proper block id
                 channel.update_transfer(
                     nonce=balance_proof.nonce,
                     balance_hash=balance_proof.balance_hash,
                     additional_hash=balance_proof.message_hash,
                     partner_signature=balance_proof.signature,
                     signature=our_signature,
+                    block_identifier='latest',
                 )
             except ChannelOutdatedError as e:
                 log.error(
@@ -413,7 +417,8 @@ class RaidenEventHandler:
             merkle_tree_leaves = get_batch_unlock(our_state)
 
         try:
-            payment_channel.unlock(merkle_tree_leaves)
+            # LEFTODO: Supply a proper block id
+            payment_channel.unlock(merkle_tree_leave=merkle_tree_leaves, block_identifier='latest')
         except ChannelOutdatedError as e:
             log.error(
                 str(e),
@@ -521,11 +526,13 @@ class RaidenEventHandler:
             partner_locked_amount = 0
             partner_locksroot = EMPTY_HASH
 
+        # LEFTODO: Supply a proper block id
         payment_channel.settle(
-            our_transferred_amount,
-            our_locked_amount,
-            our_locksroot,
-            partner_transferred_amount,
-            partner_locked_amount,
-            partner_locksroot,
+            transferred_amount=our_transferred_amount,
+            locked_amount=our_locked_amount,
+            locksroot=our_locksroot,
+            partner_transferred_amount=partner_transferred_amount,
+            partner_locked_amount=partner_locked_amount,
+            partner_locksroot=partner_locksroot,
+            block_identifier='latest',
         )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -763,7 +763,12 @@ class RaidenService(Runnable):
     ) -> AsyncResult:
 
         secret_hash = sha3(secret)
-        if self.default_secret_registry.check_registered(secret_hash):
+        # LEFTODO: Supply a proper block id
+        secret_registered = self.default_secret_registry.check_registered(
+            secrethash=secret_hash,
+            block_identifier='latest',
+        )
+        if secret_registered:
             raise RaidenUnrecoverableError(
                 f'Attempted to initiate a locked transfer with secrethash {pex(secret_hash)}.'
                 f' That secret is already registered onchain.',

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -40,8 +40,9 @@ def test_payment_channel_proxy_basics(
 
     # create a channel
     channel_identifier = c1_token_network_proxy.new_netting_channel(
-        c2_client.address,
-        TEST_SETTLE_TIMEOUT_MIN,
+        partner=c2_client.address,
+        settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+        given_block_identifier='latest',
     )
     assert channel_identifier is not None
 
@@ -65,8 +66,8 @@ def test_payment_channel_proxy_basics(
     assert channel_proxy_1.channel_identifier == channel_identifier
     assert channel_proxy_2.channel_identifier == channel_identifier
 
-    assert channel_proxy_1.opened() is True
-    assert channel_proxy_2.opened() is True
+    assert channel_proxy_1.opened('latest') is True
+    assert channel_proxy_2.opened('latest') is True
 
     # check the settlement timeouts
     assert channel_proxy_1.settle_timeout() == channel_proxy_2.settle_timeout()
@@ -84,7 +85,7 @@ def test_payment_channel_proxy_basics(
     assert initial_balance_c2 == 0
 
     # actual deposit
-    channel_proxy_1.set_total_deposit(10)
+    channel_proxy_1.set_total_deposit(total_deposit=10, block_identifier='latest')
 
     events = channel_filter.get_all_entries()
     assert len(events) == 2  # ChannelOpened, ChannelNewDeposit
@@ -111,9 +112,10 @@ def test_payment_channel_proxy_basics(
         nonce=balance_proof.nonce,
         additional_hash=decode_hex(balance_proof.additional_hash),
         signature=decode_hex(balance_proof.signature),
+        given_block_identifier='latest',
     )
-    assert channel_proxy_1.closed() is True
-    assert channel_proxy_2.closed() is True
+    assert channel_proxy_1.closed('latest') is True
+    assert channel_proxy_2.closed('latest') is True
 
     events = channel_filter.get_all_entries()
     assert len(events) == 3  # ChannelOpened, ChannelNewDeposit, ChannelClosed
@@ -136,9 +138,10 @@ def test_payment_channel_proxy_basics(
         partner_transferred_amount=transferred_amount,
         partner_locked_amount=0,
         partner_locksroot=EMPTY_HASH,
+        given_block_identifier='latest',
     )
-    assert channel_proxy_1.settled() is True
-    assert channel_proxy_2.settled() is True
+    assert channel_proxy_1.settled('latest') is True
+    assert channel_proxy_2.settled('latest') is True
 
     events = channel_filter.get_all_entries()
 
@@ -167,8 +170,9 @@ def test_payment_channel_outdated_channel_close(
 
     # create a channel
     channel_identifier = token_network_proxy.new_netting_channel(
-        partner,
-        TEST_SETTLE_TIMEOUT_MIN,
+        partner=partner,
+        settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+        given_block_identifier='latest',
     )
     assert channel_identifier is not None
 
@@ -186,7 +190,7 @@ def test_payment_channel_outdated_channel_close(
 
     assert channel_proxy_1.channel_identifier == channel_identifier
 
-    assert channel_proxy_1.opened() is True
+    assert channel_proxy_1.opened('latest') is True
 
     # balance proof by c1
     balance_proof = BalanceProof(
@@ -209,8 +213,9 @@ def test_payment_channel_outdated_channel_close(
         nonce=balance_proof.nonce,
         additional_hash=bytes(32),
         signature=decode_hex(balance_proof.signature),
+        given_block_identifier='latest',
     )
-    assert channel_proxy_1.closed() is True
+    assert channel_proxy_1.closed('latest') is True
 
     events = channel_filter.get_all_entries()
     assert len(events) == 2  # ChannelOpened, ChannelClosed
@@ -230,8 +235,9 @@ def test_payment_channel_outdated_channel_close(
         partner_transferred_amount=0,
         partner_locked_amount=0,
         partner_locksroot=EMPTY_HASH,
+        given_block_identifier='latest',
     )
-    assert channel_proxy_1.settled() is True
+    assert channel_proxy_1.settled('latest') is True
 
     events = channel_filter.get_all_entries()
 
@@ -240,8 +246,9 @@ def test_payment_channel_outdated_channel_close(
     # Create a new channel with a different identifier
     # create a channel
     new_channel_identifier = token_network_proxy.new_netting_channel(
-        partner,
-        TEST_SETTLE_TIMEOUT_MIN,
+        partner=partner,
+        settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+        given_block_identifier='latest',
     )
     assert new_channel_identifier is not None
     # create channel proxies
@@ -252,7 +259,7 @@ def test_payment_channel_outdated_channel_close(
     )
 
     assert channel_proxy_2.channel_identifier == new_channel_identifier
-    assert channel_proxy_2.opened() is True
+    assert channel_proxy_2.opened('latest') is True
 
     with pytest.raises(ChannelOutdatedError):
         token_network_proxy.close(
@@ -262,4 +269,5 @@ def test_payment_channel_outdated_channel_close(
             nonce=balance_proof.nonce,
             additional_hash=bytes(32),
             signature=decode_hex(balance_proof.signature),
+            given_block_identifier='latest',
         )

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -78,7 +78,7 @@ def test_payment_channel_proxy_basics(
 
     # test deposits
     initial_token_balance = 100
-    token_proxy.transfer(c1_client.address, initial_token_balance)
+    token_proxy.transfer(c1_client.address, initial_token_balance, 'latest')
     initial_balance_c1 = token_proxy.balance_of(c1_client.address)
     assert initial_balance_c1 == initial_token_balance
     initial_balance_c2 = token_proxy.balance_of(c2_client.address)

--- a/raiden/tests/integration/contracts/test_secret_registry.py
+++ b/raiden/tests/integration/contracts/test_secret_registry.py
@@ -12,7 +12,7 @@ def test_secret_registry(secret_registry_proxy):
     #  register secret
     secret = make_secret()
     event_filter = secret_registry_proxy.secret_registered_filter()
-    secret_registry_proxy.register_secret(secret)
+    secret_registry_proxy.register_secret(secret=secret, given_block_identifier='latest')
 
     # check if event is raised
     logs = event_filter.get_all_entries()
@@ -21,11 +21,18 @@ def test_secret_registry(secret_registry_proxy):
     data = keccak(secret)
     assert decoded_event['args']['secrethash'] == data
     # check if registration block matches
-    block = secret_registry_proxy.get_register_block_for_secrethash(data)
+    block = secret_registry_proxy.get_register_block_for_secrethash(
+        secrethash=data,
+        block_identifier='latest',
+    )
     assert logs[0]['blockNumber'] == block
 
     #  test non-existing secret
-    assert 0 == secret_registry_proxy.get_register_block_for_secrethash(b'\x11' * 32)
+    block = secret_registry_proxy.get_register_block_for_secrethash(
+        secrethash=b'\x11' * 32,
+        block_identifier='latest',
+    )
+    assert 0 == block
 
 
 def test_secret_registry_register_batch(secret_registry_proxy):
@@ -33,12 +40,18 @@ def test_secret_registry_register_batch(secret_registry_proxy):
     secrethashes = [keccak(secret) for secret in secrets]
 
     event_filter = secret_registry_proxy.secret_registered_filter()
-    secret_registry_proxy.register_secret_batch(secrets)
+    secret_registry_proxy.register_secret_batch(
+        secrets=secrets,
+        given_block_identifier='latest',
+    )
 
     logs = event_filter.get_all_entries()
     assert len(logs) == 4
 
-    block = secret_registry_proxy.get_register_block_for_secrethash(secrethashes[0])
+    block = secret_registry_proxy.get_register_block_for_secrethash(
+        secrethash=secrethashes[0],
+        block_identifier='latest',
+    )
     decoded_events = [secret_registry_proxy.proxy.decode_event(log) for log in logs]
     assert all(event['blockNumber'] == block for event in decoded_events)
 
@@ -60,7 +73,7 @@ def secret_registry_proxy_patched(secret_registry_proxy, contract_manager):
         for secret in secrets:
             assert secret not in self.trigger
             self.trigger[secret] = True
-        return register_secret_batch(secrets)
+        return register_secret_batch(secrets=secrets, given_block_identifier='latest')
 
     secret_registry_patched._register_secret_batch = types.MethodType(
         register_secret_batch_patched,
@@ -86,6 +99,7 @@ def test_concurrent_access(
         gevent.spawn(
             secret_registry_proxy_patched.register_secret,
             secret,
+            'latest',
         )
         for _ in range(0, 40)
     ]

--- a/raiden/tests/integration/contracts/test_token.py
+++ b/raiden/tests/integration/contracts/test_token.py
@@ -24,13 +24,13 @@ def test_token(
 
     # send some funds from deployer to generated address
     transfer_funds = 100
-    token_proxy.transfer(address, transfer_funds)
+    token_proxy.transfer(address, transfer_funds, 'latest')
     assert transfer_funds == token_proxy.balance_of(address)
     allow_funds = 100
-    token_proxy.approve(address, allow_funds)
+    token_proxy.approve(address, allow_funds, 'latest')
     assert allow_funds == token_proxy.proxy.contract.functions.allowance(
         to_checksum_address(deploy_client.address),
         to_checksum_address(address),
     ).call(block_identifier='latest')
-    other_token_proxy.transfer(deploy_client.address, transfer_funds)
+    other_token_proxy.transfer(deploy_client.address, transfer_funds, 'latest')
     assert token_proxy.balance_of(address) == 0

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -43,21 +43,24 @@ def test_token_network_deposit_race(
     )
     token_proxy.transfer(c1_client.address, 10)
     channel_identifier = c1_token_network_proxy.new_netting_channel(
-        c2_client.address,
-        TEST_SETTLE_TIMEOUT_MIN,
+        partner=c2_client.address,
+        settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+        given_block_identifier='latest',
     )
     assert channel_identifier is not None
 
     c1_token_network_proxy.set_total_deposit(
-        channel_identifier,
-        2,
-        c2_client.address,
+        given_block_identifier='latest',
+        channel_identifier=channel_identifier,
+        total_deposit=2,
+        partner=c2_client.address,
     )
     with pytest.raises(DepositMismatch):
         c1_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            1,
-            c2_client.address,
+            given_block_identifier='latest',
+            channel_identifier=channel_identifier,
+            total_deposit=1,
+            partner=c2_client.address,
         )
 
 
@@ -111,39 +114,45 @@ def test_token_network_proxy_basics(
         to_checksum_address(c2_client.address),
     )
     assert c1_token_network_proxy.channel_is_opened(
-        c1_client.address,
-        c2_client.address,
-        channel_identifier,
+        participant1=c1_client.address,
+        participant2=c2_client.address,
+        block_identifier='latest',
+        channel_identifier=channel_identifier,
     ) is False
     assert c1_token_network_proxy.channel_is_closed(
-        c1_client.address,
-        c2_client.address,
-        channel_identifier,
+        participant1=c1_client.address,
+        participant2=c2_client.address,
+        block_identifier='latest',
+        channel_identifier=channel_identifier,
     ) is False
     # test timeout limits
     with pytest.raises(InvalidSettleTimeout):
         c1_token_network_proxy.new_netting_channel(
-            c2_client.address,
-            TEST_SETTLE_TIMEOUT_MIN - 1,
+            partner=c2_client.address,
+            settle_timeout=TEST_SETTLE_TIMEOUT_MIN - 1,
+            given_block_identifier='latest',
         )
     with pytest.raises(InvalidSettleTimeout):
         c1_token_network_proxy.new_netting_channel(
-            c2_client.address,
-            TEST_SETTLE_TIMEOUT_MAX + 1,
+            partner=c2_client.address,
+            settle_timeout=TEST_SETTLE_TIMEOUT_MAX + 1,
+            given_block_identifier='latest',
         )
     # channel to self
     with pytest.raises(SamePeerAddress):
         c1_token_network_proxy.new_netting_channel(
-            c1_client.address,
-            TEST_SETTLE_TIMEOUT_MIN,
+            partner=c1_client.address,
+            settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+            given_block_identifier='latest',
         )
 
     # Channel is not open yet
     with pytest.raises(RaidenUnrecoverableError) as exc:
         c1_token_network_proxy.set_total_deposit(
-            1,
-            1,
-            c2_client.address,
+            given_block_identifier='latest',
+            channel_identifier=1,
+            total_deposit=1,
+            partner=c2_client.address,
         )
 
         assert 'does not exist' in str(exc)
@@ -151,27 +160,30 @@ def test_token_network_proxy_basics(
     # Channel is not open yet
     with pytest.raises(RaidenUnrecoverableError) as exc:
         c1_token_network_proxy.close(
-            1,
-            c2_client.address,
-            EMPTY_HASH,
-            0,
-            EMPTY_HASH,
-            EMPTY_HASH,
+            channel_identifier=1,
+            partner=c2_client.address,
+            balance_hash=EMPTY_HASH,
+            nonce=0,
+            additional_hash=EMPTY_HASH,
+            signature=EMPTY_HASH,
+            given_block_identifier='latest',
         )
 
         assert 'does not exist' in str(exc)
 
     # actually create a channel
     channel_identifier = c1_token_network_proxy.new_netting_channel(
-        c2_client.address,
-        TEST_SETTLE_TIMEOUT_MIN,
+        partner=c2_client.address,
+        settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+        given_block_identifier='latest',
     )
     assert channel_identifier is not None
     # multiple channels with the same peer are not allowed
     with pytest.raises(DuplicatedChannelError):
         c1_token_network_proxy.new_netting_channel(
-            c2_client.address,
-            TEST_SETTLE_TIMEOUT_MIN,
+            partner=c2_client.address,
+            settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+            given_block_identifier='latest',
         )
     assert c1_token_network_proxy.channel_exists_and_not_settled(
         participant1=c1_client.address,
@@ -182,6 +194,7 @@ def test_token_network_proxy_basics(
     assert c1_token_network_proxy.channel_is_opened(
         participant1=c1_client.address,
         participant2=c2_client.address,
+        block_identifier='latest',
         channel_identifier=channel_identifier,
     ) is True
 
@@ -189,23 +202,26 @@ def test_token_network_proxy_basics(
     # deposit with no balance
     with pytest.raises(DepositMismatch):
         c1_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            101,
-            c2_client.address,
+            given_block_identifier='latest',
+            channel_identifier=channel_identifier,
+            total_deposit=101,
+            partner=c2_client.address,
         )
 
     # no negative deposit
     with pytest.raises(DepositMismatch):
         c1_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            -1,
-            c2_client.address,
+            given_block_identifier='latest',
+            channel_identifier=channel_identifier,
+            total_deposit=-1,
+            partner=c2_client.address,
         )
     # actual deposit
     c1_token_network_proxy.set_total_deposit(
-        channel_identifier,
-        10,
-        c2_client.address,
+        given_block_identifier='latest',
+        channel_identifier=channel_identifier,
+        total_deposit=10,
+        partner=c2_client.address,
     )
 
     # balance proof by c2
@@ -231,6 +247,7 @@ def test_token_network_proxy_basics(
             nonce=balance_proof.nonce,
             additional_hash=decode_hex(balance_proof.additional_hash),
             signature=b'\x11' * 65,
+            given_block_identifier='latest',
         )
 
     # correct close
@@ -241,10 +258,12 @@ def test_token_network_proxy_basics(
         nonce=balance_proof.nonce,
         additional_hash=decode_hex(balance_proof.additional_hash),
         signature=decode_hex(balance_proof.signature),
+        given_block_identifier='latest',
     )
     assert c1_token_network_proxy.channel_is_closed(
         participant1=c1_client.address,
         participant2=c2_client.address,
+        block_identifier='latest',
         channel_identifier=channel_identifier,
     ) is True
     assert c1_token_network_proxy.channel_exists_and_not_settled(
@@ -263,13 +282,15 @@ def test_token_network_proxy_basics(
             nonce=balance_proof.nonce,
             additional_hash=decode_hex(balance_proof.additional_hash),
             signature=decode_hex(balance_proof.signature),
+            given_block_identifier='latest',
         )
 
     with pytest.raises(RaidenRecoverableError) as exc:
         c2_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            20,
-            c1_client.address,
+            given_block_identifier='latest',
+            channel_identifier=channel_identifier,
+            total_deposit=20,
+            partner=c1_client.address,
         )
 
         assert 'not in an open state' in str(exc)
@@ -282,6 +303,7 @@ def test_token_network_proxy_basics(
             nonce=balance_proof.nonce,
             additional_hash=decode_hex(balance_proof.additional_hash),
             signature=decode_hex(balance_proof.signature),
+            given_block_identifier='latest',
         )
 
         assert 'not in an open state' in str(exc)
@@ -302,6 +324,7 @@ def test_token_network_proxy_basics(
             partner_transferred_amount=transferred_amount,
             partner_locked_amount=0,
             partner_locksroot=EMPTY_HASH,
+            given_block_identifier='latest',
         )
 
     c2_token_network_proxy.settle(
@@ -313,6 +336,7 @@ def test_token_network_proxy_basics(
         partner_transferred_amount=transferred_amount,
         partner_locked_amount=0,
         partner_locksroot=EMPTY_HASH,
+        given_block_identifier='latest',
     )
     assert c1_token_network_proxy.channel_exists_and_not_settled(
         participant1=c1_client.address,
@@ -325,9 +349,10 @@ def test_token_network_proxy_basics(
 
     with pytest.raises(RaidenUnrecoverableError) as exc:
         c1_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            10,
-            c2_client.address,
+            given_block_identifier='latest',
+            channel_identifier=channel_identifier,
+            total_deposit=10,
+            partner=c2_client.address,
         )
         # No channel exists
         assert 'getChannelIdentifier returned 0' in str(exc)
@@ -359,8 +384,9 @@ def test_token_network_proxy_update_transfer(
     )
     # create a channel
     channel_identifier = c1_token_network_proxy.new_netting_channel(
-        c2_client.address,
-        10,
+        partner=c2_client.address,
+        settle_timeout=10,
+        given_block_identifier='latest',
     )
     # deposit to the channel
     initial_balance = 100
@@ -371,14 +397,16 @@ def test_token_network_proxy_update_transfer(
     initial_balance_c2 = token_proxy.balance_of(c2_client.address)
     assert initial_balance_c2 == initial_balance
     c1_token_network_proxy.set_total_deposit(
-        channel_identifier,
-        10,
-        c2_client.address,
+        given_block_identifier='latest',
+        channel_identifier=channel_identifier,
+        total_deposit=10,
+        partner=c2_client.address,
     )
     c2_token_network_proxy.set_total_deposit(
-        channel_identifier,
-        10,
-        c1_client.address,
+        given_block_identifier='latest',
+        channel_identifier=channel_identifier,
+        total_deposit=10,
+        partner=c1_client.address,
     )
     # balance proof signed by c1
     transferred_amount_c1 = 1
@@ -418,13 +446,14 @@ def test_token_network_proxy_update_transfer(
 
     with pytest.raises(RaidenUnrecoverableError) as exc:
         c2_token_network_proxy.update_transfer(
-            channel_identifier,
-            c1_client.address,
-            decode_hex(balance_proof_c1.balance_hash),
-            balance_proof_c1.nonce,
-            decode_hex(balance_proof_c1.additional_hash),
-            decode_hex(balance_proof_c1.signature),
-            non_closing_signature,
+            channel_identifier=channel_identifier,
+            partner=c1_client.address,
+            balance_hash=decode_hex(balance_proof_c1.balance_hash),
+            nonce=balance_proof_c1.nonce,
+            additional_hash=decode_hex(balance_proof_c1.additional_hash),
+            closing_signature=decode_hex(balance_proof_c1.signature),
+            non_closing_signature=non_closing_signature,
+            given_block_identifier='latest',
         )
 
         assert 'not in a closed state' in str(exc)
@@ -437,18 +466,20 @@ def test_token_network_proxy_update_transfer(
         nonce=balance_proof_c2.nonce,
         additional_hash=decode_hex(balance_proof_c2.additional_hash),
         signature=decode_hex(balance_proof_c2.signature),
+        given_block_identifier='latest',
     )
 
     # update transfer with completely invalid closing signature
     with pytest.raises(RaidenUnrecoverableError) as excinfo:
         c2_token_network_proxy.update_transfer(
-            channel_identifier,
-            c1_client.address,
-            decode_hex(balance_proof_c1.balance_hash),
-            balance_proof_c1.nonce,
-            decode_hex(balance_proof_c1.additional_hash),
-            b'',
-            b'',
+            channel_identifier=channel_identifier,
+            partner=c1_client.address,
+            balance_hash=decode_hex(balance_proof_c1.balance_hash),
+            nonce=balance_proof_c1.nonce,
+            additional_hash=decode_hex(balance_proof_c1.additional_hash),
+            closing_signature=b'',
+            non_closing_signature=b'',
+            given_block_identifier='latest',
         )
     assert str(excinfo.value) == "Couldn't verify the balance proof signature"
 
@@ -460,13 +491,14 @@ def test_token_network_proxy_update_transfer(
     )
     with pytest.raises(RaidenUnrecoverableError):
         c2_token_network_proxy.update_transfer(
-            channel_identifier,
-            c1_client.address,
-            decode_hex(balance_proof_c1.balance_hash),
-            balance_proof_c1.nonce,
-            decode_hex(balance_proof_c1.additional_hash),
-            decode_hex(balance_proof_c1.signature),
-            non_closing_signature,
+            channel_identifier=channel_identifier,
+            partner=c1_client.address,
+            balance_hash=decode_hex(balance_proof_c1.balance_hash),
+            nonce=balance_proof_c1.nonce,
+            additional_hash=decode_hex(balance_proof_c1.additional_hash),
+            closing_signature=decode_hex(balance_proof_c1.signature),
+            non_closing_signature=non_closing_signature,
+            given_block_identifier='latest',
         )
 
     non_closing_data = balance_proof_c1.serialize_bin(
@@ -476,13 +508,14 @@ def test_token_network_proxy_update_transfer(
         data=non_closing_data,
     )
     c2_token_network_proxy.update_transfer(
-        channel_identifier,
-        c1_client.address,
-        decode_hex(balance_proof_c1.balance_hash),
-        balance_proof_c1.nonce,
-        decode_hex(balance_proof_c1.additional_hash),
-        decode_hex(balance_proof_c1.signature),
-        non_closing_signature,
+        channel_identifier=channel_identifier,
+        partner=c1_client.address,
+        balance_hash=decode_hex(balance_proof_c1.balance_hash),
+        nonce=balance_proof_c1.nonce,
+        additional_hash=decode_hex(balance_proof_c1.additional_hash),
+        closing_signature=decode_hex(balance_proof_c1.signature),
+        non_closing_signature=non_closing_signature,
+        given_block_identifier='latest',
     )
 
     with pytest.raises(RaidenUnrecoverableError) as exc:
@@ -495,6 +528,7 @@ def test_token_network_proxy_update_transfer(
             partner_transferred_amount=transferred_amount_c2,
             partner_locked_amount=0,
             partner_locksroot=EMPTY_HASH,
+            given_block_identifier='latest',
         )
 
         assert 'cannot be settled before settlement window is over' in str(exc)
@@ -512,6 +546,7 @@ def test_token_network_proxy_update_transfer(
             partner_transferred_amount=2,
             partner_locked_amount=0,
             partner_locksroot=EMPTY_HASH,
+            given_block_identifier='latest',
         )
 
     # proper settle
@@ -524,6 +559,7 @@ def test_token_network_proxy_update_transfer(
         partner_transferred_amount=transferred_amount_c2,
         partner_locked_amount=0,
         partner_locksroot=EMPTY_HASH,
+        given_block_identifier='latest',
     )
     assert (token_proxy.balance_of(c2_client.address) ==
             (initial_balance_c2 + transferred_amount_c1 - transferred_amount_c2))
@@ -533,9 +569,10 @@ def test_token_network_proxy_update_transfer(
     # Already settled
     with pytest.raises(RaidenUnrecoverableError) as exc:
         c2_token_network_proxy.set_total_deposit(
-            channel_identifier,
-            20,
-            c1_client.address,
+            given_block_identifier='latest',
+            channel_identifier=channel_identifier,
+            total_deposit=20,
+            partner=c1_client.address,
         )
 
         assert 'getChannelIdentifier returned 0' in str(exc)

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -41,7 +41,7 @@ def test_token_network_deposit_race(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
     )
-    token_proxy.transfer(c1_client.address, 10)
+    token_proxy.transfer(c1_client.address, 10, 'latest')
     channel_identifier = c1_token_network_proxy.new_netting_channel(
         partner=c2_client.address,
         settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
@@ -93,8 +93,8 @@ def test_token_network_proxy_basics(
     )
 
     initial_token_balance = 100
-    token_proxy.transfer(c1_client.address, initial_token_balance)
-    token_proxy.transfer(c2_client.address, initial_token_balance)
+    token_proxy.transfer(c1_client.address, initial_token_balance, 'latest')
+    token_proxy.transfer(c2_client.address, initial_token_balance, 'latest')
     initial_balance_c1 = token_proxy.balance_of(c1_client.address)
     assert initial_balance_c1 == initial_token_balance
     initial_balance_c2 = token_proxy.balance_of(c2_client.address)
@@ -390,8 +390,8 @@ def test_token_network_proxy_update_transfer(
     )
     # deposit to the channel
     initial_balance = 100
-    token_proxy.transfer(c1_client.address, initial_balance)
-    token_proxy.transfer(c2_client.address, initial_balance)
+    token_proxy.transfer(c1_client.address, initial_balance, 'latest')
+    token_proxy.transfer(c2_client.address, initial_balance, 'latest')
     initial_balance_c1 = token_proxy.balance_of(c1_client.address)
     assert initial_balance_c1 == initial_balance
     initial_balance_c2 = token_proxy.balance_of(c2_client.address)

--- a/raiden/tests/integration/contracts/test_token_network_registry.py
+++ b/raiden/tests/integration/contracts/test_token_network_registry.py
@@ -20,7 +20,7 @@ def test_token_network_registry(
     bad_token_address = make_address()
     # try to register non-existing token network
     with pytest.raises(RaidenUnrecoverableError):
-        token_network_registry_proxy.add_token(bad_token_address)
+        token_network_registry_proxy.add_token(bad_token_address, 'latest')
     # create token network & register it
     test_token = deploy_token(
         deploy_client=deploy_client,
@@ -33,12 +33,14 @@ def test_token_network_registry(
     test_token_address = to_canonical_address(test_token.contract.address)
     event_filter = token_network_registry_proxy.tokenadded_filter()
     token_network_address = token_network_registry_proxy.add_token(
-        test_token_address,
+        token_address=test_token_address,
+        given_block_identifier='latest',
     )
 
     with pytest.raises(RaidenRecoverableError) as exc:
         token_network_address = token_network_registry_proxy.add_token(
-            test_token_address,
+            token_address=test_token_address,
+            given_block_identifier='latest',
         )
 
         assert 'Token already registered' in str(exc)

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -42,7 +42,8 @@ def token_addresses(
 
     if register_tokens:
         for token in token_addresses:
-            deploy_service.token_network_registry(token_network_registry_address).add_token(token)
+            registry = deploy_service.token_network_registry(token_network_registry_address)
+            registry.add_token(token_address=token, given_block_identifier='latest')
 
     return token_addresses
 

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -477,6 +477,7 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
     with pytest.raises(RaidenUnrecoverableError):
         netting_channel.unlock(
             merkle_tree_leaves=batch_unlock,
+            block_identifier='latest',
         )
 
     expected_balance0 = initial_balance0 + deposit0 - amount * 2

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -341,7 +341,7 @@ def test_batch_unlock(raiden_network, token_addresses, secret_registry_address, 
     secret_registry_proxy = alice_app.raiden.chain.secret_registry(
         secret_registry_address,
     )
-    secret_registry_proxy.register_secret(secret)
+    secret_registry_proxy.register_secret(secret=secret, given_block_identifier='latest')
 
     assert lock, 'the lock must still be part of the node state'
     msg = 'the secret must be registered before the lock expires'
@@ -537,7 +537,10 @@ def test_automatic_secret_registration(raiden_chain, token_addresses):
     lock_expiration = target_task.target_state.transfer.lock.expiration
     app1.raiden.chain.wait_until_block(target_block_number=lock_expiration)
 
-    assert app1.raiden.default_secret_registry.check_registered(secrethash)
+    assert app1.raiden.default_secret_registry.check_registered(
+        secrethash=secrethash,
+        block_identifier='latest',
+    )
 
 
 @pytest.mark.xfail(reason='test incomplete')

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -70,6 +70,7 @@ def test_node_can_settle_if_close_didnt_use_any_balance_proof(
         nonce=0,
         additional_hash=EMPTY_HASH,
         signature=EMPTY_SIGNATURE,
+        given_block_identifier='latest',
     )
     waiting.wait_for_close(
         raiden=app0.raiden,

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -24,8 +24,9 @@ def test_channel_with_self(raiden_network, settle_timeout, token_addresses):
 
     with pytest.raises(SamePeerAddress) as excinfo:
         token_network0.new_netting_channel(
-            app0.raiden.address,
-            settle_timeout,
+            partner=app0.raiden.address,
+            settle_timeout=settle_timeout,
+            given_block_identifier='latest',
         )
 
     assert 'The other peer must not have the same address as the client.' in str(excinfo.value)

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -259,18 +259,18 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
 
 
 def test_regression_register_secret_once(secret_registry_address, deploy_service):
-    """Register secret transaction must not sent if the secret is already registered"""
+    """Register secret transaction must not be sent if the secret is already registered"""
     # pylint: disable=protected-access
 
     secret_registry = deploy_service.secret_registry(secret_registry_address)
 
     secret = sha3(b'test_regression_register_secret_once')
-    secret_registry.register_secret(secret)
+    secret_registry.register_secret(secret=secret, given_block_identifier='latest')
 
     previous_nonce = deploy_service.client._available_nonce
-    secret_registry.register_secret(secret)
+    secret_registry.register_secret(secret=secret, given_block_identifier='latest')
     assert previous_nonce == deploy_service.client._available_nonce
 
     previous_nonce = deploy_service.client._available_nonce
-    secret_registry.register_secret_batch([secret])
+    secret_registry.register_secret_batch(secrets=[secret], given_block_identifier='latest')
     assert previous_nonce == deploy_service.client._available_nonce

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -83,7 +83,7 @@ def test_locked_transfer_secret_registered_onchain(
     secret_registry_proxy = app0.raiden.chain.secret_registry(
         secret_registry_address,
     )
-    secret_registry_proxy.register_secret(transfer_secret)
+    secret_registry_proxy.register_secret(secret=transfer_secret, given_block_identifier='latest')
 
     # Test that sending a transfer with a secret already registered on-chain fails
     with pytest.raises(RaidenUnrecoverableError):

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -52,11 +52,11 @@ def check_channel(
     assert settle_timeout == netcontract2.settle_timeout()
 
     if deposit_amount > 0:
-        assert netcontract1.can_transfer()
-        assert netcontract2.can_transfer()
+        assert netcontract1.can_transfer('latest')
+        assert netcontract2.can_transfer('latest')
 
-    app1_details = netcontract1.detail()
-    app2_details = netcontract2.detail()
+    app1_details = netcontract1.detail('latest')
+    app2_details = netcontract2.detail('latest')
 
     assert (
         app1_details.participants_data.our_details.address ==
@@ -92,8 +92,9 @@ def payment_channel_open_and_deposit(app0, app1, token_address, deposit, settle_
     token_network_proxy = app0.raiden.chain.token_network(token_network_address)
 
     channel_identifier = token_network_proxy.new_netting_channel(
-        app1.raiden.address,
-        settle_timeout,
+        partner=app1.raiden.address,
+        settle_timeout=settle_timeout,
+        given_block_identifier='latest',
     )
     assert channel_identifier
 
@@ -112,7 +113,7 @@ def payment_channel_open_and_deposit(app0, app1, token_address, deposit, settle_
 
         # the payment channel proxy will call approve
         # token.approve(token_network_proxy.address, deposit)
-        payment_channel_proxy.set_total_deposit(deposit)
+        payment_channel_proxy.set_total_deposit(total_deposit=deposit, block_identifier='latest')
 
         # Balance must decrease by at least but not exactly `deposit` amount,
         # because channels can be openned in parallel

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -112,7 +112,7 @@ def payment_channel_open_and_deposit(app0, app1, token_address, deposit, settle_
         assert previous_balance >= deposit
 
         # the payment channel proxy will call approve
-        # token.approve(token_network_proxy.address, deposit)
+        # token.approve(token_network_proxy.address, deposit, 'latest')
         payment_channel_proxy.set_total_deposit(total_deposit=deposit, block_identifier='latest')
 
         # Balance must decrease by at least but not exactly `deposit` amount,

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -72,8 +72,9 @@ def deploy_tokens_and_fund_accounts(
         # transfer from the creator to the other nodes
         for transfer_to in participants:
             deploy_service.token(token_address).transfer(
-                transfer_to,
-                token_amount // len(participants),
+                to_address=transfer_to,
+                amount=token_amount // len(participants),
+                given_block_identifier='latest',
             )
 
     return result

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -281,7 +281,10 @@ def setup_testchain_and_raiden(transport, matrix_server, print_step, contracts_v
         registry_address=contract_addresses[CONTRACT_TOKEN_NETWORK_REGISTRY],
         contract_manager=contract_manager,
     )
-    registry.add_token(to_canonical_address(token.contract.address))
+    registry.add_token(
+        token_address=to_canonical_address(token.contract.address),
+        given_block_identifier='latest',
+    )
 
     print_step('Setting up Raiden')
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -233,7 +233,11 @@ class ConsoleTools:
         token_address = decode_hex(token_address_hex)
 
         registry = self._raiden.chain.token_network_registry(registry_address)
-        token_network_address = registry.add_token(token_address)
+        # LEFTODO: Supply a proper block id
+        token_network_address = registry.add_token(
+            token_address=token_address,
+            given_block_identifier='latest',
+        )
 
         # Register the channel manager with the raiden registry
         waiting.wait_for_payment_network(


### PR DESCRIPTION
### Introdunction

~~Merge after #3389 as its diff is also included here.~~ [Augusto: done]

This is a step towards the completion of https://github.com/raiden-network/raiden/issues/2885
In the spirit of smaller PRs for easier review I am making this a standalone PR.

### What this PR does

- Add `block_identifier` to all proxy query functions that were missing it and make sure the call chain uses it properly.
- Add `given_block_identifier` (a better name suggestion is also welcome) to all proxy functions that send an on chain transaction. This block identifier will be used for all onchain queries for preconditions required for the action. Should eventually come from the state machine. Also added it to functions that don't have any preconditions for consistency's sake.
- Add the comment `# LEFTODO: Supply a proper block id` for all the product logic locations where the `block_identifier` should be properly provided. Either from the state machine, or from the user or just `latest` should be used. This is my big TODO where the next PRs will pick up from.
- For most of the tests the `'latest'` block_identifier was given.