### PR TITLE
Upgrade isort to 4.3.16

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -3,7 +3,7 @@ flake8==3.7.5
 flake8-bugbear==18.8.0
 flake8-commas==2.0.0
 flake8-tuple==0.2.13
-isort==4.2.15
+isort==4.3.16
 readme-renderer==21.0
 pylint==2.1.1
 # Dependency of pylint, pinned until https://github.com/PyCQA/astroid/issues/651 is fixed


### PR DESCRIPTION
This also seems to avoid the problem we started seeing with the
following discrepancy between isort locally and in Circle:

```diff
--- /home/circleci/raiden/raiden/transfer/views.py:before	2019-04-03 15:35:36
+++ /home/circleci/raiden/raiden/transfer/views.py:after	2019-04-03 15:38:08.183534
@@ -1,6 +1,5 @@
+from dataclasses import dataclass
 from enum import Enum
-
-from dataclasses import dataclass

 from raiden.transfer import channel
 from raiden.transfer.architecture import ContractSendEvent, State
```