### PR TITLE
Send PFS updates on own BP changes as well

### DIFF
--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -764,8 +764,8 @@ def test_pfs_global_messages(
     channel_state.our_state.balance_proof = balance_proof
     channel_state.partner_state.balance_proof = balance_proof
     monkeypatch.setattr(
-        raiden.raiden_service,
-        'get_channelstate_by_token_network_and_partner',
+        raiden.transfer.views,
+        'get_channelstate_by_canonical_identifier',
         lambda *a, **kw: channel_state,
     )
     update_path_finding_service_from_balance_proof(

--- a/raiden/tests/unit/test_version_check.py
+++ b/raiden/tests/unit/test_version_check.py
@@ -7,6 +7,7 @@ from pkg_resources import parse_version
 
 from raiden.tasks import SECURITY_EXPRESSION, _do_check_version
 
+
 LATEST_RELEASE_RESPONSE = """{"url":
             "https://api.github.com/repos/raiden-network/raiden/releases/14541434",
             "assets_url":


### PR DESCRIPTION
Before this PR only changes in BPs of channel partners were observed. This is what's necessary for the MS to work, but for the PFS to work correctly both the partners as well as a nodes own BPs changes need to be observed.

This PR changes the `detect_balance_proof_change` function to also check for changes in the nodes own BPs.  The changes are furthermore annotated with the information of which BP changed (`OWN` or `PARTNER`, in theory the type should be enough, but I chose not to trust it here).

This information is then used to send the appropriate monitor requests and updates to the PFS.