### PR TITLE
Resolve unlock channel early

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -21,7 +21,7 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
 )
-from raiden.utils import CHANNEL_ID_UNSPECIFIED, CanonicalIdentifier, pex, typing
+from raiden.utils import CanonicalIdentifier, pex, typing
 from raiden_contracts.constants import (
     EVENT_SECRET_REVEALED,
     EVENT_TOKEN_NETWORK_CREATED,
@@ -303,18 +303,39 @@ def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
     block_number = data['block_number']
     block_hash = data['block_hash']
     transaction_hash = data['transaction_hash']
+    participant1 = args['participant']
+    participant2 = args['partner']
 
     chain_state = views.state_from_raiden(raiden)
+    token_network_state = views.get_token_network_by_identifier(
+        chain_state,
+        token_network_identifier,
+    )
+    netting_channel_state = None
+    for channel_state in list(token_network_state.channelidentifiers_to_channels.values()):
+        are_addresses_valid1 = (
+            channel_state.our_state.address == participant1 and
+            channel_state.partner_state.address == participant2
+        )
+        are_addresses_valid2 = (
+            channel_state.our_state.address == participant2 and
+            channel_state.partner_state.address == participant1
+        )
+        is_valid_locksroot = True
+        is_valid_channel = (
+            (are_addresses_valid1 or are_addresses_valid2) and
+            is_valid_locksroot
+        )
+
+        if is_valid_channel:
+            netting_channel_state = channel_state
+            break
+
+    if netting_channel_state is None:
+        return
     unlock_state_change = ContractReceiveChannelBatchUnlock(
         transaction_hash=transaction_hash,
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=chain_state.chain_id,
-            token_network_address=token_network_identifier,
-            # FIXME: we will resolve the channel identifier only further down in
-            # raiden.transfer.token_network::handle_batch_unlock
-            # can/should we do it here already?
-            channel_identifier=CHANNEL_ID_UNSPECIFIED,
-        ),
+        canonical_identifier=netting_channel_state.canonical_identifier,
         participant=args['participant'],
         partner=args['partner'],
         locksroot=args['locksroot'],

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -15,13 +15,7 @@ from raiden.transfer.state import (
     TransactionChannelNewBalance,
 )
 from raiden.transfer.utils import pseudo_random_generator_from_json
-from raiden.utils import (
-    CHAIN_ID_UNSPECIFIED,
-    CHANNEL_ID_UNSPECIFIED,
-    CanonicalIdentifier,
-    pex,
-    sha3,
-)
+from raiden.utils import CHAIN_ID_UNSPECIFIED, CanonicalIdentifier, pex, sha3
 from raiden.utils.serialization import deserialize_bytes, serialize_bytes
 from raiden.utils.typing import (
     Address,
@@ -890,6 +884,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
         super().__init__(transaction_hash, block_number, block_hash)
 
         self.token_network_identifier = token_network_identifier
+        self.canonical_identifier = canonical_identifier
         self.participant = participant
         self.partner = partner
         self.locksroot = locksroot
@@ -915,7 +910,7 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
     def __eq__(self, other):
         return (
             isinstance(other, ContractReceiveChannelBatchUnlock) and
-            self.token_network_identifier == other.token_network_identifier and
+            self.canonical_identifier == other.canonical_identifier and
             self.participant == other.participant and
             self.partner == other.partner and
             self.locksroot == other.locksroot and
@@ -938,17 +933,14 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
             'returned_tokens': str(self.returned_tokens),
             'block_number': str(self.block_number),
             'block_hash': serialize_bytes(self.block_hash),
+            'canonical_identifier': self.canonical_identifier.to_dict(),
         }
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'ContractReceiveChannelBatchUnlock':
         return cls(
             transaction_hash=deserialize_bytes(data['transaction_hash']),
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=CHAIN_ID_UNSPECIFIED,
-                token_network_address=to_canonical_address(data['token_network_identifier']),
-                channel_identifier=CHANNEL_ID_UNSPECIFIED,
-            ),
+            canonical_identifier=CanonicalIdentifier.from_dict(data['canonical_identifier']),
             participant=to_canonical_address(data['participant']),
             partner=to_canonical_address(data['partner']),
             locksroot=deserialize_bytes(data['locksroot']),

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -188,43 +188,28 @@ def handle_batch_unlock(
         block_number: BlockNumber,
         block_hash: BlockHash,
 ):
-    participant1 = state_change.participant
-    participant2 = state_change.partner
-
     events = list()
-    for channel_state in list(token_network_state.channelidentifiers_to_channels.values()):
-        are_addresses_valid1 = (
-            channel_state.our_state.address == participant1 and
-            channel_state.partner_state.address == participant2
+    channel_state = token_network_state.channelidentifiers_to_channels.get(
+        state_change.canonical_identifier.channel_identifier,
+    )
+    if channel_state is not None:
+        sub_iteration = channel.state_transition(
+            channel_state=channel_state,
+            state_change=state_change,
+            block_number=block_number,
+            block_hash=block_hash,
         )
-        are_addresses_valid2 = (
-            channel_state.our_state.address == participant2 and
-            channel_state.partner_state.address == participant1
-        )
-        is_valid_locksroot = True
-        is_valid_channel = (
-            (are_addresses_valid1 or are_addresses_valid2) and
-            is_valid_locksroot
-        )
+        events.extend(sub_iteration.events)
 
-        if is_valid_channel:
-            sub_iteration = channel.state_transition(
-                channel_state=channel_state,
-                state_change=state_change,
-                block_number=block_number,
-                block_hash=block_hash,
-            )
-            events.extend(sub_iteration.events)
+        if sub_iteration.new_state is None:
 
-            if sub_iteration.new_state is None:
+            token_network_state.partneraddresses_to_channelidentifiers[
+                channel_state.partner_state.address
+            ].remove(channel_state.identifier)
 
-                token_network_state.partneraddresses_to_channelidentifiers[
-                    channel_state.partner_state.address
-                ].remove(channel_state.identifier)
-
-                del token_network_state.channelidentifiers_to_channels[
-                    channel_state.identifier
-                ]
+            del token_network_state.channelidentifiers_to_channels[
+                channel_state.identifier
+            ]
 
     return TransitionResult(token_network_state, events)
 


### PR DESCRIPTION
`ContractReceiveChannelBatchUnlock` is now created with a fully qualified `CanonicalIdentifier`, that is also serialized.

This belongs to #3622 

## Backwards Compatibility
This changes the serialization of `raiden/transfer/state_change.py::ContractReceiveChannelBatchUnlock` to also persist and deserialize `.canonical_identifier`. In order to be mergeable, it will need a migration!