### PR TITLE
Coverage raiden transfer node

### DIFF
--- a/raiden/tests/unit/fixtures.py
+++ b/raiden/tests/unit/fixtures.py
@@ -81,8 +81,14 @@ def token_network_state(
 
 
 @pytest.fixture
-def netting_channel_state(chain_state, token_network_state, payment_network_state):
-    partner = factories.make_address()
+def partner():
+    return None
+
+
+@pytest.fixture
+def netting_channel_state(chain_state, token_network_state, payment_network_state, partner):
+    if partner is None:
+        partner = factories.make_address()
     canonical_identifier = factories.make_canonical_identifier(
         token_network_address=token_network_state.address
     )

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -2,14 +2,20 @@ from copy import deepcopy
 
 from raiden.constants import EMPTY_MERKLE_ROOT
 from raiden.tests.utils import factories
-from raiden.tests.utils.factories import HOP1, HOP2, UNIT_SECRETHASH, make_block_hash
-from raiden.transfer.architecture import TransitionResult
+from raiden.tests.utils.factories import (
+    HOP1,
+    HOP2,
+    UNIT_CHANNEL_ID,
+    UNIT_SECRETHASH,
+    make_block_hash,
+)
 from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.node import (
     get_networks,
     is_transaction_effect_satisfied,
     state_transition,
     subdispatch_initiatortask,
+    subdispatch_targettask,
 )
 from raiden.transfer.state import PaymentNetworkState, TokenNetworkState
 from raiden.transfer.state_change import (
@@ -103,6 +109,20 @@ def test_subdispatch_invalid_initiatortask(chain_state, token_network_id):
         chain_state=chain_state,
         state_change=None,
         token_network_identifier=token_network_id,
+        secrethash=UNIT_SECRETHASH,
+    )
+    assert transition_result.new_state == chain_state
+    assert not transition_result.events
+
+
+def test_subdispatch_invalid_targettask(chain_state, token_network_id):
+    subtask = object()
+    chain_state.payment_mapping.secrethashes_to_task[UNIT_SECRETHASH] = subtask
+    transition_result = subdispatch_targettask(
+        chain_state=chain_state,
+        state_change=None,
+        token_network_identifier=token_network_id,
+        channel_identifier=UNIT_CHANNEL_ID,
         secrethash=UNIT_SECRETHASH,
     )
     assert transition_result.new_state == chain_state

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 import raiden.transfer.node
@@ -297,18 +299,20 @@ def test_subdispatch_by_canonical_id(chain_state):
     chain_state.tokennetworkaddresses_to_paymentnetworkaddresses[
         canonical_identifier.token_network_address
     ] = payment_network.address
-    # dispatching a Block will raise an assertion error
-    with pytest.raises(AssertionError):
-        state_change = Block(
-            block_number=chain_state.block_number,
-            gas_limit=GAS_LIMIT,
-            block_hash=chain_state.block_hash,
-        )
-        subdispatch_by_canonical_id(
-            chain_state=chain_state,
-            canonical_identifier=canonical_identifier,
-            state_change=state_change,
-        )
+    # dispatching a Block will be ignored
+    previous_state = copy.deepcopy(chain_state)
+    state_change = Block(
+        block_number=chain_state.block_number,
+        gas_limit=GAS_LIMIT,
+        block_hash=chain_state.block_hash,
+    )
+    transition_result = subdispatch_by_canonical_id(
+        chain_state=chain_state,
+        canonical_identifier=canonical_identifier,
+        state_change=state_change,
+    )
+    assert transition_result.new_state == previous_state
+    assert transition_result.events == []
 
     state_change = ActionChannelClose(canonical_identifier=canonical_identifier)
 

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -418,7 +418,7 @@ def test_inplace_delete_message_queue(chain_state):
     )
 
     chain_state.queueids_to_queues[global_identifier] = None
-    assert global_identifier in chain_state.queueids_to_queues, "queue mapping not mutable"
+    assert global_identifier in chain_state.queueids_to_queues, "queue mapping insertion failed"
     inplace_delete_message_queue(
         chain_state=chain_state, state_change=delivered_state_change, queueid=global_identifier
     )
@@ -431,7 +431,7 @@ def test_inplace_delete_message_queue(chain_state):
             message_identifier=message_id,
         )
     ]
-    assert global_identifier in chain_state.queueids_to_queues, "queue mapping not mutable"
+    assert global_identifier in chain_state.queueids_to_queues, "queue mapping insertion failed"
     handle_delivered(chain_state=chain_state, state_change=delivered_state_change)
     assert global_identifier not in chain_state.queueids_to_queues, "did not clear queue"
 

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -44,6 +44,7 @@ from raiden.transfer.node import (
     subdispatch_to_paymenttask,
 )
 from raiden.transfer.state import (
+    CHANNEL_STATE_CLOSING,
     CHANNEL_STATE_OPENED,
     NODE_NETWORK_REACHABLE,
     BalanceProofSignedState,
@@ -335,7 +336,7 @@ def test_subdispatch_by_canonical_id(chain_state):
         state_change=state_change,
     )
 
-    assert get_status(channel_state) != CHANNEL_STATE_OPENED
+    assert get_status(channel_state) == CHANNEL_STATE_CLOSING
     assert transition_result.new_state == chain_state, transition_result
 
 

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -13,6 +13,7 @@ from raiden.transfer.events import ContractSendChannelBatchUnlock
 from raiden.transfer.node import (
     get_networks,
     is_transaction_effect_satisfied,
+    maybe_add_tokennetwork,
     state_transition,
     subdispatch_initiatortask,
     subdispatch_targettask,
@@ -127,3 +128,19 @@ def test_subdispatch_invalid_targettask(chain_state, token_network_id):
     )
     assert transition_result.new_state == chain_state
     assert not transition_result.events
+
+
+def test_maybe_add_tokennetwork_unknown_payment_network(chain_state, token_network_id):
+    payment_network_identifier = factories.make_address()
+    token_address = factories.make_address()
+    token_network = TokenNetworkState(address=token_network_id, token_address=token_address)
+    msg = "test state invalid, payment_network already in chain_state"
+    assert payment_network_identifier not in chain_state.identifiers_to_paymentnetworks, msg
+    maybe_add_tokennetwork(
+        chain_state=chain_state,
+        payment_network_identifier=payment_network_identifier,
+        token_network_state=token_network,
+    )
+    # new payment network should have been added to chain_state
+    payment_network_state = chain_state.identifiers_to_paymentnetworks[payment_network_identifier]
+    assert payment_network_state.address == payment_network_identifier

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 import pytest
 
 import raiden.transfer.node
@@ -29,7 +27,6 @@ from raiden.transfer.mediated_transfer.state_change import ReceiveLockExpired
 from raiden.transfer.mediated_transfer.tasks import MediatorTask, TargetTask
 from raiden.transfer.merkle_tree import merkleroot
 from raiden.transfer.node import (
-    get_networks,
     handle_delivered,
     handle_new_payment_network,
     handle_new_token_network,
@@ -67,6 +64,7 @@ from raiden.transfer.state_change import (
     ReceiveDelivered,
     ReceiveProcessed,
 )
+from raiden.transfer.views import get_networks
 
 
 def test_is_transaction_effect_satisfied(
@@ -117,38 +115,6 @@ def test_is_transaction_effect_satisfied(
     iteration = state_transition(chain_state=chain_state, state_change=channel_settled)
 
     assert is_transaction_effect_satisfied(iteration.new_state, transaction, state_change)
-
-
-def test_get_networks(chain_state, token_network_address):
-    orig_chain_state = deepcopy(chain_state)
-    token_address = factories.make_address()
-    payment_network_empty = PaymentNetworkState(
-        address=factories.make_address(), token_network_list=[]
-    )
-    chain_state.identifiers_to_paymentnetworks[
-        payment_network_empty.address
-    ] = payment_network_empty
-    assert get_networks(
-        chain_state=chain_state,
-        payment_network_address=payment_network_empty.address,
-        token_address=token_address,
-    ) == (payment_network_empty, None)
-
-    chain_state = orig_chain_state
-    token_network = TokenNetworkState(
-        address=token_network_address,
-        token_address=token_address,
-        network_graph=TokenNetworkGraphState(token_network_address=token_network_address),
-    )
-    payment_network = PaymentNetworkState(
-        address=factories.make_address(), token_network_list=[token_network]
-    )
-    chain_state.identifiers_to_paymentnetworks[payment_network.address] = payment_network
-    assert get_networks(
-        chain_state=chain_state,
-        payment_network_address=payment_network.address,
-        token_address=token_address,
-    ) == (payment_network, token_network)
 
 
 def test_subdispatch_invalid_initiatortask(chain_state, token_network_address):

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -408,10 +408,7 @@ def test_inplace_delete_message_queue(chain_state):
     canonical_identifier = factories.make_canonical_identifier()
     message_id = factories.make_message_identifier()
     delivered_state_change = ReceiveDelivered(sender=sender, message_identifier=message_id)
-    handle_delivered(chain_state=chain_state, state_change=delivered_state_change)
-
     processed_state_change = ReceiveProcessed(sender=sender, message_identifier=message_id)
-    handle_processed(chain_state=chain_state, state_change=processed_state_change)
 
     global_identifier = QueueIdentifier(
         recipient=sender, canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -607,8 +607,8 @@ def handle_node_change_network_state(
     network_state = state_change.network_state
     chain_state.nodeaddresses_to_networkstates[node_address] = network_state
 
-    for secrethash, subtask in chain_state.payment_mapping.secrethashes_to_task.items():
-        # This assert would not have been needed if token_network_address, a common attribute
+    for secrethash, subtask in list(chain_state.payment_mapping.secrethashes_to_task.items()):
+        # This assert would not have been needed if token_network_identifier, a common attribute
         # for all TransferTasks was part of the TransferTasks superclass.
         assert isinstance(subtask, (InitiatorTask, MediatorTask, TargetTask))
         result = subdispatch_mediatortask(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -464,6 +464,8 @@ def inplace_delete_message_queue(
     """ Filter messages from queue, if the queue becomes empty, cleanup the queue itself. """
     queue = chain_state.queueids_to_queues.get(queueid)
     if not queue:
+        if queueid in chain_state.queueids_to_queues:
+            chain_state.queueids_to_queues.pop(queueid)
         return
 
     inplace_delete_message(message_queue=queue, state_change=state_change)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -610,7 +610,7 @@ def handle_node_change_network_state(
     chain_state.nodeaddresses_to_networkstates[node_address] = network_state
 
     for secrethash, subtask in list(chain_state.payment_mapping.secrethashes_to_task.items()):
-        # This assert would not have been needed if token_network_identifier, a common attribute
+        # This assert would not have been needed if token_network_address, a common attribute
         # for all TransferTasks was part of the TransferTasks superclass.
         assert isinstance(subtask, (InitiatorTask, MediatorTask, TargetTask))
         result = subdispatch_mediatortask(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -776,7 +776,7 @@ def handle_update_transport_authdata(
 
 def handle_state_change(
     chain_state: ChainState, state_change: StateChange
-) -> TransitionResult[ChainState]:
+) -> TransitionResult[ChainState]:  # pragma: no cover
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION
         iteration = handle_block(chain_state, state_change)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -71,9 +71,7 @@ from raiden.utils.typing import (
     Optional,
     PaymentNetworkAddress,
     SecretHash,
-    TokenAddress,
     TokenNetworkAddress,
-    Tuple,
     Union,
 )
 
@@ -90,27 +88,6 @@ TokenNetworkStateChange = Union[
     ContractReceiveChannelClosed,
     ContractReceiveChannelWithdraw,
 ]
-
-
-def get_networks(
-    chain_state: ChainState,
-    payment_network_address: PaymentNetworkAddress,
-    token_address: TokenAddress,
-) -> Tuple[Optional[PaymentNetworkState], Optional[TokenNetworkState]]:
-    token_network_state = None
-    payment_network_state = chain_state.identifiers_to_paymentnetworks.get(payment_network_address)
-
-    if payment_network_state:
-        token_network_address = payment_network_state.tokenaddresses_to_tokennetworkaddresses.get(
-            token_address
-        )
-
-        if token_network_address:
-            token_network_state = payment_network_state.tokennetworkaddresses_to_tokennetworks.get(
-                token_network_address
-            )
-
-    return payment_network_state, token_network_state
 
 
 def get_token_network_by_address(
@@ -431,7 +408,7 @@ def maybe_add_tokennetwork(
     token_network_address = token_network_state.address
     token_address = token_network_state.token_address
 
-    payment_network_state, token_network_state_previous = get_networks(
+    payment_network_state, token_network_state_previous = views.get_networks(
         chain_state, payment_network_address, token_address
     )
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -243,13 +243,6 @@ class ContractReceiveChannelSettled(ContractReceiveStateChange):
 
 
 @dataclass
-class ActionLeaveAllNetworks(StateChange):
-    """ User is quitting all payment networks. """
-
-    pass
-
-
-@dataclass
 class ActionChangeNodeNetworkState(StateChange):
     """ The network state of `node_address` changed. """
 

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -335,6 +335,7 @@ def state_transition(
     pseudo_random_generator: random.Random,
 ) -> TransitionResult:
     # pylint: disable=too-many-branches,unidiomatic-typecheck
+    iteration = TransitionResult(token_network_state, [])
 
     if type(state_change) == ActionChannelClose:
         assert isinstance(state_change, ActionChannelClose), MYPY_ANNOTATION
@@ -449,11 +450,6 @@ def state_transition(
             block_number=block_number,
             block_hash=block_hash,
             pseudo_random_generator=pseudo_random_generator,
-        )
-    else:
-        raise AssertionError(
-            f"Illegal dispatch: state_change {state_change} "
-            "must not be dispatched to token_network."
         )
 
     return iteration

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -450,5 +450,10 @@ def state_transition(
             block_hash=block_hash,
             pseudo_random_generator=pseudo_random_generator,
         )
+    else:
+        raise AssertionError(
+            f"Illegal dispatch: state_change {state_change} "
+            "must not be dispatched to token_network."
+        )
 
     return iteration

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -33,6 +33,7 @@ from raiden.utils.typing import (
     Set,
     TokenAddress,
     TokenNetworkAddress,
+    Tuple,
     Union,
 )
 
@@ -592,3 +593,24 @@ def detect_balance_proof_change(
                     if our_state_updated:
                         assert current_channel.our_state.balance_proof, MYPY_ANNOTATION
                         yield current_channel.our_state.balance_proof
+
+
+def get_networks(
+    chain_state: ChainState,
+    payment_network_address: PaymentNetworkAddress,
+    token_address: TokenAddress,
+) -> Tuple[Optional[PaymentNetworkState], Optional[TokenNetworkState]]:
+    token_network_state = None
+    payment_network_state = chain_state.identifiers_to_paymentnetworks.get(payment_network_address)
+
+    if payment_network_state:
+        token_network_address = payment_network_state.tokenaddresses_to_tokennetworkaddresses.get(
+            token_address
+        )
+
+        if token_network_address:
+            token_network_state = payment_network_state.tokennetworkaddresses_to_tokennetworks.get(
+                token_network_address
+            )
+
+    return payment_network_state, token_network_state


### PR DESCRIPTION
Task 1 of #3993 

Apart from implementing tests for previously untested branches, this also removes some dead code from `node.py` and should push coverage to the target of >=90%.

**Edit**: ~now at 88%~
now at 87%