### PR TITLE
Consistent blockchain view Iteration 5 -- add  blockhash to chainstate

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -217,7 +217,7 @@ class RaidenAPI:
             registry = self.raiden.chain.token_network_registry(registry_address)
             return registry.add_token(
                 token_address=token_address,
-                given_block_identifier='latest',
+                given_block_identifier=views.state_from_raiden(self.raiden).block_hash,
             )
         except RaidenRecoverableError as e:
             if 'Token already registered' in str(e):
@@ -380,7 +380,7 @@ class RaidenAPI:
                 token_network.new_netting_channel(
                     partner=partner_address,
                     settle_timeout=settle_timeout,
-                    given_block_identifier='latest',
+                    given_block_identifier=views.state_from_raiden(self.raiden).block_hash,
                 )
             except DuplicatedChannelError:
                 log.info('partner opened channel first')
@@ -500,7 +500,10 @@ class RaidenAPI:
 
         # set_total_deposit calls approve
         # token.approve(netcontract_address, addendum, 'latest')
-        channel_proxy.set_total_deposit(total_deposit, block_identifier='latest')
+        channel_proxy.set_total_deposit(
+            total_deposit=total_deposit,
+            block_identifier=views.state_from_raiden(self.raiden).block_hash,
+        )
 
         target_address = self.raiden.address
         waiting.wait_for_participant_newbalance(

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -161,6 +161,7 @@ def decode_event_to_internal(abi, log_event):
     # translate from web3's to raiden's name convention
     data['block_number'] = log_event.pop('blockNumber')
     data['transaction_hash'] = log_event.pop('transactionHash')
+    data['block_hash'] = bytes(log_event.pop('blockHash'))
 
     assert data['block_number'], 'The event must have the block_number'
     assert data['transaction_hash'], 'The event must have the transaction hash field'

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -41,7 +41,7 @@ def handle_tokennetwork_new(raiden: 'RaidenService', event: Event):
     block_number = data['block_number']
     token_network_address = args['token_network_address']
     token_address = typing.TokenAddress(args['token_address'])
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
 
     token_network_proxy = raiden.chain.token_network(token_network_address)
     raiden.blockchain_events.add_token_network_listener(
@@ -70,7 +70,7 @@ def handle_tokennetwork_new(raiden: 'RaidenService', event: Event):
 def handle_channel_new(raiden: 'RaidenService', event: Event):
     data = event.event_data
     block_number = data['block_number']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
     args = data['args']
     token_network_identifier = event.originating_contract
     transaction_hash = event.event_data['transaction_hash']
@@ -134,7 +134,7 @@ def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
     channel_identifier = args['channel_identifier']
     token_network_identifier = event.originating_contract
     participant_address = args['participant']
@@ -192,7 +192,7 @@ def handle_channel_closed(raiden: 'RaidenService', event: Event):
     args = data['args']
     channel_identifier = args['channel_identifier']
     transaction_hash = data['transaction_hash']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
 
     channel_state = views.get_channelstate_by_token_network_identifier(
         views.state_from_raiden(raiden),
@@ -231,7 +231,7 @@ def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
     channel_identifier = args['channel_identifier']
     transaction_hash = data['transaction_hash']
     block_number = data['block_number']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
 
     channel_state = views.get_channelstate_by_token_network_identifier(
         views.state_from_raiden(raiden),
@@ -256,7 +256,7 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
     token_network_identifier = event.originating_contract
     channel_identifier = data['args']['channel_identifier']
     block_number = data['block_number']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
     transaction_hash = data['transaction_hash']
 
     channel_state = views.get_channelstate_by_token_network_identifier(
@@ -281,7 +281,7 @@ def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
     transaction_hash = data['transaction_hash']
 
     unlock_state_change = ContractReceiveChannelBatchUnlock(
@@ -304,7 +304,7 @@ def handle_secret_revealed(raiden: 'RaidenService', event: Event):
     data = event.event_data
     args = data['args']
     block_number = data['block_number']
-    block_hash = bytes(data['blockHash'])
+    block_hash = data['block_hash']
     transaction_hash = data['transaction_hash']
     registeredsecret_state_change = ContractReceiveSecretReveal(
         transaction_hash=transaction_hash,

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -149,7 +149,7 @@ class MessageHandler:
         secret_hash = message.lock.secrethash
         registered = raiden.default_secret_registry.check_registered(
             secrethash=secret_hash,
-            block_identifier='latest',
+            block_identifier=views.state_from_raiden(raiden).block_hash,
         )
         if registered:
             log.warning(

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -13,6 +13,8 @@ from raiden.network.proxies import (
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.utils.typing import (
     Address,
+    BlockHash,
+    BlockNumber,
     ChannelID,
     PaymentNetworkID,
     T_ChannelID,
@@ -54,8 +56,11 @@ class BlockChainService:
     def node_address(self) -> Address:
         return self.client.address
 
-    def block_number(self) -> int:
+    def block_number(self) -> BlockNumber:
         return self.client.block_number()
+
+    def block_hash(self) -> BlockHash:
+        return self.client.blockhash_from_blocknumber(self.block_number())
 
     def get_block(self, block_identifier):
         return self.client.web3.eth.getBlock(block_identifier=block_identifier)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -283,14 +283,12 @@ class RaidenEventHandler:
             channel_id=channel_close_event.channel_identifier,
         )
 
-        # LEFTODO: Here we should normally get ContractSendChannelClose.triggered_by_block_hash
-        # but it's not populated properly yet.
         channel_proxy.close(
             nonce=nonce,
             balance_hash=balance_hash,
             additional_hash=message_hash,
             signature=signature,
-            block_identifier='latest',
+            block_identifier=channel_close_event.triggered_by_block_hash,
         )
 
     @staticmethod

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -254,15 +254,9 @@ class RaidenEventHandler:
             raiden: RaidenService,
             channel_reveal_secret_event: ContractSendSecretReveal,
     ):
-        # LEFTODO: Here we should normally get ContractSendChannelClose.triggered_by_block_hash
-        # but it may not be properly populated yet
-        if channel_reveal_secret_event.triggered_by_block_hash == bytes(0):
-            given_block_identifier = 'latest'
-        else:
-            given_block_identifier = channel_reveal_secret_event.triggered_by_block_hash
         raiden.default_secret_registry.register_secret(
             secret=channel_reveal_secret_event.secret,
-            given_block_identifier=given_block_identifier,
+            given_block_identifier=channel_reveal_secret_event.triggered_by_block_hash,
         )
 
     @staticmethod

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -319,10 +319,11 @@ class RaidenService(Runnable):
             )
 
             state_change = ActionInitChain(
-                random.Random(),
-                last_log_block_number,
-                self.chain.node_address,
-                self.chain.network_id,
+                pseudo_random_generator=random.Random(),
+                block_number=last_log_block_number,
+                block_hash=last_log_block_hash,
+                our_address=self.chain.node_address,
+                chain_id=self.chain.network_id,
             )
             self.handle_and_track_state_change(state_change)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -832,7 +832,7 @@ class RaidenService(Runnable):
 
         secret_registered = self.default_secret_registry.check_registered(
             secrethash=secret_hash,
-            block_identifier='latest',
+            block_identifier=views.state_from_raiden(self).block_hash,
         )
         if secret_registered:
             raise RaidenUnrecoverableError(

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -18,7 +18,6 @@ from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.network.blockchain_service import BlockChainService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils.events import must_have_event, search_for_item, wait_for_state_change
-from raiden.tests.utils.factories import make_block_hash
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldOffChainSecretRequest
 from raiden.tests.utils.transfer import assert_synced_channel_state, get_channelstate
@@ -551,7 +550,7 @@ def test_secret_revealed_on_chain(
         token_address=channel_state2_1.token_address,
         token_network_identifier=token_network_identifier,
         balance_proof=channel_state2_1.partner_state.balance_proof,
-        triggered_by_block_hash=make_block_hash(),
+        triggered_by_block_hash=app0.raiden.chain.block_hash(),
     )
     app2.raiden.raiden_event_handler.on_raiden_event(app2.raiden, channel_close_event)
 

--- a/raiden/tests/unit/fixtures.py
+++ b/raiden/tests/unit/fixtures.py
@@ -34,10 +34,11 @@ def chain_state(our_address):
     block_number = 1
 
     return ChainState(
-        random.Random(),
-        block_number,
-        our_address,
-        UNIT_CHAIN_ID,
+        pseudo_random_generator=random.Random(),
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
+        our_address=our_address,
+        chain_id=UNIT_CHAIN_ID,
     )
 
 

--- a/raiden/tests/unit/migrations/test_v16_to_v17.py
+++ b/raiden/tests/unit/migrations/test_v16_to_v17.py
@@ -20,6 +20,7 @@ def setup_storage(db_path):
         ActionInitChain(
             pseudo_random_generator=random.Random(),
             block_number=1,
+            block_hash=factories.make_block_hash(),
             our_address=factories.make_address(),
             chain_id=1,
         ),

--- a/raiden/tests/unit/migrations/test_v16_to_v17.py
+++ b/raiden/tests/unit/migrations/test_v16_to_v17.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import SerializedSQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage, SQLiteStorage
 from raiden.tests.utils import factories
 from raiden.transfer.state_change import ActionInitChain
 from raiden.utils.upgrades import UpgradeManager
@@ -52,6 +52,6 @@ def test_upgrade_v16_to_v17(tmp_path):
     manager = UpgradeManager(db_filename=str(db_path))
     manager.run()
 
-    storage = SerializedSQLiteStorage(str(db_path), JSONSerializer())
+    storage = SQLiteStorage(str(db_path))
     snapshot = storage.get_latest_state_snapshot()
     assert snapshot is not None

--- a/raiden/tests/unit/migrations/test_v17_to_v18.py
+++ b/raiden/tests/unit/migrations/test_v17_to_v18.py
@@ -20,6 +20,7 @@ def setup_storage(db_path):
         ActionInitChain(
             pseudo_random_generator=random.Random(),
             block_number=1,
+            block_hash=factories.make_block_hash(),
             our_address=factories.make_address(),
             chain_id=1,
         ),

--- a/raiden/tests/unit/migrations/test_v17_to_v18.py
+++ b/raiden/tests/unit/migrations/test_v17_to_v18.py
@@ -1,10 +1,11 @@
+import json
 import random
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
 from raiden.storage.serialize import JSONSerializer
-from raiden.storage.sqlite import SerializedSQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage, SQLiteStorage
 from raiden.tests.utils import factories
 from raiden.transfer.state_change import ActionInitChain
 from raiden.utils.upgrades import UpgradeManager
@@ -52,10 +53,11 @@ def test_upgrade_v17_to_v18(tmp_path):
     manager = UpgradeManager(db_filename=str(db_path))
     manager.run()
 
-    storage = SerializedSQLiteStorage(str(db_path), JSONSerializer())
+    storage = SQLiteStorage(str(db_path))
     _, snapshot = storage.get_latest_state_snapshot()
 
-    secrethash = list(snapshot.payment_mapping.secrethashes_to_task.keys())[0]
-    mediator_task = snapshot.payment_mapping.secrethashes_to_task[secrethash]
-    assert mediator_task.mediator_state.waiting_transfer is not None
-    assert mediator_task.mediator_state.routes
+    snapshot_data = json.loads(snapshot)
+    secrethash = list(snapshot_data['payment_mapping']['secrethashes_to_task'].keys())[0]
+    mediator_task = snapshot_data['payment_mapping']['secrethashes_to_task'][secrethash]
+    assert mediator_task['mediator_state']['waiting_transfer'] is not None
+    assert mediator_task['mediator_state']['routes']

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -207,10 +207,11 @@ def test_channelstate_update_contract_balance():
 
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
-        deepcopy(channel_state),
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        channel_state=deepcopy(channel_state),
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
     new_state = iteration.new_state
 
@@ -256,10 +257,11 @@ def test_channelstate_decreasing_contract_balance():
 
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
-        deepcopy(channel_state),
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        channel_state=deepcopy(channel_state),
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
     new_state = iteration.new_state
 
@@ -306,10 +308,11 @@ def test_channelstate_repeated_contract_balance():
 
     for _ in range(10):
         iteration = channel.state_transition(
-            deepcopy(channel_state),
-            state_change,
-            pseudo_random_generator,
-            block_number,
+            channel_state=deepcopy(channel_state),
+            state_change=state_change,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+            block_hash=factories.make_block_hash(),
         )
         new_state = iteration.new_state
 
@@ -353,24 +356,27 @@ def test_deposit_must_wait_for_confirmation():
     )
     pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
-        deepcopy(channel_state),
-        new_balance,
-        pseudo_random_generator,
-        block_number,
+        channel_state=deepcopy(channel_state),
+        state_change=new_balance,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
     unconfirmed_state = iteration.new_state
 
     for block_number in range(block_number, confirmed_deposit_block_number):
+        block_hash = factories.make_transaction_hash()
         unconfirmed_block = Block(
             block_number=block_number,
             gas_limit=1,
-            block_hash=factories.make_transaction_hash(),
+            block_hash=block_hash,
         )
         iteration = channel.state_transition(
-            deepcopy(unconfirmed_state),
-            unconfirmed_block,
-            pseudo_random_generator,
-            block_number,
+            channel_state=deepcopy(unconfirmed_state),
+            state_change=unconfirmed_block,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+            block_hash=block_hash,
         )
         unconfirmed_state = iteration.new_state
 
@@ -385,16 +391,18 @@ def test_deposit_must_wait_for_confirmation():
             partner_model1,
         )
 
+    confirmed_block_hash = factories.make_transaction_hash()
     confirmed_block = Block(
         block_number=confirmed_deposit_block_number,
         gas_limit=1,
-        block_hash=factories.make_transaction_hash(),
+        block_hash=confirmed_block_hash,
     )
     iteration = channel.state_transition(
-        deepcopy(unconfirmed_state),
-        confirmed_block,
-        pseudo_random_generator,
-        confirmed_deposit_block_number,
+        channel_state=deepcopy(unconfirmed_state),
+        state_change=confirmed_block,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=confirmed_deposit_block_number,
+        block_hash=confirmed_block_hash,
     )
     confirmed_state = iteration.new_state
 
@@ -1591,10 +1599,11 @@ def test_action_close_must_change_the_channel_state():
         channel_state.identifier,
     )
     iteration = channel.state_transition(
-        channel_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        channel_state=channel_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
     assert channel.get_status(iteration.new_state) == CHANNEL_STATE_CLOSING
 
@@ -1640,10 +1649,11 @@ def test_update_must_be_called_if_close_lost_race():
         channel_state.identifier,
     )
     iteration = channel.state_transition(
-        channel_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        channel_state=channel_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     state_change = ContractReceiveChannelClosed(
@@ -1673,10 +1683,11 @@ def test_update_transfer():
         channel_state.identifier,
     )
     iteration = channel.state_transition(
-        channel_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        channel_state=channel_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     # update_transaction in channel state should not be set

--- a/raiden/tests/unit/test_node_queue.py
+++ b/raiden/tests/unit/test_node_queue.py
@@ -18,10 +18,11 @@ def test_delivered_message_must_clean_unordered_messages(chain_id):
     secret = factories.random_secret()
 
     chain_state = state.ChainState(
-        pseudo_random_generator,
-        block_number,
-        our_address,
-        chain_id,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
+        our_address=our_address,
+        chain_id=chain_id,
     )
     queue_identifier = QueueIdentifier(
         recipient,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -79,6 +79,7 @@ def create_square_network_topology(
         state_change=channel_new_state_change1,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration2 = token_network.state_transition(
@@ -87,6 +88,7 @@ def create_square_network_topology(
         state_change=channel_new_state_change2,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     graph_state = channel_new_iteration2.new_state.network_graph
@@ -110,6 +112,7 @@ def create_square_network_topology(
         state_change=channel_new_state_change3,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     graph_state = channel_new_iteration3.new_state.network_graph
@@ -131,6 +134,7 @@ def create_square_network_topology(
         state_change=channel_new_state_change4,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     graph_state = channel_new_iteration4.new_state.network_graph

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -157,10 +157,11 @@ def test_actioninitchain_restore():
     chain_id = 777
 
     original_obj = state_change.ActionInitChain(
-        pseudo_random_generator,
-        block_number,
-        our_address,
-        chain_id,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
+        our_address=our_address,
+        chain_id=chain_id,
     )
 
     decoded_obj = JSONSerializer.deserialize(
@@ -179,6 +180,7 @@ def test_chainstate_restore():
     original_obj = state.ChainState(
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
         our_address=our_address,
         chain_id=chain_id,
     )

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -26,6 +26,7 @@ from raiden.utils import sha3
 
 def test_contract_receive_channelnew_must_be_idempotent():
     block_number = 10
+    block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
 
     token_network_id = factories.make_address()
@@ -43,15 +44,16 @@ def test_contract_receive_channelnew_must_be_idempotent():
         token_network_identifier=token_network_id,
         channel_state=channel_state1,
         block_number=block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=block_hash,
     )
 
     token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        state_change1,
-        pseudo_random_generator,
-        block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=state_change1,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
     state_change2 = ContractReceiveChannelNew(
@@ -64,11 +66,12 @@ def test_contract_receive_channelnew_must_be_idempotent():
 
     # replay the ContractReceiveChannelNew state change
     iteration = token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        state_change2,
-        pseudo_random_generator,
-        block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=state_change2,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
     msg = 'the channel must not have been overwritten'
@@ -82,6 +85,7 @@ def test_contract_receive_channelnew_must_be_idempotent():
 
 def test_channel_settle_must_properly_cleanup():
     open_block_number = 10
+    open_block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
 
     token_network_id = factories.make_address()
@@ -98,15 +102,16 @@ def test_channel_settle_must_properly_cleanup():
         token_network_identifier=token_network_id,
         channel_state=channel_state,
         block_number=open_block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration = token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        channel_new_state_change,
-        pseudo_random_generator,
-        open_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=channel_new_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     closed_block_number = open_block_number + 10
@@ -121,11 +126,12 @@ def test_channel_settle_must_properly_cleanup():
     )
 
     channel_closed_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_new_iteration.new_state,
-        channel_close_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_new_iteration.new_state,
+        state_change=channel_close_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
@@ -138,11 +144,12 @@ def test_channel_settle_must_properly_cleanup():
     )
 
     channel_settled_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_closed_iteration.new_state,
-        channel_settled_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_closed_iteration.new_state,
+        state_change=channel_settled_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     token_network_state_after_settle = channel_settled_iteration.new_state
@@ -156,6 +163,7 @@ def test_channel_data_removed_after_unlock(
         our_address,
 ):
     open_block_number = 10
+    open_block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
     pkey, address = factories.make_privkey_address()
 
@@ -175,15 +183,16 @@ def test_channel_data_removed_after_unlock(
         token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration = token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        channel_new_state_change,
-        pseudo_random_generator,
-        open_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=channel_new_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     lock_amount = 30
@@ -224,11 +233,12 @@ def test_channel_data_removed_after_unlock(
     )
 
     channel_closed_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_new_iteration.new_state,
-        channel_close_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_new_iteration.new_state,
+        state_change=channel_close_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
@@ -241,11 +251,12 @@ def test_channel_data_removed_after_unlock(
     )
 
     channel_settled_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_closed_iteration.new_state,
-        channel_settled_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_closed_iteration.new_state,
+        state_change=channel_settled_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     token_network_state_after_settle = channel_settled_iteration.new_state
@@ -266,11 +277,12 @@ def test_channel_data_removed_after_unlock(
         block_hash=factories.make_block_hash(),
     )
     channel_unlock_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_settled_iteration.new_state,
-        channel_batch_unlock_state_change,
-        pseudo_random_generator,
-        unlock_blocknumber,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_settled_iteration.new_state,
+        state_change=channel_batch_unlock_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=unlock_blocknumber,
+        block_hash=factories.make_block_hash(),
     )
 
     token_network_state_after_unlock = channel_unlock_iteration.new_state
@@ -288,6 +300,7 @@ def test_mediator_clear_pairs_after_batch_unlock(
     he is a participant is received.
     """
     open_block_number = 10
+    open_block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
     pkey, address = factories.make_privkey_address()
 
@@ -307,15 +320,16 @@ def test_mediator_clear_pairs_after_batch_unlock(
         token_network_identifier=token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration = token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        channel_new_state_change,
-        pseudo_random_generator,
-        open_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=channel_new_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     lock_amount = 30
@@ -357,11 +371,12 @@ def test_mediator_clear_pairs_after_batch_unlock(
     )
 
     channel_closed_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_new_iteration.new_state,
-        channel_close_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_new_iteration.new_state,
+        state_change=channel_close_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
@@ -374,11 +389,12 @@ def test_mediator_clear_pairs_after_batch_unlock(
     )
 
     channel_settled_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_closed_iteration.new_state,
-        channel_settled_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_closed_iteration.new_state,
+        state_change=channel_settled_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     token_network_state_after_settle = channel_settled_iteration.new_state
@@ -434,6 +450,7 @@ def test_multiple_channel_states(
         our_address,
 ):
     open_block_number = 10
+    open_block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
     pkey, address = factories.make_privkey_address()
 
@@ -453,15 +470,16 @@ def test_multiple_channel_states(
         token_network_identifier=token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=open_block_hash,
     )
 
     channel_new_iteration = token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        channel_new_state_change,
-        pseudo_random_generator,
-        open_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=channel_new_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     lock_amount = 30
@@ -502,11 +520,12 @@ def test_multiple_channel_states(
     )
 
     channel_closed_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_new_iteration.new_state,
-        channel_close_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_new_iteration.new_state,
+        state_change=channel_close_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
@@ -519,11 +538,12 @@ def test_multiple_channel_states(
     )
 
     channel_settled_iteration = token_network.state_transition(
-        payment_network_identifier,
-        channel_closed_iteration.new_state,
-        channel_settled_state_change,
-        pseudo_random_generator,
-        closed_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=channel_closed_iteration.new_state,
+        state_change=channel_settled_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     token_network_state_after_settle = channel_settled_iteration.new_state
@@ -546,11 +566,12 @@ def test_multiple_channel_states(
     )
 
     channel_new_iteration = token_network.state_transition(
-        payment_network_identifier,
-        token_network_state,
-        channel_new_state_change,
-        pseudo_random_generator,
-        open_block_number,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network_state,
+        state_change=channel_new_state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     token_network_state_after_new_open = channel_new_iteration.new_state
@@ -596,6 +617,7 @@ def test_routing_updates(
         state_change=channel_new_state_change,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_hash,
     )
 
     graph_state = channel_new_iteration1.new_state.network_graph
@@ -622,6 +644,7 @@ def test_routing_updates(
         state_change=channel_new_state_change,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     graph_state = channel_new_iteration2.new_state.network_graph
@@ -650,6 +673,7 @@ def test_routing_updates(
         state_change=channel_close_state_change1,
         pseudo_random_generator=pseudo_random_generator,
         block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     # Check that a second ContractReceiveChannelClosed events is handled properly
@@ -670,6 +694,7 @@ def test_routing_updates(
         state_change=channel_close_state_change2,
         pseudo_random_generator=pseudo_random_generator,
         block_number=closed_block_number,
+        block_hash=closed_block_hash,
     )
 
     graph_state = channel_closed_iteration2.new_state.network_graph
@@ -694,17 +719,19 @@ def test_routing_updates(
         state_change=channel_close_state_change3,
         pseudo_random_generator=pseudo_random_generator,
         block_number=closed_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     # Check that a second ContractReceiveRouteClosed events is handled properly.
     # This might have been sent from the second participant of the channel
     # See issue #2449
+    closed_block_plus_10_hash = factories.make_block_hash()
     channel_close_state_change4 = ContractReceiveRouteClosed(
         transaction_hash=factories.make_transaction_hash(),
         token_network_identifier=token_network_state.address,
         channel_identifier=new_channel_identifier,
         block_number=closed_block_number + 10,
-        block_hash=factories.make_block_hash(),
+        block_hash=closed_block_plus_10_hash,
     )
 
     channel_closed_iteration4 = token_network.state_transition(
@@ -713,6 +740,7 @@ def test_routing_updates(
         state_change=channel_close_state_change4,
         pseudo_random_generator=pseudo_random_generator,
         block_number=closed_block_number + 10,
+        block_hash=closed_block_plus_10_hash,
     )
 
     graph_state = channel_closed_iteration4.new_state.network_graph
@@ -780,6 +808,7 @@ def test_routing_issue2663(
         state_change=channel_new_state_change1,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration2 = token_network.state_transition(
@@ -788,6 +817,7 @@ def test_routing_issue2663(
         state_change=channel_new_state_change2,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     graph_state = channel_new_iteration2.new_state.network_graph
@@ -811,6 +841,7 @@ def test_routing_issue2663(
         state_change=channel_new_state_change3,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     graph_state = channel_new_iteration3.new_state.network_graph
@@ -832,6 +863,7 @@ def test_routing_issue2663(
         state_change=channel_new_state_change4,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     graph_state = channel_new_iteration4.new_state.network_graph
@@ -1024,6 +1056,7 @@ def test_routing_priority(
         state_change=channel_new_state_change1,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     channel_new_iteration2 = token_network.state_transition(
@@ -1032,6 +1065,7 @@ def test_routing_priority(
         state_change=channel_new_state_change2,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number,
+        block_hash=open_block_number_hash,
     )
 
     # create new channels without being participant
@@ -1051,6 +1085,7 @@ def test_routing_priority(
         state_change=channel_new_state_change3,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_state_change4 = ContractReceiveRouteNew(
@@ -1069,6 +1104,7 @@ def test_routing_priority(
         state_change=channel_new_state_change4,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_state_change5 = ContractReceiveRouteNew(
@@ -1087,6 +1123,7 @@ def test_routing_priority(
         state_change=channel_new_state_change5,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     channel_new_state_change6 = ContractReceiveRouteNew(
@@ -1105,6 +1142,7 @@ def test_routing_priority(
         state_change=channel_new_state_change6,
         pseudo_random_generator=pseudo_random_generator,
         block_number=open_block_number + 10,
+        block_hash=factories.make_block_hash(),
     )
 
     # test routing priority with all nodes available

--- a/raiden/tests/unit/test_upgrade.py
+++ b/raiden/tests/unit/test_upgrade.py
@@ -17,6 +17,7 @@ def setup_storage(db_path):
         ActionInitChain(
             pseudo_random_generator=random.Random(),
             block_number=1,
+            block_hash=factories.make_block_hash(),
             our_address=factories.make_address(),
             chain_id=1,
         ),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1076,6 +1076,7 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
         state_change=channel_closed,
         pseudo_random_generator=setup.prng,
         block_number=block_number,
+        block_hash=block_hash,
     )
     channel_state = channel_close_transition.new_state
 
@@ -1201,6 +1202,7 @@ def test_initiator_handle_contract_receive_after_channel_closed():
     during the settlement window.
     """
     block_number = 10
+    block_hash = factories.make_block_hash()
     setup = setup_initiator_tests(amount=UNIT_TRANSFER_AMOUNT * 2, block_number=block_number)
 
     initiator_task = get_transfer_at_index(setup.current_state, 0)
@@ -1213,7 +1215,7 @@ def test_initiator_handle_contract_receive_after_channel_closed():
         token_network_identifier=setup.channel.token_network_identifier,
         channel_identifier=setup.channel.identifier,
         block_number=block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=block_hash,
     )
 
     channel_close_transition = channel.state_transition(
@@ -1221,6 +1223,7 @@ def test_initiator_handle_contract_receive_after_channel_closed():
         state_change=channel_closed,
         pseudo_random_generator=setup.prng,
         block_number=block_number,
+        block_hash=block_hash,
     )
     channel_state = channel_close_transition.new_state
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -757,6 +757,7 @@ def test_secret_learned():
         nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
 
     iteration = mediator.secret_learned(
@@ -764,6 +765,7 @@ def test_secret_learned():
         channelidentifiers_to_channels=channels.channel_map,
         pseudo_random_generator=pseudo_random_generator,
         block_number=1,
+        block_hash=factories.make_block_hash(),
         secret=UNIT_SECRET,
         secrethash=UNIT_SECRETHASH,
         payee_address=channels[1].partner_state.address,
@@ -813,6 +815,7 @@ def test_secret_learned_with_refund():
         nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
 
     assert not transition_result.events
@@ -875,6 +878,7 @@ def test_init_mediator():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
 
     assert isinstance(iteration.new_state, MediatorTransferState)
@@ -908,6 +912,7 @@ def test_mediator_reject_keccak_empty_hash():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
 
     assert not iteration.new_state
@@ -930,6 +935,7 @@ def test_mediator_secret_reveal_empty_hash():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
     assert isinstance(iteration.new_state, MediatorTransferState)
     assert iteration.new_state.transfers_pair[0].payer_transfer == from_transfer
@@ -944,6 +950,7 @@ def test_mediator_secret_reveal_empty_hash():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=2,
+        block_hash=factories.make_block_hash(),
     )
     assert len(iteration.events) == 0
 
@@ -964,6 +971,7 @@ def test_mediator_secret_reveal_empty_hash():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=2,
+        block_hash=factories.make_block_hash(),
     )
     assert secrethash not in channels[0].partner_state.secrethashes_to_onchain_unlockedlocks
 
@@ -998,6 +1006,7 @@ def test_no_valid_routes():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
     msg = (
         'The task must be kept alive, '
@@ -1065,6 +1074,7 @@ def test_lock_timeout_larger_than_settlement_period_must_be_ignored():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
 
     msg = (
@@ -1155,6 +1165,7 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
         nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     attack_block_number = from_transfer.lock.expiration - attacked_channel.reveal_timeout
@@ -1181,6 +1192,7 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
             nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
             pseudo_random_generator=pseudo_random_generator,
             block_number=new_block_number,
+            block_hash=factories.make_block_hash(),
         )
 
         assert not any(
@@ -1201,6 +1213,7 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
         nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=attack_block_number,
+        block_hash=factories.make_block_hash(),
     )
     assert not any(
         isinstance(event, ContractSendChannelClose)
@@ -1209,10 +1222,11 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
 
     # don't go on-chain since the balance proof was not received
     for new_block_number in range(block_number, from_transfer.lock.expiration + 1):
+        new_block_hash = factories.make_block_hash()
         block = Block(
             block_number=new_block_number,
             gas_limit=1,
-            block_hash=factories.make_transaction_hash(),
+            block_hash=new_block_hash,
         )
         new_iteration = mediator.state_transition(
             mediator_state=new_iteration.new_state,
@@ -1221,6 +1235,7 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
             nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
             pseudo_random_generator=pseudo_random_generator,
             block_number=new_block_number,
+            block_hash=new_block_hash,
         )
         assert not any(
             event
@@ -1390,6 +1405,7 @@ def test_mediate_transfer_with_maximum_pending_transfers_exceeded():
             nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
             pseudo_random_generator=pseudo_random_generator,
             block_number=1,
+            block_hash=factories.make_block_hash(),
         ))
 
     # last iteration should have failed due to exceeded pending transfer limit
@@ -1441,10 +1457,11 @@ def test_mediator_lock_expired_with_new_block():
     transfer = send_transfer.transfer
 
     block_expiration_number = channel.get_sender_expiration_threshold(transfer.lock)
+    block_expiration_hash = factories.make_block_hash()
     block = Block(
         block_number=block_expiration_number,
         gas_limit=1,
-        block_hash=factories.make_transaction_hash(),
+        block_hash=block_expiration_hash,
     )
     iteration = mediator.state_transition(
         mediator_state=mediator_state,
@@ -1453,6 +1470,7 @@ def test_mediator_lock_expired_with_new_block():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_expiration_number,
+        block_hash=block_expiration_hash,
     )
 
     assert iteration.events
@@ -1514,10 +1532,11 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
     channel_state = channel_close_transition.new_state
 
     block_expiration_number = channel.get_sender_expiration_threshold(transfer.lock)
+    block_expiration_hash = factories.make_transaction_hash()
     block = Block(
         block_number=block_expiration_number,
         gas_limit=1,
-        block_hash=factories.make_transaction_hash(),
+        block_hash=block_expiration_hash,
     )
     iteration = mediator.state_transition(
         mediator_state=mediator_state,
@@ -1526,6 +1545,7 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_expiration_number,
+        block_hash=block_expiration_hash,
     )
 
     assert iteration.events
@@ -1550,6 +1570,7 @@ def test_mediator_lock_expired_with_receive_lock_expired():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
 
     assert search_for_item(iteration.events, SendLockedTransfer, {
@@ -1594,6 +1615,7 @@ def test_mediator_lock_expired_with_receive_lock_expired():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_before_confirmed_expiration,
+        block_hash=factories.make_block_hash(),
     )
     assert not search_for_item(iteration.events, SendProcessed, {})
 
@@ -1605,6 +1627,7 @@ def test_mediator_lock_expired_with_receive_lock_expired():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_lock_expired,
+        block_hash=factories.make_block_hash(),
     )
     assert search_for_item(iteration.events, SendProcessed, {})
 
@@ -1643,6 +1666,7 @@ def test_mediator_receive_lock_expired_after_secret_reveal():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
 
     secrethash = transfer.lock.secrethash
@@ -1661,6 +1685,7 @@ def test_mediator_receive_lock_expired_after_secret_reveal():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_lock_expired,
+        block_hash=factories.make_block_hash(),
     )
 
     # Make sure the lock was moved
@@ -1691,6 +1716,7 @@ def test_mediator_receive_lock_expired_after_secret_reveal():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_lock_expired + 1,
+        block_hash=factories.make_block_hash(),
     )
 
     # LockExpired should remove the lock from both lockedlocks and unlockedlocks
@@ -1728,6 +1754,7 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
 
     secrethash = transfer.lock.secrethash
@@ -1746,6 +1773,7 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_lock_expired,
+        block_hash=factories.make_block_hash(),
     )
 
     # Mediator should NOT send balance proof
@@ -1773,6 +1801,7 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_expiration_number,
+        block_hash=factories.make_block_hash(),
     )
 
     assert secrethash not in channels[0].our_state.secrethashes_to_unlockedlocks
@@ -1884,6 +1913,7 @@ def test_node_change_network_state_reachable_node():
         nodeaddresses_to_networkstates=setup.channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
         block_number=1,
+        block_hash=factories.make_block_hash(),
     )
 
     # A LockedTransfer is expected

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1485,6 +1485,7 @@ def test_mediator_lock_expired_with_new_block():
 
 def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
     block_number = 5
+    block_hash = factories.make_block_hash()
     pseudo_random_generator = random.Random()
 
     channels = mediator_make_channel_pair()
@@ -1521,13 +1522,14 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
         token_network_identifier=channel_state.token_network_identifier,
         channel_identifier=channel_state.identifier,
         block_number=block_number,
-        block_hash=factories.make_block_hash(),
+        block_hash=block_hash,
     )
     channel_close_transition = channel.state_transition(
         channel_state=channel_state,
         state_change=channel_closed,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
+        block_hash=block_hash,
     )
     channel_state = channel_close_transition.new_state
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -65,6 +65,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
 
     send_transfer = search_for_item(initial_iteration.events, SendLockedTransfer, {})
@@ -101,6 +102,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
+        block_hash=factories.make_block_hash(),
     )
     paid_state = paid_iteration.new_state
     assert paid_state.transfers_pair[0].payee_state == 'payee_balance_proof'
@@ -242,6 +244,7 @@ def test_regression_mediator_send_lock_expired_with_new_block():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
     assert init_iteration.new_state is not None
     send_transfer = search_for_item(init_iteration.events, SendLockedTransfer, {})
@@ -262,6 +265,7 @@ def test_regression_mediator_send_lock_expired_with_new_block():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_expiration_number,
+        block_hash=factories.make_block_hash(),
     )
 
     msg = (
@@ -322,6 +326,7 @@ def test_regression_mediator_task_no_routes():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
 
     msg = 'The task must not be cleared, even if there is no route to forward the transfer'
@@ -353,17 +358,19 @@ def test_regression_mediator_task_no_routes():
     # Regression: The mediator must still be able to process the block which
     # expires the lock
     expired_block_number = channel.get_sender_expiration_threshold(lock)
+    block_hash = factories.make_block_hash()
     expire_block_iteration = mediator.state_transition(
         mediator_state=init_iteration.new_state,
         state_change=Block(
             block_number=expired_block_number,
             gas_limit=0,
-            block_hash=None,
+            block_hash=block_hash,
         ),
         channelidentifiers_to_channels=channels.channel_map,
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=expired_block_number,
+        block_hash=block_hash,
     )
     assert expire_block_iteration.new_state is not None
 
@@ -378,6 +385,7 @@ def test_regression_mediator_task_no_routes():
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=expired_block_number,
+        block_hash=block_hash,
     )
 
     msg = 'The only used channel had the lock cleared, the task must be cleared'
@@ -410,6 +418,7 @@ def test_regression_mediator_not_update_payer_state_twice():
         nodeaddresses_to_networkstates=pair.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=5,
+        block_hash=factories.make_block_hash(),
     )
     assert iteration.new_state is not None
 
@@ -432,6 +441,7 @@ def test_regression_mediator_not_update_payer_state_twice():
         nodeaddresses_to_networkstates=pair.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_expiration_number,
+        block_hash=factories.make_block_hash(),
     )
 
     msg = 'At the expiration block we should get an EventUnlockClaimFailed'
@@ -456,6 +466,7 @@ def test_regression_mediator_not_update_payer_state_twice():
         nodeaddresses_to_networkstates=pair.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=next_block.block_number,
+        block_hash=next_block.block_hash,
     )
     current_state = iteration.new_state
     lock = payer_transfer.lock
@@ -479,6 +490,7 @@ def test_regression_mediator_not_update_payer_state_twice():
         nodeaddresses_to_networkstates=pair.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_expiration_number,
+        block_hash=factories.make_block_hash(),
     )
     msg = 'At the next block we should not get the same event'
     assert not search_for_item(iteration.events, EventUnlockClaimFailed, {}), msg
@@ -511,6 +523,7 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
         nodeaddresses_to_networkstates=setup.channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=setup.block_number,
+        block_hash=setup.block_hash,
     )
     assert secrethash in payer_channel.partner_state.secrethashes_to_unlockedlocks
 
@@ -524,12 +537,13 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
             secrethash=secrethash,
             secret=secret,
             block_number=setup.block_number,
-            block_hash=factories.make_block_hash(),
+            block_hash=setup.block_hash,
         ),
         channelidentifiers_to_channels=setup.channel_map,
         nodeaddresses_to_networkstates=setup.channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=setup.block_number,
+        block_hash=setup.block_hash,
     )
     assert secrethash in payer_channel.partner_state.secrethashes_to_onchain_unlockedlocks
 
@@ -561,5 +575,6 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
         nodeaddresses_to_networkstates=setup.channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
         block_number=expired_block_number,
+        block_hash=factories.make_block_hash(),
     )
     assert secrethash in payer_channel.partner_state.secrethashes_to_onchain_unlockedlocks

--- a/raiden/tests/unit/transfer/test_state_diff.py
+++ b/raiden/tests/unit/transfer/test_state_diff.py
@@ -1,6 +1,7 @@
 import random
 from copy import deepcopy
 
+from raiden.tests.utils import factories
 from raiden.transfer.state import (
     ChainState,
     NettingChannelEndState,
@@ -14,8 +15,21 @@ from raiden.transfer.views import detect_balance_proof_change
 
 def test_detect_balance_proof_change():
     prng = random.Random()
-    old = ChainState(prng, 1, 2, 3)
-    new = ChainState(prng, 1, 2, 3)
+    block_hash = factories.make_block_hash()
+    old = ChainState(
+        pseudo_random_generator=prng,
+        block_number=1,
+        block_hash=block_hash,
+        our_address=2,
+        chain_id=3,
+    )
+    new = ChainState(
+        pseudo_random_generator=prng,
+        block_number=1,
+        block_hash=block_hash,
+        our_address=2,
+        chain_id=3,
+    )
 
     def diff():
         return list(detect_balance_proof_change(old, new))

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 
 from raiden.constants import EMPTY_MERKLE_ROOT, UINT64_MAX, UINT256_MAX
 from raiden.messages import Lock, LockedTransfer
+from raiden.tests.utils import factories
 from raiden.transfer import balance_proof, channel
 from raiden.transfer.mediated_transfer import mediator
 from raiden.transfer.mediated_transfer.state import (
@@ -1031,7 +1032,8 @@ class MediatorTransfersPair(NamedTuple):
     channels: ChannelSet
     transfers_pair: typing.List[MediationPairState]
     amount: int
-    block_number: int
+    block_number: typing.BlockNumber
+    block_hash: typing.BlockHash
 
     @property
     def channel_map(self) -> typing.ChannelMap:
@@ -1120,7 +1122,13 @@ def make_transfers_pair(
         )
         transfers_pairs.append(pair)
 
-    return MediatorTransfersPair(channels, transfers_pairs, amount, block_number)
+    return MediatorTransfersPair(
+        channels=channels,
+        transfers_pair=transfers_pairs,
+        amount=amount,
+        block_number=block_number,
+        block_hash=factories.make_block_hash(),
+    )
 
 
 def make_node_availability_map(nodes):

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -57,10 +57,11 @@ class MockRaidenService:
         self.wal = WriteAheadLog(state_manager, storage)
 
         state_change = ActionInitChain(
-            random.Random(),
-            0,
-            self.chain.node_address,
-            self.chain.network_id,
+            pseudo_random_generator=random.Random(),
+            block_number=0,
+            block_hash=factories.make_block_hash(),
+            our_address=self.chain.node_address,
+            chain_id=self.chain.network_id,
         )
 
         self.wal.log_and_dispatch(state_change)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -451,6 +451,7 @@ def handle_block(
 ) -> TransitionResult[ChainState]:
     block_number = state_change.block_number
     chain_state.block_number = block_number
+    chain_state.block_hash = state_change.block_hash
 
     # Subdispatch Block state change
     channels_result = subdispatch_to_all_channels(
@@ -472,10 +473,11 @@ def handle_chain_init(
 ) -> TransitionResult[ChainState]:
     if chain_state is None:
         chain_state = ChainState(
-            state_change.pseudo_random_generator,
-            state_change.block_number,
-            state_change.our_address,
-            state_change.chain_id,
+            pseudo_random_generator=state_change.pseudo_random_generator,
+            block_number=state_change.block_number,
+            block_hash=state_change.block_hash,
+            our_address=state_change.our_address,
+            chain_id=state_change.chain_id,
         )
     events: List[Event] = list()
     return TransitionResult(chain_state, events)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -148,6 +148,7 @@ def subdispatch_to_paymenttask(
         secrethash: SecretHash,
 ) -> TransitionResult[ChainState]:
     block_number = chain_state.block_number
+    block_hash = chain_state.block_hash
     sub_task = chain_state.payment_mapping.secrethashes_to_task.get(secrethash)
     events: List[Event] = list()
     sub_iteration = None
@@ -179,13 +180,15 @@ def subdispatch_to_paymenttask(
             )
 
             if token_network_state:
+                channelids_to_channels = token_network_state.channelidentifiers_to_channels
                 sub_iteration = mediator.state_transition(
-                    sub_task.mediator_state,
-                    state_change,
-                    token_network_state.channelidentifiers_to_channels,
-                    chain_state.nodeaddresses_to_networkstates,
-                    pseudo_random_generator,
-                    block_number,
+                    mediator_state=sub_task.mediator_state,
+                    state_change=state_change,
+                    channelidentifiers_to_channels=channelids_to_channels,
+                    nodeaddresses_to_networkstates=chain_state.nodeaddresses_to_networkstates,
+                    pseudo_random_generator=pseudo_random_generator,
+                    block_number=block_number,
+                    block_hash=block_hash,
                 )
                 events = sub_iteration.events
 
@@ -274,6 +277,7 @@ def subdispatch_mediatortask(
 ) -> TransitionResult[ChainState]:
 
     block_number = chain_state.block_number
+    block_hash = chain_state.block_hash
     sub_task = chain_state.payment_mapping.secrethashes_to_task.get(secrethash)
 
     if not sub_task:
@@ -297,12 +301,13 @@ def subdispatch_mediatortask(
 
         pseudo_random_generator = chain_state.pseudo_random_generator
         iteration = mediator.state_transition(
-            mediator_state,
-            state_change,
-            token_network_state.channelidentifiers_to_channels,
-            chain_state.nodeaddresses_to_networkstates,
-            pseudo_random_generator,
-            block_number,
+            mediator_state=mediator_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=token_network_state.channelidentifiers_to_channels,
+            nodeaddresses_to_networkstates=chain_state.nodeaddresses_to_networkstates,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+            block_hash=block_hash,
         )
         events = iteration.events
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -35,6 +35,7 @@ from raiden.utils.typing import (
     SecretHash,
     SecretRegistryAddress,
     T_Address,
+    T_BlockHash,
     T_BlockNumber,
     T_Secret,
     T_SecretHash,
@@ -369,23 +370,29 @@ class ActionInitChain(StateChange):
             self,
             pseudo_random_generator,
             block_number: BlockNumber,
+            block_hash: BlockHash,
             our_address: Address,
             chain_id: ChainID,
     ):
-        if not isinstance(block_number, int):
-            raise ValueError('block_number must be int')
+        if not isinstance(block_number, T_BlockNumber):
+            raise ValueError('block_number must be of type BlockNumber')
+
+        if not isinstance(block_hash, T_BlockHash):
+            raise ValueError('block_hash must be of type BlockHash')
 
         if not isinstance(chain_id, int):
             raise ValueError('chain_id must be int')
 
         self.block_number = block_number
+        self.block_hash = block_hash
         self.chain_id = chain_id
         self.our_address = our_address
         self.pseudo_random_generator = pseudo_random_generator
 
     def __repr__(self):
-        return '<ActionInitChain block_number:{} chain_id:{}>'.format(
+        return '<ActionInitChain block_number:{} block_hash:{} chain_id:{}>'.format(
             self.block_number,
+            pex(self.block_hash),
             self.chain_id,
         )
 
@@ -394,6 +401,7 @@ class ActionInitChain(StateChange):
             isinstance(other, ActionInitChain) and
             self.pseudo_random_generator.getstate() == other.pseudo_random_generator.getstate() and
             self.block_number == other.block_number and
+            self.block_hash == other.block_hash and
             self.our_address == other.our_address and
             self.chain_id == other.chain_id
         )
@@ -404,6 +412,7 @@ class ActionInitChain(StateChange):
     def to_dict(self) -> Dict[str, Any]:
         return {
             'block_number': str(self.block_number),
+            'block_hash': serialize_bytes(self.block_hash),
             'our_address': to_checksum_address(self.our_address),
             'chain_id': self.chain_id,
             'pseudo_random_generator': self.pseudo_random_generator.getstate(),
@@ -416,6 +425,7 @@ class ActionInitChain(StateChange):
         return cls(
             pseudo_random_generator=pseudo_random_generator,
             block_number=BlockNumber(int(data['block_number'])),
+            block_hash=deserialize_bytes(data['block_hash']),
             our_address=to_canonical_address(data['our_address']),
             chain_id=data['chain_id'],
         )

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -19,6 +19,7 @@ def subdispatch_to_channel_by_id(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     events = list()
 
@@ -28,10 +29,11 @@ def subdispatch_to_channel_by_id(
 
     if channel_state:
         result = channel.state_transition(
-            channel_state,
-            state_change,
-            pseudo_random_generator,
-            block_number,
+            channel_state=channel_state,
+            state_change=state_change,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+            block_hash=block_hash,
         )
 
         partner_to_channelids = token_network_state.partneraddresses_to_channelidentifiers[
@@ -55,12 +57,14 @@ def handle_channel_close(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     return subdispatch_to_channel_by_id(
-        token_network_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        token_network_state=token_network_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
 
@@ -97,12 +101,14 @@ def handle_balance(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     return subdispatch_to_channel_by_id(
-        token_network_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        token_network_state=token_network_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
 
@@ -111,6 +117,7 @@ def handle_closed(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     network_graph_state = token_network_state.network_graph
 
@@ -129,10 +136,11 @@ def handle_closed(
         ]
 
     return subdispatch_to_channel_by_id(
-        token_network_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        token_network_state=token_network_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
 
@@ -141,12 +149,14 @@ def handle_settled(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     return subdispatch_to_channel_by_id(
-        token_network_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        token_network_state=token_network_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
 
@@ -155,12 +165,14 @@ def handle_updated_transfer(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     return subdispatch_to_channel_by_id(
-        token_network_state,
-        state_change,
-        pseudo_random_generator,
-        block_number,
+        token_network_state=token_network_state,
+        state_change=state_change,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
+        block_hash=block_hash,
     )
 
 
@@ -169,6 +181,7 @@ def handle_batch_unlock(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     participant1 = state_change.participant
     participant2 = state_change.partner
@@ -191,10 +204,11 @@ def handle_batch_unlock(
 
         if is_valid_channel:
             sub_iteration = channel.state_transition(
-                channel_state,
-                state_change,
-                pseudo_random_generator,
-                block_number,
+                channel_state=channel_state,
+                state_change=state_change,
+                pseudo_random_generator=pseudo_random_generator,
+                block_number=block_number,
+                block_hash=block_hash,
             )
             events.extend(sub_iteration.events)
 
@@ -252,6 +266,7 @@ def handle_receive_transfer_refund(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     events = list()
 
@@ -260,10 +275,11 @@ def handle_receive_transfer_refund(
 
     if channel_state:
         result = channel.state_transition(
-            channel_state,
-            state_change,
-            pseudo_random_generator,
-            block_number,
+            channel_state=channel_state,
+            state_change=state_change,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
+            block_hash=block_hash,
         )
         events.extend(result.events)
 
@@ -276,6 +292,7 @@ def state_transition(
         state_change,
         pseudo_random_generator,
         block_number,
+        block_hash,
 ):
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 
@@ -286,6 +303,7 @@ def state_transition(
             state_change,
             pseudo_random_generator,
             block_number,
+            block_hash,
         )
     elif type(state_change) == ContractReceiveChannelNew:
         assert isinstance(state_change, ContractReceiveChannelNew), MYPY_ANNOTATION
@@ -300,6 +318,7 @@ def state_transition(
             state_change,
             pseudo_random_generator,
             block_number,
+            block_hash,
         )
     elif type(state_change) == ContractReceiveChannelClosed:
         assert isinstance(state_change, ContractReceiveChannelClosed), MYPY_ANNOTATION
@@ -308,6 +327,7 @@ def state_transition(
             state_change,
             pseudo_random_generator,
             block_number,
+            block_hash,
         )
     elif type(state_change) == ContractReceiveChannelSettled:
         assert isinstance(state_change, ContractReceiveChannelSettled), MYPY_ANNOTATION
@@ -316,6 +336,7 @@ def state_transition(
             state_change,
             pseudo_random_generator,
             block_number,
+            block_hash,
         )
     elif type(state_change) == ContractReceiveUpdateTransfer:
         assert isinstance(state_change, ContractReceiveUpdateTransfer), MYPY_ANNOTATION
@@ -324,6 +345,7 @@ def state_transition(
             state_change,
             pseudo_random_generator,
             block_number,
+            block_hash,
         )
     elif type(state_change) == ContractReceiveChannelBatchUnlock:
         assert isinstance(state_change, ContractReceiveChannelBatchUnlock), MYPY_ANNOTATION
@@ -332,6 +354,7 @@ def state_transition(
             state_change,
             pseudo_random_generator,
             block_number,
+            block_hash,
         )
     elif type(state_change) == ContractReceiveRouteNew:
         assert isinstance(state_change, ContractReceiveRouteNew), MYPY_ANNOTATION

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -12,6 +12,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.network.proxies import TokenNetwork
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
+from raiden.transfer import views
 from raiden.utils import typing
 from raiden.utils.smart_contracts import deploy_contract_web3
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
@@ -233,7 +234,7 @@ class ConsoleTools:
         registry = self._raiden.chain.token_network_registry(registry_address)
         token_network_address = registry.add_token(
             token_address=token_address,
-            given_block_identifier='latest',
+            given_block_identifier=views.state_from_raiden(self._raiden).block_hash,
         )
 
         # Register the channel manager with the raiden registry


### PR DESCRIPTION
~~Don't merge before https://github.com/raiden-network/raiden/pull/3505 and before #3485.~~
^ Done

This PR depends on them.

----

### What this PR does

This PR handles the "problem" that is described in the description on the first comment of https://github.com/raiden-network/raiden/pull/3505.

- It adds the `blockhash` to the `ChainState` and to the `ActionInitChain` state change
- Adjusts all tests (big diff)
- Fixes the tests for the DB upgrades by using the raw sqlite storage.

### What this PR does not

This PR just like #3485 and #3505 skips DB upgrages. So after this PR DB upgrades for:

- Adding blockhash to all contract receive state changes (to make up for #3485 changes)
- Adding blockhash to all contract send events (to make up for the changes in #3505 )
- Adding blockhash to `ChainState` (to make up for changes in this PR)
- Adding blockhash to `ActionInitChain` (to make up for changes in this PR)

need to be written
