### PR TITLE
No need to subclass from object in Py3.

### DIFF
--- a/.pylint.rc
+++ b/.pylint.rc
@@ -26,7 +26,7 @@ logging-modules=logging,structlog
 [MESSAGES CONTROL]
 
 disable=all
-enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin,bad-continuation,unused-variable,no-self-use,import-self,gevent-joinall
+enable=no-value-for-parameter,too-many-format-args,no-member,bad-except-order,redefined-builtin,bad-continuation,unused-variable,no-self-use,import-self,gevent-joinall,useless-object-inheritance,
 
 [REPORTS]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,7 +450,7 @@ Minimal Example:
 
 ```python
 
-class Diary(object):
+class Diary:
 
     def __init__(self, entries):
         self._entries = entries

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -12,7 +12,7 @@ from raiden.transfer.state import make_empty_merkle_tree
 from raiden.utils import serialization
 
 
-class MockObject(object):
+class MockObject:
     """ Used for testing JSON encoding/decoding """
 
     def __init__(self, **kwargs):

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -24,7 +24,7 @@ _SYNAPSE_LOGS_PATH = os.environ.get('RAIDEN_TESTS_SYNAPSE_LOGS_DIR', False)
 _SYNAPSE_CONFIG_TEMPLATE = Path(__file__).parent.joinpath('synapse_config.yaml.template')
 
 
-class MockDiscovery(object):
+class MockDiscovery:
     @staticmethod
     def get(node_address: bytes):
         return '127.0.0.1:5252'
@@ -53,7 +53,7 @@ class ParsedURL(str):
 
 
 # Used from within synapse during tests
-class EthAuthProvider(object):
+class EthAuthProvider:
     __version__ = '0.1'
     _user_re = re.compile(r'^@(0x[0-9a-f]{40}):(.+)$')
     _password_re = re.compile(r'^0x[0-9a-f]{130}$')


### PR DESCRIPTION
Hence, remove that requirement from the
styleguide in CONTRIBUTING.md.