### PR TITLE
Fix Rest API affected by webargs CVE-2019-9710

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -111,7 +111,7 @@ Twisted==18.9.0
 unpaddedbase64==1.1.0
 urllib3==1.23
 web3==4.7.1
-webargs==4.0.0
+webargs==5.1.3
 websockets==6.0
 Werkzeug==0.14.1
 zope.interface==4.6.0

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -225,7 +225,7 @@ def api_error(errors, status_code):
 
 
 @parser.error_handler
-def handle_request_parsing_error(err, _req, _schema):
+def handle_request_parsing_error(err, _req, _schema, _err_status_code, err_headers):
     """ This handles request parsing errors generated for example by schema
     field validation failing."""
     abort(HTTPStatus.BAD_REQUEST, errors=err.messages)


### PR DESCRIPTION
The CVE description can be found
[here](https://nvd.nist.gov/vuln/detail/CVE-2019-9710#vulnCurrentDescriptionTitle).

Essentially webargs JSON parsing uses a short-lived cache to store the parsed JSON body. This cache is not thread-safe, meaning that incorrect JSON payloads could have been parsed for concurrent requests.


**side note**

We really should put all of our requirements back into `requirements.txt` and just keep the non-direct dependencies pinning in `constraints.txt`. We no longer get github security updates because of our current structure. I saw this due to another project.