### PR TITLE
get_random_service() should use the confirmed block

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -549,6 +549,14 @@ class JSONRPCClient:
         """ Return the most recent block. """
         return self.web3.eth.blockNumber
 
+    def get_confirmed_blockhash(self):
+        """ Gets the block CONFIRMATION_BLOCKS in the past and returns its block hash """
+        confirmed_block_number = self.web3.eth.blockNumber - self.default_block_num_confirmations
+        if confirmed_block_number < 0:
+            confirmed_block_number = 0
+
+        return self.blockhash_from_blocknumber(confirmed_block_number)
+
     def blockhash_from_blocknumber(self, block_number: BlockSpecification) -> BlockHash:
         """Given a block number, query the chain to get its corresponding block hash"""
         return bytes(self.web3.eth.getBlock(block_number)['hash'])

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -43,7 +43,7 @@ def test_service_registry_random_pfs(
     assert not c1_service_proxy.get_service_address('latest', 9999)
 
     # Test that getting a random service from the proxy works
-    assert get_random_service(c1_service_proxy) in zip(urls, addresses)
+    assert get_random_service(c1_service_proxy, 'latest') in zip(urls, addresses)
 
 
 def test_configure_pfs(

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -109,7 +109,7 @@ def deploy_service_registry_and_set_urls(
     )
 
     # Test that getting a random service for an empty registry returns None
-    pfs_address, pfs_eth_address = get_random_service(c1_service_proxy)
+    pfs_address, pfs_eth_address = get_random_service(c1_service_proxy, 'latest')
     assert pfs_address is None
     assert pfs_eth_address is None
 


### PR DESCRIPTION
Fix #3757 

The solution is not ideal as it's not using Raiden Chain State's
confirmed block, but the two should be identical.

The reason why this is not using Raiden chain state's confirmed block
is that at the startup when the proxies are instantiated is when
`get_random_service()` is called. And at that point there is no raiden
App and no raiden service so the chain state has not been initialized yet.