### PR TITLE
Consistent blockchain view - Iteration number 3

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -211,7 +211,7 @@ class BlockchainEvents:
     def __init__(self):
         self.event_listeners = list()
 
-    def poll_blockchain_events(self, block_number: int):
+    def poll_blockchain_events(self, block_number: typing.BlockNumber):
         """ Poll for new blockchain events up to `block_number`. """
 
         for event_listener in self.event_listeners:

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -55,6 +55,7 @@ def handle_tokennetwork_new(raiden, event: Event):
         transaction_hash=transaction_hash,
         payment_network_identifier=event.originating_contract,
         token_network=token_network_state,
+        block_number=block_number,
         block_hash=block_hash,
     )
     raiden.handle_state_change(new_token_network)
@@ -63,6 +64,7 @@ def handle_tokennetwork_new(raiden, event: Event):
 def handle_channel_new(raiden, event: Event):
     data = event.event_data
     block_number = data['block_number']
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
     args = data['args']
     token_network_identifier = event.originating_contract
     transaction_hash = event.event_data['transaction_hash']
@@ -92,6 +94,7 @@ def handle_channel_new(raiden, event: Event):
             token_network_identifier=token_network_identifier,
             channel_state=channel_state,
             block_number=block_number,
+            block_hash=block_hash,
         )
         raiden.handle_state_change(new_channel)
 
@@ -109,6 +112,7 @@ def handle_channel_new(raiden, event: Event):
             participant1=participant1,
             participant2=participant2,
             block_number=block_number,
+            block_hash=block_hash,
         )
         raiden.handle_state_change(new_route)
 
@@ -123,6 +127,7 @@ def handle_channel_new_balance(raiden, event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
     channel_identifier = args['channel_identifier']
     token_network_identifier = event.originating_contract
     participant_address = args['participant']
@@ -154,6 +159,7 @@ def handle_channel_new_balance(raiden, event: Event):
             channel_identifier=channel_identifier,
             deposit_transaction=deposit_transaction,
             block_number=block_number,
+            block_hash=block_hash,
         )
         raiden.handle_state_change(newbalance_statechange)
 
@@ -178,6 +184,7 @@ def handle_channel_closed(raiden, event: Event):
     args = data['args']
     channel_identifier = args['channel_identifier']
     transaction_hash = data['transaction_hash']
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
 
     channel_state = views.get_channelstate_by_token_network_identifier(
         views.state_from_raiden(raiden),
@@ -194,6 +201,7 @@ def handle_channel_closed(raiden, event: Event):
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
             block_number=block_number,
+            block_hash=block_hash,
         )
         raiden.handle_state_change(channel_closed)
     else:
@@ -203,6 +211,7 @@ def handle_channel_closed(raiden, event: Event):
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
             block_number=block_number,
+            block_hash=block_hash,
         )
         raiden.handle_state_change(channel_closed)
 
@@ -213,6 +222,8 @@ def handle_channel_update_transfer(raiden, event: Event):
     args = data['args']
     channel_identifier = args['channel_identifier']
     transaction_hash = data['transaction_hash']
+    block_number = data['block_number']
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
 
     channel_state = views.get_channelstate_by_token_network_identifier(
         views.state_from_raiden(raiden),
@@ -226,7 +237,8 @@ def handle_channel_update_transfer(raiden, event: Event):
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
             nonce=args['nonce'],
-            block_number=data['block_number'],
+            block_number=block_number,
+            block_hash=block_hash,
         )
         raiden.handle_state_change(channel_transfer_updated)
 
@@ -235,6 +247,7 @@ def handle_channel_settled(raiden, event: Event):
     data = event.event_data
     token_network_identifier = event.originating_contract
     channel_identifier = data['args']['channel_identifier']
+    block_number = data['block_number']
 
     transaction_hash = data['transaction_hash']
 
@@ -249,7 +262,8 @@ def handle_channel_settled(raiden, event: Event):
             transaction_hash=transaction_hash,
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
-            block_number=data['block_number'],
+            block_number=block_number,
+            block_hash=views.blockhash_from_blocknumber(raiden.chain, block_number),
         )
         raiden.handle_state_change(channel_settled)
 
@@ -258,7 +272,8 @@ def handle_channel_batch_unlock(raiden, event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     args = data['args']
-
+    block_number = data['block_number']
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
     transaction_hash = data['transaction_hash']
 
     unlock_state_change = ContractReceiveChannelBatchUnlock(
@@ -269,7 +284,8 @@ def handle_channel_batch_unlock(raiden, event: Event):
         locksroot=args['locksroot'],
         unlocked_amount=args['unlocked_amount'],
         returned_tokens=args['returned_tokens'],
-        block_number=data['block_number'],
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
     raiden.handle_state_change(unlock_state_change)
@@ -279,15 +295,17 @@ def handle_secret_revealed(raiden, event: Event):
     secret_registry_address = event.originating_contract
     data = event.event_data
     args = data['args']
+    block_number = data['block_number']
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
 
     transaction_hash = data['transaction_hash']
-
     registeredsecret_state_change = ContractReceiveSecretReveal(
         transaction_hash=transaction_hash,
         secret_registry_address=secret_registry_address,
         secrethash=args['secrethash'],
         secret=args['secret'],
-        block_number=data['block_number'],
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
     raiden.handle_state_change(registeredsecret_state_change)

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -35,13 +35,13 @@ def handle_tokennetwork_new(raiden, event: Event):
     block_number = data['block_number']
     token_network_address = args['token_network_address']
     token_address = typing.TokenAddress(args['token_address'])
-    latest_block_hash = views.latest_confirmed_block_hash_from_raiden(raiden)
+    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
 
     token_network_proxy = raiden.chain.token_network(token_network_address)
     raiden.blockchain_events.add_token_network_listener(
         token_network_proxy=token_network_proxy,
         contract_manager=raiden.contract_manager,
-        from_block=block_number,
+        from_block=block_hash,
     )
 
     token_network_state = TokenNetworkState(
@@ -55,7 +55,7 @@ def handle_tokennetwork_new(raiden, event: Event):
         transaction_hash=transaction_hash,
         payment_network_identifier=event.originating_contract,
         token_network=token_network_state,
-        block_number=block_number,
+        block_hash=block_hash,
     )
     raiden.handle_state_change(new_token_network)
 

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -35,6 +35,7 @@ def handle_tokennetwork_new(raiden, event: Event):
     block_number = data['block_number']
     token_network_address = args['token_network_address']
     token_address = typing.TokenAddress(args['token_address'])
+    latest_block_hash = views.latest_confirmed_block_hash_from_raiden(raiden)
 
     token_network_proxy = raiden.chain.token_network(token_network_address)
     raiden.blockchain_events.add_token_network_listener(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -35,7 +35,7 @@ def handle_tokennetwork_new(raiden, event: Event):
     block_number = data['block_number']
     token_network_address = args['token_network_address']
     token_address = typing.TokenAddress(args['token_address'])
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
 
     token_network_proxy = raiden.chain.token_network(token_network_address)
     raiden.blockchain_events.add_token_network_listener(
@@ -64,7 +64,7 @@ def handle_tokennetwork_new(raiden, event: Event):
 def handle_channel_new(raiden, event: Event):
     data = event.event_data
     block_number = data['block_number']
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
     args = data['args']
     token_network_identifier = event.originating_contract
     transaction_hash = event.event_data['transaction_hash']
@@ -127,7 +127,7 @@ def handle_channel_new_balance(raiden, event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
     channel_identifier = args['channel_identifier']
     token_network_identifier = event.originating_contract
     participant_address = args['participant']
@@ -184,7 +184,7 @@ def handle_channel_closed(raiden, event: Event):
     args = data['args']
     channel_identifier = args['channel_identifier']
     transaction_hash = data['transaction_hash']
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
 
     channel_state = views.get_channelstate_by_token_network_identifier(
         views.state_from_raiden(raiden),
@@ -223,7 +223,7 @@ def handle_channel_update_transfer(raiden, event: Event):
     channel_identifier = args['channel_identifier']
     transaction_hash = data['transaction_hash']
     block_number = data['block_number']
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
 
     channel_state = views.get_channelstate_by_token_network_identifier(
         views.state_from_raiden(raiden),
@@ -248,6 +248,7 @@ def handle_channel_settled(raiden, event: Event):
     token_network_identifier = event.originating_contract
     channel_identifier = data['args']['channel_identifier']
     block_number = data['block_number']
+    block_hash = bytes(data['blockHash'])
 
     transaction_hash = data['transaction_hash']
 
@@ -263,7 +264,7 @@ def handle_channel_settled(raiden, event: Event):
             token_network_identifier=token_network_identifier,
             channel_identifier=channel_identifier,
             block_number=block_number,
-            block_hash=views.blockhash_from_blocknumber(raiden.chain, block_number),
+            block_hash=block_hash,
         )
         raiden.handle_state_change(channel_settled)
 
@@ -273,7 +274,7 @@ def handle_channel_batch_unlock(raiden, event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
     transaction_hash = data['transaction_hash']
 
     unlock_state_change = ContractReceiveChannelBatchUnlock(
@@ -296,7 +297,7 @@ def handle_secret_revealed(raiden, event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
-    block_hash = views.blockhash_from_blocknumber(raiden.chain, block_number)
+    block_hash = bytes(data['blockHash'])
 
     transaction_hash = data['transaction_hash']
     registeredsecret_state_change = ContractReceiveSecretReveal(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -41,7 +41,7 @@ def handle_tokennetwork_new(raiden, event: Event):
     raiden.blockchain_events.add_token_network_listener(
         token_network_proxy=token_network_proxy,
         contract_manager=raiden.contract_manager,
-        from_block=block_hash,
+        from_block=block_number,
     )
 
     token_network_state = TokenNetworkState(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -52,6 +52,14 @@ from raiden.utils.typing import (
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
+def logs_blocks_sanity_check(from_block: BlockSpecification, to_block: BlockSpecification) -> None:
+    """Checks that the from/to blocks passed onto log calls contain only appropriate types"""
+    is_valid_from = isinstance(from_block, int) or isinstance(from_block, str)
+    assert is_valid_from, 'event log from block can be integer or latest,pending, earliest'
+    is_valid_to = isinstance(to_block, int) or isinstance(to_block, str)
+    assert is_valid_to, 'event log to block can be integer or latest,pending, earliest'
+
+
 def geth_assert_rpc_interfaces(web3: Web3):
 
     try:
@@ -750,6 +758,7 @@ class JSONRPCClient:
             to_block: BlockSpecification = 'latest',
     ) -> StatelessFilter:
         """ Create a filter in the ethereum node. """
+        logs_blocks_sanity_check(from_block, to_block)
         return StatelessFilter(
             self.web3,
             {
@@ -768,6 +777,7 @@ class JSONRPCClient:
             to_block: BlockSpecification = 'latest',
     ) -> List[Dict]:
         """ Get events for the given query. """
+        logs_blocks_sanity_check(from_block, to_block)
         return self.web3.eth.getLogs({
             'fromBlock': from_block,
             'toBlock': to_block,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -44,6 +44,8 @@ from raiden.utils.typing import (
     ABI,
     Address,
     AddressHex,
+    BlockHash,
+    BlockNumber,
     BlockSpecification,
     Nonce,
     TransactionHash,
@@ -453,6 +455,10 @@ class JSONRPCClient:
     def block_number(self):
         """ Return the most recent block. """
         return self.web3.eth.blockNumber
+
+    def blockhash_from_blocknumber(self, block_number: BlockNumber) -> BlockHash:
+        """Given a block number, query the chain to get its corresponding block hash"""
+        return bytes(self.web3.eth.getBlock(block_number)['hash'])
 
     def balance(self, account: Address):
         """ Return the balance of the account of the given address. """

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -311,6 +311,10 @@ class RaidenService(Runnable):
             # network, to reconstruct all token network graphs and find opened
             # channels
             last_log_block_number = self.query_start_block
+            last_log_block_hash = views.blockhash_from_blocknumber(
+                self.chain,
+                last_log_block_number,
+            )
 
             state_change = ActionInitChain(
                 random.Random(),
@@ -325,9 +329,10 @@ class RaidenService(Runnable):
                 [],  # empty list of token network states as it's the node's startup
             )
             state_change = ContractReceiveNewPaymentNetwork(
-                constants.EMPTY_HASH,
-                payment_network,
-                last_log_block_number,
+                transaction_hash=constants.EMPTY_HASH,
+                payment_network=payment_network,
+                block_number=last_log_block_number,
+                block_hash=last_log_block_hash,
             )
             self.handle_state_change(state_change)
         else:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -311,8 +311,7 @@ class RaidenService(Runnable):
             # network, to reconstruct all token network graphs and find opened
             # channels
             last_log_block_number = self.query_start_block
-            last_log_block_hash = views.blockhash_from_blocknumber(
-                self.chain,
+            last_log_block_hash = self.chain.client.blockhash_from_blocknumber(
                 last_log_block_number,
             )
 

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -93,10 +93,11 @@ class ChainStateStateMachine(RuleBasedStateMachine):
         partner_address = self.new_channel()
 
         channel_new_state_change = ContractReceiveChannelNew(
-            factories.make_transaction_hash(),
-            self.token_network_id,
-            self.address_to_channel[partner_address],
-            self.block_number,
+            transaction_hash=factories.make_transaction_hash(),
+            token_network_identifier=self.token_network_id,
+            channel_state=self.address_to_channel[partner_address],
+            block_number=self.block_number,
+            block_hash=factories.make_block_hash(),
         )
         node.state_transition(self.chain_state, channel_new_state_change)
 
@@ -427,6 +428,7 @@ class OnChainMixin:
             token_network_identifier=channel.token_network_identifier,
             channel_identifier=channel.identifier,
             block_number=self.block_number + 1,
+            block_hash=factories.make_block_hash(),
         )
 
         node.state_transition(self.chain_state, channel_settled_state_change)

--- a/raiden/tests/unit/test_node_queue.py
+++ b/raiden/tests/unit/test_node_queue.py
@@ -134,6 +134,7 @@ def test_channel_closed_must_clear_ordered_messages(
         token_network_identifier=token_network_state.address,
         channel_identifier=channel_identifier,
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
 
     iteration = node.handle_state_change(

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -28,6 +28,7 @@ def create_square_network_topology(
     typing.List[NettingChannelState],
 ]:
     open_block_number = 10
+    open_block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
     address1 = factories.make_address()
     address2 = factories.make_address()
@@ -62,12 +63,14 @@ def create_square_network_topology(
         token_network_identifier=token_network_state.address,
         channel_state=channel_state1,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
     channel_new_state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_state=channel_state2,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration1 = token_network.state_transition(
@@ -98,6 +101,7 @@ def create_square_network_topology(
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration3 = token_network.state_transition(
@@ -119,6 +123,7 @@ def create_square_network_topology(
         participant1=address3,
         participant2=address1,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
     channel_new_iteration4 = token_network.state_transition(
         payment_network_identifier=payment_network_state.address,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -39,10 +39,11 @@ def test_contract_receive_channelnew_must_be_idempotent():
     channel_state2 = copy.deepcopy(channel_state1)
 
     state_change1 = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_id,
-        channel_state1,
-        block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_id,
+        channel_state=channel_state1,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     token_network.state_transition(
@@ -54,10 +55,11 @@ def test_contract_receive_channelnew_must_be_idempotent():
     )
 
     state_change2 = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_id,
-        channel_state2,
-        block_number + 1,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_id,
+        channel_state=channel_state2,
+        block_number=block_number + 1,
+        block_hash=factories.make_block_hash(),
     )
 
     # replay the ContractReceiveChannelNew state change
@@ -92,10 +94,11 @@ def test_channel_settle_must_properly_cleanup():
     channel_state = factories.make_channel(our_balance=our_balance)
 
     channel_new_state_change = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_id,
-        channel_state,
-        open_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_id,
+        channel_state=channel_state,
+        block_number=open_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -107,12 +110,14 @@ def test_channel_settle_must_properly_cleanup():
     )
 
     closed_block_number = open_block_number + 10
+    closed_block_hash = factories.make_block_hash()
     channel_close_state_change = ContractReceiveChannelClosed(
-        factories.make_transaction_hash(),
-        channel_state.partner_state.address,
-        token_network_id,
-        channel_state.identifier,
-        closed_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        transaction_from=channel_state.partner_state.address,
+        token_network_identifier=token_network_id,
+        channel_identifier=channel_state.identifier,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration = token_network.state_transition(
@@ -125,10 +130,11 @@ def test_channel_settle_must_properly_cleanup():
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
-        factories.make_transaction_hash(),
-        token_network_id,
-        channel_state.identifier,
-        settle_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_id,
+        channel_identifier=channel_state.identifier,
+        block_number=settle_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_settled_iteration = token_network.state_transition(
@@ -167,8 +173,9 @@ def test_channel_data_removed_after_unlock(
     channel_new_state_change = ContractReceiveChannelNew(
         factories.make_transaction_hash(),
         token_network_state.address,
-        channel_state,
-        open_block_number,
+        channel_state=channel_state,
+        block_number=open_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -206,12 +213,14 @@ def test_channel_data_removed_after_unlock(
     node.state_transition(chain_state, init_target)
 
     closed_block_number = open_block_number + 10
+    closed_block_hash = factories.make_block_hash()
     channel_close_state_change = ContractReceiveChannelClosed(
-        factories.make_transaction_hash(),
-        channel_state.partner_state.address,
-        token_network_state.address,
-        channel_state.identifier,
-        closed_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        transaction_from=channel_state.partner_state.address,
+        token_network_identifier=token_network_state.address,
+        channel_identifier=channel_state.identifier,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration = token_network.state_transition(
@@ -224,10 +233,11 @@ def test_channel_data_removed_after_unlock(
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
-        factories.make_transaction_hash(),
-        token_network_state.address,
-        channel_state.identifier,
-        settle_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_state.address,
+        channel_identifier=channel_state.identifier,
+        block_number=settle_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_settled_iteration = token_network.state_transition(
@@ -253,6 +263,7 @@ def test_channel_data_removed_after_unlock(
         unlocked_amount=lock_amount,
         returned_tokens=0,
         block_number=closed_block_number + 1,
+        block_hash=factories.make_block_hash(),
     )
     channel_unlock_iteration = token_network.state_transition(
         payment_network_identifier,
@@ -292,10 +303,11 @@ def test_mediator_clear_pairs_after_batch_unlock(
     payment_network_identifier = factories.make_payment_network_identifier()
 
     channel_new_state_change = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_state.address,
-        channel_state,
-        open_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_state.address,
+        channel_state=channel_state,
+        block_number=open_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -334,12 +346,14 @@ def test_mediator_clear_pairs_after_batch_unlock(
     node.state_transition(chain_state, init_mediator)
 
     closed_block_number = open_block_number + 10
+    closed_block_hash = factories.make_block_hash()
     channel_close_state_change = ContractReceiveChannelClosed(
-        factories.make_transaction_hash(),
-        channel_state.partner_state.address,
-        token_network_state.address,
-        channel_state.identifier,
-        closed_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        transaction_from=channel_state.partner_state.address,
+        token_network_identifier=token_network_state.address,
+        channel_identifier=channel_state.identifier,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration = token_network.state_transition(
@@ -352,10 +366,11 @@ def test_mediator_clear_pairs_after_batch_unlock(
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
-        factories.make_transaction_hash(),
-        token_network_state.address,
-        channel_state.identifier,
-        settle_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_state.address,
+        channel_identifier=channel_state.identifier,
+        block_number=settle_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_settled_iteration = token_network.state_transition(
@@ -381,6 +396,7 @@ def test_mediator_clear_pairs_after_batch_unlock(
         unlocked_amount=lock_amount,
         returned_tokens=0,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
     channel_unlock_iteration = node.state_transition(
         chain_state=chain_state,
@@ -433,10 +449,11 @@ def test_multiple_channel_states(
     payment_network_identifier = factories.make_payment_network_identifier()
 
     channel_new_state_change = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_state.address,
-        channel_state,
-        open_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_state.address,
+        channel_state=channel_state,
+        block_number=open_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -474,12 +491,14 @@ def test_multiple_channel_states(
     node.state_transition(chain_state, init_target)
 
     closed_block_number = open_block_number + 10
+    closed_block_hash = factories.make_block_hash()
     channel_close_state_change = ContractReceiveChannelClosed(
-        factories.make_transaction_hash(),
-        channel_state.partner_state.address,
-        token_network_state.address,
-        channel_state.identifier,
-        closed_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        transaction_from=channel_state.partner_state.address,
+        token_network_identifier=token_network_state.address,
+        channel_identifier=channel_state.identifier,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration = token_network.state_transition(
@@ -492,10 +511,11 @@ def test_multiple_channel_states(
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
-        factories.make_transaction_hash(),
-        token_network_state.address,
-        channel_state.identifier,
-        settle_block_number,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_state.address,
+        channel_identifier=channel_state.identifier,
+        block_number=settle_block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_settled_iteration = token_network.state_transition(
@@ -518,10 +538,11 @@ def test_multiple_channel_states(
         partner_address=address,
     )
     channel_new_state_change = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_state.address,
-        new_channel_state,
-        closed_block_number + 1,
+        transaction_hash=factories.make_transaction_hash(),
+        token_network_identifier=token_network_state.address,
+        channel_state=new_channel_state,
+        block_number=closed_block_number + 1,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_iteration = token_network.state_transition(
@@ -559,12 +580,14 @@ def test_routing_updates(
     )
     payment_network_identifier = factories.make_payment_network_identifier()
 
+    open_block_hash = factories.make_block_hash()
     # create a new channel as participant, check graph update
     channel_new_state_change = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration1 = token_network.state_transition(
@@ -590,6 +613,7 @@ def test_routing_updates(
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration2 = token_network.state_transition(
@@ -610,12 +634,14 @@ def test_routing_updates(
 
     # close the channel the node is a participant of, check edge is removed from graph
     closed_block_number = open_block_number + 20
+    closed_block_hash = factories.make_block_hash()
     channel_close_state_change1 = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
         token_network_identifier=token_network_state.address,
         channel_identifier=channel_state.identifier,
         block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration1 = token_network.state_transition(
@@ -635,6 +661,7 @@ def test_routing_updates(
         token_network_identifier=token_network_state.address,
         channel_identifier=channel_state.identifier,
         block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration2 = token_network.state_transition(
@@ -658,6 +685,7 @@ def test_routing_updates(
         token_network_identifier=token_network_state.address,
         channel_identifier=new_channel_identifier,
         block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     channel_closed_iteration3 = token_network.state_transition(
@@ -676,6 +704,7 @@ def test_routing_updates(
         token_network_identifier=token_network_state.address,
         channel_identifier=new_channel_identifier,
         block_number=closed_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_closed_iteration4 = token_network.state_transition(
@@ -700,6 +729,7 @@ def test_routing_issue2663(
         our_address,
 ):
     open_block_number = 10
+    open_block_number_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
     address1 = factories.make_address()
     address2 = factories.make_address()
@@ -734,12 +764,14 @@ def test_routing_issue2663(
         token_network_identifier=token_network_state.address,
         channel_state=channel_state1,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
     channel_new_state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_state=channel_state2,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration1 = token_network.state_transition(
@@ -770,6 +802,7 @@ def test_routing_issue2663(
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration3 = token_network.state_transition(
@@ -791,6 +824,7 @@ def test_routing_issue2663(
         participant1=address3,
         participant2=address1,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
     channel_new_iteration4 = token_network.state_transition(
         payment_network_identifier=payment_network_state.address,
@@ -932,6 +966,7 @@ def test_routing_priority(
         our_address,
 ):
     open_block_number = 10
+    open_block_number_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
     address1 = factories.make_address()
     address2 = factories.make_address()
@@ -973,12 +1008,14 @@ def test_routing_priority(
         token_network_identifier=token_network_state.address,
         channel_state=channel_state1,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
     channel_new_state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_state=channel_state2,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration1 = token_network.state_transition(
@@ -1005,6 +1042,7 @@ def test_routing_priority(
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration3 = token_network.state_transition(
@@ -1022,6 +1060,7 @@ def test_routing_priority(
         participant1=address3,
         participant2=address1,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration4 = token_network.state_transition(
@@ -1039,6 +1078,7 @@ def test_routing_priority(
         participant1=address3,
         participant2=address4,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration5 = token_network.state_transition(
@@ -1056,6 +1096,7 @@ def test_routing_priority(
         participant1=address2,
         participant2=address4,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     token_network.state_transition(

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -73,10 +73,11 @@ def test_write_read_log():
     wal = new_wal(state_transition_noop)
 
     block_number = 1337
+    block_hash = factories.make_transaction_hash()
     block = Block(
         block_number=block_number,
         gas_limit=1,
-        block_hash=factories.make_transaction_hash(),
+        block_hash=block_hash,
     )
     unlocked_amount = 10
     returned_amount = 5
@@ -92,6 +93,7 @@ def test_write_read_log():
         unlocked_amount=unlocked_amount,
         returned_tokens=returned_amount,
         block_number=block_number,
+        block_hash=block_hash,
     )
 
     state_changes1 = wal.storage.get_statechanges_by_identifier(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1060,6 +1060,7 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
     closed.
     """
     block_number = 10
+    block_hash = factories.make_block_hash()
     setup = setup_initiator_tests(amount=UNIT_TRANSFER_AMOUNT * 2, block_number=block_number)
 
     channel_closed = ContractReceiveChannelClosed(
@@ -1068,6 +1069,7 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
         token_network_identifier=setup.channel.token_network_identifier,
         channel_identifier=setup.channel.identifier,
         block_number=block_number,
+        block_hash=block_hash,
     )
     channel_close_transition = channel.state_transition(
         channel_state=setup.channel,
@@ -1081,7 +1083,7 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
     block = Block(
         block_number=expiration_block_number,
         gas_limit=1,
-        block_hash=factories.make_transaction_hash(),
+        block_hash=factories.make_block_hash(),
     )
     channel_map = {channel_state.identifier: channel_state}
     iteration = initiator_manager.state_transition(
@@ -1110,6 +1112,7 @@ def test_initiator_handle_contract_receive_secret_reveal():
         secrethash=transfer.lock.secrethash,
         secret=UNIT_SECRET,
         block_number=transfer.lock.expiration,
+        block_hash=factories.make_block_hash(),
     )
 
     message_identifier = message_identifier_from_prng(deepcopy(setup.prng))
@@ -1145,6 +1148,7 @@ def test_initiator_handle_contract_receive_emptyhash_secret_reveal():
         secrethash=transfer.lock.secrethash,
         secret=EMPTY_HASH,
         block_number=transfer.lock.expiration,
+        block_hash=factories.make_block_hash(),
     )
 
     iteration = initiator_manager.handle_onchain_secretreveal(
@@ -1175,6 +1179,7 @@ def test_initiator_handle_contract_receive_secret_reveal_expired():
         secrethash=transfer.lock.secrethash,
         secret=UNIT_SECRET,
         block_number=transfer.lock.expiration + 1,
+        block_hash=factories.make_block_hash(),
     )
 
     iteration = initiator_manager.handle_onchain_secretreveal(
@@ -1208,6 +1213,7 @@ def test_initiator_handle_contract_receive_after_channel_closed():
         token_network_identifier=setup.channel.token_network_identifier,
         channel_identifier=setup.channel.identifier,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_close_transition = channel.state_transition(
@@ -1224,6 +1230,7 @@ def test_initiator_handle_contract_receive_after_channel_closed():
         secrethash=transfer.lock.secrethash,
         secret=UNIT_SECRET,
         block_number=transfer.lock.expiration,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_map = {

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -950,6 +950,7 @@ def test_mediator_secret_reveal_empty_hash():
         secrethash=secrethash,
         secret=EMPTY_HASH,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
     iteration = mediator.state_transition(
         mediator_state=current_state,
@@ -1497,6 +1498,7 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
         token_network_identifier=channel_state.token_network_identifier,
         channel_identifier=channel_state.identifier,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
     channel_close_transition = channel.state_transition(
         channel_state=channel_state,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -519,11 +519,12 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
     mediator.state_transition(
         mediator_state=mediator_state,
         state_change=ContractReceiveSecretReveal(
-            transaction_hash,
-            secret_registry_address,
-            secrethash,
-            secret,
-            setup.block_number,
+            transaction_hash=transaction_hash,
+            secret_registry_address=secret_registry_address,
+            secrethash=secrethash,
+            secret=secret,
+            block_number=setup.block_number,
+            block_hash=factories.make_block_hash(),
         ),
         channelidentifiers_to_channels=setup.channel_map,
         nodeaddresses_to_networkstates=setup.channels.nodeaddresses_to_networkstates,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -327,6 +327,7 @@ def test_handle_onchain_secretreveal():
         secrethash=EMPTY_HASH_KECCAK,
         secret=EMPTY_HASH,
         block_number=block_number_prior_the_expiration,
+        block_hash=factories.make_block_hash(),
     )
     onchain_secret_reveal_iteration = target.state_transition(
         target_state=offchain_secret_reveal_iteration.new_state,

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,5 +1,5 @@
 from raiden.constants import EMPTY_MERKLE_ROOT
-from raiden.tests.utils.factories import HOP1, HOP2, UNIT_SECRETHASH
+from raiden.tests.utils.factories import HOP1, HOP2, UNIT_SECRETHASH, make_block_hash
 from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.node import is_transaction_effect_satisfied
 from raiden.transfer.state_change import ContractReceiveChannelBatchUnlock
@@ -26,6 +26,7 @@ def test_is_transaction_effect_satisfied(
         unlocked_amount=0,
         returned_tokens=0,
         block_number=1,
+        block_hash=make_block_hash(),
     )
     # unlock for a channel in which this node is not a participant must return False
     assert not is_transaction_effect_satisfied(chain_state, transaction, state_change)

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -84,6 +84,10 @@ def make_transaction_hash() -> typing.TransactionHash:
     return typing.TransactionHash(make_32bytes())
 
 
+def make_block_hash() -> typing.BlockHash:
+    return typing.BlockHash(make_32bytes())
+
+
 def make_privatekey_bin() -> bin:
     return make_32bytes()
 

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -5,11 +5,13 @@ from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.utils.typing import (
     Address,
     BlockExpiration,
+    BlockHash,
     BlockNumber,
     ChannelID,
     Generic,
     List,
     MessageID,
+    T_BlockHash,
     T_BlockNumber,
     T_ChannelID,
     TransactionHash,
@@ -197,18 +199,27 @@ class ContractSendExpirableEvent(ContractSendEvent):
 class ContractReceiveStateChange(StateChange):
     """ Marker used for state changes which represent on-chain logs. """
 
-    def __init__(self, transaction_hash: TransactionHash, block_number: BlockNumber):
+    def __init__(
+            self,
+            transaction_hash: TransactionHash,
+            block_number: BlockNumber,
+            block_hash: BlockHash,
+    ):
         if not isinstance(block_number, T_BlockNumber):
             raise ValueError('block_number must be of type block_number')
+        if not isinstance(block_hash, T_BlockHash):
+            raise ValueError('block_hash must be of type block_hash')
 
         self.transaction_hash = transaction_hash
         self.block_number = block_number
+        self.block_hash = block_hash
 
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveStateChange) and
             self.transaction_hash == other.transaction_hash and
-            self.block_number == other.block_number
+            self.block_number == other.block_number and
+            self.block_hash == other.block_hash
         )
 
     def __ne__(self, other):

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -252,18 +252,21 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             token_network_identifier: TokenNetworkID,
             channel_state: NettingChannelState,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.channel_state = channel_state
         self.channel_identifier = channel_state.identifier
 
     def __repr__(self):
-        return '<ContractReceiveChannelNew token_network:{} state:{} block:{}>'.format(
-            pex(self.token_network_identifier),
-            self.channel_state,
-            self.block_number,
+        return (
+            '<ContractReceiveChannelNew token_network:{} state:{} block:{}>'.format(
+                pex(self.token_network_identifier),
+                self.channel_state,
+                self.block_number,
+            )
         )
 
     def __eq__(self, other):
@@ -283,6 +286,7 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_state': self.channel_state,
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -292,6 +296,7 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_state=data['channel_state'],
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -305,8 +310,9 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             token_network_identifier: TokenNetworkID,
             channel_identifier: ChannelID,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.transaction_from = transaction_from
         self.token_network_identifier = token_network_identifier
@@ -343,6 +349,7 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': str(self.channel_identifier),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -353,6 +360,7 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -469,8 +477,9 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
             channel_identifier: ChannelID,
             deposit_transaction: TransactionChannelNewBalance,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
@@ -479,7 +488,7 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
     def __repr__(self):
         return (
             '<ContractReceiveChannelNewBalance'
-            ' token_network:{} channel:{} transaction:{} block:{}'
+            ' token_network:{} channel:{} transaction:{} block_number:{}'
             '>'
         ).format(
             pex(self.token_network_identifier),
@@ -507,6 +516,7 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
             'channel_identifier': str(self.channel_identifier),
             'deposit_transaction': self.deposit_transaction,
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -517,6 +527,7 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             deposit_transaction=data['deposit_transaction'],
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -529,8 +540,9 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             token_network_identifier: TokenNetworkID,
             channel_identifier: ChannelID,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
@@ -561,6 +573,7 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': str(self.channel_identifier),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -570,6 +583,7 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -644,11 +658,12 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
             transaction_hash: TransactionHash,
             payment_network: PaymentNetworkState,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
         if not isinstance(payment_network, PaymentNetworkState):
             raise ValueError('payment_network must be a PaymentNetworkState instance')
 
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.payment_network = payment_network
 
@@ -673,6 +688,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
             'transaction_hash': serialize_bytes(self.transaction_hash),
             'payment_network': self.payment_network,
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -681,6 +697,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             payment_network=data['payment_network'],
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -693,20 +710,23 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             payment_network_identifier: PaymentNetworkID,
             token_network: TokenNetworkState,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
         if not isinstance(token_network, TokenNetworkState):
             raise ValueError('token_network must be a TokenNetworkState instance')
 
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.payment_network_identifier = payment_network_identifier
         self.token_network = token_network
 
     def __repr__(self):
-        return '<ContractReceiveNewTokenNetwork payment_network:{} network:{} block:{}>'.format(
-            pex(self.payment_network_identifier),
-            self.token_network,
-            self.block_number,
+        return (
+            '<ContractReceiveNewTokenNetwork payment_network:{} network:{} block:{}>'.format(
+                pex(self.payment_network_identifier),
+                self.token_network,
+                self.block_number,
+            )
         )
 
     def __eq__(self, other):
@@ -726,6 +746,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             'payment_network_identifier': to_checksum_address(self.payment_network_identifier),
             'token_network': self.token_network,
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -735,6 +756,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network=data['token_network'],
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -748,6 +770,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             secrethash: SecretHash,
             secret: Secret,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
         if not isinstance(secret_registry_address, T_SecretRegistryAddress):
             raise ValueError('secret_registry_address must be of type SecretRegistryAddress')
@@ -756,7 +779,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
         if not isinstance(secret, T_Secret):
             raise ValueError('secret must be of type Secret')
 
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.secret_registry_address = secret_registry_address
         self.secrethash = secrethash
@@ -793,6 +816,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             'secrethash': serialize_bytes(self.secrethash),
             'secret': serialize_bytes(self.secret),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -803,6 +827,7 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
             secrethash=deserialize_bytes(data['secrethash']),
             secret=deserialize_bytes(data['secret']),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -827,6 +852,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             unlocked_amount: TokenAmount,
             returned_tokens: TokenAmount,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
 
         if not isinstance(token_network_identifier, T_TokenNetworkID):
@@ -838,7 +864,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
         if not isinstance(partner, T_Address):
             raise ValueError('partner must be of type address')
 
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.participant = participant
@@ -888,6 +914,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             'unlocked_amount': str(self.unlocked_amount),
             'returned_tokens': str(self.returned_tokens),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -901,6 +928,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             unlocked_amount=int(data['unlocked_amount']),
             returned_tokens=int(data['returned_tokens']),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -915,6 +943,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
             participant1: Address,
             participant2: Address,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
 
         if not isinstance(participant1, T_Address):
@@ -923,7 +952,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
         if not isinstance(participant2, T_Address):
             raise ValueError('participant2 must be of type address')
 
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
@@ -964,6 +993,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
             'participant1': to_checksum_address(self.participant1),
             'participant2': to_checksum_address(self.participant2),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -975,6 +1005,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
             participant1=to_canonical_address(data['participant1']),
             participant2=to_canonical_address(data['participant2']),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -987,8 +1018,9 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
             token_network_identifier: TokenNetworkID,
             channel_identifier: ChannelID,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
@@ -1017,6 +1049,7 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
             'token_network_identifier': to_checksum_address(self.token_network_identifier),
             'channel_identifier': str(self.channel_identifier),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -1026,6 +1059,7 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 
@@ -1037,15 +1071,18 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             channel_identifier: ChannelID,
             nonce: Nonce,
             block_number: BlockNumber,
+            block_hash: BlockHash,
     ):
-        super().__init__(transaction_hash, block_number)
+        super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
         self.channel_identifier = channel_identifier
         self.nonce = nonce
 
     def __repr__(self):
-        return f'<ContractReceiveUpdateTransfer nonce:{self.nonce} block:{self.block_number}>'
+        return (
+            f'<ContractReceiveUpdateTransfer nonce:{self.nonce} block:{self.block_number}>'
+        )
 
     def __eq__(self, other):
         return (
@@ -1066,6 +1103,7 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             'channel_identifier': str(self.channel_identifier),
             'nonce': str(self.nonce),
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
         }
 
     @classmethod
@@ -1076,6 +1114,7 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             nonce=int(data['nonce']),
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )
 
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -67,7 +67,7 @@ def latest_confirmed_block_hash(
         confirmation_blocks: int,
 ) -> BlockHash:
     block_number = max(0, chain_state.block_number - confirmation_blocks)
-    return web3.getBlock(block_number)['hash']
+    return bytes(web3.getBlock(block_number)['hash'])
 
 
 def latest_confirmed_block_hash_from_raiden(raiden) -> BlockHash:
@@ -77,6 +77,10 @@ def latest_confirmed_block_hash_from_raiden(raiden) -> BlockHash:
         web3=raiden.chain.client.web3,
         confirmation_block=raiden.config['blockchain']['confirmation_blocks'],
     )
+
+
+def blockhash_from_blocknumber(blockchain_service, block_number: BlockNumber) -> BlockHash:
+    return bytes(blockchain_service.client.web3.eth.getBlock(block_number)['hash'])
 
 
 def count_token_network_channels(

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -75,7 +75,7 @@ def latest_confirmed_block_hash_from_raiden(raiden) -> BlockHash:
     return latest_confirmed_block_hash(
         chain_state=chain,
         web3=raiden.chain.client.web3,
-        confirmation_block=raiden.config['blockchain']['confirmation_blocks'],
+        confirmation_blocks=raiden.config['blockchain']['confirmation_blocks'],
     )
 
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -61,28 +61,6 @@ def block_number(chain_state: ChainState) -> BlockNumber:
     return chain_state.block_number
 
 
-def latest_confirmed_block_hash(
-        chain_state: ChainState,
-        web3: Web3,
-        confirmation_blocks: int,
-) -> BlockHash:
-    block_number = max(0, chain_state.block_number - confirmation_blocks)
-    return bytes(web3.getBlock(block_number)['hash'])
-
-
-def latest_confirmed_block_hash_from_raiden(raiden) -> BlockHash:
-    chain = state_from_raiden(raiden)
-    return latest_confirmed_block_hash(
-        chain_state=chain,
-        web3=raiden.chain.client.web3,
-        confirmation_blocks=raiden.config['blockchain']['confirmation_blocks'],
-    )
-
-
-def blockhash_from_blocknumber(blockchain_service, block_number: BlockNumber) -> BlockHash:
-    return bytes(blockchain_service.client.web3.eth.getBlock(block_number)['hash'])
-
-
 def count_token_network_channels(
         chain_state: ChainState,
         payment_network_id: PaymentNetworkID,

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -1,3 +1,5 @@
+from web3 import Web3
+
 from raiden.transfer import channel
 from raiden.transfer.architecture import ContractSendEvent, State
 from raiden.transfer.state import (
@@ -21,6 +23,7 @@ from raiden.transfer.state import (
 )
 from raiden.utils.typing import (
     Address,
+    BlockHash,
     BlockNumber,
     Callable,
     ChannelID,
@@ -56,6 +59,24 @@ def all_neighbour_nodes(chain_state: ChainState) -> Set[Address]:
 
 def block_number(chain_state: ChainState) -> BlockNumber:
     return chain_state.block_number
+
+
+def latest_confirmed_block_hash(
+        chain_state: ChainState,
+        web3: Web3,
+        confirmation_blocks: int,
+) -> BlockHash:
+    block_number = max(0, chain_state.block_number - confirmation_blocks)
+    return web3.getBlock(block_number)['hash']
+
+
+def latest_confirmed_block_hash_from_raiden(raiden) -> BlockHash:
+    chain = state_from_raiden(raiden)
+    return latest_confirmed_block_hash(
+        chain_state=chain,
+        web3=raiden.chain.client.web3,
+        confirmation_block=raiden.config['blockchain']['confirmation_blocks'],
+    )
 
 
 def count_token_network_channels(

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -1,5 +1,3 @@
-from web3 import Web3
-
 from raiden.transfer import channel
 from raiden.transfer.architecture import ContractSendEvent, State
 from raiden.transfer.state import (
@@ -23,7 +21,6 @@ from raiden.transfer.state import (
 )
 from raiden.utils.typing import (
     Address,
-    BlockHash,
     BlockNumber,
     Callable,
     ChannelID,


### PR DESCRIPTION
This is the third PR for the consistent blockchain view issue: https://github.com/raiden-network/raiden/issues/2885

### What this PR does

- Adds the `blockchash` as an extra argument to all the `ContractReceiveXXX` state changes.
- Initializes the `ContractReceiveXXX` state changes at `blockchain_events_handler.py` with the blockhash of the corresponding block number the event came from.
- Changes all the tests for the above. This is, unfortunately, the biggest part of the diff.

### Remaining to do before merging

- [ ] Add DB upgrades for the `ContractReceiveXXX` changes.

### Remaining for subsequent PRs

- [ ] Go through the `# LEFTODO: Supply a proper block id` comments and provide a proper block hash instead of `latest` where required.
- [ ] Review the entire logic and see which raiden state_changes/events need to also contain a block hash as identifier and then implement it for them too. The above will require insertion of blockchash to `ContractSendXXX` state changes to know which blockhash caused the state changes to be generator. Naturally this will require another DB upgrade.
- [ ] More?