### PR TITLE
enabled stacktrace reporting by default

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -49,14 +49,6 @@ def pytest_addoption(parser):
         help='Run integration tests with udp, with matrix, with both or not at all.',
     )
 
-    parser.addoption(
-        '--gevent-monitoring-signal',
-        action='store_true',
-        dest='gevent_monitoring_signal',
-        default=False,
-        help='Install a SIGUSR1 signal handler to print gevent run_info.',
-    )
-
 
 @pytest.fixture(scope='session', autouse=True)
 def enable_gevent_monitoring_signal(request):
@@ -65,14 +57,13 @@ def enable_gevent_monitoring_signal(request):
     See http://www.gevent.org/monitoring.html for more information.
 
     Usage:
-        pytest [...] --gevent-monitoring-signal
+        pytest [...]
         # while test is running (or stopped in a pdb session):
         kill -SIGUSR1 $(pidof -x pytest)
     """
-    if request.config.option.gevent_monitoring_signal:
-        import gevent.util
-        import signal
-        signal.signal(signal.SIGUSR1, gevent.util.print_run_info)
+    import gevent.util
+    import signal
+    signal.signal(signal.SIGUSR1, gevent.util.print_run_info)
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
The signal is not used by anything else in the application, and for long running tests that may fail it's preferable to have it enabled instead of having to run a new test session with the flag.