### PR TITLE
Clear ContractSendChannelBatchUnlock on restart properly

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -370,8 +370,8 @@ class RaidenEventHandler:
         if not channel_state:
             # channel was cleaned up already due to an unlock
             raise RaidenUnrecoverableError(
-                f'Failed to find channel state with partner '
-                f'{participant}, token_network:pex(token_network_identifier)',
+                f'Failed to find channel state with partner:'
+                f'{to_checksum_address(participant)}, token_network:pex(token_network_identifier)',
             )
 
         our_address = channel_state.our_state.address

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -46,6 +46,7 @@ def test_is_transaction_effect_satisfied(
 
     # ContractSendChannelBatchUnlock would only be satisfied if both sides are unlocked
     # and if the channel was cleared
+    assert not is_transaction_effect_satisfied(chain_state, transaction, state_change)
 
     channel_settled = ContractReceiveChannelSettled(
         transaction_hash=bytes(32),

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,8 +1,11 @@
 from raiden.constants import EMPTY_MERKLE_ROOT
 from raiden.tests.utils.factories import HOP1, HOP2, UNIT_SECRETHASH, make_block_hash
 from raiden.transfer.events import ContractSendChannelBatchUnlock
-from raiden.transfer.node import is_transaction_effect_satisfied
-from raiden.transfer.state_change import ContractReceiveChannelBatchUnlock
+from raiden.transfer.node import is_transaction_effect_satisfied, state_transition
+from raiden.transfer.state_change import (
+    ContractReceiveChannelBatchUnlock,
+    ContractReceiveChannelSettled,
+)
 
 
 def test_is_transaction_effect_satisfied(
@@ -40,4 +43,22 @@ def test_is_transaction_effect_satisfied(
     # finally call with us being the participant and not the partner which should check out
     state_change.participant = netting_channel_state.partner_state.address
     state_change.partner = netting_channel_state.our_state.address
-    assert is_transaction_effect_satisfied(chain_state, transaction, state_change)
+
+    # ContractSendChannelBatchUnlock would only be satisfied if both sides are unlocked
+    # and if the channel was cleared
+
+    channel_settled = ContractReceiveChannelSettled(
+        transaction_hash=bytes(32),
+        canonical_identifier=canonical_identifier,
+        our_onchain_locksroot=EMPTY_MERKLE_ROOT,
+        partner_onchain_locksroot=EMPTY_MERKLE_ROOT,
+        block_number=1,
+        block_hash=make_block_hash(),
+    )
+
+    iteration = state_transition(
+        chain_state=chain_state,
+        state_change=channel_settled,
+    )
+
+    assert is_transaction_effect_satisfied(iteration.new_state, transaction, state_change)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1145,13 +1145,8 @@ def is_transaction_effect_satisfied(
                 partner_address,
             )
 
-            if channel_state:
-                already_batch_unlocked = (
-                    state_change.participant == transaction.participant and
-                    state_change.token_network_identifier == transaction.token_network_identifier
-                )
-                if already_batch_unlocked:
-                    return True
+            if channel_state is None:
+                return True
 
     return False
 

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1144,7 +1144,11 @@ def is_transaction_effect_satisfied(
                 TokenNetworkID(state_change.token_network_identifier),
                 partner_address,
             )
-
+            # If the channel was cleared, that means that both
+            # sides of the channel were successfully unlocked.
+            # In this case, we only clear the batch unlock
+            # transaction from the queue only in case there
+            # were no more locked funds to unlock.
             if channel_state is None:
                 return True
 

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1146,7 +1146,7 @@ def is_transaction_effect_satisfied(
             )
             # If the channel was cleared, that means that both
             # sides of the channel were successfully unlocked.
-            # In this case, we only clear the batch unlock
+            # In this case, we clear the batch unlock
             # transaction from the queue only in case there
             # were no more locked funds to unlock.
             if channel_state is None:


### PR DESCRIPTION
This solves the problem of having a Batch Unlock transaction in the
pending transaction queue which doesn't get cleared properly.

The pending transaction doesn't get cleared because our transaction
invalidation logic includes checks for the transaction clearing our
partner's side of the channel which is not true any more since the
current node could be trying to unlock it's own side of the channel.

The change basically clears batch unlock pending transaction in case
both sides of the channel were unlocked (channel got cleared).

### TODO
- [x] Write a unit test for `is_transaction_effect_satisfied`
- [x] Write an integration test where:
```
- A sends B a transfer (secret is not revealed)
- B sends A a transfer (secret is not revealed)
- Channel is closed
- Wait for settle
- Crash A
- Wait for unlock from B (trying to unlock it's side)
- Restart A
- Assert A has unlocked it's side.
```

Resolves #3874 