### PR TITLE
Split make_signed_transfer() factory in two and fix test

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -96,6 +96,7 @@ def test_locked_transfer_secret_registered_onchain(
             transfer_secret,
         )
 
+    # Test that receiving a transfer with a secret already registered on chain fails
     expiration = 9999
     transfer = make_signed_transfer(
         amount,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1464,7 +1464,7 @@ def test_refund_transfer_matches_received():
         UNIT_SECRET,
     )
 
-    refund_lower_expiration = factories.make_signed_transfer(
+    refund_lower_expiration = factories.make_signed_transfer_state(
         amount,
         UNIT_TRANSFER_INITIATOR,
         UNIT_TRANSFER_TARGET,
@@ -1474,7 +1474,7 @@ def test_refund_transfer_matches_received():
 
     assert channel.refund_transfer_matches_received(refund_lower_expiration, transfer) is False
 
-    refund_same_expiration = factories.make_signed_transfer(
+    refund_same_expiration = factories.make_signed_transfer_state(
         amount,
         UNIT_TRANSFER_INITIATOR,
         UNIT_TRANSFER_TARGET,
@@ -1496,7 +1496,7 @@ def test_refund_transfer_does_not_match_received():
         UNIT_SECRET,
     )
 
-    refund_from_target = factories.make_signed_transfer(
+    refund_from_target = factories.make_signed_transfer_state(
         amount,
         UNIT_TRANSFER_INITIATOR,
         UNIT_TRANSFER_TARGET,

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -78,7 +78,7 @@ def make_signed_transfer_from_counter(counter):
         secrethash=sha3(factories.make_secret(next(counter))),
     )
 
-    signed_transfer = factories.make_signed_transfer(
+    signed_transfer = factories.make_signed_transfer_state(
         amount=next(counter),
         initiator=factories.make_address(),
         target=factories.make_address(),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -531,7 +531,7 @@ def test_refund_transfer_next_route():
     initiator_state = get_transfer_at_index(current_state, 0)
     original_transfer = initiator_state.transfer
 
-    refund_transfer = factories.make_signed_transfer(
+    refund_transfer = factories.make_signed_transfer_state(
         amount,
         our_address,
         original_transfer.target,
@@ -583,7 +583,7 @@ def test_refund_transfer_no_more_routes():
 
     initiator_state = get_transfer_at_index(setup.current_state, 0)
     original_transfer = initiator_state.transfer
-    refund_transfer = factories.make_signed_transfer(
+    refund_transfer = factories.make_signed_transfer_state(
         amount,
         original_transfer.initiator,
         original_transfer.target,
@@ -1337,7 +1337,7 @@ def test_secret_reveal_cancel_other_transfers():
     initiator_state = get_transfer_at_index(current_state, 0)
     original_transfer = initiator_state.transfer
 
-    refund_transfer = factories.make_signed_transfer(
+    refund_transfer = factories.make_signed_transfer_state(
         amount,
         our_address,
         original_transfer.target,
@@ -1447,7 +1447,7 @@ def test_refund_after_secret_request():
     current_state = iteration.new_state
     assert current_state is not None
 
-    refund_transfer = factories.make_signed_transfer(
+    refund_transfer = factories.make_signed_transfer_state(
         amount,
         original_transfer.initiator,
         original_transfer.target,
@@ -1531,7 +1531,7 @@ def test_clearing_payment_state_on_lock_expires_with_refunded_transfers():
     initiator_state = get_transfer_at_index(current_state, 0)
     original_transfer = initiator_state.transfer
 
-    refund_transfer = factories.make_signed_transfer(
+    refund_transfer = factories.make_signed_transfer_state(
         amount,
         our_address,
         original_transfer.target,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1855,7 +1855,7 @@ def test_node_change_network_state_reachable_node():
     ]
 
     lock_expiration = UNIT_REVEAL_TIMEOUT * 2
-    received_transfer = factories.make_signed_transfer(
+    received_transfer = factories.make_signed_transfer_state(
         amount=1,
         initiator=UNIT_TRANSFER_SENDER,
         target=UNIT_TRANSFER_TARGET,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -147,7 +147,7 @@ def test_regression_send_refund():
     channel_identifier = last_pair.payee_transfer.balance_proof.channel_identifier
     lock_expiration = last_pair.payee_transfer.lock.expiration
 
-    received_transfer = factories.make_signed_transfer(
+    received_transfer = factories.make_signed_transfer_state(
         amount=UNIT_TRANSFER_AMOUNT,
         initiator=UNIT_TRANSFER_INITIATOR,
         target=UNIT_TRANSFER_TARGET,

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -307,7 +307,7 @@ def make_signed_transfer(
         token: typing.TargetAddress = EMPTY,
         pkey: bytes = EMPTY,
         sender: typing.Address = EMPTY,
-) -> LockedTransferSignedState:
+) -> LockedTransfer:
 
     amount = if_empty(amount, UNIT_TRANSFER_AMOUNT)
     initiator = if_empty(initiator, make_address())
@@ -358,7 +358,48 @@ def make_signed_transfer(
     )
     transfer.sign(signer)
     assert transfer.sender == sender
+    return transfer
 
+
+def make_signed_transfer_state(
+        amount: typing.TokenAmount = EMPTY,
+        initiator: typing.InitiatorAddress = EMPTY,
+        target: typing.TargetAddress = EMPTY,
+        expiration: typing.BlockExpiration = EMPTY,
+        secret: typing.Secret = EMPTY,
+        payment_identifier: typing.PaymentID = EMPTY,
+        message_identifier: typing.MessageID = EMPTY,
+        nonce: typing.Nonce = EMPTY,
+        transferred_amount: typing.TokenAmount = EMPTY,
+        locked_amount: typing.TokenAmount = EMPTY,
+        locksroot: typing.Locksroot = EMPTY,
+        recipient: typing.Address = EMPTY,
+        channel_identifier: typing.ChannelID = EMPTY,
+        token_network_address: typing.TokenNetworkID = EMPTY,
+        token: typing.TargetAddress = EMPTY,
+        pkey: bytes = EMPTY,
+        sender: typing.Address = EMPTY,
+) -> LockedTransferSignedState:
+
+    transfer = make_signed_transfer(
+        amount=amount,
+        initiator=initiator,
+        target=target,
+        expiration=expiration,
+        secret=secret,
+        payment_identifier=payment_identifier,
+        message_identifier=message_identifier,
+        nonce=nonce,
+        transferred_amount=transferred_amount,
+        locked_amount=locked_amount,
+        locksroot=locksroot,
+        recipient=recipient,
+        channel_identifier=channel_identifier,
+        token_network_address=token_network_address,
+        token=token,
+        pkey=pkey,
+        sender=sender,
+    )
     return lockedtransfersigned_from_message(transfer)
 
 
@@ -1033,7 +1074,7 @@ def make_transfers_pair(
         payee_index = payer_index + 1
 
         receiver_channel = channels[payer_index]
-        received_transfer = make_signed_transfer(
+        received_transfer = make_signed_transfer_state(
             amount=amount,
             initiator=UNIT_TRANSFER_INITIATOR,
             target=UNIT_TRANSFER_TARGET,


### PR DESCRIPTION
This was noticed while trying to fix tests for https://github.com/raiden-network/raiden/pull/3515 and I split it out into a different PR to make reviews easier.

`test_locked_transfer_secret_registered_onchain` was using
`make_signed_transfer()` as a factory of `LockedTransfer` while it's a
factory of `LockedTransferSignedState`.

The `test_locked_transfer_secret_registered_onchain`
test was not failing since the secret registration check got us
out of the function early enough to not hit any attribute errors.

This commit splits `make_signed_transfer()` into two different
factories and uses the correct one in test_locked_transfer_secret_registered_onchain