### PR TITLE
Fix smoketest stdout redirection

### DIFF
--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,9 +1,11 @@
+import contextlib
 import os
 import shutil
 import sys
 import tempfile
 import traceback
 from http import HTTPStatus
+from typing import IO
 
 import click
 import requests
@@ -90,6 +92,7 @@ def run_smoketests(
         transport: str,
         token_addresses,
         discovery_address,
+        orig_stdout: IO[str],
         debug: bool = False,
 ):
     """ Test that the assembled raiden_service correctly reflects the configuration from the
@@ -137,8 +140,9 @@ def run_smoketests(
     except:  # NOQA pylint: disable=bare-except
         error = traceback.format_exc()
         if debug:
-            import pdb
-            pdb.post_mortem()  # pylint: disable=no-member
+            with contextlib.redirect_stdout(orig_stdout):
+                import pdb
+                pdb.post_mortem()  # pylint: disable=no-member
         return error
 
     return None

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -516,6 +516,8 @@ def smoketest(ctx, debug):
         step_count = 8
     step = 0
 
+    stdout = sys.stdout
+
     def print_step(description, error=False):
         nonlocal step
         step += 1
@@ -524,6 +526,7 @@ def smoketest(ctx, debug):
                 click.style(f'[{step}/{step_count}]', fg='blue'),
                 click.style(description, fg='green' if not error else 'red'),
             ),
+            file=stdout,
         )
 
     print_step('Getting smoketest configuration')
@@ -591,6 +594,7 @@ def smoketest(ctx, debug):
                     token_addresses,
                     contract_addresses[CONTRACT_ENDPOINT_REGISTRY],
                     debug=debug,
+                    orig_stdout=stdout,
                 )
                 if error is not None:
                     append_report('Smoketest assertion error', error)


### PR DESCRIPTION
With the introduction of `contextlib.redirect_stdout`:
- step `[7/8]` was no longer printed to stdout. I added the `file`
target to `print_step`, so we always print steps to the original stdout
- the `--debug` pdb post-mortem hook was no longer displayed at stdout.
I pass the original stdout to the smoketest function, in order to
recover it on `pdb.post_mortem()`.