### PR TITLE
Fix no-member complaint by pylint

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -101,17 +101,19 @@ class AccountManager:
                             self.accounts[address] = str(fullpath)
                     except (
                             IOError,
+                            OSError,
+                    ) as ex:
+                        msg = 'Can not read account file (errno=%s)' % ex.errno
+                        log.warning(msg, path=fullpath, ex=ex)
+                    except(
                             json.JSONDecodeError,
                             KeyError,
-                            OSError,
                             UnicodeDecodeError,
                     ) as ex:
                         # Invalid file - skip
                         if f.startswith('UTC--'):
                             # Should be a valid account file - warn user
                             msg = 'Invalid account file'
-                            if isinstance(ex, IOError) or isinstance(ex, OSError):
-                                msg = 'Can not read account file (errno=%s)' % ex.errno
                             if isinstance(ex, json.decoder.JSONDecodeError):
                                 msg = 'The account file is not valid JSON format'
                             log.warning(msg, path=fullpath, ex=ex)


### PR DESCRIPTION
Newest `astroid` version 2.2.0 started to complain about `no-member` for
`Exception.errno` for `(JSONDecodeError, KeyError, UnicodeDecodeError)`,
albeit there was an `isinstance` check before accessing it. By
separating the `except` blocks, I was able to mute that problem.