### PR TITLE
Add docker hub build trigger to nightly workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,6 +641,9 @@ jobs:
             twine upload -u $PYPI_USER -p $PYPI_PASSWORD dist/*.{tar.gz,whl}
 
   build-nightly-image:
+    executor:
+      name: machine
+
     steps:
       - run:
           name: Trigger nightly automated build on Docker Hub.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,7 +644,7 @@ jobs:
     steps:
       - run:
           name: Trigger nightly automated build on Docker Hub.
-          command: curl -h --data docker_tag=nightly -X POST ${NIGHTLY_BUILD_TRIGGER}
+          command: curl -H "Content-Type: application/json" --data '{"docker_tag":"nightly"}' -X POST ${NIGHTLY_BUILD_TRIGGER}
 
 workflows:
   raiden-default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,7 +642,7 @@ jobs:
 
   build-nightly-image:
     executor:
-      name: machine
+      name: docker
 
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,6 +640,12 @@ jobs:
           command: |
             twine upload -u $PYPI_USER -p $PYPI_PASSWORD dist/*.{tar.gz,whl}
 
+  build-nightly-image:
+    steps:
+      - run:
+          name: Trigger nightly automated build on Docker Hub.
+          command: curl -h --data docker_tag=nightly -X POST ${NIGHTLY_BUILD_TRIGGER}
+
 workflows:
   raiden-default:
     jobs:
@@ -1076,6 +1082,11 @@ workflows:
           architecture: "aarch64"
           requires:
             - finalize
+
+      - build-nightly-image:
+          requires:
+            - finalize
+            - prepare-python-linux-3.7
 
       - prepare-system-macos:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,7 +644,8 @@ jobs:
     steps:
       - run:
           name: Trigger nightly automated build on Docker Hub.
-          command: curl -H "Content-Type: application/json" --data '{"docker_tag":"nightly"}' -X POST ${NIGHTLY_BUILD_TRIGGER}
+          command: >
+            curl -H "Content-Type: application/json" --data '{"docker_tag":"nightly"}' -X POST ${NIGHTLY_BUILD_TRIGGER}
 
 workflows:
   raiden-default:


### PR DESCRIPTION
This should be enough to trigger the `nightly` image creation.

Variable `NIGHTLY_BUILD_TRIGGER` was added via circle-ci web app.