### PR TITLE
Disable debug logfile in automated ci tests

### DIFF
--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -75,6 +75,7 @@ def cli_args(raiden_testchain, removed_args, changed_args):
         initial_args['secret_registry_contract_address'],
         '--endpoint-registry-contract-address',
         initial_args['endpoint_registry_contract_address'],
+        '--disable-debug-logfile',
     ]
 
     for arg_name, arg_value in initial_args.items():


### PR DESCRIPTION
In the past, the `raiden/tests/integration/cli/test_cli_*` family created `raiden-debug*` logfiles in the project directory. Since there aren't any assertions on the creation of the debug log, I just disabled them via `--disable-debug-logfile` in the `cli_args` fixture.