### PR TITLE
All mypy complaints under the transfer directory adressed - Mypywork 5 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ lint:
 	pylint --load-plugins=tools.pylint.gevent_checker --rcfile .pylint.rc $(LINT_PATHS)
 	python setup.py check --restructuredtext --strict
 
+	mypy raiden/transfer raiden/messages.py raiden/encoding --ignore-missing-imports
+
 	# We are starting small with a few files and directories here,
 	# but mypy should run on the whole codebase soon.
-	mypy raiden/transfer raiden/api raiden/messages.py raiden/blockchain \
-	raiden/encoding raiden/storage raiden/network \
+	mypy raiden/api raiden/blockchain raiden/storage raiden/network \
 	--ignore-missing-imports | grep error > mypy-out.txt || true
 	# Expecting status code 1 from `grep`, which indicates no match.
 	# Again, we are starting small, detecting only errors related to

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -127,8 +127,8 @@ class MessageHandler:
         )
 
         role = views.get_transfer_role(
-            chain_state,
-            from_transfer.lock.secrethash,
+            chain_state=chain_state,
+            secrethash=from_transfer.lock.secrethash,
         )
 
         state_change: StateChange

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -61,6 +61,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
     TokenNetworkID,
+    Type,
 )
 
 __all__ = (
@@ -1946,7 +1947,7 @@ class UpdatePFS(SignedMessage):
         )
 
 
-CMDID_TO_CLASS: Dict[int, Any] = {
+CMDID_TO_CLASS: Dict[int, Type[Message]] = {
     messages.DELIVERED: Delivered,
     messages.LOCKEDTRANSFER: LockedTransfer,
     messages.PING: Ping,

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -74,8 +74,9 @@ def test_request_monitoring():
     request_monitoring.sign(signer)
     as_dict = request_monitoring.to_dict()
     assert RequestMonitoring.from_dict(as_dict) == request_monitoring
-    packed = request_monitoring.pack(request_monitoring.packed())
-    assert RequestMonitoring.unpack(packed) == request_monitoring
+    request_monitoring_packed = request_monitoring.packed()
+    request_monitoring.pack(request_monitoring_packed)
+    assert RequestMonitoring.unpack(request_monitoring_packed) == request_monitoring
     # RequestMonitoring can be created directly from BalanceProofSignedState
     direct_created = RequestMonitoring.from_balance_proof_signed_state(
         balance_proof,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -97,6 +97,7 @@ from raiden.utils.typing import (
     NamedTuple,
     Nonce,
     Optional,
+    PaymentAmount,
     PaymentID,
     PaymentWithFeeAmount,
     Secret,
@@ -106,6 +107,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkID,
     Tuple,
+    Union,
     cast,
 )
 
@@ -291,7 +293,7 @@ def is_balance_proof_safe_for_onchain_operations(
 
 def is_valid_amount(
         end_state: NettingChannelEndState,
-        amount: TokenAmount,
+        amount: Union[TokenAmount, PaymentAmount],
 ) -> bool:
     (
         _,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -92,6 +92,7 @@ from raiden.utils.typing import (
     List,
     LockHash,
     Locksroot,
+    LockType,
     MerkleTreeLeaves,
     MessageID,
     NamedTuple,
@@ -128,7 +129,7 @@ class UnlockGain(NamedTuple):
     from_partner_locks: TokenAmount
 
 
-def get_sender_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
+def get_sender_expiration_threshold(lock: LockType) -> BlockNumber:
     """ Returns the block number at which the sender can send the remove expired lock.
 
     The remove lock expired message will be rejected if the expiration block
@@ -191,7 +192,7 @@ def is_lock_locked(
 
 def is_lock_expired(
         end_state: NettingChannelEndState,
-        lock: HashTimeLockState,
+        lock: LockType,
         block_number: BlockNumber,
         lock_expiration_threshold: BlockNumber,
 ) -> SuccessOrError:
@@ -293,7 +294,7 @@ def is_balance_proof_safe_for_onchain_operations(
 
 def is_valid_amount(
         end_state: NettingChannelEndState,
-        amount: Union[TokenAmount, PaymentAmount],
+        amount: Union[TokenAmount, PaymentAmount, PaymentWithFeeAmount],
 ) -> bool:
     (
         _,
@@ -1463,7 +1464,7 @@ def events_for_close(
 
 def create_sendexpiredlock(
         sender_end_state: NettingChannelEndState,
-        locked_lock: HashTimeLockState,
+        locked_lock: LockType,
         pseudo_random_generator: random.Random,
         chain_id: ChainID,
         token_network_identifier: TokenNetworkID,
@@ -1509,7 +1510,7 @@ def create_sendexpiredlock(
 
 def events_for_expired_lock(
         channel_state: NettingChannelState,
-        locked_lock: HashTimeLockState,
+        locked_lock: LockType,
         pseudo_random_generator: random.Random,
 ) -> List[SendLockExpired]:
     msg = 'caller must make sure the channel is open'

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -21,6 +21,7 @@ from raiden.utils.typing import (
     InitiatorAddress,
     MessageID,
     Optional,
+    PaymentAmount,
     PaymentID,
     PaymentNetworkID,
     Secret,
@@ -385,7 +386,7 @@ class EventPaymentSentSuccess(Event):
             payment_network_identifier: PaymentNetworkID,
             token_network_identifier: TokenNetworkID,
             identifier: PaymentID,
-            amount: TokenAmount,
+            amount: PaymentAmount,
             target: TargetAddress,
     ) -> None:
         self.payment_network_identifier = payment_network_identifier
@@ -440,7 +441,7 @@ class EventPaymentSentSuccess(Event):
             payment_network_identifier=to_canonical_address(data['payment_network_identifier']),
             token_network_identifier=to_canonical_address(data['token_network_identifier']),
             identifier=PaymentID(int(data['identifier'])),
-            amount=TokenAmount(int(data['amount'])),
+            amount=PaymentAmount(int(data['amount'])),
             target=to_canonical_address(data['target']),
         )
 

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -24,6 +24,7 @@ from raiden.utils.typing import (
     BlockNumber,
     ChannelMap,
     List,
+    Optional,
     SecretHash,
     TokenNetworkID,
     cast,
@@ -198,7 +199,7 @@ def handle_block(
 
 
 def handle_init(
-        payment_state: InitiatorPaymentState,
+        payment_state: Optional[InitiatorPaymentState],
         state_change: ActionInitInitiator,
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
@@ -466,7 +467,7 @@ def handle_secretrequest(
 
 
 def state_transition(
-        payment_state: InitiatorPaymentState,
+        payment_state: Optional[InitiatorPaymentState],
         state_change: StateChange,
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
@@ -475,67 +476,76 @@ def state_transition(
     # pylint: disable=unidiomatic-typecheck
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION
+        assert payment_state, 'Block state changes should be accompanied by a valid payment state'
         iteration = handle_block(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            pseudo_random_generator,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
         )
     elif type(state_change) == ActionInitInitiator:
         assert isinstance(state_change, ActionInitInitiator), MYPY_ANNOTATION
         iteration = handle_init(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            pseudo_random_generator,
-            block_number,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
         )
     elif type(state_change) == ReceiveSecretRequest:
         assert isinstance(state_change, ReceiveSecretRequest), MYPY_ANNOTATION
+        assert payment_state, 'ReceiveSecretRequest should be accompanied by a valid payment state'
         iteration = handle_secretrequest(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            pseudo_random_generator,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
         )
     elif type(state_change) == ReceiveTransferRefundCancelRoute:
         assert isinstance(state_change, ReceiveTransferRefundCancelRoute), MYPY_ANNOTATION
+        msg = 'ReceiveTransferRefundCancelRoute should be accompanied by a valid payment state'
+        assert payment_state, msg
         iteration = handle_transferrefundcancelroute(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            pseudo_random_generator,
-            block_number,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
+            block_number=block_number,
         )
     elif type(state_change) == ActionCancelPayment:
         assert isinstance(state_change, ActionCancelPayment), MYPY_ANNOTATION
+        assert payment_state, 'ActionCancelPayment should be accompanied by a valid payment state'
         iteration = handle_cancelpayment(
-            payment_state,
-            channelidentifiers_to_channels,
+            payment_state=payment_state,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
         )
     elif type(state_change) == ReceiveSecretReveal:
         assert isinstance(state_change, ReceiveSecretReveal), MYPY_ANNOTATION
+        assert payment_state, 'ReceiveSecretReveal should be accompanied by a valid payment state'
         iteration = handle_offchain_secretreveal(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            pseudo_random_generator,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
         )
     elif type(state_change) == ReceiveLockExpired:
         assert isinstance(state_change, ReceiveLockExpired), MYPY_ANNOTATION
+        assert payment_state, 'ReceiveLockExpired should be accompanied by a valid payment state'
         iteration = handle_lock_expired(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            block_number,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            block_number=block_number,
         )
     elif type(state_change) == ContractReceiveSecretReveal:
         assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
+        msg = 'ContractReceiveSecretReveal should be accompanied by a valid payment state'
+        assert payment_state, msg
         iteration = handle_onchain_secretreveal(
-            payment_state,
-            state_change,
-            channelidentifiers_to_channels,
-            pseudo_random_generator,
+            payment_state=payment_state,
+            state_change=state_change,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            pseudo_random_generator=pseudo_random_generator,
         )
     else:
         iteration = TransitionResult(payment_state, list())

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -24,7 +24,6 @@ from raiden.utils.typing import (
     BlockNumber,
     ChannelMap,
     List,
-    Optional,
     SecretHash,
     TokenNetworkID,
     cast,
@@ -33,7 +32,7 @@ from raiden.utils.typing import (
 
 def clear_if_finalized(
         iteration: TransitionResult,
-) -> TransitionResult[Optional[InitiatorPaymentState]]:
+) -> TransitionResult[InitiatorPaymentState]:
     """ Clear the initiator payment task if all transfers have been finalized
     or expired. """
     state = cast(InitiatorPaymentState, iteration.new_state)
@@ -80,7 +79,7 @@ def events_for_cancel_current_route(
 
 def cancel_current_route(
         payment_state: InitiatorPaymentState,
-        initiator_state: InitiatorPaymentState,
+        initiator_state: InitiatorTransferState,
 ) -> List[Event]:
     """ Cancel current route.
 
@@ -141,7 +140,7 @@ def subdispatch_to_initiatortransfer(
         state_change: StateChange,
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
-) -> TransitionResult[InitiatorPaymentState]:
+) -> TransitionResult[InitiatorTransferState]:
     channel_identifier = initiator_state.channel_identifier
     channel_state = channelidentifiers_to_channels.get(channel_identifier)
     if not channel_state:
@@ -204,7 +203,7 @@ def handle_init(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult[Optional[InitiatorPaymentState]]:
+) -> TransitionResult[InitiatorPaymentState]:
     events: List[Event]
     if payment_state is None:
         sub_iteration = initiator.try_new_route(
@@ -472,7 +471,7 @@ def state_transition(
         channelidentifiers_to_channels: ChannelMap,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult[Optional[InitiatorPaymentState]]:
+) -> TransitionResult[InitiatorPaymentState]:
     # pylint: disable=unidiomatic-typecheck
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1541,8 +1541,6 @@ def handle_node_change_network_state(
     payer_channel = channelidentifiers_to_channels.get(payer_channel_identifier)
     payee_channel = channelidentifiers_to_channels.get(route.channel_identifier)
 
-    # TODO: Is this state transition correct here? payer_channel was not checked for None
-    # but later down the call stack it's assumed to not be None.
     if not payee_channel or not payer_channel:
         return TransitionResult(mediator_state, list())
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -27,6 +27,7 @@ from raiden.utils.typing import (
     BlockNumber,
     List,
     Optional,
+    TokenAmount,
     TokenNetworkID,
 )
 
@@ -86,6 +87,7 @@ def events_for_onchain_secretreveal(
             channel_state.partner_state,
             transfer.lock.secrethash,
         )
+        assert secret, 'secret should be known at this point'
         return secret_registry.events_for_onchain_secretreveal(
             channel_state=channel_state,
             secret=secret,
@@ -101,7 +103,7 @@ def handle_inittarget(
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult[Optional[TargetTransferState]]:
+) -> TransitionResult[TargetTransferState]:
     """ Handles an ActionInitTarget state change. """
     transfer = state_change.transfer
     route = state_change.route
@@ -240,7 +242,7 @@ def handle_unlock(
         target_state: TargetTransferState,
         state_change: ReceiveUnlock,
         channel_state: NettingChannelState,
-) -> TransitionResult[Optional[TargetTransferState]]:
+) -> TransitionResult[TargetTransferState]:
     """ Handles a ReceiveUnlock state change. """
     balance_proof_sender = state_change.balance_proof.sender
 
@@ -248,6 +250,7 @@ def handle_unlock(
         channel_state,
         state_change,
     )
+    next_target_state: Optional[TargetTransferState] = target_state
 
     if is_valid:
         transfer = target_state.transfer
@@ -255,7 +258,7 @@ def handle_unlock(
             payment_network_identifier=channel_state.payment_network_identifier,
             token_network_identifier=TokenNetworkID(channel_state.token_network_identifier),
             identifier=transfer.payment_identifier,
-            amount=transfer.lock.amount,
+            amount=TokenAmount(transfer.lock.amount),
             initiator=transfer.initiator,
         )
 
@@ -271,9 +274,9 @@ def handle_unlock(
         )
 
         events.extend([payment_received_success, unlock_success, send_processed])
-        target_state = None
+        next_target_state = None
 
-    return TransitionResult(target_state, events)
+    return TransitionResult(next_target_state, events)
 
 
 def handle_block(
@@ -286,7 +289,7 @@ def handle_block(
     handle expiration of the hash time lock.
     """
     transfer = target_state.transfer
-    events = list()
+    events: List[Event] = list()
     lock = transfer.lock
 
     secret_known = channel.is_secret_known(
@@ -324,7 +327,7 @@ def handle_lock_expired(
         state_change: ReceiveLockExpired,
         channel_state: NettingChannelState,
         block_number: BlockNumber,
-) -> TransitionResult[Optional[TargetTransferState]]:
+) -> TransitionResult[TargetTransferState]:
     """Remove expired locks from channel states."""
     result = channel.handle_receive_lock_expired(
         channel_state=channel_state,
@@ -352,7 +355,7 @@ def state_transition(
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
         block_number: BlockNumber,
-) -> TransitionResult[Optional[TargetTransferState]]:
+) -> TransitionResult[TargetTransferState]:
     """ State machine for the target node of a mediated transfer. """
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -350,7 +350,7 @@ def handle_lock_expired(
 
 
 def state_transition(
-        target_state: TargetTransferState,
+        target_state: Optional[TargetTransferState],
         state_change: StateChange,
         channel_state: NettingChannelState,
         pseudo_random_generator: random.Random,
@@ -372,6 +372,7 @@ def state_transition(
     elif type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION
         assert state_change.block_number == block_number
+        assert target_state, 'Block state changes should be accompanied by a valid target state'
 
         iteration = handle_block(
             target_state=target_state,
@@ -381,6 +382,7 @@ def state_transition(
         )
     elif type(state_change) == ReceiveSecretReveal:
         assert isinstance(state_change, ReceiveSecretReveal), MYPY_ANNOTATION
+        assert target_state, 'ReceiveSecretReveal should be accompanied by a valid target state'
         iteration = handle_offchain_secretreveal(
             target_state=target_state,
             state_change=state_change,
@@ -390,6 +392,8 @@ def state_transition(
         )
     elif type(state_change) == ContractReceiveSecretReveal:
         assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
+        msg = 'ContractReceiveSecretReveal should be accompanied by a valid target state'
+        assert target_state, msg
         iteration = handle_onchain_secretreveal(
             target_state,
             state_change,
@@ -397,18 +401,20 @@ def state_transition(
         )
     elif type(state_change) == ReceiveUnlock:
         assert isinstance(state_change, ReceiveUnlock), MYPY_ANNOTATION
+        assert target_state, 'ReceiveUnlock should be accompanied by a valid target state'
         iteration = handle_unlock(
-            target_state,
-            state_change,
-            channel_state,
+            target_state=target_state,
+            state_change=state_change,
+            channel_state=channel_state,
         )
     elif type(state_change) == ReceiveLockExpired:
         assert isinstance(state_change, ReceiveLockExpired), MYPY_ANNOTATION
+        assert target_state, 'ReceiveLockExpired should be accompanied by a valid target state'
         iteration = handle_lock_expired(
-            target_state,
-            state_change,
-            channel_state,
-            block_number,
+            target_state=target_state,
+            state_change=state_change,
+            channel_state=channel_state,
+            block_number=block_number,
         )
 
     sanity_check(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -81,6 +81,19 @@ from raiden.utils.typing import (
     Union,
 )
 
+# All State changes that are subdispatched as token network actions
+TokenNetworkStateChange = Union[
+    ActionChannelClose,
+    ContractReceiveChannelBatchUnlock,
+    ContractReceiveChannelNew,
+    ContractReceiveChannelNewBalance,
+    ContractReceiveChannelSettled,
+    ContractReceiveRouteNew,
+    ContractReceiveRouteClosed,
+    ContractReceiveUpdateTransfer,
+    ContractReceiveChannelClosed,
+]
+
 
 def get_networks(
         chain_state: ChainState,
@@ -556,20 +569,6 @@ def handle_chain_init(
         )
     events: List[Event] = list()
     return TransitionResult(chain_state, events)
-
-
-# All State changes that are subdispatched as token network actions
-TokenNetworkStateChange = Union[
-    ActionChannelClose,
-    ContractReceiveChannelBatchUnlock,
-    ContractReceiveChannelNew,
-    ContractReceiveChannelNewBalance,
-    ContractReceiveChannelSettled,
-    ContractReceiveRouteNew,
-    ContractReceiveRouteClosed,
-    ContractReceiveUpdateTransfer,
-    ContractReceiveChannelClosed,
-]
 
 
 def handle_token_network_action(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -16,6 +16,11 @@ from raiden.transfer.events import (
 )
 from raiden.transfer.mediated_transfer import initiator_manager, mediator, target
 from raiden.transfer.mediated_transfer.events import CHANNEL_IDENTIFIER_GLOBAL_QUEUE
+from raiden.transfer.mediated_transfer.state import (
+    InitiatorPaymentState,
+    MediatorTransferState,
+    TargetTransferState,
+)
 from raiden.transfer.mediated_transfer.state_change import (
     ActionInitInitiator,
     ActionInitMediator,
@@ -29,13 +34,10 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.queue_identifier import QueueIdentifier
 from raiden.transfer.state import (
     ChainState,
-    InitiatorPaymentState,
     InitiatorTask,
     MediatorTask,
-    MediatorTransferState,
     PaymentNetworkState,
     TargetTask,
-    TargetTransferState,
     TokenNetworkState,
 )
 from raiden.transfer.state_change import (

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -142,6 +142,8 @@ def to_comparable_graph(network: networkx.Graph) -> List[List[Any]]:
 
 
 class TransferTask(State):
+    # TODO: When we turn these into dataclasses it would be a good time to move common attributes
+    # of all transfer tasks like the `token_network_identifier` into the common subclass
     pass
 
 

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -1,5 +1,5 @@
 from raiden.transfer import channel
-from raiden.transfer.architecture import StateChange, TransitionResult
+from raiden.transfer.architecture import Event, StateChange, TransitionResult
 from raiden.transfer.state import TokenNetworkState
 from raiden.transfer.state_change import (
     ActionChannelClose,
@@ -13,12 +13,23 @@ from raiden.transfer.state_change import (
     ContractReceiveRouteNew,
     ContractReceiveUpdateTransfer,
 )
-from raiden.utils.typing import MYPY_ANNOTATION, BlockHash, BlockNumber
+from raiden.utils.typing import MYPY_ANNOTATION, BlockHash, BlockNumber, List, Union
+
+# TODO: The proper solution would be to introduce a marker for state changes
+# that contains channel IDs and other specific channel attributes
+StateChangeWithChannelID = Union[
+    ActionChannelClose,
+    ActionChannelSetFee,
+    ContractReceiveChannelClosed,
+    ContractReceiveChannelNewBalance,
+    ContractReceiveChannelSettled,
+    ContractReceiveUpdateTransfer,
+]
 
 
 def subdispatch_to_channel_by_id(
         token_network_state: TokenNetworkState,
-        state_change: StateChange,
+        state_change: StateChangeWithChannelID,
         block_number: BlockNumber,
         block_hash: BlockHash,
 ) -> TransitionResult:
@@ -70,7 +81,7 @@ def handle_channelnew(
         token_network_state: TokenNetworkState,
         state_change: ContractReceiveChannelNew,
 ) -> TransitionResult:
-    events = list()
+    events: List[Event] = list()
 
     channel_state = state_change.channel_state
     channel_identifier = channel_state.identifier
@@ -220,7 +231,7 @@ def handle_newroute(
         token_network_state: TokenNetworkState,
         state_change: ContractReceiveRouteNew,
 ) -> TransitionResult:
-    events = list()
+    events: List[Event] = list()
 
     token_network_state.network_graph.network.add_edge(
         state_change.participant1,
@@ -237,7 +248,7 @@ def handle_closeroute(
         token_network_state: TokenNetworkState,
         state_change: ContractReceiveRouteClosed,
 ) -> TransitionResult:
-    events = list()
+    events: List[Event] = list()
 
     network_graph_state = token_network_state.network_graph
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -1,5 +1,5 @@
 from raiden.transfer import channel
-from raiden.transfer.architecture import ContractSendEvent, State
+from raiden.transfer.architecture import ContractSendEvent
 from raiden.transfer.state import (
     CHANNEL_STATE_CLOSED,
     CHANNEL_STATE_CLOSING,
@@ -22,6 +22,7 @@ from raiden.transfer.state import (
 )
 from raiden.utils import CanonicalIdentifier
 from raiden.utils.typing import (
+    MYPY_ANNOTATION,
     Address,
     BlockNumber,
     Callable,
@@ -355,7 +356,7 @@ def get_channelstate_filter(
         token_address,
     )
 
-    result = []
+    result: List[NettingChannelState] = []
     if not token_network:
         return result
 
@@ -436,8 +437,8 @@ def get_channelstate_settled(
     )
 
 
-def role_from_transfer_task(transfer_task: TransferTask) -> Optional[str]:
-    """Return the role fo the transfer, None on error."""
+def role_from_transfer_task(transfer_task: TransferTask) -> str:
+    """Return the role for the transfer. Throws an exception on error"""
     if isinstance(transfer_task, InitiatorTask):
         return 'initiator'
     if isinstance(transfer_task, MediatorTask):
@@ -445,13 +446,19 @@ def role_from_transfer_task(transfer_task: TransferTask) -> Optional[str]:
     if isinstance(transfer_task, TargetTask):
         return 'target'
 
-    return None
+    raise ValueError('Argument to role_from_transfer_task is not a TransferTask')
 
 
-def get_transfer_role(chain_state: ChainState, secrethash: SecretHash) -> str:
-    return role_from_transfer_task(
-        chain_state.payment_mapping.secrethashes_to_task.get(secrethash),
-    )
+def get_transfer_role(chain_state: ChainState, secrethash: SecretHash) -> Optional[str]:
+    """
+    Returns 'initiator', 'mediator' or 'target' to signify the role the node has
+    in a transfer. If a transfer task is not found for the secrethash then the
+    function returns None
+    """
+    task = chain_state.payment_mapping.secrethashes_to_task.get(secrethash)
+    if not task:
+        return None
+    return role_from_transfer_task(task)
 
 
 def get_transfer_task(chain_state: ChainState, secrethash: SecretHash):
@@ -483,7 +490,7 @@ def list_channelstate_for_tokennetwork(
 
 
 def list_all_channelstate(chain_state: ChainState) -> List[NettingChannelState]:
-    result = []
+    result: List[NettingChannelState] = []
     for payment_network in chain_state.identifiers_to_paymentnetworks.values():
         for token_network in payment_network.tokenidentifiers_to_tokennetworks.values():
             # TODO: Either enforce immutability or make a copy
@@ -505,7 +512,7 @@ def filter_channels_by_partneraddress(
         token_address,
     )
 
-    result = []
+    result: List[NettingChannelState] = []
     if not token_network:
         return result
 
@@ -544,8 +551,8 @@ def filter_channels_by_status(
 
 
 def detect_balance_proof_change(
-        old_state: State,
-        current_state: State,
+        old_state: ChainState,
+        current_state: ChainState,
 ) -> Iterator[Union[BalanceProofSignedState, BalanceProofUnsignedState]]:
     """ Compare two states for any received balance_proofs that are not in `old_state`. """
     if old_state == current_state:
@@ -557,6 +564,7 @@ def detect_balance_proof_change(
             )
         except AttributeError:
             old_payment_network = None
+
         current_payment_network = current_state.identifiers_to_paymentnetworks[
             payment_network_identifier
         ]
@@ -564,12 +572,13 @@ def detect_balance_proof_change(
             continue
 
         for token_network_identifier in current_payment_network.tokenidentifiers_to_tokennetworks:
-            try:
+            if old_payment_network:
                 old_token_network = old_payment_network.tokenidentifiers_to_tokennetworks.get(
                     token_network_identifier,
                 )
-            except AttributeError:
+            else:
                 old_token_network = None
+
             current_token_network = current_payment_network.tokenidentifiers_to_tokennetworks[
                 token_network_identifier
             ]
@@ -577,12 +586,13 @@ def detect_balance_proof_change(
                 continue
 
             for channel_identifier in current_token_network.channelidentifiers_to_channels:
-                try:
+                if old_token_network:
                     old_channel = old_token_network.channelidentifiers_to_channels.get(
                         channel_identifier,
                     )
-                except AttributeError:
+                else:
                     old_channel = None
+
                 current_channel = current_token_network.channelidentifiers_to_channels[
                     channel_identifier
                 ]
@@ -600,6 +610,7 @@ def detect_balance_proof_change(
                     )
 
                     if partner_state_updated:
+                        assert current_channel.partner_state.balance_proof, MYPY_ANNOTATION
                         yield current_channel.partner_state.balance_proof
 
                     our_state_updated = (
@@ -612,4 +623,5 @@ def detect_balance_proof_change(
                     )
 
                     if our_state_updated:
+                        assert current_channel.our_state.balance_proof, MYPY_ANNOTATION
                         yield current_channel.our_state.balance_proof

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -168,4 +168,4 @@ Host = NewType('Host', str)
 Port = NewType('Port', int)
 HostPort = Tuple[Host, Optional[Port]]
 
-LockType = Union[HashTimeLockState, UnlockPartialProofState]
+LockType = Union['HashTimeLockState', 'UnlockPartialProofState']

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -167,3 +167,5 @@ NodeNetworkStateMap = Dict[Address, str]
 Host = NewType('Host', str)
 Port = NewType('Port', int)
 HostPort = Tuple[Host, Optional[Port]]
+
+LockType = Union[HashTimeLockState, UnlockPartialProofState]


### PR DESCRIPTION
Big chunk of work towards https://github.com/raiden-network/raiden/issues/3798.

At the tip of this PR: `mypy raiden/transfer/ --ignore-missing-imports` returns `0`

This has uncovered a few places where perhaps the architecture of the state machine could be changed but I think that these places can be improved when it is switched to data classes.