### PR TITLE
Fix test race condition

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -830,9 +830,18 @@ class RaidenService(Runnable):
         if secret_hash is None:
             secret_hash = sha3(secret)
 
+        # We must check if the secret was registered against the latest block,
+        # even if the block is forked away and the transaction that registers
+        # the secret is removed from the blockchain. The rationale here is that
+        # someone else does know the secret, regardless of the chain state, so
+        # the node must not use it to start a payment.
+        #
+        # For this particular case, it's preferable to use `latest` instead of
+        # having a specific block_hash, because it's preferable to know if the secret
+        # was ever known, rather than having a consistent view of the blockchain.
         secret_registered = self.default_secret_registry.check_registered(
             secrethash=secret_hash,
-            block_identifier=views.state_from_raiden(self).block_hash,
+            block_identifier='latest',
         )
         if secret_registered:
             raise RaidenUnrecoverableError(


### PR DESCRIPTION
The test `test_locked_transfer_secret_registered_onchain` was used to
guarantee that a node does not reuse a known secret. It first registered
the secret and then called `start_mediated_transfer_with_secret`. Because
the Raiden node was only querying the blockchain state from confirmed
blocks the recently registered secret was missed.

In this particular instance, using `latest` as a block_identifier is
fine, we don't need a consistent view of the blockchain for that
particular call.