### PR TITLE
Geth: Moved logging to a separate folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
     environment:
       RAIDEN_TESTS_SYNAPSE_BASE_DIR: /home/circleci/.cache/synapse
       RAIDEN_TESTS_SYNAPSE_LOGS_DIR: /tmp/synapse-logs
-      RAIDEN_TESTS_GETH_DATADIR: /tmp/geth
+      RAIDEN_TESTS_GETH_LOGSDIR: /tmp/geth/logs
       COVERAGE_DIR: /home/circleci/raiden/coverage
 
     parallelism: << parameters.parallelism >>

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -16,7 +16,7 @@ from raiden_contracts.contract_manager import ContractManager, contracts_precomp
 
 # pylint: disable=redefined-outer-name,too-many-arguments,unused-argument,too-many-locals
 
-_GETH_DATADIR = os.environ.get('RAIDEN_TESTS_GETH_DATADIR', False)
+_GETH_LOGDIR = os.environ.get('RAIDEN_TESTS_GETH_LOGSDIR', False)
 
 
 @pytest.fixture
@@ -74,17 +74,19 @@ def web3(
             for key in keys_to_fund
         ]
 
-        if _GETH_DATADIR:
-            base_datadir = _GETH_DATADIR
-            os.makedirs(base_datadir, exist_ok=True)
+        base_datadir = str(tmpdir)
+
+        if _GETH_LOGDIR:
+            base_logdir = os.path.join(_GETH_LOGDIR, request.node.name)
         else:
-            base_datadir = str(tmpdir)
+            base_logdir = os.path.join(base_datadir, 'logs')
 
         geth_processes = geth_run_private_blockchain(
             web3=web3,
             accounts_to_fund=accounts_to_fund,
             geth_nodes=geth_nodes,
             base_datadir=base_datadir,
+            log_dir=base_logdir,
             chain_id=chain_id,
             verbosity=request.config.option.verbose,
             random_marker=random_marker,


### PR DESCRIPTION
Currently a single test session will run multiple tests, each test
starts a new set of geth nodes /sharing/ the log paths, because geth
overwrites logs on subsequent runs this results in loss of logs.

This commit adds an explicit logpath to the fixtures, allowing all logs
to be collected in a single folder, which can be used to publish these
logs as artificats from the CI.

Because each new geth cluster uses a different set of private keys, the
address of each node will be different, meaning that log file names
won't collide.