### PR TITLE
Reintroduced psutils based port generator

### DIFF
--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -1,67 +1,85 @@
 import errno
 import socket
+import sys
 from contextlib import closing
 from itertools import count, repeat
 from socket import SocketKind
 from time import sleep
-from typing import Optional
 
+import psutil
 import requests
 from requests import RequestException
 
+from raiden.utils.typing import Iterable, Optional, Port
 
-def get_free_port(
-        initial_port: int = 0,
-        socket_kind: SocketKind = SocketKind.SOCK_STREAM,
-        reliable: bool = True,
-):
-    """
-    Find an unused TCP port.
+LOOPBACK = '127.0.0.1'
 
-    Unless the `reliable` parameter is set to `True` (the default) this is prone to race
-    conditions - some other process may grab the port before the caller of this function has
-    a chance to use it.
-    When using `reliable` the port is forced into TIME_WAIT mode, ensuring that it will not be
-    considered 'free' by the OS for the next 60 seconds. This does however require that the
-    process using the port sets SO_REUSEADDR on it's sockets. Most 'server' applications do.
+# The solution based on psutils does not work on MacOS because it needs
+# root access
+if sys.platform == 'darwin':
+    def _unused_ports(initial_port: Optional[int]) -> Iterable[Port]:
+        socket_kind: SocketKind = SocketKind.SOCK_STREAM
+
+        if not initial_port:
+            next_port = repeat(0)
+        else:
+            next_port = count(start=initial_port)
+
+        for port_candidate in next_port:
+            # Don't inline the variable until
+            # https://github.com/PyCQA/pylint/issues/1437 is fixed
+            sock = socket.socket(socket.AF_INET, socket_kind)
+            with closing(sock):
+                # Force the port into TIME_WAIT mode, ensuring that it will not
+                # be considered 'free' by the OS for the next 60 seconds. This
+                # does however require that the process using the port sets
+                # SO_REUSEADDR on it's sockets. Most 'server' applications do.
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                try:
+                    sock.bind((LOOPBACK, port_candidate))
+                except OSError as ex:
+                    if ex.errno == errno.EADDRINUSE:
+                        continue
+                    raise
+
+                sock_addr = sock.getsockname()
+                port = sock_addr[1]
+
+                # Connect to the socket to force it into TIME_WAIT state (see
+                # above)
+                sock.listen(1)
+                sock2 = socket.socket(socket.AF_INET, socket_kind)
+                with closing(sock2):
+                    sock2.connect(sock_addr)
+                    sock.accept()
+
+            yield Port(port)
+else:
+    def _unused_ports(initial_port: Optional[int]) -> Iterable[Port]:
+        initial_port = initial_port or 27854
+
+        for port in count(initial_port):
+            connect_using_port = (
+                conn
+                for conn in psutil.net_connections()
+                if hasattr(conn, 'laddr') and
+                conn.laddr[0] == LOOPBACK and
+                conn.laddr[1] == port
+            )
+
+            if not any(connect_using_port):
+                yield Port(port)
+
+
+def get_free_port(initial_port: Optional[int] = None) -> Iterable[Port]:
+    """Find an unused TCP port.
 
     If `initial_port` is passed the function will try to find a port as close as possible.
     Otherwise a random port is chosen by the OS.
 
     Returns an iterator that will return unused port numbers.
     """
-
-    def _port_generator():
-        if initial_port == 0:
-            next_port = repeat(0)
-        else:
-            next_port = count(start=initial_port)
-
-        for port_candidate in next_port:
-            # Don't inline the variable until https://github.com/PyCQA/pylint/issues/1437 is fixed
-            sock = socket.socket(socket.AF_INET, socket_kind)
-            with closing(sock):
-                if reliable:
-                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                try:
-                    sock.bind(('127.0.0.1', port_candidate))
-                except OSError as ex:
-                    if ex.errno == errno.EADDRINUSE:
-                        continue
-
-                sock_addr = sock.getsockname()
-                port = sock_addr[1]
-
-                if reliable:
-                    # Connect to the socket to force it into TIME_WAIT state
-                    sock.listen(1)
-                    # see above
-                    sock2 = socket.socket(socket.AF_INET, socket_kind)
-                    with closing(sock2):
-                        sock2.connect(sock_addr)
-                        sock.accept()
-            yield port
-    return _port_generator()
+    return _unused_ports(initial_port=initial_port)
 
 
 def get_http_rtt(

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -59,11 +59,11 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        '--synapse-base-port',
+        '--base-port',
         action='store',
         default=8500,
         type='int',
-        help='Base port number to use for synapse servers being started during Matrix tests.',
+        help='Base port number to use for tests.',
     )
 
 

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -263,9 +263,9 @@ def blockchain_private_keys(blockchain_number_of_nodes, blockchain_key_seed):
 
 
 @pytest.fixture(scope='session')
-def port_generator():
+def port_generator(request):
     """ count generator used to get a unique port number. """
-    return get_free_port()
+    return get_free_port(request.config.getoption('base_port'))
 
 
 @pytest.fixture

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -11,9 +11,15 @@ from raiden.tests.utils.smoketest import setup_raiden, setup_testchain
 
 
 @pytest.fixture(scope='session')
-def testchain_provider(blockchain_type):
+def testchain_provider(blockchain_type, port_generator):
     eth_client = EthClient(blockchain_type)
-    with setup_testchain(eth_client=eth_client, print_step=lambda x: None) as testchain:
+    chain_manager = setup_testchain(
+        eth_client=eth_client,
+        print_step=lambda x: None,
+        free_port_generator=port_generator,
+    )
+
+    with chain_manager as testchain:
         yield testchain
 
 

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -29,16 +29,17 @@ def local_matrix_servers(
         transport_protocol,
         matrix_server_count,
         synapse_config_generator,
+        port_generator,
 ):
     if transport_protocol is not TransportProtocol.MATRIX:
         yield [None]
         return
 
     starter = matrix_server_starter(
+        free_port_generator=port_generator,
         count=matrix_server_count,
         config_generator=synapse_config_generator,
         log_context=request.node.name,
-        initial_port=request.config.getoption('synapse_base_port'),
     )
     with starter as server_urls:
         yield server_urls

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -9,13 +9,12 @@ from contextlib import ExitStack, contextmanager
 from datetime import datetime
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import ContextManager
+from typing import ContextManager, Iterator
 from urllib.parse import urljoin, urlsplit
 
 import requests
 from twisted.internet import defer
 
-from raiden.network.utils import get_free_port
 from raiden.utils.http import HTTPExecutor
 from raiden.utils.signer import recover
 
@@ -177,17 +176,17 @@ def generate_synapse_config() -> ContextManager:
 
 @contextmanager
 def matrix_server_starter(
+        free_port_generator: Iterator[int],
         *,
         count: int = 1,
         config_generator: ContextManager = None,
         log_context: str = None,
-        initial_port: int = 8500,
 ) -> ContextManager:
     with ExitStack() as exit_stack:
         if config_generator is None:
             config_generator = exit_stack.enter_context(generate_synapse_config())
         server_urls = []
-        for _, port in zip(range(count), get_free_port(initial_port=initial_port)):
+        for _, port in zip(range(count), free_port_generator):
             server_name, config_file = config_generator(port)
             server_url = ParsedURL(f'https://{server_name}')
             server_urls.append(server_url)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -555,10 +555,12 @@ def version(short):
     if short:
         print(get_system_spec()['raiden'])
     else:
-        print(json.dumps(
-            get_system_spec(),
-            indent=2,
-        ))
+        print(
+            json.dumps(
+                get_system_spec(),
+                indent=2,
+            ),
+        )
 
 
 @run.command()
@@ -586,6 +588,7 @@ def smoketest(ctx, debug, eth_client):
         log_file=report_file,
         disable_debug_logfile=ctx.parent.params['disable_debug_logfile'],
     )
+    free_port_generator = get_free_port()
     click.secho(f'Report file: {report_file}', fg='yellow')
 
     def append_report(subject: str, data: Optional[AnyStr] = None):
@@ -631,6 +634,7 @@ def smoketest(ctx, debug, eth_client):
             matrix_server=ctx.parent.params['matrix_server'],
             contracts_version=contracts_version,
             print_step=print_step,
+            free_port_generator=free_port_generator,
     ) as result:
         args = result['args']
         contract_addresses = result['contract_addresses']
@@ -644,7 +648,7 @@ def smoketest(ctx, debug, eth_client):
             else:
                 args[option_.name] = option_.default
 
-        port = next(get_free_port(5001))
+        port = next(free_port_generator)
 
         args['api_address'] = 'localhost:' + str(port)
 
@@ -664,7 +668,7 @@ def smoketest(ctx, debug, eth_client):
             args['mapped_socket'] = None
             print_step('Starting Matrix transport')
             try:
-                with matrix_server_starter() as server_urls:
+                with matrix_server_starter(free_port_generator=free_port_generator) as server_urls:
                     # Disable TLS verification so we can connect to the self signed certificate
                     make_requests_insecure()
                     urllib3.disable_warnings(InsecureRequestWarning)

--- a/tools/parallel_tests.sh
+++ b/tools/parallel_tests.sh
@@ -21,7 +21,7 @@ alltest=${tmpdir}/all_test
 output=${tmpdir}/sessions
 logs=${tmpdir}/logs
 session_prefixes="${output}/raiden-tests"
-synapse_base_port=10500
+base_port=10500
 
 echo "Tests files located at ${tmpdir}"
 
@@ -50,7 +50,7 @@ if (type tmux &> /dev/null); then
             args+=(split-window)
         fi
         logfile=$(basename ${f})
-        args+=("pytest raiden/tests --select-from-file ${f} -v --color yes --synapse-base-port $(( ${synapse_base_port} + ( ${idx} * 1000) )) | tee ${logs}/${logfile}; echo 'Ctrl-C to exit'; read")
+        args+=("pytest raiden/tests --select-from-file ${f} -v --color yes --base-port $(( ${base_port} + ( ${idx} * 1000) )) | tee ${logs}/${logfile}; echo 'Ctrl-C to exit'; read")
         args+=(";")
         args+=("select-layout" "${LAYOUT}" ";")
         idx=$(( $idx + 1 ))
@@ -66,7 +66,7 @@ else
     idx=0
     for f in ${session_prefixes}*; do
         logfile=$(basename ${f})
-        pytest raiden/tests --select-from-file ${f} -v --synapse-base-port $(( ${synapse_base_port} + ( ${idx} * 1000) )) > ${logs}/${logfile} &
+        pytest raiden/tests --select-from-file ${f} -v --base-port $(( ${base_port} + ( ${idx} * 1000) )) > ${logs}/${logfile} &
         idx=$(( $idx + 1 ))
     done
     wait  # wait for all tests to run


### PR DESCRIPTION
psutils cannot be used for mac, however it works reliably in the CI
system. The solution based on socket bind/TIME_WAIT is flaky and leads
to multiple build failures a day. This adds back the psutils for
non-macos systems only, the goal is to decrease the number of flaky
build failures.

Note: The problem may persist for MacOS systems, since SO_REUSEADDR
behaves differently across Unixes, ref:

https://stackoverflow.com/questions/14388706/socket-options-so-reuseaddr-and-so-reuseport-how-do-they-differ-do-they-mean-t