### PR TITLE
Matrix dead lock fix

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -262,6 +262,7 @@ class GMatrixClient(MatrixClient):
         assert not self.should_listen and self.sync_thread is None, 'Already running'
         self.should_listen = True
         self.sync_thread = gevent.spawn(self.listen_forever, timeout_ms, exception_handler)
+        self.sync_thread.name = f'GMatrixClient.listen_forever user_id:{self.user_id}'
 
     def stop_listener_thread(self):
         """ Kills sync_thread greenlet before joining it """
@@ -397,7 +398,9 @@ class GMatrixClient(MatrixClient):
 
         is_first_sync = (prev_sync_token is None)
         self._handle_thread = gevent.Greenlet(self._handle_response, response, is_first_sync)
-        self._handle_thread.name = f'sync_handle_response-{prev_sync_token}'
+        self._handle_thread.name = (
+            f'GMatrixClient._sync user_id:{self.user_id} sync_token:{prev_sync_token}'
+        )
         self._handle_thread.link_exception(lambda g: self.sync_thread.kill(g.exception))
         self._handle_thread.start()
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -419,6 +419,7 @@ class RaidenService(Runnable):
 
     def _run(self, *args, **kwargs):  # pylint: disable=method-hidden
         """ Busy-wait on long-lived subtasks/greenlets, re-raise if any error occurs """
+        self.greenlet.name = f'RaidenService._run node:{pex(self.address)}'
         try:
             self.stop_event.wait()
         except gevent.GreenletExit:  # killed without exception
@@ -464,7 +465,7 @@ class RaidenService(Runnable):
         greenlet.link_exception(self.on_error)
 
     def __repr__(self):
-        return '<{} {}>'.format(self.__class__.__name__, pex(self.address))
+        return f'<{self.__class__.__name__} node:{pex(self.address)}>'
 
     def start_neighbours_healthcheck(self, chain_state: ChainState):
         for neighbour in views.all_neighbour_nodes(chain_state):

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -123,12 +123,16 @@ class AlarmTask(Runnable):
         # probability of a new block increases.
         self.sleep_time = 0.5
 
+    def __repr__(self):
+        return f'<{self.__class__.__name__} node:{pex(self.chain.client.address)}>'
+
     def start(self):
         log.debug('Alarm task started', node=pex(self.chain.node_address))
         self._stop_event = AsyncResult()
         super().start()
 
     def _run(self):  # pylint: disable=method-hidden
+        self.greenlet.name = f'AlarmTask._run node:{pex(self.chain.client.address)}'
         try:
             self.loop_until_stop()
         finally:

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -8,6 +8,7 @@ from raiden.tests.utils.network import (
     create_apps,
     create_network_channels,
     create_sequential_channels,
+    parallel_start_apps,
     wait_for_alarm_start,
     wait_for_channels,
     wait_for_token_networks,
@@ -73,8 +74,7 @@ def raiden_chain(
         private_rooms=private_rooms,
     )
 
-    start_tasks = [gevent.spawn(app.raiden.start) for app in raiden_apps]
-    gevent.joinall(start_tasks, raise_error=True)
+    parallel_start_apps(raiden_apps)
 
     from_block = GENESIS_BLOCK_NUMBER
     for app in raiden_apps:
@@ -170,8 +170,7 @@ def raiden_network(
         private_rooms=private_rooms,
     )
 
-    start_tasks = [gevent.spawn(app.raiden.start) for app in raiden_apps]
-    gevent.joinall(start_tasks, raise_error=True)
+    parallel_start_apps(raiden_apps)
 
     exception = RuntimeError('`raiden_chain` fixture setup failed, token networks unavailable')
     with gevent.Timeout(seconds=30, exception=exception):

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -14,7 +14,7 @@ from raiden.network.transport import MatrixTransport, UDPTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, DEFAULT_RETRY_TIMEOUT
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
-from raiden.utils import merge_dict
+from raiden.utils import merge_dict, pex
 from raiden.waiting import wait_for_payment_network
 
 CHAIN = object()  # Flag used by create a network does make a loop with the channels
@@ -386,6 +386,18 @@ def create_apps(
         apps.append(app)
 
     return apps
+
+
+def parallel_start_apps(raiden_apps):
+    """Start all the raiden apps in parallel."""
+    start_tasks = list()
+
+    for app in raiden_apps:
+        greenlet = gevent.spawn(app.raiden.start)
+        greenlet.name = f'Fixture:raiden_network node:{pex(app.raiden.address)}'
+        start_tasks.append(greenlet)
+
+    gevent.joinall(start_tasks, raise_error=True)
 
 
 def jsonrpc_services(


### PR DESCRIPTION
    bugfix: Matrix transport hang forever

    - `gevent.wait` will block forever if there is an **unstarted**
    `gevent.Greenlet` in the list.
    - `Matrix._get_retrier` always adds the `RetryQueue` item to its
    internal mapping
        - If the `Matrix._stop_event` is set, the retrier is not started.
    - During a call to `Matrix.stop` the first thing done is to set
    `_stop_event`, and then the transport waits on the existing greenlets
    and *retries*
    - Because there is additional logic after setting the event and waiting
    for the retriers which does context switch, a race existed which would
    add an unstarted retrier to the transport mapping and wait on it.