### PR TITLE
Better name for shared serialization/deserialization class

### DIFF
--- a/raiden/storage/serialize.py
+++ b/raiden/storage/serialize.py
@@ -4,7 +4,7 @@ import json
 from raiden.utils.typing import Any
 
 
-class SerdeBase:
+class SerializationBase:
     """ Base interface for serialization / deserialization. """
     @staticmethod
     def serialize(obj: Any):
@@ -71,7 +71,7 @@ class RaidenJSONDecoder(json.JSONDecoder):
         return klass
 
 
-class JSONSerializer(SerdeBase):
+class JSONSerializer(SerializationBase):
     @staticmethod
     def serialize(obj):
         return json.dumps(obj, cls=RaidenJSONEncoder)

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -8,7 +8,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import get_system_spec
 from raiden.utils.typing import Any, Dict, NamedTuple, Optional, Tuple
 
-from .serialize import SerdeBase
+from .serialize import SerializationBase
 
 # The latest DB version
 RAIDEN_DB_VERSION = 17
@@ -37,7 +37,7 @@ def assert_sqlite_version() -> bool:
     return True
 
 
-class SQLiteStorage(SerdeBase):
+class SQLiteStorage(SerializationBase):
     def __init__(self, database_path):
         conn = sqlite3.connect(database_path, detect_types=sqlite3.PARSE_DECLTYPES)
         conn.text_factory = str
@@ -391,7 +391,7 @@ class SQLiteStorage(SerdeBase):
 
 
 class SerializedSQLiteStorage(SQLiteStorage):
-    def __init__(self, database_path, serializer: SerdeBase):
+    def __init__(self, database_path, serializer: SerializationBase):
         super().__init__(database_path)
 
         self.serializer = serializer

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -85,7 +85,7 @@ class UpgradeManager:
         with the new version. However, the previous version's data
         is going to exist in a file whose name contains the old version.
         Therefore, running the migration means that we have to copy
-        all data to the current version's database, execute the migration
+        all data to the current version's database and execute the migration
         functions.
         """
         old_db_filename = older_db_file(str(self._current_db_filename.parent))


### PR DESCRIPTION
@rakanalh for your consideration.

I guess "SerdeBase" was some kind of abbreviation for "Ser[ialization]de[sierialization]Base".
Took me some time to figure out it wasn't a typo. I think my proposal may be more readable. Serialization encompasses the deserialization part too in the naming.