### PR TITLE
Declare raiden to be typed via PEP561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     author_email='contact@brainbot.li',
     url='https://github.com/raiden-network/raiden',
     packages=find_packages(),
+    package_data={"raiden": ["py.typed"]},
     include_package_data=True,
     license='MIT',
     zip_safe=False,


### PR DESCRIPTION
When other packages import raiden, the raiden type signatures will not
be used by mypy unless that package declares itself as properly types.
This can be done via PEP561:
https://mypy.readthedocs.io/en/latest/installed_packages.html#using-pep-561-compatible-packages-with-mypy

Adding this will greatly improve type checking quality in
raiden-services (and potential other packages) whenever imports from
raiden are used.