### PR TITLE
Netting channel canonical constructor

### DIFF
--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -3,6 +3,7 @@ from raiden.transfer.state import (
     NettingChannelState,
     TransactionExecutionStatus,
 )
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.typing import (
     BlockHash,
     BlockNumber,
@@ -10,7 +11,6 @@ from raiden.utils.typing import (
     PaymentNetworkID,
     TokenAddress,
     TokenNetworkAddress,
-    TokenNetworkID,
 )
 
 
@@ -62,11 +62,13 @@ def get_channel_state(
     settle_transaction = None
 
     channel = NettingChannelState(
-        identifier=identifier,
-        chain_id=channel_details.chain_id,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=channel_details.chain_id,
+            token_network_address=token_network_address,
+            channel_identifier=identifier,
+        ),
         token_address=token_address,
         payment_network_identifier=payment_network_identifier,
-        token_network_identifier=TokenNetworkID(token_network_address),
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
         our_state=our_state,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -771,11 +771,12 @@ def test_invalid_timeouts():
         small_settle_timeout = 49
 
         NettingChannelState(
-            identifier=identifier,
-            chain_id=UNIT_CHAIN_ID,
+            canonical_identifier=make_canonical_identifier(
+                token_network_address=token_network_identifier,
+                channel_identifier=identifier,
+            ),
             token_address=token_address,
             payment_network_identifier=payment_network_identifier,
-            token_network_identifier=token_network_identifier,
             reveal_timeout=large_reveal_timeout,
             settle_timeout=small_settle_timeout,
             our_state=our_state,
@@ -789,11 +790,12 @@ def test_invalid_timeouts():
     for invalid_value in (-1, 0, 1.1, 1.0):
         with pytest.raises(ValueError):
             NettingChannelState(
-                identifier=identifier,
-                chain_id=UNIT_CHAIN_ID,
+                canonical_identifier=make_canonical_identifier(
+                    token_network_address=token_network_identifier,
+                    channel_identifier=identifier,
+                ),
                 token_address=token_address,
                 payment_network_identifier=payment_network_identifier,
-                token_network_identifier=token_network_identifier,
                 reveal_timeout=invalid_value,
                 settle_timeout=settle_timeout,
                 our_state=our_state,
@@ -805,11 +807,12 @@ def test_invalid_timeouts():
 
         with pytest.raises(ValueError):
             NettingChannelState(
-                identifier=identifier,
-                chain_id=UNIT_CHAIN_ID,
+                canonical_identifier=make_canonical_identifier(
+                    token_network_address=token_network_identifier,
+                    channel_identifier=identifier,
+                ),
                 token_address=token_address,
                 payment_network_identifier=payment_network_identifier,
-                token_network_identifier=token_network_identifier,
                 reveal_timeout=reveal_timeout,
                 settle_timeout=invalid_value,
                 our_state=our_state,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -22,6 +22,7 @@ from raiden.tests.utils.factories import (
     NettingChannelStateProperties,
     TransactionExecutionStatusProperties,
     create,
+    make_canonical_identifier,
     make_secret,
 )
 from raiden.tests.utils.transfer import make_receive_expired_lock, make_receive_transfer_mediated

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -1,7 +1,7 @@
 import pytest
 
 from raiden.messages import Ping, RequestMonitoring, SignedBlindedBalanceProof, UpdatePFS
-from raiden.tests.utils.factories import make_privkey_address
+from raiden.tests.utils.factories import make_canonical_identifier, make_privkey_address
 from raiden.tests.utils.messages import (
     ADDRESS as PARTNER_ADDRESS,
     MEDIATED_TRANSFER_INVALID_VALUES,
@@ -18,7 +18,6 @@ from raiden.transfer.balance_proof import (
     pack_reward_proof,
 )
 from raiden.transfer.state import BalanceProofUnsignedState
-from raiden.utils import CanonicalIdentifier
 from raiden.utils.signer import LocalSigner, recover
 
 PRIVKEY, ADDRESS = make_privkey_address()
@@ -110,7 +109,7 @@ def test_request_monitoring():
         nonce=request_monitoring.balance_proof.nonce,
         balance_hash=request_monitoring.balance_proof.balance_hash,
         additional_hash=request_monitoring.balance_proof.additional_hash,
-        canonical_identifier=CanonicalIdentifier(
+        canonical_identifier=make_canonical_identifier(
             chain_identifier=request_monitoring.balance_proof.chain_id,
             token_network_address=request_monitoring.balance_proof.token_network_address,
             channel_identifier=request_monitoring.balance_proof.channel_identifier,
@@ -123,7 +122,7 @@ def test_request_monitoring():
         nonce=request_monitoring.balance_proof.nonce,
         balance_hash=request_monitoring.balance_proof.balance_hash,
         additional_hash=request_monitoring.balance_proof.additional_hash,
-        canonical_identifier=CanonicalIdentifier(
+        canonical_identifier=make_canonical_identifier(
             chain_identifier=request_monitoring.balance_proof.chain_id,
             token_network_address=request_monitoring.balance_proof.token_network_address,
             channel_identifier=request_monitoring.balance_proof.channel_identifier,

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -25,7 +25,7 @@ from raiden.transfer.utils import (
     get_event_with_balance_proof_by_balance_hash,
     get_state_change_with_balance_proof_by_balance_hash,
 )
-from raiden.utils import CanonicalIdentifier, sha3
+from raiden.utils import sha3
 
 
 def make_signed_balance_proof_from_counter(counter):
@@ -55,7 +55,7 @@ def make_balance_proof_from_counter(counter) -> BalanceProofUnsignedState:
         transferred_amount=next(counter),
         locked_amount=next(counter),
         locksroot=sha3(next(counter).to_bytes(1, 'big')),
-        canonical_identifier=CanonicalIdentifier(
+        canonical_identifier=factories.make_canonical_identifier(
             chain_identifier=next(counter),
             token_network_address=factories.make_address(),
             channel_identifier=next(counter),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -33,6 +33,7 @@ from raiden.tests.utils.factories import (
     NettingChannelStateProperties,
     create,
     create_properties,
+    make_canonical_identifier,
     make_channel_set,
     mediator_make_channel_pair,
     mediator_make_init_action,
@@ -188,12 +189,25 @@ def test_next_route_amount():
 def test_next_route_reveal_timeout():
     """ Routes with a larger reveal timeout than timeout_blocks must be ignored. """
     timeout_blocks = 10
+    identifiers = [make_canonical_identifier(channel_identifier=i) for i in range(1, 5)]
 
     channels = make_channel_set([
-        NettingChannelStateProperties(identifier=1, reveal_timeout=timeout_blocks * 2),
-        NettingChannelStateProperties(identifier=2, reveal_timeout=timeout_blocks + 1),
-        NettingChannelStateProperties(identifier=3, reveal_timeout=timeout_blocks // 2),
-        NettingChannelStateProperties(identifier=4, reveal_timeout=timeout_blocks),
+        NettingChannelStateProperties(
+            canonical_identifier=identifiers[0],
+            reveal_timeout=timeout_blocks * 2,
+        ),
+        NettingChannelStateProperties(
+            canonical_identifier=identifiers[1],
+            reveal_timeout=timeout_blocks + 1,
+        ),
+        NettingChannelStateProperties(
+            canonical_identifier=identifiers[2],
+            reveal_timeout=timeout_blocks // 2,
+        ),
+        NettingChannelStateProperties(
+            canonical_identifier=identifiers[3],
+            reveal_timeout=timeout_blocks,
+        ),
     ])
 
     chosen_channel = mediator.next_channel_from_routes(
@@ -979,18 +993,18 @@ def test_mediator_secret_reveal_empty_hash():
 def test_no_valid_routes():
     channels = make_channel_set([
         NettingChannelStateProperties(
-            identifier=1,
+            canonical_identifier=make_canonical_identifier(channel_identifier=1),
             partner_state=NettingChannelEndStateProperties(
                 balance=UNIT_TRANSFER_AMOUNT,
                 address=UNIT_TRANSFER_SENDER,
             ),
         ),
         NettingChannelStateProperties(
-            identifier=2,
+            make_canonical_identifier(channel_identifier=2),
             our_state=NettingChannelEndStateProperties(balance=UNIT_TRANSFER_AMOUNT - 1),
         ),
         NettingChannelStateProperties(
-            identifier=3,
+            make_canonical_identifier(channel_identifier=3),
             our_state=NettingChannelEndStateProperties(balance=0),
         ),
     ])
@@ -1362,14 +1376,14 @@ def test_mediate_transfer_with_maximum_pending_transfers_exceeded():
     balance = 2 * MAXIMUM_PENDING_TRANSFERS * UNIT_TRANSFER_AMOUNT
     channels = make_channel_set([
         NettingChannelStateProperties(
-            identifier=1,
+            make_canonical_identifier(channel_identifier=1),
             partner_state=NettingChannelEndStateProperties(
                 balance=balance,
                 address=UNIT_TRANSFER_SENDER,
             ),
         ),
         NettingChannelStateProperties(
-            identifier=2,
+            make_canonical_identifier(channel_identifier=2),
             our_state=NettingChannelEndStateProperties(balance=balance),
         ),
     ])

--- a/raiden/tests/unit/transfer/test_state_diff.py
+++ b/raiden/tests/unit/transfer/test_state_diff.py
@@ -47,10 +47,8 @@ def test_detect_balance_proof_change():
     assert len(diff()) == 0
 
     channel = NettingChannelState(
-        1,
-        0,
+        factories.make_canonical_identifier(),
         b'a',
-        1,
         1,
         1,
         2,

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -274,8 +274,7 @@ def make_transfer(
         transferred_amount=transferred_amount,
         locked_amount=locked_amount,
         locksroot=locksroot,
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=UNIT_CHAIN_ID,
+        canonical_identifier=make_canonical_identifier(
             token_network_address=token_network_identifier,
             channel_identifier=channel_identifier,
         ),
@@ -437,8 +436,7 @@ def make_signed_balance_proof(
         nonce=nonce,
         balance_hash=balance_hash,
         additional_hash=extra_hash,
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=UNIT_CHAIN_ID,
+        canonical_identifier=make_canonical_identifier(
             token_network_address=token_network_address,
             channel_identifier=channel_identifier,
         ),
@@ -454,8 +452,7 @@ def make_signed_balance_proof(
         message_hash=extra_hash,
         signature=signature,
         sender=sender_address,
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=UNIT_CHAIN_ID,
+        canonical_identifier=make_canonical_identifier(
             token_network_address=token_network_address,
             channel_identifier=channel_identifier,
         ),
@@ -721,7 +718,7 @@ def _(properties: BalanceProofSignedStateProperties, defaults=None) -> BalancePr
         keys = ('transferred_amount', 'locked_amount', 'locksroot')
         balance_hash = hash_balance_data(**_partial_dict(params, *keys))
 
-        canonical_identifier = CanonicalIdentifier(
+        canonical_identifier = make_canonical_identifier(
             chain_identifier=params.pop('chain_id'),
             token_network_address=params.pop('token_network_identifier'),
             channel_identifier=params.pop('channel_identifier'),
@@ -778,7 +775,7 @@ def _(properties, defaults=None) -> LockedTransferUnsignedState:
         parameters.pop('balance_proof'),
         defaults.balance_proof,
     )
-    balance_proof_parameters['canonical_identifier'] = CanonicalIdentifier(
+    balance_proof_parameters['canonical_identifier'] = make_canonical_identifier(
         chain_identifier=balance_proof_parameters.pop('chain_id'),
         token_network_address=balance_proof_parameters.pop('token_network_identifier'),
         channel_identifier=balance_proof_parameters.pop('channel_identifier'),

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -518,6 +518,18 @@ RANDOM_FACTORIES = {
 }
 
 
+def make_canonical_identifier(
+        chain_identifier=UNIT_CHAIN_ID,
+        token_network_address=UNIT_TOKEN_NETWORK_ADDRESS,
+        channel_identifier=UNIT_CHANNEL_ID,
+) -> CanonicalIdentifier:
+    return CanonicalIdentifier(
+        chain_identifier=chain_identifier,
+        token_network_address=token_network_address,
+        channel_identifier=channel_identifier,
+    )
+
+
 def make_merkletree_leaves(width: int) -> typing.List[typing.Secret]:
     return [make_secret() for _ in range(width)]
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -183,11 +183,12 @@ def make_channel_state(
     )
 
     return NettingChannelState(
-        identifier=channel_identifier,
-        chain_id=UNIT_CHAIN_ID,
+        canonical_identifier=make_canonical_identifier(
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
         token_address=token_address,
         payment_network_identifier=payment_network_identifier,
-        token_network_identifier=token_network_identifier,
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
         our_state=our_state,
@@ -622,11 +623,9 @@ def _(properties, defaults=None) -> NettingChannelEndState:
 
 
 class NettingChannelStateProperties(NamedTuple):
-    identifier: typing.ChannelID = EMPTY
-    chain_id: typing.ChainID = EMPTY
+    canonical_identifier: CanonicalIdentifier = EMPTY
     token_address: typing.TokenAddress = EMPTY
     payment_network_identifier: typing.PaymentNetworkID = EMPTY
-    token_network_identifier: typing.TokenNetworkID = EMPTY
 
     reveal_timeout: typing.BlockTimeout = EMPTY
     settle_timeout: typing.BlockTimeout = EMPTY
@@ -640,11 +639,9 @@ class NettingChannelStateProperties(NamedTuple):
 
 
 NETTING_CHANNEL_STATE_DEFAULTS = NettingChannelStateProperties(
-    identifier=UNIT_CHANNEL_ID,
-    chain_id=UNIT_CHAIN_ID,
+    canonical_identifier=make_canonical_identifier(),
     token_address=UNIT_TOKEN_ADDRESS,
     payment_network_identifier=UNIT_PAYMENT_NETWORK_IDENTIFIER,
-    token_network_identifier=UNIT_TOKEN_NETWORK_ADDRESS,
     reveal_timeout=UNIT_REVEAL_TIMEOUT,
     settle_timeout=UNIT_SETTLE_TIMEOUT,
     our_state=NETTING_CHANNEL_END_STATE_DEFAULTS,
@@ -1033,14 +1030,14 @@ def mediator_make_channel_pair(
 ) -> ChannelSet:
     properties_list = [
         NettingChannelStateProperties(
-            identifier=1,
+            canonical_identifier=make_canonical_identifier(channel_identifier=1),
             partner_state=NettingChannelEndStateProperties(
                 address=UNIT_TRANSFER_SENDER,
                 balance=amount,
             ),
         ),
         NettingChannelStateProperties(
-            identifier=2,
+            canonical_identifier=make_canonical_identifier(channel_identifier=2),
             our_state=NettingChannelEndStateProperties(balance=amount),
             partner_state=NettingChannelEndStateProperties(address=UNIT_TRANSFER_TARGET),
         ),
@@ -1082,7 +1079,7 @@ def make_transfers_pair(
     ))
     properties_list = [
         NettingChannelStateProperties(
-            identifier=i,
+            canonical_identifier=make_canonical_identifier(channel_identifier=i),
             our_state=NettingChannelEndStateProperties(
                 address=ChannelSet.ADDRESSES[0],
                 privatekey=ChannelSet.PKEYS[0],

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1394,7 +1394,7 @@ def events_for_close(
         close_event = ContractSendChannelClose(
             channel_identifier=channel_state.identifier,
             token_address=channel_state.token_address,
-            token_network_identifier=channel_state.token_network_identifier,
+            token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
             balance_proof=balance_proof,
             triggered_by_block_hash=block_hash,
         )
@@ -1463,7 +1463,7 @@ def events_for_expired_lock(
         locked_lock=locked_lock,
         pseudo_random_generator=pseudo_random_generator,
         chain_id=channel_state.chain_id,
-        token_network_identifier=channel_state.token_network_identifier,
+        token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
         channel_identifier=channel_state.identifier,
         recipient=channel_state.partner_state.address,
     )
@@ -1808,7 +1808,7 @@ def handle_channel_closed(
             update = ContractSendChannelUpdateTransfer(
                 expiration=expiration,
                 channel_identifier=channel_state.identifier,
-                token_network_identifier=channel_state.token_network_identifier,
+                token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
                 balance_proof=balance_proof,
                 triggered_by_block_hash=state_change.block_hash,
             )
@@ -1856,7 +1856,7 @@ def handle_channel_settled(
         if not is_settle_pending and merkle_tree_leaves:
             onchain_unlock = ContractSendChannelBatchUnlock(
                 token_address=channel_state.token_address,
-                token_network_identifier=channel_state.token_network_identifier,
+                token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
                 channel_identifier=channel_state.identifier,
                 participant=channel_state.partner_state.address,
                 triggered_by_block_hash=state_change.block_hash,

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -42,6 +42,7 @@ from raiden.utils.typing import (
     Secret,
     SecretHash,
     TokenAmount,
+    TokenNetworkID,
     cast,
 )
 
@@ -69,7 +70,7 @@ def events_for_unlock_lock(
 
     payment_sent_success = EventPaymentSentSuccess(
         payment_network_identifier=channel_state.payment_network_identifier,
-        token_network_identifier=channel_state.token_network_identifier,
+        token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
         identifier=transfer_description.payment_identifier,
         amount=transfer_description.amount,
         target=transfer_description.target,

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -20,7 +20,15 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.state import NettingChannelState, message_identifier_from_prng
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, ReceiveUnlock
 from raiden.transfer.utils import is_valid_secret_reveal
-from raiden.utils.typing import MYPY_ANNOTATION, Address, BlockHash, BlockNumber, List, Optional
+from raiden.utils.typing import (
+    MYPY_ANNOTATION,
+    Address,
+    BlockHash,
+    BlockNumber,
+    List,
+    Optional,
+    TokenNetworkID,
+)
 
 
 def sanity_check(
@@ -245,7 +253,7 @@ def handle_unlock(
         transfer = target_state.transfer
         payment_received_success = EventPaymentReceivedSuccess(
             payment_network_identifier=channel_state.payment_network_identifier,
-            token_network_identifier=channel_state.token_network_identifier,
+            token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
             identifier=transfer.payment_identifier,
             amount=transfer.lock.amount,
             initiator=transfer.initiator,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1517,11 +1517,9 @@ class NettingChannelState(State):
 
     def __init__(
             self,
-            identifier: ChannelID,
-            chain_id: ChainID,
+            canonical_identifier: CanonicalIdentifier,
             token_address: TokenAddress,
             payment_network_identifier: PaymentNetworkID,
-            token_network_identifier: TokenNetworkID,
             reveal_timeout: BlockTimeout,
             settle_timeout: BlockTimeout,
             our_state: NettingChannelEndState,
@@ -1531,6 +1529,9 @@ class NettingChannelState(State):
             settle_transaction: TransactionExecutionStatus = None,
             update_transaction: TransactionExecutionStatus = None,
     ):
+        chain_id = canonical_identifier.chain_identifier
+        identifier = canonical_identifier.channel_identifier
+        token_network_identifier = canonical_identifier.token_network_address
 
         if reveal_timeout >= settle_timeout:
             raise ValueError('reveal_timeout must be smaller than settle_timeout')
@@ -1656,11 +1657,13 @@ class NettingChannelState(State):
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'NettingChannelState':
         restored = cls(
-            identifier=ChannelID(int(data['identifier'])),
-            chain_id=data['chain_id'],
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=data['chain_id'],
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['identifier'])),
+            ),
             token_address=to_canonical_address(data['token_address']),
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
             reveal_timeout=int(data['reveal_timeout']),
             settle_timeout=int(data['settle_timeout']),
             our_state=data['our_state'],

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -32,6 +32,23 @@ class CanonicalIdentifier(NamedTuple):
     token_network_address: Union[typing.TokenNetworkAddress, typing.TokenNetworkID]
     channel_identifier: typing.ChannelID
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return dict(
+            chain_identifier=str(self.chain_identifier),
+            token_network_address=encode_hex(self.token_network_address),
+            channel_identifier=str(self.channel_identifier),
+        )
+
+    @classmethod
+    def from_dict(cls, data: typing.Dict[str, typing.Any]) -> 'CanonicalIdentifier':
+        return cls(
+            chain_identifier=typing.ChainID(int(data['chain_identifier'])),
+            token_network_address=typing.TokenNetworkAddress(
+                decode_hex(data['token_network_address']),
+            ),
+            channel_identifier=typing.ChannelID(int(data['channel_identifier'])),
+        )
+
 
 def random_secret():
     """ Return a random 32 byte secret except the 0 secret since it's not accepted in the contracts


### PR DESCRIPTION
This adds usage of `CanonicalIdentifier` in the constructor of `NettingChannelState`.
It does **not** change serialization behavior and therefore should not need migrations.

It also adds a factory method for use in tests, `make_canonical_identifier` that allows for minimally specified identifiers (uses default unit test values for unspecified attributes). Using the factory in tests also has the benefit of minimizing the changes, that would be necessary if the import path of `CanonicalIdentifier` should ever change.

This is a follow-up to #3584 and should be reviewed/merged only after it. 