### PR TITLE
Use `CanonicalIdentifier` when creating `PaymentChannel`

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -477,8 +477,7 @@ class RaidenAPI:
         token_network_address = token_network_registry.get_token_network(token_address)
         token_network_proxy = self.raiden.chain.token_network(token_network_address)
         channel_proxy = self.raiden.chain.payment_channel(
-            token_network_address=token_network_proxy.address,
-            channel_id=channel_state.identifier,
+            canonical_identifier=channel_state.canonical_identifier,
         )
 
         if total_deposit == 0:

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -83,8 +83,11 @@ def handle_channel_new(raiden: 'RaidenService', event: Event):
     # Raiden node is participant
     if is_participant:
         channel_proxy = raiden.chain.payment_channel(
-            token_network_identifier,
-            channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=views.state_from_raiden(raiden).chain_id,
+                token_network_address=token_network_identifier,
+                channel_identifier=channel_identifier,
+            ),
         )
         token_address = channel_proxy.token_address()
         channel_state = get_channel_state(

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -11,11 +11,11 @@ from raiden.network.proxies import (
     TokenNetworkRegistry,
 )
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.typing import (
     Address,
     BlockHash,
     BlockNumber,
-    ChannelID,
     PaymentNetworkID,
     T_ChannelID,
     TokenNetworkAddress,
@@ -192,9 +192,11 @@ class BlockChainService:
 
     def payment_channel(
             self,
-            token_network_address: TokenNetworkAddress,
-            channel_id: ChannelID,
+            canonical_identifier: CanonicalIdentifier,
     ) -> PaymentChannel:
+
+        token_network_address = TokenNetworkAddress(canonical_identifier.token_network_address)
+        channel_id = canonical_identifier.channel_identifier
 
         if not is_binary_address(token_network_address):
             raise ValueError('address must be a valid address')

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -272,8 +272,11 @@ class RaidenEventHandler:
             message_hash = EMPTY_HASH
 
         channel_proxy = raiden.chain.payment_channel(
-            token_network_address=channel_close_event.token_network_identifier,
-            channel_id=channel_close_event.channel_identifier,
+            canonical_identifier=CanonicalIdentifier(
+                chain_identifier=state_from_raiden(raiden).chain_id,
+                token_network_address=channel_close_event.token_network_identifier,
+                channel_identifier=channel_close_event.channel_identifier,
+            ),
         )
 
         channel_proxy.close(
@@ -292,20 +295,16 @@ class RaidenEventHandler:
         balance_proof = channel_update_event.balance_proof
 
         if balance_proof:
+            canonical_identifier = balance_proof.canonical_identifier
             channel = raiden.chain.payment_channel(
-                token_network_address=channel_update_event.token_network_identifier,
-                channel_id=channel_update_event.channel_identifier,
+                canonical_identifier=canonical_identifier,
             )
 
             non_closing_data = pack_balance_proof_update(
                 nonce=balance_proof.nonce,
                 balance_hash=balance_proof.balance_hash,
                 additional_hash=balance_proof.message_hash,
-                canonical_identifier=CanonicalIdentifier(
-                    chain_identifier=balance_proof.chain_id,
-                    token_network_address=balance_proof.token_network_identifier,
-                    channel_identifier=balance_proof.channel_identifier,
-                ),
+                canonical_identifier=canonical_identifier,
                 partner_signature=balance_proof.signature,
             )
             our_signature = raiden.signer.sign(data=non_closing_data)
@@ -340,8 +339,7 @@ class RaidenEventHandler:
         triggered_by_block_hash = channel_unlock_event.triggered_by_block_hash
 
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
-            token_network_address=canonical_identifier.token_network_address,
-            channel_id=canonical_identifier.channel_identifier,
+            canonical_identifier=canonical_identifier,
         )
         token_network: TokenNetwork = payment_channel.token_network
 
@@ -449,10 +447,8 @@ class RaidenEventHandler:
         triggered_by_block_hash = channel_settle_event.triggered_by_block_hash
 
         payment_channel: PaymentChannel = raiden.chain.payment_channel(
-            token_network_address=channel_settle_event.token_network_identifier,
-            channel_id=channel_settle_event.channel_identifier,
+            canonical_identifier=canonical_identifier,
         )
-
         token_network_proxy: TokenNetwork = payment_channel.token_network
         participants_details = token_network_proxy.detail_participants(
             participant1=payment_channel.participant1,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -475,8 +475,7 @@ def test_settled_lock(token_addresses, raiden_network, deposit, skip_if_parity):
     )
 
     netting_channel = app1.raiden.chain.payment_channel(
-        token_network_identifier,
-        channelstate_0_1.identifier,
+        canonical_identifier=channelstate_0_1.canonical_identifier,
     )
 
     # The transfer locksroot must not contain the unlocked lock, the

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -7,6 +7,7 @@ from raiden.tests.utils import factories
 from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
 from raiden.transfer.state_change import ActionInitChain
+from raiden.utils import CanonicalIdentifier
 from raiden.utils.signer import LocalSigner
 
 
@@ -35,8 +36,8 @@ class MockChain:
         # let's make a single mock token network for testing
         self.token_network = MockTokenNetwork()
 
-    def payment_channel(self, token_network_address, channel_id):
-        return MockPaymentChannel(self.token_network, channel_id)
+    def payment_channel(self, canonical_identifier: CanonicalIdentifier):
+        return MockPaymentChannel(self.token_network, canonical_identifier.channel_identifier)
 
 
 class MockRaidenService:


### PR DESCRIPTION
This changes the arguments for summoning a `PaymentChannel` from `raiden/network/blockchain_service.py` to use only a `CanonicalIdentifier`. This is another step for #3493 and is serialization compatible.