### PR TITLE
Fix spawn transport

### DIFF
--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -215,7 +215,7 @@ def matrix_server_starter(
                         '-m',
                         'synapse.app.homeserver',
                         f'--server-name={server_name}',
-                        f'--config-path={config_file.name}',
+                        f'--config-path={config_file!s}',
                     ],
                     url=urljoin(server_url, '/_matrix/client/versions'),
                     method='GET',


### PR DESCRIPTION
Was having issues running tests because spawning the matrix server process claimed to have failed because the configuration file did not exist:

```
________________________________ ERROR at setup of test_batch_unlock[matrix-False-2] _________________________________

request = <SubRequest 'local_matrix_servers' for <Function test_batch_unlock[matrix-False-2]>>
transport_protocol = <TransportProtocol.MATRIX: 'matrix'>, matrix_server_count = 1
synapse_config_generator = <function generate_synapse_config.<locals>.generate_config at 0x7ffba1237a60>

    @pytest.fixture
    def local_matrix_servers(
            request,
            transport_protocol,
            matrix_server_count,
            synapse_config_generator,
    ):
        if transport_protocol is not TransportProtocol.MATRIX:
            yield [None]
            return

        starter = matrix_server_starter(
            count=matrix_server_count,
            config_generator=synapse_config_generator,
            log_context=request.node.name,
        )
>       with starter as server_urls:

matrix_server_count = 1
request    = <SubRequest 'local_matrix_servers' for <Function test_batch_unlock[matrix-False-2]>>
starter    = <contextlib._GeneratorContextManager object at 0x7ffba139d3c8>
synapse_config_generator = <function generate_synapse_config.<locals>.generate_config at 0x7ffba1237a60>
transport_protocol = <TransportProtocol.MATRIX: 'matrix'>

raiden/tests/integration/fixtures/transport.py:42:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.pyenv/versions/3.7.0/lib/python3.7/contextlib.py:112: in __enter__
    return next(self.gen)
raiden/tests/utils/transport.py:227: in matrix_server_starter
    io=synapse_io,
../../.pyenv/versions/3.7.0/lib/python3.7/contextlib.py:426: in enter_context
    result = _cm_type.__enter__(cm)
../../.pyenv/versions/3.7.0/envs/raiden-withdraw/lib/python3.7/site-packages/mirakuru/base.py:136: in __enter__
    return self.start()
raiden/utils/http.py:88: in start
    self.wait_for(self.check_subprocess)
../../.pyenv/versions/3.7.0/envs/raiden-withdraw/lib/python3.7/site-packages/mirakuru/base.py:357: in wait_for
    if wait_for():
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <raiden.utils.http.HTTPExecutor: "/home/raka..." 0x7ffba09570b8>

    def check_subprocess(self):
        """
        Make sure the process didn't exit with an error and run the checks.

        :rtype: bool
        :return: the actual check status
        :raise ProcessExitedWithError: when the main process exits with
            an error
        """
        exit_code = self.process.poll()
        if exit_code is not None and exit_code != 0:
            # The main process exited with an error. Clean up the children
            # if any.
            self._kill_all_kids(self._sig_kill)
            self._clear_process()
>           raise ProcessExitedWithError(self, exit_code)
E           mirakuru.exceptions.ProcessExitedWithError: The process invoked by the <raiden.utils.http.HTTPExecutor: "/home/rakan/.pyenv/versions/3.7.0/envs/raiden-withdraw/bin/python -m synapse.app.homeserver --server-name=localhost:8500 --config-path=synapse_config.yaml"> executor has exited with a non-zero code: 1.

exit_code  = 1
self       = <raiden.utils.http.HTTPExecutor: "/home/raka..." 0x7ffba09570b8>
```

This should resolve the issue