### PR TITLE
Introduce CanonicalIdentifier

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -34,7 +34,7 @@ from raiden.transfer.state import (
     HashTimeLockState,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import ishash, pex, sha3, typing
+from raiden.utils import CanonicalIdentifier, ishash, pex, sha3, typing
 from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import (
     Address,
@@ -357,9 +357,11 @@ class EnvelopeMessage(SignedRetrieableMessage):
             nonce=self.nonce,
             balance_hash=balance_hash,
             additional_hash=self.message_hash,
-            channel_identifier=self.channel_identifier,
-            token_network_identifier=typing.TokenNetworkID(self.token_network_address),
-            chain_id=self.chain_id,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.chain_id,
+                token_network_address=self.token_network_address,
+                channel_identifier=self.channel_identifier,
+            ),
         )
         return balance_proof_packed
 
@@ -1522,7 +1524,7 @@ class SignedBlindedBalanceProof:
         assert isinstance(balance_proof, BalanceProofSignedState)
         return cls(
             channel_identifier=balance_proof.channel_identifier,
-            token_network_address=balance_proof.token_network_identifier,
+            token_network_address=typing.TokenNetworkID(balance_proof.token_network_identifier),
             nonce=balance_proof.nonce,
             additional_hash=balance_proof.message_hash,
             chain_id=balance_proof.chain_id,
@@ -1539,9 +1541,11 @@ class SignedBlindedBalanceProof:
             nonce=self.nonce,
             balance_hash=self.balance_hash,
             additional_hash=self.additional_hash,
-            channel_identifier=self.channel_identifier,
-            token_network_identifier=self.token_network_address,
-            chain_id=self.chain_id,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.chain_id,
+                token_network_address=self.token_network_address,
+                channel_identifier=self.channel_identifier,
+            ),
             partner_signature=self.signature,
         )
         return packed
@@ -1741,17 +1745,21 @@ class RequestMonitoring(SignedMessage):
             nonce=self.balance_proof.nonce,
             balance_hash=self.balance_proof.balance_hash,
             additional_hash=self.balance_proof.additional_hash,
-            channel_identifier=self.balance_proof.channel_identifier,
-            token_network_identifier=self.balance_proof.token_network_address,
-            chain_id=self.balance_proof.chain_id,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.balance_proof.chain_id,
+                token_network_address=self.balance_proof.token_network_address,
+                channel_identifier=self.balance_proof.channel_identifier,
+            ),
         )
         blinded_data = pack_balance_proof_update(
             nonce=self.balance_proof.nonce,
             balance_hash=self.balance_proof.balance_hash,
             additional_hash=self.balance_proof.additional_hash,
-            channel_identifier=self.balance_proof.channel_identifier,
-            token_network_identifier=self.balance_proof.token_network_address,
-            chain_id=self.balance_proof.chain_id,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.balance_proof.chain_id,
+                token_network_address=self.balance_proof.token_network_address,
+                channel_identifier=self.balance_proof.channel_identifier,
+            ),
             partner_signature=self.balance_proof.signature,
         )
         reward_proof_data = pack_reward_proof(

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -28,7 +28,7 @@ from raiden.network.proxies.utils import compare_contract_versions
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.transfer.balance_proof import pack_balance_proof
-from raiden.utils import pex, safe_gas_limit
+from raiden.utils import CanonicalIdentifier, pex, safe_gas_limit
 from raiden.utils.signer import recover
 from raiden.utils.typing import (
     AdditionalHash,
@@ -46,7 +46,6 @@ from raiden.utils.typing import (
     T_ChannelState,
     TokenAmount,
     TokenNetworkAddress,
-    TokenNetworkID,
 )
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
@@ -1018,9 +1017,11 @@ class TokenNetwork:
             nonce=nonce,
             balance_hash=balance_hash,
             additional_hash=additional_hash,
-            channel_identifier=channel_identifier,
-            token_network_identifier=TokenNetworkID(self.address),
-            chain_id=self.proxy.contract.functions.chain_id().call(),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.proxy.contract.functions.chain_id().call(),
+                token_network_address=self.address,
+                channel_identifier=channel_identifier,
+            ),
         )
 
         try:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -43,7 +43,7 @@ from raiden.transfer.utils import (
     get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.transfer.views import get_channelstate_by_token_network_and_partner, state_from_raiden
-from raiden.utils import pex
+from raiden.utils import CanonicalIdentifier, pex
 
 # type alias to avoid both circular dependencies and flake8 errors
 RaidenService = 'RaidenService'
@@ -301,9 +301,11 @@ class RaidenEventHandler:
                 nonce=balance_proof.nonce,
                 balance_hash=balance_proof.balance_hash,
                 additional_hash=balance_proof.message_hash,
-                channel_identifier=balance_proof.channel_identifier,
-                token_network_identifier=balance_proof.token_network_identifier,
-                chain_id=balance_proof.chain_id,
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=balance_proof.chain_id,
+                    token_network_address=balance_proof.token_network_identifier,
+                    channel_identifier=balance_proof.channel_identifier,
+                ),
                 partner_signature=balance_proof.signature,
             )
             our_signature = raiden.signer.sign(data=non_closing_data)

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -18,6 +18,7 @@ from raiden.transfer.balance_proof import (
     pack_reward_proof,
 )
 from raiden.transfer.state import BalanceProofUnsignedState
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.signer import LocalSigner, recover
 
 PRIVKEY, ADDRESS = make_privkey_address()
@@ -109,9 +110,11 @@ def test_request_monitoring():
         nonce=request_monitoring.balance_proof.nonce,
         balance_hash=request_monitoring.balance_proof.balance_hash,
         additional_hash=request_monitoring.balance_proof.additional_hash,
-        channel_identifier=request_monitoring.balance_proof.channel_identifier,
-        token_network_identifier=request_monitoring.balance_proof.token_network_address,
-        chain_id=request_monitoring.balance_proof.chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=request_monitoring.balance_proof.chain_id,
+            token_network_address=request_monitoring.balance_proof.token_network_address,
+            channel_identifier=request_monitoring.balance_proof.channel_identifier,
+        ),
         partner_signature=request_monitoring.balance_proof.signature,
     )
     assert recover(blinded_data, request_monitoring.non_closing_signature) == ADDRESS
@@ -120,9 +123,11 @@ def test_request_monitoring():
         nonce=request_monitoring.balance_proof.nonce,
         balance_hash=request_monitoring.balance_proof.balance_hash,
         additional_hash=request_monitoring.balance_proof.additional_hash,
-        channel_identifier=request_monitoring.balance_proof.channel_identifier,
-        token_network_identifier=request_monitoring.balance_proof.token_network_address,
-        chain_id=request_monitoring.balance_proof.chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=request_monitoring.balance_proof.chain_id,
+            token_network_address=request_monitoring.balance_proof.token_network_address,
+            channel_identifier=request_monitoring.balance_proof.channel_identifier,
+        ),
     )
     assert recover(
         balance_proof_data,

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -1,3 +1,4 @@
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
     AdditionalHash,
@@ -16,9 +17,7 @@ def pack_balance_proof(
         nonce: Nonce,
         balance_hash: BalanceHash,
         additional_hash: AdditionalHash,
-        channel_identifier: ChannelID,
-        token_network_identifier: TokenNetworkID,
-        chain_id: ChainID,
+        canonical_identifier: CanonicalIdentifier,
         msg_type: MessageTypeId = MessageTypeId.BALANCE_PROOF,
 ) -> bytes:
     """Packs balance proof data to be signed
@@ -35,10 +34,10 @@ def pack_balance_proof(
         'uint256',
         'bytes32',
     ], [
-        token_network_identifier,
-        chain_id,
+        canonical_identifier.token_network_address,
+        canonical_identifier.chain_identifier,
         msg_type,
-        channel_identifier,
+        canonical_identifier.channel_identifier,
         balance_hash,
         nonce,
         additional_hash,
@@ -49,9 +48,7 @@ def pack_balance_proof_update(
         nonce: Nonce,
         balance_hash: BalanceHash,
         additional_hash: AdditionalHash,
-        channel_identifier: ChannelID,
-        token_network_identifier: TokenNetworkID,
-        chain_id: ChainID,
+        canonical_identifier: CanonicalIdentifier,
         partner_signature: Signature,
 ) -> bytes:
     """Packs balance proof data to be signed for updateNonClosingBalanceProof
@@ -63,9 +60,7 @@ def pack_balance_proof_update(
         nonce=nonce,
         balance_hash=balance_hash,
         additional_hash=additional_hash,
-        channel_identifier=channel_identifier,
-        token_network_identifier=token_network_identifier,
-        chain_id=chain_id,
+        canonical_identifier=canonical_identifier,
         msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
     ) + partner_signature
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -75,7 +75,7 @@ from raiden.transfer.state_change import (
     ReceiveUnlock,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import pex
+from raiden.utils import CanonicalIdentifier, pex
 from raiden.utils.signer import recover
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
@@ -323,9 +323,11 @@ def is_valid_signature(
         nonce=balance_proof.nonce,
         balance_hash=balance_hash,
         additional_hash=balance_proof.message_hash,
-        channel_identifier=balance_proof.channel_identifier,
-        token_network_identifier=balance_proof.token_network_identifier,
-        chain_id=balance_proof.chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=balance_proof.chain_id,
+            token_network_address=balance_proof.token_network_identifier,
+            channel_identifier=balance_proof.channel_identifier,
+        ),
     )
 
     try:

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -681,7 +681,7 @@ def handle_init_mediator(
     return subdispatch_mediatortask(
         chain_state,
         state_change,
-        token_network_identifier,
+        TokenNetworkID(token_network_identifier),
         secrethash,
     )
 
@@ -698,7 +698,7 @@ def handle_init_target(
     return subdispatch_targettask(
         chain_state,
         state_change,
-        token_network_identifier,
+        TokenNetworkID(token_network_identifier),
         channel_identifier,
         secrethash,
     )

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -5,7 +5,7 @@ import re
 import sys
 import time
 from itertools import zip_longest
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union, NamedTuple
 
 import gevent
 from eth_keys import keys
@@ -24,6 +24,13 @@ from raiden import constants
 from raiden.exceptions import InvalidAddress
 from raiden.utils import typing
 from raiden.utils.signing import sha3  # noqa
+
+
+class CanonicalIdentifier(NamedTuple):
+    chain_identifier: typing.ChainID
+    # introducing the type as Union, to avoid casting for now. Should be only `..Address` later
+    token_network_address: Union[typing.TokenNetworkAddress, typing.TokenNetworkID]
+    channel_identifier: typing.ChannelID
 
 
 def random_secret():


### PR DESCRIPTION
As raised in #3493 we want to tighten the definition of what identifies a channel.

This PR introduces the new type `CanonicalIdentifier` as a (named) tuple of 
`(chain_identifier, token_network_address, channel_identifier)`.

- In order to allow for a gradual introduction, I chose to use the identifier with signed balance proofs first.
- In order to avoid migrations at this point in time, the identifier is used as an `__init__` argument, but then destructured into the existing fields.
- To minimize the amount of mypy casts introduced by this, `CanonicalIdentifier.token_network_address` is typed as a union of `TokenNetworkAddress` and `TokenNetworkID` for now.