### PR TITLE
Add GET endpoint to /token/<address>

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -280,7 +280,7 @@ Querying Information About Channels and Tokens
 
 .. http:get:: /api/(version)/tokens/(token_address)
 
-   Returns the address of the corresponding token network fot the given token, if the token is registered.
+   Returns the address of the corresponding token network for the given token, if the token is registered.
 
    **Example Request**:
 
@@ -299,7 +299,7 @@ Querying Information About Channels and Tokens
       "0x61bB630D3B2e8eda0FC1d50F9f958eC02e3969F6"
 
    :statuscode 200: Successful query
-   :statuscode 404: No token network found for the provided token
+   :statuscode 404: No token network found for the provided token address
 
 .. http:get:: /api/(version)/tokens/(token_address)/partners
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -278,6 +278,29 @@ Querying Information About Channels and Tokens
    :statuscode 200: Successful query
    :statuscode 500: Internal Raiden node error
 
+.. http:get:: /api/(version)/tokens/(token_address)
+
+   Returns the address of the corresponding token network fot the given token, if the token is registered.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      GET /api/v1/tokens/0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8 HTTP/1.1
+      Host: localhost:5001
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      "0x61bB630D3B2e8eda0FC1d50F9f958eC02e3969F6"
+
+   :statuscode 200: Successful query
+   :statuscode 404: No token network found for the provided token
+
 .. http:get:: /api/(version)/tokens/(token_address)/partners
 
    Returns a list of all partners with whom you have non-settled channels for a certain token.

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -429,7 +429,7 @@ class RaidenAPI:
         """
         chain_state = views.state_from_raiden(self.raiden)
 
-        token_networks = views.get_token_network_addresses_for(
+        token_addresses = views.get_token_identifiers(
             chain_state,
             registry_address,
         )
@@ -446,7 +446,7 @@ class RaidenAPI:
         if not is_binary_address(partner_address):
             raise InvalidAddress('Expected binary address format for partner in channel deposit')
 
-        if token_address not in token_networks:
+        if token_address not in token_addresses:
             raise UnknownTokenAddress('Unknown token address')
 
         if channel_state is None:
@@ -554,7 +554,7 @@ class RaidenAPI:
         if not all(map(is_binary_address, partner_addresses)):
             raise InvalidAddress('Expected binary address format for partner in channel close')
 
-        valid_tokens = views.get_token_network_addresses_for(
+        valid_tokens = views.get_token_identifiers(
             chain_state=views.state_from_raiden(self.raiden),
             payment_network_id=registry_address,
         )
@@ -671,11 +671,22 @@ class RaidenAPI:
 
     def get_tokens_list(self, registry_address: typing.PaymentNetworkID):
         """Returns a list of tokens the node knows about"""
-        tokens_list = views.get_token_network_addresses_for(
+        tokens_list = views.get_token_identifiers(
             chain_state=views.state_from_raiden(self.raiden),
             payment_network_id=registry_address,
         )
         return tokens_list
+
+    def get_token_network_address_for_token_address(
+            self,
+            registry_address: typing.PaymentNetworkID,
+            token_address: typing.TokenAddress,
+    ) -> typing.Optional[typing.TokenNetworkID]:
+        return views.get_token_network_identifier_by_token_address(
+            chain_state=views.state_from_raiden(self.raiden),
+            payment_network_id=registry_address,
+            token_address=token_address,
+        )
 
     def transfer_and_wait(
             self,
@@ -754,7 +765,7 @@ class RaidenAPI:
         if secret is not None and secret_hash is not None and secret_hash != sha3(secret):
             raise InvalidSecretOrSecretHash('provided secret and secret_hash do not match.')
 
-        valid_tokens = views.get_token_network_addresses_for(
+        valid_tokens = views.get_token_identifiers(
             views.state_from_raiden(self.raiden),
             registry_address,
         )

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -826,6 +826,28 @@ class RestAPI:
         result = self.address_list_schema.dump(tokens_list)
         return api_response(result=result.data)
 
+    def get_token_network_for_token(
+            self,
+            registry_address: typing.PaymentNetworkID,
+            token_address: typing.TokenAddress,
+    ):
+        log.debug(
+            'Getting token network for token',
+            node=pex(self.raiden_api.address),
+            token_address=to_checksum_address(token_address),
+        )
+        token_network_address = self.raiden_api.get_token_network_address_for_token_address(
+            registry_address=registry_address,
+            token_address=token_address,
+        )
+
+        if token_network_address is not None:
+            return api_response(result=to_checksum_address(token_network_address))
+        else:
+            pretty_address = to_checksum_address(token_address)
+            message = f'No token network registered for token "{pretty_address}"'
+            return api_error(message, status_code=HTTPStatus.NOT_FOUND)
+
     def get_blockchain_events_network(
             self,
             registry_address: typing.PaymentNetworkID,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -166,6 +166,12 @@ class RaidenInternalEventsResource(BaseResource):
 
 class RegisterTokenResource(BaseResource):
 
+    def get(self, token_address):
+        return self.rest_api.get_token_network_for_token(
+            self.rest_api.raiden_api.raiden.default_registry.address,
+            token_address,
+        )
+
     def put(self, token_address):
         return self.rest_api.register_token(
             self.rest_api.raiden_api.raiden.default_registry.address,

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1327,6 +1327,63 @@ def test_register_token(
     assert_response_with_error(poor_response, HTTPStatus.PAYMENT_REQUIRED)
 
 
+@pytest.mark.parametrize('number_of_tokens', [0])
+@pytest.mark.parametrize('number_of_nodes', [1])
+@pytest.mark.parametrize('channels_per_node', [0])
+@pytest.mark.parametrize('environment_type', [Environment.DEVELOPMENT])
+def test_get_token_network_for_token(
+        api_server_test_instance,
+        token_amount,
+        token_addresses,
+        raiden_network,
+        contract_manager,
+):
+    app0 = raiden_network[0]
+
+    new_token_address = deploy_contract_web3(
+        CONTRACT_HUMAN_STANDARD_TOKEN,
+        app0.raiden.chain.client,
+        contract_manager=contract_manager,
+        constructor_arguments=(
+            token_amount,
+            2,
+            'raiden',
+            'Rd',
+        ),
+    )
+
+    # unregistered token returns 404
+    token_request = grequests.get(api_url_for(
+        api_server_test_instance,
+        'registertokenresource',
+        token_address=to_checksum_address(new_token_address),
+    ))
+    token_response = token_request.send().response
+    assert_proper_response(token_response, status_code=HTTPStatus.NOT_FOUND)
+
+    # register token
+    register_request = grequests.put(api_url_for(
+        api_server_test_instance,
+        'registertokenresource',
+        token_address=to_checksum_address(new_token_address),
+    ))
+    register_response = register_request.send().response
+    assert_proper_response(register_response, status_code=HTTPStatus.CREATED)
+    token_network_address = register_response.json()['token_network_address']
+
+    gevent.sleep(app0.raiden.alarm.sleep_time * 10)
+
+    # now it should return the token address
+    token_request = grequests.get(api_url_for(
+        api_server_test_instance,
+        'registertokenresource',
+        token_address=to_checksum_address(new_token_address),
+    ))
+    token_response = token_request.send().response
+    assert_proper_response(token_response, status_code=HTTPStatus.OK)
+    assert token_network_address == token_response.json()
+
+
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('number_of_tokens', [1])

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -114,7 +114,7 @@ def run_smoketests(
             discovery = chain.address_to_discovery[discovery_addresses[0]]
             assert discovery.endpoint_by_address(raiden_service.address) != TEST_ENDPOINT
 
-        token_networks = views.get_token_network_addresses_for(
+        token_networks = views.get_token_identifiers(
             views.state_from_raiden(raiden_service),
             raiden_service.default_registry.address,
         )

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -168,7 +168,7 @@ def get_token_network_identifier_by_token_address(
         chain_state: ChainState,
         payment_network_id: PaymentNetworkID,
         token_address: TokenAddress,
-) -> TokenNetworkID:
+) -> Optional[TokenNetworkID]:
     token_network = get_token_network_by_token_address(
         chain_state,
         payment_network_id,
@@ -207,22 +207,6 @@ def get_token_identifiers(
         return [
             token_address
             for token_address in payment_network.tokenaddresses_to_tokenidentifiers.keys()
-        ]
-
-    return list()
-
-
-def get_token_network_addresses_for(
-        chain_state: ChainState,
-        payment_network_id: PaymentNetworkID,
-) -> List[Address]:
-    """ Return the list of tokens registered with the given payment network. """
-    payment_network = chain_state.identifiers_to_paymentnetworks.get(payment_network_id)
-
-    if payment_network is not None:
-        return [
-            token_network.token_address
-            for token_network in payment_network.tokenidentifiers_to_tokennetworks.values()
         ]
 
     return list()


### PR DESCRIPTION
Add as GET endpoint to `/tokens/<hexaddress:token_address>'`

This is necessary for #3509 to get the corresponding token networks address for a given token.

