### PR TITLE
logging: Added logs for the runnables lifetime

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -471,9 +471,10 @@ class APIServer(Runnable):
 
     def start(self):
         log.debug(
-            'Starting rest api',
+            'REST API starting',
             host=self.config['host'],
             port=self.config['port'],
+            node=pex(self.rest_api.raiden_api.address),
         )
 
         # WSGI expects an stdlib logger. With structlog there's conflict of
@@ -500,22 +501,33 @@ class APIServer(Runnable):
 
         self.wsgiserver = wsgiserver
 
-        log.debug('REST API started', node=pex(self.rest_api.raiden_api.address))
+        log.debug(
+            'REST API started',
+            host=self.config['host'],
+            port=self.config['port'],
+            node=pex(self.rest_api.raiden_api.address),
+        )
 
         super().start()
 
     def stop(self):
         log.debug(
-            'Stopping rest api',
+            'REST API stoping',
             host=self.config['host'],
             port=self.config['port'],
+            node=pex(self.rest_api.raiden_api.address),
         )
 
         if self.wsgiserver is not None:
             self.wsgiserver.stop()
             self.wsgiserver = None
 
-        log.debug('REST API stopped', node=pex(self.rest_api.raiden_api.address))
+        log.debug(
+            'REST API stopped',
+            host=self.config['host'],
+            port=self.config['port'],
+            node=pex(self.rest_api.raiden_api.address),
+        )
 
     def unhandled_exception(self, exception: Exception):
         """ Flask.errorhandler when an exception wasn't correctly handled """

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -228,8 +228,6 @@ class UDPTransport(Runnable):
         self.log.debug('UDP started')
         super().start()
 
-        log.debug('UDP transport started')
-
     def _run(self):  # pylint: disable=method-hidden
         """ Runnable main method, perform wait on long-running subtasks """
         try:
@@ -273,7 +271,7 @@ class UDPTransport(Runnable):
         for async_result in self.messageids_to_asyncresults.values():
             async_result.set(False)
 
-        log.debug('UDP stopped', node=pex(self.raiden.address))
+        self.log.debug('UDP stopped')
         del self.log_healthcheck
         del self.log
 


### PR DESCRIPTION
Very small commit cherry-picked from the crash stress test.

Most of the changes have been done in other PRs, this just make the log lines consistent and remove a duplicated from the udp transport.