### PR TITLE
Actually run migrations v21 to v22

### DIFF
--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -13,6 +13,7 @@ from raiden.storage.migrations.v17_to_v18 import upgrade_v17_to_v18
 from raiden.storage.migrations.v18_to_v19 import upgrade_v18_to_v19
 from raiden.storage.migrations.v19_to_v20 import upgrade_v19_to_v20
 from raiden.storage.migrations.v20_to_v21 import upgrade_v20_to_v21
+from raiden.storage.migrations.v21_to_v22 import upgrade_v21_to_v22
 from raiden.storage.sqlite import SQLiteStorage
 from raiden.storage.versions import VERSION_RE, filter_db_names, latest_db_file
 from raiden.utils.typing import Callable, List, NamedTuple
@@ -43,6 +44,10 @@ UPGRADES_LIST = [
     UpgradeRecord(
         from_version=20,
         function=upgrade_v20_to_v21,
+    ),
+    UpgradeRecord(
+        from_version=21,
+        function=upgrade_v21_to_v22,
     ),
 ]
 


### PR DESCRIPTION
The PR #3644 forgot to include the migration in the upgrade manager.

This fixes #3960