### PR TITLE
Simplified some channel.py functions

### DIFF
--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -205,11 +205,9 @@ def test_channelstate_update_contract_balance():
         block_hash=block_hash,
     )
 
-    pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         channel_state=deepcopy(channel_state),
         state_change=state_change,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=block_hash,
     )
@@ -255,11 +253,9 @@ def test_channelstate_decreasing_contract_balance():
         block_hash=deposit_block_hash,
     )
 
-    pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         channel_state=deepcopy(channel_state),
         state_change=state_change,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -304,13 +300,11 @@ def test_channelstate_repeated_contract_balance():
         contract_balance=balance1_new,
     )
     partner_model2 = partner_model1
-    pseudo_random_generator = random.Random()
 
     for _ in range(10):
         iteration = channel.state_transition(
             channel_state=deepcopy(channel_state),
             state_change=state_change,
-            pseudo_random_generator=pseudo_random_generator,
             block_number=block_number,
             block_hash=factories.make_block_hash(),
         )
@@ -354,11 +348,9 @@ def test_deposit_must_wait_for_confirmation():
         block_number=block_number,
         block_hash=block_hash,
     )
-    pseudo_random_generator = random.Random()
     iteration = channel.state_transition(
         channel_state=deepcopy(channel_state),
         state_change=new_balance,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=block_hash,
     )
@@ -374,7 +366,6 @@ def test_deposit_must_wait_for_confirmation():
         iteration = channel.state_transition(
             channel_state=deepcopy(unconfirmed_state),
             state_change=unconfirmed_block,
-            pseudo_random_generator=pseudo_random_generator,
             block_number=block_number,
             block_hash=block_hash,
         )
@@ -400,7 +391,6 @@ def test_deposit_must_wait_for_confirmation():
     iteration = channel.state_transition(
         channel_state=deepcopy(unconfirmed_state),
         state_change=confirmed_block,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=confirmed_deposit_block_number,
         block_hash=confirmed_block_hash,
     )
@@ -1592,7 +1582,6 @@ def test_action_close_must_change_the_channel_state():
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
 
-    pseudo_random_generator = random.Random()
     block_number = 10
     state_change = ActionChannelClose(
         channel_state.token_network_identifier,
@@ -1601,7 +1590,6 @@ def test_action_close_must_change_the_channel_state():
     iteration = channel.state_transition(
         channel_state=channel_state,
         state_change=state_change,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -1642,7 +1630,6 @@ def test_update_must_be_called_if_close_lost_race():
     )
     assert is_valid, msg
 
-    pseudo_random_generator = random.Random()
     block_number = 10
     state_change = ActionChannelClose(
         channel_state.token_network_identifier,
@@ -1651,7 +1638,6 @@ def test_update_must_be_called_if_close_lost_race():
     iteration = channel.state_transition(
         channel_state=channel_state,
         state_change=state_change,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -1676,7 +1662,6 @@ def test_update_transfer():
     partner_model1, _ = create_model(100)
     channel_state = create_channel_from_models(our_model1, partner_model1)
 
-    pseudo_random_generator = random.Random()
     block_number = 10
     state_change = ActionChannelClose(
         channel_state.token_network_identifier,
@@ -1685,7 +1670,6 @@ def test_update_transfer():
     iteration = channel.state_transition(
         channel_state=channel_state,
         state_change=state_change,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=factories.make_block_hash(),
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1074,7 +1074,6 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
     channel_close_transition = channel.state_transition(
         channel_state=setup.channel,
         state_change=channel_closed,
-        pseudo_random_generator=setup.prng,
         block_number=block_number,
         block_hash=block_hash,
     )
@@ -1221,7 +1220,6 @@ def test_initiator_handle_contract_receive_after_channel_closed():
     channel_close_transition = channel.state_transition(
         channel_state=setup.channel,
         state_change=channel_closed,
-        pseudo_random_generator=setup.prng,
         block_number=block_number,
         block_hash=block_hash,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1527,7 +1527,6 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
     channel_close_transition = channel.state_transition(
         channel_state=channel_state,
         state_change=channel_closed,
-        pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
         block_hash=block_hash,
     )

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -160,6 +160,9 @@ def is_deposit_confirmed(
         channel_state: NettingChannelState,
         block_number: BlockNumber,
 ) -> bool:
+    """True if the block which mined the deposit transaction has been
+    confirmed.
+    """
     if not channel_state.deposit_transaction_queue:
         return False
 
@@ -205,7 +208,7 @@ def is_lock_expired(
     return (True, None)
 
 
-def transfer_expired(
+def is_transfer_expired(
         transfer: LockedTransferSignedState,
         affected_channel: NettingChannelState,
         block_number: BlockNumber,
@@ -1154,9 +1157,9 @@ def create_sendlockedtransfer(
     assert get_status(channel_state) == CHANNEL_STATE_OPENED, msg
 
     lock = HashTimeLockState(
-        amount,
-        expiration,
-        secrethash,
+        amount=amount,
+        expiration=expiration,
+        secrethash=secrethash,
     )
 
     merkletree = compute_merkletree_with(
@@ -1918,7 +1921,6 @@ def handle_channel_batch_unlock(
 def state_transition(
         channel_state: NettingChannelState,
         state_change: StateChange,
-        pseudo_random_generator: Any,
         block_number: BlockNumber,
         block_hash: BlockHash,
 ) -> TransitionResult[Optional[NettingChannelState]]:

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -637,7 +637,7 @@ def events_for_expired_pairs(
         if not payer_channel:
             continue
 
-        has_payer_transfer_expired = channel.transfer_expired(
+        has_payer_transfer_expired = channel.is_transfer_expired(
             transfer=pair.payer_transfer,
             affected_channel=payer_channel,
             block_number=block_number,
@@ -1294,7 +1294,7 @@ def handle_offchain_secretreveal(
     if not payer_channel:
         return TransitionResult(mediator_state, list())
 
-    has_payer_transfer_expired = channel.transfer_expired(
+    has_payer_transfer_expired = channel.is_transfer_expired(
         transfer=transfer_pair.payer_transfer,
         affected_channel=payer_channel,
         block_number=block_number,

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -167,7 +167,7 @@ def handle_offchain_secretreveal(
         transfer_secrethash=target_state.transfer.lock.secrethash,
         secret=state_change.secret,
     )
-    has_transfer_expired = channel.transfer_expired(
+    has_transfer_expired = channel.is_transfer_expired(
         transfer=target_state.transfer,
         affected_channel=channel_state,
         block_number=block_number,

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -123,7 +123,6 @@ def subdispatch_to_all_channels(
                 result = channel.state_transition(
                     channel_state=channel_state,
                     state_change=state_change,
-                    pseudo_random_generator=chain_state.pseudo_random_generator,
                     block_number=block_number,
                     block_hash=block_hash,
                 )

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -34,7 +34,6 @@ def subdispatch_to_channel_by_id(
         result = channel.state_transition(
             channel_state=channel_state,
             state_change=state_change,
-            pseudo_random_generator=pseudo_random_generator,
             block_number=block_number,
             block_hash=block_hash,
         )
@@ -212,7 +211,6 @@ def handle_batch_unlock(
             sub_iteration = channel.state_transition(
                 channel_state=channel_state,
                 state_change=state_change,
-                pseudo_random_generator=pseudo_random_generator,
                 block_number=block_number,
                 block_hash=block_hash,
             )


### PR DESCRIPTION
- Removed unused PRNG from the functions arguments, as a consequence the
PRNG doesn't need to be instantiated in some tests
- Added a `is_` prefix to a predicate function
- Added a siple docstring explaining some predicated functions