### PR TITLE
increase test_cli_change_environment_type timeout

### DIFF
--- a/raiden/tests/integration/cli/test_cli_development.py
+++ b/raiden/tests/integration/cli/test_cli_development.py
@@ -12,10 +12,12 @@ pytestmark = pytest.mark.parametrize(
 )
 
 
-@pytest.mark.timeout(65)
-@pytest.mark.parametrize('changed_args', [{
-    'environment_type': Environment.DEVELOPMENT.value,
-}])
+@pytest.mark.timeout(80)
+@pytest.mark.parametrize(
+    'changed_args', [{
+        'environment_type': Environment.DEVELOPMENT.value,
+    }],
+)
 def test_cli_change_environment_type(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     try:


### PR DESCRIPTION
Increasing the timeout because the test failed during tear down

culprit: https://circleci.com/gh/raiden-network/raiden/41313#tests/containers/14