### PR TITLE
Add a simplified verification interface to RequestMonitoring

### DIFF
--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -127,3 +127,5 @@ def test_request_monitoring():
         balance_proof_data,
         request_monitoring.balance_proof.signature,
     ) == PARTNER_ADDRESS
+
+    assert request_monitoring.verify_request_monitoring(PARTNER_ADDRESS, ADDRESS)


### PR DESCRIPTION
Since `RequestMonitoring` is a complex message with three signatures,
verifying signatures is error-prone and incomplete verification can lead
to accepting tampered messages (see #3455).