### PR TITLE
Properly type account/key operations

### DIFF
--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -34,6 +34,8 @@ from raiden.utils.typing import (
     List,
     Optional,
     Port,
+    PrivateKey,
+    PublicKey,
     Secret,
     T_BlockHash,
     T_BlockNumber,
@@ -117,7 +119,7 @@ def split_endpoint(endpoint: str) -> HostPort:
     return Host(host), returned_port
 
 
-def privatekey_to_publickey(private_key_bin: bytes) -> bytes:
+def privatekey_to_publickey(private_key_bin: PrivateKey) -> PublicKey:
     """ Returns public key in bitcoins 'bin' encoding. """
     if not ishash(private_key_bin):
         raise ValueError('private_key_bin format mismatch. maybe hex encoded?')


### PR DESCRIPTION
Part of #3798 

The `accounts` module follows a "return-value-or-None" pattern, but many functions were typed non-optional. I changed the return types and added asserts to properly support mypy with type inference/checking.

Impact:
```
# Before
mypy --ignore-missing-imports raiden |grep -v raiden.tests |wc -l
55
# After
mypy --ignore-missing-imports raiden |grep -v raiden.tests |wc -l
46
```