### PR TITLE
Use raiden-contracts v0.17.0 and introduce click 7.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@ canonicaljson==1.1.4
 certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
-click==6.7
+click==7.0
 coincurve==11.0.0
 colorama==0.3.9
 constantly==15.1.0
@@ -91,7 +91,7 @@ pystun-patched-for-raiden==0.1.0
 python-dateutil==2.7.5
 pytoml==0.1.19
 pytz==2018.5
-raiden-contracts==0.16.0
+raiden-contracts==0.17.0
 raiden-webui==0.8.0
 requests==2.20.0
 rlp==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pysha3==1.0.2
 py-solc==3.2.0
 pystun-patched-for-raiden==0.1.0
 pytoml==0.1.19
-raiden-contracts==0.15.0
+raiden-contracts==0.17.0
 raiden-webui==0.8.0
 requests==2.20.0
 structlog==18.2.0


### PR DESCRIPTION
This PR should remove one obstacle against private net deployment.  Currently, with `click==6.7`, contract deployment scripts fail.  `raiden-contracts 0.17.0` specifies `click>=7.0`.  This PR specifies `click==7.0` and `raiden-contracts==0.17.0`.