### PR TITLE
Coverage raiden transfer views

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -489,7 +489,7 @@ class RaidenService(Runnable):
                 node=pex(self.address),
             )
 
-            known_networks = views.get_payment_network_addresss(views.state_from_raiden(self))
+            known_networks = views.get_payment_network_address(views.state_from_raiden(self))
             if known_networks and self.default_registry.address not in known_networks:
                 configured_registry = pex(self.default_registry.address)
                 known_registries = lpex(known_networks)

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,5 +1,8 @@
 from raiden.tests.utils import factories
-from raiden.transfer.views import filter_channels_by_partneraddress
+from raiden.transfer.views import (
+    filter_channels_by_partneraddress,
+    filter_channels_by_status,
+)
 
 
 def test_filter_channels_by_partneraddress_empty(chain_state):
@@ -14,4 +17,15 @@ def test_filter_channels_by_partneraddress_empty(chain_state):
             partner_addresses=partner_addresses,
         )
         == []
+    )
+
+
+def test_filter_channels_by_status_empty_excludes():
+    channel_states = factories.make_channel_set(number_of_channels=3).channels
+    channel_states[1].close_transaction = channel_states[1].open_transaction
+    channel_states[2].close_transaction = channel_states[2].open_transaction
+    channel_states[2].settle_transaction = channel_states[2].open_transaction
+    assert (
+        filter_channels_by_status(channel_states=channel_states, exclude_states=None)
+        == channel_states
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -4,6 +4,7 @@ from raiden.transfer.views import (
     filter_channels_by_partneraddress,
     filter_channels_by_status,
     get_participants_addresses,
+    get_token_identifiers,
     get_token_network_identifiers,
     get_token_network_registry_by_token_network_identifier,
 )
@@ -71,5 +72,12 @@ def test_get_token_network_identifiers_empty_list_for_payment_network_none(chain
         get_token_network_identifiers(
             chain_state=chain_state, payment_network_id=factories.make_address()
         )
+        == list()
+    )
+
+
+def test_token_identifiers_empty_list_for_payment_network_none(chain_state):
+    assert (
+        get_token_identifiers(chain_state=chain_state, payment_network_id=factories.make_address())
         == list()
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -4,6 +4,7 @@ from raiden.transfer.views import (
     filter_channels_by_partneraddress,
     filter_channels_by_status,
     get_participants_addresses,
+    get_token_network_identifiers,
     get_token_network_registry_by_token_network_identifier,
 )
 
@@ -62,4 +63,13 @@ def test_get_token_network_registry_by_token_network_identifier_is_none(chain_st
             chain_state=chain_state, token_network_identifier=factories.make_address()
         )
         is None
+    )
+
+
+def test_get_token_network_identifiers_empty_list_for_payment_network_none(chain_state):
+    assert (
+        get_token_network_identifiers(
+            chain_state=chain_state, payment_network_id=factories.make_address()
+        )
+        == list()
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -2,7 +2,7 @@ import pytest
 
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.state import InitiatorPaymentState
-from raiden.transfer.state import InitiatorTask
+from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.transfer.views import (
     count_token_network_channels,
     filter_channels_by_partneraddress,

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -279,3 +279,42 @@ def test_filter_channels_by_partneraddress():
         )
         == test_state.channels[1:]
     )
+
+
+def test_total_token_network_channels():
+    number_of_channels = 3
+    test_state = factories.make_chain_state(number_of_channels=number_of_channels)
+    unknown_token_address = factories.make_address()
+    unknown_payment_network_address = factories.make_address()
+    assert (
+        views.total_token_network_channels(
+            chain_state=test_state.chain_state,
+            payment_network_address=unknown_payment_network_address,
+            token_address=unknown_token_address,
+        )
+        == 0
+    )
+    assert (
+        views.total_token_network_channels(
+            chain_state=test_state.chain_state,
+            payment_network_address=unknown_payment_network_address,
+            token_address=test_state.token_address,
+        )
+        == 0
+    )
+    assert (
+        views.total_token_network_channels(
+            chain_state=test_state.chain_state,
+            payment_network_address=test_state.payment_network_address,
+            token_address=unknown_token_address,
+        )
+        == 0
+    )
+    assert (
+        views.total_token_network_channels(
+            chain_state=test_state.chain_state,
+            payment_network_address=test_state.payment_network_address,
+            token_address=test_state.token_address,
+        )
+        == number_of_channels
+    )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -318,3 +318,26 @@ def test_total_token_network_channels():
         )
         == number_of_channels
     )
+
+
+def test_get_token_network_registry_by_token_network_address():
+    test_state = factories.make_chain_state(number_of_channels=1)
+    assert (
+        views.get_token_network_registry_by_token_network_address(
+            chain_state=test_state.chain_state, token_network_address=factories.make_address()
+        )
+        is None
+    )
+    assert (
+        views.get_token_network_registry_by_token_network_address(
+            chain_state=test_state.chain_state, token_network_address=test_state.token_address
+        )
+        is None
+    )
+    assert (
+        views.get_token_network_registry_by_token_network_address(
+            chain_state=test_state.chain_state,
+            token_network_address=test_state.token_network_address,
+        ).address
+        == test_state.payment_network_address
+    )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,8 +1,0 @@
-from raiden.tests.utils.factories import UNIT_SECRETHASH
-from raiden.transfer.views import get_transfer_task
-
-
-def test_get_transfer_task(chain_state):
-    subtask = object()
-    chain_state.payment_mapping.secrethashes_to_task[UNIT_SECRETHASH] = subtask
-    assert get_transfer_task(chain_state=chain_state, secrethash=UNIT_SECRETHASH) == subtask

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -377,3 +377,30 @@ def test_get_token_network_address_by_token_address():
         )
         == test_state.token_network_address
     )
+
+
+def test_listings():
+    test_state = factories.make_chain_state(number_of_channels=3)
+    assert (
+        views.get_token_network_addresses(
+            chain_state=test_state.chain_state, payment_network_address=factories.make_address()
+        )
+        == []
+    )
+    assert views.get_token_network_addresses(
+        chain_state=test_state.chain_state,
+        payment_network_address=test_state.payment_network_address,
+    ) == [test_state.token_network_address]
+    assert (
+        views.get_token_identifiers(
+            chain_state=test_state.chain_state, payment_network_address=factories.make_address()
+        )
+        == []
+    )
+    assert views.get_token_identifiers(
+        chain_state=test_state.chain_state,
+        payment_network_address=test_state.payment_network_address,
+    ) == [test_state.token_address]
+    assert views.get_payment_network_address(chain_state=test_state.chain_state) == [
+        test_state.payment_network_address
+    ]

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -3,6 +3,7 @@ from raiden.transfer.views import (
     count_token_network_channels,
     filter_channels_by_partneraddress,
     filter_channels_by_status,
+    get_participants_addresses,
 )
 
 
@@ -40,4 +41,15 @@ def test_count_token_network_channels_no_token_network(chain_state):
             token_address=factories.make_address(),
         )
         == 0
+    )
+
+
+def test_get_participants_addresses_no_token_network(chain_state):
+    assert (
+        get_participants_addresses(
+            chain_state=chain_state,
+            payment_network_id=factories.make_address(),
+            token_address=factories.make_address(),
+        )
+        == set()
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -341,3 +341,39 @@ def test_get_token_network_registry_by_token_network_address():
         ).address
         == test_state.payment_network_address
     )
+
+
+def test_get_token_network_address_by_token_address():
+    test_state = factories.make_chain_state(number_of_channels=1)
+    assert (
+        views.get_token_network_address_by_token_address(
+            chain_state=test_state.chain_state,
+            payment_network_address=factories.make_address(),
+            token_address=factories.make_address(),
+        )
+        is None
+    )
+    assert (
+        views.get_token_network_address_by_token_address(
+            chain_state=test_state.chain_state,
+            payment_network_address=test_state.payment_network_address,
+            token_address=factories.make_address(),
+        )
+        is None
+    )
+    assert (
+        views.get_token_network_address_by_token_address(
+            chain_state=test_state.chain_state,
+            payment_network_address=factories.make_address(),
+            token_address=test_state.token_address,
+        )
+        is None
+    )
+    assert (
+        views.get_token_network_address_by_token_address(
+            chain_state=test_state.chain_state,
+            payment_network_address=test_state.payment_network_address,
+            token_address=test_state.token_address,
+        )
+        == test_state.token_network_address
+    )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,5 +1,6 @@
 from raiden.tests.utils import factories
 from raiden.transfer.views import (
+    count_token_network_channels,
     filter_channels_by_partneraddress,
     filter_channels_by_status,
 )
@@ -28,4 +29,15 @@ def test_filter_channels_by_status_empty_excludes():
     assert (
         filter_channels_by_status(channel_states=channel_states, exclude_states=None)
         == channel_states
+    )
+
+
+def test_count_token_network_channels_no_token_network(chain_state):
+    assert (
+        count_token_network_channels(
+            chain_state=chain_state,
+            payment_network_id=factories.make_address(),
+            token_address=factories.make_address(),
+        )
+        == 0
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,0 +1,17 @@
+from raiden.tests.utils import factories
+from raiden.transfer.views import filter_channels_by_partneraddress
+
+
+def test_filter_channels_by_partneraddress_empty(chain_state):
+    payment_network_id = factories.make_address()
+    token_address = factories.make_address()
+    partner_addresses = [factories.make_address(), factories.make_address()]
+    assert (
+        filter_channels_by_partneraddress(
+            chain_state=chain_state,
+            payment_network_id=payment_network_id,
+            token_address=token_address,
+            partner_addresses=partner_addresses,
+        )
+        == []
+    )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,3 +1,5 @@
+import pytest
+
 from raiden.tests.utils import factories
 from raiden.transfer.views import (
     count_token_network_channels,
@@ -7,6 +9,7 @@ from raiden.transfer.views import (
     get_token_identifiers,
     get_token_network_identifiers,
     get_token_network_registry_by_token_network_identifier,
+    role_from_transfer_task,
 )
 
 
@@ -81,3 +84,8 @@ def test_token_identifiers_empty_list_for_payment_network_none(chain_state):
         get_token_identifiers(chain_state=chain_state, payment_network_id=factories.make_address())
         == list()
     )
+
+
+def test_role_from_transfer_task_raises_value_error():
+    with pytest.raises(ValueError):
+        role_from_transfer_task(object())

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -4,6 +4,7 @@ from raiden.transfer.views import (
     filter_channels_by_partneraddress,
     filter_channels_by_status,
     get_participants_addresses,
+    get_token_network_registry_by_token_network_identifier,
 )
 
 
@@ -52,4 +53,13 @@ def test_get_participants_addresses_no_token_network(chain_state):
             token_address=factories.make_address(),
         )
         == set()
+    )
+
+
+def test_get_token_network_registry_by_token_network_identifier_is_none(chain_state):
+    assert (
+        get_token_network_registry_by_token_network_identifier(
+            chain_state=chain_state, token_network_identifier=factories.make_address()
+        )
+        is None
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,0 +1,8 @@
+from raiden.tests.utils.factories import UNIT_SECRETHASH
+from raiden.transfer.views import get_transfer_task
+
+
+def test_get_transfer_task(chain_state):
+    subtask = object()
+    chain_state.payment_mapping.secrethashes_to_task[UNIT_SECRETHASH] = subtask
+    assert get_transfer_task(chain_state=chain_state, secrethash=UNIT_SECRETHASH) == subtask

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -10,21 +10,21 @@ from raiden.transfer.views import (
     filter_channels_by_status,
     get_participants_addresses,
     get_token_identifiers,
-    get_token_network_identifiers,
-    get_token_network_registry_by_token_network_identifier,
+    get_token_network_addresses,
+    get_token_network_registry_by_token_network_address,
     get_transfer_secret,
     role_from_transfer_task,
 )
 
 
 def test_filter_channels_by_partneraddress_empty(chain_state):
-    payment_network_id = factories.make_address()
+    payment_network_address = factories.make_address()
     token_address = factories.make_address()
     partner_addresses = [factories.make_address(), factories.make_address()]
     assert (
         filter_channels_by_partneraddress(
             chain_state=chain_state,
-            payment_network_id=payment_network_id,
+            payment_network_address=payment_network_address,
             token_address=token_address,
             partner_addresses=partner_addresses,
         )
@@ -47,7 +47,7 @@ def test_count_token_network_channels_no_token_network(chain_state):
     assert (
         count_token_network_channels(
             chain_state=chain_state,
-            payment_network_id=factories.make_address(),
+            payment_network_address=factories.make_address(),
             token_address=factories.make_address(),
         )
         == 0
@@ -58,26 +58,26 @@ def test_get_participants_addresses_no_token_network(chain_state):
     assert (
         get_participants_addresses(
             chain_state=chain_state,
-            payment_network_id=factories.make_address(),
+            payment_network_address=factories.make_address(),
             token_address=factories.make_address(),
         )
         == set()
     )
 
 
-def test_get_token_network_registry_by_token_network_identifier_is_none(chain_state):
+def test_get_token_network_registry_by_token_network_address_is_none(chain_state):
     assert (
-        get_token_network_registry_by_token_network_identifier(
-            chain_state=chain_state, token_network_identifier=factories.make_address()
+        get_token_network_registry_by_token_network_address(
+            chain_state=chain_state, token_network_address=factories.make_address()
         )
         is None
     )
 
 
-def test_get_token_network_identifiers_empty_list_for_payment_network_none(chain_state):
+def test_get_token_network_addresses_empty_list_for_payment_network_none(chain_state):
     assert (
-        get_token_network_identifiers(
-            chain_state=chain_state, payment_network_id=factories.make_address()
+        get_token_network_addresses(
+            chain_state=chain_state, payment_network_address=factories.make_address()
         )
         == list()
     )
@@ -85,7 +85,9 @@ def test_get_token_network_identifiers_empty_list_for_payment_network_none(chain
 
 def test_token_identifiers_empty_list_for_payment_network_none(chain_state):
     assert (
-        get_token_identifiers(chain_state=chain_state, payment_network_id=factories.make_address())
+        get_token_identifiers(
+            chain_state=chain_state, payment_network_address=factories.make_address()
+        )
         == list()
     )
 
@@ -99,9 +101,9 @@ def test_get_transfer_secret_none_for_none_transfer_state(chain_state):
     secret = factories.make_secret()
     transfer = factories.create(factories.LockedTransferUnsignedStateProperties(secret=secret))
     secrethash = transfer.lock.secrethash
-    payment_state = InitiatorPaymentState({secrethash: None})
+    payment_state = InitiatorPaymentState(initiator_transfers={secrethash: None}, routes=[])
     task = InitiatorTask(
-        token_network_identifier=factories.UNIT_TOKEN_NETWORK_ADDRESS, manager_state=payment_state
+        token_network_address=factories.UNIT_TOKEN_NETWORK_ADDRESS, manager_state=payment_state
     )
     chain_state.payment_mapping.secrethashes_to_task[secrethash] = task
     assert get_transfer_secret(chain_state=chain_state, secrethash=secrethash) is None

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -5,6 +5,7 @@ from raiden.transfer.mediated_transfer.state import InitiatorPaymentState
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.transfer.views import (
     count_token_network_channels,
+    detect_balance_proof_change,
     filter_channels_by_partneraddress,
     filter_channels_by_status,
     get_participants_addresses,
@@ -104,3 +105,9 @@ def test_get_transfer_secret_none_for_none_transfer_state(chain_state):
     )
     chain_state.payment_mapping.secrethashes_to_task[secrethash] = task
     assert get_transfer_secret(chain_state=chain_state, secrethash=secrethash) is None
+
+
+def test_detect_balance_proof_chain_handles_attribute_error(chain_state):
+    chain_state.identifiers_to_paymentnetworks["123"] = None
+    changes_iterator = detect_balance_proof_change(old_state=object(), current_state=chain_state)
+    assert len(list(changes_iterator)) == 0

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -132,7 +132,7 @@ def get_our_capacity_for_token_network(
     return total_deposit
 
 
-def get_payment_network_addresss(chain_state: ChainState) -> List[PaymentNetworkAddress]:
+def get_payment_network_address(chain_state: ChainState) -> List[PaymentNetworkAddress]:
     return list(chain_state.identifiers_to_paymentnetworks.keys())
 
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -398,6 +398,7 @@ def get_channelstate_settled(
 
 def role_from_transfer_task(transfer_task: TransferTask) -> str:
     """Return the role and type for the transfer. Throws an exception on error"""
+    # pragma: no cover
     if isinstance(transfer_task, InitiatorTask):
         return "initiator"
     if isinstance(transfer_task, MediatorTask):


### PR DESCRIPTION
Task 2 of #3993 

Apart from implementing tests for previously untested branches, this also removes some dead code from views.py and should push coverage to the target of >=90%.

**Edit** now at 91%