### PR TITLE
Added autopep8 as a linting tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ ISORT_PARAMS = --ignore-whitespace --settings-path ./ --recursive raiden/ -sg */
 
 lint:
 	flake8 raiden/ tools/
+	autopep8 --diff --exit-code $(shell find raiden -iname '*.py')
 	isort $(ISORT_PARAMS) --diff --check-only
 	pylint --load-plugins=tools.pylint.gevent_checker --rcfile .pylint.rc raiden/
 	python setup.py check --restructuredtext --strict

--- a/raiden/network/sockfactory.py
+++ b/raiden/network/sockfactory.py
@@ -11,8 +11,8 @@ log = structlog.get_logger(__name__)
 
 
 class PortMappedSocket:
-    """Wrapper around a socket instance with port mapping information.
-    """
+    """Wrapper around a socket instance with port mapping information."""
+
     def __init__(self, sock, method, external_ip, external_port, **meta):
         self.socket = sock
         self.method = method
@@ -119,8 +119,10 @@ class SocketFactory:
             if result is not None:
                 self.storage['router'] = router
                 self.storage['external_port'] = result[1]
-                return PortMappedSocket(self.socket, 'UPnP', result[0], result[1],
-                                        router_location=location)
+                return PortMappedSocket(
+                    self.socket, 'UPnP', result[0], result[1],
+                    router_location=location,
+                )
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
                 raise RaidenServicePortInUseError()
@@ -151,8 +153,10 @@ class SocketFactory:
                 default_gw_if = netifaces.gateways()['default'][netifaces.AF_INET][1]
                 self.source_ip = netifaces.ifaddresses(default_gw_if)[netifaces.AF_INET][0]['addr']
             except (OSError, IndexError, KeyError):
-                log.critical("Couldn't get interface address. "
-                             "Try specifying with '--nat ext:<ip>'.")
+                log.critical(
+                    "Couldn't get interface address. "
+                    "Try specifying with '--nat ext:<ip>'.",
+                )
                 raise
         log.warning('Using internal interface address. Connectivity issues are likely.')
         return PortMappedSocket(self.socket, 'NONE', self.source_ip, self.source_port)

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,4 @@
+autopep8==1.4.3
 flake8==3.7.5
 flake8-bugbear==18.8.0
 flake8-commas==2.0.0


### PR DESCRIPTION
This gets some additional cases in respect to the pycodestyle tool. Namely:

```
    Correct deprecated or non-idiomatic Python code (via lib2to3). Use this for making Python 2.7 code more compatible with Python 3. (This is triggered if W690 is enabled.)
    Normalize files with mixed line endings.
    Put a blank line between a class docstring and its first method declaration. (Enabled with E301.)
    Remove blank lines between a function declaration and its docstring. (Enabled with E303.)
```