### PR TITLE
Fixed data races on node state

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -352,6 +352,8 @@ def handle_channel_settled(raiden: 'RaidenService', event: Event):
 
 
 def handle_channel_batch_unlock(raiden: 'RaidenService', event: Event):
+    assert raiden.wal, 'The Raiden Service must be initialize to handle events'
+
     token_network_identifier = event.originating_contract
     data = event.event_data
     args = data['args']

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -366,6 +366,8 @@ class RaidenEventHandler:
             chain_state: ChainState,
             channel_unlock_event: ContractSendChannelBatchUnlock,
     ):
+        assert raiden.wal, 'The Raiden Service must be initialize to handle events'
+
         canonical_identifier = channel_unlock_event.canonical_identifier
         token_network_identifier = canonical_identifier.token_network_address
         channel_identifier = canonical_identifier.channel_identifier
@@ -504,6 +506,8 @@ class RaidenEventHandler:
             raiden: 'RaidenService',
             channel_settle_event: ContractSendChannelSettle,
     ):
+        assert raiden.wal, 'The Raiden Service must be initialize to handle events'
+
         canonical_identifier = CanonicalIdentifier(
             chain_identifier=raiden.chain.network_id,
             token_network_address=channel_settle_event.token_network_identifier,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -864,7 +864,11 @@ class RaidenService(Runnable):
 
         for transaction in pending_transactions:
             try:
-                self.raiden_event_handler.on_raiden_event(self, transaction)
+                self.raiden_event_handler.on_raiden_event(
+                    raiden=self,
+                    chain_state=chain_state,
+                    event=transaction,
+                )
             except RaidenRecoverableError as e:
                 log.error(str(e))
             except InvalidDBData:

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,10 +1,9 @@
 from raiden.exceptions import RaidenUnrecoverableError
+from raiden.storage.wal import restore_to_state_change
 from raiden.transfer import node, views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import NettingChannelState
 from raiden.utils import typing
-
-from .wal import restore_to_state_change
 
 
 def channel_state_until_state_change(

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -4,11 +4,10 @@ from contextlib import contextmanager
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
+from raiden.storage.serialize import SerializationBase
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.utils import get_system_spec
 from raiden.utils.typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union
-
-from .serialize import SerializationBase
 
 
 class EventRecord(NamedTuple):
@@ -63,7 +62,7 @@ def _filter_from_dict(current: Dict[str, Any]) -> Dict[str, Any]:
     return filter_
 
 
-class SQLiteStorage(SerializationBase):
+class SQLiteStorage:
     def __init__(self, database_path):
         conn = sqlite3.connect(database_path, detect_types=sqlite3.PARSE_DECLTYPES)
         conn.text_factory = str

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -619,7 +619,12 @@ def run_test_secret_revealed_on_chain(
         balance_proof=channel_state2_1.partner_state.balance_proof,
         triggered_by_block_hash=app0.raiden.chain.block_hash(),
     )
-    app2.raiden.raiden_event_handler.on_raiden_event(app2.raiden, channel_close_event)
+    current_state = app2.raiden.wal.state_manager.current_state
+    app2.raiden.raiden_event_handler.on_raiden_event(
+        raiden=app2.raiden,
+        chain_state=current_state,
+        event=channel_close_event,
+    )
 
     settle_expiration = (
         app0.raiden.chain.block_number() +

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -90,4 +90,8 @@ def test_handle_contract_send_channelunlock_already_unlocked():
     )
 
     # This should not throw an unrecoverable error
-    RaidenEventHandler().on_raiden_event(raiden=raiden, event=event)
+    RaidenEventHandler().on_raiden_event(
+        raiden=raiden,
+        chain_state=raiden.wal.state_manager.current_state,
+        event=event,
+    )

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -16,8 +16,12 @@ from raiden.transfer.state_change import Block, ContractReceiveChannelBatchUnloc
 from raiden.utils import sha3
 
 
+class Empty(State):
+    pass
+
+
 def state_transition_noop(state, state_change):  # pylint: disable=unused-argument
-    return TransitionResult(state, list())
+    return TransitionResult(Empty(), list())
 
 
 class AccState(State):
@@ -42,8 +46,7 @@ def state_transtion_acc(state, state_change):
     return TransitionResult(state, list())
 
 
-def new_wal(state_transition):
-    state = None
+def new_wal(state_transition, state=None):
     serializer = JSONSerializer
 
     state_manager = StateManager(state_transition, state)

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -336,6 +336,8 @@ def wait_for_transfer_success(
     Note:
         This does not time out, use gevent.Timeout.
     """
+    assert raiden.wal, 'The Raiden Service must be initialize to handle events'
+
     found = False
     while not found:
         state_events = raiden.wal.storage.get_events()


### PR DESCRIPTION
The event handler for a ContractSendChannelBatchUnlock needs to load the
channel's data from the ChainState. However the event handler and the
state change dispatch are /not/ synchronized, meaning that once the
event handler has a chance to run other events may have been processed
meanwhile.

Consider this:

- Node A process the contract receive channel settled event, as a
  side-effect it produces a contract send batch unlock to unlock the
  only pending merkle tree (say from A->B). This event is then added to
  a queue of raiden events to be processed (currently the queue is not
  explicit, but it exisits in the form of multiple greenlets waiting to
  be executed). This means the processing of the event may take a while.
- At the same time Node B process the same event, and it too decides to
  unlock the merkle tree.
- Now, assume that node A is under heavy cpu load, whereas node B has
  plenty of computational resources available, additionally B has an
  agreesive gas price setting, used to mine transactions faster. If it
  takes B `n` blocks to process the settle event, send the unlock
  transaction, and for the transaction to be mined, this is the maximum
  amount of time that A may take to process its send batch unlock.
  Otherwise once A starts processing the send batch unlock, the channel
  may have been removed already.

This may be a bit unlikely, but it's a possible race condition. Restarts
don't have a problem with this because the batch unlock would be
cleared from the pending transaction queue during start up and it would
never be sent.