### PR TITLE
CanonicalIdentifier in Events (plus some cleanups)

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -40,7 +40,7 @@ from raiden.transfer.events import (
 from raiden.transfer.mediated_transfer.state import LockedTransferState
 from raiden.transfer.state import BalanceProofSignedState, NettingChannelState, TransferTask
 from raiden.transfer.state_change import ActionChannelClose
-from raiden.utils import CanonicalIdentifier, pex, sha3, typing
+from raiden.utils import pex, sha3, typing
 from raiden.utils.gas_reserve import has_enough_gas_reserve
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
@@ -586,21 +586,11 @@ class RaidenAPI:
             token_address=token_address,
             partner_addresses=partner_addresses,
         )
-        token_network_identifier = views.get_token_network_identifier_by_token_address(
-            chain_state=views.state_from_raiden(self.raiden),
-            payment_network_id=registry_address,
-            token_address=token_address,
-        )
 
         greenlets: typing.Set[Greenlet] = set()
-        assert token_network_identifier
         for channel_state in channels_to_close:
             channel_close = ActionChannelClose(
-                canonical_identifier=CanonicalIdentifier(
-                    chain_identifier=channel_state.chain_id,
-                    token_network_address=token_network_identifier,
-                    channel_identifier=channel_state.identifier,
-                ),
+                canonical_identifier=channel_state.canonical_identifier,
             )
 
             greenlets.update(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -167,11 +167,7 @@ def handle_channel_new_balance(raiden: 'RaidenService', event: Event):
 
         newbalance_statechange = ContractReceiveChannelNewBalance(
             transaction_hash=transaction_hash,
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=previous_channel_state.chain_id,
-                token_network_address=token_network_identifier,
-                channel_identifier=channel_identifier,
-            ),
+            canonical_identifier=previous_channel_state.canonical_identifier,
             deposit_transaction=deposit_transaction,
             block_number=block_number,
             block_hash=block_hash,
@@ -218,11 +214,7 @@ def handle_channel_closed(raiden: 'RaidenService', event: Event):
         channel_closed = ContractReceiveChannelClosed(
             transaction_hash=transaction_hash,
             transaction_from=args['closing_participant'],
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=channel_state.chain_id,
-                token_network_address=token_network_identifier,
-                channel_identifier=channel_identifier,
-            ),
+            canonical_identifier=channel_state.canonical_identifier,
             block_number=block_number,
             block_hash=block_hash,
         )
@@ -264,11 +256,7 @@ def handle_channel_update_transfer(raiden: 'RaidenService', event: Event):
     if channel_state:
         channel_transfer_updated = ContractReceiveUpdateTransfer(
             transaction_hash=transaction_hash,
-            canonical_identifier=CanonicalIdentifier(
-                channel_identifier=channel_identifier,
-                token_network_address=token_network_identifier,
-                chain_identifier=channel_state.chain_id,
-            ),
+            canonical_identifier=channel_state.canonical_identifier,
             nonce=args['nonce'],
             block_number=block_number,
             block_hash=block_hash,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1671,10 +1671,12 @@ class RequestMonitoring(SignedMessage):
     def _data_to_sign(self) -> bytes:
         """ Return the binary data to be/which was signed """
         packed = pack_reward_proof(
-            channel_identifier=self.balance_proof.channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.balance_proof.chain_id,
+                token_network_address=self.balance_proof.token_network_address,
+                channel_identifier=self.balance_proof.channel_identifier,
+            ),
             reward_amount=self.reward_amount,
-            token_network_address=self.balance_proof.token_network_address,
-            chain_id=self.balance_proof.chain_id,
             nonce=self.balance_proof.nonce,
         )
         return packed
@@ -1764,10 +1766,12 @@ class RequestMonitoring(SignedMessage):
             partner_signature=self.balance_proof.signature,
         )
         reward_proof_data = pack_reward_proof(
-            channel_identifier=self.balance_proof.channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=self.balance_proof.chain_id,
+                token_network_address=self.balance_proof.token_network_address,
+                channel_identifier=self.balance_proof.channel_identifier,
+            ),
             reward_amount=self.reward_amount,
-            token_network_address=self.balance_proof.token_network_address,
-            chain_id=self.balance_proof.chain_id,
             nonce=self.balance_proof.nonce,
         )
         return (

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -26,7 +26,7 @@ from raiden.transfer.events import ContractSendChannelClose
 from raiden.transfer.mediated_transfer.events import SendLockedTransfer
 from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
 from raiden.transfer.state_change import ContractReceiveSecretReveal
-from raiden.utils import sha3, wait_until
+from raiden.utils import CanonicalIdentifier, sha3, wait_until
 from raiden.utils.typing import Address, BlockSpecification, ChannelID
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
@@ -552,9 +552,12 @@ def test_secret_revealed_on_chain(
 
     # Close the channel. This must register the secret on chain
     channel_close_event = ContractSendChannelClose(
-        channel_identifier=channel_state2_1.identifier,
+        canonical_identifier=CanonicalIdentifier(
+            chain_identifier=channel_state2_1.chain_id,
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_state2_1.identifier,
+        ),
         token_address=channel_state2_1.token_address,
-        token_network_identifier=token_network_identifier,
         balance_proof=channel_state2_1.partner_state.balance_proof,
         triggered_by_block_hash=app0.raiden.chain.block_hash(),
     )

--- a/raiden/tests/integration/test_matrix_transport.py
+++ b/raiden/tests/integration/test_matrix_transport.py
@@ -35,7 +35,7 @@ from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
 from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.transfer.state import BalanceProofUnsignedState, HashTimeLockState
 from raiden.transfer.state_change import ActionChannelClose, ActionUpdateTransportAuthData
-from raiden.utils import CanonicalIdentifier, pex
+from raiden.utils import pex
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address, List, Optional, Union
 
@@ -360,11 +360,7 @@ def test_matrix_tx_error_handling(
 
     def make_tx(*args, **kwargs):
         close_channel = ActionChannelClose(
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=channel_state.chain_id,
-                token_network_address=channel_state.token_network_identifier,
-                channel_identifier=channel_state.identifier,
-            ),
+            canonical_identifier=channel_state.canonical_identifier,
         )
         app0.raiden.handle_and_track_state_change(close_channel)
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -199,11 +199,7 @@ def test_channelstate_update_contract_balance():
     )
     state_change = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
         block_number=block_number,
         block_hash=block_hash,
@@ -250,11 +246,7 @@ def test_channelstate_decreasing_contract_balance():
     )
     state_change = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
         block_number=deposit_block_number,
         block_hash=deposit_block_hash,
@@ -294,11 +286,7 @@ def test_channelstate_repeated_contract_balance():
     )
     state_change = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
         block_number=deposit_block_number,
         block_hash=deposit_block_hash,
@@ -352,11 +340,7 @@ def test_deposit_must_wait_for_confirmation():
     )
     new_balance = ContractReceiveChannelNewBalance(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
         block_number=block_number,
         block_hash=block_hash,
@@ -1343,11 +1327,7 @@ def test_channelstate_unlock_without_locks():
     state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=our_model1.participant_address,
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=77,
         block_hash=factories.make_block_hash(),
     )
@@ -1445,11 +1425,7 @@ def test_channelstate_unlock():
     close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -1567,11 +1543,7 @@ def test_settle_transaction_must_be_sent_only_once():
     close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -1613,11 +1585,7 @@ def test_action_close_must_change_the_channel_state():
 
     block_number = 10
     state_change = ActionChannelClose(
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
     )
     iteration = channel.state_transition(
         channel_state=channel_state,
@@ -1664,11 +1632,7 @@ def test_update_must_be_called_if_close_lost_race():
 
     block_number = 10
     state_change = ActionChannelClose(
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
     )
     iteration = channel.state_transition(
         channel_state=channel_state,
@@ -1680,11 +1644,7 @@ def test_update_must_be_called_if_close_lost_race():
     state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=77,
         block_hash=factories.make_block_hash(),
     )
@@ -1702,11 +1662,7 @@ def test_update_transfer():
 
     block_number = 10
     state_change = ActionChannelClose(
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
     )
     iteration = channel.state_transition(
         channel_state=channel_state,
@@ -1724,11 +1680,7 @@ def test_update_transfer():
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=partner_model1.participant_address,
-        canonical_identifier=make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -1743,11 +1695,7 @@ def test_update_transfer():
 
     update_transfer_state_change = ContractReceiveUpdateTransfer(
         transaction_hash=partner_model1.participant_address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         nonce=23,
         block_number=closed_block_number + 1,
         block_hash=factories.make_block_hash(),

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -96,11 +96,13 @@ def test_request_monitoring():
 
     # test signature verification
     reward_proof_data = pack_reward_proof(
-        request_monitoring.balance_proof.channel_identifier,
-        request_monitoring.reward_amount,
-        request_monitoring.balance_proof.token_network_address,
-        request_monitoring.balance_proof.chain_id,
-        request_monitoring.balance_proof.nonce,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=request_monitoring.balance_proof.chain_id,
+            token_network_address=request_monitoring.balance_proof.token_network_address,
+            channel_identifier=request_monitoring.balance_proof.channel_identifier,
+        ),
+        reward_amount=request_monitoring.reward_amount,
+        nonce=request_monitoring.balance_proof.nonce,
     )
 
     assert recover(reward_proof_data, request_monitoring.reward_proof_signature) == ADDRESS
@@ -173,11 +175,13 @@ def test_tamper_request_monitoring():
     exploited_signature = request_monitoring.reward_proof_signature
 
     reward_proof_data = pack_reward_proof(
-        request_monitoring.balance_proof.channel_identifier,
-        request_monitoring.reward_amount,
-        request_monitoring.balance_proof.token_network_address,
-        request_monitoring.balance_proof.chain_id,
-        request_monitoring.balance_proof.nonce,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=request_monitoring.balance_proof.chain_id,
+            token_network_address=request_monitoring.balance_proof.token_network_address,
+            channel_identifier=request_monitoring.balance_proof.channel_identifier,
+        ),
+        reward_amount=request_monitoring.reward_amount,
+        nonce=request_monitoring.balance_proof.nonce,
     )
 
     # An attacker might change the balance hash
@@ -188,12 +192,15 @@ def test_tamper_request_monitoring():
         reward_amount=55,
     )
 
+    tampered_bp = tampered_balance_hash_request_monitoring.balance_proof
     tampered_balance_hash_reward_proof_data = pack_reward_proof(
-        tampered_balance_hash_request_monitoring.balance_proof.channel_identifier,
-        tampered_balance_hash_request_monitoring.reward_amount,
-        tampered_balance_hash_request_monitoring.balance_proof.token_network_address,
-        tampered_balance_hash_request_monitoring.balance_proof.chain_id,
-        tampered_balance_hash_request_monitoring.balance_proof.nonce,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=tampered_bp.chain_id,
+            token_network_address=tampered_bp.token_network_address,
+            channel_identifier=tampered_bp.channel_identifier,
+        ),
+        reward_amount=tampered_balance_hash_request_monitoring.reward_amount,
+        nonce=tampered_balance_hash_request_monitoring.balance_proof.nonce,
     )
     # The signature works/is unaffected by that change...
     recovered_address_tampered = recover(
@@ -218,12 +225,15 @@ def test_tamper_request_monitoring():
         reward_amount=55,
     )
 
+    tampered_bp = tampered_additional_hash_request_monitoring.balance_proof
     tampered_additional_hash_reward_proof_data = pack_reward_proof(
-        tampered_additional_hash_request_monitoring.balance_proof.channel_identifier,
-        tampered_additional_hash_request_monitoring.reward_amount,
-        tampered_additional_hash_request_monitoring.balance_proof.token_network_address,
-        tampered_additional_hash_request_monitoring.balance_proof.chain_id,
-        tampered_additional_hash_request_monitoring.balance_proof.nonce,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=tampered_bp.chain_id,
+            token_network_address=tampered_bp.token_network_address,
+            channel_identifier=tampered_bp.channel_identifier,
+        ),
+        reward_amount=tampered_additional_hash_request_monitoring.reward_amount,
+        nonce=tampered_additional_hash_request_monitoring.balance_proof.nonce,
     )
 
     # The signature works/is unaffected by that change...
@@ -249,12 +259,15 @@ def test_tamper_request_monitoring():
         reward_amount=55,
     )
 
+    tampered_bp = tampered_non_closing_signature_request_monitoring.balance_proof
     tampered_non_closing_signature_reward_proof_data = pack_reward_proof(
-        tampered_non_closing_signature_request_monitoring.balance_proof.channel_identifier,
-        tampered_non_closing_signature_request_monitoring.reward_amount,
-        tampered_non_closing_signature_request_monitoring.balance_proof.token_network_address,
-        tampered_non_closing_signature_request_monitoring.balance_proof.chain_id,
-        tampered_non_closing_signature_request_monitoring.balance_proof.nonce,
+        canonical_identifier=make_canonical_identifier(
+            chain_identifier=tampered_bp.chain_id,
+            token_network_address=tampered_bp.token_network_address,
+            channel_identifier=tampered_bp.channel_identifier,
+        ),
+        reward_amount=tampered_non_closing_signature_request_monitoring.reward_amount,
+        nonce=tampered_non_closing_signature_request_monitoring.balance_proof.nonce,
     )
 
     # The signature works/is unaffected by that change...

--- a/raiden/tests/unit/test_node_queue.py
+++ b/raiden/tests/unit/test_node_queue.py
@@ -132,11 +132,7 @@ def test_channel_closed_must_clear_ordered_messages(
     closed = state_change.ContractReceiveChannelClosed(
         transaction_hash=EMPTY_HASH,
         transaction_from=recipient,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=netting_channel_state.chain_id,
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_identifier,
-        ),
+        canonical_identifier=netting_channel_state.canonical_identifier,
         block_number=1,
         block_hash=factories.make_block_hash(),
     )

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -1,7 +1,12 @@
 from raiden.constants import EMPTY_HASH
 from raiden.network.proxies.token_network import ParticipantDetails, ParticipantsDetails
 from raiden.raiden_event_handler import RaidenEventHandler
-from raiden.tests.utils.factories import make_32bytes, make_address, make_block_hash
+from raiden.tests.utils.factories import (
+    make_32bytes,
+    make_address,
+    make_block_hash,
+    make_canonical_identifier,
+)
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.utils import hash_balance_data
@@ -58,8 +63,10 @@ def test_handle_contract_send_channelunlock_already_unlocked():
 
     event = ContractSendChannelBatchUnlock(
         token_address=token_address,
-        token_network_identifier=token_network_identifier,
-        channel_identifier=channel_identifier,
+        canonical_identifier=make_canonical_identifier(
+            token_network_address=token_network_identifier,
+            channel_identifier=channel_identifier,
+        ),
         participant=participant,
         triggered_by_block_hash=make_block_hash(),
     )

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -116,11 +116,7 @@ def test_channel_settle_must_properly_cleanup():
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=token_network_id,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -137,10 +133,7 @@ def test_channel_settle_must_properly_cleanup():
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            token_network_address=token_network_id,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -227,11 +220,7 @@ def test_channel_data_removed_after_unlock(
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -248,10 +237,7 @@ def test_channel_data_removed_after_unlock(
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -273,9 +259,7 @@ def test_channel_data_removed_after_unlock(
     unlock_blocknumber = settle_block_number + 5
     channel_batch_unlock_state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            token_network_address=token_network_state.address,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         participant=our_address,
         partner=address,
         locksroot=lock_secrethash,
@@ -371,11 +355,7 @@ def test_mediator_clear_pairs_after_batch_unlock(
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -392,10 +372,7 @@ def test_mediator_clear_pairs_after_batch_unlock(
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -417,9 +394,7 @@ def test_mediator_clear_pairs_after_batch_unlock(
     block_number = closed_block_number + 1
     channel_batch_unlock_state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            token_network_address=token_network_state.address,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         participant=our_address,
         partner=address,
         locksroot=lock_secrethash,
@@ -526,11 +501,7 @@ def test_multiple_channel_states(
     channel_close_state_change = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -547,10 +518,7 @@ def test_multiple_channel_states(
     settle_block_number = closed_block_number + channel_state.settle_timeout + 1
     channel_settled_state_change = ContractReceiveChannelSettled(
         transaction_hash=factories.make_transaction_hash(),
-        canonical_identifier=factories.make_canonical_identifier(
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=settle_block_number,
         block_hash=factories.make_block_hash(),
     )
@@ -679,11 +647,7 @@ def test_routing_updates(
     channel_close_state_change1 = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.partner_state.address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )
@@ -703,11 +667,7 @@ def test_routing_updates(
     channel_close_state_change2 = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=channel_state.our_state.address,
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=token_network_state.address,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=closed_block_number,
         block_hash=closed_block_hash,
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1533,11 +1533,7 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
     channel_closed = ContractReceiveChannelClosed(
         transaction_hash=factories.make_transaction_hash(),
         transaction_from=factories.make_address(),
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
         block_number=block_number,
         block_hash=block_hash,
     )

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,11 +1,5 @@
 from raiden.constants import EMPTY_MERKLE_ROOT
-from raiden.tests.utils.factories import (
-    HOP1,
-    HOP2,
-    UNIT_SECRETHASH,
-    make_block_hash,
-    make_canonical_identifier,
-)
+from raiden.tests.utils.factories import HOP1, HOP2, UNIT_SECRETHASH, make_block_hash
 from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.node import is_transaction_effect_satisfied
 from raiden.transfer.state_change import ContractReceiveChannelBatchUnlock
@@ -17,18 +11,17 @@ def test_is_transaction_effect_satisfied(
         token_network_id,
         netting_channel_state,
 ):
+    canonical_identifier = netting_channel_state.canonical_identifier
+    assert token_network_id == canonical_identifier.token_network_address
     transaction = ContractSendChannelBatchUnlock(
         token_address=token_network_state.token_address,
-        token_network_identifier=token_network_id,
-        channel_identifier=netting_channel_state.identifier,
+        canonical_identifier=canonical_identifier,
         participant=HOP2,
         triggered_by_block_hash=make_block_hash(),
     )
     state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=UNIT_SECRETHASH,
-        canonical_identifier=make_canonical_identifier(
-            token_network_address=token_network_id,
-        ),
+        canonical_identifier=canonical_identifier,
         participant=HOP1,
         partner=HOP2,
         locksroot=EMPTY_MERKLE_ROOT,

--- a/raiden/transfer/balance_proof.py
+++ b/raiden/transfer/balance_proof.py
@@ -1,15 +1,6 @@
 from raiden.utils import CanonicalIdentifier
 from raiden.utils.signing import pack_data
-from raiden.utils.typing import (
-    AdditionalHash,
-    BalanceHash,
-    ChainID,
-    ChannelID,
-    Nonce,
-    Signature,
-    TokenAmount,
-    TokenNetworkID,
-)
+from raiden.utils.typing import AdditionalHash, BalanceHash, Nonce, Signature, TokenAmount
 from raiden_contracts.constants import MessageTypeId
 
 
@@ -66,12 +57,13 @@ def pack_balance_proof_update(
 
 
 def pack_reward_proof(
-        channel_identifier: ChannelID,
+        canonical_identifier: CanonicalIdentifier,
         reward_amount: TokenAmount,
-        token_network_address: TokenNetworkID,
-        chain_id: ChainID,
         nonce: Nonce,
 ) -> bytes:
+    channel_identifier = canonical_identifier.channel_identifier
+    token_network_address = canonical_identifier.token_network_address
+    chain_id = canonical_identifier.chain_identifier
     return pack_data([
         'uint256',
         'uint256',

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1843,8 +1843,7 @@ def handle_channel_settled(
         if not is_settle_pending and merkle_tree_leaves:
             onchain_unlock = ContractSendChannelBatchUnlock(
                 token_address=channel_state.token_address,
-                token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
-                channel_identifier=channel_state.identifier,
+                canonical_identifier=channel_state.canonical_identifier,
                 participant=channel_state.partner_state.address,
                 triggered_by_block_hash=state_change.block_hash,
             )

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1192,11 +1192,7 @@ def create_sendlockedtransfer(
         transferred_amount=transferred_amount,
         locked_amount=locked_amount,
         locksroot=locksroot,
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
     )
 
     locked_transfer = LockedTransferUnsignedState(
@@ -1259,11 +1255,7 @@ def create_unlock(
         transferred_amount=transferred_amount,
         locked_amount=locked_amount,
         locksroot=locksroot,
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=channel_state.chain_id,
-            token_network_address=channel_state.token_network_identifier,
-            channel_identifier=channel_state.identifier,
-        ),
+        canonical_identifier=channel_state.canonical_identifier,
     )
 
     unlock_lock = SendBalanceProof(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -102,7 +102,6 @@ from raiden.utils.typing import (
     SuccessOrError,
     TargetAddress,
     TokenAmount,
-    TokenNetworkAddress,
     TokenNetworkID,
     Tuple,
 )
@@ -1752,10 +1751,8 @@ def handle_block(
                 None,
                 None,
             )
-            token_network_identifier = TokenNetworkAddress(channel_state.token_network_identifier)
             event = ContractSendChannelSettle(
-                channel_identifier=channel_state.identifier,
-                token_network_identifier=token_network_identifier,
+                canonical_identifier=channel_state.canonical_identifier,
                 triggered_by_block_hash=state_change.block_hash,
             )
             events.append(event)

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1384,9 +1384,8 @@ def events_for_close(
         assert balance_proof is None or isinstance(balance_proof, BalanceProofSignedState)
 
         close_event = ContractSendChannelClose(
-            channel_identifier=channel_state.identifier,
+            canonical_identifier=channel_state.canonical_identifier,
             token_address=channel_state.token_address,
-            token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
             balance_proof=balance_proof,
             triggered_by_block_hash=block_hash,
         )

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1795,8 +1795,7 @@ def handle_channel_closed(
             # proof available update this node half of the state
             update = ContractSendChannelUpdateTransfer(
                 expiration=expiration,
-                channel_identifier=channel_state.identifier,
-                token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
+                canonical_identifier=channel_state.canonical_identifier,
                 balance_proof=balance_proof,
                 triggered_by_block_hash=state_change.block_hash,
             )

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1795,7 +1795,6 @@ def handle_channel_closed(
             # proof available update this node half of the state
             update = ContractSendChannelUpdateTransfer(
                 expiration=expiration,
-                canonical_identifier=channel_state.canonical_identifier,
                 balance_proof=balance_proof,
                 triggered_by_block_hash=state_change.block_hash,
             )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -8,7 +8,7 @@ from raiden.transfer.architecture import (
     SendMessageEvent,
 )
 from raiden.transfer.state import BalanceProofSignedState
-from raiden.utils import pex, serialization, sha3
+from raiden.utils import CHAIN_ID_UNSPECIFIED, CanonicalIdentifier, pex, serialization, sha3
 from raiden.utils.serialization import deserialize_bytes, serialize_bytes
 from raiden.utils.typing import (
     Address,
@@ -44,16 +44,15 @@ class ContractSendChannelClose(ContractSendEvent):
 
     def __init__(
             self,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             token_address: TokenAddress,
-            token_network_identifier: TokenNetworkID,
             balance_proof: Optional[BalanceProofSignedState],
             triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash)
-        self.channel_identifier = channel_identifier
+        self.channel_identifier = canonical_identifier.channel_identifier
         self.token_address = token_address
-        self.token_network_identifier = token_network_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
         self.balance_proof = balance_proof
 
     def __repr__(self):
@@ -95,9 +94,12 @@ class ContractSendChannelClose(ContractSendEvent):
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractSendChannelClose':
         restored = cls(
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             token_address=to_canonical_address(data['token_address']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
             balance_proof=data['balance_proof'],
             triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -176,6 +176,7 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     def __init__(
             self,
             expiration: BlockExpiration,
+            # FIXME: balance_proof below needs to be fully identified, so we could get rid of this
             canonical_identifier: CanonicalIdentifier,
             balance_proof: BalanceProofSignedState,
             triggered_by_block_hash: BlockHash,

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -176,15 +176,14 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     def __init__(
             self,
             expiration: BlockExpiration,
-            channel_identifier: ChannelID,
-            token_network_identifier: TokenNetworkID,
+            canonical_identifier: CanonicalIdentifier,
             balance_proof: BalanceProofSignedState,
             triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash, expiration)
 
-        self.channel_identifier = channel_identifier
-        self.token_network_identifier = token_network_identifier
+        self.channel_identifier = canonical_identifier.channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
         self.balance_proof = balance_proof
 
     def __repr__(self):
@@ -225,8 +224,11 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractSendChannelUpdateTransfer':
         restored = cls(
             expiration=int(data['expiration']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             balance_proof=data['balance_proof'],
             triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -242,15 +242,14 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
     def __init__(
             self,
             token_address: TokenAddress,
-            token_network_identifier: TokenNetworkID,
-            channel_identifier: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
             participant: Address,
             triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash)
         self.token_address = token_address
-        self.token_network_identifier = token_network_identifier
-        self.channel_identifier = channel_identifier
+        self.token_network_identifier = canonical_identifier.token_network_address
+        self.channel_identifier = canonical_identifier.channel_identifier
         self.participant = participant
 
     def __repr__(self):
@@ -294,8 +293,11 @@ class ContractSendChannelBatchUnlock(ContractSendEvent):
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractSendChannelBatchUnlock':
         restored = cls(
             token_address=to_canonical_address(data['token_address']),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             participant=to_canonical_address(data['participant']),
             triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -176,13 +176,12 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
     def __init__(
             self,
             expiration: BlockExpiration,
-            # FIXME: balance_proof below needs to be fully identified, so we could get rid of this
-            canonical_identifier: CanonicalIdentifier,
             balance_proof: BalanceProofSignedState,
             triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash, expiration)
 
+        canonical_identifier = balance_proof.canonical_identifier
         self.channel_identifier = canonical_identifier.channel_identifier
         self.token_network_identifier = canonical_identifier.token_network_address
         self.balance_proof = balance_proof

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -29,7 +29,6 @@ from raiden.utils.typing import (
     TargetAddress,
     TokenAddress,
     TokenAmount,
-    TokenNetworkAddress,
     TokenNetworkID,
 )
 
@@ -112,11 +111,12 @@ class ContractSendChannelSettle(ContractSendEvent):
 
     def __init__(
             self,
-            channel_identifier: ChannelID,
-            token_network_identifier: TokenNetworkAddress,
+            canonical_identifier: CanonicalIdentifier,
             triggered_by_block_hash: BlockHash,
     ):
         super().__init__(triggered_by_block_hash)
+        channel_identifier = canonical_identifier.channel_identifier
+        token_network_identifier = canonical_identifier.token_network_address
         if not isinstance(channel_identifier, T_ChannelID):
             raise ValueError('channel_identifier must be a ChannelID instance')
 
@@ -159,8 +159,11 @@ class ContractSendChannelSettle(ContractSendEvent):
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractSendChannelSettle':
         restored = cls(
-            channel_identifier=ChannelID(int(data['channel_identifier'])),
-            token_network_identifier=to_canonical_address(data['token_network_identifier']),
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
+                token_network_address=to_canonical_address(data['token_network_identifier']),
+                channel_identifier=ChannelID(int(data['channel_identifier'])),
+            ),
             triggered_by_block_hash=BlockHash(deserialize_bytes(data['triggered_by_block_hash'])),
         )
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -891,7 +891,6 @@ class BalanceProofSignedState(State):
         'signature',
         'sender',
         'chain_id',
-        'canonical_identifier',
     )
 
     def __init__(

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -845,6 +845,14 @@ class BalanceProofUnsignedState(State):
             locksroot=self.locksroot,
         )
 
+    @property
+    def canonical_identifier(self) -> CanonicalIdentifier:
+        return CanonicalIdentifier(
+            chain_identifier=self.chain_id,
+            token_network_address=self.token_network_identifier,
+            channel_identifier=self.channel_identifier,
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             'nonce': self.nonce,
@@ -1017,6 +1025,14 @@ class BalanceProofSignedState(State):
             transferred_amount=self.transferred_amount,
             locked_amount=self.locked_amount,
             locksroot=self.locksroot,
+        )
+
+    @property
+    def canonical_identifier(self) -> CanonicalIdentifier:
+        return CanonicalIdentifier(
+            chain_identifier=self.chain_id,
+            token_network_address=self.token_network_identifier,
+            channel_identifier=self.channel_identifier,
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -1624,6 +1624,14 @@ class NettingChannelState(State):
     def partner_total_deposit(self):
         return self.partner_state.contract_balance
 
+    @property
+    def canonical_identifier(self) -> CanonicalIdentifier:
+        return CanonicalIdentifier(
+            chain_identifier=self.chain_id,
+            token_network_address=self.token_network_identifier,
+            channel_identifier=self.identifier,
+        )
+
     def __ne__(self, other):
         return not self.__eq__(other)
 


### PR DESCRIPTION
This adds the `CanonicalIdentifier` for #3493 to the classes in `raiden/transfer/events.py` (where applicable).
It also adds a transient `.canonical_identifier` property to `NettingChannelState` (based on the already existing partial identifiers), which allows for a lot of code simplification.
`pack_reward_proof` now also uses a `CanonicalIdentifier` as an argument (instead of the singular arguments).
This is still all done without serialization changes.