### PR TITLE
Allow inject secret hash without secret

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -765,7 +765,7 @@ class RaidenAPI:
         if secret is None and secret_hash is not None:
             pass
 
-        valid_tokens = views.get_token_network_addresses_for(
+        valid_tokens = views.get_token_identifiers(
             views.state_from_raiden(self.raiden),
             registry_address,
         )

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -759,13 +759,13 @@ class RaidenAPI:
                 raise InvalidSecretOrSecretHash('secret_hash is not an hexadecimal string.')
             secret_hash = to_bytes(hexstr=secret_hash)
 
-        if secret is None and secret_hash is not None:
-            raise InvalidSecretOrSecretHash('secret_hash without a secret is not supported yet.')
-
         if secret is not None and secret_hash is not None and secret_hash != sha3(secret):
             raise InvalidSecretOrSecretHash('provided secret and secret_hash do not match.')
 
-        valid_tokens = views.get_token_identifiers(
+        if secret is None and secret_hash is not None:
+            pass
+
+        valid_tokens = views.get_token_network_addresses_for(
             views.state_from_raiden(self.raiden),
             registry_address,
         )

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -85,10 +85,10 @@ from raiden.utils import (
     create_default_identifier,
     optional_address_to_string,
     pex,
+    sha3,
     split_endpoint,
     typing,
 )
-from raiden.utils import sha3
 from raiden.utils.runnable import Runnable
 
 log = structlog.get_logger(__name__)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -88,6 +88,7 @@ from raiden.utils import (
     split_endpoint,
     typing,
 )
+from raiden.utils import sha3
 from raiden.utils.runnable import Runnable
 
 log = structlog.get_logger(__name__)
@@ -1101,6 +1102,8 @@ class RestAPI:
                 status_code=HTTPStatus.CONFLICT,
             )
 
+        secret = payment_status.payment_done.get()
+
         payment = {
             'initiator_address': self.raiden_api.address,
             'registry_address': registry_address,
@@ -1108,8 +1111,8 @@ class RestAPI:
             'target_address': target_address,
             'amount': amount,
             'identifier': identifier,
-            'secret': to_hex(payment_status.secret),
-            'secret_hash': to_hex(payment_status.secret_hash),
+            'secret': to_hex(secret),
+            'secret_hash': to_hex(sha3(secret)),
         }
         result = self.payment_schema.dump(payment)
         return api_response(result=result.data)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -210,7 +210,7 @@ class RaidenEventHandler:
         # With the introduction of the lock we should always get
         # here only once per identifier so payment_status should always exist
         # see: https://github.com/raiden-network/raiden/pull/3191
-        payment_status.payment_done.set(True)
+        payment_status.payment_done.set(payment_sent_success_event.secret)
 
     @staticmethod
     def handle_paymentsentfailed(

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -983,7 +983,6 @@ def test_api_payments_secret_hash_errors(
     token_address = token_addresses[0]
     target_address = app1.raiden.address
     secret = '0x78c8d676e2f2399aa2a015f3433a2083c55003591a0f3f3349b6e50fc9ca44f1'
-    secret_hash = to_hex(sha3(to_bytes(hexstr=secret)))
     bad_secret = 'Not Hex String. 0x78c8d676e2f2399aa2a015f3433a2083c55003591a0f3f33'
     bad_secret_hash = 'Not Hex String. 0x78c8d676e2f2399aa2a015f3433a2083c55003591a0f3f33'
     short_secret = '0x123'
@@ -1063,22 +1062,6 @@ def test_api_payments_secret_hash_errors(
         json={
             'amount': amount,
             'identifier': identifier,
-            'secret_hash': secret_hash,
-        },
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
-
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            'token_target_paymentresource',
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            'amount': amount,
-            'identifier': identifier,
             'secret': secret,
             'secret_hash': secret,
         },
@@ -1128,6 +1111,50 @@ def test_api_payments_with_secret_no_hash(
     response = response.json()
     assert_payment_secret_and_hash(response, payment)
     assert secret == response['secret']
+
+
+@pytest.mark.parametrize('number_of_nodes', [2])
+def test_api_payments_with_hash_no_secret(
+        api_server_test_instance,
+        raiden_network,
+        token_addresses,
+):
+    _, app1 = raiden_network
+    amount = 200
+    identifier = 42
+    token_address = token_addresses[0]
+    target_address = app1.raiden.address
+    secret = '0x78c8d676e2f2399aa2a015f3433a2083c55003591a0f3f3349b6e50fc9ca44f1'
+    secret_hash = to_hex(sha3(to_bytes(hexstr=secret)))
+
+    our_address = api_server_test_instance.rest_api.raiden_api.address
+
+    payment = {
+        'initiator_address': to_checksum_address(our_address),
+        'target_address': to_checksum_address(target_address),
+        'token_address': to_checksum_address(token_address),
+        'amount': amount,
+        'identifier': identifier,
+    }
+
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            'token_target_paymentresource',
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={
+            'amount': amount,
+            'identifier': identifier,
+            'secret_hash': secret_hash,
+        },
+    )
+    response = request.send().response
+    assert_proper_response(response)
+    response = response.json()
+    assert_payment_secret_and_hash(response, payment)
+    assert secret != response['secret']
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -73,6 +73,7 @@ def events_for_unlock_lock(
         identifier=transfer_description.payment_identifier,
         amount=transfer_description.amount,
         target=transfer_description.target,
+        secret=secret,
     )
 
     unlock_success = EventUnlockSuccess(

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -627,8 +627,10 @@ class TransferDescriptionWithSecretState(State):
             initiator: InitiatorAddress,
             target: TargetAddress,
             secret: Secret,
+            secret_hash: SecretHash = None,
     ):
-        secrethash = sha3(secret)
+        if secret_hash is None:
+            secret_hash = sha3(secret)
 
         self.payment_network_identifier = payment_network_identifier
         self.payment_identifier = payment_identifier
@@ -637,7 +639,7 @@ class TransferDescriptionWithSecretState(State):
         self.initiator = initiator
         self.target = target
         self.secret = secret
-        self.secrethash = secrethash
+        self.secrethash = secret_hash
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Feature: Allow inject secret-hash without a secret

With this commit the REST api allows the caller to provide a secret-hash without a secret. The intention is that the secret will be provided by the payee(target).
Since the target does not yet support this capability, in the case that only secret-hash provided, the code ignores the secret-hash, select a secret an use it. This will be removed next when the state machine is enhanced to support this mode.  
The EventPaymentsSecretSuccess includes now the secret so that the API can should it to the user. The secret and secrethash removed from payment_status.

Points to consider:
- How the secret is returned to the api level (payment_status)
