### PR TITLE
Fix raiden crashing at startup if starting from a fresh DB

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`3558` Raiden will no longer crash if starting with a fresh DB due to the ethereum node queries timing out.
 * :bug:`3567` Properly check handling offline partners
 * :feature:`2436` Add an API endpoint to list pending transfers
 * :bug:`3475` Properly check async_result in rest api payments

--- a/raiden/network/rpc/middleware.py
+++ b/raiden/network/rpc/middleware.py
@@ -1,8 +1,12 @@
 import functools
 from json.decoder import JSONDecodeError
+from typing import Tuple
 
+import gevent
 from cachetools import LRUCache
+from requests import exceptions
 from web3.middleware.cache import construct_simple_cache_middleware
+from web3.middleware.exception_retry_request import check_if_retry_on_failure
 
 from raiden.exceptions import EthNodeCommunicationError
 
@@ -40,3 +44,43 @@ block_hash_cache_middleware = construct_simple_cache_middleware(
     cache_class=functools.partial(LRUCache, 150),
     rpc_whitelist=BLOCK_HASH_CACHE_RPC_WHITELIST,
 )
+
+
+# This one is taken directly from the PFS code:
+# https://github.com/raiden-network/raiden-services/blob/51b2b3093915c482e3d8307a09f2952ffa3c6c7e/src/pathfinding_service/middleware.py
+# We could potentially move it to a common code repository
+def http_retry_with_backoff_middleware(
+        make_request,
+        web3,
+        errors: Tuple = (
+            exceptions.ConnectionError,
+            exceptions.HTTPError,
+            exceptions.Timeout,
+            exceptions.TooManyRedirects,
+        ),
+        retries: int = 10,
+        first_backoff: float = 0.2,
+        backoff_factor: float = 2,
+):
+    """ Retry requests with exponential backoff
+    Creates middleware that retries failed HTTP requests and exponentially
+    increases the backoff between retries. Meant to replace the default
+    middleware `http_retry_request_middleware` for HTTPProvider.
+    """
+    def middleware(method, params):
+        backoff = first_backoff
+        if check_if_retry_on_failure(method):
+            for i in range(retries):
+                try:
+                    return make_request(method, params)
+                except errors:
+                    if i < retries - 1:
+                        gevent.sleep(backoff)
+                        backoff *= backoff_factor
+                        continue
+                    else:
+                        raise
+        else:
+            return make_request(method, params)
+
+    return middleware

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -117,7 +117,11 @@ class StatelessFilter(LogFilter):
         filter_params['fromBlock'] = from_block
         filter_params['toBlock'] = to_block
 
-        log.debug(f'Querying filter from block {from_block} to block {to_block}')
+        log.debug(
+            'Querying StatelessFilter',
+            from_block=from_block,
+            to_block=to_block,
+        )
         result = self.web3.eth.getLogs(filter_params)
         self._last_block = to_block
         return result


### PR DESCRIPTION
Fix #3558 

## What this PR does

This PR does two things to address the problems seen in #3558.

1. Introduces the same middleware they use in PFS for retrying requests with backoffs for web3 as seen [here](https://github.com/raiden-network/raiden-services/blob/51b2b3093915c482e3d8307a09f2952ffa3c6c7e/src/pathfinding_service/middleware.py). This change alone fixes the crash for geth but not for parity or infura.
**side note**
@palango I made a few changes to the code when copying. You are using the native built-in `ConnectionError` while you should use the one from requests. Also ... we should probably have these stuff in some common code repository as long as we don't go for the monorepo approach

2. Querying filter for new entries now queries up to 100k blocks with each query. Querying all 7,8 million blocks in one query is the main reason parity and infura were crashing.

## How I tested it

I reproduced the crash with  a geth node, a parity node and infura. Then re-ran all after the fixes and it works fine with all three backends.