### PR TITLE
Cleanup message class hierarchy

### DIFF
--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -19,8 +19,6 @@ REFUNDTRANSFER = 8
 REVEALSECRET = 11
 DELIVERED = 12
 LOCKEXPIRED = 13
-REQUESTMONITORING = 20
-UPDATEPFS = 30
 
 
 # pylint: disable=invalid-name
@@ -233,8 +231,6 @@ Lock = namedbuffer(
 RequestMonitoring = namedbuffer(
     'request_monitoring',
     [
-        cmdid(REQUESTMONITORING),
-        pad(3),
         nonce,
         chain_id,
         token_network_address,
@@ -252,8 +248,6 @@ RequestMonitoring = namedbuffer(
 UpdatePFS = namedbuffer(
     'update_pfs',
     [
-        cmdid(UPDATEPFS),
-        pad(3),
         nonce,
         chain_id,
         token_network_address,
@@ -277,8 +271,6 @@ CMDID_MESSAGE = {
     REFUNDTRANSFER: RefundTransfer,
     DELIVERED: Delivered,
     LOCKEXPIRED: LockExpired,
-    REQUESTMONITORING: RequestMonitoring,
-    UPDATEPFS: UpdatePFS,
 }
 
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -229,12 +229,19 @@ class Message:
         raise NotImplementedError('Method needs to be implemented in a subclass.')
 
 
-class SignedMessage(Message):
+class AuthenticatedMessage(Message):
+    """ Message, that has a sender. """
+
+    def sender(self) -> typing.Address:
+        raise NotImplementedError('Property needs to be implemented in subclass.')
+
+
+class SignedMessage(AuthenticatedMessage):
     # signing is a bit problematic, we need to pack the data to sign, but the
     # current API assumes that signing is called before, this can be improved
     # by changing the order to packing then signing
     def __init__(self):
-        super().__init__()
+        AuthenticatedMessage.__init__(self)
         self.signature = b''
 
     def _data_to_sign(self) -> bytes:
@@ -279,10 +286,26 @@ class SignedMessage(Message):
         return cls.unpack(packed)
 
 
-class EnvelopeMessage(SignedMessage):
+class RetrieableMessage:
+    """ Message, that supports a retry-queue. """
+
+    def __init__(self, message_identifier: typing.MessageID):
+        self.message_identifier = message_identifier
+
+
+class SignedRetrieableMessage(SignedMessage, RetrieableMessage):
+    """ Mixin of SignedMessage and RetrieableMessage. """
+
+    def __init__(self, message_identifier):
+        SignedMessage.__init__(self)
+        RetrieableMessage.__init__(self, message_identifier)
+
+
+class EnvelopeMessage(SignedRetrieableMessage):
     def __init__(
             self,
             chain_id: ChainID,
+            message_identifier: MessageID,
             nonce: None,
             transferred_amount: TokenAmount,
             locked_amount: TokenAmount,
@@ -290,7 +313,7 @@ class EnvelopeMessage(SignedMessage):
             channel_identifier: ChannelID,
             token_network_address: TokenNetworkAddress,
     ):
-        super().__init__()
+        SignedRetrieableMessage.__init__(self, message_identifier)
         assert_envelope_values(
             nonce,
             channel_identifier,
@@ -477,7 +500,7 @@ class Ping(SignedMessage):
         packed.signature = self.signature
 
 
-class SecretRequest(SignedMessage):
+class SecretRequest(SignedRetrieableMessage):
     """ Requests the secret which unlocks a secrethash. """
     cmdid = messages.SECRETREQUEST
 
@@ -719,7 +742,7 @@ class Unlock(EnvelopeMessage):
         return message
 
 
-class RevealSecret(SignedMessage):
+class RevealSecret(SignedRetrieableMessage):
     """Message used to reveal a secret to party known to have interest in it.
 
     This message is not sufficient for state changes in the raiden Channel, the
@@ -891,8 +914,8 @@ class LockedTransferBase(EnvelopeMessage):
     def __init__(
             self,
             chain_id: ChainID,
-            message_identifier: MessageID,
             payment_identifier: PaymentID,
+            message_identifier: MessageID,
             nonce: int,
             token_network_address: TokenNetworkAddress,
             token: TokenAddress,
@@ -907,13 +930,13 @@ class LockedTransferBase(EnvelopeMessage):
             chain_id=chain_id,
             nonce=nonce,
             transferred_amount=transferred_amount,
+            message_identifier=message_identifier,
             locked_amount=locked_amount,
             locksroot=locksroot,
             channel_identifier=channel_identifier,
             token_network_address=token_network_address,
         )
         assert_transfer_values(payment_identifier, token, recipient)
-
         self.message_identifier = message_identifier
         self.payment_identifier = payment_identifier
         self.token = token
@@ -1444,7 +1467,7 @@ class SignedBlindedBalanceProof:
             chain_id: typing.ChainID,
             signature: typing.Signature,
             balance_hash: typing.BalanceHash,
-    ) -> None:
+    ):
 
         super().__init__()
         self.channel_identifier = channel_identifier
@@ -1460,9 +1483,9 @@ class SignedBlindedBalanceProof:
 
     @classmethod
     def from_balance_proof_signed_state(
-            cls: typing.Type[typing.T_SignedBlindedBalanceProof],
+            cls,
             balance_proof: BalanceProofSignedState,
-    ) -> typing.T_SignedBlindedBalanceProof:
+    ) -> 'SignedBlindedBalanceProof':
         assert isinstance(balance_proof, BalanceProofSignedState)
         return cls(
             channel_identifier=balance_proof.channel_identifier,
@@ -1512,9 +1535,9 @@ class SignedBlindedBalanceProof:
 
     @classmethod
     def from_dict(
-            cls: typing.Type[typing.T_SignedBlindedBalanceProof],
+            cls,
             data: typing.Dict,
-    ) -> typing.T_SignedBlindedBalanceProof:
+    ) -> 'SignedBlindedBalanceProof':
         assert data['type'] == cls.__name__
         return cls(
             channel_identifier=data['channel_identifier'],
@@ -1528,7 +1551,6 @@ class SignedBlindedBalanceProof:
 
 
 class RequestMonitoring(SignedMessage):
-    cmdid = messages.REQUESTMONITORING
     """Message to request channel watching from a monitoring service.
     Spec:
         https://raiden-network-specification.readthedocs.io/en/latest/monitoring_service.html\
@@ -1541,7 +1563,7 @@ class RequestMonitoring(SignedMessage):
             reward_amount: typing.TokenAmount,
             non_closing_signature: typing.Signature = b'',
             reward_proof_signature: typing.Signature = b'',
-    ) -> None:
+    ):
         super().__init__()
         if onchain_balance_proof is None:
             raise ValueError('no balance proof given')
@@ -1558,10 +1580,10 @@ class RequestMonitoring(SignedMessage):
 
     @classmethod
     def from_balance_proof_signed_state(
-            cls: typing.Type[typing.T_SignedBlindedBalanceProof],
+            cls,
             balance_proof: BalanceProofSignedState,
             reward_amount: typing.TokenAmount,
-    ) -> typing.T_RequestMonitoring:
+    ) -> 'RequestMonitoring':
         assert isinstance(balance_proof, BalanceProofSignedState)
         onchain_balance_proof = SignedBlindedBalanceProof.from_balance_proof_signed_state(
             balance_proof=balance_proof,
@@ -1577,9 +1599,9 @@ class RequestMonitoring(SignedMessage):
 
     @classmethod
     def from_dict(
-            cls: typing.Type[typing.T_RequestMonitoring],
+            cls,
             data: typing.Dict,
-    ) -> typing.T_RequestMonitoring:
+    ) -> 'RequestMonitoring':
         assert data['type'] == cls.__name__
         onchain_balance_proof = SignedBlindedBalanceProof.from_dict(
             data['onchain_balance_proof'],
@@ -1645,9 +1667,9 @@ class RequestMonitoring(SignedMessage):
 
     @classmethod
     def unpack(
-            cls: typing.Type[typing.T_RequestMonitoring],
+            cls,
             packed: bytes,
-    ) -> typing.T_RequestMonitoring:
+    ) -> 'RequestMonitoring':
         assert packed.balance_hash
         onchain_balance_proof = SignedBlindedBalanceProof(
             nonce=packed.nonce,
@@ -1706,7 +1728,6 @@ class RequestMonitoring(SignedMessage):
 
 class UpdatePFS(SignedMessage):
     """ Message to inform a pathfinding service about a capacity change. """
-    cmdid = messages.UPDATEPFS
 
     def __init__(
             self,
@@ -1821,8 +1842,6 @@ CMDID_TO_CLASS = {
     messages.UNLOCK: Unlock,
     messages.SECRETREQUEST: SecretRequest,
     messages.LOCKEXPIRED: LockExpired,
-    messages.REQUESTMONITORING: RequestMonitoring,
-    messages.UPDATEPFS: UpdatePFS,
 }
 
 CLASSNAME_TO_CLASS = {klass.__name__: klass for klass in CMDID_TO_CLASS.values()}

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -25,7 +25,7 @@ from raiden.messages import (
     Message,
     Ping,
     Pong,
-    SignedMessage,
+    SignedRetrieableMessage,
     decode as message_from_bytes,
     from_dict as message_from_dict,
 )
@@ -762,7 +762,7 @@ class MatrixTransport(Runnable):
             )
             return False
 
-        messages: List[SignedMessage] = list()
+        messages: List[SignedRetrieableMessage] = list()
 
         if data.startswith('0x'):
             try:
@@ -812,7 +812,7 @@ class MatrixTransport(Runnable):
                         _exc=ex,
                     )
                     continue
-                if not isinstance(message, SignedMessage):
+                if not isinstance(message, SignedRetrieableMessage):
                     self.log.warning(
                         'Received invalid message',
                         message=message,
@@ -856,7 +856,7 @@ class MatrixTransport(Runnable):
 
         self._raiden_service.on_message(delivered)
 
-    def _receive_message(self, message: SignedMessage):
+    def _receive_message(self, message: SignedRetrieableMessage):
         self.log.debug(
             'Message received',
             node=pex(self._raiden_service.address),

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -1,5 +1,5 @@
 from typing import *  # NOQA pylint:disable=wildcard-import,unused-wildcard-import
-from typing import Dict, List, NewType, Optional, Tuple, TypeVar, Union
+from typing import Dict, List, NewType, Optional, Tuple, Union
 
 MYPY_ANNOTATION = (
     'This assert is used to tell mypy what is the type of the variable'
@@ -120,16 +120,6 @@ SecretRegistryAddress = NewType('SecretRegistryAddress', T_SecretRegistryAddress
 
 T_Signature = bytes
 Signature = NewType('Signature', T_Signature)
-
-T_SignedBlindedBalanceProof = TypeVar(
-    'T_SignedBlindedBalanceProof',
-    bound='raiden.messages.SignedBlindedBalanceProof',
-)
-
-T_RequestMonitoring = TypeVar(
-    'T_RequestMonitoring',
-    bound='raiden.messages.RequestMonitoring',
-)
 
 T_TransactionHash = bytes
 TransactionHash = NewType('TransactionHash', T_TransactionHash)


### PR DESCRIPTION
PR #3374 introduced a potential DoS vector: since the message specified
a command-ID, it could be sent to a client (instead of a service).

Since clients expect a `message_identifier` for protocol messages, this
would lead to `AttributeError` on processing e.g. a `RequestMonitoring`
message in the client.

A couple of different traits of messages (has `message_identifier`, has
`sender`, has `signature`), so far were rather implicit. I introduced a
couple of message classes, to allow for explicit definition _and_ allow
re-use of `SignedMessage` in non Raiden-Off-Chain-Protocol messages
(i.e. `RequestMonitoring` or `UpdatePFS`, #3477).