### PR TITLE
Integrations tests raise if an app crashes

### DIFF
--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -3,6 +3,7 @@ from eth_utils import to_checksum_address
 
 from raiden.api.python import RaidenAPI
 from raiden.exceptions import DepositMismatch, UnknownTokenAddress
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import must_have_event, wait_for_state_change
 from raiden.tests.utils.transfer import get_channelstate
 from raiden.transfer import channel, views
@@ -19,6 +20,15 @@ from raiden_contracts.constants import ChannelEvent
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('number_of_tokens', [1])
 def test_token_addresses(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_token_addresses,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_token_addresses(raiden_network, token_addresses):
     app = raiden_network[0]
     api = RaidenAPI(app.raiden)
     registry_address = app.raiden.default_registry.address
@@ -29,6 +39,17 @@ def test_token_addresses(raiden_network, token_addresses):
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, retry_timeout):
     """Uses RaidenAPI to go through a complete channel lifecycle."""
+    raise_on_failure(
+        raiden_network,
+        run_test_raidenapi_channel_lifecycle,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        retry_timeout=retry_timeout,
+    )
+
+
+def run_test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, retry_timeout):
     node1, node2 = raiden_network
     token_address = token_addresses[0]
     token_network_identifier = views.get_token_network_identifier_by_token_address(

--- a/raiden/tests/integration/api/test_pythonapi_regression.py
+++ b/raiden/tests/integration/api/test_pythonapi_regression.py
@@ -3,6 +3,7 @@ import pytest
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
+from raiden.tests.utils.detect_failure import raise_on_failure
 
 
 @pytest.mark.parametrize('number_of_nodes', [2])
@@ -11,6 +12,16 @@ def test_close_regression(raiden_network, deposit, token_addresses):
     """ The python api was using the wrong balance proof to close the channel,
     thus the close was failing if a transfer was made.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_close_regression,
+        raiden_network=raiden_network,
+        deposit=deposit,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_close_regression(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -17,6 +17,7 @@ from raiden.blockchain.events import (
 from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.network.blockchain_service import BlockChainService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import must_have_event, search_for_item, wait_for_state_change
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldOffChainSecretRequest
@@ -188,6 +189,16 @@ def wait_both_channel_deposit(
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_channel_new(raiden_chain, retry_timeout, token_addresses):
+    raise_on_failure(
+        raiden_chain,
+        run_test_channel_new,
+        raiden_chain=raiden_chain,
+        retry_timeout=retry_timeout,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_channel_new(raiden_chain, retry_timeout, token_addresses):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -219,6 +230,17 @@ def test_channel_new(raiden_chain, retry_timeout, token_addresses):
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
+    raise_on_failure(
+        raiden_chain,
+        run_test_channel_deposit,
+        raiden_chain=raiden_chain,
+        deposit=deposit,
+        retry_timeout=retry_timeout,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
 
@@ -296,6 +318,28 @@ def test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_query_events(
+        raiden_chain,
+        token_addresses,
+        deposit,
+        settle_timeout,
+        retry_timeout,
+        contract_manager,
+        blockchain_type,
+):
+    raise_on_failure(
+        raiden_chain,
+        run_test_query_events,
+        raiden_chain=raiden_chain,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        settle_timeout=settle_timeout,
+        retry_timeout=retry_timeout,
+        contract_manager=contract_manager,
+        blockchain_type=blockchain_type,
+    )
+
+
+def run_test_query_events(
         raiden_chain,
         token_addresses,
         deposit,
@@ -506,6 +550,24 @@ def test_secret_revealed_on_chain(
         token_addresses,
         retry_interval,
 ):
+    raise_on_failure(
+        raiden_chain,
+        run_test_secret_revealed_on_chain,
+        raiden_chain=raiden_chain,
+        deposit=deposit,
+        settle_timeout=settle_timeout,
+        token_addresses=token_addresses,
+        retry_interval=retry_interval,
+    )
+
+
+def run_test_secret_revealed_on_chain(
+        raiden_chain,
+        deposit,
+        settle_timeout,
+        token_addresses,
+        retry_interval,
+):
     """ A node must reveal the secret on-chain if it's known and the channel is closed. """
     app0, app1, app2 = raiden_chain
     token_address = token_addresses[0]
@@ -594,6 +656,16 @@ def test_secret_revealed_on_chain(
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_clear_closed_queue(raiden_network, token_addresses, network_wait):
     """ Closing a channel clears the respective message queue. """
+    raise_on_failure(
+        raiden_network,
+        run_test_clear_closed_queue,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_clear_closed_queue(raiden_network, token_addresses, network_wait):
     app0, app1 = raiden_network
 
     hold_event_handler = HoldOffChainSecretRequest()

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -10,6 +10,7 @@ from raiden.exceptions import RaidenUnrecoverableError
 from raiden.messages import LockedTransfer, LockExpired, RevealSecret
 from raiden.storage.restore import channel_state_until_state_change
 from raiden.tests.utils import factories
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldOffChainSecretRequest, WaitForMessage
@@ -45,6 +46,15 @@ def wait_for_batch_unlock(app, token_network_id, participant, partner):
 
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_settle_is_automatically_called(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_settle_is_automatically_called,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_settle_is_automatically_called(raiden_network, token_addresses):
     """Settle is automatically called by one of the nodes."""
     app0, app1 = raiden_network
     registry_address = app0.raiden.default_registry.address
@@ -132,6 +142,16 @@ def test_settle_is_automatically_called(raiden_network, token_addresses):
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_lock_expiry(raiden_network, token_addresses, deposit):
     """Test lock expiry and removal."""
+    raise_on_failure(
+        raiden_network,
+        run_test_lock_expiry,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        deposit=deposit,
+    )
+
+
+def run_test_lock_expiry(raiden_network, token_addresses, deposit):
     alice_app, bob_app = raiden_network
     token_address = token_addresses[0]
     token_network_identifier = views.get_token_network_identifier_by_token_address(
@@ -251,6 +271,24 @@ def test_lock_expiry(raiden_network, token_addresses, deposit):
 
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_batch_unlock(
+        raiden_network,
+        token_addresses,
+        secret_registry_address,
+        deposit,
+        blockchain_type,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_batch_unlock,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        secret_registry_address=secret_registry_address,
+        deposit=deposit,
+        blockchain_type=blockchain_type,
+    )
+
+
+def run_test_batch_unlock(
         raiden_network,
         token_addresses,
         secret_registry_address,
@@ -409,6 +447,20 @@ def test_settled_lock(
         raiden_network,
         deposit,
 ):
+    raise_on_failure(
+        raiden_network,
+        run_test_settled_lock,
+        token_addresses=token_addresses,
+        raiden_network=raiden_network,
+        deposit=deposit,
+    )
+
+
+def run_test_settled_lock(
+        token_addresses,
+        raiden_network,
+        deposit,
+):
     """ Any transfer following a secret reveal must update the locksroot, so
     that an attacker cannot reuse a secret to double claim a lock.
     """
@@ -507,6 +559,15 @@ def test_settled_lock(
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_automatic_secret_registration(raiden_chain, token_addresses):
+    raise_on_failure(
+        raiden_chain,
+        run_test_automatic_secret_registration,
+        raiden_chain=raiden_chain,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_automatic_secret_registration(raiden_chain, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
     token_network_identifier = views.get_token_network_identifier_by_token_address(
@@ -564,6 +625,16 @@ def test_automatic_secret_registration(raiden_chain, token_addresses):
 @pytest.mark.xfail(reason='test incomplete')
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_start_end_attack(token_addresses, raiden_chain, deposit):
+    raise_on_failure(
+        raiden_chain,
+        run_test_start_end_attack,
+        token_addresses=token_addresses,
+        raiden_chain=raiden_chain,
+        deposit=deposit,
+    )
+
+
+def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
     """ An attacker can try to steal tokens from a hub or the last node in a
     path.
 
@@ -668,6 +739,16 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit):
 
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_automatic_dispute(raiden_network, deposit, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_automatic_dispute,
+        raiden_network=raiden_network,
+        deposit=deposit,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_automatic_dispute(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -4,6 +4,7 @@ import pytest
 from raiden import routing, waiting
 from raiden.api.python import RaidenAPI
 from raiden.exceptions import InvalidAmount
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED
 
@@ -75,10 +76,16 @@ def saturated_count(connection_managers, registry_address, token_address):
 @pytest.mark.parametrize('channels_per_node', [0])
 @pytest.mark.parametrize('settle_timeout', [6])
 @pytest.mark.parametrize('reveal_timeout', [3])
-def test_participant_selection(
+def test_participant_selection(raiden_network, token_addresses):
+    raise_on_failure(
         raiden_network,
-        token_addresses,
-):
+        run_test_participant_selection,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_participant_selection(raiden_network, token_addresses):
     # pylint: disable=too-many-locals
     registry_address = raiden_network[0].raiden.default_registry.address
     token_address = token_addresses[0]

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -4,6 +4,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.constants import EMPTY_HASH, EMPTY_SIGNATURE
 from raiden.network.proxies.token_network import TokenNetwork
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import get_channelstate, transfer
@@ -30,7 +31,22 @@ def test_node_can_settle_if_close_didnt_use_any_balance_proof(
     - Assert that app0 can settle the closed channel, even though app1 didn't
     use the latest balance proof
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_node_can_settle_if_close_didnt_use_any_balance_proof,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
 
+
+def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
+        raiden_network,
+        number_of_nodes,
+        token_addresses,
+        network_wait,
+):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -111,7 +127,22 @@ def test_node_can_settle_if_partner_does_not_call_update_transfer(
     - Assert that app0 can settle the closed channel, even though app1 didn't
     use the latest balance proof
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_node_can_settle_if_partner_does_not_call_update_transfer,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
 
+
+def run_test_node_can_settle_if_partner_does_not_call_update_transfer(
+        raiden_network,
+        number_of_nodes,
+        token_addresses,
+        network_wait,
+):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -1,12 +1,23 @@
 import pytest
 
 from raiden.exceptions import SamePeerAddress
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.transfer import views
 
 
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_channel_with_self(raiden_network, settle_timeout, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_channel_with_self,
+        raiden_network=raiden_network,
+        settle_timeout=settle_timeout,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_channel_with_self(raiden_network, settle_timeout, token_addresses):
     app0, = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
     registry_address = app0.raiden.default_registry.address

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -4,6 +4,7 @@ from eth_utils import to_hex
 
 from raiden.api.python import RaidenAPI
 from raiden.messages import Unlock
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
@@ -19,6 +20,18 @@ from raiden.utils.echo_node import EchoNode
 @pytest.mark.parametrize('settle_timeout', [120])
 @pytest.mark.skip('Issue: 3750')
 def test_event_transfer_received_success(
+        token_addresses,
+        raiden_chain,
+):
+    raise_on_failure(
+        raiden_chain,
+        run_test_event_transfer_received_success,
+        token_addresses=token_addresses,
+        raiden_chain=raiden_chain,
+    )
+
+
+def run_test_event_transfer_received_success(
         token_addresses,
         raiden_chain,
 ):
@@ -74,6 +87,16 @@ def test_event_transfer_received_success(
 @pytest.mark.parametrize('settle_timeout', [120])
 @pytest.mark.skip('Issue: 3750')
 def test_echo_node_response(token_addresses, raiden_chain, network_wait):
+    raise_on_failure(
+        raiden_chain,
+        run_test_echo_node_response,
+        token_addresses=token_addresses,
+        raiden_chain=raiden_chain,
+        network_wait=network_wait,
+    )
+
+
+def run_test_echo_node_response(token_addresses, raiden_chain, network_wait):
     app0, app1, app2, echo_app = raiden_chain
     address_to_app = {app.raiden.address: app for app in raiden_chain}
     token_address = token_addresses[0]
@@ -139,6 +162,16 @@ def test_echo_node_response(token_addresses, raiden_chain, network_wait):
 @pytest.mark.parametrize('settle_timeout', [120])
 @pytest.mark.skip('Issue: 3750')
 def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
+    raise_on_failure(
+        raiden_chain,
+        run_test_echo_node_lottery,
+        token_addresses=token_addresses,
+        raiden_chain=raiden_chain,
+        network_wait=network_wait,
+    )
+
+
+def run_test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
     app0, app1, app2, app3, echo_app, app4, app5, app6 = raiden_chain
     address_to_app = {app.raiden.address: app for app in raiden_chain}
     token_address = token_addresses[0]

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -20,6 +20,7 @@ from raiden.exceptions import (
 )
 from raiden.messages import RequestMonitoring
 from raiden.tests.utils.client import burn_eth
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import must_have_event, wait_for_state_change
 from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.network import CHAIN
@@ -49,6 +50,17 @@ TEST_TOKEN_SWAP_SETTLE_TIMEOUT = (
 @pytest.mark.parametrize('number_of_tokens', [1])
 @pytest.mark.parametrize('environment_type', [Environment.DEVELOPMENT])
 def test_register_token(raiden_network, token_amount, contract_manager, retry_timeout):
+    raise_on_failure(
+        raiden_network,
+        run_test_register_token,
+        raiden_network=raiden_network,
+        token_amount=token_amount,
+        contract_manager=contract_manager,
+        retry_timeout=retry_timeout,
+    )
+
+
+def run_test_register_token(raiden_network, token_amount, contract_manager, retry_timeout):
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -107,6 +119,20 @@ def test_register_token_insufficient_eth(
         token_amount,
         contract_manager,
 ):
+    raise_on_failure(
+        raiden_network,
+        run_test_register_token_insufficient_eth,
+        raiden_network=raiden_network,
+        token_amount=token_amount,
+        contract_manager=contract_manager,
+    )
+
+
+def run_test_register_token_insufficient_eth(
+        raiden_network,
+        token_amount,
+        contract_manager,
+):
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -150,6 +176,17 @@ def test_token_registered_race(raiden_chain, token_amount, retry_timeout, contra
     node that receives an error for "already registered token" must see the
     token in the token list. Issue: #784
     """
+    raise_on_failure(
+        raiden_chain,
+        run_test_token_registered_race,
+        raiden_chain=raiden_chain,
+        token_amount=token_amount,
+        retry_timeout=retry_timeout,
+        contract_manager=contract_manager,
+    )
+
+
+def run_test_token_registered_race(raiden_chain, token_amount, retry_timeout, contract_manager):
     app0, app1 = raiden_chain
 
     api0 = RaidenAPI(app0.raiden)
@@ -220,6 +257,15 @@ def test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
     `ContractReceiveChannelNewBalance` message since the API needs to return
     the channel with the deposit balance updated.
     """
+    raise_on_failure(
+        raiden_chain,
+        run_test_deposit_updates_balance_immediately,
+        raiden_chain=raiden_chain,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
     app0, app1 = raiden_chain
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -241,6 +287,15 @@ def test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_transfer_to_unknownchannel(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_transfer_to_unknownchannel,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_transfer_to_unknownchannel(raiden_network, token_addresses):
     app0, _ = raiden_network
     token_address = token_addresses[0]
     non_existing_address = '\xf0\xef3\x01\xcd\xcfe\x0f4\x9c\xf6d\xa2\x01?X4\x84\xa9\xf1'
@@ -312,6 +367,15 @@ def test_token_swap(raiden_network, deposit, token_addresses):
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_api_channel_events(raiden_chain, token_addresses):
+    raise_on_failure(
+        raiden_chain,
+        run_test_api_channel_events,
+        raiden_chain=raiden_chain,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_api_channel_events(raiden_chain, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
 
@@ -347,6 +411,16 @@ def test_api_channel_events(raiden_chain, token_addresses):
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [1])
 def test_insufficient_funds(raiden_network, token_addresses, deposit):
+    raise_on_failure(
+        raiden_network,
+        run_test_insufficient_funds,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        deposit=deposit,
+    )
+
+
+def run_test_insufficient_funds(raiden_network, token_addresses, deposit):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
@@ -363,6 +437,15 @@ def test_insufficient_funds(raiden_network, token_addresses, deposit):
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_funds_check_for_openchannel(raiden_network, token_addresses):
     """Reproduces issue 2923 -- two open channel racing through the gas reserve"""
+    raise_on_failure(
+        raiden_network,
+        run_test_funds_check_for_openchannel,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_funds_check_for_openchannel(raiden_network, token_addresses):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
 
@@ -411,6 +494,25 @@ def test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=unus
     exist when the lock expires for this transfer.
 
     Issue: https://github.com/raiden-network/raiden/issues/3094"""
+
+    raise_on_failure(
+        raiden_network,
+        run_test_payment_timing_out_if_partner_does_not_respond,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        reveal_timeout=reveal_timeout,
+        skip_if_not_matrix=skip_if_not_matrix,
+        retry_timeout=retry_timeout,
+    )
+
+
+def run_test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=unused-argument
+        raiden_network,
+        token_addresses,
+        reveal_timeout,
+        skip_if_not_matrix,
+        retry_timeout,
+):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
@@ -444,6 +546,22 @@ def test_set_deposit_limit_crash(raiden_network, token_amount, contract_manager,
     """The development contracts as of 10/12/2018 were crashing if more than an amount was given
     Regression test for https://github.com/raiden-network/raiden/issues/3135
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_set_deposit_limit_crash,
+        raiden_network=raiden_network,
+        token_amount=token_amount,
+        contract_manager=contract_manager,
+        retry_timeout=retry_timeout,
+    )
+
+
+def run_test_set_deposit_limit_crash(
+        raiden_network,
+        token_amount,
+        contract_manager,
+        retry_timeout,
+):
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -502,6 +620,15 @@ def test_set_deposit_limit_crash(raiden_network, token_amount, contract_manager,
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_create_monitoring_request(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_create_monitoring_request,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_create_monitoring_request(raiden_network, token_addresses):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -7,6 +7,7 @@ from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import transfer
@@ -22,6 +23,14 @@ def test_regression_filters_must_be_installed_from_confirmed_block(raiden_networ
 
     Regression test for: https://github.com/raiden-network/raiden/issues/2894.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_regression_filters_must_be_installed_from_confirmed_block,
+        raiden_network=raiden_network,
+    )
+
+
+def run_test_regression_filters_must_be_installed_from_confirmed_block(raiden_network):
     app0 = raiden_network[0]
 
     app0.raiden.alarm.stop()
@@ -70,6 +79,24 @@ def test_regression_transport_global_queues_are_initialized_on_restart_for_servi
 
     Regression test for: https://github.com/raiden-network/raiden/issues/3656.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_regression_transport_global_queues_are_initialized_on_restart_for_services,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+        user_deposit_address=user_deposit_address,
+    )
+
+
+def run_test_regression_transport_global_queues_are_initialized_on_restart_for_services(
+        raiden_network,
+        number_of_nodes,
+        token_addresses,
+        network_wait,
+        user_deposit_address,
+):
     app0, app1 = raiden_network
 
     app0.config['services']['monitoring_enabled'] = True

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -7,6 +7,7 @@ from raiden.constants import EMPTY_MERKLE_ROOT, UINT64_MAX
 from raiden.messages import Lock, LockedTransfer, RevealSecret, Unlock
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.integration.fixtures.raiden_network import CHAIN, wait_for_channels
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.tests.utils.network import payment_channel_open_and_deposit
@@ -32,6 +33,22 @@ def test_regression_unfiltered_routes(
     Transfers failed in networks where two or more paths to the destination are
     possible but they share same node as a first hop.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_regression_unfiltered_routes,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        settle_timeout=settle_timeout,
+        deposit=deposit,
+    )
+
+
+def run_test_regression_unfiltered_routes(
+        raiden_network,
+        token_addresses,
+        settle_timeout,
+        deposit,
+):
     app0, app1, app2, app3, app4 = raiden_network
     token = token_addresses[0]
     registry_address = app0.raiden.default_registry.address
@@ -89,6 +106,20 @@ def test_regression_revealsecret_after_secret(raiden_network, token_addresses, t
     """ A RevealSecret message received after a Unlock message must be cleanly
     handled.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_regression_revealsecret_after_secret,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        transport_protocol=transport_protocol,
+    )
+
+
+def run_test_regression_revealsecret_after_secret(
+        raiden_network,
+        token_addresses,
+        transport_protocol,
+):
     app0, app1, app2 = raiden_network
     token = token_addresses[0]
 
@@ -151,6 +182,16 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
     unregistered. And because the channel was already updated an exception was raised
     for an unknown secret.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_regression_multiple_revealsecret,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        transport_protocol=transport_protocol,
+    )
+
+
+def run_test_regression_multiple_revealsecret(raiden_network, token_addresses, transport_protocol):
     app0, app1 = raiden_network
     token = token_addresses[0]
     token_network_identifier = views.get_token_network_identifier_by_token_address(
@@ -257,7 +298,7 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
     gevent.joinall(wait)
 
 
-def test_regression_register_secret_once(secret_registry_address, deploy_service):
+def run_test_regression_register_secret_once(secret_registry_address, deploy_service):
     """Register secret transaction must not be sent if the secret is already registered"""
     # pylint: disable=protected-access
 

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -6,6 +6,7 @@ from raiden.app import App
 from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import raiden_events_search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldRaidenEvent, dont_handle_node_change_network_state
@@ -26,6 +27,22 @@ def test_send_queued_messages(  # pylint: disable=unused-argument
         skip_if_not_matrix,
 ):
     """Test re-sending of undelivered messages on node restart"""
+    raise_on_failure(
+        raiden_network,
+        run_test_send_queued_messages,
+        raiden_network=raiden_network,
+        deposit=deposit,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_send_queued_messages(
+        raiden_network,
+        deposit,
+        token_addresses,
+        network_wait,
+):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -151,6 +168,20 @@ def test_payment_statuses_are_restored(  # pylint: disable=unused-argument
     started the transfers.
     Related issue: https://github.com/raiden-network/raiden/issues/3432
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_payment_statuses_are_restored,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_payment_statuses_are_restored(
+        raiden_network,
+        token_addresses,
+        network_wait,
+):
     app0, app1 = raiden_network
 
     token_address = token_addresses[0]

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -8,6 +8,7 @@ from raiden.message_handler import MessageHandler
 from raiden.messages import LockedTransfer, RevealSecret, SecretRequest
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils import factories
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
@@ -22,6 +23,24 @@ from raiden.waiting import wait_for_block
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_mediated_transfer(
+        raiden_network,
+        number_of_nodes,
+        deposit,
+        token_addresses,
+        network_wait,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        deposit=deposit,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_mediated_transfer(
         raiden_network,
         number_of_nodes,
         deposit,
@@ -67,6 +86,22 @@ def test_mediated_transfer(
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [1])
 def test_locked_transfer_secret_registered_onchain(
+        raiden_network,
+        token_addresses,
+        secret_registry_address,
+        retry_timeout,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_locked_transfer_secret_registered_onchain,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        secret_registry_address=secret_registry_address,
+        retry_timeout=retry_timeout,
+    )
+
+
+def run_test_locked_transfer_secret_registered_onchain(
         raiden_network,
         token_addresses,
         secret_registry_address,
@@ -144,6 +179,24 @@ def test_mediated_transfer_with_entire_deposit(
         deposit,
         network_wait,
 ):
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer_with_entire_deposit,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        network_wait=network_wait,
+    )
+
+
+def run_test_mediated_transfer_with_entire_deposit(
+        raiden_network,
+        number_of_nodes,
+        token_addresses,
+        deposit,
+        network_wait,
+):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -195,6 +248,22 @@ def test_mediated_transfer_messages_out_of_order(  # pylint: disable=unused-argu
         token_addresses,
         network_wait,
         skip_if_not_matrix,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer_messages_out_of_order,
+        raiden_network=raiden_network,
+        deposit=deposit,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_mediated_transfer_messages_out_of_order(
+        raiden_network,
+        deposit,
+        token_addresses,
+        network_wait,
 ):
     """Raiden must properly handle repeated locked transfer messages."""
     app0, app1, app2 = raiden_network
@@ -286,7 +355,15 @@ def test_mediated_transfer_messages_out_of_order(  # pylint: disable=unused-argu
 @pytest.mark.parametrize('number_of_nodes', (1,))
 @pytest.mark.parametrize('channels_per_node', (CHAIN,))
 def test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer_calls_pfs,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
 
+
+def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
     app0, = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -335,7 +412,7 @@ def test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [4])
-def test_mediated_transfer_with_allocated_fee(  # pylint: disable=unused-argument
+def test_mediated_transfer_with_allocated_fee(
         raiden_network,
         number_of_nodes,
         deposit,
@@ -353,6 +430,24 @@ def test_mediated_transfer_with_allocated_fee(  # pylint: disable=unused-argumen
     deducted from received transfer's fee and the rest goes to
     the mediators in the next hops and maybe eventually to the target.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer_with_allocated_fee,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        deposit=deposit,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_mediated_transfer_with_allocated_fee(
+        raiden_network,
+        number_of_nodes,
+        deposit,
+        token_addresses,
+        network_wait,
+):
     app0, app1, app2, app3 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -459,6 +554,24 @@ def test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
     Which means that the initiator will not reveal the secret
     to the target.
     """
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer_with_node_consuming_more_than_allocated_fee,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        deposit=deposit,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
+        raiden_network,
+        number_of_nodes,
+        deposit,
+        token_addresses,
+        network_wait,
+):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -1,5 +1,6 @@
 import pytest
 
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import transfer
@@ -15,6 +16,22 @@ from raiden.utils import wait_until
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 @pytest.mark.parametrize('number_of_nodes', [3])
 def test_mediated_transfer_events(raiden_network, number_of_nodes, token_addresses, network_wait):
+    raise_on_failure(
+        raiden_network,
+        run_test_mediated_transfer_events,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        network_wait=network_wait,
+    )
+
+
+def run_test_mediated_transfer_events(
+        raiden_network,
+        number_of_nodes,
+        token_addresses,
+        network_wait,
+):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -6,6 +6,7 @@ import pytest
 from raiden.api.python import RaidenAPI
 from raiden.constants import UINT64_MAX
 from raiden.messages import Lock, LockedTransfer
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.factories import (
     UNIT_CHAIN_ID,
     UNIT_SECRETHASH,
@@ -27,6 +28,20 @@ from raiden.utils.signer import LocalSigner
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('number_of_nodes', [2])
 def test_failsfast_lockedtransfer_exceeding_distributable(
+        raiden_network,
+        token_addresses,
+        deposit,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_failsfast_lockedtransfer_exceeding_distributable,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        deposit=deposit,
+    )
+
+
+def run_test_failsfast_lockedtransfer_exceeding_distributable(
         raiden_network,
         token_addresses,
         deposit,
@@ -61,6 +76,15 @@ def test_failsfast_lockedtransfer_exceeding_distributable(
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_failfast_lockedtransfer_nochannel,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
     """When the node has no channels it should fail without raising exceptions."""
     token_address = token_addresses[0]
     app0, app1 = raiden_network
@@ -84,6 +108,26 @@ def test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_receive_lockedtransfer_invalidnonce(
+        raiden_network,
+        number_of_nodes,
+        deposit,
+        token_addresses,
+        reveal_timeout,
+        network_wait,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_receive_lockedtransfer_invalidnonce,
+        raiden_network=raiden_network,
+        number_of_nodes=number_of_nodes,
+        deposit=deposit,
+        token_addresses=token_addresses,
+        reveal_timeout=reveal_timeout,
+        network_wait=network_wait,
+    )
+
+
+def run_test_receive_lockedtransfer_invalidnonce(
         raiden_network,
         number_of_nodes,
         deposit,
@@ -156,6 +200,22 @@ def test_receive_lockedtransfer_invalidsender(
         deposit,
         reveal_timeout,
 ):
+    raise_on_failure(
+        raiden_network,
+        run_test_receive_lockedtransfer_invalidsender,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        reveal_timeout=reveal_timeout,
+    )
+
+
+def run_test_receive_lockedtransfer_invalidsender(
+        raiden_network,
+        token_addresses,
+        deposit,
+        reveal_timeout,
+):
 
     app0, app1 = raiden_network
     token_address = token_addresses[0]
@@ -203,6 +263,22 @@ def test_receive_lockedtransfer_invalidsender(
 @pytest.mark.parametrize('number_of_nodes', [2])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_receive_lockedtransfer_invalidrecipient(
+        raiden_network,
+        token_addresses,
+        reveal_timeout,
+        deposit,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_receive_lockedtransfer_invalidrecipient,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+        reveal_timeout=reveal_timeout,
+        deposit=deposit,
+    )
+
+
+def run_test_receive_lockedtransfer_invalidrecipient(
         raiden_network,
         token_addresses,
         reveal_timeout,
@@ -257,6 +333,22 @@ def test_receive_lockedtransfer_invalidrecipient(
 @pytest.mark.parametrize('channels_per_node', [1])
 @pytest.mark.parametrize('settle_timeout', [30])
 def test_received_lockedtransfer_closedchannel(
+        raiden_network,
+        reveal_timeout,
+        token_addresses,
+        deposit,
+):
+    raise_on_failure(
+        raiden_network,
+        run_test_received_lockedtransfer_closedchannel,
+        raiden_network=raiden_network,
+        reveal_timeout=reveal_timeout,
+        token_addresses=token_addresses,
+        deposit=deposit,
+    )
+
+
+def run_test_received_lockedtransfer_closedchannel(
         raiden_network,
         reveal_timeout,
         token_addresses,

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -4,6 +4,7 @@ import pytest
 
 from raiden.constants import UINT64_MAX
 from raiden.messages import RevealSecret, SecretRequest, Unlock
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.factories import (
     HOP1_KEY,
     UNIT_CHAIN_ID,
@@ -20,6 +21,15 @@ from raiden.utils.signer import LocalSigner
 @pytest.mark.parametrize('number_of_nodes', [1])
 @pytest.mark.parametrize('channels_per_node', [0])
 def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
+    raise_on_failure(
+        raiden_network,
+        run_test_receive_secrethashtransfer_unknown,
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     app0 = raiden_network[0]
     token_address = token_addresses[0]
 

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -2,6 +2,7 @@ import gevent
 import pytest
 
 from raiden.api.python import RaidenAPI
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import (
     raiden_events_search_for_item,
     search_for_item,
@@ -35,6 +36,17 @@ from raiden.waiting import wait_for_block, wait_for_settle
 @pytest.mark.parametrize('number_of_nodes', [3])
 @pytest.mark.parametrize('settle_timeout', [50])
 def test_refund_messages(raiden_chain, token_addresses, deposit, network_wait):
+    raise_on_failure(
+        raiden_chain,
+        run_test_refund_messages,
+        raiden_chain=raiden_chain,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        network_wait=network_wait,
+    )
+
+
+def run_test_refund_messages(raiden_chain, token_addresses, deposit, network_wait):
     # The network has the following topology:
     #
     #   App0 <---> App1 <---> App2
@@ -112,6 +124,26 @@ def test_refund_transfer(
         # UDP does not seem to retry messages until processed
         # https://github.com/raiden-network/raiden/issues/3185
         skip_if_not_matrix,  # pylint: disable=unused-argument
+):
+    raise_on_failure(
+        raiden_chain,
+        run_test_refund_transfer,
+        raiden_chain=raiden_chain,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        network_wait=network_wait,
+        retry_timeout=retry_timeout,
+    )
+
+
+def run_test_refund_transfer(
+        raiden_chain,
+        number_of_nodes,
+        token_addresses,
+        deposit,
+        network_wait,
+        retry_timeout,
 ):
     """A failed transfer must send a refund back.
 
@@ -312,6 +344,28 @@ def test_different_view_of_last_bp_during_unlock(
         skip_if_not_matrix,  # pylint: disable=unused-argument
         blockchain_type,
 ):
+    raise_on_failure(
+        raiden_chain,
+        run_test_different_view_of_last_bp_during_unlock,
+        raiden_chain=raiden_chain,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        network_wait=network_wait,
+        retry_timeout=retry_timeout,
+        blockchain_type=blockchain_type,
+    )
+
+
+def run_test_different_view_of_last_bp_during_unlock(
+        raiden_chain,
+        number_of_nodes,
+        token_addresses,
+        deposit,
+        network_wait,
+        retry_timeout,
+        blockchain_type,
+):
     """Test for https://github.com/raiden-network/raiden/issues/3196#issuecomment-449163888"""
     # Topology:
     #
@@ -505,6 +559,24 @@ def test_different_view_of_last_bp_during_unlock(
 @pytest.mark.parametrize('number_of_tokens', [1])
 @pytest.mark.parametrize('channels_per_node', [CHAIN])
 def test_refund_transfer_after_2nd_hop(
+        raiden_chain,
+        number_of_nodes,
+        token_addresses,
+        deposit,
+        network_wait,
+):
+    raise_on_failure(
+        raiden_chain,
+        run_test_refund_transfer_after_2nd_hop,
+        raiden_chain=raiden_chain,
+        number_of_nodes=number_of_nodes,
+        token_addresses=token_addresses,
+        deposit=deposit,
+        network_wait=network_wait,
+    )
+
+
+def run_test_refund_transfer_after_2nd_hop(
         raiden_chain,
         number_of_nodes,
         token_addresses,

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -1,0 +1,18 @@
+import gevent
+from gevent.event import AsyncResult
+
+
+def raise_on_failure(raiden_apps, test_function, **kwargs):
+    """Wait on the result for the test function and any of the apps.
+
+    This utility should be used for happy path testing with more than one app.
+    This will raise if any of the apps is killed.
+    """
+    result = AsyncResult()
+
+    for app in raiden_apps:
+        assert app.raiden
+        app.raiden.link(result)
+
+    gevent.spawn(test_function, **kwargs).link(result)
+    result.get()


### PR DESCRIPTION
This change introduces an utility to run the tests an monitor the test's
apps. This is useful because exceptions are always propagated on the
Raiden code base, tests which use this tool will fail faster with the
actual raised exception.

~~Review/Merge after: #3818~~