### PR TITLE
Json encoder

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -44,7 +44,6 @@ from raiden.network.transport.matrix.utils import (
 )
 from raiden.network.transport.udp import udp_utils
 from raiden.raiden_service import RaidenService
-from raiden.storage.serialize import JSONSerializer
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.events import CHANNEL_IDENTIFIER_GLOBAL_QUEUE
 from raiden.transfer.queue_identifier import QueueIdentifier
@@ -165,7 +164,7 @@ class _RetryQueue(Runnable):
             self._message_queue.append(_RetryQueue._MessageData(
                 queue_identifier=queue_identifier,
                 message=message,
-                text=JSONSerializer.serialize(message),
+                text=json.dumps(message.to_dict()),
                 expiration_generator=expiration_generator,
             ))
         self.notify()
@@ -586,7 +585,7 @@ class MatrixTransport(Runnable):
             if messages:
                 for room_name in set(room_name for room_name, _ in messages):
                     message_text = '\n'.join(
-                        JSONSerializer.serialize(message)
+                        json.dumps(message.to_dict())
                         for target_room, message in messages
                         if target_room == room_name
                     )

--- a/raiden/storage/serialize.py
+++ b/raiden/storage/serialize.py
@@ -2,7 +2,7 @@
 this means that arbitrary modules are imported and potentially arbitrary code
 can be executed (altough, the code which can be executed is limited to our
 internal interfaces). Nevertheless, because of this, this must only be used
-with sanitize input, to avoid the risk of exploits.
+with sanitized input, to avoid the risk of exploits.
 """
 import importlib
 import json
@@ -28,12 +28,12 @@ def from_dict_hook(data):
     """Decode internal objects encoded using `to_dict_hook`.
 
     This automatically imports the class defined in the `_type` metadata field,
-    and calls the `from_dict` method hook to insantiate an object of that
+    and calls the `from_dict` method hook to instantiate an object of that
     class.
 
     Note:
         Because this function will do automatic module loading it's really
-        important to only use this with sanitize or trusted input, otherwise
+        important to only use this with sanitized or trusted input, otherwise
         arbitrary modules can be imported and potentially arbitrary code can be
         executed.
     """
@@ -42,7 +42,7 @@ def from_dict_hook(data):
         klass = _import_type(type_)
 
         msg = '_type must point to a class with `from_dict` static method'
-        assert isinstance(klass, 'from_dict'), msg
+        assert hasattr(klass, 'from_dict'), msg
 
         return klass.from_dict(data)
     return data
@@ -82,7 +82,9 @@ def to_dict_hook(obj):
         result['_version'] = 0
         return result
 
-    return obj
+    raise TypeError(
+        f'Object of type {obj.__class__.__name__} is not JSON serializable',
+    )
 
 
 class SerializationBase:

--- a/raiden/storage/serialize.py
+++ b/raiden/storage/serialize.py
@@ -1,3 +1,9 @@
+""" This module contains logic for automatically importing modules/objects,
+this means that arbitrary modules are imported and potentially arbitrary code
+can be executed (altough, the code which can be executed is limited to our
+internal interfaces). Nevertheless, because of this, this must only be used
+with sanitize input, to avoid the risk of exploits.
+"""
 import importlib
 import json
 
@@ -18,26 +24,68 @@ def _import_type(type_name):
     return klass
 
 
-def object_hook(data):
+def from_dict_hook(data):
+    """Decode internal objects encoded using `to_dict_hook`.
+
+    This automatically imports the class defined in the `_type` metadata field,
+    and calls the `from_dict` method hook to insantiate an object of that
+    class.
+
+    Note:
+        Because this function will do automatic module loading it's really
+        important to only use this with sanitize or trusted input, otherwise
+        arbitrary modules can be imported and potentially arbitrary code can be
+        executed.
     """
-    detects the type of a JSON object, imports the class
-    of that type and calls `to_dict`
-    """
-    if '_type' in data:
-        obj = None
-        obj_type = data['_type']
+    type_ = data.get('_type', None)
+    if type_ is not None:
+        klass = _import_type(type_)
 
-        klass = _import_type(obj_type)
-        if hasattr(klass, 'from_dict'):
-            obj = klass.from_dict(data)
+        msg = '_type must point to a class with `from_dict` static method'
+        assert isinstance(klass, 'from_dict'), msg
 
-        return obj
-
+        return klass.from_dict(data)
     return data
 
 
+def to_dict_hook(obj):
+    """Convert internal objects to a serializable representation.
+
+    During serialization if the object has the hook method `to_dict` it will be
+    automatically called and metadata for decoding will be added. This allows
+    for the translation of objects trees of arbitrary depth. E.g.:
+
+    >>> class Root:
+    >>>     def __init__(self, left, right):
+    >>>         self.left = left
+    >>>         self.right = right
+    >>>     def to_dict(self):
+    >>>         return {
+    >>>           'left': left,
+    >>>           'right': right,
+    >>>         }
+    >>> class Node:
+    >>>     def to_dict(self):
+    >>>         return {'value': 'node'}
+    >>> root = Root(left=None(), right=None())
+    >>> json.dumps(root, default=to_dict_hook)
+    '{
+        "_type": "Root",
+        "left": {"_type": "Node", "value": "node"},
+        "right": {"_type": "Node", "value": "node"}
+    }'
+    """
+    if hasattr(obj, 'to_dict'):
+        result = obj.to_dict()
+        assert isinstance(result, dict), 'to_dict must return a dictionary'
+        result['_type'] = f'{obj.__module__}.{obj.__class__.__name__}'
+        result['_version'] = 0
+        return result
+
+    return obj
+
+
 class SerializationBase:
-    """ Base interface for serialization / deserialization. """
     @staticmethod
     def serialize(obj: Any):
         raise NotImplementedError
@@ -47,37 +95,11 @@ class SerializationBase:
         raise NotImplementedError
 
 
-class RaidenJSONEncoder(json.JSONEncoder):
-    """ A custom JSON encoder to provide convenience
-    of recursive instance encoding. """
-
-    def default(self, obj):
-        """
-        If an object has `to_dict` method, call that method.
-        """
-        if hasattr(obj, 'to_dict'):
-            result = obj.to_dict()
-            result['_type'] = f'{obj.__module__}.{obj.__class__.__name__}'
-            result['_version'] = 0
-            return result
-        return super().default(obj)
-
-
-class RaidenJSONDecoder(json.JSONDecoder):
-    """ A custom JSON decoder which facilitates
-    specific object type invocation to restore
-    its state.
-    """
-
-    def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=object_hook, *args, **kwargs)
-
-
 class JSONSerializer(SerializationBase):
     @staticmethod
     def serialize(obj):
-        return json.dumps(obj, cls=RaidenJSONEncoder)
+        return json.dumps(obj, default=to_dict_hook)
 
     @staticmethod
     def deserialize(data):
-        return json.loads(data, cls=RaidenJSONDecoder)
+        return json.loads(data, object_hook=from_dict_hook)


### PR DESCRIPTION
Added documentation to clarify that we do automagic module imports in the storage encoder, and remove the usage of the encoder from the matrix transport to avoid any future problems