### PR TITLE
Fix mypy errors in startup / cli

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -134,7 +134,7 @@ def configure_pfs_or_exit(
         pfs_eth_address: Optional[str],
         routing_mode: RoutingMode,
         service_registry,
-) -> Optional[PFSConfiguration]:
+) -> PFSConfiguration:
     """
     Take in the given pfs_address argument, the service registry and find out a
     pfs address to use.
@@ -146,11 +146,8 @@ def configure_pfs_or_exit(
     Returns a NamedTuple containing url, eth_address and fee (per paths request) of
     the selected PFS, or None if we use basic routing instead of a PFS.
     """
-    if routing_mode == RoutingMode.BASIC:
-        msg = 'Not using path finding services, falling back to basic routing.'
-        log.info(msg)
-        click.secho(msg)
-        return None
+    msg = 'Invalid code path; configure pfs needs routing mode PFS'
+    assert routing_mode == RoutingMode.PFS, msg
 
     msg = "With PFS routing mode we shouldn't get to configure pfs with pfs_address being None"
     assert pfs_address, msg

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -73,14 +73,14 @@ def test_configure_pfs(
     response.configure_mock(status_code=200)
     response.json = Mock(return_value=json_data)
 
-    # With basic routing configure pfs should return None
-    config = configure_pfs_or_exit(
-        pfs_address=None,
-        pfs_eth_address=None,
-        routing_mode=RoutingMode.BASIC,
-        service_registry=service_proxy,
-    )
-    assert config is None
+    # With basic routing configure pfs should raise assertion
+    with pytest.raises(AssertionError):
+        config = configure_pfs_or_exit(
+            pfs_address=None,
+            pfs_eth_address=None,
+            routing_mode=RoutingMode.BASIC,
+            service_registry=service_proxy,
+        )
 
     # Asking for auto address
     with patch.object(requests, 'get', return_value=response):

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -592,9 +592,12 @@ def smoketest(ctx, debug, eth_client):
         with open(report_file, 'a', encoding='UTF-8') as handler:
             handler.write(f'{f" {subject.upper()} ":=^80}{os.linesep}')
             if data is not None:
+                write_data: str
                 if isinstance(data, bytes):
-                    data = data.decode()
-                handler.writelines([data + os.linesep])
+                    write_data = data.decode()
+                else:
+                    write_data = data
+                handler.writelines([write_data + os.linesep])
 
     append_report('Raiden version', json.dumps(get_system_spec()))
     append_report('Raiden log')

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -168,11 +168,11 @@ class Proxies(NamedTuple):
 
 def setup_proxies_or_exit(
         config: Dict[str, Any],
-        tokennetwork_registry_contract_address: str,
-        secret_registry_contract_address: str,
-        endpoint_registry_contract_address: str,
-        user_deposit_contract_address: str,
-        service_registry_contract_address: str,
+        tokennetwork_registry_contract_address: Address,
+        secret_registry_contract_address: Address,
+        endpoint_registry_contract_address: Address,
+        user_deposit_contract_address: Address,
+        service_registry_contract_address: Address,
         blockchain_service: BlockChainService,
         contracts: Dict[str, Any],
         routing_mode: RoutingMode,
@@ -207,11 +207,14 @@ def setup_proxies_or_exit(
         sys.exit(1)
 
     try:
-        token_network_registry = blockchain_service.token_network_registry(
-            tokennetwork_registry_contract_address or to_canonical_address(
+        registered_address: Address
+        if tokennetwork_registry_contract_address is not None:
+            registered_address = Address(tokennetwork_registry_contract_address)
+        else:
+            registered_address = to_canonical_address(
                 contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]['address'],
-            ),
-        )
+            )
+        token_network_registry = blockchain_service.token_network_registry(registered_address)
     except ContractVersionMismatch as e:
         handle_contract_version_mismatch(e)
     except AddressWithoutCode:

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -128,7 +128,7 @@ def setup_contracts_or_exit(
                 version=contracts_version,
             )
         except ValueError:
-            return contracts, False
+            return contracts
 
         contracts = deployment_data['contracts']
 

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -116,7 +116,7 @@ def setup_contracts_or_exit(
         )
         sys.exit(1)
 
-    contracts = dict()
+    contracts: Dict[str, Any] = dict()
     contracts_version = environment_type_to_contracts_version(environment_type)
 
     config['contracts_path'] = contracts_precompiled_path(contracts_version)

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -3,16 +3,16 @@ import os
 import re
 import string
 import sys
-from enum import Enum
+from enum import EnumMeta
 from ipaddress import AddressValueError, IPv4Address
 from itertools import groupby
 from pathlib import Path
 from string import Template
-from typing import Any, Callable, Dict, List, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import click
 import requests
-from click import BadParameter
+from click import BadParameter, Choice
 from click._compat import term_len
 from click.formatting import iter_rows, measure_table, wrap_text
 from eth_utils import is_checksum_address
@@ -24,8 +24,6 @@ from raiden.utils import address_checksum_and_decode
 from raiden_contracts.constants import NETWORKNAME_TO_ID
 
 LOG_CONFIG_OPTION_NAME = 'log_config'
-
-T_Enum = TypeVar('T_Enum', bound=Enum)
 
 
 class HelpFormatter(click.HelpFormatter):
@@ -276,10 +274,14 @@ class NetworkChoiceType(click.Choice):
             return NETWORKNAME_TO_ID[network_name]
 
 
-class EnumChoiceType(click.Choice):
-    def __init__(self, enum_type: T_Enum, case_sensitive=True):
+class EnumChoiceType(Choice):
+    def __init__(self, enum_type: EnumMeta, case_sensitive=True):
         self._enum_type = enum_type
-        super().__init__([choice.value for choice in enum_type], case_sensitive)
+        # https://github.com/python/typeshed/issues/2942
+        super().__init__(  # type: ignore
+            [choice.value for choice in enum_type],  # type: ignore
+            case_sensitive=case_sensitive,
+        )
 
     def convert(self, value, param, ctx):
         try:

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -376,7 +376,10 @@ def apply_config_file(
         # Silently ignore if 'file not found' and the config file path is the default
         config_file_param = paramname_to_param[config_file_option_name]
         config_file_default_path = Path(
-            config_file_param.type.expand_default(config_file_param.get_default(ctx), cli_params),
+            config_file_param.type.expand_default(  # type: ignore
+                config_file_param.get_default(ctx),
+                cli_params,
+            ),
         )
         default_config_missing = (
             ex.errno == errno.ENOENT and

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -368,7 +368,7 @@ def apply_config_file(
     }
 
     config_file_path = Path(cli_params[config_file_option_name])
-    config_file_values = dict()
+    config_file_values: Dict[str, Any] = dict()
     try:
         with config_file_path.open() as config_file:
             config_file_values = load(config_file)


### PR DESCRIPTION
Part of #3798 
```
# Before
mypy --ignore-missing-imports raiden |grep -v raiden.tests|grep -v transport|wc -l
32
# After
mypy --ignore-missing-imports raiden |grep -v raiden.tests|grep -v transport|wc -l
6
```