### PR TITLE
Removed broken util get_contract_path

### DIFF
--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -1,9 +1,8 @@
-from eth_utils import to_canonical_address
-
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils import typing
+from raiden.utils.smart_contracts import deploy_contract_web3
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
 
@@ -78,20 +77,3 @@ def deploy_tokens_and_fund_accounts(
             )
 
     return result
-
-
-def deploy_contract_web3(
-        contract_name: str,
-        deploy_client: JSONRPCClient,
-        contract_manager: ContractManager,
-        constructor_arguments: typing.Tuple[typing.Any, ...] = (),
-) -> typing.Address:
-    compiled = {
-        contract_name: contract_manager.get_contract(contract_name),
-    }
-    contract_proxy = deploy_client.deploy_solidity_contract(
-        contract_name=contract_name,
-        all_contracts=compiled,
-        constructor_parameters=constructor_arguments,
-    )
-    return typing.Address(to_canonical_address(contract_proxy.contract.address))

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -148,16 +148,6 @@ def get_relative_path(file_name) -> str:
     return file_name.replace(prefix + '/', '')
 
 
-def get_contract_path(contract_name: str) -> str:
-    contract_path = os.path.join(
-        get_project_root(),
-        'smart_contracts',
-        contract_name,
-    )
-    assert os.path.isfile(contract_path)
-    return get_relative_path(contract_path)
-
-
 def get_system_spec() -> typing.Dict[str, str]:
     """Collect information about the system and installation.
     """

--- a/raiden/utils/smart_contracts.py
+++ b/raiden/utils/smart_contracts.py
@@ -1,0 +1,22 @@
+from eth_utils import to_canonical_address
+
+from raiden.network.rpc.client import JSONRPCClient
+from raiden.utils.typing import Address, Any, Tuple
+from raiden_contracts.contract_manager import ContractManager
+
+
+def deploy_contract_web3(
+        contract_name: str,
+        deploy_client: JSONRPCClient,
+        contract_manager: ContractManager,
+        constructor_arguments: Tuple[Any, ...] = (),
+) -> Address:
+    compiled = {
+        contract_name: contract_manager.get_contract(contract_name),
+    }
+    contract_proxy = deploy_client.deploy_solidity_contract(
+        contract_name=contract_name,
+        all_contracts=compiled,
+        constructor_parameters=constructor_arguments,
+    )
+    return Address(to_canonical_address(contract_proxy.contract.address))


### PR DESCRIPTION
The smart contracts are not part of the raiden code anymore, the
contract manager from the raiden-contracts must be used. This removes
the util get_contract_path since it pointed to a phantom folder, and
changes the utility code to deploy from the contract manager.