### PR TITLE
Bugfix kill during migration

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -110,8 +110,8 @@ class SQLiteStorage(SerializationBase):
     def update_version(self):
         cursor = self.conn.cursor()
         cursor.execute(
-            'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
-            ('version', str(RAIDEN_DB_VERSION)),
+            'INSERT OR REPLACE INTO settings(name, value) VALUES("version", ?)',
+            (str(RAIDEN_DB_VERSION), ),
         )
         self.maybe_commit()
 
@@ -125,7 +125,7 @@ class SQLiteStorage(SerializationBase):
     def get_version(self) -> int:
         cursor = self.conn.cursor()
         query = cursor.execute(
-            'SELECT value FROM settings WHERE name=?;', ('version',),
+            'SELECT value FROM settings WHERE name="version";',
         )
         query = query.fetchall()
         # If setting is not set, it's the latest version

--- a/raiden/storage/versions.py
+++ b/raiden/storage/versions.py
@@ -1,21 +1,24 @@
 import os.path
 import re
 
-from raiden.utils.typing import Optional
+from raiden.utils.typing import List, Optional
 
 VERSION_RE = re.compile(r'^v(\d+)_log[.]db$')
 
 
-def older_db_file(paths) -> Optional[str]:
-    """Returns the path with matches our database naming convention and has the
-    highest version number or None.
+def latest_db_file(paths: List[str]) -> Optional[str]:
+    """Returns the path with the highest `version` number.
+
+    Raises:
+        AssertionError: If any the `paths` in list is an invalid name.
+
+    Args:
+        paths: A list of file names.
     """
     dbs = {}
     for db_path in paths:
-        # Ignore files that don't match our naming format
-        matches = VERSION_RE.search(os.path.basename(db_path))
-        if not matches:
-            continue
+        matches = VERSION_RE.match(os.path.basename(db_path))
+        assert matches, f'Invalid path name {db_path}'
 
         try:
             version = int(matches.group(1))
@@ -29,3 +32,16 @@ def older_db_file(paths) -> Optional[str]:
         return dbs[highest_version]
 
     return None
+
+
+def filter_db_names(paths: List[str]) -> List[str]:
+    """Returns a filtered list of `paths`, where every name matches our format.
+
+    Args:
+        paths: A list of file names.
+    """
+    return [
+        db_path
+        for db_path in paths
+        if VERSION_RE.match(os.path.basename(db_path))
+    ]

--- a/raiden/storage/versions.py
+++ b/raiden/storage/versions.py
@@ -10,7 +10,7 @@ def latest_db_file(paths: List[str]) -> Optional[str]:
     """Returns the path with the highest `version` number.
 
     Raises:
-        AssertionError: If any the `paths` in list is an invalid name.
+        AssertionError: If any of the `paths` in the list is an invalid name.
 
     Args:
         paths: A list of file names.

--- a/raiden/tests/unit/storage/migrations/test_v16_to_v17.py
+++ b/raiden/tests/unit/storage/migrations/test_v16_to_v17.py
@@ -36,11 +36,13 @@ def setup_storage(db_path):
 
 def test_upgrade_v16_to_v17(tmp_path):
     old_db_filename = tmp_path / Path('v16_log.db')
-    with patch('raiden.utils.upgrades.older_db_file') as older_db_file:
-        older_db_file.return_value = str(old_db_filename)
-        storage = setup_storage(str(old_db_filename))
-        with patch('raiden.constants.RAIDEN_DB_VERSION', new=16):
+    with patch('raiden.utils.upgrades.latest_db_file') as latest_db_file:
+        latest_db_file.return_value = str(old_db_filename)
+
+        with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=16):
+            storage = setup_storage(str(old_db_filename))
             storage.update_version()
+
         storage.conn.close()
 
     db_path = tmp_path / Path('v17_log.db')

--- a/raiden/tests/unit/storage/migrations/test_v17_to_v18.py
+++ b/raiden/tests/unit/storage/migrations/test_v17_to_v18.py
@@ -36,8 +36,8 @@ def setup_storage(db_path):
 
 def test_upgrade_v17_to_v18(tmp_path):
     old_db_filename = tmp_path / Path('v17_log.db')
-    with patch('raiden.utils.upgrades.older_db_file') as older_db_file:
-        older_db_file.return_value = str(old_db_filename)
+    with patch('raiden.utils.upgrades.latest_db_file') as latest_db_file:
+        latest_db_file.return_value = str(old_db_filename)
         storage = setup_storage(str(old_db_filename))
         with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=17):
             storage.update_version()

--- a/raiden/tests/unit/storage/migrations/test_v18_to_v19.py
+++ b/raiden/tests/unit/storage/migrations/test_v18_to_v19.py
@@ -53,8 +53,8 @@ def setup_storage(db_path):
 
 def test_upgrade_v18_to_v19(tmp_path):
     old_db_filename = tmp_path / Path('v18_log.db')
-    with patch('raiden.utils.upgrades.older_db_file') as older_db_file:
-        older_db_file.return_value = str(old_db_filename)
+    with patch('raiden.utils.upgrades.latest_db_file') as latest_db_file:
+        latest_db_file.return_value = str(old_db_filename)
         storage = setup_storage(str(old_db_filename))
         with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=18):
             storage.update_version()

--- a/raiden/tests/unit/storage/migrations/test_v19_to_v20.py
+++ b/raiden/tests/unit/storage/migrations/test_v19_to_v20.py
@@ -37,8 +37,8 @@ def setup_storage(db_path):
 
 def test_upgrade_v19_to_v20(tmp_path):
     old_db_filename = tmp_path / Path('v19_log.db')
-    with patch('raiden.utils.upgrades.older_db_file') as older_db_file:
-        older_db_file.return_value = str(old_db_filename)
+    with patch('raiden.utils.upgrades.latest_db_file') as latest_db_file:
+        latest_db_file.return_value = str(old_db_filename)
         storage = setup_storage(str(old_db_filename))
         with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=19):
             storage.update_version()

--- a/raiden/tests/unit/storage/migrations/test_v20_to_v21.py
+++ b/raiden/tests/unit/storage/migrations/test_v20_to_v21.py
@@ -102,8 +102,8 @@ def assert_snapshots_are_transformed(storage: SQLiteStorage) -> None:
 
 def test_upgrade_v20_to_v21(tmp_path):
     old_db_filename = tmp_path / Path('v20_log.db')
-    with patch('raiden.utils.upgrades.older_db_file') as older_db_file:
-        older_db_file.return_value = str(old_db_filename)
+    with patch('raiden.utils.upgrades.latest_db_file') as latest_db_file:
+        latest_db_file.return_value = str(old_db_filename)
         storage = setup_storage(str(old_db_filename))
         with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=20):
             storage.update_version()

--- a/raiden/tests/unit/storage/test_versions.py
+++ b/raiden/tests/unit/storage/test_versions.py
@@ -1,16 +1,42 @@
-from raiden.storage.versions import older_db_file
+import pytest
+
+from raiden.storage.versions import filter_db_names, latest_db_file
 
 
-def test_older_db_file():
-    assert older_db_file(['v10_log.db', 'v9_log.db']) == 'v10_log.db'
-    assert older_db_file(['v9_log.db', 'v10_log.db']) == 'v10_log.db'
-    assert older_db_file(['v1_log.db', 'v9_log.db']) == 'v9_log.db'
-    assert older_db_file(['v9_log.db', 'v1_log.db']) == 'v9_log.db'
+def test_latest_db_file():
+    assert latest_db_file(['v10_log.db', 'v9_log.db']) == 'v10_log.db'
+    assert latest_db_file(['v9_log.db', 'v10_log.db']) == 'v10_log.db'
+    assert latest_db_file(['v1_log.db', 'v9_log.db']) == 'v9_log.db'
+    assert latest_db_file(['v9_log.db', 'v1_log.db']) == 'v9_log.db'
+    assert latest_db_file([]) is None
 
-    assert older_db_file([]) is None
-    assert older_db_file(['a']) is None
-    assert older_db_file(['.db']) is None
-    assert older_db_file(['v9.db']) is None
-    assert older_db_file(['9_log.db']) is None
-    assert older_db_file(['va9_log.db']) is None
-    assert older_db_file(['v9a_log.db']) is None
+    values = [
+        'a',
+        '.db',
+        'v9.db',
+        '9_log.db',
+        'va9_log.db',
+        'v9a_log.db',
+    ]
+    for invalid_value in values:
+        with pytest.raises(AssertionError):
+            latest_db_file([invalid_value])
+
+
+def test_filter_db_names():
+    assert filter_db_names(['v10_log.db', 'v9_log.db']) == ['v10_log.db', 'v9_log.db']
+    assert filter_db_names(['v9_log.db', 'v10_log.db']) == ['v9_log.db', 'v10_log.db']
+    assert filter_db_names(['v1_log.db', 'v9_log.db']) == ['v1_log.db', 'v9_log.db']
+    assert filter_db_names(['v9_log.db', 'v1_log.db']) == ['v9_log.db', 'v1_log.db']
+
+    values = [
+        [],
+        ['a'],
+        ['.db'],
+        ['v9.db'],
+        ['9_log.db'],
+        ['va9_log.db'],
+        ['v9a_log.db'],
+    ]
+    for invalid_value in values:
+        assert filter_db_names(invalid_value) == []

--- a/raiden/tests/unit/test_upgrade.py
+++ b/raiden/tests/unit/test_upgrade.py
@@ -51,7 +51,7 @@ def test_no_upgrade_executes_if_already_upgraded(tmp_path):
     with patch('raiden.utils.upgrades.UpgradeManager._upgrade') as upgrade_mock:
         with patch('raiden.utils.upgrades.RAIDEN_DB_VERSION', new=version):
             UpgradeManager(db_filename=db_path).run()
-            # Oldest database is of the same version as the current, no migrations should execute
+            # Latest database is of the same version as the current, no migrations should execute
             assert not upgrade_mock.called
 
 

--- a/raiden/tests/unit/utils/upgrades.py
+++ b/raiden/tests/unit/utils/upgrades.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from raiden.storage.versions import VERSION_RE
+from raiden.utils.upgrades import delete_dbs_with_failed_migrations
+
+
+def _return_valid_db_version(db_filename):
+    version = int(VERSION_RE.match(db_filename).group(1))
+    return version
+
+
+def _return_smaller_db_version(db_filename):
+    version = int(VERSION_RE.match(db_filename).group(1)) - 1
+    return version
+
+
+def _return_higher_db_version(db_filename):
+    version = int(VERSION_RE.match(db_filename).group(1)) + 1
+    return version
+
+
+class GetLockMock:
+    # pylint: disable=unused-argument
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, a_, b_, c_):
+        pass
+
+
+def test_delete_dbs_with_failed_migrations(monkeypatch):
+    """Only sqlite databases which have an older version in the settings table
+    in respect to *its* filename should be removed.
+
+    This is testing that nothing else is removed, since it's crucial that the
+    wrong database is not deleted.
+    """
+    file_names = [
+        'v1_log.db',
+        'v11_log.db',
+        'v9_log.db',
+        'v9999_log.db',
+    ]
+
+    exists_mock = MagicMock(return_value=True)
+    monkeypatch.setattr('raiden.utils.upgrades.get_file_lock', GetLockMock)
+
+    with monkeypatch.context() as m:
+        remove_mock = MagicMock()
+
+        m.setattr('raiden.utils.upgrades.get_db_version', _return_valid_db_version)
+        m.setattr('raiden.utils.upgrades.os.path.exists', exists_mock)
+        m.setattr('raiden.utils.upgrades.os.remove', remove_mock)
+
+        delete_dbs_with_failed_migrations(list(file_names))
+        remove_mock.assert_not_called()
+
+    with monkeypatch.context() as m:
+        remove_mock = MagicMock()
+
+        m.setattr('raiden.utils.upgrades.get_db_version', _return_higher_db_version)
+        m.setattr('raiden.utils.upgrades.os.path.exists', exists_mock)
+        m.setattr('raiden.utils.upgrades.os.remove', remove_mock)
+
+        with pytest.raises(RuntimeError):
+            delete_dbs_with_failed_migrations(list(file_names))
+
+        remove_mock.assert_not_called()
+
+    with monkeypatch.context() as m:
+        remove_mock = MagicMock()
+
+        m.setattr('raiden.utils.upgrades.get_db_version', _return_smaller_db_version)
+        m.setattr('raiden.utils.upgrades.os.path.exists', exists_mock)
+        m.setattr('raiden.utils.upgrades.os.remove', remove_mock)
+
+        delete_dbs_with_failed_migrations(list(file_names))
+
+        for value in file_names:
+            remove_mock.assert_any_call(value)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,11 +1,9 @@
-import contextlib
 import os
 import shutil
 import sys
 import tempfile
 import traceback
 from http import HTTPStatus
-from typing import IO
 
 import click
 import requests
@@ -100,8 +98,6 @@ def run_smoketests(
         transport: str,
         token_addresses,
         discovery_address,
-        orig_stdout: IO[str],
-        debug: bool = False,
 ):
     """ Test that the assembled raiden_service correctly reflects the configuration from the
     smoketest_genesis. """
@@ -147,10 +143,6 @@ def run_smoketests(
         run_restapi_smoketests()
     except:  # NOQA pylint: disable=bare-except
         error = traceback.format_exc()
-        if debug:
-            with contextlib.redirect_stdout(orig_stdout):
-                import pdb
-                pdb.post_mortem()  # pylint: disable=no-member
         return error
 
     return None

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -650,9 +650,8 @@ def smoketest(ctx, debug):
 
         raiden_stdout = StringIO()
         with contextlib.redirect_stdout(raiden_stdout):
-            app = run_app(**args)
-
             try:
+                app = run_app(**args)
                 raiden_api = RaidenAPI(app.raiden)
                 rest_api = RestAPI(raiden_api)
                 (api_host, api_port) = split_endpoint(args['api_address'])
@@ -689,13 +688,16 @@ def smoketest(ctx, debug):
                     args['transport'],
                     token_addresses,
                     contract_addresses[CONTRACT_ENDPOINT_REGISTRY],
-                    debug=debug,
-                    orig_stdout=stdout,
                 )
                 if error is not None:
                     append_report('Smoketest assertion error', error)
                 else:
                     success = True
+            except:  # NOQA pylint: disable=bare-except
+                if debug:
+                    with contextlib.redirect_stdout(stdout):
+                        import pdb
+                        pdb.post_mortem()  # pylint: disable=no-member
             finally:
                 app.stop()
                 app.raiden.get()

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -59,8 +59,8 @@ def get_file_lock(db_filename: Path):
 def update_version(storage: SQLiteStorage, version: int):
     cursor = storage.conn.cursor()
     cursor.execute(
-        'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
-        ('version', str(version)),
+        'INSERT OR REPLACE INTO settings(name, value) VALUES("version", ?)',
+        (str(version), ),
     )
 
 

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -129,7 +129,7 @@ def delete_dbs_with_failed_migrations(valid_db_names: List[str]) -> None:
             elif db_version > file_version:
                 raise RuntimeError(
                     f'Impossible database version. '
-                    f'The database {db_path} has a version too high ({db_version}), '
+                    f'The database {db_path} has too high a version ({db_version}), '
                     f'this should never happen.',
                 )
 

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -182,6 +182,11 @@ class UpgradeManager:
         paths = glob(f'{self._current_db_filename.parent}/v*_log.db')
         valid_db_names = filter_db_names(paths)
         latest_db_path = latest_db_file(valid_db_names)
+
+        # First run, there is no database file available
+        if latest_db_path is None:
+            return
+
         file_version = get_file_version(latest_db_path)
 
         # The latest version matches our target version, nothing to do.

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sqlite3
 from contextlib import closing
 from glob import glob
@@ -95,11 +94,6 @@ def get_db_version(db_filename: Path) -> Optional[int]:
         )
 
     return int(result[0])
-
-
-def _backup_old_db(filename: str):
-    backup_name = filename.replace('_log.db', '_log.backup')
-    shutil.move(filename, backup_name)
 
 
 def _copy(old_db_filename, current_db_filename):
@@ -206,8 +200,6 @@ class UpgradeManager:
                             **self._kwargs,
                         )
                     update_version(storage, RAIDEN_DB_VERSION)
-                    # Prevent the upgrade from happening on next restart
-                    _backup_old_db(str(old_db_filename))
             except Exception as e:
                 self._delete_current_db()
                 log.error(f'Failed to upgrade database: {str(e)}')


### PR DESCRIPTION
Fixed a bug introduced by: https://github.com/raiden-network/raiden/pull/3643 . The offending change is the removal of this check:

https://github.com/raiden-network/raiden/pull/3643/files#diff-fa75f1f3933a68f8046af87ad43aff37L28

Without that check the values of `old_db_filename` and `current_db_filename` could be the same:

https://github.com/hackaugusto/raiden/blob/edfebfe0ed7fa9d3462320054cff742f419127c7/raiden/utils/upgrades.py#L171

Additionally, this fix the special case were the cleanup is not executed:

https://github.com/hackaugusto/raiden/blob/edfebfe0ed7fa9d3462320054cff742f419127c7/raiden/utils/upgrades.py#L193-L196

Which can happens with a sigkill