### PR TITLE
Consistent blockchain view Iteration 4 -- blockhash in ContractSendXXX events

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -213,7 +213,6 @@ class RaidenAPI:
 
         try:
             registry = self.raiden.chain.token_network_registry(registry_address)
-            # LEFTODO: Supply a proper block id
             return registry.add_token(
                 token_address=token_address,
                 given_block_identifier='latest',
@@ -376,7 +375,6 @@ class RaidenAPI:
                 ))
 
             try:
-                # LEFTODO: Supply a proper block id
                 token_network.new_netting_channel(
                     partner=partner_address,
                     settle_timeout=settle_timeout,
@@ -500,7 +498,6 @@ class RaidenAPI:
 
         # set_total_deposit calls approve
         # token.approve(netcontract_address, addendum, 'latest')
-        # LEFTODO: Supply a proper block id
         channel_proxy.set_total_deposit(total_deposit, block_identifier='latest')
 
         target_address = self.raiden.address

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -3,18 +3,27 @@ from raiden.transfer.state import (
     NettingChannelState,
     TransactionExecutionStatus,
 )
+from raiden.utils.typing import (
+    BlockHash,
+    BlockNumber,
+    BlockTimeout,
+    PaymentNetworkID,
+    TokenAddress,
+    TokenNetworkAddress,
+    TokenNetworkID,
+)
 
 
 def get_channel_state(
-        token_address,
-        payment_network_identifier,
-        token_network_address,
-        reveal_timeout,
+        token_address: TokenAddress,
+        payment_network_identifier: PaymentNetworkID,
+        token_network_address: TokenNetworkAddress,
+        reveal_timeout: BlockTimeout,
         payment_channel_proxy,
-        opened_block_number,
+        opened_block_number: BlockNumber,
+        opened_block_hash: BlockHash,
 ):
-    # LEFTODO: Supply a proper block id
-    channel_details = payment_channel_proxy.detail('latest')
+    channel_details = payment_channel_proxy.detail(opened_block_hash)
 
     our_state = NettingChannelEndState(
         channel_details.participants_data.our_details.address,
@@ -57,7 +66,7 @@ def get_channel_state(
         chain_id=channel_details.chain_id,
         token_address=token_address,
         payment_network_identifier=payment_network_identifier,
-        token_network_identifier=token_network_address,
+        token_network_identifier=TokenNetworkID(token_network_address),
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
         our_state=our_state,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -87,12 +87,13 @@ def handle_channel_new(raiden: 'RaidenService', event: Event):
         )
         token_address = channel_proxy.token_address()
         channel_state = get_channel_state(
-            token_address,
-            raiden.default_registry.address,
-            token_network_identifier,
-            raiden.config['reveal_timeout'],
-            channel_proxy,
-            block_number,
+            token_address=token_address,
+            payment_network_identifier=raiden.default_registry.address,
+            token_network_address=token_network_identifier,
+            reveal_timeout=raiden.config['reveal_timeout'],
+            payment_channel_proxy=channel_proxy,
+            opened_block_number=block_number,
+            opened_block_hash=block_hash,
         )
 
         new_channel = ContractReceiveChannelNew(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -256,7 +256,6 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
     channel_identifier = data['args']['channel_identifier']
     block_number = data['block_number']
     block_hash = bytes(data['blockHash'])
-
     transaction_hash = data['transaction_hash']
 
     channel_state = views.get_channelstate_by_token_network_identifier(
@@ -305,7 +304,6 @@ def handle_secret_revealed(raiden: 'RaidenService', event: Event):
     args = data['args']
     block_number = data['block_number']
     block_hash = bytes(data['blockHash'])
-
     transaction_hash = data['transaction_hash']
     registeredsecret_state_change = ContractReceiveSecretReveal(
         transaction_hash=transaction_hash,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -87,7 +87,7 @@ def handle_channel_new(raiden: 'RaidenService', event: Event):
         )
         token_address = channel_proxy.token_address()
         channel_state = get_channel_state(
-            token_address=token_address,
+            token_address=typing.TokenAddress(token_address),
             payment_network_identifier=raiden.default_registry.address,
             token_network_address=token_network_identifier,
             reveal_timeout=raiden.config['reveal_timeout'],

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -147,7 +147,6 @@ class MessageHandler:
     @staticmethod
     def handle_message_lockedtransfer(raiden: RaidenService, message: LockedTransfer):
         secret_hash = message.lock.secrethash
-        # LEFTODO: Supply a proper block id
         registered = raiden.default_secret_registry.check_registered(
             secrethash=secret_hash,
             block_identifier='latest',

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -786,7 +786,6 @@ class RaidenService(Runnable):
         if secret_hash is None:
             secret_hash = sha3(secret)
 
-        # LEFTODO: Supply a proper block id
         secret_registered = self.default_secret_registry.check_registered(
             secrethash=secret_hash,
             block_identifier='latest',

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -18,6 +18,7 @@ from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.network.blockchain_service import BlockChainService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils.events import must_have_event, search_for_item, wait_for_state_change
+from raiden.tests.utils.factories import make_block_hash
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldOffChainSecretRequest
 from raiden.tests.utils.transfer import assert_synced_channel_state, get_channelstate
@@ -550,6 +551,7 @@ def test_secret_revealed_on_chain(
         token_address=channel_state2_1.token_address,
         token_network_identifier=token_network_identifier,
         balance_proof=channel_state2_1.partner_state.balance_proof,
+        triggered_by_block_hash=make_block_hash(),
     )
     app2.raiden.raiden_event_handler.on_raiden_event(app2.raiden, channel_close_event)
 

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -1,7 +1,7 @@
 from raiden.constants import EMPTY_HASH
 from raiden.network.proxies.token_network import ParticipantDetails, ParticipantsDetails
 from raiden.raiden_event_handler import RaidenEventHandler
-from raiden.tests.utils.factories import make_32bytes, make_address
+from raiden.tests.utils.factories import make_32bytes, make_address, make_block_hash
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.utils import hash_balance_data
@@ -61,6 +61,7 @@ def test_handle_contract_send_channelunlock_already_unlocked():
         token_network_identifier=token_network_identifier,
         channel_identifier=channel_identifier,
         participant=participant,
+        triggered_by_block_hash=make_block_hash(),
     )
     # This should not throw an unrecoverable error
     RaidenEventHandler().on_raiden_event(raiden=raiden, event=event)

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -666,19 +666,21 @@ def test_events_for_onchain_secretreveal():
 
     # If we are not in the unsafe region, we must NOT emit ContractSendSecretReveal
     events = mediator.events_for_onchain_secretreveal_if_dangerzone(
-        setup.channel_map,
-        UNIT_SECRETHASH,
-        setup.transfers_pair,
-        block_number - 1,
+        channelmap=setup.channel_map,
+        secrethash=UNIT_SECRETHASH,
+        transfers_pair=setup.transfers_pair,
+        block_number=block_number - 1,
+        block_hash=factories.make_block_hash(),
     )
     assert not events
 
     # If we are in the unsafe region, we must emit ContractSendSecretReveal
     events = mediator.events_for_onchain_secretreveal_if_dangerzone(
-        setup.channel_map,
-        UNIT_SECRETHASH,
-        setup.transfers_pair,
-        block_number,
+        channelmap=setup.channel_map,
+        secrethash=UNIT_SECRETHASH,
+        transfers_pair=setup.transfers_pair,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     assert search_for_item(events, ContractSendSecretReveal, {
@@ -700,10 +702,11 @@ def test_events_for_onchain_secretreveal_once():
     )
 
     events = mediator.events_for_onchain_secretreveal_if_dangerzone(
-        setup.channel_map,
-        UNIT_SECRETHASH,
-        setup.transfers_pair,
-        start_danger_zone_block_number,
+        channelmap=setup.channel_map,
+        secrethash=UNIT_SECRETHASH,
+        transfers_pair=setup.transfers_pair,
+        block_number=start_danger_zone_block_number,
+        block_hash=factories.make_block_hash(),
     )
     assert len(events) == 1
 
@@ -715,10 +718,11 @@ def test_events_for_onchain_secretreveal_once():
     )
 
     events = mediator.events_for_onchain_secretreveal_if_dangerzone(
-        setup.channel_map,
-        UNIT_SECRETHASH,
-        setup.transfers_pair,
-        end_danger_zone_block_number,
+        channelmap=setup.channel_map,
+        secrethash=UNIT_SECRETHASH,
+        transfers_pair=setup.transfers_pair,
+        block_number=end_danger_zone_block_number,
+        block_hash=factories.make_block_hash(),
     )
     assert not events
 
@@ -726,10 +730,11 @@ def test_events_for_onchain_secretreveal_once():
         assert pair.payer_state == 'payer_waiting_secret_reveal'
 
     events = mediator.events_for_onchain_secretreveal_if_dangerzone(
-        setup.channel_map,
-        UNIT_SECRETHASH,
-        setup.transfers_pair,
-        pair.payer_transfer.lock.expiration,
+        channelmap=setup.channel_map,
+        secrethash=UNIT_SECRETHASH,
+        transfers_pair=setup.transfers_pair,
+        block_number=pair.payer_transfer.lock.expiration,
+        block_hash=factories.make_block_hash(),
     )
     assert not events
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -139,16 +139,31 @@ def test_events_for_onchain_secretreveal():
     unsafe_to_wait = expiration - channels[0].reveal_timeout
 
     state = TargetTransferState(channels.get_route(0), from_transfer)
-    events = target.events_for_onchain_secretreveal(state, channels[0], safe_to_wait)
+    events = target.events_for_onchain_secretreveal(
+        target_state=state,
+        channel_state=channels[0],
+        block_number=safe_to_wait,
+        block_hash=factories.make_block_hash(),
+    )
     assert not events
 
-    events = target.events_for_onchain_secretreveal(state, channels[0], unsafe_to_wait)
+    events = target.events_for_onchain_secretreveal(
+        target_state=state,
+        channel_state=channels[0],
+        block_number=unsafe_to_wait,
+        block_hash=factories.make_block_hash(),
+    )
 
     msg = 'when its not safe to wait, the contract send must be emitted'
     assert search_for_item(events, ContractSendSecretReveal, {'secret': UNIT_SECRET}), msg
 
     msg = 'second call must not emit ContractSendSecretReveal again'
-    assert not target.events_for_onchain_secretreveal(state, channels[0], unsafe_to_wait), msg
+    assert not target.events_for_onchain_secretreveal(
+        target_state=state,
+        channel_state=channels[0],
+        block_number=unsafe_to_wait,
+        block_hash=factories.make_block_hash(),
+    ), msg
 
 
 def test_handle_inittarget():
@@ -358,6 +373,7 @@ def test_handle_onchain_secretreveal():
         target_state=onchain_secret_reveal_iteration.new_state,
         channel_state=setup.channel,
         block_number=block_number_prior_the_expiration + 1,
+        block_hash=factories.make_block_hash(),
     )
     assert len(extra_block_handle_transition.events) == 0
 

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -16,6 +16,7 @@ def test_is_transaction_effect_satisfied(
         token_network_identifier=token_network_id,
         channel_identifier=netting_channel_state.identifier,
         participant=HOP2,
+        triggered_by_block_hash=make_block_hash(),
     )
     state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=UNIT_SECRETHASH,

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -175,7 +175,20 @@ class BalanceProofStateChange(AuthenticatedSenderStateChange):
 
 class ContractSendEvent(Event):
     """ Marker used for events which represent on-chain transactions. """
-    pass
+    def __init__(self, triggered_by_block_hash: BlockHash):
+        if not isinstance(triggered_by_block_hash, T_BlockHash):
+            raise ValueError('triggered_by_block_hash must be of type block_hash')
+        # This is the blockhash for which the event was triggered
+        self.triggered_by_block_hash = triggered_by_block_hash
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, ContractSendEvent) and
+            self.triggered_by_block_hash == other.triggered_by_block_hash
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class ContractSendExpirableEvent(ContractSendEvent):
@@ -183,11 +196,13 @@ class ContractSendExpirableEvent(ContractSendEvent):
     time dependent.
     """
 
-    def __init__(self, expiration: BlockExpiration):
+    def __init__(self, triggered_by_block_hash: BlockHash, expiration: BlockExpiration):
+        super().__init__(triggered_by_block_hash)
         self.expiration = expiration
 
     def __eq__(self, other):
         return (
+            super().__eq__(other) and
             isinstance(other, ContractSendExpirableEvent) and
             self.expiration == other.expiration
         )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -14,7 +14,7 @@ from raiden.utils.typing import (
     Address,
     Any,
     BlockExpiration,
-    Blockhash,
+    BlockHash,
     ChannelID,
     Dict,
     InitiatorAddress,
@@ -48,7 +48,7 @@ class ContractSendChannelClose(ContractSendEvent):
             token_address: TokenAddress,
             token_network_identifier: TokenNetworkID,
             balance_proof: Optional[BalanceProofSignedState],
-            triggered_by_block_hash: Blockhash,
+            triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash)
         self.channel_identifier = channel_identifier
@@ -99,7 +99,7 @@ class ContractSendChannelClose(ContractSendEvent):
             token_address=to_canonical_address(data['token_address']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             balance_proof=data['balance_proof'],
-            triggered_by_block_hash=Blockhash(deserialize_bytes(data['triggered_by_block_hash'])),
+            triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )
 
         return restored
@@ -112,7 +112,7 @@ class ContractSendChannelSettle(ContractSendEvent):
             self,
             channel_identifier: ChannelID,
             token_network_identifier: TokenNetworkAddress,
-            triggered_by_block_hash: Blockhash,
+            triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash)
         if not isinstance(channel_identifier, T_ChannelID):
@@ -159,7 +159,7 @@ class ContractSendChannelSettle(ContractSendEvent):
         restored = cls(
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            triggered_by_block_hash=Blockhash(deserialize_bytes(data['triggered_by_block_hash'])),
+            triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )
 
         return restored
@@ -174,7 +174,7 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
             channel_identifier: ChannelID,
             token_network_identifier: TokenNetworkID,
             balance_proof: BalanceProofSignedState,
-            triggered_by_block_hash: Blockhash,
+            triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash, expiration)
 
@@ -223,7 +223,7 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             balance_proof=data['balance_proof'],
-            triggered_by_block_hash=Blockhash(deserialize_bytes(data['triggered_by_block_hash'])),
+            triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )
 
         return restored
@@ -238,7 +238,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             token_network_identifier: TokenNetworkID,
             channel_identifier: ChannelID,
             participant: Address,
-            triggered_by_block_hash: Blockhash,
+            triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash)
         self.token_address = token_address
@@ -290,7 +290,7 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_identifier=ChannelID(int(data['channel_identifier'])),
             participant=to_canonical_address(data['participant']),
-            triggered_by_block_hash=Blockhash(deserialize_bytes(data['triggered_by_block_hash'])),
+            triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )
 
         return restored
@@ -303,7 +303,7 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
             self,
             expiration: BlockExpiration,
             secret: Secret,
-            triggered_by_block_hash: Blockhash,
+            triggered_by_block_hash: BlockHash,
     ):
         if not isinstance(secret, T_Secret):
             raise ValueError('secret must be a Secret instance')
@@ -341,7 +341,7 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
         restored = cls(
             expiration=BlockExpiration(int(data['expiration'])),
             secret=Secret(serialization.deserialize_bytes(data['secret'])),
-            triggered_by_block_hash=Blockhash(deserialize_bytes(data['triggered_by_block_hash'])),
+            triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )
 
         return restored

--- a/raiden/transfer/secret_registry.py
+++ b/raiden/transfer/secret_registry.py
@@ -6,13 +6,14 @@ from raiden.transfer.state import (
     CHANNEL_STATES_PRIOR_TO_CLOSED,
     NettingChannelState,
 )
-from raiden.utils.typing import BlockExpiration, List, Secret, T_Secret
+from raiden.utils.typing import BlockExpiration, BlockHash, List, Secret, T_Secret
 
 
 def events_for_onchain_secretreveal(
         channel_state: NettingChannelState,
         secret: Secret,
         expiration: BlockExpiration,
+        block_hash: BlockHash,
 ) -> List[Event]:
     events: List[Event] = list()
 
@@ -23,6 +24,7 @@ def events_for_onchain_secretreveal(
         reveal_event = ContractSendSecretReveal(
             expiration=expiration,
             secret=secret,
+            triggered_by_block_hash=block_hash,
         )
         events.append(reveal_event)
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -231,7 +231,6 @@ class ConsoleTools:
         token_address = decode_hex(token_address_hex)
 
         registry = self._raiden.chain.token_network_registry(registry_address)
-        # LEFTODO: Supply a proper block id
         token_network_address = registry.add_token(
             token_address=token_address,
             given_block_identifier='latest',


### PR DESCRIPTION
~~Don't merge before https://github.com/raiden-network/raiden/pull/3485.~~ done
This PR depends on it.

----

### What this PR does

This PR adds the `blockhash` to all ContractSendXXX events and utilizes it later in the event handling to forward it to the proxies to achieve consistent blockchain view of what generated the event and what the proxy checks right before sending a transaction.

### Discovered problems while writting this

In two places marked with comments in the code, there is no way to get the current blockhash from inside the state machine. For all other places I get it from the `ContractReceiveXXX` state changes.

But for `ContractSendChannelClose` and for `ContractSendSecretReveal` only
in the case a mediator receives an offchain secret reveal we don't
have any way of getting the block hash. We have the block number, but
we can't make an I/O RPC call to get the blockhash from the block
number since we are in the state machine.

For these cases as a hack I temporarily give a blockhash of `bytes(0)` and end up using 'latest' as the block identifier in the proxy. The real solution would be to also add the blockhash to the chain state itself. I will probably do this in a follow up PR so that the diffs don't become too big.

### What this PR does not

This PR just like #3485 skips DB upgrages. So after this PR DB upgrades for:

- Adding blockhash to all contract receive state changes (to make up for #3485 changes)
- Adding blockhash to all conttact send events (to make up for the changes in this PR)

need to be written
