### PR TITLE
CanonicalIdentifier in `raiden.transfer.utils`

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -489,9 +489,7 @@ class RaidenEventHandler:
         if our_details.balance_hash != EMPTY_HASH:
             event_record = get_event_with_balance_proof_by_balance_hash(
                 storage=raiden.wal.storage,
-                chain_id=canonical_identifier.chain_identifier,
-                token_network_identifier=canonical_identifier.token_network_address,
-                channel_identifier=canonical_identifier.channel_identifier,
+                canonical_identifier=canonical_identifier,
                 balance_hash=our_details.balance_hash,
             )
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -442,9 +442,11 @@ class RaidenEventHandler:
             raiden: RaidenService,
             channel_settle_event: ContractSendChannelSettle,
     ):
-        chain_id = raiden.chain.network_id
-        token_network_identifier = channel_settle_event.token_network_identifier
-        channel_identifier = channel_settle_event.channel_identifier
+        canonical_identifier = CanonicalIdentifier(
+            chain_identifier=raiden.chain.network_id,
+            token_network_address=channel_settle_event.token_network_identifier,
+            channel_identifier=channel_settle_event.channel_identifier,
+        )
         triggered_by_block_hash = channel_settle_event.triggered_by_block_hash
 
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
@@ -464,9 +466,9 @@ class RaidenEventHandler:
         partner_details = participants_details.partner_details
 
         log_details = {
-            'chain_id': chain_id,
-            'token_network_identifier': token_network_identifier,
-            'channel_identifier': channel_identifier,
+            'chain_id': canonical_identifier.chain_identifier,
+            'token_network_identifier': canonical_identifier.token_network_address,
+            'channel_identifier': canonical_identifier.channel_identifier,
             'node': pex(raiden.address),
             'partner': to_checksum_address(partner_details.address),
             'our_deposit': our_details.deposit,
@@ -488,9 +490,9 @@ class RaidenEventHandler:
         if our_details.balance_hash != EMPTY_HASH:
             event_record = get_event_with_balance_proof_by_balance_hash(
                 storage=raiden.wal.storage,
-                chain_id=chain_id,
-                token_network_identifier=token_network_identifier,
-                channel_identifier=channel_identifier,
+                chain_id=canonical_identifier.chain_identifier,
+                token_network_identifier=canonical_identifier.token_network_address,
+                channel_identifier=canonical_identifier.channel_identifier,
                 balance_hash=our_details.balance_hash,
             )
 
@@ -515,9 +517,7 @@ class RaidenEventHandler:
         if partner_details.balance_hash != EMPTY_HASH:
             state_change_record = get_state_change_with_balance_proof_by_balance_hash(
                 storage=raiden.wal.storage,
-                chain_id=chain_id,
-                token_network_identifier=token_network_identifier,
-                channel_identifier=channel_identifier,
+                canonical_identifier=canonical_identifier,
                 balance_hash=partner_details.balance_hash,
                 sender=participants_details.partner_details.address,
             )

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -378,9 +378,7 @@ class RaidenEventHandler:
         elif is_our_unlock:
             event_record = get_event_with_balance_proof_by_locksroot(
                 storage=raiden.wal.storage,
-                chain_id=raiden.chain.network_id,
-                token_network_identifier=canonical_identifier.token_network_address,
-                channel_identifier=canonical_identifier.channel_identifier,
+                canonical_identifier=canonical_identifier,
                 locksroot=our_locksroot.balance_hash,
             )
             state_change_identifier = event_record.state_change_identifier

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -274,9 +274,7 @@ def test_get_event_with_balance_proof():
     for event, balance_proof in events_balanceproofs:
         event_record = get_event_with_balance_proof_by_balance_hash(
             storage=storage,
-            chain_id=balance_proof.chain_id,
-            token_network_identifier=balance_proof.token_network_identifier,
-            channel_identifier=balance_proof.channel_identifier,
+            canonical_identifier=balance_proof.canonical_identifier,
             balance_hash=balance_proof.balance_hash,
         )
         assert event_record.data == event

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -208,9 +208,7 @@ def test_get_state_change_with_balance_proof():
     for state_change, balance_proof in statechanges_balanceproofs:
         state_change_record = get_state_change_with_balance_proof_by_balance_hash(
             storage=storage,
-            chain_id=balance_proof.chain_id,
-            token_network_identifier=balance_proof.token_network_identifier,
-            channel_identifier=balance_proof.channel_identifier,
+            canonical_identifier=balance_proof.canonical_identifier,
             sender=balance_proof.sender,
             balance_hash=balance_proof.balance_hash,
         )

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -43,9 +43,7 @@ def get_state_change_with_balance_proof_by_balance_hash(
 
 def get_state_change_with_balance_proof_by_locksroot(
         storage: sqlite.SQLiteStorage,
-        chain_id: ChainID,
-        token_network_identifier: TokenNetworkID,
-        channel_identifier: ChannelID,
+        canonical_identifier: CanonicalIdentifier,
         locksroot: Locksroot,
         sender: Address,
 ) -> sqlite.StateChangeRecord:
@@ -57,9 +55,11 @@ def get_state_change_with_balance_proof_by_locksroot(
     balance proof.
     """
     return storage.get_latest_state_change_by_data_field({
-        'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
-        'balance_proof.channel_identifier': str(channel_identifier),
+        'balance_proof.chain_id': canonical_identifier.chain_identifier,
+        'balance_proof.token_network_identifier': to_checksum_address(
+            canonical_identifier.token_network_address,
+        ),
+        'balance_proof.channel_identifier': str(canonical_identifier.channel_identifier),
         'balance_proof.locksroot': serialize_bytes(locksroot),
         'balance_proof.sender': to_checksum_address(sender),
     })

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -5,6 +5,7 @@ from web3 import Web3
 
 from raiden.constants import EMPTY_HASH
 from raiden.storage import sqlite
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.serialization import serialize_bytes
 from raiden.utils.typing import (
     Address,
@@ -19,9 +20,7 @@ from raiden.utils.typing import (
 
 def get_state_change_with_balance_proof_by_balance_hash(
         storage: sqlite.SQLiteStorage,
-        chain_id: ChainID,
-        token_network_identifier: TokenNetworkID,
-        channel_identifier: ChannelID,
+        canonical_identifier: CanonicalIdentifier,
         balance_hash: BalanceHash,
         sender: Address,
 ) -> sqlite.StateChangeRecord:
@@ -32,9 +31,11 @@ def get_state_change_with_balance_proof_by_balance_hash(
     has the blinded balance proof data.
     """
     return storage.get_latest_state_change_by_data_field({
-        'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
-        'balance_proof.channel_identifier': str(channel_identifier),
+        'balance_proof.chain_id': canonical_identifier.chain_identifier,
+        'balance_proof.token_network_identifier': to_checksum_address(
+            canonical_identifier.token_network_address,
+        ),
+        'balance_proof.channel_identifier': str(canonical_identifier.channel_identifier),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
         'balance_proof.sender': to_checksum_address(sender),
     })

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -88,9 +88,7 @@ def get_event_with_balance_proof_by_balance_hash(
 
 def get_event_with_balance_proof_by_locksroot(
         storage: sqlite.SQLiteStorage,
-        chain_id: ChainID,
-        token_network_identifier: TokenNetworkID,
-        channel_identifier: ChannelID,
+        canonical_identifier: CanonicalIdentifier,
         locksroot: Locksroot,
 ) -> sqlite.EventRecord:
     """ Returns the event which contains the corresponding balance proof.
@@ -100,9 +98,11 @@ def get_event_with_balance_proof_by_locksroot(
     balance proof.
     """
     return storage.get_latest_event_by_data_field({
-        'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
-        'balance_proof.channel_identifier': str(channel_identifier),
+        'balance_proof.chain_id': canonical_identifier.chain_identifier,
+        'balance_proof.token_network_identifier': to_checksum_address(
+            canonical_identifier.token_network_address,
+        ),
+        'balance_proof.channel_identifier': str(canonical_identifier.channel_identifier),
         'balance_proof.locksroot': serialize_bytes(locksroot),
     })
 

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -7,15 +7,7 @@ from raiden.constants import EMPTY_HASH
 from raiden.storage import sqlite
 from raiden.utils import CanonicalIdentifier
 from raiden.utils.serialization import serialize_bytes
-from raiden.utils.typing import (
-    Address,
-    BalanceHash,
-    ChainID,
-    ChannelID,
-    Locksroot,
-    TokenAmount,
-    TokenNetworkID,
-)
+from raiden.utils.typing import Address, BalanceHash, Locksroot, TokenAmount
 
 
 def get_state_change_with_balance_proof_by_balance_hash(
@@ -67,9 +59,7 @@ def get_state_change_with_balance_proof_by_locksroot(
 
 def get_event_with_balance_proof_by_balance_hash(
         storage: sqlite.SQLiteStorage,
-        chain_id: ChainID,
-        token_network_identifier: TokenNetworkID,
-        channel_identifier: ChannelID,
+        canonical_identifier: CanonicalIdentifier,
         balance_hash: BalanceHash,
 ) -> sqlite.EventRecord:
     """ Returns the event which contains the corresponding balance
@@ -79,9 +69,11 @@ def get_event_with_balance_proof_by_balance_hash(
     has the blinded balance proof data.
     """
     return storage.get_latest_event_by_data_field({
-        'balance_proof.chain_id': chain_id,
-        'balance_proof.token_network_identifier': to_checksum_address(token_network_identifier),
-        'balance_proof.channel_identifier': str(channel_identifier),
+        'balance_proof.chain_id': canonical_identifier.chain_identifier,
+        'balance_proof.token_network_identifier': to_checksum_address(
+            canonical_identifier.token_network_address,
+        ),
+        'balance_proof.channel_identifier': str(canonical_identifier.channel_identifier),
         'balance_proof.balance_hash': serialize_bytes(balance_hash),
     })
 


### PR DESCRIPTION
This uses `CanonicalIdentifier` when querying the DB for #3493 