### PR TITLE
Token network update transfer

### DIFF
--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -149,15 +149,6 @@ class PaymentChannel:
             channel_identifier=self.channel_identifier,
         )
 
-    def closing_address(self, block_identifier: BlockSpecification) -> Optional[Address]:
-        """ Returns the address of the closer of the channel. """
-        return self.token_network.closing_address(
-            participant1=self.participant1,
-            participant2=self.participant2,
-            block_identifier=block_identifier,
-            channel_identifier=self.channel_identifier,
-        )
-
     def can_transfer(self, block_identifier: BlockSpecification) -> bool:
         """ Returns True if the channel is opened and the node has deposit in it. """
         return self.token_network.can_transfer(

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1168,7 +1168,7 @@ class TokenNetwork:
 
                 # These checks do not have problems with race conditions because
                 # `poll`ing waits for the transaction to be confirmed.
-                mining_block = receipt_or_none['blockNumber']
+                mining_block = int(receipt_or_none['blockNumber'])
 
                 if receipt_or_none['cumulativeGasUsed'] == gas_limit:
                     msg = (
@@ -1260,7 +1260,7 @@ class TokenNetwork:
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
             failed_at = self.proxy.jsonrpc_client.get_block('latest')
-            failed_at_blockhash = bytes(failed_at['hash'])
+            failed_at_blockhash = str(failed_at['hash'])
 
             # This check contains a race condition, it could be the case that a
             # new block is mined changing the account's balance.

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -561,55 +561,6 @@ class TokenNetwork:
             return False
         return channel_state >= ChannelState.SETTLED
 
-    def closing_address(
-            self,
-            participant1: Address,
-            participant2: Address,
-            block_identifier: BlockSpecification,
-            channel_identifier: ChannelID,
-    ) -> Optional[Address]:
-        """ Returns the address of the closer, if the channel is closed and not settled. None
-        otherwise. """
-        if not isinstance(channel_identifier, T_ChannelID):
-            raise ValueError('channel_identifier must be of type T_ChannelID')
-
-        if channel_identifier <= 0:
-            raise ValueError('channel_identifier must be larger then 0')
-
-        channel_data = self._call_and_check_result(
-            block_identifier,
-            'getChannelInfo',
-            channel_identifier=channel_identifier,
-            participant1=to_checksum_address(participant1),
-            participant2=to_checksum_address(participant2),
-        )
-        state = channel_data[ChannelInfoIndex.STATE]
-
-        if state != ChannelState.CLOSED:
-            return None
-
-        our_details = self._detail_participant(
-            channel_identifier=channel_identifier,
-            participant=participant1,
-            partner=participant2,
-            block_identifier=block_identifier,
-        )
-
-        if our_details.is_closer:
-            return our_details.address
-
-        partner_details = self._detail_participant(
-            channel_identifier=channel_identifier,
-            participant=participant2,
-            partner=participant1,
-            block_identifier=block_identifier,
-        )
-
-        if partner_details.is_closer:
-            return partner_details.address
-
-        return None
-
     def can_transfer(
             self,
             participant1: Address,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1095,15 +1095,12 @@ class TokenNetwork:
             # performed.
             pass
         else:
-            if channel_onchain_detail.channel_identifier != channel_identifier:
-                msg = (
-                    f'The provided channel identifier does not match the value '
-                    f'on-chain at the provided block ({given_block_identifier}). '
-                    f'This call should never have been attempted. '
-                    f'provided_channel_identifier={channel_identifier}, '
-                    f'onchain_channel_identifier={channel_onchain_detail.channel_identifier}'
-                )
-                raise RaidenUnrecoverableError(msg)
+            # The latest channel is of no importance for the update transfer
+            # precondition checks, the only constraint that has to be satisfied
+            # is that the provided channel id provided is at the correct
+            # state. For this reason `getChannelIdentifier` is not called, as
+            # for version 0.4.0 that would return the identifier of the latest
+            # channel.
 
             if channel_onchain_detail.state != ChannelState.CLOSED:
                 msg = (

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1186,10 +1186,15 @@ class TokenNetwork:
                     channel_identifier=channel_identifier,
                 )
 
-                if channel_data.channel_identifier != channel_identifier:
-                    # This is not a problem, the channel identifier can be set
-                    # to 0 if the channel is settled, or it could have a higher
-                    # value if a new channel was opened
+                # The channel identifier can be set to 0 if the channel is
+                # settled, or it could have a higher value if a new channel was
+                # opened. A lower value is an unrecoverable error.
+                was_channel_gone = (
+                    channel_data.channel_identifier == 0 or
+                    channel_data.channel_identifier > channel_identifier
+                )
+
+                if was_channel_gone:
                     msg = (
                         f'The provided channel identifier does not match the value '
                         f'on-chain at the block the update transfer was mined ({mining_block}). '

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -12,7 +12,7 @@ from eth_utils import (
 from gevent.event import AsyncResult
 from gevent.lock import RLock, Semaphore
 
-from raiden.constants import EMPTY_HASH, GENESIS_BLOCK_NUMBER, UNLOCK_TX_GAS_LIMIT
+from raiden.constants import EMPTY_HASH, GENESIS_BLOCK_NUMBER, UINT256_MAX, UNLOCK_TX_GAS_LIMIT
 from raiden.exceptions import (
     ChannelOutdatedError,
     DepositMismatch,
@@ -396,6 +396,8 @@ class TokenNetwork:
             )
         elif not isinstance(channel_identifier, T_ChannelID):
             raise ValueError('channel_identifier must be of type T_ChannelID')
+        elif channel_identifier <= 0 or channel_identifier > UINT256_MAX:
+            raise ValueError('channel_identifier must be larger then 0 and smaller then uint256')
 
         channel_data = self._call_and_check_result(
             block_identifier,
@@ -438,6 +440,8 @@ class TokenNetwork:
             )
         elif not isinstance(channel_identifier, T_ChannelID):
             raise ValueError('channel_identifier must be of type T_ChannelID')
+        elif channel_identifier <= 0 or channel_identifier > UINT256_MAX:
+            raise ValueError('channel_identifier must be larger then 0 and smaller then uint256')
 
         our_data = self._detail_participant(
             channel_identifier=channel_identifier,
@@ -1067,6 +1071,9 @@ class TokenNetwork:
 
         if balance_hash is EMPTY_HASH:
             raise RaidenUnrecoverableError('update_transfer called with an empty balance_hash')
+
+        if nonce <= 0 or nonce > UINT256_MAX:
+            raise RaidenUnrecoverableError('update_transfer called with an invalid nonce')
 
         data_that_was_signed = pack_balance_proof(
             nonce=nonce,

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -617,10 +617,9 @@ def test_query_pruned_state(
     block = c1_client.web3.eth.getBlock('latest')
     block_number = int(block['number'])
     block_hash = bytes(block['hash'])
-    channel_id = c1_token_network_proxy._inspect_channel_identifier(
+    channel_id = c1_token_network_proxy.get_channel_identifier(
         participant1=c1_client.address,
         participant2=c2_client.address,
-        called_by_fn='test',
         block_identifier=block_hash,
     )
     assert channel_id == channel_identifier

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from raiden.messages import RequestMonitoring  # noqa: F401
     from raiden.exceptions import RaidenUnrecoverableError, RaidenRecoverableError  # noqa: F401
 
+
 MYPY_ANNOTATION = (
     'This assert is used to tell mypy what is the type of the variable'
 )


### PR DESCRIPTION
The current update transfer method in the token network proxy is utterly unnecessarily complex, this PR does a few changes:

- Remove some unused methods
- Properly handle state pruning by relying on exceptions (explanation in the comments)
- Reduce the number of RPC calls by removing unnecessary indirection
- Streamlines the logic by:
  - Removing indirection
  - raising the exception *where the check is done*, this means we don't have to spend time digging through the logs to understand why an exception was raised, and reduce the changes for some errors (like not raising the exception)
  - split the the checks for unsuccessful transaction execution and unsuccessful gas estimation