### PR TITLE
[SP] Add assert_pfs_routes task

### DIFF
--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -92,8 +92,8 @@ nodes:
 ## - store_channel_info
 ## - assert_events
 ## - assert_ms_claim
-## - assert_pfs_api
 ## - assert_pfs_routes
+## - assert_pfs_history
 
 scenario:
   serial:
@@ -203,24 +203,24 @@ scenario:
 #      assert_pfs_routes: {from: 0, to: 1, amount: 100, expected_paths: 2}
 #
 #      # Check that PFS response contains 3 of 3 requested routes
-#      assert_pfs_routes: {source: 0, target: 1, amount: 100, max_paths: 3, expected routes: 3}
+#      assert_pfs_routes: {source: 0, target: 1, amount: 100, max_paths: 3, expected_paths: 3}
 #
 #      ## 4 requests where made from source node 0
-#      - assert_pfs_routes: {source: 0, request_count: 4}
+#      - assert_pfs_history: {source: 0, request_count: 4}
 #
 #      ## 4 requests where made from source node 0 to target node 1
-#      - assert_pfs_routes: {source: 0, target: 1, request_count: 4}
+#      - assert_pfs_history: {source: 0, target: 1, request_count: 4}
 #
 #      ## 4 requests where made from source node 0 to target node 1 and 3 routes each have been
 #      ## returned
-#      - assert_pfs_routes: {source: 0, target: 1, request_count: 4, routes_count: 3}
+#      - assert_pfs_history: {source: 0, target: 1, request_count: 4, routes_count: 3}
 #
 #      ## 4 requests where made from source node 0 to target node 1 and the specified number of
 #      ## routes have been returned
-#      - assert_pfs_routes: {source: 0, target: 1, request_count: 4, routes_count: [3, 2, 1, 2]}
+#      - assert_pfs_history: {source: 0, target: 1, request_count: 4, routes_count: [3, 2, 1, 2]}
 #
 #      ## The listed routes have been returned for requests from source node 0 to target node 1
-#      - assert_pfs_routes:
+#      - assert_pfs_history:
 #          source: 0
 #          target: 1
 #          expected_routes:

--- a/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
+++ b/tools/scenario-player/example-scenarios/scenario-example-v2.yaml
@@ -92,6 +92,7 @@ nodes:
 ## - store_channel_info
 ## - assert_events
 ## - assert_ms_claim
+## - assert_pfs_api
 ## - assert_pfs_routes
 
 scenario:
@@ -197,6 +198,12 @@ scenario:
 #      - store_channel_info: {from: 0, to: 1, key: "channel-0-1"}
 #      - close_channel: {from: 0, to: 1}
 #      - assert_ms_claim: {channel_info_key: "channel-0-1"}
+#
+#      # Check that PFS response contains 2 routes
+#      assert_pfs_routes: {from: 0, to: 1, amount: 100, expected_paths: 2}
+#
+#      # Check that PFS response contains 3 of 3 requested routes
+#      assert_pfs_routes: {source: 0, target: 1, amount: 100, max_paths: 3, expected routes: 3}
 #
 #      ## 4 requests where made from source node 0
 #      - assert_pfs_routes: {source: 0, request_count: 4}

--- a/tools/scenario-player/scenario_player/node_support.py
+++ b/tools/scenario-player/scenario_player/node_support.py
@@ -63,7 +63,9 @@ MANAGED_CONFIG_OPTIONS_OVERRIDABLE = {
     'endpoint-registry-contract-address',
     'tokennetwork-registry-contract-address',
     'secret-registry-contract-address',
+    'service-registry-contract-address',
     'pathfinding-service-address',
+    'pathfinding-eth-address',
 }
 
 

--- a/tools/scenario-player/scenario_player/tasks/api_base.py
+++ b/tools/scenario-player/scenario_player/tasks/api_base.py
@@ -44,7 +44,7 @@ class RESTAPIActionTask(Task):
 
     def _run(self, *args, **kwargs):  # pylint: disable=unused-argument
         url = self._expand_url()
-        log.debug('Requesting', url=url, method=self._method)
+        log.debug('Requesting', url=url, method=self._method, json=self._request_params)
         try:
             resp = self._runner.session.request(
                 method=self._method,
@@ -67,6 +67,8 @@ class RESTAPIActionTask(Task):
                 response_dict = {}
             else:
                 response_dict = resp.json()
+
+            log.debug('Received response', json=response_dict)
             return self._process_response(response_dict)
         except (ValueError, UnicodeDecodeError) as ex:
             raise RESTAPIError(

--- a/tools/scenario-player/scenario_player/tasks/services.py
+++ b/tools/scenario-player/scenario_player/tasks/services.py
@@ -6,9 +6,9 @@ from scenario_player.tasks.api_base import RESTAPIActionTask
 log = structlog.get_logger(__name__)
 
 
-class PFSAPIAssertTask(RESTAPIActionTask):
+class AssertPFSRoutesTask(RESTAPIActionTask):
     """
-    PFS API Assert task
+    Assert PFS routes task
 
     Example usages:
 
@@ -16,11 +16,11 @@ class PFSAPIAssertTask(RESTAPIActionTask):
         assert_pfs_routes: {from: 0, to: 1, amount: 100, expected_paths: 2}
 
         # Check that PFS response contains 3 of 3 requested routes
-        assert_pfs_routes: {source: 0, target: 1, amount: 100, max_paths: 3, expected routes: 3}
+        assert_pfs_routes: {source: 0, target: 1, amount: 100, max_paths: 3, expected_paths: 3}
 
         Default of `max_paths` is 5
     """
-    _name = 'assert_pfs_api'
+    _name = 'assert_pfs_routes'
     _method = 'post'
     _url_template = "{pfs_url}/api/v1/{token_network_address}/paths"
 
@@ -51,7 +51,7 @@ class PFSAPIAssertTask(RESTAPIActionTask):
 
     @property
     def _url_params(self):
-        pfs_url = self._runner.scenario.settings.get('services', {}).get('pfs', {}).get('url')
+        pfs_url = self._runner.scenario.services.get('pfs', {}).get('url')
         if not pfs_url:
             raise ScenarioError('PFS tasks require settings.services.pfs.url to be set.')
 
@@ -62,11 +62,9 @@ class PFSAPIAssertTask(RESTAPIActionTask):
         return params
 
     def _process_response(self, response_dict: dict):
-        log.debug('Received response', response=response_dict)
-
         paths = response_dict.get('result')
         if paths is None:
-            raise ScenarioAssertionError("No 'return' key in result from PFS")
+            raise ScenarioAssertionError("No 'result' key in result from PFS")
 
         num_paths = len(paths)
         exptected_paths = int(self._config['expected_paths'])
@@ -77,28 +75,28 @@ class PFSAPIAssertTask(RESTAPIActionTask):
             )
 
 
-class PFSAssertTask(RESTAPIActionTask):
+class AssertPFSHistoryTask(RESTAPIActionTask):
     """
-    PFS Assert task
+    Assert PFS history task
 
     Example usages:
 
         # 4 requests where made from source node 0
-        assert_pfs_routes: {source: 0, request_count: 4}
+        assert_pfs_history: {source: 0, request_count: 4}
 
         # 4 requests where made from source node 0 to target node 1
-        assert_pfs_routes: {source: 0, target: 1, request_count: 4}
+        assert_pfs_history: {source: 0, target: 1, request_count: 4}
 
         # 4 requests where made from source node 0 to target node 1 and 3 routes each have been
         # returned
-        assert_pfs_routes: {source: 0, target: 1, request_count: 4, routes_count: 3}
+        assert_pfs_history: {source: 0, target: 1, request_count: 4, routes_count: 3}
 
         # 4 requests where made from source node 0 to target node 1 and the specified number of
         # routes have been returned
-        assert_pfs_routes: {source: 0, target: 1, request_count: 4, routes_count: [3, 2, 1, 2]}
+        assert_pfs_history: {source: 0, target: 1, request_count: 4, routes_count: [3, 2, 1, 2]}
 
         # The listed routes have been returned for requests from source node 0 to target node 1
-        assert_pfs_routes:
+        assert_pfs_history:
           source: 0
           target: 1
           expected_routes:
@@ -121,12 +119,12 @@ class PFSAssertTask(RESTAPIActionTask):
             ]
         }
     """
-    _name = 'assert_pfs_routes'
+    _name = 'assert_pfs_history'
     _url_template = "{pfs_url}/api/v1/_debug/routes/{token_address}/{source_address}{extra_params}"
 
     @property
     def _url_params(self):
-        pfs_url = self._runner.scenario.settings.get('services', {}).get('pfs', {}).get('url')
+        pfs_url = self._runner.scenario.services.get('pfs', {}).get('url')
         if not pfs_url:
             raise ScenarioError('PFS tasks require settings.services.pfs.url to be set.')
 


### PR DESCRIPTION
This PR add the `assert_pfs_routes` task to the scenario player.

This is a simple way to check that the PFS got certain information from nodes and will help to make some initial integration tests run.