### PR TITLE
Add missing classes to `__all__` in raiden/messages.py

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -50,15 +50,22 @@ from raiden.utils.typing import (
 
 __all__ = (
     'Delivered',
+    'EnvelopeMessage',
     'Lock',
     'LockedTransfer',
     'LockedTransferBase',
+    'LockExpired',
+    'Message',
     'Ping',
+    'Pong',
     'Processed',
     'RefundTransfer',
-    'Unlock',
+    'RequestMonitoring',
+    'RevealSecret',
     'SecretRequest',
+    'SignedBlindedBalanceProof',
     'SignedMessage',
+    'Unlock',
     'decode',
     'from_dict',
 )


### PR DESCRIPTION
Some colleagues IDE's were complaining about the missing definitions...