### PR TITLE
Upgrade jinja2 constraint due to CVE2016-10745

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -32,7 +32,7 @@ idna==2.7
 ipython-genutils==0.2.0
 ipython==4.2.1
 itsdangerous==0.24
-Jinja2==2.8.1
+Jinja2==2.10
 lru-dict==1.1.6
 MarkupSafe==1.0
 marshmallow-polyfield==5.5

--- a/constraints.txt
+++ b/constraints.txt
@@ -32,7 +32,7 @@ idna==2.7
 ipython-genutils==0.2.0
 ipython==4.2.1
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.8.1
 lru-dict==1.1.6
 MarkupSafe==1.0
 marshmallow-polyfield==5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ eth-utils==1.4.1
 filelock==3.0.8
 Flask-Cors==3.0.6
 Flask-RESTful==0.3.6
-Flask==1.0.2
+Flask==1.0.3
 gevent==1.3.6
 ipython<5.0.0
 marshmallow-polyfield==5.5


### PR DESCRIPTION
Link: https://nvd.nist.gov/vuln/detail/CVE-2016-10745

@ulope Does this make sense?