### PR TITLE
typing: Made TransitionResult state not optional

### DIFF
--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -10,7 +10,6 @@ from raiden.utils.typing import (
     Generic,
     List,
     MessageID,
-    Optional,
     T_BlockNumber,
     T_ChannelID,
     TransactionHash,
@@ -299,7 +298,7 @@ class TransitionResult(Generic[ST]):  # pylint: disable=unsubscriptable-object
         'events',
     )
 
-    def __init__(self, new_state: Optional[ST], events: List[Event]):
+    def __init__(self, new_state: ST, events: List[Event]):
         self.new_state = new_state
         self.events = events
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -680,7 +680,7 @@ def valid_lockedtransfer_check(
 def refund_transfer_matches_received(
         refund_transfer: LockedTransferSignedState,
         received_transfer: LockedTransferUnsignedState,
-):
+) -> bool:
     refund_transfer_sender = refund_transfer.balance_proof.sender
     # Ignore a refund from the target
     if refund_transfer_sender == received_transfer.target:
@@ -897,7 +897,7 @@ def get_distributable(
 
 def get_batch_unlock(
         end_state: NettingChannelEndState,
-) -> Optional[MerkleTreeLeaves]:
+) -> MerkleTreeLeaves:
     """ Unlock proof for an entire merkle tree of pending locks
 
     The unlock proof contains all the merkle tree data, tightly packed, needed by the token
@@ -1011,7 +1011,10 @@ def get_status(channel_state):
     return result
 
 
-def _del_unclaimed_lock(end_state: NettingChannelEndState, secrethash: SecretHash):
+def _del_unclaimed_lock(
+        end_state: NettingChannelEndState,
+        secrethash: SecretHash,
+) -> None:
     if secrethash in end_state.secrethashes_to_lockedlocks:
         del end_state.secrethashes_to_lockedlocks[secrethash]
 
@@ -1108,7 +1111,7 @@ def compute_merkletree_with(
 def compute_merkletree_without(
         merkletree: MerkleTreeState,
         lockhash: LockHash,
-) -> MerkleTreeState:
+) -> Optional[MerkleTreeState]:
     # Use None to inform the caller the lockshash is unknown
     result = None
 
@@ -1228,6 +1231,9 @@ def create_unlock(
         our_state.merkletree,
         lock.lockhash,
     )
+    msg = 'the lock is pending, it must be in the merkletree'
+    assert merkletree is not None, msg
+
     locksroot = merkleroot(merkletree)
 
     token_address = channel_state.token_address
@@ -1556,7 +1562,7 @@ def handle_action_close(
         channel_state: NettingChannelState,
         close: ActionChannelClose,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     msg = 'caller must make sure the ids match'
     assert channel_state.identifier == close.channel_identifier, msg
 
@@ -1568,7 +1574,7 @@ def handle_refundtransfer(
         received_transfer: LockedTransferUnsignedState,
         channel_state: NettingChannelState,
         refund: ReceiveTransferRefund,
-):
+) -> EventsOrError:
     is_valid, msg, merkletree = is_valid_refund(
         refund=refund,
         channel_state=channel_state,
@@ -1603,7 +1609,7 @@ def handle_receive_lock_expired(
         channel_state: NettingChannelState,
         state_change: ReceiveLockExpired,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     """Remove expired locks from channel states."""
     is_valid, msg, merkletree = is_valid_lock_expired(
         state_change=state_change,
@@ -1717,7 +1723,7 @@ def handle_block(
         channel_state: NettingChannelState,
         state_change: Block,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     assert state_change.block_number == block_number
 
     events = list()
@@ -1751,7 +1757,7 @@ def handle_block(
 def handle_channel_closed(
         channel_state: NettingChannelState,
         state_change: ContractReceiveChannelClosed,
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     events = list()
 
     just_closed = (
@@ -1794,7 +1800,7 @@ def handle_channel_updated_transfer(
         channel_state: NettingChannelState,
         state_change: ContractReceiveUpdateTransfer,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     if state_change.channel_identifier == channel_state.identifier:
         # update transfer was called, make sure we don't call it again
         channel_state.update_transaction = TransactionExecutionStatus(
@@ -1810,7 +1816,7 @@ def handle_channel_settled(
         channel_state: NettingChannelState,
         state_change: ContractReceiveChannelSettled,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[NettingChannelState]]:
     events: List[Event] = list()
 
     # At the moment each participant unlocks its receiving half of the
@@ -1847,7 +1853,7 @@ def handle_channel_newbalance(
         channel_state: NettingChannelState,
         state_change: ContractReceiveChannelNewBalance,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     deposit_transaction = state_change.deposit_transaction
 
     if is_transaction_confirmed(deposit_transaction.deposit_block_number, block_number):
@@ -1879,7 +1885,7 @@ def apply_channel_newbalance(
 def handle_channel_batch_unlock(
         channel_state: NettingChannelState,
         state_change: ContractReceiveChannelBatchUnlock,
-) -> TransitionResult:
+) -> TransitionResult[Optional[NettingChannelState]]:
     events = list()
 
     # Unlock is allowed by the smart contract only on a settled channel.
@@ -1898,7 +1904,7 @@ def state_transition(
         state_change: StateChange,
         pseudo_random_generator: Any,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[NettingChannelState]]:
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 
     events: List[Event] = list()

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -88,7 +88,7 @@ def handle_block(
         state_change: Block,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorTransferState]]:
     """ Checks if the lock has expired, and if it has sends a remove expired
     lock and emits the failing events.
     """
@@ -216,7 +216,7 @@ def try_new_route(
         transfer_description: TransferDescriptionWithSecretState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorTransferState]]:
 
     channel_state = next_channel_from_routes(
         available_routes,
@@ -298,7 +298,7 @@ def handle_secretrequest(
         state_change: ReceiveSecretRequest,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorTransferState]:
 
     is_message_from_target = (
         state_change.sender == initiator_state.transfer_description.target and
@@ -359,7 +359,7 @@ def handle_offchain_secretreveal(
         state_change: ReceiveSecretReveal,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorTransferState]]:
     """ Once the next hop proves it knows the secret, the initiator can unlock
     the mediated transfer.
 
@@ -396,7 +396,7 @@ def handle_onchain_secretreveal(
         state_change: ContractReceiveSecretReveal,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorTransferState]]:
     """ When a secret is revealed on-chain all nodes learn the secret.
 
     This check the on-chain secret corresponds to the one used by the
@@ -449,7 +449,7 @@ def state_transition(
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorTransferState]]:
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION
         iteration = handle_block(

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -19,10 +19,20 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state import RouteState
 from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal
-from raiden.utils.typing import MYPY_ANNOTATION, BlockNumber, ChannelMap, List, SecretHash, cast
+from raiden.utils.typing import (
+    MYPY_ANNOTATION,
+    BlockNumber,
+    ChannelMap,
+    List,
+    Optional,
+    SecretHash,
+    cast,
+)
 
 
-def clear_if_finalized(iteration: TransitionResult) -> TransitionResult:
+def clear_if_finalized(
+        iteration: TransitionResult,
+) -> TransitionResult[Optional[InitiatorPaymentState]]:
     """ Clear the initiator payment task if all transfers have been finalized
     or expired. """
     state = cast(InitiatorPaymentState, iteration.new_state)
@@ -93,7 +103,7 @@ def maybe_try_new_route(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     events: List[Event] = list()
     if can_cancel(initiator_state):
         cancel_events = cancel_current_route(payment_state, initiator_state)
@@ -132,7 +142,7 @@ def subdispatch_to_initiatortransfer(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     channel_identifier = initiator_state.channel_identifier
     channel_state = channelidentifiers_to_channels.get(channel_identifier)
     if not channel_state:
@@ -158,7 +168,7 @@ def subdispatch_to_all_initiatortransfer(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     events = list()
     ''' Copy and iterate over the list of keys because this loop
     will alter the `initiator_transfers` list and this is not
@@ -184,7 +194,7 @@ def handle_block(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     return subdispatch_to_all_initiatortransfer(
         payment_state=payment_state,
         state_change=state_change,
@@ -200,7 +210,7 @@ def handle_init(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorPaymentState]]:
     events: List[Event]
     if payment_state is None:
         sub_iteration = initiator.try_new_route(
@@ -228,7 +238,7 @@ def handle_init(
 def handle_cancelpayment(
         payment_state: InitiatorPaymentState,
         channelidentifiers_to_channels: ChannelMap,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     """ Cancel the payment and all related transfers. """
     # Cannot cancel a transfer after the secret is revealed
     events = list()
@@ -265,7 +275,7 @@ def handle_transferrefundcancelroute(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     initiator_state = payment_state.initiator_transfers.get(state_change.transfer.lock.secrethash)
     if not initiator_state:
         return TransitionResult(payment_state, list())
@@ -338,7 +348,7 @@ def handle_lock_expired(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     """Initiator also needs to handle LockExpired messages when refund transfers are involved.
 
     A -> B -> C
@@ -416,7 +426,7 @@ def handle_onchain_secretreveal(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     initiator_state = payment_state.initiator_transfers.get(state_change.secrethash)
 
     if not initiator_state:
@@ -446,7 +456,7 @@ def handle_secretrequest(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[InitiatorPaymentState]:
     initiator_state = payment_state.initiator_transfers.get(state_change.secrethash)
 
     if not initiator_state:
@@ -473,7 +483,7 @@ def state_transition(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[InitiatorPaymentState]]:
     # pylint: disable=unidiomatic-typecheck
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -278,7 +278,7 @@ def sanity_check(state: MediatorTransferState) -> None:
 def clear_if_finalized(
         iteration: TransitionResult,
         channelidentifiers_to_channels: ChannelMap,
-) -> TransitionResult:
+) -> TransitionResult[Optional[MediatorTransferState]]:
     """Clear the mediator task if all the locks have been finalized.
 
     A lock is considered finalized if it has been removed from the merkle tree
@@ -958,7 +958,7 @@ def secret_learned(
         secret: Secret,
         secrethash: SecretHash,
         payee_address: Address,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     """ Unlock the payee lock, reveal the lock to the payer, and if necessary
     register the secret on-chain.
     """
@@ -1012,7 +1012,7 @@ def mediate_transfer(
         pseudo_random_generator: random.Random,
         payer_transfer: LockedTransferSignedState,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     """ Try a new route or fail back to a refund.
 
     The mediator can safely try a new route knowing that the tokens from
@@ -1077,7 +1077,7 @@ def handle_init(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[MediatorTransferState]]:
     routes = state_change.routes
 
     from_route = state_change.from_route
@@ -1119,7 +1119,7 @@ def handle_block(
         state_change: Block,
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     """ After Raiden learns about a new block this function must be called to
     handle expiration of the hash time locks.
     Args:
@@ -1162,7 +1162,7 @@ def handle_refundtransfer(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) ->TransitionResult:
+) ->TransitionResult[MediatorTransferState]:
     """ Validate and handle a ReceiveTransferRefund mediator_state change.
     A node might participate in mediated transfer more than once because of
     refund transfers, eg. A-B-C-B-D-T, B tried to mediate the transfer through
@@ -1221,7 +1221,7 @@ def handle_offchain_secretreveal(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     """ Handles the secret reveal and sends SendBalanceProof/RevealSecret if necessary. """
     is_valid_reveal = is_valid_secret_reveal(
         state_change=mediator_state_change,
@@ -1269,7 +1269,7 @@ def handle_onchain_secretreveal(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     """ The secret was revealed on-chain, set the state of all transfers to
     secret known.
     """
@@ -1312,7 +1312,7 @@ def handle_unlock(
         mediator_state: MediatorTransferState,
         state_change: ReceiveUnlock,
         channelidentifiers_to_channels: ChannelMap,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     """ Handle a ReceiveUnlock state change. """
     events = list()
     balance_proof_sender = state_change.balance_proof.sender
@@ -1354,7 +1354,7 @@ def handle_lock_expired(
         state_change: ReceiveLockExpired,
         channelidentifiers_to_channels: ChannelMap,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[MediatorTransferState]:
     events = list()
 
     for transfer_pair in mediator_state.transfers_pair:
@@ -1397,7 +1397,7 @@ def state_transition(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[MediatorTransferState]]:
     """ State machine for a node mediating a transfer. """
     # pylint: disable=too-many-branches
     # Notes:

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -91,7 +91,7 @@ def handle_inittarget(
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """ Handles an ActionInitTarget state change. """
     transfer = state_change.transfer
     route = state_change.route
@@ -158,7 +158,7 @@ def handle_offchain_secretreveal(
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[TargetTransferState]:
     """ Validates and handles a ReceiveSecretReveal state change. """
     valid_secret = is_valid_secret_reveal(
         state_change=state_change,
@@ -204,7 +204,7 @@ def handle_onchain_secretreveal(
         target_state: TargetTransferState,
         state_change: ContractReceiveSecretReveal,
         channel_state: NettingChannelState,
-) -> TransitionResult:
+) -> TransitionResult[TargetTransferState]:
     """ Validates and handles a ContractReceiveSecretReveal state change. """
     valid_secret = is_valid_secret_reveal(
         state_change=state_change,
@@ -230,7 +230,7 @@ def handle_unlock(
         target_state: TargetTransferState,
         state_change: ReceiveUnlock,
         channel_state: NettingChannelState,
-) -> TransitionResult:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """ Handles a ReceiveUnlock state change. """
     balance_proof_sender = state_change.balance_proof.sender
 
@@ -270,7 +270,7 @@ def handle_block(
         target_state: TargetTransferState,
         channel_state: NettingChannelState,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[TargetTransferState]:
     """ After Raiden learns about a new block this function must be called to
     handle expiration of the hash time lock.
     """
@@ -312,7 +312,7 @@ def handle_lock_expired(
         state_change: ReceiveLockExpired,
         channel_state: NettingChannelState,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """Remove expired locks from channel states."""
     result = channel.handle_receive_lock_expired(
         channel_state=channel_state,
@@ -339,7 +339,7 @@ def state_transition(
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """ State machine for the target node of a mediated transfer. """
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -55,7 +55,7 @@ Locksroot = NewType('Locksroot', T_Locksroot)
 T_LockHash = bytes
 LockHash = NewType('LockHash', T_LockHash)
 
-T_MerkleTreeLeaves = List['HashTimeLockState']
+T_MerkleTreeLeaves = List[Union['HashTimeLockState', 'UnlockPartialProofState']]
 MerkleTreeLeaves = NewType('MerkleTreeLeaves', T_MerkleTreeLeaves)
 
 T_MessageID = int


### PR DESCRIPTION
Not all state transitions can result in a None state, namely the chain,
and the token network can never be deleted. For this reason the
`Optional[]` part of the type was moved out of the `TransitionResult`.

This additionally add the missing type parameter to the most functions.