### PR TITLE
Rollback transaction for any exception

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -447,6 +447,7 @@ class RaidenService(Runnable):
             database_path=self.database_path,
             serializer=serialize.JSONSerializer(),
         )
+        storage.update_version()
         storage.log_run()
         self.wal = wal.restore_to_state_change(
             transition_function=node.state_transition,

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -105,7 +105,6 @@ class SQLiteStorage(SerializationBase):
         self.conn = conn
         self.write_lock = threading.Lock()
         self.in_transaction = False
-        self.update_version()
 
     def update_version(self):
         cursor = self.conn.cursor()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -573,7 +573,7 @@ class SQLiteStorage(SerializationBase):
             cursor.execute('BEGIN')
             yield
             cursor.execute('COMMIT')
-        except Exception:
+        except:  # noqa
             cursor.execute('ROLLBACK')
             raise
         finally:

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import pytest
+
+from raiden.storage.sqlite import RAIDEN_DB_VERSION, SQLiteStorage
+
+
+def test_transaction_commit(tmp_path):
+    filename = f'v{RAIDEN_DB_VERSION}_db.log'
+    storage = SQLiteStorage(f'{tmp_path}/{filename}')
+
+    with storage.transaction():
+        with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=1000):
+            storage.update_version()
+
+    assert storage.get_version() == 1000
+
+
+def test_transaction_rollback(tmp_path):
+    filename = f'v{RAIDEN_DB_VERSION}_db.log'
+    storage = SQLiteStorage(f'{tmp_path}/{filename}')
+    storage.update_version()
+
+    assert storage.get_version() == RAIDEN_DB_VERSION
+
+    with pytest.raises(KeyboardInterrupt):
+        with storage.transaction():
+            with patch('raiden.storage.sqlite.RAIDEN_DB_VERSION', new=1000):
+                storage.update_version()
+                raise KeyboardInterrupt()
+    assert storage.get_version() == RAIDEN_DB_VERSION

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -233,7 +233,7 @@ class UpgradeManager:
                         )
 
                     update_version(storage, RAIDEN_DB_VERSION)
-            except Exception as e:
+            except BaseException as e:
                 log.error(f'Failed to upgrade database: {e}')
                 raise
 


### PR DESCRIPTION
Resolves #3832 

Causes of failure:
1. `KeyboardInterrupt` was not triggering a rollback as this its parent class is a `BaseException` which wasn't included in the `except` block.
2. At some point, instantiating `SQLiteStorage` caused an implicit `update_version` in the constructor which stored `RAIDEN_DB_VERSION` in that database and overrode what the upgrade manager was expecting.

@czepluch ran the branch on his failing account and confirms the fix works.