### PR TITLE
Parity between solc version used in client and contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,6 @@ templates:
     PARITY_URL_MACOS: 'https://releases.parity.io/ethereum/v2.3.3/x86_64-apple-darwin/parity'
     PARITY_VERSION: 'v2.3.3'
     SOLC_URL_LINUX: 'https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux'
-    SOLC_URL_MACOS: 'https://www.dropbox.com/s/4amq3on2ds1dq36/solc_0.4.23?dl=0'
     SOLC_VERSION: 'v0.5.4'
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ templates:
     PARITY_URL_LINUX: 'https://releases.parity.io/ethereum/v2.3.3/x86_64-unknown-linux-gnu/parity'
     PARITY_URL_MACOS: 'https://releases.parity.io/ethereum/v2.3.3/x86_64-apple-darwin/parity'
     PARITY_VERSION: 'v2.3.3'
-    SOLC_URL_LINUX: 'https://github.com/ethereum/solidity/releases/download/v0.4.23/solc-static-linux'
+    SOLC_URL_LINUX: 'https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux'
     SOLC_URL_MACOS: 'https://www.dropbox.com/s/4amq3on2ds1dq36/solc_0.4.23?dl=0'
-    SOLC_VERSION: 'v0.4.23'
+    SOLC_VERSION: 'v0.5.4'
 
 
 executors:

--- a/.circleci/fetch_geth_parity_solc.sh
+++ b/.circleci/fetch_geth_parity_solc.sh
@@ -29,6 +29,11 @@ if [[ ! -x ${PARITY_PATH} ]]; then
 fi
 ln -sf ${PARITY_PATH} ${LOCAL_BASE}/bin/parity
 
+# Only deal with solc for Linux since it's only used for testing
+if [[ ${OS_NAME} != "LINUX" ]]; then
+    exit 0
+fi
+
 SOLC_PATH="${LOCAL_BASE}/bin/solc-${OS_NAME}-${SOLC_VERSION}"
 if [[ ! -x ${SOLC_PATH} ]]; then
   mkdir -p ${LOCAL_BASE}/bin

--- a/constraints.txt
+++ b/constraints.txt
@@ -74,7 +74,7 @@ ptyprocess==0.6.0
 py-ecc==1.4.3
 py-evm==0.2.0a32
 py-geth==2.0.1
-py-solc==3.1.0
+py-solc==3.2.0
 py==1.6.0
 pyasn1-modules==0.2.2
 pyasn1==0.4.4

--- a/raiden/tests/integration/rpc/RpcTest.sol
+++ b/raiden/tests/integration/rpc/RpcTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.16;
+pragma solidity ^0.5.4;
 
 contract RpcTest {
     function fail() pure public {
@@ -22,6 +22,6 @@ contract RpcTest {
     );
 
     function createEvent(uint _someId) public {
-        RpcEvent(_someId);
+        emit RpcEvent(_someId);
     }
 }

--- a/raiden/tests/integration/rpc/test_assumptions.py
+++ b/raiden/tests/integration/rpc/test_assumptions.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from eth_utils import decode_hex, to_checksum_address
 

--- a/raiden/utils/solc.py
+++ b/raiden/utils/solc.py
@@ -91,7 +91,14 @@ def compile_files_cwd(*args, **kwargs):
     cwd = os.getcwd()
     try:
         os.chdir(compile_wd)
-        compiled_contracts = compile_files(file_list, **kwargs)
+        compiled_contracts = compile_files(
+            source_files=file_list,
+            # We need to specify output values here because py-solc by default
+            # provides them all and does not know that "clone-bin" does not exist
+            # in solidity >= v0.5.0
+            output_values=('abi', 'asm', 'ast', 'bin', 'bin-runtime'),
+            **kwargs,
+        )
     finally:
         os.chdir(cwd)
     return compiled_contracts


### PR DESCRIPTION
We use `solc` in raiden only to compile one contract in the assumptions
test.

Our tests right now don't work with solidity >= v0.5.0 and the
contracts actually use solidity v0.5.4.

This PR fixes the tests and makes them work with solidity v0.5.4 which
is the same as in the contracts repo.

There is one tiny problem I need help from either @palango or @ulope for