### PR TITLE
Make sure isort and black do not interfere

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,11 +10,14 @@ max-line-length = 99
 [isort]
 line_length=99
 known_future_library=future
-multi_line_output=3
 known_first_party=raiden,raiden_contracts,scenario_player
-include_trailing_comma=1
 default_section=THIRDPARTY
 combine_as_imports=1
+# black compatibility
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
While rebasing some PRs I noticed some interaction between `black` and `isort`. 

According to https://black.readthedocs.io/en/stable/the_black_code_style.html#how-black-wraps-lines (end of section, "a compatible isort.cfg"), these settings should keep the tools happier together.