### PR TITLE
Workaround for web3 throwing exception in

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -611,6 +611,10 @@ class JSONRPCClient:
             # we can sporadically get an AtttributeError here. If that happens
             # use latest gas price
             price = int(self.web3.eth.gasPrice)
+        except IndexError:  # work around for a web3.py exception when
+            # the blockchain is somewhat empty.
+            # https://github.com/ethereum/web3.py/issues/1149
+            price = int(self.web3.eth.gasPrice)
 
         return price
 


### PR DESCRIPTION
web3.eth.generateGasPrice() when there are not many transactions in the chain.

This fixes https://github.com/raiden-network/raiden/issues/3244 on the procedure documented in
https://github.com/raiden-network/raiden/blob/fe45769dd3c3f339b30a214599d028eb8351dc6a/docs/private_net_tutorial.rst