### PR TITLE
Add logging of REST-API results

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -184,6 +184,7 @@ def api_response(result, status_code=HTTPStatus.OK):
     else:
         data = json.dumps(result)
 
+    log.debug('Request successful', response=result, status_code=status_code)
     response = make_response((
         data,
         status_code,
@@ -194,6 +195,7 @@ def api_response(result, status_code=HTTPStatus.OK):
 
 def api_error(errors, status_code):
     assert status_code in ERROR_STATUS_CODES, 'Programming error, unexpected error status code'
+    log.error('Error processing request', errors=errors, status_code=status_code)
     response = make_response((
         json.dumps(dict(errors=errors)),
         status_code,


### PR DESCRIPTION
Currently we only perform logging at the beginning of REST-API calls making it difficult to diagnose issues with API responses.

This adds logging calls to the `api_response` and `api_error` helpers which should cover all cases.