### PR TITLE
Extended asserts

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -20,6 +20,15 @@ from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
 
+pytest.register_assert_rewrite('raiden.tests.utils.eth_node')
+pytest.register_assert_rewrite('raiden.tests.utils.factories')
+pytest.register_assert_rewrite('raiden.tests.utils.messages')
+pytest.register_assert_rewrite('raiden.tests.utils.network')
+pytest.register_assert_rewrite('raiden.tests.utils.protocol')
+pytest.register_assert_rewrite('raiden.tests.utils.smartcontracts')
+pytest.register_assert_rewrite('raiden.tests.utils.smoketest')
+pytest.register_assert_rewrite('raiden.tests.utils.transfer')
+
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -96,6 +96,9 @@ PaymentAmount = NewType('PaymentAmount', T_PaymentAmount)
 T_FeeAmount = int
 FeeAmount = NewType('FeeAmount', T_FeeAmount)
 
+T_LockedAmount = int
+LockedAmount = NewType('LockedAmount', T_LockedAmount)
+
 T_PaymentWithFeeAmount = int
 PaymentWithFeeAmount = NewType('PaymentWithFeeAmount', T_FeeAmount)
 


### PR DESCRIPTION
the test `test_recovery_happy_case` seems flaky, and the assertion error is not very useful for debugging, this adds extra information to the assert message, and also enables pytest assert rewrite for the tests.utils