### PR TITLE
Omit LATEST_XXX.txt from release artifacts when uploading to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,6 +601,7 @@ jobs:
             - run:
                 name: "Publish Release on GitHub"
                 command: |
+                  rm dist/archive/*.txt
                   echo "TAG: ${CIRCLE_TAG}"
                   RAIDEN_VERSION=${CIRCLE_TAG}
                   ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${RAIDEN_VERSION} dist/archive/


### PR DESCRIPTION
@ulope please take a look if this will do the trick. I am not sure if wildcard will work there, and the `ghr` tool's [docs](https://github.com/tcnksm/ghr) don't have an example with excluding files.