### PR TITLE
MatrixTransport.send_global method

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -510,8 +510,8 @@ class MatrixTransport(Runnable):
     def send_global(self, room: str, message: Message) -> None:
         """Sends a message to one of the global rooms
 
-        These rooms aren't listened and therefore no reply could be heard, so these messages are
-        sent in a send-and-forget async way.
+        These rooms aren't being listened on and therefore no reply could be heard, so these
+        messages are sent in a send-and-forget async way.
         The actual room name is composed from the suffix given as parameter and chain name or id
         e.g.: raiden_ropsten_discovery
         Params:
@@ -519,15 +519,7 @@ class MatrixTransport(Runnable):
             message: Message instance to be serialized and sent
         """
         room_name = self._make_room_alias(room)
-        if room_name not in self._global_rooms:
-            self.log.warning(
-                'Tried to send_global message to an unknown global room. Ignoring.',
-                message=message,
-                room_suffix=room,
-                room_name=room_name,
-                global_rooms=self._global_rooms,
-            )
-            return
+        assert self._global_rooms.get(room_name), f'Unknown global room: {room_name!r}'
 
         def _send_global():
             text = JSONSerializer.serialize(message)

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -442,7 +442,7 @@ class UDPTransport(Runnable):
             message: Message,
     ) -> None:
         """ This method exists only for interface compatibility with MatrixTransport """
-        self.log.warning('UDP has no global room mechanism. Ignoring.')
+        self.log.warning('UDP is unable to send global messages. Ignoring')
 
     def maybe_send(self, recipient: typing.Address, message: Message):
         """ Send message to recipient if the transport is running. """

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -436,6 +436,14 @@ class UDPTransport(Runnable):
                 message=message,
             )
 
+    def send_global(
+            self,
+            room: str,
+            message: Message,
+    ) -> None:
+        """ This method exists only for interface compatibility with MatrixTransport """
+        self.log.warning('UDP has no global room mechanism. Ignoring.')
+
     def maybe_send(self, recipient: typing.Address, message: Message):
         """ Send message to recipient if the transport is running. """
 

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -529,7 +529,6 @@ def test_matrix_discovery_room_offline_server(
 
 
 def test_matrix_send_global(
-        caplog,
         local_matrix_servers,
         retries_before_backoff,
         retry_interval,
@@ -565,15 +564,12 @@ def test_matrix_send_global(
 
     assert ms_room.send_text.call_count == 5
 
-    message = Processed(10)
-    transport.send_global(
-        'unknown_suffix',
-        message,
-    )
-
-    # there's a warning for the unknown suffix, but no exception should be raised or new send_text
-    assert ms_room.send_text.call_count == 5
-    assert any(record.levelname == 'WARNING' for record in caplog.records)
+    # unknown room suffix is an error
+    with pytest.raises(AssertionError):
+        transport.send_global(
+            'unknown_suffix',
+            Processed(10),
+        )
 
     transport.stop()
     transport.get()


### PR DESCRIPTION
Method to send messages to one of the configured global rooms.
Needed for #3273 , based on top of #3427 so should be merged after it.