### PR TITLE
Avoid errors when running scenarios

### DIFF
--- a/tools/scenario-player/scenario_player/utils.py
+++ b/tools/scenario-player/scenario_player/utils.py
@@ -8,7 +8,7 @@ from collections import defaultdict, deque
 from datetime import datetime
 from itertools import islice
 from pathlib import Path
-from typing import Dict, Union, Tuple
+from typing import Dict, Tuple, Union
 
 import click
 import mirakuru
@@ -68,6 +68,8 @@ class LogBuffer:
 
 
 class ConcatenableNone:
+    msg = ''
+
     def __radd__(self, other):
         return other
 


### PR DESCRIPTION
Without this, I get frequent errors about `ConcatenableNone` missing a
`msg` attribute. This is a quick work-around. I assume this can be
properly solved in a different way.

@ulope: I'm pushing this because @Dominik1999 has this problem too and was asking for a way around it.