### PR TITLE
Canonical identifier in views/get_channelstate

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -21,7 +21,7 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
 )
-from raiden.utils import pex, typing
+from raiden.utils import CanonicalIdentifier, pex, typing
 from raiden_contracts.constants import (
     EVENT_SECRET_REVEALED,
     EVENT_TOKEN_NETWORK_CREATED,
@@ -142,10 +142,14 @@ def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
     total_deposit = args['total_deposit']
     transaction_hash = data['transaction_hash']
 
-    previous_channel_state = views.get_channelstate_by_token_network_identifier(
-        views.state_from_raiden(raiden),
-        token_network_identifier,
-        channel_identifier,
+    chain_state = views.state_from_raiden(raiden)
+    previous_channel_state = views.get_channelstate_by_canonical_identifier(
+        chain_state=chain_state,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_state.chain_id,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
     )
 
     # Channels will only be registered if this node is a participant
@@ -192,10 +196,14 @@ def handle_channel_closed(raiden: 'RaidenService', event: Event):
     transaction_hash = data['transaction_hash']
     block_hash = data['block_hash']
 
-    channel_state = views.get_channelstate_by_token_network_identifier(
-        views.state_from_raiden(raiden),
-        token_network_identifier,
-        channel_identifier,
+    chain_state = views.state_from_raiden(raiden)
+    channel_state = views.get_channelstate_by_canonical_identifier(
+        chain_state=chain_state,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_state.chain_id,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
     )
 
     channel_closed: StateChange
@@ -232,10 +240,14 @@ def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
     block_number = data['block_number']
     block_hash = data['block_hash']
 
-    channel_state = views.get_channelstate_by_token_network_identifier(
-        views.state_from_raiden(raiden),
-        token_network_identifier,
-        channel_identifier,
+    chain_state = views.state_from_raiden(raiden)
+    channel_state = views.get_channelstate_by_canonical_identifier(
+        chain_state=chain_state,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_state.chain_id,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
     )
 
     if channel_state:
@@ -258,10 +270,14 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
     block_hash = data['block_hash']
     transaction_hash = data['transaction_hash']
 
-    channel_state = views.get_channelstate_by_token_network_identifier(
-        views.state_from_raiden(raiden),
-        token_network_identifier,
-        channel_identifier,
+    chain_state = views.state_from_raiden(raiden)
+    channel_state = views.get_channelstate_by_canonical_identifier(
+        chain_state=chain_state,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_state.chain_id,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
     )
 
     if channel_state:

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,7 +1,7 @@
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.transfer import node, views
 from raiden.transfer.state import NettingChannelState
-from raiden.utils import typing
+from raiden.utils import CanonicalIdentifier, typing
 
 from .wal import restore_to_state_change
 
@@ -23,11 +23,21 @@ def channel_state_until_state_change(
     msg = 'There is a state change, therefore the state must not be None'
     assert wal.state_manager.current_state is not None, msg
 
-    channel_state = views.get_channelstate_by_id(
-        chain_state=wal.state_manager.current_state,
+    chain_state = wal.state_manager.current_state
+    token_network_address = views.get_token_network_by_token_address(
+        chain_state=chain_state,
         payment_network_id=payment_network_identifier,
         token_address=token_address,
-        channel_id=channel_identifier,
+    ).address
+
+    canonical_identifier = CanonicalIdentifier(
+        chain_identifier=chain_state.chain_id,
+        token_network_address=token_network_address,
+        channel_identifier=channel_identifier,
+    )
+    channel_state = views.get_channelstate_by_canonical_identifier(
+        chain_state=wal.state_manager.current_state,
+        canonical_identifier=canonical_identifier,
     )
 
     if not channel_state:

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -58,6 +58,7 @@ from raiden.transfer.state_change import (
     ReceiveProcessed,
     ReceiveUnlock,
 )
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
     BlockHash,
@@ -198,10 +199,13 @@ def subdispatch_to_paymenttask(
             token_network_identifier = sub_task.token_network_identifier
             channel_identifier = sub_task.channel_identifier
 
-            channel_state = views.get_channelstate_by_token_network_identifier(
-                chain_state,
-                token_network_identifier,
-                channel_identifier,
+            channel_state = views.get_channelstate_by_canonical_identifier(
+                chain_state=chain_state,
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=chain_state.chain_id,
+                    token_network_address=token_network_identifier,
+                    channel_identifier=channel_identifier,
+                ),
             )
 
             if channel_state:
@@ -351,10 +355,13 @@ def subdispatch_targettask(
     events = list()
     channel_state = None
     if is_valid_subtask:
-        channel_state = views.get_channelstate_by_token_network_identifier(
-            chain_state,
-            token_network_identifier,
-            channel_identifier,
+        channel_state = views.get_channelstate_by_canonical_identifier(
+            chain_state=chain_state,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=chain_state.chain_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
         )
 
     if channel_state:
@@ -529,10 +536,13 @@ def handle_contract_receive_channel_closed(
         state_change: ContractReceiveChannelClosed,
 ) -> TransitionResult[ChainState]:
     # cleanup queue for channel
-    channel_state = views.get_channelstate_by_token_network_identifier(
+    channel_state = views.get_channelstate_by_canonical_identifier(
         chain_state=chain_state,
-        token_network_id=state_change.token_network_identifier,
-        channel_id=state_change.channel_identifier,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_state.chain_id,
+            token_network_address=state_change.token_network_identifier,
+            channel_identifier=state_change.channel_identifier,
+        ),
     )
     if channel_state:
         queue_id = QueueIdentifier(

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -24,7 +24,6 @@ from raiden.utils.typing import (
     Address,
     BlockNumber,
     Callable,
-    ChannelID,
     Dict,
     Iterator,
     List,
@@ -338,25 +337,6 @@ def get_channelstate_by_canonical_identifier(
         channel_state = token_network.channelidentifiers_to_channels.get(
             canonical_identifier.channel_identifier,
         )
-
-    return channel_state
-
-
-def get_channelstate_by_id(
-        chain_state: ChainState,
-        payment_network_id: PaymentNetworkID,
-        token_address: TokenAddress,
-        channel_id: ChannelID,
-) -> Optional[NettingChannelState]:
-    token_network = get_token_network_by_token_address(
-        chain_state=chain_state,
-        payment_network_id=payment_network_id,
-        token_address=token_address,
-    )
-
-    channel_state = None
-    if token_network:
-        channel_state = token_network.channelidentifiers_to_channels.get(channel_id)
 
     return channel_state
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -19,6 +19,7 @@ from raiden.transfer.state import (
     TokenNetworkState,
     TransferTask,
 )
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.typing import (
     Address,
     BlockNumber,
@@ -322,20 +323,21 @@ def get_channelstate_by_token_network_and_partner(
     return channel_state
 
 
-def get_channelstate_by_token_network_identifier(
+def get_channelstate_by_canonical_identifier(
         chain_state: ChainState,
-        token_network_id: TokenNetworkID,
-        channel_id: ChannelID,
+        canonical_identifier: CanonicalIdentifier,
 ) -> Optional[NettingChannelState]:
     """ Return the NettingChannelState if it exists, None otherwise. """
     token_network = get_token_network_by_identifier(
         chain_state,
-        token_network_id,
+        TokenNetworkID(canonical_identifier.token_network_address),
     )
 
     channel_state = None
     if token_network:
-        channel_state = token_network.channelidentifiers_to_channels.get(channel_id)
+        channel_state = token_network.channelidentifiers_to_channels.get(
+            canonical_identifier.channel_identifier,
+        )
 
     return channel_state
 


### PR DESCRIPTION
Add usage of `CanonicalIdentifier` as an argument in view functions for the channel state.
It also refactors two functions in the `waiting.py` module, to share the common code and deletes an almost duplicated view function.
