### PR TITLE
Fix call to pfs

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -123,6 +123,7 @@ class MessageHandler:
             amount=from_transfer.lock.amount,
             previous_address=message.sender,
             config=raiden.config,
+            privkey=raiden.privkey,
         )
 
         role = views.get_transfer_role(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -146,6 +146,7 @@ def initiator_init(
         amount=transfer_amount,
         previous_address=previous_address,
         config=raiden.config,
+        privkey=raiden.privkey,
     )
     init_initiator_statechange = ActionInitInitiator(
         transfer_state,
@@ -164,6 +165,7 @@ def mediator_init(raiden, transfer: LockedTransfer):
         amount=from_transfer.lock.amount,
         previous_address=transfer.sender,
         config=raiden.config,
+        privkey=raiden.privkey,
     )
     from_route = RouteState(
         transfer.sender,
@@ -556,6 +558,10 @@ class RaidenService(Runnable):
     @property
     def confirmation_blocks(self):
         return self.config['blockchain']['confirmation_blocks']
+
+    @property
+    def privkey(self):
+        return self.chain.client.privkey
 
     def add_pending_greenlet(self, greenlet: Greenlet):
         """ Ensures an error on the passed greenlet crashes self/main greenlet. """

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -22,11 +22,11 @@ def get_best_routes(
         amount: int,
         previous_address: typing.Optional[typing.Address],
         config: Dict[str, Any],
-        privkey: typing.Optional[bytes] = None,
+        privkey: bytes,
 ) -> List[RouteState]:
     services_config = config.get('services', None)
 
-    if privkey and services_config and services_config['pathfinding_service_address'] is not None:
+    if services_config and services_config['pathfinding_service_address'] is not None:
         pfs_answer_ok, pfs_routes = get_best_routes_pfs(
             chain_state=chain_state,
             token_network_id=token_network_id,

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -172,6 +172,7 @@ def test_participant_selection(
                 amount=1,
                 previous_address=None,
                 config={},
+                privkey=b'',  # not used if pfs is not configured
             )
             assert routes is not None
 

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -808,6 +808,7 @@ def test_routing_issue2663(
         amount=50,
         previous_address=None,
         config={},
+        privkey=b'',  # not used if pfs is not configured
     )
     assert routes1[0].node_address == address1
     assert routes1[1].node_address == address2
@@ -820,6 +821,7 @@ def test_routing_issue2663(
         amount=51,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes2[0].node_address == address1
 
@@ -838,6 +840,7 @@ def test_routing_issue2663(
         amount=50,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes1[0].node_address == address1
 
@@ -849,6 +852,7 @@ def test_routing_issue2663(
         amount=51,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes2[0].node_address == address1
 
@@ -868,6 +872,7 @@ def test_routing_issue2663(
         amount=50,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes1[0].node_address == address1
     assert routes1[1].node_address == address2
@@ -880,6 +885,7 @@ def test_routing_issue2663(
         amount=51,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes2[0].node_address == address1
 
@@ -898,6 +904,7 @@ def test_routing_issue2663(
         amount=50,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     # right now the channel to 1 gets filtered out as it is offline
     assert routes1[0].node_address == address1
@@ -910,6 +917,7 @@ def test_routing_issue2663(
         amount=51,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes2[0].node_address == address1
 
@@ -1075,6 +1083,7 @@ def test_routing_priority(
         amount=1,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes[0].node_address == address1
     assert routes[1].node_address == address2
@@ -1095,6 +1104,7 @@ def test_routing_priority(
         amount=1,
         previous_address=None,
         config={},
+        privkey=b'',
     )
     assert routes[0].node_address == address2
     assert routes[1].node_address == address1


### PR DESCRIPTION
Turn the `privkey` argument (which is necessary to sign IOUs for the pathfinding service) of `raiden_service.get_best_routes` from an optional to a mandatory argument. It used to be optional in case we only wanted to use internal routing, e. g. in tests. However, in some calls to `get_best_routes` it was accidentally ommited, which caused it to only use internal routing there too.

Closes #3660 