### PR TITLE
Added type annotation to blockchain_events_handler

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -1,10 +1,11 @@
+from typing import TYPE_CHECKING
+
 import gevent
 import structlog
 
 from raiden.blockchain.events import Event
 from raiden.blockchain.state import get_channel_state
 from raiden.connection_manager import ConnectionManager
-from raiden.raiden_service import RaidenService
 from raiden.transfer import views
 from raiden.transfer.state import TokenNetworkState, TransactionChannelNewBalance
 from raiden.transfer.state_change import (
@@ -26,10 +27,14 @@ from raiden_contracts.constants import (
     ChannelEvent,
 )
 
+if TYPE_CHECKING:
+    from raiden.raiden_service import RaidenService  # noqa: F401
+
+
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
-def handle_tokennetwork_new(raiden: RaidenService, event: Event):
+def handle_tokennetwork_new(raiden: 'RaidenService', event: Event):
     """ Handles a `TokenNetworkCreated` event. """
     data = event.event_data
     args = data['args']
@@ -60,7 +65,7 @@ def handle_tokennetwork_new(raiden: RaidenService, event: Event):
     raiden.handle_state_change(new_token_network)
 
 
-def handle_channel_new(raiden: RaidenService, event: Event):
+def handle_channel_new(raiden: 'RaidenService', event: Event):
     data = event.event_data
     block_number = data['block_number']
     args = data['args']
@@ -119,7 +124,7 @@ def handle_channel_new(raiden: RaidenService, event: Event):
     raiden.add_pending_greenlet(retry_connect)
 
 
-def handle_channel_new_balance(raiden: RaidenService, event: Event):
+def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
@@ -172,7 +177,7 @@ def handle_channel_new_balance(raiden: RaidenService, event: Event):
             raiden.add_pending_greenlet(join_channel)
 
 
-def handle_channel_closed(raiden: RaidenService, event: Event):
+def handle_channel_closed(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     block_number = data['block_number']
@@ -208,7 +213,7 @@ def handle_channel_closed(raiden: RaidenService, event: Event):
         raiden.handle_state_change(route_closed)
 
 
-def handle_channel_update_transfer(raiden: RaidenService, event: Event):
+def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     args = data['args']
@@ -232,7 +237,7 @@ def handle_channel_update_transfer(raiden: RaidenService, event: Event):
         raiden.handle_state_change(channel_transfer_updated)
 
 
-def handle_channel_settled(raiden: RaidenService, event: Event):
+def handle_channel_settled(raiden: 'RaidenService', event: Event):
     data = event.event_data
     token_network_identifier = event.originating_contract
     channel_identifier = data['args']['channel_identifier']
@@ -255,7 +260,7 @@ def handle_channel_settled(raiden: RaidenService, event: Event):
         raiden.handle_state_change(channel_settled)
 
 
-def handle_channel_batch_unlock(raiden: RaidenService, event: Event):
+def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     data = event.event_data
     args = data['args']
@@ -276,7 +281,7 @@ def handle_channel_batch_unlock(raiden: RaidenService, event: Event):
     raiden.handle_state_change(unlock_state_change)
 
 
-def handle_secret_revealed(raiden: RaidenService, event: Event):
+def handle_secret_revealed(raiden: 'RaidenService', event: Event):
     secret_registry_address = event.originating_contract
     data = event.event_data
     args = data['args']
@@ -294,7 +299,7 @@ def handle_secret_revealed(raiden: RaidenService, event: Event):
     raiden.handle_state_change(registeredsecret_state_change)
 
 
-def on_blockchain_event(raiden: RaidenService, event: Event):
+def on_blockchain_event(raiden: 'RaidenService', event: Event):
     data = event.event_data
     log.debug(
         'Blockchain event',


### PR DESCRIPTION
Two mypy errors squashed:
```
raiden/blockchain_events_handler.py:141: error: Item "None" of "Optional[NettingChannelState]" has no attribute "our_state"
raiden/blockchain_events_handler.py:200: error: Incompatible types in assignment (expression has type "ContractReceiveRouteClosed", variable has type "ContractReceiveChannelClosed")
```