### PR TITLE
Add send_to_device method to matrix transport. 

### DIFF
--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -19,6 +19,7 @@ REFUNDTRANSFER = 8
 REVEALSECRET = 11
 DELIVERED = 12
 LOCKEXPIRED = 13
+TODEVICE = 14
 
 
 # pylint: disable=invalid-name
@@ -269,6 +270,16 @@ UpdatePFS = namedbuffer(
     ],
 )
 
+ToDevice = namedbuffer(
+    'to_device',
+    [
+        cmdid(TODEVICE),
+        pad(3),
+        nonce,
+        signature,
+    ],
+)
+
 CMDID_MESSAGE = {
     PROCESSED: Processed,
     PING: Ping,
@@ -280,6 +291,7 @@ CMDID_MESSAGE = {
     REFUNDTRANSFER: RefundTransfer,
     DELIVERED: Delivered,
     LOCKEXPIRED: LockExpired,
+    TODEVICE: ToDevice,
 }
 
 

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -275,7 +275,7 @@ ToDevice = namedbuffer(
     [
         cmdid(TODEVICE),
         pad(3),
-        nonce,
+        message_identifier,
         signature,
     ],
 )

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -452,41 +452,41 @@ class ToDevice(SignedMessage):
     """
     cmdid = messages.TODEVICE
 
-    def __init__(self, *, nonce: typing.Nonce, **kwargs):
+    def __init__(self, *, message_identifier: MessageID, **kwargs):
         super().__init__(**kwargs)
-        self.nonce = nonce
+        self.message_identifier = message_identifier
 
     @classmethod
     def unpack(cls, packed):
         to_device = cls(
-            nonce=packed.nonce,
+            message_identifier=packed.message_identifier,
         )
         to_device.signature = packed.signature
         return to_device
 
-    def pack(self, packed):
-        packed.nonce = self.nonce
+    def pack(self, packed) -> None:
+        packed.message_identifier = self.message_identifier
         packed.signature = self.signature
 
     def __repr__(self):
-        return '<{} [nonce:{}]>'.format(
+        return '<{} [message_identifier:{}]>'.format(
             self.__class__.__name__,
-            self.nonce,
-            self.signature,
+            self.message_identifier,
         )
 
     def to_dict(self):
         return {
             'type': self.__class__.__name__,
-            'nonce': self.nonce,
+            'message_identifier': self.message_identifier,
             'signature': encode_hex(self.signature),
         }
 
     @classmethod
     def from_dict(cls, data):
-        assert data['type'] == cls.__name__
+        msg = f'Cannot decode data. Provided type is {data["type"]}, expected {cls.__name__}'
+        assert data['type'] == cls.__name__, msg
         to_device = cls(
-            nonce=data['nonce'],
+            message_identifier=data['message_identifier'],
         )
         to_device.signature = decode_hex(data['signature'])
         return to_device

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -28,9 +28,11 @@ from gevent.event import Event
 from gevent.lock import Semaphore
 from matrix_client.errors import MatrixError, MatrixRequestError
 
-from raiden.exceptions import InvalidSignature, TransportError
+from raiden.exceptions import InvalidProtocolMessage, InvalidSignature, TransportError
+from raiden.messages import Message, decode as message_from_bytes, from_dict as message_from_dict
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.utils import get_http_rtt
+from raiden.utils import pex
 from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import Address, ChainID
 from raiden_contracts.constants import ID_TO_NETWORKNAME
@@ -547,3 +549,75 @@ def make_room_alias(chain_id: ChainID, *suffixes: str) -> str:
     """
     network_name = ID_TO_NETWORKNAME.get(chain_id, str(chain_id))
     return ROOM_NAME_SEPARATOR.join([ROOM_NAME_PREFIX, network_name, *suffixes])
+
+
+def validate_and_parse_message(data, peer_address) -> List[Message]:
+    messages = list()
+
+    if not isinstance(data, str):
+        log.warning(
+            'Received ToDevice Message body not a string',
+            message_data=data,
+            peer_address=pex(peer_address),
+        )
+        return False
+
+    if data.startswith('0x'):
+        try:
+            message = message_from_bytes(decode_hex(data))
+            if not message:
+                raise InvalidProtocolMessage
+        except (DecodeError, AssertionError) as ex:
+            log.warning(
+                "Can't parse ToDevice Message binary data",
+                message_data=data,
+                peer_address=pex(peer_address),
+                _exc=ex,
+            )
+            return False
+        except InvalidProtocolMessage as ex:
+            log.warning(
+                'Received ToDevice Message binary data is not a valid message',
+                message_data=data,
+                peer_address=pex(peer_address),
+                _exc=ex,
+            )
+            return False
+        else:
+            messages.append(message)
+
+    else:
+        for line in data.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message_dict = json.loads(line)
+                message = message_from_dict(message_dict)
+            except (UnicodeDecodeError, json.JSONDecodeError) as ex:
+                log.warning(
+                    "Can't parse ToDevice Message data JSON",
+                    message_data=line,
+                    peer_address=pex(peer_address),
+                    _exc=ex,
+                )
+                continue
+            except InvalidProtocolMessage as ex:
+                log.warning(
+                    "ToDevice Message data JSON are not a valid ToDevice Message",
+                    message_data=line,
+                    peer_address=pex(peer_address),
+                    _exc=ex,
+                )
+                continue
+            if message.sender != peer_address:
+                log.warning(
+                    'ToDevice Message not signed by sender!',
+                    message=message,
+                    signer=message.sender,
+                    peer_address=pex(peer_address),
+                )
+                continue
+            messages.append(message)
+
+    return messages

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1218,6 +1218,11 @@ def test_send_to_device(matrix_transports):
 
     transport0.start_health_check(raiden_service1.address)
     transport1.start_health_check(raiden_service0.address)
+    message = Processed(message_identifier=1)
+    transport0._raiden_service.sign(message)
+    transport0.send_to_device(raiden_service1.address, message)
+    gevent.sleep(.5)
+    transport1._receive_to_device.assert_not_called()
     message = ToDevice(message_identifier=1)
     transport0._raiden_service.sign(message)
     transport0.send_to_device(raiden_service1.address, message)


### PR DESCRIPTION
This PR enables sending messages to a whitelisted node via `transport.send_to_device`. 
- A ToDevice message can be send to all known devices of a user without creating a room first
- The receiver transport receives the message via `_sync` and handles it. 

To do's:
- [ ] add to `RetryQueue` ?
 - [ ] Clarify handshake message usage context:  #3893,  #3694

Caveats: 

The message is  delivered exactly once and is non retrievable.