### PR TITLE
[NO-MERGE] Test vs. fixture execution times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,8 +767,8 @@ workflows:
           requires:
             - smoketest-udp-production-geth-3.7
             - smoketest-udp-development-geth-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - test:
           name: test-integration-matrix-geth-3.7
@@ -781,8 +781,8 @@ workflows:
           requires:
             - smoketest-matrix-production-geth-3.7
             - smoketest-matrix-development-geth-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - test:
           name: test-integration-udp-parity-3.7
@@ -795,8 +795,8 @@ workflows:
           requires:
             - smoketest-udp-production-geth-3.7
             - smoketest-udp-development-geth-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - test:
           name: test-integration-matrix-parity-3.7
@@ -810,8 +810,8 @@ workflows:
             - smoketest-matrix-production-geth-3.7
             - smoketest-matrix-development-geth-3.7
             - smoketest-matrix-development-parity-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - finalize:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1027,8 +1027,8 @@ workflows:
           requires:
             - smoketest-udp-production-geth-3.7
             - smoketest-udp-development-geth-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - test:
           name: test-integration-matrix-geth-3.7
@@ -1041,8 +1041,8 @@ workflows:
           requires:
             - smoketest-matrix-production-geth-3.7
             - smoketest-matrix-development-geth-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - test:
           name: test-integration-udp-parity-3.7
@@ -1055,8 +1055,8 @@ workflows:
           requires:
             - smoketest-udp-production-geth-3.7
             - smoketest-udp-development-geth-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - test:
           name: test-integration-matrix-parity-3.7
@@ -1070,8 +1070,8 @@ workflows:
             - smoketest-matrix-production-geth-3.7
             - smoketest-matrix-development-geth-3.7
             - smoketest-matrix-development-parity-3.7
-            - test-unit-3.7
-            - test-fuzz-3.7
+#            - test-unit-3.7
+#            - test-fuzz-3.7
 
       - finalize:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,6 +390,8 @@ jobs:
               --select-fail-on-missing \
               --select-from-file selected-tests.txt \
               << parameters.additional-args >>
+            # Force fail - we don't want to pollute the circle ci parallelization time database
+            false
 
       - run:
           name: Store coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ omit =
 
 [tool:pytest]
 timeout = 540
+junit_duration_report = call
 norecursedirs = node_modules
 ; Ignore warnings:
 ; - grequests monkeypatch


### PR DESCRIPTION
**DON'T MERGE**

This runs the tests with pytest's `junit_duration_report` option set to `call` mode. This excludes the fixtures from the time reporting, allowing us to estimate how much time we spend on fixture setup/teardown.