### PR TITLE
Fixed skipif mark

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -180,11 +180,10 @@ def pytest_generate_tests(metafunc):
         transport = metafunc.config.getoption('transport')
         transport_and_privacy = list()
 
-        # avoid collecting test if 'skip_if_not_*'
-        if transport in ('udp', 'all') and 'skip_if_not_matrix' not in metafunc.fixturenames:
+        if transport in ('udp', 'all'):
             transport_and_privacy.append(('udp', None))
 
-        if transport in ('matrix', 'all') and 'skip_if_not_udp' not in metafunc.fixturenames:
+        if transport in ('matrix', 'all'):
             if 'public_and_private_rooms' in metafunc.fixturenames:
                 transport_and_privacy.extend([('matrix', False), ('matrix', True)])
             else:

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -351,26 +351,3 @@ def transport(request):
 @pytest.fixture
 def transport_protocol(transport):
     return TransportProtocol(transport)
-
-
-@pytest.fixture
-def skip_if_not_udp(request):
-    """Skip the test if not run with UDP transport"""
-    if request.config.option.transport in ('udp', 'all'):
-        return
-    pytest.skip('This test works only with UDP transport')
-
-
-@pytest.fixture
-def skip_if_not_matrix(request):
-    """Skip the test if not run with Matrix transport"""
-    if request.config.option.transport in ('matrix', 'all'):
-        return
-    pytest.skip('This test works only with Matrix transport')
-
-
-@pytest.fixture
-def skip_if_parity(blockchain_type):
-    """Skip the test if it is run with a Parity node"""
-    if blockchain_type == 'parity':
-        pytest.skip('This test does not work with parity.')

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -582,13 +582,16 @@ def test_api_open_close_and_settle_channel(
     assert check_dict_nested_attrs(response.json(), expected_response)
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_api_close_insufficient_eth(
         api_server_test_instance,
         token_addresses,
         reveal_timeout,
-        skip_if_parity,
 ):
     # FIXME parity version of this test fails:
     # parity reports 'insufficient funds' correctly but raiden does not recognize it.
@@ -1265,6 +1268,10 @@ def test_register_token_mainnet(
     )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('number_of_tokens', [0])
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
@@ -1275,7 +1282,6 @@ def test_register_token(
         token_addresses,
         raiden_network,
         contract_manager,
-        skip_if_parity,
 ):
     app0 = raiden_network[0]
     new_token_address = deploy_contract_web3(
@@ -1332,6 +1338,10 @@ def test_register_token(
     assert_response_with_error(poor_response, HTTPStatus.PAYMENT_REQUIRED)
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('number_of_tokens', [0])
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
@@ -1342,7 +1352,6 @@ def test_get_token_network_for_token(
         token_addresses,
         raiden_network,
         contract_manager,
-        skip_if_parity,
 ):
     app0 = raiden_network[0]
 

--- a/raiden/tests/integration/contracts/test_payment_channel.py
+++ b/raiden/tests/integration/contracts/test_payment_channel.py
@@ -12,6 +12,10 @@ from raiden.utils.signer import LocalSigner
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 def test_payment_channel_proxy_basics(
         token_network_proxy,
         private_keys,
@@ -19,7 +23,6 @@ def test_payment_channel_proxy_basics(
         chain_id,
         web3,
         contract_manager,
-        skip_if_parity,
 ):
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
@@ -152,13 +155,16 @@ def test_payment_channel_proxy_basics(
     assert len(events) == 4  # ChannelOpened, ChannelNewDeposit, ChannelClosed, ChannelSettled
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 def test_payment_channel_outdated_channel_close(
         token_network_proxy,
         private_keys,
         chain_id,
         web3,
         contract_manager,
-        skip_if_parity,
 ):
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 

--- a/raiden/tests/integration/contracts/test_token_network.py
+++ b/raiden/tests/integration/contracts/test_token_network.py
@@ -64,6 +64,10 @@ def test_token_network_deposit_race(
         )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 def test_token_network_proxy_basics(
         token_network_proxy,
         private_keys,
@@ -71,7 +75,6 @@ def test_token_network_proxy_basics(
         chain_id,
         web3,
         contract_manager,
-        skip_if_parity,
 ):
     # check settlement timeouts
     assert token_network_proxy.settlement_timeout_min() == TEST_SETTLE_TIMEOUT_MIN
@@ -362,6 +365,10 @@ def test_token_network_proxy_basics(
         assert 'getChannelIdentifier returned 0' in str(exc)
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 def test_token_network_proxy_update_transfer(
         token_network_proxy,
         private_keys,
@@ -369,7 +376,6 @@ def test_token_network_proxy_update_transfer(
         chain_id,
         web3,
         contract_manager,
-        skip_if_parity,
 ):
     """Tests channel lifecycle, with `update_transfer` before settling"""
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)

--- a/raiden/tests/integration/contracts/test_token_network_registry.py
+++ b/raiden/tests/integration/contracts/test_token_network_registry.py
@@ -8,11 +8,14 @@ from raiden.tests.utils.smartcontracts import deploy_token
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 def test_token_network_registry(
         deploy_client,
         contract_manager,
         token_network_registry_address,
-        skip_if_parity,
 ):
     registry_address = to_canonical_address(token_network_registry_address)
 

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -397,9 +397,13 @@ def test_batch_unlock(
     assert token_proxy.balance_of(bob_app.raiden.address) == bob_new_balance
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
-def test_settled_lock(token_addresses, raiden_network, deposit, skip_if_parity):
+def test_settled_lock(token_addresses, raiden_network, deposit):
     """ Any transfer following a secret reveal must update the locksroot, so
     that an attacker cannot reuse a secret to double claim a lock.
     """

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -347,6 +347,10 @@ def assert_channels(raiden_network, token_network_identifier, deposit):
         )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP specific test',
+)
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('number_of_tokens', [1])
 @pytest.mark.parametrize('channels_per_node', [2])
@@ -360,7 +364,6 @@ def test_stress(
         retry_timeout,
         token_addresses,
         port_generator,
-        skip_if_not_udp,  # pylint: disable=unused-argument
 ):
 
     config_converter = LogLevelConfigType()

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -71,6 +71,10 @@ def saturated_count(connection_managers, registry_address, token_address):
 # - Check if this test needs to be adapted for the matrix transport
 #   layer when activating it again. It might as it depends on the
 #   raiden_network fixture.
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('number_of_nodes', [6])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('settle_timeout', [6])
@@ -78,7 +82,6 @@ def saturated_count(connection_managers, registry_address, token_address):
 def test_participant_selection(  # pylint: disable=too-many-locals
         raiden_network,
         token_addresses,
-        skip_if_parity,
 ):
     registry_address = raiden_network[0].raiden.default_registry.address
     token_address = token_addresses[0]

--- a/raiden/tests/integration/network/transport/test_udp.py
+++ b/raiden/tests/integration/network/transport/test_udp.py
@@ -5,8 +5,12 @@ from raiden.messages import Ping
 from raiden.transfer import state, views
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP specific test',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
-def test_udp_reachable_node(raiden_network, skip_if_not_udp):
+def test_udp_reachable_node(raiden_network):
     """A node that answers the ping message must have its state set to
     reachable.
     """
@@ -31,8 +35,12 @@ def test_udp_reachable_node(raiden_network, skip_if_not_udp):
     assert network_state is state.NODE_NETWORK_REACHABLE
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP specific test',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
-def test_udp_unreachable_node(raiden_network, skip_if_not_udp):
+def test_udp_unreachable_node(raiden_network):
     """A node that does *not* answer the ping message must have its state set to
     reachable.
     """
@@ -66,10 +74,14 @@ def test_udp_unreachable_node(raiden_network, skip_if_not_udp):
     assert network_state is state.NODE_NETWORK_UNREACHABLE
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Parity not supported',
+)
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('number_of_tokens', [1])
-def test_suite_survives_unhandled_exception(raiden_network, skip_if_parity):
+def test_suite_survives_unhandled_exception(raiden_network):
     """ Commit 56a617085e59fc88517e7043b629ffc9dcc0b8c4 removed code that changed
     gevent's SYSTEM_ERROR for tests. This test aims to show that there is no regression. """
     class UnhandledTestException(Exception):

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from eth_utils import decode_hex, to_checksum_address
 
@@ -56,7 +57,11 @@ def get_list_of_block_numbers(item):
     return list()
 
 
-def test_call_invalid_selector(deploy_client, skip_if_parity):
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
+def test_call_invalid_selector(deploy_client):
     """ A JSON RPC call to a valid address but with an invalid selector returns
     the empty string.
     """
@@ -91,7 +96,11 @@ def test_call_inexisting_address(deploy_client):
     assert deploy_client.web3.eth.call(transaction) == b''
 
 
-def test_call_throws(deploy_client, skip_if_parity):
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
+def test_call_throws(deploy_client):
     """ A JSON RPC call to a function that throws returns the empty string. """
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
@@ -101,7 +110,11 @@ def test_call_throws(deploy_client, skip_if_parity):
     assert call() == []
 
 
-def test_estimate_gas_fail(deploy_client, skip_if_parity):
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
+def test_estimate_gas_fail(deploy_client):
     """ A JSON RPC estimate gas call for a throwing transaction returns None"""
     contract_proxy = deploy_rpc_test_contract(deploy_client)
 
@@ -112,7 +125,11 @@ def test_estimate_gas_fail(deploy_client, skip_if_parity):
     assert not contract_proxy.estimate_gas(check_block, 'fail')
 
 
-def test_duplicated_transaction_same_gas_price_raises(deploy_client, skip_if_parity):
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
+def test_duplicated_transaction_same_gas_price_raises(deploy_client):
     """ If the same transaction is sent twice a JSON RPC error is raised. """
     gas_price = 2000000000
     gas_price_strategy = make_fixed_gas_price_strategy(gas_price)

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -43,7 +43,10 @@ USERID1 = '@Alice:Wonderland'
 
 
 # All tests in this module require matrix
-pytestmark = pytest.mark.usefixtures('skip_if_not_matrix')
+pytestmark = pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='Test does not work with UDP',
+)
 
 
 class MessageHandler:
@@ -336,13 +339,22 @@ def test_matrix_message_sync(
     transport1.get()
 
 
-@pytest.mark.skipif(getattr(pytest, 'config').getvalue('usepdb'), reason='test fails with pdb')
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('usepdb'),
+    reason='test fails with pdb',
+)
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') != 'matrix',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_tokens', [1])
 def test_matrix_tx_error_handling(
-        skip_if_not_matrix,
-        skip_if_parity,
         raiden_chain,
         token_addresses,
 ):

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -87,6 +87,10 @@ def test_register_token(raiden_network, token_amount, contract_manager, retry_ti
         api1.token_network_register(registry_address, token_address)
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('blockchain_type') == 'parity',
+    reason='Test does not work with parity',
+)
 @pytest.mark.parametrize('privatekey_seed', ['test_token_registration:{}'])
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
@@ -95,7 +99,6 @@ def test_register_token_insufficient_eth(
         raiden_network,
         token_amount,
         contract_manager,
-        skip_if_parity,
 ):
     app1 = raiden_network[0]
 
@@ -378,6 +381,10 @@ def test_funds_check_for_openchannel(raiden_network, token_addresses):
         gevent.joinall(greenlets, raise_error=True)
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='Test does not work with UDP',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('reveal_timeout', [8])
@@ -386,7 +393,6 @@ def test_payment_timing_out_if_partner_does_not_respond(
         raiden_network,
         token_addresses,
         reveal_timeout,
-        skip_if_not_matrix,
         retry_timeout,
 ):
     """ Test to make sure that when our target does not respond payment times out

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -20,6 +20,10 @@ from raiden.transfer.state_change import (
 from raiden.utils import create_default_identifier
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP specific test',
+)
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
@@ -29,7 +33,6 @@ def test_recovery_happy_case(
         deposit,
         token_addresses,
         network_wait,
-        skip_if_not_udp,
 ):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
@@ -148,6 +151,10 @@ def test_recovery_happy_case(
     )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP specific test',
+)
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
@@ -157,7 +164,6 @@ def test_recovery_unhappy_case(
         deposit,
         token_addresses,
         network_wait,
-        skip_if_not_udp,
         retry_timeout,
 ):
     app0, app1, app2 = raiden_network
@@ -248,6 +254,10 @@ def test_recovery_unhappy_case(
     })
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP specific test',
+)
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [2])
@@ -257,7 +267,6 @@ def test_recovery_blockchain_events(
         deposit,
         token_addresses,
         network_wait,
-        skip_if_not_udp,
 ):
     """ Close one of the two raiden apps that have a channel between them,
     have the counterparty close the channel and then make sure the restarted

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -15,6 +15,10 @@ from raiden.transfer.events import EventPaymentSentSuccess
 from raiden.transfer.mediated_transfer.events import SendSecretReveal
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='Test does not work with UDP',
+)
 @pytest.mark.parametrize('deposit', [10])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [2])
@@ -24,7 +28,6 @@ def test_send_queued_messages(
         deposit,
         token_addresses,
         network_wait,
-        skip_if_not_matrix,
 ):
     """Test re-sending of undelivered messages on node restart"""
     app0, app1 = raiden_network
@@ -131,6 +134,10 @@ def test_send_queued_messages(
     )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='Test does not work with UDP',
+)
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_tokens', [1])
@@ -139,7 +146,6 @@ def test_payment_statuses_are_restored(
         number_of_nodes,
         token_addresses,
         network_wait,
-        skip_if_not_matrix,
 ):
     """ Test that when the Raiden is restarted, the dictionary of
     `targets_to_identifiers_to_statuses` is populated before the transport

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -182,6 +182,10 @@ def test_mediated_transfer_with_entire_deposit(
         )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='Test does not work with UDP',
+)
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_mediated_transfer_messages_out_of_order(
@@ -189,7 +193,6 @@ def test_mediated_transfer_messages_out_of_order(
         deposit,
         token_addresses,
         network_wait,
-        skip_if_not_matrix,
 ):
     """Raiden must properly handle repeated locked transfer messages."""
     app0, app1, app2 = raiden_network

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -94,6 +94,10 @@ def test_refund_messages(raiden_chain, token_addresses, deposit):
     )
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='UDP does not seem to retry messages until processed #3185',
+)
 @pytest.mark.parametrize('privatekey_seed', ['test_refund_transfer:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
@@ -104,9 +108,6 @@ def test_refund_transfer(
         deposit,
         network_wait,
         retry_timeout,
-        # UDP does not seem to retry messages until processed
-        # https://github.com/raiden-network/raiden/issues/3185
-        skip_if_not_matrix,
 ):
     """A failed transfer must send a refund back.
 
@@ -284,6 +285,10 @@ def test_refund_transfer(
     assert secrethash not in state_from_raiden(app1.raiden).payment_mapping.secrethashes_to_task
 
 
+@pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') == 'udp',
+    reason='UDP does not seem to retry messages until processed #3185',
+)
 @pytest.mark.parametrize('privatekey_seed', ['test_different_view_of_last_bp_during_unlock:{}'])
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
@@ -294,9 +299,6 @@ def test_different_view_of_last_bp_during_unlock(
         deposit,
         network_wait,
         retry_timeout,
-        # UDP does not seem to retry messages until processed
-        # https://github.com/raiden-network/raiden/issues/3185
-        skip_if_not_matrix,
         blockchain_type,
 ):
     """Test for https://github.com/raiden-network/raiden/issues/3196#issuecomment-449163888"""

--- a/raiden/tests/unit/test_udp_transport.py
+++ b/raiden/tests/unit/test_udp_transport.py
@@ -11,7 +11,10 @@ from raiden.tests.utils.factories import ADDR, UNIT_SECRETHASH, make_address
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.tests.utils.transport import MockDiscovery
 
-pytestmark = pytest.mark.usefixtures('skip_if_not_udp')
+pytestmark = pytest.mark.skipif(
+    getattr(pytest, 'config').getvalue('transport') not in ('udp', 'all'),
+    reason='UDP only test',
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
Calling skipif from inside a fixture means that pytest has to execute
the fixture in order to know if the test should be executed or not. It
happens to be the case that fixtures are executed in the same order as
the test function parameter list, meaning that if the skip_if fixture is
at the end of the list, time will be wasted executing the fixtures
before it.

This removes the skip_if fixtures, and uses the pytest.mark.skip_if
instead, allowing the fixtures to be exited early.