### PR TITLE
Fix Scenario Player release download

### DIFF
--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -152,8 +152,9 @@ def configure_logging(
         log_file: str = None,
         disable_debug_logfile: bool = False,
         debug_log_file_name: str = None,
-        _first_party_packages: FrozenSet[str] = _FIRST_PARTY_PACKAGES,
         cache_logger_on_first_use: bool = True,
+        _first_party_packages: FrozenSet[str] = _FIRST_PARTY_PACKAGES,
+        _debug_log_file_additional_level_filters: Dict[str, str] = None,
 ):
     structlog.reset_defaults()
 
@@ -228,6 +229,7 @@ def configure_logging(
                     'log_level_config': {
                         '': DEFAULT_LOG_LEVEL,
                         'raiden': 'DEBUG',
+                        **(_debug_log_file_additional_level_filters or {}),
                     },
                 },
             },

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -67,15 +67,15 @@ def test_cli_option_dependencies(cli_runner, args, error_message):
 def test_cli_version(cli_runner):
     result = cli_runner(run, ['version'])
     result_json = json.loads(result.output)
-    result_expected_keys = [
+    result_expected_keys = {
         'raiden',
         'python_implementation',
         'python_version',
         'system',
+        'architecture',
         'distribution',
-    ]
-    for expected_key in result_expected_keys:
-        assert expected_key in result_json
+    }
+    assert result_expected_keys == result_json.keys()
     assert result.exit_code == 0
 
 

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -167,11 +167,10 @@ def get_system_spec() -> typing.Dict[str, str]:
             platform.architecture()[0],
         )
     else:
-        system_info = '{} {} {} {}'.format(
+        system_info = '{} {} {}'.format(
             platform.system(),
-            '_'.join(platform.architecture()),
+            '_'.join(part for part in platform.architecture() if part),
             platform.release(),
-            platform.machine(),
         )
 
     try:
@@ -188,6 +187,7 @@ def get_system_spec() -> typing.Dict[str, str]:
         'python_implementation': platform.python_implementation(),
         'python_version': platform.python_version(),
         'system': system_info,
+        'architecture': platform.machine(),
         'distribution': 'bundled' if getattr(sys, 'frozen', False) else 'source',
     }
     return system_spec

--- a/tools/scenario-player/scenario_player/main.py
+++ b/tools/scenario-player/scenario_player/main.py
@@ -91,6 +91,7 @@ def main(
         {'': 'INFO', 'raiden': 'DEBUG', 'scenario_player': 'DEBUG'},
         debug_log_file_name=log_file_name,
         _first_party_packages=_FIRST_PARTY_PACKAGES | frozenset(['scenario_player']),
+        _debug_log_file_additional_level_filters={'scenario_player': 'DEBUG'},
     )
 
     log_buffer = None


### PR DESCRIPTION
Fixes: #3582 
Fixes: #2739


Small drive by fixes:
- Include architecture in `get_system_spec` output.
- Fix scenario player file logging (`debug` level messages were missing from file log)