### PR TITLE
Initiator restart crash fix

### DIFF
--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -168,13 +168,15 @@ def test_payment_statuses_are_restored(
     amount = 1
     spent_amount = 7
     identifier = 1
+
     for _ in range(spent_amount):
-        app0.raiden.mediated_transfer_async(
+        payment_status = app0.raiden.mediated_transfer_async(
             token_network_identifier=token_network_identifier,
             amount=amount,
             target=app1.raiden.address,
             identifier=identifier,
         )
+        assert payment_status.payment_identifier == identifier
         identifier += 1
 
     raiden_event_handler = RaidenEventHandler()

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -137,6 +137,7 @@ def test_payment_statuses_are_restored(
         number_of_nodes,
         token_addresses,
         network_wait,
+        skip_if_not_matrix,
 ):
     """ Test that when the Raiden is restarted, the dictionary of
     `targets_to_identifiers_to_statuses` is populated before the transport

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -7,9 +7,10 @@ from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.utils.network import CHAIN
-from raiden.tests.utils.protocol import dont_handle_node_change_network_state
+from raiden.tests.utils.protocol import HoldRaidenEvent, dont_handle_node_change_network_state
 from raiden.tests.utils.transfer import assert_synced_channel_state
 from raiden.transfer import views
+from raiden.transfer.mediated_transfer.events import SendSecretReveal
 
 
 @pytest.mark.parametrize('deposit', [10])
@@ -125,4 +126,90 @@ def test_send_queued_messages(
         token_network_identifier,
         app0_restart, deposit - spent_amount, [],
         app1, deposit + spent_amount, [],
+    )
+
+
+@pytest.mark.parametrize('number_of_nodes', [2])
+@pytest.mark.parametrize('channels_per_node', [1])
+@pytest.mark.parametrize('number_of_tokens', [1])
+def test_payment_statuses_are_restored(
+        raiden_network,
+        number_of_nodes,
+        token_addresses,
+        network_wait,
+):
+    """ Test that when the Raiden is restarted, the dictionary of
+    `targets_to_identifiers_to_statuses` is populated before the transport
+    is started.
+    This should happen because if a client gets restarted during a transfer
+    cycle, once restarted, the client will proceed with the cycle
+    until the transfer is successfully sent. However, the dictionary
+    `targets_to_identifiers_to_statuses` will not contain the payment
+    identifiers that were originally registered when the previous client
+    started the transfers.
+    Related issue: https://github.com/raiden-network/raiden/issues/3432
+    """
+    app0, app1 = raiden_network
+
+    token_address = token_addresses[0]
+    chain_state = views.state_from_app(app0)
+    payment_network_id = app0.raiden.default_registry.address
+    token_network_identifier = views.get_token_network_identifier_by_token_address(
+        chain_state,
+        payment_network_id,
+        token_address,
+    )
+
+    app0.event_handler = HoldRaidenEvent()
+    app0.event_handler.hold(SendSecretReveal, {})
+
+    # make a few transfers from app0 to app1
+    amount = 1
+    spent_amount = 7
+    identifier = 1
+    for _ in range(spent_amount):
+        app0.raiden.mediated_transfer_async(
+            token_network_identifier=token_network_identifier,
+            amount=amount,
+            target=app1.raiden.address,
+            identifier=identifier,
+        )
+        identifier += 1
+
+    raiden_event_handler = RaidenEventHandler()
+    message_handler = MessageHandler()
+
+    app0_restart = App(
+        config=app0.config,
+        chain=app0.raiden.chain,
+        query_start_block=0,
+        default_registry=app0.raiden.default_registry,
+        default_secret_registry=app0.raiden.default_secret_registry,
+        transport=MatrixTransport(
+            app0.raiden.config['transport']['matrix'],
+        ),
+        raiden_event_handler=raiden_event_handler,
+        message_handler=message_handler,
+        discovery=app0.raiden.discovery,
+    )
+
+    app0.stop()
+    del app0  # from here on the app0_restart should be used
+
+    app0_restart.start()
+
+    waiting.wait_for_healthy(
+        app0_restart.raiden,
+        app1.raiden.address,
+        network_wait,
+    )
+
+    waiting.wait_for_payment_balance(
+        raiden=app1.raiden,
+        payment_network_id=payment_network_id,
+        token_address=token_address,
+        partner_address=app0_restart.raiden.address,
+        target_address=app1.raiden.address,
+        target_balance=spent_amount,
+        retry_timeout=network_wait,
     )


### PR DESCRIPTION
Resolves #3432.

https://github.com/raiden-network/raiden/blob/cbbe30f440d0f2cea9afed7f3714af94fbdb253a/raiden/raiden_service.py#L618-L642

The problem is as follows:
1. The above code looks at the `event_queues` and then tries to `register_payment_state` if we find that we have a `SendLockedTransfer` event that the current node emitted.
2. When the client crashes / is stopped, the queues are not restored to the state it had previously (this only happens when a snapshot is taken)

Possible solutions i have in mind:
1. Snapshot when the raiden client is stopped
2. Somehow restore the queues between runs based on `SendMessageEvent`s stored in the DB (though there is no guarantee to know which ones were sent and which ones were not).

Thoughts @hackaugusto, @LefterisJP?