### PR TITLE
Update master with v0.100.2 commits

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.100.2-rc4
+current_version = 0.100.2
 commit = True
 tag = False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,7 +603,7 @@ jobs:
                 command: |
                   echo "TAG: ${CIRCLE_TAG}"
                   RAIDEN_VERSION=${CIRCLE_TAG}
-                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${RAIDEN_VERSION} build/archive/
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${RAIDEN_VERSION} dist/archive/
 
   deploy-pypi:
     parameters:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,10 @@ Changelog
 * :feature:`3318` allow secret and/or hash with payment request
 * :feature:`3425` Update raiden-contracts package to version 0.9.0
 
+* :release:`0.100.2 <2019-02-21>`
+* :bug:`3528` Do not crash raiden if a LockExpired message with invalid channel identifier is received.
+* :bug:`3529` Do not crash raiden if a SecretRequest message with invalid channel identifier is received.
+
 * :release:`0.100.2-rc4 <2019-02-04>`
 * :feature:`3317` Return the secretHash and the Secret as part of payment response
 * :bug:`3380` Connection manager no longer attempts deposit if per partner funds are zero.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ master_doc = 'index'
 project = 'Raiden Network'
 author = 'Raiden Project'
 
-version_string = '0.100.2-rc4'
+version_string = '0.100.2'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with open('constraints.txt') as req_file:
 test_requirements = []
 
 # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
-version = '0.100.2-rc4'
+version = '0.100.2'
 
 setup(
     name='raiden',


### PR DESCRIPTION
These are the commits from v0.100.2 that bumped the version, added the critical fixes to the changelog and fixed the build for github deployment in CircleCI. Also contains the fix for the issues which in master turns out to be a no-op commit since the diff is already in there.