### PR TITLE
Only check ethereum network id periodically

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -1,5 +1,4 @@
 import gevent
-from cachetools.func import ttl_cache
 from eth_utils import is_binary_address
 from gevent.lock import Semaphore
 
@@ -40,6 +39,9 @@ class BlockChainService:
 
         self.client = jsonrpc_client
         self.contract_manager = contract_manager
+
+        # Ask for the network id only once and store it here
+        self.network_id = int(self.client.web3.version.network)
 
         self._token_creation_lock = Semaphore()
         self._discovery_creation_lock = Semaphore()
@@ -210,8 +212,3 @@ class BlockChainService:
                 )
 
         return self.identifier_to_payment_channel[dict_key]
-
-    @property
-    @ttl_cache(ttl=30)
-    def network_id(self) -> int:
-        return int(self.client.web3.version.network)

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -25,7 +25,7 @@ from raiden.exceptions import (
 )
 from raiden.log_config import configure_logging
 from raiden.network.sockfactory import SocketFactory
-from raiden.tasks import check_gas_reserve, check_version
+from raiden.tasks import check_gas_reserve, check_network_id, check_version
 from raiden.utils import get_system_spec, merge_dict, split_endpoint, typing
 from raiden.utils.echo_node import EchoNode
 from raiden.utils.runnable import Runnable
@@ -158,6 +158,14 @@ class NodeRunner:
 
         # spawn a greenlet to handle the gas reserve check
         tasks.append(gevent.spawn(check_gas_reserve, app_.raiden))
+        # spawn a greenlet to handle the periodic check for the network id
+        tasks.append(gevent.spawn(
+            check_network_id,
+            app_.raiden.chain.network_id,
+            app_.raiden.chain.client.web3,
+        ))
+
+        # spawn a greenlet to handle the functions
 
         self._startup_hook()
 


### PR DESCRIPTION
This PR takes the conversation from
[here](https://github.com/raiden-network/raiden/pull/3418#discussion_r254208431)
and presents an alternative approach.

Instead of having a cache on the network ID, we simply store it once
in the blockchain service at startup. From that point on we
periodically check the underlying ethereum node's network id and if it
changes under our feet we crash and burn (with a nice explanation).

Supersedes https://github.com/raiden-network/raiden/pull/3418. If this is merged I will close that old one.