### PR TITLE
Saving raiden node logs

### DIFF
--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -1,12 +1,11 @@
 # pylint: disable=redefined-outer-name
-import os
 import random
 from enum import Enum
 
 import pytest
-from eth_utils import remove_0x_prefix, to_normalized_address
+from eth_utils import remove_0x_prefix
 
-from raiden.constants import RAIDEN_DB_VERSION, RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT, Environment
+from raiden.constants import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT, Environment
 from raiden.network.utils import get_free_port
 from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
@@ -15,7 +14,7 @@ from raiden.settings import (
     DEFAULT_TRANSPORT_THROTTLE_FILL_RATE,
 )
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
-from raiden.utils import privatekey_to_address, sha3
+from raiden.utils import sha3
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
 # we need to use fixture for the default values otherwise
@@ -306,22 +305,6 @@ def raiden_udp_ports(number_of_nodes, port_generator):
 def rest_api_port_number(port_generator):
     """ Unique port for the REST API server. """
     return next(port_generator)
-
-
-@pytest.fixture
-def database_paths(tmpdir, private_keys):
-    """ Sqlite database paths for each app. """
-    database_paths = list()
-    for pkey in private_keys:
-        app_dir = os.path.join(
-            tmpdir.strpath,
-            to_normalized_address(privatekey_to_address(pkey))[2:8],
-        )
-        if not os.path.exists(app_dir):
-            os.makedirs(app_dir)
-        database_paths.append(os.path.join(app_dir, f'v{RAIDEN_DB_VERSION}_log.db'))
-
-    return database_paths
 
 
 @pytest.fixture

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -88,7 +88,7 @@ def web3(
     base_datadir = str(tmpdir)
 
     if _ETH_LOGDIR:
-        base_logdir = os.path.join(_ETH_LOGDIR, blockchain_type, request.node.name)
+        base_logdir = os.path.join(_ETH_LOGDIR, request.node.name, blockchain_type)
     else:
         base_logdir = os.path.join(base_datadir, 'logs')
 

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -34,7 +34,6 @@ def raiden_chain(
         endpoint_discovery_services,
         raiden_udp_ports,
         reveal_timeout,
-        database_paths,
         retry_interval,
         retries_before_backoff,
         throttle_capacity,
@@ -49,6 +48,7 @@ def raiden_chain(
         blockchain_type,
         contracts_path,
         user_deposit_address,
+        tmpdir,
 ):
 
     if len(token_addresses) != 1:
@@ -73,7 +73,7 @@ def raiden_chain(
         raiden_udp_ports=raiden_udp_ports,
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
-        database_paths=database_paths,
+        database_basedir=tmpdir.strpath,
         retry_interval=retry_interval,
         retries_before_backoff=retries_before_backoff,
         throttle_capacity=throttle_capacity,
@@ -147,7 +147,6 @@ def raiden_network(
         endpoint_discovery_services,
         raiden_udp_ports,
         reveal_timeout,
-        database_paths,
         retry_interval,
         retries_before_backoff,
         throttle_capacity,
@@ -162,10 +161,12 @@ def raiden_network(
         blockchain_type,
         contracts_path,
         user_deposit_address,
+        tmpdir,
 ):
     service_registry_address = None
     if blockchain_services.service_registry:
         service_registry_address = blockchain_services.service_registry.address
+
     raiden_apps = create_apps(
         chain_id=chain_id,
         contracts_path=contracts_path,
@@ -178,7 +179,7 @@ def raiden_network(
         raiden_udp_ports=raiden_udp_ports,
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
-        database_paths=database_paths,
+        database_basedir=tmpdir.strpath,
         retry_interval=retry_interval,
         retries_before_backoff=retries_before_backoff,
         throttle_capacity=throttle_capacity,

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -1,3 +1,5 @@
+import os
+
 import gevent
 import pytest
 
@@ -14,6 +16,8 @@ from raiden.tests.utils.network import (
     wait_for_token_networks,
 )
 from raiden.tests.utils.tests import shutdown_apps_and_cleanup_tasks
+
+_ETH_LOGDIR = os.environ.get('RAIDEN_TESTS_ETH_LOGSDIR')
 
 
 def timeout(blockchain_type: str):
@@ -49,6 +53,7 @@ def raiden_chain(
         contracts_path,
         user_deposit_address,
         tmpdir,
+        request,
 ):
 
     if len(token_addresses) != 1:
@@ -58,6 +63,11 @@ def raiden_chain(
         'deployed_network uses create_sequential_network that can only work '
         'with 0, 1 or 2 channels'
     )
+
+    if _ETH_LOGDIR:
+        base_datadir = os.path.join(_ETH_LOGDIR, request.node.name, 'raiden_nodes')
+    else:
+        base_datadir = os.path.join(tmpdir.strpath, 'raiden_nodes')
 
     service_registry_address = None
     if blockchain_services.service_registry:
@@ -73,7 +83,7 @@ def raiden_chain(
         raiden_udp_ports=raiden_udp_ports,
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
-        database_basedir=tmpdir.strpath,
+        database_basedir=base_datadir,
         retry_interval=retry_interval,
         retries_before_backoff=retries_before_backoff,
         throttle_capacity=throttle_capacity,
@@ -162,10 +172,16 @@ def raiden_network(
         contracts_path,
         user_deposit_address,
         tmpdir,
+        request,
 ):
     service_registry_address = None
     if blockchain_services.service_registry:
         service_registry_address = blockchain_services.service_registry.address
+
+    if _ETH_LOGDIR:
+        base_datadir = os.path.join(_ETH_LOGDIR, request.node.name, 'raiden_nodes')
+    else:
+        base_datadir = os.path.join(tmpdir.strpath, 'raiden_nodes')
 
     raiden_apps = create_apps(
         chain_id=chain_id,
@@ -179,7 +195,7 @@ def raiden_network(
         raiden_udp_ports=raiden_udp_ports,
         reveal_timeout=reveal_timeout,
         settle_timeout=settle_timeout,
-        database_basedir=tmpdir.strpath,
+        database_basedir=base_datadir,
         retry_interval=retry_interval,
         retries_before_backoff=retries_before_backoff,
         throttle_capacity=throttle_capacity,

--- a/raiden/tests/utils/app.py
+++ b/raiden/tests/utils/app.py
@@ -1,0 +1,17 @@
+import os
+import os.path
+
+from raiden.constants import RAIDEN_DB_VERSION
+
+
+def database_from_privatekey(base_dir, app_number):
+    """ Format a database path based on the private key and app number. """
+    dbpath = os.path.join(
+        base_dir,
+        'raiden_nodes',
+        str(app_number),
+        f'v{RAIDEN_DB_VERSION}_log.db',
+    )
+    os.makedirs(os.path.dirname(dbpath))
+
+    return dbpath

--- a/raiden/tests/utils/app.py
+++ b/raiden/tests/utils/app.py
@@ -8,8 +8,7 @@ def database_from_privatekey(base_dir, app_number):
     """ Format a database path based on the private key and app number. """
     dbpath = os.path.join(
         base_dir,
-        'raiden_nodes',
-        str(app_number),
+        f'app{app_number}',
         f'v{RAIDEN_DB_VERSION}_log.db',
     )
     os.makedirs(os.path.dirname(dbpath))

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -12,6 +12,7 @@ from raiden.network.throttle import TokenBucket
 from raiden.network.transport import MatrixTransport, UDPTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, DEFAULT_RETRY_TIMEOUT
+from raiden.tests.utils.app import database_from_privatekey
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -288,7 +289,7 @@ def create_apps(
         raiden_udp_ports,
         reveal_timeout,
         settle_timeout,
-        database_paths,
+        database_basedir,
         retry_interval,
         retries_before_backoff,
         throttle_capacity,
@@ -310,6 +311,10 @@ def create_apps(
         address = blockchain.client.address
 
         host = '127.0.0.1'
+        database_path = database_from_privatekey(
+            base_dir=database_basedir,
+            app_number=idx,
+        )
 
         config = {
             'chain_id': chain_id,
@@ -318,7 +323,7 @@ def create_apps(
             'reveal_timeout': reveal_timeout,
             'settle_timeout': settle_timeout,
             'contracts_path': contracts_path,
-            'database_path': database_paths[idx],
+            'database_path': database_path,
             'blockchain': {
                 'confirmation_blocks': DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
             },

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
 from contextlib import closing
-from glob import glob
+from glob import escape, glob
 from pathlib import Path
 
 import filelock
@@ -173,13 +173,14 @@ class UpgradeManager:
         # the content of the database remains consistent, because the upgrades
         # are executed inside a migration, however making a second copy of the
         # database does no harm.
-        paths = glob(f'{self._current_db_filename.parent}/v*_log.db')
+        escaped_path = escape(str(self._current_db_filename.parent))
+        paths = glob(f'{escaped_path}/v*_log.db')
         valid_db_names = filter_db_names(paths)
         delete_dbs_with_failed_migrations(valid_db_names)
 
         # At this point we know every file version and db version match
         # (assuming there are no concurrent runs).
-        paths = glob(f'{self._current_db_filename.parent}/v*_log.db')
+        paths = glob(f'{escaped_path}/v*_log.db')
         valid_db_names = filter_db_names(paths)
         latest_db_path = latest_db_file(valid_db_names)
 


### PR DESCRIPTION
This saves the raiden node's database as CI artifacts. It can be useful for debugging.

Additionally it tries to name the directories in a way that matches our tests, e.g.:

https://github.com/raiden-network/raiden/blob/5df09ee128ec343eafa09456d55c74ef5ea4d9b2/raiden/tests/integration/test_raidenservice.py#L99-L101

`app0` and `app1` will be part of the node's datadir name 