### PR TITLE
Monitoring requests on recovery

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -920,8 +920,10 @@ def update_monitoring_service_from_balance_proof(
         raiden: RaidenService,
         new_balance_proof: BalanceProofSignedState,
 ):
+    if raiden.config['services']['monitoring_enabled'] is False:
+        return None
     log.info(
-        'Received new balance proof, creating message for Monitoring Service',
+        'Received new balance proof, creating message for Monitoring Service.',
         balance_proof=new_balance_proof,
     )
     reward_amount = 0  # FIXME: default reward is 0, should come from elsewhere

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -518,7 +518,7 @@ class RaidenService(Runnable):
 
         current_state = views.state_from_raiden(self)
         for balance_proof in views.detect_balance_proof_change(old_state, current_state):
-            raiden_event_list.append(EventNewBalanceProofReceived(balance_proof))
+            raiden_event_list.insert(0, EventNewBalanceProofReceived(balance_proof))
 
         log.debug(
             'Raiden events',

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -17,15 +17,15 @@ from raiden.messages import Processed, SecretRequest
 from raiden.network.transport.matrix import MatrixTransport, UserPresence, _RetryQueue
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import make_room_alias
-from raiden.raiden_event_handler import SEND_BALANCE_PROOF_EVENTS, RaidenMonitoringEventHandler
 from raiden.tests.utils.client import burn_eth
+from raiden.raiden_event_handler import SEND_BALANCE_PROOF_EVENTS
+from raiden.raiden_service import update_monitoring_service_from_balance_proof
 from raiden.tests.utils.factories import HOP1, HOP1_KEY, UNIT_SECRETHASH, make_address
 from raiden.tests.utils.messages import make_balance_proof, make_lock
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.events import (
     CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
-    EventNewBalanceProofReceived,
     SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
@@ -659,12 +659,10 @@ def test_monitoring_global_messages(
 
     raiden_service.transport = transport
     transport.log = MagicMock()
-    new_balance_proof_event = EventNewBalanceProofReceived(
-        make_balance_proof(signer=LocalSigner(HOP1_KEY), amount=1),
-    )
-    RaidenMonitoringEventHandler().on_raiden_event(
+    balance_proof = make_balance_proof(signer=LocalSigner(HOP1_KEY), amount=1)
+    update_monitoring_service_from_balance_proof(
         raiden_service,
-        new_balance_proof_event,
+        balance_proof,
     )
     gevent.idle()
 

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -630,8 +630,8 @@ def test_monitoring_global_messages(
         retries_before_backoff,
 ):
     """
-    Test that RaidenMonitoringEventHandler sends RequestMonitoring messages to global
-    MONITORING_BROADCASTING_ROOM room on EventNewBalanceProofReceived.
+    Test that RaidenService sends RequestMonitoring messages to global
+    MONITORING_BROADCASTING_ROOM room on newly received balance proofs.
     """
     transport = MatrixTransport({
         'global_rooms': ['discovery', MONITORING_BROADCASTING_ROOM],
@@ -645,6 +645,7 @@ def test_monitoring_global_messages(
     transport._client.api.retry_timeout = 0
     transport._send_raw = MagicMock()
     raiden_service = MockRaidenService(None)
+    raiden_service.config = dict(services=dict(monitoring_enabled=True))
 
     transport.start(
         raiden_service,

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -17,9 +17,9 @@ from raiden.messages import Processed, SecretRequest
 from raiden.network.transport.matrix import MatrixTransport, UserPresence, _RetryQueue
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import make_room_alias
-from raiden.tests.utils.client import burn_eth
 from raiden.raiden_event_handler import SEND_BALANCE_PROOF_EVENTS
 from raiden.raiden_service import update_monitoring_service_from_balance_proof
+from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.factories import HOP1, HOP1_KEY, UNIT_SECRETHASH, make_address
 from raiden.tests.utils.messages import make_balance_proof, make_lock
 from raiden.tests.utils.mocks import MockRaidenService

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -613,6 +613,7 @@ def test_matrix_send_global(
             MONITORING_BROADCASTING_ROOM,
             message,
         )
+    transport._spawn(transport._global_send_worker)
 
     gevent.idle()
 

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -3,7 +3,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.transfer.architecture import Event, SendMessageEvent
 from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
-from raiden.transfer.state import BalanceProofSignedState, BalanceProofUnsignedState
+from raiden.transfer.state import BalanceProofUnsignedState
 from raiden.utils import pex, serialization, sha3
 from raiden.utils.typing import (
     Address,
@@ -560,25 +560,6 @@ class EventUnlockFailed(Event):
         )
 
         return restored
-
-
-class EventNewBalanceProofReceived(Event):
-    """ Event for newly received balance proofs. Useful for notifying monitoring services. """
-
-    def __init__(self, balance_proof: BalanceProofSignedState):
-        self.balance_proof = balance_proof
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            'balance_proof': self.balance_proof.to_dict(),
-        }
-
-    @classmethod
-    def from_dict(
-            cls,
-            data: Dict[str, any],
-    ):
-        return cls(data['balance_proof'])
 
 
 class EventUnlockClaimSuccess(Event):

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -25,7 +25,7 @@ from raiden.network.pathfinding import get_pfs_info
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
 from raiden.network.transport import MatrixTransport, UDPTransport
-from raiden.raiden_event_handler import RaidenEventHandler, RaidenMonitoringEventHandler
+from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import (
     DEFAULT_MATRIX_KNOWN_SERVERS,
     DEFAULT_NAT_KEEPALIVE_RETRIES,
@@ -424,9 +424,6 @@ def run_app(
         raise RuntimeError(f'Unknown transport type "{transport}" given')
 
     raiden_event_handler = RaidenEventHandler()
-    if config['services']['monitoring_enabled'] is True:
-        log.info('Monitoring support is enabled. Setting up BP broadcasting.')
-        raiden_event_handler = RaidenMonitoringEventHandler()
 
     message_handler = MessageHandler()
 


### PR DESCRIPTION
This implements #3454 : after recovery, a state diff against an empty state is generated. This will yield all latest received balance proofs of the recovered state. Those are then sent to the broadcast room (if configured).

This PR also changes the way that monitoring requests are generated in general: instead of relying on a specialized event & event handler, `RaidenService` will now directly send the monitoring requests (if configured).

