### PR TITLE
 Refactor ReleaseKeeper Class.

### DIFF
--- a/tools/scenario-player/scenario_player/node_support.py
+++ b/tools/scenario-player/scenario_player/node_support.py
@@ -1,25 +1,18 @@
 import hashlib
 import json
 import os
-import platform
 import random
 import shutil
 import socket
-import stat
-import sys
 import time
+
 from datetime import timedelta
 from enum import Enum
-from pathlib import Path
-from tarfile import TarFile
 from typing import Any, Dict, Set
-from urllib.parse import urljoin
-from zipfile import ZipFile
 
 import gevent
-import requests
 import structlog
-from cachetools.func import ttl_cache
+
 from eth_keyfile import create_keyfile_json
 from eth_utils import to_checksum_address
 from eth_utils.typing import ChecksumAddress
@@ -28,16 +21,13 @@ from gevent.pool import Group, Pool
 from mirakuru import ProcessExitedWithError
 
 from raiden.ui.cli import run as cli_run
+
 from scenario_player.exceptions import ScenarioError
 from scenario_player.runner import ScenarioRunner
 from scenario_player.utils import HTTPExecutor
 
+
 log = structlog.get_logger(__name__)
-
-
-RAIDEN_RELEASES_URL = 'https://raiden-nightlies.ams3.digitaloceanspaces.com/'
-RAIDEN_RELEASES_LATEST_FILE_TEMPLATE = '_LATEST-{platform}-{arch}.txt'
-RAIDEN_RELEASES_VERSIONED_NAME_TEMPLATE = 'raiden-v{version}-{platform}-{arch}.zip'
 
 
 MANAGED_CONFIG_OPTIONS = {
@@ -76,100 +66,6 @@ FLAG_OPTIONS = {param.name.replace('_', '-') for param in cli_run.params if para
 class NodeState(Enum):
     STOPPED = 1
     STARTED = 2
-
-
-class RaidenReleaseKeeper:
-    def __init__(self, release_cache_dir: Path):
-        self._releases = {}
-        self._downloads_path = release_cache_dir.joinpath('downloads')
-        self._bin_path = release_cache_dir.joinpath('bin')
-
-        self._downloads_path.mkdir(exist_ok=True, parents=True)
-        self._bin_path.mkdir(exist_ok=True, parents=True)
-
-    def get_release(self, version: str = 'LATEST'):
-        # `version` can also be a path
-        bin_path = Path(version)
-        if bin_path.exists() and bin_path.stat().st_mode & stat.S_IXUSR == stat.S_IXUSR:
-            # File exists and is executable
-            return bin_path
-
-        if version.lower() == 'latest':
-            release_file_name = self._latest_release_name
-        else:
-            if version.startswith('v'):
-                version = version.lstrip('v')
-            release_file_name = self._expand_release_template(
-                RAIDEN_RELEASES_VERSIONED_NAME_TEMPLATE,
-                version=version,
-            )
-
-        release_file_path = self._get_release_file(release_file_name)
-        return self._get_bin_for_release(release_file_path)
-
-    def _get_bin_for_release(self, release_file_path: Path):
-        if not release_file_path.exists():
-            raise ValueError(f'Release file {release_file_path} not found')
-
-        if release_file_path.suffix == '.gz':
-            opener = TarFile.open(release_file_path, 'r:*')
-        else:
-            opener = ZipFile(release_file_path, 'r')
-
-        with opener as archive:
-            if release_file_path.suffix == '.gz':
-                contents = archive.getnames()
-            else:
-                contents = archive.namelist()
-            if len(contents) != 1:
-                raise ValueError(
-                    f'Release archive has unexpected content. '
-                    f'Expected 1 file, found {len(contents)}: {", ".join(contents)}',
-                )
-            bin_file_path = self._bin_path.joinpath(contents[0])
-            if not bin_file_path.exists():
-                log.debug(
-                    'Extracting Raiden binary',
-                    release_file_name=release_file_path.name,
-                    bin_file_name=bin_file_path.name,
-                )
-                archive.extract(contents[0], self._bin_path)
-                bin_file_path.chmod(0o770)
-            return bin_file_path
-
-    def _get_release_file(self, release_file_name: str):
-        release_file_path = self._downloads_path.joinpath(release_file_name)
-        if release_file_path.exists():
-            return release_file_path
-
-        url = RAIDEN_RELEASES_URL + release_file_name
-        with requests.get(url, stream=True) as resp, release_file_path.open('wb') as release_file:
-            log.debug('Downloading Raiden release', release_file_name=release_file_name)
-            if not 199 < resp.status_code < 300:
-                raise ValueError(
-                    f"Can't download release file {release_file_name}: "
-                    f"{resp.status_code} {resp.text}",
-                )
-            shutil.copyfileobj(resp.raw, release_file)
-        return release_file_path
-
-    @property
-    @ttl_cache(maxsize=1, ttl=600)
-    def _latest_release_name(self):
-        latest_release_file_name = self._expand_release_template(
-            RAIDEN_RELEASES_LATEST_FILE_TEMPLATE,
-        )
-        url = urljoin(RAIDEN_RELEASES_URL, latest_release_file_name)
-        log.debug('Fetching latest Raiden release', lookup_url=url)
-        return requests.get(url).text.strip()
-
-    @staticmethod
-    def _expand_release_template(template, **kwargs):
-        return template.format(
-            platform='macOS' if sys.platform == 'darwin' else sys.platform,
-            arch=platform.machine(),
-            **kwargs,
-        )
 
 
 class NodeRunner:
@@ -348,7 +244,8 @@ class NodeRunner:
 
     @property
     def _raiden_bin(self):
-        return self._runner.release_keeper.get_release(self._raiden_version)
+        _, bin_path = self._runner.release_keeper.install(self._raiden_version)
+        return bin_path
 
     @property
     def _keystore_file(self):

--- a/tools/scenario-player/scenario_player/releases.py
+++ b/tools/scenario-player/scenario_player/releases.py
@@ -2,14 +2,12 @@ import pathlib
 import shutil
 import stat
 import sys
-
 from tarfile import TarFile
-from typing import Union, Tuple, List, Dict
+from typing import Dict, List, Tuple, Union
 from zipfile import ZipFile
 
 import requests
 import structlog
-
 from cachetools.func import ttl_cache
 
 log = structlog.get_logger(__name__)
@@ -43,6 +41,7 @@ class ReleaseArchive:
     Supplies a context manager and file-type detection, which allows choosing
     the correct library for opening the archive automatically.
     """
+
     def __init__(self, path: pathlib.Path) -> None:
         self.path = path
         if self.path.suffix == '.gz':
@@ -113,6 +112,7 @@ class Release:
     If the binary for the version is not present on the local machine, it can
     be downloaded using the :meth:`Release.download` method.
     """
+
     def __init__(self, version: Union[str, pathlib.Path]) -> None:
         #: Holds the original version value; this should not be changed.
         self._version = version

--- a/tools/scenario-player/scenario_player/releases.py
+++ b/tools/scenario-player/scenario_player/releases.py
@@ -1,0 +1,318 @@
+import pathlib
+import shutil
+import stat
+import sys
+
+from tarfile import TarFile
+from typing import Union, Tuple, List, Dict
+from zipfile import ZipFile
+
+import requests
+import structlog
+
+from cachetools.func import ttl_cache
+
+log = structlog.get_logger(__name__)
+
+
+RAIDEN_RELEASES_URL = 'https://raiden-nightlies.ams3.digitaloceanspaces.com/'
+if sys.platform == 'darwin':
+    RAIDEN_RELEASES_LATEST_FILE = '_LATEST-macOS-x86_64.txt'
+    RELEASE_ARCHIVE_NAME_TEMPLATE = 'raiden-v{version}-macOS-x86_64.zip'
+else:
+    RAIDEN_RELEASES_LATEST_FILE = '_LATEST-linux-x86_64.txt'
+    RELEASE_ARCHIVE_NAME_TEMPLATE = 'raiden-v{version}-linux-x86_64.tar.gz'
+
+
+@ttl_cache(maxsize=1, ttl=600)
+def get_latest_release():
+    """Retrieve the latest release's URL path"""
+    url = RAIDEN_RELEASES_URL + RAIDEN_RELEASES_LATEST_FILE
+    log.debug('Fetching latest Raiden release')
+    return requests.get(url).text.strip()
+
+
+def is_executable(path) -> bool:
+    """Check for a set x bit on the given pathlib.Path object."""
+    return path.stat().st_mode & stat.S_IXUSR == stat.S_IXUSR
+
+
+class ReleaseArchive:
+    """Wrapper class for extracting a Raiden release from its archive.
+
+    Supplies a context manager and file-type detection, which allows choosing
+    the correct library for opening the archive automatically.
+    """
+    def __init__(self, path: pathlib.Path) -> None:
+        self.path = path
+        if self.path.suffix == '.gz':
+            self._context = TarFile.open(self.path, 'r:*')
+        else:
+            self._context = ZipFile(self.path, 'r')
+        self.validate()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+    @property
+    def files(self) -> List[str]:
+        """Return a list of files present in the archive.
+
+        Depending on the file extension, we choose the correct method to access
+        this list.
+        """
+        if self.path.suffix == '.gz':
+            return self._context.getnames()
+        else:
+            return self._context.namelist()
+
+    @property
+    def binary(self) -> str:
+        """Return the name of the first file of our list of files.
+
+        Since the archive must only contain a single file, this is automatically
+        assumed to be our binary; this assumption *is not* checked for correctness.
+        """
+        return self.files[0]
+
+    def validate(self) -> None:
+        """Confirm there is only one file present in the archive.
+
+        :raises ValueError: if the archive has an unexpected layout.
+        """
+        if len(self.files) != 1:
+            raise ValueError(
+                f'Release archive has unexpected content. '
+                f'Expected 1 file, found {len(self.files)}: {", ".join(self.files)}',
+            )
+
+    def unpack(self, target_dir: pathlib.Path) -> pathlib.Path:
+        """Unpack this release's archive to the given `target_dir`.
+
+        We also set the x bit on the extracted binary.
+        """
+        self._context.extract(self.binary, target_dir)
+        target_dir.chmod(0o770)
+        return target_dir
+
+    def close(self):
+        """Close the context, if possible."""
+        if self._context and hasattr(self._context, 'close'):
+            self._context.close()
+
+
+class Release:
+    """Represents a single Raiden release, its version and binary's path.
+
+    If the binary for the version is not present on the local machine, it can
+    be downloaded using the :meth:`Release.download` method.
+    """
+    def __init__(self, version: Union[str, pathlib.Path]) -> None:
+        #: Holds the original version value; this should not be changed.
+        self._version = version
+
+        #: Path to the binary on the local machine.
+        self.binary = None
+
+        #: Path to the archive on the local machine.
+        self.archive = None
+
+        if isinstance(self._version, pathlib.Path):
+            if not version.exists():
+                raise ValueError(
+                    'Must supply a valid release version, '
+                    'or an existing path to a binary or archive!',
+                )
+            if version.stem in ('.zip', '.gz'):
+                # this is an archive
+                self.archive = version
+            if not is_executable(version):
+                raise ValueError('Path to binary requires execution permission!')
+
+    def __repr__(self) -> str:
+        return f"Release(version={self._version!r})"
+
+    def __str__(self) -> str:
+        archive = self.archive.name if self.archive else None
+        return f"Release <Version: {self.version} | Archive: {archive} | " \
+            f"installed={self.binary_exists_locally}>"
+
+    @property
+    def version(self) -> str:
+        """Return the Raiden release version.
+
+        This constructs the version string from the internal :attr:`Release._version`
+        attribute and does one of two things:
+
+            1. Fetches the latest release version if the attributes value
+                is 'latest', and returns it.
+
+            or
+
+            2. Checks if the value starts with a 'v' and strips it, modifying
+                `version` in place; then returns it.
+        """
+        version = self._version
+        if version.lower() == 'latest':
+            version = get_latest_release()
+
+        if version.startswith('v'):
+            return version.lstrip('v')
+        return version
+
+    @property
+    def binary_exists_locally(self) -> bool:
+        """Return True if we found an *executable* binary path for :attr:`Release.binary`."""
+        return self.binary.exists() and is_executable(self.binary)
+
+    def download(self, target_folder: Union[str, pathlib.Path], overwrite=False) -> pathlib.Path:
+        """Download this release's binary from our servers to the given `target_folder`."""
+        target_file = RELEASE_ARCHIVE_NAME_TEMPLATE.format(version=self.version)
+
+        download_destination = pathlib.Path(target_folder).joinpath(target_file)
+
+        if download_destination.exists():
+            if not overwrite:
+                return download_destination
+            download_destination.unlink()
+
+        url = RAIDEN_RELEASES_URL + target_file
+
+        with requests.get(url, stream=True) as resp:
+            log.debug('Downloading Raiden release', release_file_name=target_file)
+            try:
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                raise ValueError(
+                    f"Can't download release file {target_file}!",
+                ) from e
+
+        with download_destination.open('wb') as release_file:
+            shutil.copyfileobj(resp.raw, release_file)
+
+        self.archive = download_destination
+        return download_destination
+
+    def unpack_archive(self, target_dir: pathlib.Path, overwrite=False) -> pathlib.Path:
+        """Unpack the Release archive and return the path to the extracted binary."""
+        with ReleaseArchive(target_dir) as archive:
+            bin_file_path = target_dir.joinpath(archive.binary)
+            if not bin_file_path.exists() or overwrite:
+                log.debug(
+                    'Extracting Raiden binary',
+                    release_file_name=self.archive.name,
+                    bin_file_name=bin_file_path.name,
+                )
+                self.binary = archive.unpack(bin_file_path)
+            return bin_file_path
+
+    def install(self, target_dir: pathlib.Path, overwrite=False) -> pathlib.Path:
+        """Install the binary on the local machine from this archive.
+
+        :param target_dir: The target path to install the binary to.
+        :param overwrite: whether or not we should overwrite existing files.
+        """
+        if self.archive is None or not self.archive.exists():
+            raise ValueError('Must download archive first!')
+        if not overwrite and self.binary_exists_locally:
+            return self.binary
+        extracted_bin_path = self.unpack_archive(target_dir, overwrite)
+        return extracted_bin_path
+
+    def uninstall(self) -> None:
+        """Remove the binary linked to this release, if it exists locally."""
+        if self.binary and self.binary.exists():
+            self.binary.unlink()
+        self.binary = None
+
+    def remove(self) -> None:
+        """Remove the archive linked to this release, if it exists locally."""
+        if self.archive and self.archive.exists():
+            self.archive.unlink()
+        self.archive = None
+
+    def purge(self) -> None:
+        """Remove the binary and archive linked to this release."""
+        self.uninstall()
+        self.remove()
+
+
+class ReleaseManager:
+    """Administration interface for release management.
+
+    Capable of managing several Raiden releases, represented as
+    :cls:`Release` instances.
+    """
+
+    def __init__(self, cache_path: pathlib.Path):
+        self._releases = {}
+        self._cache_path = cache_path
+
+    @property
+    def download_path(self) -> pathlib.Path:
+        """Return the download directory path.
+
+        If this does not exist yet, it will be created on the fly.
+        """
+        path = self._cache_path.joinpath('downloads')
+        path.mkdir(exist_ok=True, parents=True)
+        return path
+
+    @property
+    def bin_path(self) -> pathlib.Path:
+        """Return the binary directory path.
+
+        If this does not exist yet, it will be created on the fly.
+        """
+        path = self._cache_path.joinpath('bin')
+        path.mkdir(exist_ok=True, parents=True)
+        return path
+
+    @property
+    def releases(self) -> Dict[str, Release]:
+        """Return a version-to-release mapping containing all known versions."""
+        return self._releases
+
+    @property
+    def installed(self) -> Dict[str, Release]:
+        """Return a version-to-release mapping containing all installed versions."""
+        return {
+            version: release for version, release in self._releases.items()
+            if release.binary_exists_locally
+        }
+
+    def install(self, release: Union[Release, str], overwrite=False) -> Tuple[str, pathlib.Path]:
+        """Install the given `release` on this machine, downloading it if necessary."""
+        if isinstance(release, str):
+            # we assume this is a version number/string; if it isn't, the operation will fail.
+            release = Release(release)
+        release.download(self.download_path, overwrite)
+        release.install(self.bin_path, overwrite)
+
+        self._releases[release.version] = release
+
+        return release.version, release.binary
+
+    def uninstall(self, version) -> None:
+        """Uninstall the release with the given `version`."""
+        release = self._releases[version]
+        release.uninstall()
+
+    def purge(self, cached=False) -> None:
+        """Remove all releases registered with this ReleaseManager instance.
+
+        If `cached` is truthy, we also remove the archive file from the local
+        machine associated with each release, if present.
+        """
+        for release in self._releases.values():
+            if cached:
+                release.purge()
+            else:
+                release.uninstall()
+        self._releases = {}

--- a/tools/scenario-player/scenario_player/runner.py
+++ b/tools/scenario-player/scenario_player/runner.py
@@ -1,8 +1,8 @@
 import pathlib
 import random
 from collections import defaultdict
-from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
+from pathlib import Path
 
 import gevent
 import structlog
@@ -17,19 +17,31 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils.typing import TransactionHash
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
+
 from scenario_player.constants import (
-    API_URL_ADDRESS,
-    API_URL_TOKEN_NETWORK_ADDRESS,
-    API_URL_TOKENS,
-    DEFAULT_TOKEN_BALANCE_FUND,
     DEFAULT_TOKEN_BALANCE_MIN,
-    NODE_ACCOUNT_BALANCE_FUND,
-    NODE_ACCOUNT_BALANCE_MIN,
+    DEFAULT_TOKEN_BALANCE_FUND,
     OWN_ACCOUNT_BALANCE_MIN,
+    NODE_ACCOUNT_BALANCE_MIN,
+    NODE_ACCOUNT_BALANCE_FUND,
+    TIMEOUT,
+    API_URL_ADDRESS,
+    API_URL_TOKENS,
+    API_URL_TOKEN_NETWORK_ADDRESS,
+    SUPPORTED_SCENARIO_VERSIONS,
     NodeMode,
 )
-from scenario_player.exceptions import NodesUnreachableError, ScenarioError, TokenRegistrationError
+from scenario_player.releases import ReleaseManager
+from scenario_player.exceptions import (
+    NodesUnreachableError,
+    ScenarioError,
+    TokenRegistrationError,
+    MissingNodesConfiguration,
+    MultipleTaskDefinitions,
+    InvalidScenarioVersion,
+)
 from scenario_player.scenario import Scenario
+from scenario_player.releases import ReleaseManager
 from scenario_player.utils import (
     TimeOutHTTPAdapter,
     get_or_deploy_token,
@@ -50,12 +62,12 @@ class ScenarioRunner:
             data_path: Path,
             scenario_file: Path,
     ):
-        from scenario_player.node_support import RaidenReleaseKeeper, NodeController
+        from scenario_player.node_support import NodeController
 
         self.task_count = 0
         self.running_task_count = 0
         self.auth = auth
-        self.release_keeper = RaidenReleaseKeeper(data_path.joinpath('raiden_releases'))
+        self.release_keeper = ReleaseManager(data_path.joinpath('raiden_releases'))
         self.task_cache = {}
         # Storage for arbitrary data tasks might need to persist
         self.task_storage = defaultdict(dict)

--- a/tools/scenario-player/scenario_player/runner.py
+++ b/tools/scenario-player/scenario_player/runner.py
@@ -1,8 +1,8 @@
 import pathlib
 import random
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple
 from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
 
 import gevent
 import structlog
@@ -17,31 +17,20 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.utils.typing import TransactionHash
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
-
 from scenario_player.constants import (
-    DEFAULT_TOKEN_BALANCE_MIN,
-    DEFAULT_TOKEN_BALANCE_FUND,
-    OWN_ACCOUNT_BALANCE_MIN,
-    NODE_ACCOUNT_BALANCE_MIN,
-    NODE_ACCOUNT_BALANCE_FUND,
-    TIMEOUT,
     API_URL_ADDRESS,
-    API_URL_TOKENS,
     API_URL_TOKEN_NETWORK_ADDRESS,
-    SUPPORTED_SCENARIO_VERSIONS,
+    API_URL_TOKENS,
+    DEFAULT_TOKEN_BALANCE_FUND,
+    DEFAULT_TOKEN_BALANCE_MIN,
+    NODE_ACCOUNT_BALANCE_FUND,
+    NODE_ACCOUNT_BALANCE_MIN,
+    OWN_ACCOUNT_BALANCE_MIN,
     NodeMode,
 )
+from scenario_player.exceptions import NodesUnreachableError, ScenarioError, TokenRegistrationError
 from scenario_player.releases import ReleaseManager
-from scenario_player.exceptions import (
-    NodesUnreachableError,
-    ScenarioError,
-    TokenRegistrationError,
-    MissingNodesConfiguration,
-    MultipleTaskDefinitions,
-    InvalidScenarioVersion,
-)
 from scenario_player.scenario import Scenario
-from scenario_player.releases import ReleaseManager
 from scenario_player.utils import (
     TimeOutHTTPAdapter,
     get_or_deploy_token,

--- a/tools/scenario-player/scenario_player/scenario.py
+++ b/tools/scenario-player/scenario_player/scenario.py
@@ -1,18 +1,16 @@
-import pathlib
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Dict, Tuple, Any
+
 
 import structlog
-import yaml
-
-from scenario_player.constants import SUPPORTED_SCENARIO_VERSIONS, TIMEOUT, NodeMode
 from scenario_player.exceptions import (
-    InvalidScenarioVersion,
+    ScenarioError,
     MissingNodesConfiguration,
     MultipleTaskDefinitions,
-    ScenarioError,
+    InvalidScenarioVersion,
 )
-from scenario_player.utils import get_gas_price_strategy
+from scenario_player.utils import get_gas_prize_strategy
+
 
 log = structlog.get_logger(__name__)
 
@@ -27,7 +25,6 @@ class NodesConfig(Mapping):
     :param nodes_config: The node configuration as set in the scenario yaml.
     :param scenario_version: Version of the scenario yaml file.
     """
-
     def __init__(self, nodes_config: Dict, scenario_version: int = 1):
         self._config = nodes_config
         self._scenario_version = scenario_version
@@ -226,7 +223,7 @@ class Scenario(Mapping):
 
     @property
     def gas_price_strategy(self) -> Callable:
-        return get_gas_price_strategy(self.gas_price)
+        return get_gas_prize_strategy(self.gas_price)
 
     @property
     def nodes(self) -> NodesConfig:

--- a/tools/scenario-player/scenario_player/scenario.py
+++ b/tools/scenario-player/scenario_player/scenario.py
@@ -1,16 +1,17 @@
+import pathlib
 from collections.abc import Mapping
-from typing import Dict, Tuple, Any
-
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import structlog
+import yaml
+from scenario_player.constants import SUPPORTED_SCENARIO_VERSIONS, TIMEOUT, NodeMode
 from scenario_player.exceptions import (
-    ScenarioError,
+    InvalidScenarioVersion,
     MissingNodesConfiguration,
     MultipleTaskDefinitions,
-    InvalidScenarioVersion,
+    ScenarioError,
 )
 from scenario_player.utils import get_gas_prize_strategy
-
 
 log = structlog.get_logger(__name__)
 
@@ -25,6 +26,7 @@ class NodesConfig(Mapping):
     :param nodes_config: The node configuration as set in the scenario yaml.
     :param scenario_version: Version of the scenario yaml file.
     """
+
     def __init__(self, nodes_config: Dict, scenario_version: int = 1):
         self._config = nodes_config
         self._scenario_version = scenario_version


### PR DESCRIPTION
This refactoring aims to split the existing code
up logically, providing two new
classes, as well a multiple new methods for
managing releases.

The ReleaseArchive class provides a more pythonic
approach to reading and extracting a release's
archive file (.tar.gz or .zip).

The Release class now takes care exclusively of
downloading, unppacking, installing, uninstalling
and removing a single release to and from the
local machine.

The ReleaseManager manages several Release instances,
and supplies convenience methods to install
and uninstall a release, as well as a purge method to
uninstall and remove all releases.

Finally, we moved these classes to a new file, as
we feel their complexity warrants a dedicated module.