### PR TITLE
fixed partial initialization

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -29,7 +29,7 @@ class BlockChainService:
     def __init__(
             self,
             jsonrpc_client: JSONRPCClient,
-            contract_manager: ContractManager = None,
+            contract_manager: ContractManager,
     ):
         self.address_to_discovery = dict()
         self.address_to_secret_registry = dict()
@@ -57,9 +57,6 @@ class BlockChainService:
 
     def get_block(self, block_identifier):
         return self.client.web3.eth.getBlock(block_identifier=block_identifier)
-
-    def inject_contract_manager(self, contract_manager: ContractManager):
-        self.contract_manager = contract_manager
 
     def is_synced(self) -> bool:
         result = self.client.web3.eth.syncing

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -23,7 +23,10 @@ def test_payment_channel_proxy_basics(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(c1_client)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+    )
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
@@ -160,7 +163,10 @@ def test_payment_channel_outdated_channel_close(
     partner = privatekey_to_address(private_keys[0])
 
     client = JSONRPCClient(web3, private_keys[1])
-    chain = BlockChainService(client)
+    chain = BlockChainService(
+        jsonrpc_client=client,
+        contract_manager=contract_manager,
+    )
     token_network_proxy = TokenNetwork(
         jsonrpc_client=client,
         token_network_address=token_network_address,

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -79,7 +79,10 @@ def test_token_network_proxy_basics(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(c1_client)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+    )
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
@@ -370,7 +373,10 @@ def test_token_network_proxy_update_transfer(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(c1_client)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+    )
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -239,7 +239,7 @@ def run_app(
 
     web3 = _setup_web3(eth_rpc_endpoint)
     given_network_id = network_id
-    node_network_id = int(web3.version.network)
+    node_network_id = int(web3.version.network)  # pylint: disable=no-member
     known_given_network_id = given_network_id in ID_TO_NETWORKNAME
     known_node_network_id = node_network_id in ID_TO_NETWORKNAME
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -552,10 +552,9 @@ def smoketest(ctx, debug):
 
         raiden_stdout = StringIO()
         with contextlib.redirect_stdout(raiden_stdout):
-            try:
-                # invoke the raiden app
-                app = run_app(**args)
+            app = run_app(**args)
 
+            try:
                 raiden_api = RaidenAPI(app.raiden)
                 rest_api = RestAPI(raiden_api)
                 (api_host, api_port) = split_endpoint(args['api_address'])


### PR DESCRIPTION
The contract manager is *required* to instantiate any of the proxies
through the BlockchainService. Without a contract manager the service is
effectively useless, since it's main responsability is to be a container
of proxies, to ensure proxy instances are shared making sure the locks
work.

This changes code to alwas give a reference to the contract manager
while instantiating a blockchain service.