### PR TITLE
Use CanonicalIdentifier in BalanceProofUnsignedState

### DIFF
--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -25,7 +25,7 @@ from raiden.transfer.utils import (
     get_event_with_balance_proof_by_balance_hash,
     get_state_change_with_balance_proof_by_balance_hash,
 )
-from raiden.utils import sha3
+from raiden.utils import CanonicalIdentifier, sha3
 
 
 def make_signed_balance_proof_from_counter(counter):
@@ -55,9 +55,11 @@ def make_balance_proof_from_counter(counter) -> BalanceProofUnsignedState:
         transferred_amount=next(counter),
         locked_amount=next(counter),
         locksroot=sha3(next(counter).to_bytes(1, 'big')),
-        token_network_identifier=factories.make_address(),
-        channel_identifier=next(counter),
-        chain_id=next(counter),
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=next(counter),
+            token_network_address=factories.make_address(),
+            channel_identifier=next(counter),
+        ),
     )
 
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -274,9 +274,11 @@ def make_transfer(
         transferred_amount=transferred_amount,
         locked_amount=locked_amount,
         locksroot=locksroot,
-        token_network_identifier=token_network_identifier,
-        channel_identifier=channel_identifier,
-        chain_id=UNIT_CHAIN_ID,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=UNIT_CHAIN_ID,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
     )
 
     return LockedTransferUnsignedState(
@@ -763,6 +765,11 @@ def _(properties, defaults=None) -> LockedTransferUnsignedState:
     balance_proof_parameters = _properties_to_dict(
         parameters.pop('balance_proof'),
         defaults.balance_proof,
+    )
+    balance_proof_parameters['canonical_identifier'] = CanonicalIdentifier(
+        chain_identifier=balance_proof_parameters.pop('chain_id'),
+        token_network_address=balance_proof_parameters.pop('token_network_identifier'),
+        channel_identifier=balance_proof_parameters.pop('channel_identifier'),
     )
     if balance_proof_parameters['locksroot'] == EMPTY_MERKLE_ROOT:
         balance_proof_parameters['locksroot'] = lock.lockhash

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1192,9 +1192,11 @@ def create_sendlockedtransfer(
         transferred_amount=transferred_amount,
         locked_amount=locked_amount,
         locksroot=locksroot,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
-        chain_id=channel_state.chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
     )
 
     locked_transfer = LockedTransferUnsignedState(
@@ -1257,9 +1259,11 @@ def create_unlock(
         transferred_amount=transferred_amount,
         locked_amount=locked_amount,
         locksroot=locksroot,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
-        chain_id=channel_state.chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
     )
 
     unlock_lock = SendBalanceProof(
@@ -1429,9 +1433,11 @@ def create_sendexpiredlock(
         transferred_amount=transferred_amount,
         locked_amount=updated_locked_amount,
         locksroot=locksroot,
-        token_network_identifier=token_network_identifier,
-        channel_identifier=channel_identifier,
-        chain_id=chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_id,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
     )
 
     send_lock_expired = SendLockExpired(

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -757,10 +757,11 @@ class BalanceProofUnsignedState(State):
             transferred_amount: TokenAmount,
             locked_amount: TokenAmount,
             locksroot: Locksroot,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
-            chain_id: ChainID,
+            canonical_identifier: CanonicalIdentifier,
     ):
+        chain_id = canonical_identifier.chain_identifier
+        token_network_identifier = canonical_identifier.token_network_address
+        channel_identifier = canonical_identifier.channel_identifier
         if not isinstance(nonce, int):
             raise ValueError('nonce must be int')
 
@@ -864,9 +865,11 @@ class BalanceProofUnsignedState(State):
             transferred_amount=TokenAmount(int(data['transferred_amount'])),
             locked_amount=TokenAmount(int(data['locked_amount'])),
             locksroot=Locksroot(serialization.deserialize_bytes(data['locksroot'])),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
-            chain_id=data['chain_id'],
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=data['chain_id'],
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
         )
 
         return restored


### PR DESCRIPTION
This is the next iteration for #3493 -- introduced the `CanonicalIdentifier` to the next State item.