### PR TITLE
Raw & Serialized SQLiteStorage

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -212,7 +212,3 @@ class ChannelOutdatedError(RaidenError):
 class InsufficientGasReserve(RaidenError):
     """ Raised when an action cannot be done because the available balance
     is not sufficient for the lifecycles of all active channels. """
-
-
-class RaidenDBUpgradeError(RaidenError):
-    """ Raised when executing upgrades fails. """

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -287,7 +287,10 @@ class RaidenService(Runnable):
 
         self.maybe_upgrade_db()
 
-        storage = sqlite.SQLiteStorage(self.database_path, serialize.JSONSerializer())
+        storage = sqlite.SerializedSQLiteStorage(
+            database_path=self.database_path,
+            serializer=serialize.JSONSerializer(),
+        )
         storage.log_run()
         self.wal = wal.restore_to_state_change(
             transition_function=node.state_transition,

--- a/raiden/storage/serialize.py
+++ b/raiden/storage/serialize.py
@@ -1,6 +1,19 @@
 import importlib
 import json
 
+from raiden.utils.typing import Any
+
+
+class SerdeBase:
+    """ Base interface for serialization / deserialization. """
+    @staticmethod
+    def serialize(obj: Any):
+        raise NotImplementedError
+
+    @staticmethod
+    def deserialize(data: str):
+        raise NotImplementedError
+
 
 class RaidenJSONEncoder(json.JSONEncoder):
     """ A custom JSON encoder to provide convenience
@@ -58,7 +71,7 @@ class RaidenJSONDecoder(json.JSONDecoder):
         return klass
 
 
-class JSONSerializer:
+class JSONSerializer(SerdeBase):
     @staticmethod
     def serialize(obj):
         return json.dumps(obj, cls=RaidenJSONEncoder)

--- a/raiden/tests/unit/migrations/test_v16_to_v17.py
+++ b/raiden/tests/unit/migrations/test_v16_to_v17.py
@@ -4,14 +4,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import SQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.tests.utils import factories
 from raiden.transfer.state_change import ActionInitChain
 from raiden.utils.upgrades import UpgradeManager
 
 
 def setup_storage(db_path):
-    storage = SQLiteStorage(str(db_path), JSONSerializer())
+    storage = SerializedSQLiteStorage(str(db_path), JSONSerializer())
 
     chain_state_data = Path(__file__).parent / 'data/v16_chainstate.json'
     chain_state = chain_state_data.read_text()
@@ -50,6 +50,6 @@ def test_upgrade_v16_to_v17(tmp_path):
     manager = UpgradeManager(db_filename=str(db_path))
     manager.run()
 
-    storage = SQLiteStorage(str(db_path), JSONSerializer())
+    storage = SerializedSQLiteStorage(str(db_path), JSONSerializer())
     snapshot = storage.get_latest_state_snapshot()
     assert snapshot is not None

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from raiden.messages import Lock
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import SQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.events import (
     SendBalanceProof,
@@ -139,7 +139,7 @@ def test_get_state_change_with_balance_proof():
     querying the database.
     """
     serializer = JSONSerializer
-    storage = SQLiteStorage(':memory:', serializer)
+    storage = SerializedSQLiteStorage(':memory:', serializer)
     counter = itertools.count()
 
     lock_expired = ReceiveLockExpired(
@@ -218,7 +218,7 @@ def test_get_event_with_balance_proof():
     querying the database.
     """
     serializer = JSONSerializer
-    storage = SQLiteStorage(':memory:', serializer)
+    storage = SerializedSQLiteStorage(':memory:', serializer)
     counter = itertools.count()
 
     lock_expired = SendLockExpired(
@@ -286,7 +286,7 @@ def test_get_event_with_balance_proof():
 def test_log_run():
     with patch('raiden.storage.sqlite.get_system_spec') as get_speck_mock:
         get_speck_mock.return_value = dict(raiden='1.2.3')
-        store = SQLiteStorage(':memory:', None)
+        store = SerializedSQLiteStorage(':memory:', None)
         store.log_run()
     cursor = store.conn.cursor()
     cursor.execute('SELECT started_at, raiden_version FROM runs')

--- a/raiden/tests/unit/test_upgrade.py
+++ b/raiden/tests/unit/test_upgrade.py
@@ -5,14 +5,14 @@ from pathlib import Path
 from unittest.mock import ANY, Mock, patch
 
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import SQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.tests.utils import factories
 from raiden.transfer.state_change import ActionInitChain
 from raiden.utils.upgrades import UpgradeManager, get_db_version
 
 
 def setup_storage(db_path):
-    storage = SQLiteStorage(str(db_path), JSONSerializer())
+    storage = SerializedSQLiteStorage(str(db_path), JSONSerializer())
     storage.write_state_change(
         ActionInitChain(
             pseudo_random_generator=random.Random(),
@@ -43,7 +43,7 @@ def test_upgrade_manager_restores_backup(tmp_path):
 
     # Once restored, the state changes written above should be
     # in the restored database
-    storage = SQLiteStorage(str(db_path), JSONSerializer())
+    storage = SerializedSQLiteStorage(str(db_path), JSONSerializer())
     state_change_record = storage.get_latest_state_change_by_data_field(
         {'_type': 'raiden.transfer.state_change.ActionInitChain'},
     )

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -5,7 +5,7 @@ import pytest
 
 from raiden.exceptions import InvalidDBData
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import RAIDEN_DB_VERSION, SQLiteStorage
+from raiden.storage.sqlite import RAIDEN_DB_VERSION, SerializedSQLiteStorage
 from raiden.storage.utils import TimestampedEvent
 from raiden.storage.wal import WriteAheadLog, restore_to_state_change
 from raiden.tests.utils import factories
@@ -46,7 +46,7 @@ def new_wal(state_transition):
     serializer = JSONSerializer
 
     state_manager = StateManager(state_transition, state)
-    storage = SQLiteStorage(':memory:', serializer)
+    storage = SerializedSQLiteStorage(':memory:', serializer)
     wal = WriteAheadLog(state_manager, storage)
     return wal
 
@@ -58,7 +58,7 @@ def test_connect_to_corrupt_db(tmpdir):
         f.write(os.urandom(256))
 
     with pytest.raises(InvalidDBData):
-        SQLiteStorage(dbpath, serializer)
+        SerializedSQLiteStorage(dbpath, serializer)
 
 
 def test_wal_has_version():

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -1,7 +1,7 @@
 import random
 
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import SQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.storage.wal import WriteAheadLog
 from raiden.tests.utils import factories
 from raiden.transfer import node
@@ -53,7 +53,7 @@ class MockRaidenService:
 
         serializer = JSONSerializer
         state_manager = StateManager(state_transition, None)
-        storage = SQLiteStorage(':memory:', serializer)
+        storage = SerializedSQLiteStorage(':memory:', serializer)
         self.wal = WriteAheadLog(state_manager, storage)
 
         state_change = ActionInitChain(

--- a/raiden/utils/migrations/v16_to_v17.py
+++ b/raiden/utils/migrations/v16_to_v17.py
@@ -1,22 +1,9 @@
 import json
-import sqlite3
+
+from raiden.storage.sqlite import SQLiteStorage
 
 SOURCE_VERSION = 16
 TARGET_VERSION = 17
-
-
-def get_snapshots(cursor):
-    cursor.execute('SELECT identifier, data FROM state_snapshot')
-    snapshots = cursor.fetchall()
-    for snapshot in snapshots:
-        yield snapshot[0], snapshot[1]
-
-
-def update_snapshot(cursor, identifier, new_snapshot):
-    cursor.execute(
-        'UPDATE state_snapshot SET data=? WHERE identifier=?',
-        (new_snapshot, identifier),
-    )
 
 
 def _transform_snapshot(raw_snapshot):
@@ -53,17 +40,17 @@ def _transform_snapshot(raw_snapshot):
     return json.dumps(snapshot, indent=4)
 
 
-def _transform_snapshots(cursor: sqlite3.Cursor):
-    for identifier, snapshot in get_snapshots(cursor):
-        new_snapshot = _transform_snapshot(snapshot)
-        update_snapshot(cursor, identifier, new_snapshot)
+def _transform_snapshots(storage: SQLiteStorage):
+    for snapshot in storage.get_snapshots():
+        new_snapshot = _transform_snapshot(snapshot.data)
+        storage.update_snapshot(snapshot.identifier, new_snapshot)
 
 
-def upgrade_initiator_manager(cursor: sqlite3.Cursor, old_version: int, current_version: int):
+def upgrade_initiator_manager(storage: SQLiteStorage, old_version: int, current_version: int):
     """ InitiatorPaymentState was changed so that the "initiator"
     attribute is renamed to "initiator_transfers" and converted to a list.
     """
     if old_version == SOURCE_VERSION:
-        _transform_snapshots(cursor)
+        _transform_snapshots(storage)
 
     return TARGET_VERSION

--- a/tools/debugging/migrate_db.py
+++ b/tools/debugging/migrate_db.py
@@ -5,7 +5,6 @@ import click
 import gevent
 import structlog
 
-from raiden.exceptions import InvalidDBData, RaidenDBUpgradeError
 from raiden.storage import serialize, sqlite
 from raiden.utils.upgrades import UpgradeManager
 
@@ -25,7 +24,7 @@ def upgrade_db(current_version: int, new_version: int):
     )
     try:
         manager.run()
-    except (RaidenDBUpgradeError, InvalidDBData) as e:
+    except Exception as e:
         manager.restore_backup()
         log.error(f'Failed to upgrade database: {str(e)}')
 

--- a/tools/debugging/migrate_db.py
+++ b/tools/debugging/migrate_db.py
@@ -44,7 +44,7 @@ def main(db_file):
     global database_path
     database_path = db_file
     migrate_db(
-        storage=sqlite.SQLiteStorage(db_file, serialize.JSONSerializer()),
+        storage=sqlite.SerializedSQLiteStorage(db_file, serialize.JSONSerializer()),
     )
 
 

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -201,7 +201,7 @@ def main(db_file, token_network_identifier, partner_address, names_translator):
         translator = None
 
     replay_wal(
-        storage=sqlite.SQLiteStorage(db_file, serialize.JSONSerializer()),
+        storage=sqlite.SerializedSQLiteStorage(db_file, serialize.JSONSerializer()),
         token_network_identifier=token_network_identifier,
         partner_address=partner_address,
         translator=translator,


### PR DESCRIPTION
## What changed?
- Separate serialization logic into `SerializedSQLiteStorage` while `SQLiteStorage` returns raw data.
- Introduced `transaction` method in storage to start an explicit transaction. 
- Introduced `maybe_commit` will only commit if we're outside an explicit transaction.
- Introduced `get_snapshot` and `update_snapshot` in  `SQLiteStorage`

Resolves #3423 