### PR TITLE
Fix global room use in Matrix transport

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,7 +1,7 @@
 import structlog
 from eth_utils import to_checksum_address
 
-from raiden.constants import DISCOVERY_DEFAULT_ROOM
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM
 from raiden.exceptions import InvalidSettleTimeout
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.discovery import Discovery
@@ -61,7 +61,10 @@ class App:  # pylint: disable=too-few-public-methods
             "matrix": {
                 # None causes fetching from url in raiden.settings.py::DEFAULT_MATRIX_KNOWN_SERVERS
                 "available_servers": None,
-                "global_rooms": [DISCOVERY_DEFAULT_ROOM],
+                # TODO: Remove `PATH_FINDING_BROADCASTING_ROOM` when implementing #3735
+                #       and fix the conditional in `raiden.ui.app:_setup_matrix`
+                #       as well as the tests
+                "global_rooms": [DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM],
                 "retries_before_backoff": DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
                 "retry_interval": DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
                 "server": "auto",
@@ -146,10 +149,6 @@ class App:  # pylint: disable=too-few-public-methods
             self.raiden.start()
 
     def stop(self):
-        """ Stop the raiden app.
-
-        Args:
-            leave_channels: if True, also close and settle all channels before stopping
-        """
+        """ Stop the raiden app. """
         if not self.raiden.stop_event.is_set():
             self.raiden.stop()

--- a/raiden/tests/integration/cli/test_cli_development.py
+++ b/raiden/tests/integration/cli/test_cli_development.py
@@ -1,23 +1,30 @@
-import pexpect
 import pytest
 
 from raiden.constants import Environment
 from raiden.settings import DEVELOPMENT_CONTRACT_VERSION
-from raiden.tests.integration.cli.util import expect_cli_normal_startup
-
-pytestmark = pytest.mark.parametrize(
-    "cli_tests_contracts_version", [DEVELOPMENT_CONTRACT_VERSION], scope="module"
+from raiden.tests.integration.cli.util import (
+    expect_cli_normal_startup,
+    expect_cli_successful_connected,
+    expect_cli_until_account_selection,
 )
 
+pytestmark = [
+    pytest.mark.parametrize(
+        "cli_tests_contracts_version", [DEVELOPMENT_CONTRACT_VERSION], scope="module"
+    ),
+    pytest.mark.parametrize("environment_type", [Environment.DEVELOPMENT.value], scope="module"),
+]
 
-@pytest.mark.timeout(80)
-@pytest.mark.parametrize("changed_args", [{"environment_type": Environment.DEVELOPMENT.value}])
-def test_cli_change_environment_type(cli_args, raiden_spawner):
+
+@pytest.mark.timeout(45)
+def test_cli_full_init_dev(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        # expect the provided mode
-        expect_cli_normal_startup(child, Environment.DEVELOPMENT.value)
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+    expect_cli_normal_startup(child, Environment.DEVELOPMENT.value)
+
+
+@pytest.mark.timeout(45)
+@pytest.mark.parametrize("removed_args", [["address"]])
+def test_cli_manual_account_selection(cli_args, raiden_spawner):
+    child = raiden_spawner(cli_args)
+    expect_cli_until_account_selection(child)
+    expect_cli_successful_connected(child, Environment.DEVELOPMENT.value)

--- a/raiden/tests/integration/cli/test_cli_production.py
+++ b/raiden/tests/integration/cli/test_cli_production.py
@@ -1,4 +1,3 @@
-import pexpect
 import pytest
 from eth_utils import to_checksum_address
 
@@ -12,92 +11,66 @@ from raiden.tests.integration.cli.util import (
 
 EXPECTED_DEFAULT_ENVIRONMENT_VALUE = Environment.PRODUCTION.value
 
-pytestmark = pytest.mark.parametrize(
-    "cli_tests_contracts_version", [RED_EYES_CONTRACT_VERSION], scope="module"
-)
-pytestmark = pytest.mark.parametrize(
-    "environment_type", [EXPECTED_DEFAULT_ENVIRONMENT_VALUE], scope="module"
-)
+pytestmark = [
+    pytest.mark.parametrize(
+        "cli_tests_contracts_version", [RED_EYES_CONTRACT_VERSION], scope="module"
+    ),
+    pytest.mark.parametrize(
+        "environment_type", [EXPECTED_DEFAULT_ENVIRONMENT_VALUE], scope="module"
+    ),
+]
 
 
 @pytest.mark.timeout(65)
 def test_cli_full_init(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        # expect the default mode
-        expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+    # expect the default mode
+    expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
 
 
 @pytest.mark.timeout(45)
 @pytest.mark.parametrize("changed_args", [{"keystore_path": "."}])
 def test_cli_wrong_keystore_path(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        expect_cli_until_acknowledgment(child)
-        child.expect("No Ethereum accounts found in the provided keystore directory")
-    except pexpect.TIMEOUT as e:
-        print("PEXPECT timed out at", e)
-    finally:
-        child.close()
+    expect_cli_until_acknowledgment(child)
+    child.expect("No Ethereum accounts found in the provided keystore directory")
 
 
 @pytest.mark.timeout(45)
 @pytest.mark.parametrize("removed_args", [["password_file"]])
 def test_cli_missing_password_file_enter_password(raiden_testchain, cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        expect_cli_until_acknowledgment(child)
-        child.expect("Enter the password to unlock")
-        with open(raiden_testchain["password_file"], "r") as password_file:
-            password = password_file.readline()
-            child.sendline(password)
-        expect_cli_successful_connected(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+
+    expect_cli_until_acknowledgment(child)
+    child.expect("Enter the password to unlock")
+    with open(raiden_testchain["password_file"], "r") as password_file:
+        password = password_file.readline()
+        child.sendline(password)
+    expect_cli_successful_connected(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
 
 
-@pytest.mark.timeout(65)
+@pytest.mark.timeout(45)
 @pytest.mark.parametrize("removed_args", [["data_dir"]])
 def test_cli_missing_data_dir(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+    expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
 
 
 @pytest.mark.timeout(45)
 @pytest.mark.parametrize("changed_args", [{"eth_rpc_endpoint": "http://8.8.8.8:2020"}])
 def test_cli_wrong_rpc_endpoint(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        expect_cli_until_acknowledgment(child)
-        child.expect(".*Could not contact the Ethereum node through JSON-RPC.")
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+
+    expect_cli_until_acknowledgment(child)
+    child.expect(".*Could not contact the Ethereum node through JSON-RPC.")
 
 
 @pytest.mark.timeout(45)
 @pytest.mark.parametrize("changed_args", [{"network_id": "42"}])
 def test_cli_wrong_network_id_try_kovan(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        expect_cli_until_acknowledgment(child)
-        child.expect("The configured network.*differs from the Ethereum client's network")
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+    expect_cli_until_acknowledgment(child)
+    child.expect("The configured network.*differs from the Ethereum client's network")
 
 
 @pytest.mark.timeout(45)
@@ -113,10 +86,6 @@ def test_cli_wrong_network_id_try_kovan(cli_args, raiden_spawner):
 )
 def test_cli_registry_address_without_deployed_contract(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
-    try:
-        expect_cli_until_acknowledgment(child)
-        child.expect(".*contract does not contain code")
-    except pexpect.TIMEOUT as e:
-        print("Timed out at", e)
-    finally:
-        child.close()
+
+    expect_cli_until_acknowledgment(child)
+    child.expect(".*contract does not contain code")

--- a/raiden/tests/integration/cli/util.py
+++ b/raiden/tests/integration/cli/util.py
@@ -19,5 +19,4 @@ def expect_cli_successful_connected(child, mode):
 
 def expect_cli_normal_startup(child, mode):
     expect_cli_until_acknowledgment(child)
-    expect_cli_until_account_selection(child)
     expect_cli_successful_connected(child, mode)

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -79,4 +79,6 @@ def matrix_transports(
         transport.stop()
 
     for transport in transports:
-        transport.get()
+        # Calling `get()` on a never started Greenlet will block forever
+        if transport._started:
+            transport.get()

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -1,5 +1,6 @@
 import pytest
 
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM
 from raiden.network.transport import MatrixTransport
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.utils.transport import generate_synapse_config, matrix_server_starter
@@ -44,7 +45,8 @@ def local_matrix_servers(
 # Beware: the arguments to `global_rooms` should be lists
 @pytest.fixture
 def global_rooms():
-    return ["discovery"]
+    # TODO: adjust this depending on configuration once #3735 gets implemented
+    return [DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]
 
 
 @pytest.fixture

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -121,7 +121,7 @@ def ping_pong_message_success(transport0, transport1):
     message = Processed(message_identifier=number_of_received_messages0)
     transport0._raiden_service.sign(message)
     transport0.send_async(queueid1, message)
-    with Timeout(20):
+    with Timeout(30):
         all_messages_received = False
         while not all_messages_received:
             all_messages_received = (
@@ -133,7 +133,7 @@ def ping_pong_message_success(transport0, transport1):
     transport1._raiden_service.sign(message)
     transport1.send_async(queueid0, message)
 
-    with Timeout(20):
+    with Timeout(30):
         all_messages_received = False
         while not all_messages_received:
             all_messages_received = (

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -52,7 +52,12 @@ class MessageHandler:
 
 @pytest.fixture
 def mock_matrix(
-    monkeypatch, retry_interval, retries_before_backoff, local_matrix_servers, private_rooms
+    monkeypatch,
+    retry_interval,
+    retries_before_backoff,
+    local_matrix_servers,
+    private_rooms,
+    global_rooms,
 ):
 
     from raiden.network.transport.matrix.client import User
@@ -82,7 +87,7 @@ def mock_matrix(
         server=local_matrix_servers[0],
         server_name=local_matrix_servers[0].netloc,
         available_servers=[],
-        global_rooms=["discovery"],
+        global_rooms=global_rooms,
         private_rooms=private_rooms,
     )
 
@@ -377,7 +382,7 @@ def test_matrix_tx_error_handling(  # pylint: disable=unused-argument
 
 
 def test_matrix_message_retry(
-    local_matrix_servers, private_rooms, retry_interval, retries_before_backoff
+    local_matrix_servers, private_rooms, retry_interval, retries_before_backoff, global_rooms
 ):
     """ Test the retry mechanism implemented into the matrix client.
     The test creates a transport and sends a message. Given that the
@@ -391,7 +396,7 @@ def test_matrix_message_retry(
 
     transport = MatrixTransport(
         {
-            "global_rooms": ["discovery"],
+            "global_rooms": global_rooms,
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],
@@ -460,7 +465,7 @@ def test_matrix_message_retry(
 
 
 def test_join_invalid_discovery(
-    local_matrix_servers, private_rooms, retry_interval, retries_before_backoff
+    local_matrix_servers, private_rooms, retry_interval, retries_before_backoff, global_rooms
 ):
     """join_global_room tries to join on all servers on available_servers config
 
@@ -470,7 +475,7 @@ def test_join_invalid_discovery(
     """
     transport = MatrixTransport(
         {
-            "global_rooms": ["discovery"],
+            "global_rooms": global_rooms,
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],
@@ -530,12 +535,12 @@ def test_matrix_cross_server_with_load_balance(matrix_transports):
 
 
 def test_matrix_discovery_room_offline_server(
-    local_matrix_servers, retries_before_backoff, retry_interval, private_rooms
+    local_matrix_servers, retries_before_backoff, retry_interval, private_rooms, global_rooms
 ):
 
     transport = MatrixTransport(
         {
-            "global_rooms": ["discovery"],
+            "global_rooms": global_rooms,
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],
@@ -555,11 +560,11 @@ def test_matrix_discovery_room_offline_server(
 
 
 def test_matrix_send_global(
-    local_matrix_servers, retries_before_backoff, retry_interval, private_rooms
+    local_matrix_servers, retries_before_backoff, retry_interval, private_rooms, global_rooms
 ):
     transport = MatrixTransport(
         {
-            "global_rooms": ["discovery", MONITORING_BROADCASTING_ROOM],
+            "global_rooms": global_rooms + [MONITORING_BROADCASTING_ROOM],
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],
@@ -596,7 +601,12 @@ def test_matrix_send_global(
 
 
 def test_monitoring_global_messages(
-    local_matrix_servers, private_rooms, retry_interval, retries_before_backoff, monkeypatch
+    local_matrix_servers,
+    private_rooms,
+    retry_interval,
+    retries_before_backoff,
+    monkeypatch,
+    global_rooms,
 ):
     """
     Test that RaidenService sends RequestMonitoring messages to global
@@ -604,7 +614,7 @@ def test_monitoring_global_messages(
     """
     transport = MatrixTransport(
         {
-            "global_rooms": ["discovery", MONITORING_BROADCASTING_ROOM],
+            "global_rooms": global_rooms + [MONITORING_BROADCASTING_ROOM],
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],
@@ -653,7 +663,12 @@ def test_monitoring_global_messages(
 
 @pytest.mark.parametrize("matrix_server_count", [1])
 def test_pfs_global_messages(
-    local_matrix_servers, private_rooms, retry_interval, retries_before_backoff, monkeypatch
+    local_matrix_servers,
+    private_rooms,
+    retry_interval,
+    retries_before_backoff,
+    monkeypatch,
+    global_rooms,
 ):
     """
     Test that RaidenService sends UpdatePFS messages to global
@@ -661,7 +676,7 @@ def test_pfs_global_messages(
     """
     transport = MatrixTransport(
         {
-            "global_rooms": ["discovery", PATH_FINDING_BROADCASTING_ROOM],
+            "global_rooms": global_rooms,  # FIXME: #3735
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -11,6 +11,7 @@ from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state_change import ActionInitChain
+from raiden.utils import privatekey_to_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,
@@ -111,12 +112,16 @@ class MockChainState:
 
 
 class MockRaidenService:
-    def __init__(self, message_handler=None, state_transition=None):
-        self.chain = MockChain(network_id=17, node_address=factories.make_address())
-        self.private_key, self.address = factories.make_privkey_address()
+    def __init__(self, message_handler=None, state_transition=None, private_key=None):
+        if private_key is None:
+            self.private_key, self.address = factories.make_privkey_address()
+        else:
+            self.private_key = private_key
+            self.address = privatekey_to_address(private_key)
+
+        self.chain = MockChain(network_id=17, node_address=self.address)
         self.signer = LocalSigner(self.private_key)
 
-        self.chain.node_address = self.address
         self.message_handler = message_handler
 
         self.user_deposit = Mock()

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -6,6 +6,7 @@ from gevent import server
 
 from raiden import waiting
 from raiden.app import App
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
@@ -328,7 +329,11 @@ def create_apps(
                     "transport_type": "matrix",
                     "transport": {
                         "matrix": {
-                            "global_rooms": ["discovery"],
+                            # FIXME: #3735
+                            "global_rooms": [
+                                DISCOVERY_DEFAULT_ROOM,
+                                PATH_FINDING_BROADCASTING_ROOM,
+                            ],
                             "retries_before_backoff": retries_before_backoff,
                             "retry_interval": retry_interval,
                             "server": local_matrix_url,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -9,7 +9,11 @@ from eth_utils import to_canonical_address, to_normalized_address
 from web3 import HTTPProvider, Web3
 
 from raiden.accounts import AccountManager
-from raiden.constants import MONITORING_BROADCASTING_ROOM, RAIDEN_DB_VERSION
+from raiden.constants import (
+    MONITORING_BROADCASTING_ROOM,
+    PATH_FINDING_BROADCASTING_ROOM,
+    RAIDEN_DB_VERSION,
+)
 from raiden.exceptions import RaidenError
 from raiden.message_handler import MessageHandler
 from raiden.network.blockchain_service import BlockChainService
@@ -54,6 +58,10 @@ def _setup_matrix(config):
         available_servers = get_matrix_servers(available_servers_url)
         log.debug("Fetching available matrix servers", available_servers=available_servers)
         config["transport"]["matrix"]["available_servers"] = available_servers
+
+    # Add PFS broadcast room if enabled
+    if config['services']['pathfinding_service_address'] is not None:
+        config['transport']['matrix']['global_rooms'].append(PATH_FINDING_BROADCASTING_ROOM)
 
     # Add monitoring service broadcast room if enabled
     if config["services"]["monitoring_enabled"] is True:

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -59,9 +59,11 @@ def _setup_matrix(config):
         log.debug("Fetching available matrix servers", available_servers=available_servers)
         config["transport"]["matrix"]["available_servers"] = available_servers
 
+    # TODO: This needs to be adjusted once #3735 gets implemented
     # Add PFS broadcast room if enabled
-    if config['services']['pathfinding_service_address'] is not None:
-        config['transport']['matrix']['global_rooms'].append(PATH_FINDING_BROADCASTING_ROOM)
+    if config["services"]["pathfinding_service_address"] is not None:
+        if PATH_FINDING_BROADCASTING_ROOM not in config["transport"]["matrix"]["global_rooms"]:
+            config["transport"]["matrix"]["global_rooms"].append(PATH_FINDING_BROADCASTING_ROOM)
 
     # Add monitoring service broadcast room if enabled
     if config["services"]["monitoring_enabled"] is True:

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -67,7 +67,7 @@ class HTTPExecutor(MiHTTPExecutor):
 
         except (HTTPException, socket.timeout, socket.error) as ex:
             log.debug("Executor process not healthy yet", command=self.command, error=ex)
-            time.sleep(0.05)
+            time.sleep(0.1)
             return False
 
         return False

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -74,14 +74,8 @@ class Runnable:
 
     # redirect missing members to underlying greenlet for compatibility
     # but better use greenlet directly for now, to make use of the c extension optimizations
-    def __getattribute__(self, name):
-        try:
-            return super().__getattribute__(name)
-        except AttributeError as ex:
-            try:
-                return getattr(self.greenlet, name)
-            except AttributeError:
-                raise ex from None
+    def __getattr__(self, item):
+        return getattr(self.greenlet, item)
 
     def __bool__(self):
         return bool(self.greenlet)


### PR DESCRIPTION
Fixes: #3765 (see there for a detailed explanation what's happening)

This also fixes a whole bunch of the cli tests which were silently failing due to pexpect timeouts being ignored with just a print.
