### PR TITLE
Fix for settle blockchain event handler

### DIFF
--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -46,11 +46,35 @@ def get_onchain_locksroots(
     participant2: Address,
     block_identifier: BlockSpecification,
 ) -> Tuple[Locksroot, Locksroot]:
-    """Return the locksroot for `participant1` and `participant2` at `block_identifier`."""
+    """Return the locksroot for `participant1` and `participant2` at
+    `block_identifier`.
+
+    This is resolving a corner case where the current node view of the channel
+    state does not reflect what the blockchain contains. E.g. for a channel
+    A->B:
+
+    - A sends a LockedTransfer to B
+    - B sends a Refund to A
+    - B goes offline
+    - A sends a LockExpired to B
+      Here:
+      (1) the lock is removed from A's state
+      (2) B never received the message
+    - A closes the channel with B's refund
+    - Here a few things may happen:
+      (1) B never cames back online, and updateTransfer is never called.
+      (2) B is using monitoring services, which use the known LockExpired
+          balance proof.
+      (3) B cames back online and aclls updateTransfer with the LockExpired
+          message (For some transports B will never receive the LockExpired message
+          because the channel is closed already, and message retries may be
+          disabled).
+    - When channel is settled A must query the blockchain to figure out which
+      locksroot was used.
+    """
     payment_channel = chain.payment_channel(canonical_identifier=canonical_identifier)
     token_network = payment_channel.token_network
 
-    # This will not raise RaidenRecoverableError because we are providing the channel_identifier
     participants_details = token_network.detail_participants(
         participant1=participant1,
         participant2=participant2,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -153,10 +153,8 @@ def run_test_lock_expiry(raiden_network, token_addresses, deposit):
         views.state_from_app(alice_app), alice_app.raiden.default_registry.address, token_address
     )
 
-    hold_event_handler = HoldOffChainSecretRequest()
-    wait_message_handler = WaitForMessage()
-    bob_app.raiden.message_handler = wait_message_handler
-    bob_app.raiden.raiden_event_handler = hold_event_handler
+    hold_event_handler = bob_app.raiden.raiden_event_handler
+    wait_message_handler = bob_app.raiden.message_handler
 
     token_network = views.get_token_network_by_identifier(
         views.state_from_app(alice_app), token_network_identifier

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -1,0 +1,107 @@
+import pytest
+
+from raiden import waiting
+from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.tests.utils.events import wait_for_state_change
+from raiden.tests.utils.transfer import TransferState, get_channelstate, transfer
+from raiden.transfer import views
+from raiden.transfer.state_change import ContractReceiveChannelSettled
+
+pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
+
+# set very low values to force the client to prune old state
+STATE_PRUNNING = {
+    "pruning": "fast",
+    "pruning-history": 1,
+    "pruning-memory": 1,
+    "cache-size-db": 1,
+    "cache-size-blocks": 1,
+    "cache-size-queue": 1,
+    "cache-size": 1,
+}
+
+
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNNING])
+def test_locksroot_loading_during_channel_settle_handling(raiden_chain, token_addresses):
+    raise_on_failure(
+        raiden_chain,
+        run_test_locksroot_loading_during_channel_settle_handling,
+        raiden_chain=raiden_chain,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_locksroot_loading_during_channel_settle_handling(raiden_chain, token_addresses):
+    app0, app1 = raiden_chain
+    payment_network_id = app0.raiden.default_registry.address
+    token_address = token_addresses[0]
+
+    transfer(
+        initiator_app=app0,
+        target_app=app1,
+        token_address=token_address,
+        amount=10,
+        identifier=1,
+        transfer_state=TransferState.SECRET_NOT_REQUESTED,
+    )
+    transfer(
+        initiator_app=app1,
+        target_app=app0,
+        token_address=token_address,
+        amount=7,
+        identifier=2,
+        transfer_state=TransferState.SECRET_NOT_REQUESTED,
+    )
+
+    token_network_identifier = views.get_token_network_identifier_by_token_address(
+        chain_state=views.state_from_raiden(app0.raiden),
+        payment_network_id=payment_network_id,
+        token_address=token_address,
+    )
+    channel_state = get_channelstate(
+        app0=app0, app1=app1, token_network_identifier=token_network_identifier
+    )
+
+    channel = app0.raiden.chain.payment_channel(channel_state.canonical_identifier)
+    balance_proof = channel_state.partner_state.balance_proof
+    block_number = app0.raiden.chain.block_number()
+
+    channel.close(
+        nonce=balance_proof.nonce,
+        balance_hash=balance_proof.balance_hash,
+        additional_hash=balance_proof.message_hash,
+        signature=balance_proof.signature,
+        block_identifier=block_number,
+    )
+
+    app0.stop()
+
+    waiting.wait_for_settle(
+        raiden=app1.raiden,
+        payment_network_id=payment_network_id,
+        token_address=token_address,
+        channel_ids=[channel_state.canonical_identifier.channel_identifier],
+        retry_timeout=1,
+    )
+
+    # The private chain used for tests has a very low pruning setting
+    pruned_after_blocks = 10
+    close_event_pruned_at = app1.raiden.chain.get_block_number() + pruned_after_blocks
+    waiting.wait_for_block(raiden=app1.raiden, block_number=close_event_pruned_at, retry_timeout=1)
+
+    # make sure the block was pruned
+    with pytest.raises(ValueError, match="pruned"):
+        channel = app0.raiden.chain.payment_channel(channel_state.canonical_identifier)
+        channel.detail(block_identifier=close_event_pruned_at)
+
+    # This must not raise when the settle event is being raised and the
+    # locksroot is being recover (#3856)
+    app0.start()
+
+    assert wait_for_state_change(
+        raiden=app0.raiden,
+        item_type=ContractReceiveChannelSettled,
+        attributes={"canonical_identifier": channel_state.canonical_identifier},
+        retry_timeout=1,
+    )

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -10,11 +10,10 @@ from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.throttle import TokenBucket
 from raiden.network.transport import MatrixTransport, UDPTransport
-from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, DEFAULT_RETRY_TIMEOUT
 from raiden.tests.utils.app import database_from_privatekey
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
-from raiden.tests.utils.protocol import WaitForMessage
+from raiden.tests.utils.protocol import HoldRaidenEvent, WaitForMessage
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.views import state_from_raiden
 from raiden.utils import merge_dict, pex
@@ -371,7 +370,7 @@ def create_apps(
                 config["transport"]["udp"],
             )
 
-        raiden_event_handler = RaidenEventHandler()
+        raiden_event_handler = HoldRaidenEvent()
         message_handler = WaitForMessage()
 
         app = App(

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -13,10 +13,7 @@ from raiden.tests.utils.factories import make_address, make_secret
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.transfer import channel, views
 from raiden.transfer.mediated_transfer.events import SendSecretRequest
-from raiden.transfer.mediated_transfer.state import (
-    LockedTransferSignedState,
-    lockedtransfersigned_from_message,
-)
+from raiden.transfer.mediated_transfer.state import LockedTransferSignedState
 from raiden.transfer.mediated_transfer.state_change import ReceiveLockExpired
 from raiden.transfer.merkle_tree import MERKLEROOT, compute_layers
 from raiden.transfer.state import (
@@ -229,10 +226,10 @@ def _transfer_secret_not_requested(
         timeout = 10
 
     secret = make_secret()
-    secret_hash = sha3(secret)
+    secrethash = sha3(secret)
 
     hold_secret_request = target_app.raiden.raiden_event_handler.hold(
-        SendSecretRequest, {"secrethash": secret_hash}
+        SendSecretRequest, {"secrethash": secrethash}
     )
 
     payment_network_identifier = initiator_app.raiden.default_registry.address
@@ -248,7 +245,7 @@ def _transfer_secret_not_requested(
         target=target_app.raiden.address,
         identifier=identifier,
         secret=secret,
-        secret_hash=secret_hash,
+        secrethash=secrethash,
     )
 
     with Timeout(seconds=timeout):


### PR DESCRIPTION
~Merge after #3961~

    Handle pruned data on channel settle event

    The handler for the channel settle blockchain event may be
    executed long after the event happened. This may lead to errors because
    the node has to query the blockchain to recover th locksroot, and by
    default it uses the block at which the event was emitted.

    This adds a exception handler which just retries the query using the
    latest block. The rationale is that it is preferrable to have the
    contract receive channel settle with the correct data, which is
    available at the block in which settle was called. However, there is no
    risk of loss of funds if the data is not recovered, so in order to
    continue the node's operation if the emitting block was pruned, then a
    new query is done using latest.

Fixes #3856 . 