### PR TITLE
Fix nonce calculation for geth

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -169,11 +169,11 @@ def geth_discover_next_available_nonce(
 
     queued = pool.get('queued', {}).get(address)
     if queued:
-        return max(queued.keys()) + 1
+        return Nonce(max(int(k) for k in queued.keys()) + 1)
 
     pending = pool.get('pending', {}).get(address)
     if pending:
-        return max(pending.keys()) + 1
+        return Nonce(max(int(k) for k in pending.keys()) + 1)
 
     # The first valid nonce is 0, therefore the count is already the next
     # available nonce

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -167,6 +167,7 @@ def geth_discover_next_available_nonce(
     # the user, these will be the younger transactions. Because this needs the
     # largest nonce, queued is checked first.
 
+    address = to_checksum_address(address)
     queued = pool.get('queued', {}).get(address)
     if queued:
         return Nonce(max(int(k) for k in queued.keys()) + 1)

--- a/raiden/tests/integration/rpc/test_client.py
+++ b/raiden/tests/integration/rpc/test_client.py
@@ -4,7 +4,10 @@ from raiden.network.rpc.client import geth_discover_next_available_nonce
 from raiden.tests.utils.factories import make_address
 
 
-def test_geth_discover_next_available_nonce(deploy_client, skip_if_parity):
+def test_geth_discover_next_available_nonce(
+        deploy_client,
+        skip_if_parity,  # pylint: disable=unused-argument
+):
     """ Test that geth_discover_next_available nonce works correctly
 
     Reproduced the problem seen here:

--- a/raiden/tests/integration/rpc/test_client.py
+++ b/raiden/tests/integration/rpc/test_client.py
@@ -1,0 +1,30 @@
+import gevent
+
+from raiden.network.rpc.client import geth_discover_next_available_nonce
+from raiden.tests.utils.factories import make_address
+
+
+def test_geth_discover_next_available_nonce(deploy_client, skip_if_parity):
+    """ Test that geth_discover_next_available nonce works correctly
+
+    Reproduced the problem seen here:
+    https://github.com/raiden-network/raiden/pull/3683#issue-264551799
+    """
+
+    greenlets = set()
+    for _ in range(100):
+        greenlets.add(gevent.spawn(
+            deploy_client.send_transaction,
+            make_address(),  # to
+            50000,  # startgas
+        ))
+    gevent.sleep(.5)
+
+    nonce = geth_discover_next_available_nonce(
+        web3=deploy_client.web3,
+        address=deploy_client.address,
+    )
+    assert nonce > 0
+    assert nonce < 100
+
+    gevent.joinall(greenlets, raise_error=True)


### PR DESCRIPTION
Before I got a warning that `str`  and `int` could not be concatenated.

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/paul/Projects/brainbot/raiden/tools/scenario-player/scenario_player/__main__.py", line 9, in <module>
    prog_name='python -m scenario_player',
  File "/Users/paul/Projects/brainbot/raiden/venv/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/paul/Projects/brainbot/raiden/venv/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/paul/Projects/brainbot/raiden/venv/lib/python3.7/site-packages/click/core.py", line 1043, in invoke
    return Command.invoke(self, ctx)
  File "/Users/paul/Projects/brainbot/raiden/venv/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/paul/Projects/brainbot/raiden/venv/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/paul/Projects/brainbot/raiden/venv/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/paul/Projects/brainbot/raiden/tools/scenario-player/scenario_player/main.py", line 129, in main
    runner = ScenarioRunner(account, chain_rpc_urls, auth, Path(data_path), scenario_file)
  File "/Users/paul/Projects/brainbot/raiden/tools/scenario-player/scenario_player/runner.py", line 96, in __init__
    gas_price_strategy=self.scenario.gas_price_strategy,
  File "/Users/paul/Projects/brainbot/raiden/raiden/network/rpc/client.py", line 440, in __init__
    address_checksumed,
  File "/Users/paul/Projects/brainbot/raiden/raiden/network/rpc/client.py", line 176, in geth_discover_next_available_nonce
    return max(pending.keys()) + 1
TypeError: can only concatenate str (not "int") to str
```