### PR TITLE
Fixed secret registration

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -285,10 +285,7 @@ class RaidenEventHandler:
             raiden: 'RaidenService',
             channel_reveal_secret_event: ContractSendSecretReveal,
     ):
-        raiden.default_secret_registry.register_secret(
-            secret=channel_reveal_secret_event.secret,
-            given_block_identifier=channel_reveal_secret_event.triggered_by_block_hash,
-        )
+        raiden.default_secret_registry.register_secret(secret=channel_reveal_secret_event.secret)
 
     @staticmethod
     def handle_contract_send_channelclose(

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -388,7 +388,7 @@ def run_test_batch_unlock(
     secret_registry_proxy = alice_app.raiden.chain.secret_registry(
         secret_registry_address,
     )
-    secret_registry_proxy.register_secret(secret=secret, given_block_identifier='latest')
+    secret_registry_proxy.register_secret(secret=secret)
 
     assert lock, 'the lock must still be part of the node state'
     msg = 'the secret must be registered before the lock expires'

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -317,14 +317,14 @@ def run_test_regression_register_secret_once(secret_registry_address, deploy_ser
     secret_registry = deploy_service.secret_registry(secret_registry_address)
 
     secret = sha3(b'test_regression_register_secret_once')
-    secret_registry.register_secret(secret=secret, given_block_identifier='latest')
+    secret_registry.register_secret(secret=secret)
 
     previous_nonce = deploy_service.client._available_nonce
-    secret_registry.register_secret(secret=secret, given_block_identifier='latest')
+    secret_registry.register_secret(secret=secret)
     assert previous_nonce == deploy_service.client._available_nonce
 
     previous_nonce = deploy_service.client._available_nonce
-    secret_registry.register_secret_batch(secrets=[secret], given_block_identifier='latest')
+    secret_registry.register_secret_batch(secrets=[secret])
     assert previous_nonce == deploy_service.client._available_nonce
 
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -125,7 +125,7 @@ def run_test_locked_transfer_secret_registered_onchain(
     secret_registry_proxy = app0.raiden.chain.secret_registry(
         secret_registry_address,
     )
-    secret_registry_proxy.register_secret(secret=transfer_secret, given_block_identifier='latest')
+    secret_registry_proxy.register_secret(secret=transfer_secret)
 
     # Wait until our node has processed the block that the secret registration was mined at
     block_number = app0.raiden.get_block_number()


### PR DESCRIPTION
The block identifier is unecessary for the secret registration because
the action is always valid (there are no preconditions to check), for
this reason the blockhash is unecessary.

In order to preserve a consistent blockchain view, this removed the
unecessary argument and start using the latest confirmed block as a
reference point. This removes problems with prunned blocks and chain
reorgs.