### PR TITLE
Update raiden-contracts to for using mypy typing information from raiden-contracts.

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -56,7 +56,7 @@ pysha3==1.0.2
 pystun-patched-for-raiden==0.1.0
 pytoml==0.1.19
 pytz==2018.5
-raiden-contracts==0.17.1
+raiden-contracts==0.17.2
 raiden-webui==0.8.0
 requests==2.20.0
 rlp==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pysha3==1.0.2
 py-solc==3.2.0
 pystun-patched-for-raiden==0.1.0
 pytoml==0.1.19
-raiden-contracts==0.17.1
+raiden-contracts==0.17.2
 raiden-webui==0.8.0
 requests==2.20.0
 structlog==18.2.0


### PR DESCRIPTION
I might see mypy errors after this because raiden-contracts now
exposes typing data to the outer world https://github.com/raiden-network/raiden-contracts/pull/813 .