### PR TITLE
Fix signature typing in UpdatePFS message

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1852,7 +1852,7 @@ class UpdatePFS(SignedMessage):
         self.reveal_timeout = reveal_timeout
         self.mediation_fee = mediation_fee
         if signature is None:
-            self.signature = b''
+            self.signature = Signature(b'')
         else:
             self.signature = signature
 


### PR DESCRIPTION
When updating the raiden commit in the services it started complaining about this.