### PR TITLE
Mypy last codebase fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,28 +48,9 @@ lint:
 	isort $(ISORT_PARAMS) --diff --check-only
 	pylint --load-plugins=tools.pylint.gevent_checker --rcfile .pylint.rc $(LINT_PATHS)
 	python setup.py check --restructuredtext --strict
+	mypy raiden --ignore-missing-imports
 
-	mypy raiden/transfer raiden/messages.py raiden/encoding raiden/api raiden/network --ignore-missing-imports
-
-	# We are starting small with a few files and directories here,
-	# but mypy should run on the whole codebase soon.
-	mypy raiden/api raiden/blockchain raiden/storage raiden/network \
-	--ignore-missing-imports | grep error > mypy-out.txt || true
-	# Expecting status code 1 from `grep`, which indicates no match.
-	# Again, we are starting small, detecting only errors related to
-	# 'BlockNumber', 'Address', 'ChannelID' etc, but all mypy errors should be
-	# detected soon.
-	grep BlockNumber mypy-out.txt; [ $$? -eq 1 ]
-	grep Address mypy-out.txt; [ $$? -eq 1 ]
-	grep 'Item "None" of' mypy-out.txt; [ $$? -eq 1 ]
-	grep ChannelID mypy-out.txt; [ $$? -eq 1 ]
-	grep BalanceProof mypy-out.txt; [ $$? -eq 1 ]
-	grep SendSecret mypy-out.txt; [ $$? -eq 1 ]
-	grep NetworkTimeout mypy-out.txt; [ $$? -eq 1 ]
-	grep Nonce mypy-out.txt; [ $$? -eq 1 ]
-	grep Locksroot mypy-out.txt; [ $$? -eq 1 ]
-	grep TransactionHash mypy-out.txt; [ $$? -eq 1 ]
-	grep TokenNetwork mypy-out.txt; [ $$? -eq 1 ]
+	# Be aware, that we currently ignore all mypy errors in `raiden.tests.*` through `setup.cfg`.
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ lint:
 	mypy raiden --ignore-missing-imports
 
 	# Be aware, that we currently ignore all mypy errors in `raiden.tests.*` through `setup.cfg`.
+	# Remaining errors in tests:
+	mypy --config-file /dev/null raiden --ignore-missing-imports|grep error|wc -l
 
 isort:
 	isort $(ISORT_PARAMS)

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -30,6 +30,7 @@ from raiden.settings import (
     RED_EYES_CONTRACT_VERSION,
 )
 from raiden.utils import pex, typing
+from raiden.utils.typing import Any, Dict
 from raiden_contracts.contract_manager import contracts_precompiled_path
 
 log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
@@ -136,7 +137,7 @@ class App:  # pylint: disable=too-few-public-methods
 
         # raiden.ui.console:Console assumes that a services
         # attribute is available for auto-registration
-        self.services = dict()
+        self.services: Dict[str, Any] = dict()
 
     def __repr__(self):
         return '<{} {}>'.format(

--- a/raiden/utils/smart_contracts.py
+++ b/raiden/utils/smart_contracts.py
@@ -1,7 +1,7 @@
 from eth_utils import to_canonical_address
 
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.utils.typing import Address, Any, Tuple
+from raiden.utils.typing import ABI, Address, Any, Tuple
 from raiden_contracts.contract_manager import ContractManager
 
 
@@ -9,10 +9,10 @@ def deploy_contract_web3(
         contract_name: str,
         deploy_client: JSONRPCClient,
         contract_manager: ContractManager,
-        constructor_arguments: Tuple[Any, ...] = (),
+        constructor_arguments: Tuple[Any] = None,
 ) -> Address:
     compiled = {
-        contract_name: contract_manager.get_contract(contract_name),
+        contract_name: ABI(contract_manager.get_contract(contract_name)),
     }
     contract_proxy, _ = deploy_client.deploy_solidity_contract(
         contract_name=contract_name,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,3 +36,6 @@ norecursedirs = node_modules
 filterwarnings =
     ignore::gevent.monkey.MonkeyPatchWarning
     ignore::urllib3.exceptions.InsecureRequestWarning
+
+[mypy-raiden.tests.*]
+ignore_errors = True


### PR DESCRIPTION
Part of #3798

This fixes the remaining 3 mypy errors in the main codebase, yay!
This also enables `mypy raiden --ignore-missing-imports` in `make lint`.
Note however, that there are still `~301` remaining errors in the tests.