### PR TITLE
adding dir for adrs and testing adr doc

### DIFF
--- a/docs/adr/0002-testing-strategy.md
+++ b/docs/adr/0002-testing-strategy.md
@@ -1,0 +1,47 @@
+# Better testing framework for entire Raiden suite (client, MS and PFS)
+
+* Status: proposed
+* Deciders: @czepluch, @stefante
+* Date: 2019-11-03 (last updated) <!-- optional -->
+
+
+## Context and Problem Statement
+
+@rakanalh @karlb @LefterisJP and @czepluch had a meeting to discuss testing moving forward. More precisely how we can test the client together with the MS and PFS. Most of the discussion was focused on whether it makes sense to continue to support the scenario player and update it to support the third party services. Currently the SP is good for testing happy cases, but it is not easy to debug when errors occur and it doesn't allow for introspection in the same way as pytest does. On the other hand, the current way that the integration tests work by spinning up a new blockchain per test is very inefficient. It's also quite intimidating for people new to the project or less experienced to grasp how the integration tests work.
+Based on these short comings of the current two solutions, we discussed what could be done to create a setup that solves both problems.
+
+## Decision Drivers <!-- optional -->
+
+* Lack debug options for scenario player
+* Slow to spin up a fresh blockchain for every integration test
+* Duplicated tests between integration tests and SP
+* Make it easier for people new to the project or less experienced people to write tests
+* Have a way of testing all Raiden components
+
+## Considered Options
+
+* **Option1** New repo that integrate the client with the MS/PFS with rewritten fixtures that only spins up one blockchain per test suit session. [Link to meeting discussing this](https://github.com/raiden-network/team/issues/357)
+* **Option2** Stick with things as they are and focus on adding functionality to the scenario player
+
+## Decision Outcome
+
+**TBD**
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+* Good, because writing what we currently call integration tests will be easier
+* Good, because there will be one blockchin spun up per testing session instead of per test
+* Good, because we will use pytest and make debugging easier than it currently is with the SP
+* Good, because we will enforce a "language" that interacts with the API server instead of python functions
+* Good, because we don't need to maintain the SP anymore
+* Bad, because it will be quite some effort to rewrite all the fixtures to use one blockchain per session
+
+### [option 2]
+
+* Good, because we don't have to create a new repo and rewrite the fixtures
+* Bad, because we have to maintain the SP and write scenarios
+* Bad, because the SP offer limited flexibility
+* Bad, because debugging scenarios that fail can be very difficult
+* Bad, because it's difficult to get started writing integration tests at the moment

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
We had a discussion of where to place ADRs. I think the best proposal was to have ADRs per project, so I'm not adding it for the main repo.

If we agree this is the right approach, I will also create a corresponding folder in the raiden-contracts and raiden-services.

I am adding the testing ADR as it is right now and a template we can follow.