### PR TITLE
Make smoketest test dependencies independent of pytest

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -88,7 +88,6 @@ pyopenssl==18.0.0
 pysaml2==4.6.5
 pysha3==1.0.2
 pystun-patched-for-raiden==0.1.0
-pytest==4.1.1
 python-dateutil==2.7.5
 pytoml==0.1.19
 pytz==2018.5

--- a/raiden/tests/fixtures/constants.py
+++ b/raiden/tests/fixtures/constants.py
@@ -1,0 +1,6 @@
+from eth_utils import denoms
+
+DEFAULT_PASSPHRASE = 'notsosecret'  # Geth's account passphrase
+
+DEFAULT_BALANCE = denoms.ether * 10  # pylint: disable=no-member
+DEFAULT_BALANCE_BIN = str(DEFAULT_BALANCE)

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -4,7 +4,7 @@ import random
 from enum import Enum
 
 import pytest
-from eth_utils import denoms, remove_0x_prefix, to_normalized_address
+from eth_utils import remove_0x_prefix, to_normalized_address
 
 from raiden.constants import Environment
 from raiden.network.utils import get_free_port
@@ -20,10 +20,6 @@ from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIME
 
 # we need to use fixture for the default values otherwise
 # pytest.mark.parametrize won't work (pytest 2.9.2)
-
-DEFAULT_BALANCE = denoms.ether * 10  # pylint: disable=no-member
-DEFAULT_BALANCE_BIN = str(DEFAULT_BALANCE)
-DEFAULT_PASSPHRASE = 'notsosecret'  # Geth's account passphrase
 
 RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT = int(0.075 * 10 ** 18)
 

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -14,7 +14,7 @@ from eth_keyfile import create_keyfile_json
 from eth_utils import encode_hex, remove_0x_prefix, to_checksum_address, to_normalized_address
 from web3 import Web3
 
-from raiden.tests.fixtures.variables import DEFAULT_BALANCE_BIN, DEFAULT_PASSPHRASE
+from raiden.tests.fixtures.constants import DEFAULT_BALANCE_BIN, DEFAULT_PASSPHRASE
 from raiden.tests.utils.genesis import GENESIS_STUB, PARITY_CHAIN_SPEC_STUB
 from raiden.utils import privatekey_to_address, privatekey_to_publickey
 from raiden.utils.typing import Any, Dict, List, NamedTuple

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -25,7 +25,7 @@ from raiden.network.proxies import TokenNetworkRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.utils import get_free_port
 from raiden.raiden_service import RaidenService
-from raiden.tests.fixtures.variables import DEFAULT_PASSPHRASE
+from raiden.tests.fixtures.constants import DEFAULT_PASSPHRASE
 from raiden.tests.utils.eth_node import (
     EthNodeDescription,
     eth_node_config,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@
 -r requirements-docs.txt
 
 # Testing
+pytest==4.1.1
 pytest-cov==2.5.1
 pytest-random==0.02
 pytest-timeout==1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ py-geth
 pysha3
 py-solc
 pystun-patched-for-raiden
-pytest
 pytoml
 raiden-contracts
 raiden-webui


### PR DESCRIPTION
`smoketest` does not need `pytest`, but some of its imports did also import `pytest`. Since it were only three constants, I could just move them into an independent module and allow for pytest free smoketest execution:
    
    python -m raiden smoketest
or

    raiden smoketest
    
now work without `pytest` being installed.

cross-ref #3580 