### PR TITLE
Mypy fixes for `raiden/network/transport`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint:
 	pylint --load-plugins=tools.pylint.gevent_checker --rcfile .pylint.rc $(LINT_PATHS)
 	python setup.py check --restructuredtext --strict
 
-	mypy raiden/transfer raiden/messages.py raiden/encoding raiden/api --ignore-missing-imports
+	mypy raiden/transfer raiden/messages.py raiden/encoding raiden/api raiden/network --ignore-missing-imports
 
 	# We are starting small with a few files and directories here,
 	# but mypy should run on the whole codebase soon.

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -27,7 +27,7 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.state import balanceproof_from_envelope
 from raiden.transfer.state_change import ReceiveDelivered, ReceiveProcessed, ReceiveUnlock
 from raiden.utils import pex, random_secret
-from raiden.utils.typing import MYPY_ANNOTATION, InitiatorAddress, TokenNetworkID
+from raiden.utils.typing import MYPY_ANNOTATION, InitiatorAddress, PaymentAmount, TokenNetworkID
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -121,7 +121,7 @@ class MessageHandler:
             token_network_id=TokenNetworkID(token_network_address),
             from_address=InitiatorAddress(raiden.address),
             to_address=from_transfer.target,
-            amount=from_transfer.lock.amount,
+            amount=PaymentAmount(from_transfer.lock.amount),  # FIXME: mypy; deprecated by #3863
             previous_address=message.sender,
             config=raiden.config,
             privkey=raiden.privkey,

--- a/raiden/network/discovery.py
+++ b/raiden/network/discovery.py
@@ -72,25 +72,25 @@ class ContractDiscovery(Discovery):
 
         try:
             current_value = self.get(node_address)
+            if current_value == (host, port):
+                log.info(
+                    'endpoint already registered',
+                    node_address=pex(node_address),
+                    host=host,
+                    port=port,
+                )
+                return
         except UnknownAddress:
-            current_value = None
+            pass
 
-        if current_value == (host, port):
-            log.info(
-                'endpoint already registered',
-                node_address=pex(node_address),
-                host=host,
-                port=port,
-            )
-        else:
-            endpoint = host_port_to_endpoint(host, port)
-            self.discovery_proxy.register_endpoint(node_address, endpoint)
-            log.info(
-                'registered endpoint in discovery',
-                node_address=pex(node_address),
-                host=host,
-                port=port,
-            )
+        endpoint = host_port_to_endpoint(host, port)
+        self.discovery_proxy.register_endpoint(node_address, endpoint)
+        log.info(
+            'registered endpoint in discovery',
+            node_address=pex(node_address),
+            host=host,
+            port=port,
+        )
 
     def get(self, node_address: bytes) -> HostPort:
         endpoint = self.discovery_proxy.endpoint_by_address(node_address)

--- a/raiden/network/sockfactory.py
+++ b/raiden/network/sockfactory.py
@@ -6,7 +6,7 @@ import structlog
 
 from raiden.exceptions import RaidenServicePortInUseError, STUNUnavailableException
 from raiden.network import stunsock, upnpsock
-from raiden.utils.typing import Host, Port
+from raiden.utils.typing import Any, Dict, Host, Port
 
 log = structlog.get_logger(__name__)
 
@@ -64,7 +64,7 @@ class SocketFactory:
         self.kwargs = kwargs
         self.method = None
         self.socket = None
-        self.storage = {}
+        self.storage: Dict[str, Any] = {}
 
     def __enter__(self):
         log.debug('Acquiring socket', strategy=self.strategy_description)

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -210,7 +210,7 @@ class GMatrixClient(MatrixClient):
         # dict of 'type': 'content' key/value pairs
         self.account_data: Dict[str, Dict[str, Any]] = dict()
         self._post_hook_func: Optional[Callable[[str], None]] = None
-        self.token = None
+        self.token: Optional[str] = None
 
         super().__init__(
             base_url,
@@ -512,7 +512,7 @@ class GMatrixClient(MatrixClient):
     def set_sync_token(self, sync_token: str) -> None:
         self.sync_token = sync_token
 
-    def set_access_token(self, user_id: str, token: str) -> None:
+    def set_access_token(self, user_id: str, token: Optional[str]) -> None:
         self.user_id = user_id
         self.token = self.api.token = token
 

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -516,7 +516,7 @@ class GMatrixClient(MatrixClient):
         self.user_id = user_id
         self.token = self.api.token = token
 
-    def set_sync_limit(self, limit: int) -> Optional[int]:
+    def set_sync_limit(self, limit: Optional[int]) -> Optional[int]:
         """ Sets the events limit per room for sync and return previous limit """
         try:
             prev_limit = json.loads(self.sync_filter)['room']['timeline']['limit']

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -45,11 +45,11 @@ class Room(MatrixRoom):
                         )
         return list(self._members.values())
 
-    def _mkmembers(self, member):
+    def _mkmembers(self, member: User):
         if member.user_id not in self._members:
             self._members[member.user_id] = member
 
-    def _rmmembers(self, user_id):
+    def _rmmembers(self, user_id: str):
         self._members.pop(user_id, None)
 
     def __repr__(self):

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -700,7 +700,7 @@ class MatrixTransport(Runnable):
         # we join room and _set_room_id_for_address despite room privacy and requirements,
         # _get_room_ids_for_address will take care of returning only matching rooms and
         # _leave_unused_rooms will clear it in the future, if and when needed
-        room: Room = None
+        room: Optional[Room] = None
         last_ex: Optional[Exception] = None
         retry_interval = 0.1
         for _ in range(JOIN_RETRIES):
@@ -716,6 +716,8 @@ class MatrixTransport(Runnable):
         else:
             assert last_ex is not None
             raise last_ex  # re-raise if couldn't succeed in retries
+
+        assert room is not None, f'joining room {room} failed'
 
         if not room.listeners:
             room.add_listener(self._handle_message, 'm.room.message')

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -331,7 +331,7 @@ class MatrixTransport(Runnable):
         self._getroom_lock = Semaphore()
         self._account_data_lock = Semaphore()
 
-        self._message_handler = None
+        self._message_handler: Optional[MessageHandler] = None
 
     def __repr__(self):
         if self._raiden_service is not None:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -341,7 +341,7 @@ class MatrixTransport(Runnable):
 
         return f'<{self.__class__.__name__}{node}>'
 
-    def start(
+    def start(  # type: ignore
             self,
             raiden_service: RaidenService,
             message_handler: MessageHandler,

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -494,7 +494,7 @@ def sort_servers_closest(servers: Sequence[str]) -> Sequence[Tuple[str, float]]:
     return sorted_servers
 
 
-def make_client(servers: Sequence[str], *args, **kwargs) -> GMatrixClient:
+def make_client(servers: List[str], *args, **kwargs) -> GMatrixClient:
     """Given a list of possible servers, chooses the closest available and create a GMatrixClient
 
     Params:
@@ -519,7 +519,6 @@ def make_client(servers: Sequence[str], *args, **kwargs) -> GMatrixClient:
 
     last_ex = None
     for server_url in sorted_servers:
-        server_url: str = server_url
         client = GMatrixClient(server_url, *args, **kwargs)
         try:
             client.api._send('GET', '/versions', api_path='/_matrix/client')

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -354,6 +354,7 @@ def login_or_register(
         prev_user_id or '',
     )
     if _match_user:  # same user as before
+        assert prev_user_id is not None
         log.debug('Trying previous user login', user_id=prev_user_id)
         client.set_access_token(user_id=prev_user_id, token=prev_access_token)
 

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -560,7 +560,7 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
             message_data=data,
             peer_address=pex(peer_address),
         )
-        return False
+        return []
 
     if data.startswith('0x'):
         try:
@@ -574,7 +574,7 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
                 peer_address=pex(peer_address),
                 _exc=ex,
             )
-            return False
+            return []
         except InvalidProtocolMessage as ex:
             log.warning(
                 'Received ToDevice Message binary data is not a valid message',
@@ -582,7 +582,7 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
                 peer_address=pex(peer_address),
                 _exc=ex,
             )
-            return False
+            return []
         else:
             messages.append(message)
 

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -29,7 +29,12 @@ from gevent.lock import Semaphore
 from matrix_client.errors import MatrixError, MatrixRequestError
 
 from raiden.exceptions import InvalidProtocolMessage, InvalidSignature, TransportError
-from raiden.messages import Message, decode as message_from_bytes, from_dict as message_from_dict
+from raiden.messages import (
+    Message,
+    SignedMessage,
+    decode as message_from_bytes,
+    from_dict as message_from_dict,
+)
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.utils import get_http_rtt
 from raiden.utils import pex
@@ -608,6 +613,13 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
                     message_data=line,
                     peer_address=pex(peer_address),
                     _exc=ex,
+                )
+                continue
+            if not isinstance(message, SignedMessage):
+                log.warning(
+                    'ToDevice Message not a SignedMessage!',
+                    message=message,
+                    peer_address=pex(peer_address),
                 )
                 continue
             if message.sender != peer_address:

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -340,8 +340,8 @@ def login_or_register(
     Params:
         client: GMatrixClient instance configured with desired homeserver
         signer: raiden.utils.signer.Signer instance for signing password and displayname
-        prev_user_id: (optional) previous persisted client.user_id. Must match signer's account
-        prev_access_token: (optional) previous persistend client.access_token for prev_user_id
+        prev_user_id: (optional) previously persisted client.user_id. Must match signer's account
+        prev_access_token: (optional) previously persisted client.access_token for prev_user_id
     Returns:
         Own matrix_client.User
     """

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -157,7 +157,7 @@ class UserAddressManager:
         """
         self._userid_to_presence[user.user_id] = presence
 
-    def refresh_address_presence(self, address):
+    def refresh_address_presence(self, address: Address):
         """
         Update synthesized address presence state from cached user presence states.
 

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -212,7 +212,7 @@ class UDPTransport(Runnable):
             spawn=pool,
         )
 
-    def start(
+    def start(  # type: ignore
             self,
             raiden_service: RaidenService,
             message_handler: MessageHandler,

--- a/raiden/network/transport/udp/udp_transport.py
+++ b/raiden/network/transport/udp/udp_transport.py
@@ -11,7 +11,7 @@ from gevent.server import DatagramServer
 from raiden import constants
 from raiden.exceptions import InvalidAddress, InvalidProtocolMessage, UnknownAddress
 from raiden.message_handler import MessageHandler
-from raiden.messages import Delivered, Message, Ping, Pong, decode
+from raiden.messages import Delivered, Message, Ping, Pong, SignedRetrieableMessage, decode
 from raiden.network.transport.udp import healthcheck
 from raiden.network.transport.udp.udp_utils import (
     event_first_of,
@@ -406,7 +406,7 @@ class UDPTransport(Runnable):
     def send_async(
             self,
             queue_identifier: QueueIdentifier,
-            message: Message,
+            message: SignedRetrieableMessage,
     ):
         """ Send a new ordered message to recipient.
 
@@ -539,6 +539,7 @@ class UDPTransport(Runnable):
             assert isinstance(message, Delivered), MYPY_ANNOTATION
             self.receive_delivered(message)
         elif message is not None:
+            assert isinstance(message, SignedRetrieableMessage)
             self.receive_message(message)
         else:
             self.log.warning(
@@ -549,7 +550,7 @@ class UDPTransport(Runnable):
 
         return True
 
-    def receive_message(self, message: Message):
+    def receive_message(self, message: SignedRetrieableMessage):
         """ Handle a Raiden protocol message.
 
         The protocol requires durability of the messages. The UDP transport


### PR DESCRIPTION
Part of #3798

```
# Before
mypy --ignore-missing-imports raiden/network/transport|grep -v raiden.tests|wc -l
15
# After
mypy --ignore-missing-imports raiden/network/transport|grep -v raiden.tests|wc -l
0
```

## Notes for reviewer:
Please especially check the sanity of the commits:
- `Silence mypy`