### PR TITLE
Replace get_contracts_deployed() calls

### DIFF
--- a/tools/scenario-player/scenario_player/tasks/blockchain.py
+++ b/tools/scenario-player/scenario_player/tasks/blockchain.py
@@ -9,7 +9,7 @@ from web3.utils.events import get_event_data
 from raiden.settings import DEVELOPMENT_CONTRACT_VERSION
 from raiden.utils.typing import ABI, Address, BlockNumber
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK
-from raiden_contracts.contract_manager import ContractManager, get_contracts_deployed
+from raiden_contracts.contract_manager import ContractManager, get_contracts_deployment_info
 from scenario_player.exceptions import ScenarioAssertionError, ScenarioError
 from scenario_player.runner import ScenarioRunner
 
@@ -114,16 +114,15 @@ class BlockchainEventFilter(Task):
     def _run(self, *args, **kwargs):  # pylint: disable=unused-argument
         # get the correct contract address
         # this has to be done in `_run`, otherwise `_runner` is not initialized yet
-        service_contract_data = get_contracts_deployed(
+        contract_data = get_contracts_deployment_info(
             chain_id=self._runner.chain_id,
             version=DEVELOPMENT_CONTRACT_VERSION,
-            services=True,
         )
         if self.contract_name == CONTRACT_TOKEN_NETWORK:
             self.contract_address = self._runner.token_network_address
         else:
             try:
-                contract_info = service_contract_data['contracts'][self.contract_name]
+                contract_info = contract_data['contracts'][self.contract_name]
                 self.contract_address = contract_info['address']
             except KeyError:
                 raise ScenarioError(f'Unknown contract name: {self.contract_name}')

--- a/tools/scenario-player/scenario_player/utils.py
+++ b/tools/scenario-player/scenario_player/utils.py
@@ -27,7 +27,7 @@ from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils.typing import TransactionHash
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_USER_DEPOSIT
-from raiden_contracts.contract_manager import get_contracts_deployed
+from raiden_contracts.contract_manager import get_contracts_deployment_info
 from scenario_player.exceptions import ScenarioError, ScenarioTxError
 
 RECLAIM_MIN_BALANCE = 10 ** 12  # 1 µEth (a.k.a. Twei, szabo)
@@ -269,7 +269,7 @@ def get_udc_and_token(runner) -> Tuple[Optional[ContractProxy], Optional[Contrac
     udc_address = udc_config.get('address')
     if udc_address is None:
         log.error('chain id', id=runner.chain_id)
-        contracts = get_contracts_deployed(chain_id=runner.chain_id, services=True)
+        contracts = get_contracts_deployment_info(chain_id=runner.chain_id)
         udc_address = contracts['contracts'][CONTRACT_USER_DEPOSIT]['address']
     udc_abi = runner.contract_manager.get_contract_abi(CONTRACT_USER_DEPOSIT)
     udc_proxy = runner.client.new_contract_proxy(udc_abi, udc_address)


### PR DESCRIPTION
because now it's deprecated.

`get_contracts_deployment_info()` has a nicer name and has more functionalities. After removing the usage of the old function, `raiden_contracts` can remove the old function.