### PR TITLE
Add CanonicalIdentifier to state change constructors

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -38,7 +38,7 @@ from raiden.transfer.events import (
 from raiden.transfer.mediated_transfer.state import LockedTransferState
 from raiden.transfer.state import BalanceProofSignedState, NettingChannelState, TransferTask
 from raiden.transfer.state_change import ActionChannelClose
-from raiden.utils import pex, sha3, typing
+from raiden.utils import CanonicalIdentifier, pex, sha3, typing
 from raiden.utils.gas_reserve import has_enough_gas_reserve
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
@@ -575,10 +575,14 @@ class RaidenAPI:
         )
 
         greenlets: typing.Set[Greenlet] = set()
+        assert token_network_identifier
         for channel_state in channels_to_close:
             channel_close = ActionChannelClose(
-                token_network_identifier=token_network_identifier,
-                channel_identifier=channel_state.identifier,
+                canonical_identifier=CanonicalIdentifier(
+                    chain_identifier=channel_state.chain_id,
+                    token_network_address=token_network_identifier,
+                    channel_identifier=channel_state.identifier,
+                ),
             )
 
             greenlets.update(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -165,8 +165,11 @@ def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
 
         newbalance_statechange = ContractReceiveChannelNewBalance(
             transaction_hash=transaction_hash,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=previous_channel_state.chain_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
             deposit_transaction=deposit_transaction,
             block_number=block_number,
             block_hash=block_hash,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -265,8 +265,11 @@ def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
     if channel_state:
         channel_transfer_updated = ContractReceiveUpdateTransfer(
             transaction_hash=transaction_hash,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                channel_identifier=channel_identifier,
+                token_network_address=token_network_identifier,
+                chain_identifier=channel_state.chain_id,
+            ),
             nonce=args['nonce'],
             block_number=block_number,
             block_hash=block_hash,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -21,7 +21,7 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
 )
-from raiden.utils import CanonicalIdentifier, pex, typing
+from raiden.utils import CHANNEL_ID_UNSPECIFIED, CanonicalIdentifier, pex, typing
 from raiden_contracts.constants import (
     EVENT_SECRET_REVEALED,
     EVENT_TOKEN_NETWORK_CREATED,
@@ -311,9 +311,17 @@ def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
     block_hash = data['block_hash']
     transaction_hash = data['transaction_hash']
 
+    chain_state = views.state_from_raiden(raiden)
     unlock_state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=transaction_hash,
-        token_network_identifier=token_network_identifier,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=chain_state.chain_id,
+            token_network_address=token_network_identifier,
+            # FIXME: we will resolve the channel identifier only further down in
+            # raiden.transfer.token_network::handle_batch_unlock
+            # can/should we do it here already?
+            channel_identifier=CHANNEL_ID_UNSPECIFIED,
+        ),
         participant=args['participant'],
         partner=args['partner'],
         locksroot=args['locksroot'],

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -282,9 +282,12 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
 
     if channel_state:
         channel_settled = ContractReceiveChannelSettled(
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=chain_state.chain_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
             transaction_hash=transaction_hash,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
             block_number=block_number,
             block_hash=block_hash,
         )

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -99,7 +99,6 @@ def handle_channel_new(raiden: 'RaidenService', event: Event):
 
         new_channel = ContractReceiveChannelNew(
             transaction_hash=transaction_hash,
-            token_network_identifier=token_network_identifier,
             channel_state=channel_state,
             block_number=block_number,
             block_hash=block_hash,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -115,8 +115,11 @@ def handle_channel_new(raiden: 'RaidenService', event: Event):
     else:
         new_route = ContractReceiveRouteNew(
             transaction_hash=transaction_hash,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=raiden.chain.network_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
             participant1=participant1,
             participant2=participant2,
             block_number=block_number,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -213,8 +213,11 @@ def handle_channel_closed(raiden: 'RaidenService', event: Event):
         channel_closed = ContractReceiveChannelClosed(
             transaction_hash=transaction_hash,
             transaction_from=args['closing_participant'],
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=channel_state.chain_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
             block_number=block_number,
             block_hash=block_hash,
         )

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -232,8 +232,11 @@ def handle_channel_closed(raiden: 'RaidenService', event: Event):
         # This is a channel close event of a channel we're not a participant of
         route_closed = ContractReceiveRouteClosed(
             transaction_hash=transaction_hash,
-            token_network_identifier=token_network_identifier,
-            channel_identifier=channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=chain_state.chain_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
             block_number=block_number,
             block_hash=block_hash,
         )

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -95,7 +95,6 @@ class ChainStateStateMachine(RuleBasedStateMachine):
 
         channel_new_state_change = ContractReceiveChannelNew(
             transaction_hash=factories.make_transaction_hash(),
-            token_network_identifier=self.token_network_id,
             channel_state=self.address_to_channel[partner_address],
             block_number=self.block_number,
             block_hash=factories.make_block_hash(),

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -433,8 +433,11 @@ class OnChainMixin:
 
         channel_settled_state_change = ContractReceiveChannelSettled(
             transaction_hash=factories.make_transaction_hash(),
-            token_network_identifier=channel.token_network_identifier,
-            channel_identifier=channel.identifier,
+            canonical_identifier=factories.make_canonical_identifier(
+                chain_identifier=channel.chain_id,
+                token_network_address=channel.token_network_identifier,
+                channel_identifier=channel.identifier,
+            ),
             block_number=self.block_number + 1,
             block_hash=factories.make_block_hash(),
         )

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -35,7 +35,7 @@ from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
 from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.transfer.state import BalanceProofUnsignedState, HashTimeLockState
 from raiden.transfer.state_change import ActionChannelClose, ActionUpdateTransportAuthData
-from raiden.utils import pex
+from raiden.utils import CanonicalIdentifier, pex
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address, List, Optional, Union
 
@@ -360,8 +360,11 @@ def test_matrix_tx_error_handling(
 
     def make_tx(*args, **kwargs):
         close_channel = ActionChannelClose(
-            token_network_identifier=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=channel_state.chain_id,
+                token_network_address=channel_state.token_network_identifier,
+                channel_identifier=channel_state.identifier,
+            ),
         )
         app0.raiden.handle_and_track_state_change(close_channel)
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1592,8 +1592,11 @@ def test_action_close_must_change_the_channel_state():
 
     block_number = 10
     state_change = ActionChannelClose(
-        channel_state.token_network_identifier,
-        channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
     )
     iteration = channel.state_transition(
         channel_state=channel_state,
@@ -1640,8 +1643,11 @@ def test_update_must_be_called_if_close_lost_race():
 
     block_number = 10
     state_change = ActionChannelClose(
-        channel_state.token_network_identifier,
-        channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
     )
     iteration = channel.state_transition(
         channel_state=channel_state,
@@ -1672,8 +1678,11 @@ def test_update_transfer():
 
     block_number = 10
     state_change = ActionChannelClose(
-        channel_state.token_network_identifier,
-        channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
     )
     iteration = channel.state_transition(
         channel_state=channel_state,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -199,8 +199,11 @@ def test_channelstate_update_contract_balance():
     )
     state_change = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         deposit_transaction=deposit_transaction,
         block_number=block_number,
         block_hash=block_hash,
@@ -247,8 +250,11 @@ def test_channelstate_decreasing_contract_balance():
     )
     state_change = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         deposit_transaction=deposit_transaction,
         block_number=deposit_block_number,
         block_hash=deposit_block_hash,
@@ -288,8 +294,11 @@ def test_channelstate_repeated_contract_balance():
     )
     state_change = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         deposit_transaction=deposit_transaction,
         block_number=deposit_block_number,
         block_hash=deposit_block_hash,
@@ -343,8 +352,11 @@ def test_deposit_must_wait_for_confirmation():
     )
     new_balance = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         deposit_transaction=deposit_transaction,
         block_number=block_number,
         block_hash=block_hash,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1331,8 +1331,11 @@ def test_channelstate_unlock_without_locks():
     state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=our_model1.participant_address,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=77,
         block_hash=factories.make_block_hash(),
     )
@@ -1430,8 +1433,11 @@ def test_channelstate_unlock():
     close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -1549,8 +1555,11 @@ def test_settle_transaction_must_be_sent_only_once():
     close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -1659,8 +1668,11 @@ def test_update_must_be_called_if_close_lost_race():
     state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=77,
         block_hash=factories.make_block_hash(),
     )
@@ -1700,8 +1712,11 @@ def test_update_transfer():
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1743,8 +1743,11 @@ def test_update_transfer():
 
     update_transfer_state_change = ContractReceiveUpdateTransfer(
         transaction_hash=partner_model1.participant_address,
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         nonce=23,
         block_number=closed_block_number + 1,
         block_hash=factories.make_block_hash(),

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1440,9 +1440,11 @@ def test_channelstate_unlock():
 
     settle_block_number = lock_expiration + channel_state.reveal_timeout + 1
     settle_state_change = ContractReceiveChannelSettled(
+        canonical_identifier=make_canonical_identifier(
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -1557,8 +1559,10 @@ def test_settle_transaction_must_be_sent_only_once():
     settle_block_number = lock_expiration + channel_state.reveal_timeout + 1
     settle_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=make_canonical_identifier(
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )

--- a/raiden/tests/unit/test_node_queue.py
+++ b/raiden/tests/unit/test_node_queue.py
@@ -132,8 +132,11 @@ def test_channel_closed_must_clear_ordered_messages(
     closed = state_change.ContractReceiveChannelClosed(
         transaction_hash=EMPTY_HASH,
         transaction_from=recipient,
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=netting_channel_state.chain_id,
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_identifier,
+        ),
         block_number=1,
         block_hash=factories.make_block_hash(),
     )

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -98,8 +98,10 @@ def create_square_network_topology(
     # create new channels without being participant
     channel_new_state_change3 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=3,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=3,
+        ),
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
@@ -121,8 +123,10 @@ def create_square_network_topology(
 
     channel_new_state_change4 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=4,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=4,
+        ),
         participant1=address3,
         participant2=address1,
         block_number=open_block_number,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -60,14 +60,12 @@ def create_square_network_topology(
     # create new channels as participant
     channel_new_state_change1 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state1,
         block_number=open_block_number,
         block_hash=open_block_hash,
     )
     channel_new_state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state2,
         block_number=open_block_number,
         block_hash=open_block_hash,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -41,7 +41,6 @@ def test_contract_receive_channelnew_must_be_idempotent():
 
     state_change1 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_id,
         channel_state=channel_state1,
         block_number=block_number,
         block_hash=block_hash,
@@ -58,7 +57,6 @@ def test_contract_receive_channelnew_must_be_idempotent():
 
     state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_id,
         channel_state=channel_state2,
         block_number=block_number + 1,
         block_hash=factories.make_block_hash(),
@@ -99,7 +97,6 @@ def test_channel_settle_must_properly_cleanup():
 
     channel_new_state_change = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_id,
         channel_state=channel_state,
         block_number=open_block_number,
         block_hash=open_block_hash,
@@ -184,8 +181,7 @@ def test_channel_data_removed_after_unlock(
     payment_network_identifier = factories.make_payment_network_identifier()
 
     channel_new_state_change = ContractReceiveChannelNew(
-        factories.make_transaction_hash(),
-        token_network_state.address,
+        transaction_hash=factories.make_transaction_hash(),
         channel_state=channel_state,
         block_number=open_block_number,
         block_hash=open_block_hash,
@@ -329,7 +325,6 @@ def test_mediator_clear_pairs_after_batch_unlock(
 
     channel_new_state_change = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
         block_hash=open_block_hash,
@@ -486,7 +481,6 @@ def test_multiple_channel_states(
 
     channel_new_state_change = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
         block_hash=open_block_hash,
@@ -583,7 +577,6 @@ def test_multiple_channel_states(
     )
     channel_new_state_change = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=new_channel_state,
         block_number=closed_block_number + 1,
         block_hash=factories.make_block_hash(),
@@ -629,7 +622,6 @@ def test_routing_updates(
     # create a new channel as participant, check graph update
     channel_new_state_change = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state,
         block_number=open_block_number,
         block_hash=open_block_hash,
@@ -825,14 +817,12 @@ def test_routing_issue2663(
     # create new channels as participant
     channel_new_state_change1 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state1,
         block_number=open_block_number,
         block_hash=open_block_number_hash,
     )
     channel_new_state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state2,
         block_number=open_block_number,
         block_hash=open_block_number_hash,
@@ -1077,14 +1067,12 @@ def test_routing_priority(
     # create new channels as participant
     channel_new_state_change1 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state1,
         block_number=open_block_number,
         block_hash=open_block_number_hash,
     )
     channel_new_state_change2 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
         channel_state=channel_state2,
         block_number=open_block_number,
         block_hash=open_block_number_hash,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -277,7 +277,9 @@ def test_channel_data_removed_after_unlock(
     unlock_blocknumber = settle_block_number + 5
     channel_batch_unlock_state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+        ),
         participant=our_address,
         partner=address,
         locksroot=lock_secrethash,
@@ -420,7 +422,9 @@ def test_mediator_clear_pairs_after_batch_unlock(
     block_number = closed_block_number + 1
     channel_batch_unlock_state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+        ),
         participant=our_address,
         partner=address,
         locksroot=lock_secrethash,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -650,8 +650,10 @@ def test_routing_updates(
     new_channel_identifier = factories.make_channel_identifier()
     channel_new_state_change = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=new_channel_identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=new_channel_identifier,
+        ),
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
@@ -853,8 +855,10 @@ def test_routing_issue2663(
     # create new channels without being participant
     channel_new_state_change3 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=3,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=3,
+        ),
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
@@ -876,8 +880,10 @@ def test_routing_issue2663(
 
     channel_new_state_change4 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=4,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=4,
+        ),
         participant1=address3,
         participant2=address1,
         block_number=open_block_number,
@@ -1097,8 +1103,10 @@ def test_routing_priority(
     # create new channels without being participant
     channel_new_state_change3 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=3,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=3,
+        ),
         participant1=address2,
         participant2=address3,
         block_number=open_block_number,
@@ -1116,8 +1124,10 @@ def test_routing_priority(
 
     channel_new_state_change4 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=4,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=4,
+        ),
         participant1=address3,
         participant2=address1,
         block_number=open_block_number,
@@ -1135,8 +1145,10 @@ def test_routing_priority(
 
     channel_new_state_change5 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=4,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=4,
+        ),
         participant1=address3,
         participant2=address4,
         block_number=open_block_number,
@@ -1154,8 +1166,10 @@ def test_routing_priority(
 
     channel_new_state_change6 = ContractReceiveRouteNew(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=4,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=4,
+        ),
         participant1=address2,
         participant2=address4,
         block_number=open_block_number,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -137,8 +137,10 @@ def test_channel_settle_must_properly_cleanup():
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_id,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_id,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -244,8 +246,10 @@ def test_channel_data_removed_after_unlock(
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -382,8 +386,10 @@ def test_mediator_clear_pairs_after_batch_unlock(
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -531,8 +537,10 @@ def test_multiple_channel_states(
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -119,8 +119,11 @@ def test_channel_settle_must_properly_cleanup():
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        token_network_identifier=token_network_id,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=token_network_id,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -228,8 +231,11 @@ def test_channel_data_removed_after_unlock(
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -368,8 +374,11 @@ def test_mediator_clear_pairs_after_batch_unlock(
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -519,8 +528,11 @@ def test_multiple_channel_states(
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -669,8 +681,11 @@ def test_routing_updates(
     channel_close_state_change1 = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -690,8 +705,11 @@ def test_routing_updates(
     channel_close_state_change2 = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.our_state.address,
-        token_network_identifier=token_network_state.address,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=token_network_state.address,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -739,8 +739,10 @@ def test_routing_updates(
     # close the channel the node is not a participant of, check edge is removed from graph
     channel_close_state_change3 = ContractReceiveRouteClosed(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=new_channel_identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=new_channel_identifier,
+        ),
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -760,8 +762,10 @@ def test_routing_updates(
     closed_block_plus_10_hash = factories.make_block_hash()
     channel_close_state_change4 = ContractReceiveRouteClosed(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=token_network_state.address,
-        channel_identifier=new_channel_identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=token_network_state.address,
+            channel_identifier=new_channel_identifier,
+        ),
         block_number=closed_block_number + 10,
         block_hash=closed_block_plus_10_hash,
     )

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -86,7 +86,9 @@ def test_write_read_log():
     locksroot = sha3(b'test_write_read_log')
     contract_receive_unlock = ContractReceiveChannelBatchUnlock(
         transaction_hash=factories.make_transaction_hash(),
-        token_network_identifier=factories.make_address(),
+        canonical_identifier=factories.make_canonical_identifier(
+            token_network_address=factories.make_address(),
+        ),
         participant=participant,
         partner=partner,
         locksroot=locksroot,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1066,8 +1066,11 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
     channel_closed = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=factories.make_address(),
-        token_network_identifier=setup.channel.token_network_identifier,
-        channel_identifier=setup.channel.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=setup.channel.chain_id,
+            token_network_address=setup.channel.token_network_identifier,
+            channel_identifier=setup.channel.identifier,
+        ),
         block_number=block_number,
         block_hash=block_hash,
     )
@@ -1211,8 +1214,11 @@ def test_initiator_handle_contract_receive_after_channel_closed():
     channel_closed = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=factories.make_address(),
-        token_network_identifier=setup.channel.token_network_identifier,
-        channel_identifier=setup.channel.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=setup.channel.chain_id,
+            token_network_address=setup.channel.token_network_identifier,
+            channel_identifier=setup.channel.identifier,
+        ),
         block_number=block_number,
         block_hash=block_hash,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1533,8 +1533,11 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
     channel_closed = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=factories.make_address(),
-        token_network_identifier=channel_state.token_network_identifier,
-        channel_identifier=channel_state.identifier,
+        canonical_identifier=factories.make_canonical_identifier(
+            chain_identifier=channel_state.chain_id,
+            token_network_address=channel_state.token_network_identifier,
+            channel_identifier=channel_state.identifier,
+        ),
         block_number=block_number,
         block_hash=block_hash,
     )

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,5 +1,11 @@
 from raiden.constants import EMPTY_MERKLE_ROOT
-from raiden.tests.utils.factories import HOP1, HOP2, UNIT_SECRETHASH, make_block_hash
+from raiden.tests.utils.factories import (
+    HOP1,
+    HOP2,
+    UNIT_SECRETHASH,
+    make_block_hash,
+    make_canonical_identifier,
+)
 from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.node import is_transaction_effect_satisfied
 from raiden.transfer.state_change import ContractReceiveChannelBatchUnlock
@@ -20,7 +26,9 @@ def test_is_transaction_effect_satisfied(
     )
     state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=UNIT_SECRETHASH,
-        token_network_identifier=token_network_id,
+        canonical_identifier=make_canonical_identifier(
+            token_network_address=token_network_id,
+        ),
         participant=HOP1,
         partner=HOP2,
         locksroot=EMPTY_MERKLE_ROOT,

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1093,7 +1093,7 @@ def is_transaction_effect_satisfied(
         if partner_address:
             channel_state = views.get_channelstate_by_token_network_and_partner(
                 chain_state,
-                state_change.token_network_identifier,
+                TokenNetworkID(state_change.token_network_identifier),
                 partner_address,
             )
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -487,16 +487,15 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             deposit_transaction: TransactionChannelNewBalance,
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
         super().__init__(transaction_hash, block_number, block_hash)
 
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
         self.deposit_transaction = deposit_transaction
 
     def __repr__(self):
@@ -537,8 +536,11 @@ class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveChannelNewBalance':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             deposit_transaction=data['deposit_transaction'],
             block_number=BlockNumber(int(data['block_number'])),
             block_hash=BlockHash(deserialize_bytes(data['block_hash'])),

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -15,7 +15,7 @@ from raiden.transfer.state import (
     TransactionChannelNewBalance,
 )
 from raiden.transfer.utils import pseudo_random_generator_from_json
-from raiden.utils import pex, sha3
+from raiden.utils import CHAIN_ID_UNSPECIFIED, CanonicalIdentifier, pex, sha3
 from raiden.utils.serialization import deserialize_bytes, serialize_bytes
 from raiden.utils.typing import (
     Address,
@@ -547,15 +547,14 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
         super().__init__(transaction_hash, block_number, block_hash)
 
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
 
     def __repr__(self):
         return (
@@ -590,8 +589,11 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveChannelSettled':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             block_number=BlockNumber(int(data['block_number'])),
             block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1046,15 +1046,14 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
         super().__init__(transaction_hash, block_number, block_hash)
 
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
 
     def __repr__(self):
         return '<ContractReceiveRouteClosed token_network:{} id:{} block:{}>'.format(
@@ -1087,8 +1086,11 @@ class ContractReceiveRouteClosed(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveRouteClosed':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             block_number=BlockNumber(int(data['block_number'])),
             block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -258,14 +258,13 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
             channel_state: NettingChannelState,
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
         super().__init__(transaction_hash, block_number, block_hash)
 
-        self.token_network_identifier = token_network_identifier
+        self.token_network_identifier = channel_state.token_network_identifier
         self.channel_state = channel_state
         self.channel_identifier = channel_state.identifier
 
@@ -302,7 +301,6 @@ class ContractReceiveChannelNew(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveChannelNew':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
             channel_state=data['channel_state'],
             block_number=BlockNumber(int(data['block_number'])),
             block_hash=BlockHash(deserialize_bytes(data['block_hash'])),

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -310,16 +310,15 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
             self,
             transaction_hash: TransactionHash,
             transaction_from: Address,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
         super().__init__(transaction_hash, block_number, block_hash)
 
         self.transaction_from = transaction_from
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
 
     def __repr__(self):
         return (
@@ -360,8 +359,11 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
             transaction_from=to_canonical_address(data['transaction_from']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             block_number=BlockNumber(int(data['block_number'])),
             block_hash=BlockHash(deserialize_bytes(data['block_hash'])),
         )

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -15,7 +15,13 @@ from raiden.transfer.state import (
     TransactionChannelNewBalance,
 )
 from raiden.transfer.utils import pseudo_random_generator_from_json
-from raiden.utils import CHAIN_ID_UNSPECIFIED, CanonicalIdentifier, pex, sha3
+from raiden.utils import (
+    CHAIN_ID_UNSPECIFIED,
+    CHANNEL_ID_UNSPECIFIED,
+    CanonicalIdentifier,
+    pex,
+    sha3,
+)
 from raiden.utils.serialization import deserialize_bytes, serialize_bytes
 from raiden.utils.typing import (
     Address,
@@ -863,7 +869,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
+            canonical_identifier: CanonicalIdentifier,
             participant: Address,
             partner: Address,
             locksroot: Locksroot,
@@ -872,6 +878,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
+        token_network_identifier = canonical_identifier.token_network_address
 
         if not isinstance(token_network_identifier, T_TokenNetworkID):
             raise ValueError('token_network_identifier must be of type TokenNtetworkIdentifier')
@@ -939,7 +946,11 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveChannelBatchUnlock':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=CHANNEL_ID_UNSPECIFIED,
+            ),
             participant=to_canonical_address(data['participant']),
             partner=to_canonical_address(data['partner']),
             locksroot=deserialize_bytes(data['locksroot']),

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -178,11 +178,10 @@ class ActionChannelClose(StateChange):
 
     def __init__(
             self,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
     ):
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = TokenNetworkID(canonical_identifier.token_network_address)
+        self.channel_identifier = canonical_identifier.channel_identifier
 
     def __repr__(self):
         return '<ActionChannelClose channel_identifier:{}>'.format(
@@ -208,8 +207,11 @@ class ActionChannelClose(StateChange):
     @classmethod
     def from_dict(cls, data):
         return cls(
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=int(data['channel_identifier']),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=int(data['channel_identifier']),
+            ),
         )
 
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -956,8 +956,7 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             participant1: Address,
             participant2: Address,
             block_number: BlockNumber,
@@ -972,8 +971,8 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
 
         super().__init__(transaction_hash, block_number, block_hash)
 
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
         self.participant1 = participant1
         self.participant2 = participant2
 
@@ -1018,8 +1017,11 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveRouteNew':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             participant1=to_canonical_address(data['participant1']),
             participant2=to_canonical_address(data['participant2']),
             block_number=BlockNumber(int(data['block_number'])),

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1100,16 +1100,15 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
     def __init__(
             self,
             transaction_hash: TransactionHash,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             nonce: Nonce,
             block_number: BlockNumber,
             block_hash: BlockHash,
     ):
         super().__init__(transaction_hash, block_number, block_hash)
 
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
         self.nonce = nonce
 
     def __repr__(self):
@@ -1143,8 +1142,11 @@ class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveUpdateTransfer':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+            ),
             nonce=int(data['nonce']),
             block_number=BlockNumber(int(data['block_number'])),
             block_hash=BlockHash(deserialize_bytes(data['block_hash'])),

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -26,6 +26,10 @@ from raiden.utils import typing
 from raiden.utils.signing import sha3  # noqa
 
 
+# Placeholder chain ID for refactoring in scope of #3493
+CHAIN_ID_UNSPECIFIED = typing.ChainID(-1)
+
+
 class CanonicalIdentifier(NamedTuple):
     chain_identifier: typing.ChainID
     # introducing the type as Union, to avoid casting for now. Should be only `..Address` later

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -28,6 +28,8 @@ from raiden.utils.signing import sha3  # noqa
 
 # Placeholder chain ID for refactoring in scope of #3493
 CHAIN_ID_UNSPECIFIED = typing.ChainID(-1)
+# Placeholder channel ID for refactoring in scope of #3493
+CHANNEL_ID_UNSPECIFIED = typing.ChannelID(-2)
 
 
 class CanonicalIdentifier(NamedTuple):


### PR DESCRIPTION
This PR changes the constructors of (applicable) classes from `raiden/transfer/state_change.py` to use `CanonicalIdentifier` instead of isolated identifier arguments.
This is still serialization compatible (where the deserialization doesn't have `chain_identifier` available, it will use a dummy value).

This is one more step for #3493 

Some notes for reviewers:
- All commits are self-contained and can be reviewed in isolation!
- `ContractReceiveChannelBatchUnlock` so far does not receive a `channel_identifier`. However, the channel will be identified later in the processing. I suggest to move the `channel_identifier` resolution into the event creation, so we can treat it as a fully identified channel event (see 6364801a1a6730e3de644187c012d09d8749943a)
- `ContractReceiveChannelNew` so far overspecified `token_network_id` in the constructor, because it also contains `channel_state`. I removed the overspecification in this PR.