### PR TITLE
Simplify fixtures

### DIFF
--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -13,7 +13,7 @@ from raiden_contracts.constants import (
 )
 
 
-@pytest.fixture(name='secret_registry_contract')
+@pytest.fixture(name='secret_registry_contract_address')
 def deploy_secret_register_and_return_jsonrpc_proxy(deploy_client, contract_manager):
     """This uses the JSONRPCClient to deploy the secret registry smart
     contract, and returns a JSONRPCClient proxy to interact with the smart
@@ -22,14 +22,15 @@ def deploy_secret_register_and_return_jsonrpc_proxy(deploy_client, contract_mana
     compiled = {
         CONTRACT_SECRET_REGISTRY: contract_manager.get_contract(CONTRACT_SECRET_REGISTRY),
     }
-    return deploy_client.deploy_solidity_contract(
+    secret_registry_proxy_ = deploy_client.deploy_solidity_contract(
         CONTRACT_SECRET_REGISTRY,
         compiled,
     )
+    return secret_registry_proxy_.contract.address
 
 
 @pytest.fixture
-def secret_registry_proxy(deploy_client, secret_registry_contract, contract_manager):
+def secret_registry_proxy(deploy_client, secret_registry_contract_address, contract_manager):
     """This uses the available SecretRegistry JSONRPCClient proxy to
     instantiate a Raiden proxy.
 
@@ -40,7 +41,7 @@ def secret_registry_proxy(deploy_client, secret_registry_contract, contract_mana
     """
     return SecretRegistry(
         jsonrpc_client=deploy_client,
-        secret_registry_address=to_canonical_address(secret_registry_contract.contract.address),
+        secret_registry_address=to_canonical_address(secret_registry_contract_address),
         contract_manager=contract_manager,
     )
 
@@ -50,7 +51,7 @@ def deploy_token_network_registry_and_return_jsonrpc_proxy(
         chain_id,
         deploy_client,
         contract_manager,
-        secret_registry_contract,
+        secret_registry_contract_address,
 ):
     compiled = {
         CONTRACT_TOKEN_NETWORK_REGISTRY: contract_manager.get_contract(
@@ -61,7 +62,7 @@ def deploy_token_network_registry_and_return_jsonrpc_proxy(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         compiled,
         constructor_parameters=[
-            secret_registry_contract.contract.address,
+            secret_registry_contract_address,
             chain_id,
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
@@ -82,7 +83,7 @@ def token_network_registry_proxy(deploy_client, token_network_registry_contract,
 def deploy_token_network_and_return_jsonrpc_proxy(
         chain_id,
         deploy_client,
-        secret_registry_contract,
+        secret_registry_contract_address,
         token_contract,
         contract_manager,
 ):
@@ -96,7 +97,7 @@ def deploy_token_network_and_return_jsonrpc_proxy(
         compiled,
         constructor_parameters=[
             token_contract.contract.address,
-            secret_registry_contract.contract.address,
+            secret_registry_contract_address,
             chain_id,
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,

--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -6,7 +6,6 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
-    CONTRACT_TOKEN_NETWORK_REGISTRY,
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
@@ -29,35 +28,11 @@ def secret_registry_proxy(deploy_client, secret_registry_address, contract_manag
     )
 
 
-@pytest.fixture(name='token_network_registry_contract')
-def deploy_token_network_registry_and_return_jsonrpc_proxy(
-        chain_id,
-        deploy_client,
-        contract_manager,
-        secret_registry_address,
-):
-    compiled = {
-        CONTRACT_TOKEN_NETWORK_REGISTRY: contract_manager.get_contract(
-            CONTRACT_TOKEN_NETWORK_REGISTRY,
-        ),
-    }
-    return deploy_client.deploy_solidity_contract(
-        CONTRACT_TOKEN_NETWORK_REGISTRY,
-        compiled,
-        constructor_parameters=[
-            secret_registry_address,
-            chain_id,
-            TEST_SETTLE_TIMEOUT_MIN,
-            TEST_SETTLE_TIMEOUT_MAX,
-        ],
-    )
-
-
 @pytest.fixture
-def token_network_registry_proxy(deploy_client, token_network_registry_contract, contract_manager):
+def token_network_registry_proxy(deploy_client, token_network_registry_address, contract_manager):
     return TokenNetworkRegistry(
         jsonrpc_client=deploy_client,
-        registry_address=to_canonical_address(token_network_registry_contract.contract.address),
+        registry_address=to_canonical_address(token_network_registry_address),
         contract_manager=contract_manager,
     )
 

--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -5,7 +5,6 @@ from raiden.network.proxies import SecretRegistry, Token, TokenNetwork, TokenNet
 from raiden.tests.utils import factories
 from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import (
-    CONTRACT_SECRET_REGISTRY,
     CONTRACT_TOKEN_NETWORK,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     TEST_SETTLE_TIMEOUT_MAX,
@@ -13,24 +12,8 @@ from raiden_contracts.constants import (
 )
 
 
-@pytest.fixture(name='secret_registry_contract_address')
-def deploy_secret_register_and_return_jsonrpc_proxy(deploy_client, contract_manager):
-    """This uses the JSONRPCClient to deploy the secret registry smart
-    contract, and returns a JSONRPCClient proxy to interact with the smart
-    contract.
-    """
-    compiled = {
-        CONTRACT_SECRET_REGISTRY: contract_manager.get_contract(CONTRACT_SECRET_REGISTRY),
-    }
-    secret_registry_proxy_ = deploy_client.deploy_solidity_contract(
-        CONTRACT_SECRET_REGISTRY,
-        compiled,
-    )
-    return secret_registry_proxy_.contract.address
-
-
 @pytest.fixture
-def secret_registry_proxy(deploy_client, secret_registry_contract_address, contract_manager):
+def secret_registry_proxy(deploy_client, secret_registry_address, contract_manager):
     """This uses the available SecretRegistry JSONRPCClient proxy to
     instantiate a Raiden proxy.
 
@@ -41,7 +24,7 @@ def secret_registry_proxy(deploy_client, secret_registry_contract_address, contr
     """
     return SecretRegistry(
         jsonrpc_client=deploy_client,
-        secret_registry_address=to_canonical_address(secret_registry_contract_address),
+        secret_registry_address=to_canonical_address(secret_registry_address),
         contract_manager=contract_manager,
     )
 
@@ -51,7 +34,7 @@ def deploy_token_network_registry_and_return_jsonrpc_proxy(
         chain_id,
         deploy_client,
         contract_manager,
-        secret_registry_contract_address,
+        secret_registry_address,
 ):
     compiled = {
         CONTRACT_TOKEN_NETWORK_REGISTRY: contract_manager.get_contract(
@@ -62,7 +45,7 @@ def deploy_token_network_registry_and_return_jsonrpc_proxy(
         CONTRACT_TOKEN_NETWORK_REGISTRY,
         compiled,
         constructor_parameters=[
-            secret_registry_contract_address,
+            secret_registry_address,
             chain_id,
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,
@@ -83,7 +66,7 @@ def token_network_registry_proxy(deploy_client, token_network_registry_contract,
 def deploy_token_network_and_return_jsonrpc_proxy(
         chain_id,
         deploy_client,
-        secret_registry_contract_address,
+        secret_registry_address,
         token_contract,
         contract_manager,
 ):
@@ -97,7 +80,7 @@ def deploy_token_network_and_return_jsonrpc_proxy(
         compiled,
         constructor_parameters=[
             token_contract.contract.address,
-            secret_registry_contract_address,
+            secret_registry_address,
             chain_id,
             TEST_SETTLE_TIMEOUT_MIN,
             TEST_SETTLE_TIMEOUT_MAX,

--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -57,7 +57,7 @@ def token_network_proxy(deploy_client, token_network_contract, contract_manager)
 
 
 @pytest.fixture(name='token_contract')
-def deploy_network_and_return_jsonrpc_proxy(deploy_client, contract_manager):
+def deploy_token_and_return_jsonrpc_proxy(deploy_client, contract_manager):
     return deploy_token(
         deploy_client=deploy_client,
         contract_manager=contract_manager,

--- a/raiden/tests/integration/contracts/fixtures/contracts.py
+++ b/raiden/tests/integration/contracts/fixtures/contracts.py
@@ -1,7 +1,7 @@
 import pytest
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.network.proxies import SecretRegistry, Token, TokenNetwork, TokenNetworkRegistry
+from raiden.network.proxies import Token, TokenNetwork, TokenNetworkRegistry
 from raiden.tests.utils import factories
 from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import (
@@ -9,23 +9,6 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
-
-
-@pytest.fixture
-def secret_registry_proxy(deploy_client, secret_registry_address, contract_manager):
-    """This uses the available SecretRegistry JSONRPCClient proxy to
-    instantiate a Raiden proxy.
-
-    The JSONRPCClient proxy just exposes the functions from the smart contract
-    as methods in a generate python object, the Raiden proxy uses it to
-    provider alternative interfaces *and* most importantly to do additional
-    error checking (reason for transaction failure, gas usage, etc.).
-    """
-    return SecretRegistry(
-        jsonrpc_client=deploy_client,
-        secret_registry_address=to_canonical_address(secret_registry_address),
-        contract_manager=contract_manager,
-    )
 
 
 @pytest.fixture

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -60,7 +60,7 @@ def endpoint_registry_address(deploy_client, contract_manager) -> typing.Address
 
 
 @pytest.fixture(name='secret_registry_address')
-def deploy_secret_registyr_and_return_address(deploy_client, contract_manager) -> typing.Address:
+def deploy_secret_registry_and_return_address(deploy_client, contract_manager) -> typing.Address:
     address = deploy_contract_web3(
         contract_name=CONTRACT_SECRET_REGISTRY,
         deploy_client=deploy_client,

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -90,8 +90,8 @@ def deploy_contract_web3(
         contract_name: contract_manager.get_contract(contract_name),
     }
     contract_proxy = deploy_client.deploy_solidity_contract(
-        contract_name,
-        compiled,
+        contract_name=contract_name,
+        all_contracts=compiled,
         constructor_parameters=constructor_arguments,
     )
     return typing.Address(to_canonical_address(contract_proxy.contract.address))


### PR DESCRIPTION
This PR does:

- Removes the extra tool to `deploy_contract` that does the same things as `JSONRPCClient.deploy_solidity_contract` 
- Removes a duplicated fixtures to deploy these smart contracts:
  - Secret registry
  - Token Network Registry
