### PR TITLE
Enable Arm binary build in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,24 +431,57 @@ jobs:
     parameters:
       py-version:
         <<: *py-version-template
+      resource:
+        description: "resource type for underlying VM"
+        default: "medium"
+        type: enum
+        enum: ["small", "medium", "medium+", "large", "xlarge"]
+      remote-host:
+        description: "name of the arm server"
+        default: ""
+        type: enum
+        enum: ["", "armv7", "armv8"]
+      architecture:
+        description: "defines the architecture for which the binary is built"
+        default: "x86_64"
+        type: enum
+        enum: ["x86_64", "armv7l", "aarch64"]
+
 
     executor:
       name: docker
       py-version: "3.7"
+      resource: << parameters.resource >>
 
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "7b:c7:3d:f7:ff:1a:2b:8e:2d:18:93:be:c6:7b:b0:7c"
       - attach-and-link:
           py-version: << parameters.py-version >>
       - conditional-skip
       - config-path
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - when:
+          condition: << parameters.remote-host >>
+          steps:
+            - run:
+                name: "set remote docker host"
+                command: echo 'export DOCKER_HOST=localhost:23760' >> ${BASH_ENV}
+            - run:
+                name: SSH Port Forwarding To ARM Server
+                command: |
+                  ssh -f -N -L 127.0.0.1:23760:localhost:2376 ci@<< parameters.remote-host >>.ci.raiden.network -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+      - unless:
+          condition: << parameters.remote-host >>
+          steps:
+            - setup_remote_docker:
+                docker_layer_caching: true
       - run:
           name: Build Linux Binary
           command: |
             source .circleci/get_archive_tag.sh
             make bundle-docker
-            echo raiden-${ARCHIVE_TAG}-linux.tar.gz > dist/archive/_LATEST-linux.txt
+            echo raiden-${ARCHIVE_TAG}-linux-<<parameters.architecture>>.tar.gz > dist/archive/_LATEST-linux-<<parameters.architecture>>.txt
       - persist_to_workspace:
           root: "~"
           paths:
@@ -474,12 +507,13 @@ jobs:
             pip uninstall -y pdbpp
             mkdir -p dist/archive
             source .circleci/get_archive_tag.sh
+            echo $(uname -m)
       - run:
           name: Build macOS Binary
           command: |
             pyinstaller --noconfirm --clean raiden.spec
-            zip -9 --junk-paths dist/archive/raiden-${ARCHIVE_TAG}-macOS.zip dist/raiden-${ARCHIVE_TAG}-macOS
-            echo raiden-${ARCHIVE_TAG}-macOS.zip > dist/archive/_LATEST-macOS.txt
+            zip -9 --junk-paths dist/archive/raiden-${ARCHIVE_TAG}-macOS-x86_64.zip dist/raiden-${ARCHIVE_TAG}-macOS-x86_64
+            echo raiden-${ARCHIVE_TAG}-macOS-x86_64.zip > dist/archive/_LATEST-macOS-x86_64.txt
       - persist_to_workspace:
           root: "~"
           paths:
@@ -724,6 +758,27 @@ workflows:
             <<: *only-tagged-version-filter
 
       - build-binary-linux:
+          name: build-binary-linux-x86
+          requires:
+            - prepare-python-linux
+          filters:
+            <<: *only-tagged-version-filter
+
+      - build-binary-linux:
+          name: build-binary-linux-armv7l
+          resource: "small"
+          remote-host: "armv7"
+          architecture: "armv7l"
+          requires:
+            - prepare-python-linux
+          filters:
+            <<: *only-tagged-version-filter
+
+      - build-binary-linux:
+          name: build-binary-linux-aarch64
+          resource: "small"
+          remote-host: "armv8"
+          architecture: "aarch64"
           requires:
             - prepare-python-linux
           filters:
@@ -744,7 +799,9 @@ workflows:
       - deploy-digitalocean:
           context: "Raiden Context"
           requires:
-            - build-binary-linux
+            - build-binary-linux-x86
+            - build-binary-linux-armv7l
+            - build-binary-linux-aarch64
             - build-binary-macos
           filters:
             <<: *only-tagged-version-filter
@@ -752,7 +809,9 @@ workflows:
       - deploy-github-release:
           context: "Raiden Context"
           requires:
-            - build-binary-linux
+            - build-binary-linux-x86
+            - build-binary-linux-armv7l
+            - build-binary-linux-aarch64
             - build-binary-macos
           filters:
             <<: *only-tagged-version-filter
@@ -855,8 +914,25 @@ workflows:
           - test-integration-matrix-3.7
 
       - build-binary-linux:
-            requires:
-              - finalize
+          name: build-binary-linux-x86
+          requires:
+            - finalize
+
+      - build-binary-linux:
+          name: build-binary-linux-armv7l
+          resource: "small"
+          remote-host: "armv7"
+          architecture: "armv7l"
+          requires:
+            - finalize
+
+      - build-binary-linux:
+          name: build-binary-linux-aarch64
+          resource: "small"
+          remote-host: "armv8"
+          architecture: "aarch64"
+          requires:
+            - finalize
 
       - prepare-system-macos:
           requires:
@@ -876,7 +952,9 @@ workflows:
       - deploy-digitalocean:
           context: "Raiden Context"
           requires:
-            - build-binary-linux
+            - build-binary-linux-x86
+            - build-binary-linux-armv7l
+            - build-binary-linux-aarch64
             - build-binary-macos
 
     triggers:

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ else
 ARCHIVE_TAG_ARG=--build-arg ARCHIVE_TAG=v$(shell python setup.py --version)
 endif
 
+# architecture needs to be asked in docker because docker can be run on remote host to create binary for different architectures
+ARCHITECTURE_TAG=$(shell docker run --rm python:3.7 uname -m)
+
 GITHUB_ACCESS_TOKEN_ARG=
 ifdef GITHUB_ACCESS_TOKEN
 GITHUB_ACCESS_TOKEN_ARG=--build-arg GITHUB_ACCESS_TOKEN_FRAGMENT=$(GITHUB_ACCESS_TOKEN)@
@@ -99,11 +102,11 @@ endif
 
 
 bundle-docker:
-	@docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) $(ARCHIVE_TAG_ARG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .
+	@docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) --build-arg ARCHITECTURE_TAG=$(ARCHITECTURE_TAG) $(ARCHIVE_TAG_ARG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .
 	-(docker rm builder)
 	docker create --name builder pyinstallerbuilder
 	mkdir -p dist/archive
-	docker cp builder:/raiden/raiden-$(ARCHIVE_TAG)-linux.tar.gz dist/archive/raiden-$(ARCHIVE_TAG)-linux.tar.gz
+	docker cp builder:/raiden/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar.gz dist/archive/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar.gz
 	docker rm builder
 
 bundle:

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -6,7 +6,7 @@ ARG GETH_URL_LINUX
 
 # install dependencies
 RUN apt-get update
-RUN apt-get install -y git-core wget xz-utils
+RUN apt-get install -y git-core wget xz-utils libgmp-dev
 
 RUN wget -nv -O /usr/bin/solc ${SOLC_URL_LINUX} && \
     chmod +x /usr/bin/solc
@@ -16,18 +16,30 @@ RUN wget -nv -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && \
     mv geth-linux-amd64-*/geth /usr/bin/geth && \
     rm geth.tar.gz
 
+
+ADD requirements*.txt /tmp/
+ADD constraints.txt /tmp/
+WORKDIR /tmp
+
+RUN pip install -U 'pip<19.0.0' setuptools setuptools_scm
+RUN pip install -r requirements.txt -c constraints.txt
+RUN pip install pyinstaller
+
 ADD . /raiden
 
 WORKDIR /raiden
 RUN git fetch --tags | true
-RUN pip install -U 'pip<19.0.0' setuptools setuptools_scm
-RUN pip install -r requirements.txt -c constraints.txt
 
-# install raiden and pyinstaller
+
+# build contracts and web_ui
+RUN python setup.py build
+
+# install raiden
 RUN pip install -c constraints.txt .
-RUN pip install pyinstaller
+
 
 ARG ARCHIVE_TAG
+ARG ARCHITECTURE_TAG
 
 # build pyinstaller package
 RUN pyinstaller --noconfirm --clean raiden.spec
@@ -35,5 +47,5 @@ RUN pyinstaller --noconfirm --clean raiden.spec
 # pack result to have a unique name to get it out of the container later
 RUN export FILE_TAG=${ARCHIVE_TAG:-v$(python setup.py --version)} && \
     cd dist && \
-    tar -cvzf ./raiden-${FILE_TAG}-linux.tar.gz raiden-${FILE_TAG}-linux && \
-    mv raiden-${FILE_TAG}-linux.tar.gz ..
+    tar -cvzf ./raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG}.tar.gz raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG} && \
+    mv raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG}.tar.gz ..

--- a/raiden.spec
+++ b/raiden.spec
@@ -70,9 +70,10 @@ if hasattr(pdb, 'pdb'):
 # We don't need Tk and friends
 sys.modules['FixTk'] = None
 
-executable_name = 'raiden-{}-{}'.format(
+executable_name = 'raiden-{}-{}-{}'.format(
     os.environ.get('ARCHIVE_TAG', 'v' + get_system_spec()['raiden']),
-    'macOS' if platform.system() == 'Darwin' else platform.system().lower()
+    'macOS' if platform.system() == 'Darwin' else platform.system().lower(),
+    platform.machine()
 )
 
 a = Entrypoint(


### PR DESCRIPTION
add arm binary build to circle
add architecture information to docker builds


In the build process circle ci triggers the arm build process for armv7 and aarch64 (armv8). 

closes #3401 