### PR TITLE
Reduce parity `stepDuration` in integration tests

### DIFF
--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -27,7 +27,7 @@ PARITY_CHAIN_SPEC_STUB = {
     "engine": {
         "authorityRound": {
             "params": {
-                "stepDuration": 3,
+                "stepDuration": 1,
             },
         },
     },


### PR DESCRIPTION
This is an attempt to speed up `--blockchain-type=parity` integration tests by reducing the `stepDuration` to `1`(down from `3`) in `chainspec.json`.