### PR TITLE
Fix call to pathfinding service's /iou endpoint

### DIFF
--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -396,10 +396,10 @@ def run_test_api_channel_events(raiden_chain, token_addresses):
     assert must_have_event(app0_events, {'event': ChannelEvent.DEPOSIT})
 
     app0_events = app0.raiden.wal.storage.get_events()
-    any(isinstance(event, EventPaymentSentSuccess) for event in app0_events)
+    assert any(isinstance(event, EventPaymentSentSuccess) for event in app0_events)
 
     app1_events = app1.raiden.wal.storage.get_events()
-    any(isinstance(event, EventPaymentReceivedSuccess) for event in app1_events)
+    assert any(isinstance(event, EventPaymentReceivedSuccess) for event in app1_events)
 
     app1_events = RaidenAPI(app1.raiden).get_blockchain_events_channel(
         token_address,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -386,28 +386,33 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
         )
         assert not patched.called
 
-        app0.raiden.config['services']['pathfinding_service_address'] = 'mock_address'
-        app0.raiden.start_mediated_transfer_with_secret(
-            token_network_identifier=token_network_id,
-            amount=11,
-            fee=0,
-            target=factories.HOP2,
-            identifier=2,
-            secret=b'2' * 32,
+        config_patch = dict(
+            pathfinding_service_address='mock-address',
+            pathfinding_eth_address=factories.make_checksum_address(),
         )
-        assert patched.call_count == 1
 
-        locked_transfer = factories.make_signed_transfer(
-            amount=5,
-            initiator=factories.HOP1,
-            target=factories.HOP2,
-            sender=factories.HOP1,
-            pkey=factories.HOP1_KEY,
-            token_network_address=token_network_id,
-            token=token_address,
-        )
-        app0.raiden.mediate_mediated_transfer(locked_transfer)
-        assert patched.call_count == 2
+        with patch.dict(app0.raiden.config['services'], config_patch):
+            app0.raiden.start_mediated_transfer_with_secret(
+                token_network_identifier=token_network_id,
+                amount=11,
+                fee=0,
+                target=factories.HOP2,
+                identifier=2,
+                secret=b'2' * 32,
+            )
+            assert patched.call_count == 1
+
+            locked_transfer = factories.make_signed_transfer(
+                amount=5,
+                initiator=factories.HOP1,
+                target=factories.HOP2,
+                sender=factories.HOP1,
+                pkey=factories.HOP1_KEY,
+                token_network_address=token_network_id,
+                token=token_address,
+            )
+            app0.raiden.mediate_mediated_transfer(locked_transfer)
+            assert patched.call_count == 2
 
 
 @pytest.mark.parametrize('channels_per_node', [CHAIN])

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -168,7 +168,7 @@ def create_square_network_topology(
 CONFIG = {
     'services': {
         'pathfinding_service_address': 'my-pfs',
-        'pathfinding_eth_address': to_checksum_address(factories.make_address()),
+        'pathfinding_eth_address': factories.make_checksum_address(),
         'pathfinding_max_paths': 3,
         'pathfinding_iou_timeout': 10,
         'pathfinding_max_fee': 50,

--- a/raiden/tests/unit/test_startup.py
+++ b/raiden/tests/unit/test_startup.py
@@ -7,7 +7,7 @@ from gevent import server
 from raiden.app import App
 from raiden.constants import Environment, RoutingMode
 from raiden.network.transport import UDPTransport
-from raiden.tests.utils.factories import make_address
+from raiden.tests.utils.factories import make_address, make_checksum_address
 from raiden.tests.utils.mocks import MockChain, patched_get_for_succesful_pfs_info
 from raiden.ui.startup import (
     setup_contracts_or_exit,
@@ -246,8 +246,8 @@ def test_setup_proxies_all_addresses_are_given(routing_mode):
             blockchain_service=blockchain_service,
             contracts=contracts,
             routing_mode=routing_mode,
-            pathfinding_service_address=make_address(),
-            pathfinding_eth_address=make_address(),
+            pathfinding_service_address='my-pfs',
+            pathfinding_eth_address=make_checksum_address(),
         )
     assert proxies
     assert proxies.token_network_registry
@@ -283,8 +283,8 @@ def test_setup_proxies_all_addresses_are_known(routing_mode):
             blockchain_service=blockchain_service,
             contracts=contracts,
             routing_mode=routing_mode,
-            pathfinding_service_address=make_address(),
-            pathfinding_eth_address=make_address(),
+            pathfinding_service_address='my-pfs',
+            pathfinding_eth_address=make_checksum_address(),
         )
     assert proxies
     assert proxies.token_network_registry
@@ -322,8 +322,8 @@ def test_setup_proxies_no_service_registry_but_pfs():
             blockchain_service=blockchain_service,
             contracts=contracts,
             routing_mode=RoutingMode.PFS,
-            pathfinding_service_address=make_address(),
-            pathfinding_eth_address=make_address(),
+            pathfinding_service_address='my-pfs',
+            pathfinding_eth_address=make_checksum_address(),
         )
     assert proxies
 
@@ -357,7 +357,7 @@ def test_setup_proxies_no_service_registry_and_no_pfs_address_but_requesting_pfs
                 contracts=contracts,
                 routing_mode=RoutingMode.PFS,
                 pathfinding_service_address=None,
-                pathfinding_eth_address=make_address(),
+                pathfinding_eth_address=None,
             )
 
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -4,6 +4,8 @@ import string
 from functools import singledispatch
 from typing import NamedTuple
 
+from eth_utils import to_checksum_address
+
 from raiden.constants import EMPTY_MERKLE_ROOT, UINT64_MAX, UINT256_MAX
 from raiden.messages import Lock, LockedTransfer
 from raiden.transfer import balance_proof, channel
@@ -74,6 +76,10 @@ def make_20bytes() -> bytes:
 
 def make_address() -> typing.Address:
     return typing.Address(make_20bytes())
+
+
+def make_checksum_address() -> str:
+    return to_checksum_address(make_address())
 
 
 def make_32bytes() -> bytes:


### PR DESCRIPTION
Add the missing arguments in the request body.

Closes #3850.