### PR TITLE
Feature: secret and/or hash with payment request

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`2436` Add an API endpoint to list pending transfers
+* :feature:`3318` allow secret and/or hash with payment request
 * :feature:`3425` Update raiden-contracts package to version 0.9.0
 
 * :release:`0.100.2-rc4 <2019-02-04>`

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -66,6 +66,7 @@ from raiden.exceptions import (
     InvalidAmount,
     InvalidBlockNumberInput,
     InvalidNumberInput,
+    InvalidSecretOrSecretHash,
     InvalidSettleTimeout,
     PaymentConflict,
     SamePeerAddress,
@@ -1026,6 +1027,8 @@ class RestAPI:
             target_address: typing.Address,
             amount: typing.TokenAmount,
             identifier: typing.PaymentID,
+            secret: typing.Secret,
+            secret_hash: typing.SecretHash,
     ):
         log.debug(
             'Initiating payment',
@@ -1035,6 +1038,8 @@ class RestAPI:
             target_address=to_checksum_address(target_address),
             amount=amount,
             payment_identifier=identifier,
+            secret=secret,
+            secret_hash=secret_hash,
         )
 
         if identifier is None:
@@ -1047,8 +1052,16 @@ class RestAPI:
                 target=target_address,
                 amount=amount,
                 identifier=identifier,
+                secret=secret,
+                secret_hash=secret_hash,
             )
-        except (InvalidAmount, InvalidAddress, PaymentConflict, UnknownTokenAddress) as e:
+        except (
+                InvalidAmount,
+                InvalidAddress,
+                InvalidSecretOrSecretHash,
+                PaymentConflict,
+                UnknownTokenAddress,
+        ) as e:
             return api_error(
                 errors=str(e),
                 status_code=HTTPStatus.CONFLICT,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -213,7 +213,7 @@ class ConnectionsInfoResource(BaseResource):
 class PaymentResource(BaseResource):
 
     post_schema = PaymentSchema(
-        only=('amount', 'identifier'),
+        only=('amount', 'identifier', 'secret', 'secret_hash'),
     )
     get_schema = RaidenEventsRequestSchema()
 
@@ -239,6 +239,8 @@ class PaymentResource(BaseResource):
             target_address: typing.TargetAddress,
             amount: typing.PaymentAmount,
             identifier: typing.PaymentID,
+            secret: typing.Secret,
+            secret_hash: typing.SecretHash,
     ):
         return self.rest_api.initiate_payment(
             registry_address=self.rest_api.raiden_api.raiden.default_registry.address,
@@ -246,6 +248,8 @@ class PaymentResource(BaseResource):
             target_address=target_address,
             amount=amount,
             identifier=identifier,
+            secret=secret,
+            secret_hash=secret_hash,
         )
 
 

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,7 +1,7 @@
 import math
 from enum import Enum
 
-from eth_utils import keccak, to_checksum_address
+from eth_utils import keccak, to_checksum_address, to_hex
 
 SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
 PROTOCOL_VERSION = 1
@@ -19,6 +19,9 @@ NULL_ADDRESS = to_checksum_address(NULL_ADDRESS_BYTES)
 EMPTY_HASH = bytes(32)
 EMPTY_HASH_KECCAK = keccak(EMPTY_HASH)
 EMPTY_SIGNATURE = bytes(65)
+
+SECRET_HASH_HEXSTRING_LENGTH = len(to_hex(EMPTY_HASH))
+SECRET_HEXSTRING_LENGTH = SECRET_HASH_HEXSTRING_LENGTH
 
 
 class EthClient(Enum):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -75,6 +75,11 @@ class InvalidAddress(RaidenError):
     pass
 
 
+class InvalidSecretOrSecretHash(RaidenError):
+    """ Raised when the user provided value is not a valid secret. """
+    pass
+
+
 class InvalidAmount(RaidenError):
     """ Raised when the user provided value is not a positive integer and
     cannot be used to define a transfer value.

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -738,6 +738,8 @@ class RaidenService(Runnable):
             amount: TokenAmount,
             target: TargetAddress,
             identifier: PaymentID,
+            secret: Secret = None,
+            secret_hash: SecretHash = None,
     ) -> PaymentStatus:
         """ Transfer `amount` between this node and `target`.
 
@@ -749,14 +751,16 @@ class RaidenService(Runnable):
             - Network speed, making the transfer sufficiently fast so it doesn't
               expire.
         """
+        if secret is None:
+            secret = random_secret()
 
-        secret = random_secret()
         payment_status = self.start_mediated_transfer_with_secret(
             token_network_identifier,
             amount,
             target,
             identifier,
             secret,
+            secret_hash,
         )
 
         return payment_status
@@ -768,9 +772,12 @@ class RaidenService(Runnable):
             target: TargetAddress,
             identifier: PaymentID,
             secret: Secret,
+            secret_hash: SecretHash = None,
     ) -> PaymentStatus:
 
-        secret_hash = sha3(secret)
+        if secret_hash is None:
+            secret_hash = sha3(secret)
+
         # LEFTODO: Supply a proper block id
         secret_registered = self.default_secret_registry.check_registered(
             secrethash=secret_hash,


### PR DESCRIPTION
Feature: secret and/or hash with payment request - closes #3318 

This feature allows the payer to optionally provide a secret and/or a secret_hash that should be used for the payment. If no secret and secret_hash provided as part of the payment request the secret and the hash should be selected by Raiden. If only a secret is provided the secret hash should be extracted from the given secret. If both secret and secret hash provided they should match. Providing only the secret hash is not currently supported. 
