### PR TITLE
Skip test when running `pytest --pdb`

### DIFF
--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -336,7 +336,7 @@ def test_matrix_message_sync(
     transport1.get()
 
 
-@pytest.mark.skipif(pytest.config.getvalue('usepdb'), reason='test fails with pdb')
+@pytest.mark.skipif(getattr(pytest, 'config').getvalue('usepdb'), reason='test fails with pdb')
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_tokens', [1])

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -336,6 +336,7 @@ def test_matrix_message_sync(
     transport1.get()
 
 
+@pytest.mark.skipif(pytest.config.getvalue('usepdb'), reason='test fails with pdb')
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_tokens', [1])


### PR DESCRIPTION
Our `--pdb` hook for debugging greenlets interferes with the test logic in `test_matrix_tx_error_handling`. To spare other developers from debugging a non existing test failure, I marked the test to skip if run with the `--pdb` option.