### PR TITLE
Simplified get_onchain_locksroots

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -22,7 +22,13 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
 )
-from raiden.utils import CHANNEL_ID_UNSPECIFIED, CanonicalIdentifier, pex, typing
+from raiden.utils import (
+    CHAIN_ID_UNSPECIFIED,
+    CHANNEL_ID_UNSPECIFIED,
+    CanonicalIdentifier,
+    pex,
+    typing,
+)
 from raiden_contracts.constants import (
     EVENT_SECRET_REVEALED,
     EVENT_TOKEN_NETWORK_CREATED,
@@ -327,10 +333,14 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
     to calculate the gain and potentially perform unlocks in case
     there is value to be gained.
     """
-    our_locksroot, partner_locksroot = get_onchain_locksroots(
-        raiden=raiden,
+    canonical_identifier = CanonicalIdentifier(
+        chain_identifier=CHAIN_ID_UNSPECIFIED,
         token_network_address=token_network_identifier,
         channel_identifier=channel_identifier,
+    )
+    our_locksroot, partner_locksroot = get_onchain_locksroots(
+        chain=raiden.chain,
+        canonical_identifier=canonical_identifier,
         participant1=channel_state.our_state.address,
         participant2=channel_state.partner_state.address,
         block_identifier=block_hash,

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -9,6 +9,7 @@ from raiden.utils import CanonicalIdentifier
 from raiden.utils.typing import Address, BlockSpecification, Locksroot, Tuple
 
 if TYPE_CHECKING:
+    # pylint: disable=unused-import
     from raiden.network.blockchain_service import BlockChainService
 
 

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -1,17 +1,15 @@
+from typing import TYPE_CHECKING
+
 from eth_utils import to_normalized_address
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.exceptions import AddressWrongContract, ContractVersionMismatch
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
-from raiden.utils import CHAIN_ID_UNSPECIFIED, CanonicalIdentifier
-from raiden.utils.typing import (
-    Address,
-    BlockSpecification,
-    ChannelID,
-    Locksroot,
-    TokenNetworkAddress,
-    Tuple,
-)
+from raiden.utils import CanonicalIdentifier
+from raiden.utils.typing import Address, BlockSpecification, Locksroot, Tuple
+
+if TYPE_CHECKING:
+    from raiden.network.blockchain_service import BlockChainService
 
 
 def compare_contract_versions(
@@ -44,26 +42,21 @@ def compare_contract_versions(
 
 
 def get_onchain_locksroots(
-        raiden,
-        token_network_address: TokenNetworkAddress,
-        channel_identifier: ChannelID,
+        chain: 'BlockChainService',
+        canonical_identifier: CanonicalIdentifier,
         participant1: Address,
         participant2: Address,
         block_identifier: BlockSpecification,
 ) -> Tuple[Locksroot, Locksroot]:
-    payment_channel = raiden.chain.payment_channel(
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=CHAIN_ID_UNSPECIFIED,
-            token_network_address=token_network_address,
-            channel_identifier=channel_identifier,
-        ),
-    )
+    """Return the locksroot for `participant1` and `participant2` at `block_identifier`."""
+    payment_channel = chain.payment_channel(canonical_identifier=canonical_identifier)
     token_network = payment_channel.token_network
 
+    # This will not raise RaidenRecoverableError because we are providing the channel_identifier
     participants_details = token_network.detail_participants(
         participant1=participant1,
         participant2=participant2,
-        channel_identifier=channel_identifier,
+        channel_identifier=canonical_identifier.channel_identifier,
         block_identifier=block_identifier,
     )
 

--- a/raiden/storage/migrations/v19_to_v20.py
+++ b/raiden/storage/migrations/v19_to_v20.py
@@ -7,6 +7,7 @@ from gevent.pool import Pool
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.network.proxies.utils import get_onchain_locksroots
 from raiden.storage.sqlite import SQLiteStorage, StateChangeRecord
+from raiden.utils import CHAIN_ID_UNSPECIFIED, CanonicalIdentifier
 from raiden.utils.serialization import serialize_bytes
 from raiden.utils.typing import Any, Dict, Locksroot, Tuple
 
@@ -46,10 +47,15 @@ def _get_onchain_locksroots(
             f'token network address: {token_network["address"]} being created. ',
         )
 
-    our_locksroot, partner_locksroot = get_onchain_locksroots(
-        raiden=raiden,
+    canonical_identifier = CanonicalIdentifier(
+        chain_identifier=CHAIN_ID_UNSPECIFIED,
         token_network_address=to_canonical_address(token_network['address']),
         channel_identifier=int(channel['identifier']),
+    )
+
+    our_locksroot, partner_locksroot = get_onchain_locksroots(
+        chain=raiden.chain,
+        canonical_identifier=canonical_identifier,
         participant1=to_canonical_address(channel['our_state']['address']),
         participant2=to_canonical_address(channel['partner_state']['address']),
         block_identifier='latest',
@@ -132,10 +138,15 @@ def _add_onchain_locksroot_to_channel_settled_state_changes(
 
             channel_state_data = json.loads(channel_new_state_change.data)
             new_channel_state = channel_state_data['channel_state']
-            our_locksroot, partner_locksroot = get_onchain_locksroots(
-                raiden=raiden,
+
+            canonical_identifier = CanonicalIdentifier(
+                chain_identifier=CHAIN_ID_UNSPECIFIED,
                 token_network_address=to_canonical_address(token_network_identifier),
                 channel_identifier=int(channel_identifier),
+            )
+            our_locksroot, partner_locksroot = get_onchain_locksroots(
+                chain=raiden.chain,
+                canonical_identifier=canonical_identifier,
                 participant1=to_canonical_address(new_channel_state['our_state']['address']),
                 participant2=to_canonical_address(new_channel_state['partner_state']['address']),
                 block_identifier='latest',
@@ -208,7 +219,7 @@ def _add_onchain_locksroot_to_snapshots(
     storage.update_snapshots(updated_snapshots_data)
 
 
-def upgrade_v19_to_v20(
+def upgrade_v19_to_v20(  # pylint: disable=unused-argument
         storage: SQLiteStorage,
         old_version: int,
         current_version: int,


### PR DESCRIPTION
Small change that simplified a bit the interface of `get_onchain_locksroots`.

Depends on #3653 to fix the reference cycles.