### PR TITLE
[SP] Add assert_ms_claim task, to check for MS claim events

### DIFF
--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -90,6 +90,7 @@ nodes:
 ## - join_network
 ## - leave_network
 ## - assert_events
+##  - assert_ms_claim
 ## - assert_pfs_routes
 
 scenario:
@@ -184,6 +185,7 @@ scenario:
 #            - close_channel: {from: 0, to: 1}
 #            - close_channel: {from: 1, to: 2}
 #      - assert_events: {contract_name: "TokenNetwork", event_name: "ChannelClosed", num_events: 2}
+#      - assert_ms_claim: {from: 0, to: 1}
 #      - assert: {from: 0, to: 1, total_deposit: 100, balance: 5, state: "closed"}
 #
 #      ## Wait for 20 blocks

--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -89,8 +89,9 @@ nodes:
 ## - wait_blocks
 ## - join_network
 ## - leave_network
+## - store_channel_info
 ## - assert_events
-##  - assert_ms_claim
+## - assert_ms_claim
 ## - assert_pfs_routes
 
 scenario:
@@ -185,11 +186,17 @@ scenario:
 #            - close_channel: {from: 0, to: 1}
 #            - close_channel: {from: 1, to: 2}
 #      - assert_events: {contract_name: "TokenNetwork", event_name: "ChannelClosed", num_events: 2}
-#      - assert_ms_claim: {from: 0, to: 1}
 #      - assert: {from: 0, to: 1, total_deposit: 100, balance: 5, state: "closed"}
+#
 #
 #      ## Wait for 20 blocks
 #      - wait_blocks: 20
+#
+#
+#      ## Save channel information, close , assert MS claim action on stored data
+#      - store_channel_info: {from: 0, to: 1, key: "channel-0-1"}
+#      - close_channel: {from: 0, to: 1}
+#      - assert_ms_claim: {channel_info_key: "channel-0-1"}
 #
 #      ## 4 requests where made from source node 0
 #      - assert_pfs_routes: {source: 0, request_count: 4}

--- a/tools/scenario-player/scenario_player/runner.py
+++ b/tools/scenario-player/scenario_player/runner.py
@@ -57,6 +57,7 @@ class ScenarioRunner:
         self.auth = auth
         self.release_keeper = RaidenReleaseKeeper(data_path.joinpath('raiden_releases'))
         self.task_cache = {}
+        # Storage for arbitrary data tasks might need to persist
         self.task_storage = defaultdict(dict)
 
         self.scenario = Scenario(pathlib.Path(scenario_file.name))

--- a/tools/scenario-player/scenario_player/tasks/blockchain.py
+++ b/tools/scenario-player/scenario_player/tasks/blockchain.py
@@ -1,17 +1,22 @@
 from typing import Any, Dict, List
 
 import structlog
-from eth_utils import decode_hex, event_abi_to_log_topic, to_checksum_address
+from eth_utils import decode_hex, encode_hex, event_abi_to_log_topic, to_checksum_address
 from web3 import Web3
 from web3.utils.abi import filter_by_type
 from web3.utils.events import get_event_data
 
 from raiden.settings import DEVELOPMENT_CONTRACT_VERSION
 from raiden.utils.typing import ABI, Address, BlockNumber
-from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK
-from raiden_contracts.contract_manager import ContractManager, get_contracts_deployment_info
+from raiden_contracts.constants import (
+    CONTRACT_MONITORING_SERVICE,
+    CONTRACT_TOKEN_NETWORK,
+    MonitoringServiceEvent,
+)
+from raiden_contracts.contract_manager import ContractManager, get_contracts_deployed
 from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.runner import ScenarioRunner
+from scenario_player.tasks.channels import AssertTask
 
 from .base import Task
 
@@ -114,7 +119,7 @@ class BlockchainEventFilter(Task):
     def _run(self, *args, **kwargs):  # pylint: disable=unused-argument
         # get the correct contract address
         # this has to be done in `_run`, otherwise `_runner` is not initialized yet
-        contract_data = get_contracts_deployment_info(
+        contract_data = get_contracts_deployed(
             chain_id=self._runner.chain_id,
             version=DEVELOPMENT_CONTRACT_VERSION,
         )
@@ -146,3 +151,81 @@ class BlockchainEventFilter(Task):
                 f'Expected number of events ({self.num_events}) did not match the number '
                 f'of events found ({len(events)})',
             )
+
+
+class MSClaimEventFilter(AssertTask):
+    _name = 'assert_ms_claim'
+
+    def __init__(
+            self,
+            runner: ScenarioRunner,
+            config: Any,
+            parent: 'Task' = None,
+            abort_on_fail: bool = True,
+    ) -> None:
+        super().__init__(runner, config, parent, abort_on_fail)
+
+        required_keys = ['from', 'to']
+        all_required_options_provided = all(
+            key in config.keys() for key in required_keys
+        )
+        if not all_required_options_provided:
+            raise ScenarioError(
+                'Not all required keys provided. Required: ' + ', '.join(required_keys),
+            )
+
+        self.web3 = self._runner.client.web3
+        self.contract_name = CONTRACT_MONITORING_SERVICE
+
+    def _run(self, *args, **kwargs):  # pylint: disable=unused-argument
+
+        # get channel data from `AssertTask`
+        channel_infos = super()._run(*args, **kwargs)
+
+        # calculate reward_id
+        assert 'token_network_identifier' in channel_infos.keys()
+        assert 'channel_identifier' in channel_infos.keys()
+
+        reward_id = bytes(Web3.soliditySha3(  # pylint: disable=no-value-for-parameter
+            ['uint256', 'address'],
+            [channel_infos['channel_identifier'], channel_infos['token_network_identifier']],
+        ))
+
+        log.info('Calculated reward ID', reward_id=reward_id, reward_id_hex=encode_hex(reward_id))
+
+        # get the MS contract address
+        service_contract_data = get_contracts_deployed(
+            chain_id=self._runner.chain_id,
+            version=DEVELOPMENT_CONTRACT_VERSION,
+            services=True,
+        )
+        try:
+            contract_info = service_contract_data['contracts'][self.contract_name]
+            self.contract_address = contract_info['address']
+        except KeyError:
+            raise ScenarioError(f'Unknown contract name: {self.contract_name}')
+
+        events = query_blockchain_events(
+            web3=self.web3,
+            contract_manager=self._runner.contract_manager,
+            contract_address=self.contract_address,
+            contract_name=self.contract_name,
+            topics=[],
+            from_block=BlockNumber(self._runner.token_deployment_block),
+            to_block=BlockNumber(self.web3.eth.blockNumber),
+        )
+
+        # Filter matching events
+        def match_event(event: Dict):
+            if not event['event'] == MonitoringServiceEvent.REWARD_CLAIMED:
+                return False
+
+            event_reward_id = bytes(event['args']['reward_identifier'])
+            return event_reward_id == reward_id
+
+        events = [e for e in events if match_event(e)]
+        log.info('Matching events', events=events)
+
+        # Raise exception when no event was found
+        if len(events) == 0:
+            raise ScenarioAssertionError('No RewardClaimed event found for this channel')

--- a/tools/scenario-player/scenario_player/tasks/channels.py
+++ b/tools/scenario-player/scenario_player/tasks/channels.py
@@ -125,6 +125,7 @@ class AssertTask(ChannelActionTask):
                     f'Is: "{response_dict[field]}" '
                     f'Channel: {response_dict}',
                 )
+        return response_dict
 
 
 class AssertAllTask(ChannelActionTask):

--- a/tools/scenario-player/scenario_player/utils.py
+++ b/tools/scenario-player/scenario_player/utils.py
@@ -27,7 +27,7 @@ from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils.typing import TransactionHash
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_USER_DEPOSIT
-from raiden_contracts.contract_manager import get_contracts_deployment_info
+from raiden_contracts.contract_manager import get_contracts_deployed
 from scenario_player.exceptions import ScenarioError, ScenarioTxError
 
 RECLAIM_MIN_BALANCE = 10 ** 12  # 1 µEth (a.k.a. Twei, szabo)
@@ -268,8 +268,7 @@ def get_udc_and_token(runner) -> Tuple[Optional[ContractProxy], Optional[Contrac
 
     udc_address = udc_config.get('address')
     if udc_address is None:
-        log.error('chain id', id=runner.chain_id)
-        contracts = get_contracts_deployment_info(chain_id=runner.chain_id)
+        contracts = get_contracts_deployed(chain_id=runner.chain_id, services=True)
         udc_address = contracts['contracts'][CONTRACT_USER_DEPOSIT]['address']
     udc_abi = runner.contract_manager.get_contract_abi(CONTRACT_USER_DEPOSIT)
     udc_proxy = runner.client.new_contract_proxy(udc_abi, udc_address)
@@ -377,7 +376,7 @@ def reclaim_eth(account: Account, chain_rpc_urls: dict, data_path: str, min_age_
 
     log.info('Reclaiming candidates', addresses=list(addresses.keys()))
 
-    txs = defaultdict(list)
+    txs = defaultdict(set)
     reclaim_amount = defaultdict(int)
     for chain_name, web3 in web3s.items():
         log.info('Checking chain', chain=chain_name)
@@ -393,7 +392,7 @@ def reclaim_eth(account: Account, chain_rpc_urls: dict, data_path: str, min_age_
                 )
                 reclaim_amount[chain_name] += drain_amount
                 client = JSONRPCClient(web3, privkey)
-                txs[chain_name].append(
+                txs[chain_name].add(
                     client.send_transaction(
                         to=account.address,
                         value=drain_amount,


### PR DESCRIPTION
As we use the same MonitoringContract for all token networks, we need a stateless version of the `assert_events` task.
The `assert_ms_claim` is quite specific (and hopefully can be better abstracted in the future. It calculated the `reward_id` for a given channel and checks that a `Claim`  event for that channel exists.