### PR TITLE
Change codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: no
+    patch: no


### PR DESCRIPTION
By default, the codecov check fails whenever coverage decreases, which is impractical with our current workflow. This pr disables the github checks for now.