### PR TITLE
Fix incorrect deployment build version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 dist/
-tools/testnet/.terraform
+tools/testnet/.terraform/plugins

--- a/.gitignore
+++ b/.gitignore
@@ -67,34 +67,19 @@ docs/_build/
 # PyBuilder
 target/
 
-# truffle related
-truffle/.babel.json
-truffle/environments/development/contracts/
-truffle/.bash_history
-
 # never check in .static-abi.json files
 *.static-abi.json
-
-# ignore node_modules
-raiden/raidenwebui/node_modules/
-
-raiden/ui/web/node_modules/
 
 # editors
 .idea
 .vscode
-.synapse
-raiden/smart_contracts/contracts.json
 
 # Our logs
-raiden-debug.log*
+raiden-debug_*.log
 
 # direnv virtual envs
 .direnv
 .envrc
-
-# tools
-tools/circleci/
 
 # venvs
 venv/

--- a/tools/testnet/.gitignore
+++ b/tools/testnet/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 terraform.tfstate.backup
+.terraform/plugins


### PR DESCRIPTION
The linux deployment builds contained a `dirty` version tag since there was a mismatch between `.gitignore` and `.dockerignore` leading to files being seen as modified inside the build container that didn't actually change.

Fixes #3531 