### PR TITLE
Coverage raiden transfer channel

### DIFF
--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -16,7 +16,6 @@ from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import assert_synced_channel_state, get_channelstate, transfer
 from raiden.transfer import channel, views
-from raiden.transfer.state import UnlockProofState
 from raiden.transfer.state_change import (
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -629,8 +628,9 @@ def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
     ).external_state.netting_channel.address
 
     # the attacker can create a merkle proof of the locked transfer
-    lock = attack_channel.partner_state.get_lock_by_secrethash(secrethash)
-    unlock_proof = attack_channel.partner_state.compute_proof_for_lock(secret, lock)
+    # <the commented code below is left for documentation purposes>
+    # lock = attack_channel.partner_state.get_lock_by_secrethash(secrethash)
+    # unlock_proof = attack_channel.partner_state.compute_proof_for_lock(secret, lock)
 
     # start the settle counter
     attack_balance_proof = attack_transfer.to_balanceproof()
@@ -641,9 +641,10 @@ def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
     app2.raiden.chain.wait_until_block(target_block_number=attack_transfer.lock.expiration - 1)
 
     # since the attacker knows the secret he can net the lock
-    attack_channel.netting_channel.unlock(
-        UnlockProofState(unlock_proof, attack_transfer.lock, secret)
-    )
+    # <the commented code below is left for documentation purposes>
+    # attack_channel.netting_channel.unlock(
+    #     UnlockProofState(unlock_proof, attack_transfer.lock, secret)
+    # )
     # XXX: verify that the secret was publicized
 
     # at this point the hub might not know the secret yet, and won't be able to

--- a/raiden/tests/unit/test_mtree.py
+++ b/raiden/tests/unit/test_mtree.py
@@ -2,13 +2,7 @@ import pytest
 
 from raiden.constants import EMPTY_MERKLE_ROOT
 from raiden.exceptions import HashLengthNot32
-from raiden.transfer.merkle_tree import (
-    MERKLEROOT,
-    compute_layers,
-    compute_merkleproof_for,
-    merkleroot,
-    validate_proof,
-)
+from raiden.transfer.merkle_tree import MERKLEROOT, compute_layers, merkleroot
 from raiden.transfer.state import MerkleTreeState
 from raiden.utils import sha3
 
@@ -49,90 +43,3 @@ def test_compute_layers_single_entry():
 
     tree = MerkleTreeState(layers)
     assert merkleroot(tree) == hash_0
-
-
-def test_one():
-    hash_0 = b"a" * 32
-
-    leaves = [hash_0]
-    layers = compute_layers(leaves)
-    tree = MerkleTreeState(layers)
-    root = merkleroot(tree)
-    proof = compute_merkleproof_for(tree, hash_0)
-
-    assert proof == []
-    assert root == hash_0
-    assert validate_proof(proof, root, hash_0) is True
-
-
-def test_two():
-    hash_0 = b"a" * 32
-    hash_1 = b"b" * 32
-
-    leaves = [hash_0, hash_1]
-    layers = compute_layers(leaves)
-    tree = MerkleTreeState(layers)
-    root = merkleroot(tree)
-    proof0 = compute_merkleproof_for(tree, hash_0)
-    proof1 = compute_merkleproof_for(tree, hash_1)
-
-    assert proof0 == [hash_1]
-    assert root == sha3(hash_0 + hash_1)
-    assert validate_proof(proof0, root, hash_0)
-
-    assert proof1 == [hash_0]
-    assert root == sha3(hash_0 + hash_1)
-    assert validate_proof(proof1, root, hash_1)
-
-
-def test_three():
-    hash_0 = b"a" * 32
-    hash_1 = b"b" * 32
-    hash_2 = b"c" * 32
-
-    leaves = [hash_0, hash_1, hash_2]
-    layers = compute_layers(leaves)
-    tree = MerkleTreeState(layers)
-    root = merkleroot(tree)
-
-    hash_01 = (
-        b"me\xef\x9c\xa9=5\x16\xa4\xd3\x8a\xb7\xd9\x89\xc2\xb5\x00"
-        b"\xe2\xfc\x89\xcc\xdc\xf8x\xf9\xc4m\xaa\xf6\xad\r["
-    )
-    assert sha3(hash_0 + hash_1) == hash_01
-    calculated_root = sha3(hash_2 + hash_01)
-
-    proof0 = compute_merkleproof_for(tree, hash_0)
-    proof1 = compute_merkleproof_for(tree, hash_1)
-    proof2 = compute_merkleproof_for(tree, hash_2)
-
-    assert proof0 == [hash_1, hash_2]
-    assert root == calculated_root
-    assert validate_proof(proof0, root, hash_0)
-
-    assert proof1 == [hash_0, hash_2]
-    assert root == calculated_root
-    assert validate_proof(proof1, root, hash_1)
-
-    # with an odd number of values, the last value wont appear by itself in the
-    # proof since it isn't hashed with another value
-    assert proof2 == [sha3(hash_0 + hash_1)]
-    assert root == calculated_root
-    assert validate_proof(proof2, root, hash_2)
-
-
-def test_many(tree_up_to=10):
-    for number_of_leaves in range(1, tree_up_to):  # skipping the empty tree
-
-        leaves = [sha3(str(value).encode()) for value in range(number_of_leaves)]
-
-        layers = compute_layers(leaves)
-        tree = MerkleTreeState(layers)
-        root = merkleroot(tree)
-
-        for value in leaves:
-            proof = compute_merkleproof_for(tree, value)
-            assert validate_proof(proof, root, value)
-
-        reversed_tree = MerkleTreeState(compute_layers(reversed(leaves)))
-        assert root == merkleroot(reversed_tree)

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1161,10 +1161,9 @@ def create_unlock(
     assert get_status(channel_state) == CHANNEL_STATE_OPENED, msg
 
     our_balance_proof = our_state.balance_proof
-    if our_balance_proof:
-        transferred_amount = TokenAmount(lock.amount + our_balance_proof.transferred_amount)
-    else:
-        transferred_amount = TokenAmount(lock.amount)
+    msg = "the lock is pending, it must be in the merkletree"
+    assert our_balance_proof is not None, msg
+    transferred_amount = TokenAmount(lock.amount + our_balance_proof.transferred_amount)
 
     merkletree = compute_merkletree_without(our_state.merkletree, lock.lockhash)
     msg = "the lock is pending, it must be in the merkletree"
@@ -1275,7 +1274,7 @@ def send_unlock(
     secrethash: SecretHash,
 ) -> SendBalanceProof:
     lock = get_lock(channel_state.our_state, secrethash)
-    assert lock
+    assert lock, "caller must ensure the lock exists"
 
     unlock, merkletree = create_unlock(
         channel_state, message_identifier, payment_identifier, secret, lock

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -41,7 +41,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveLockExpired,
     ReceiveTransferRefund,
 )
-from raiden.transfer.merkle_tree import LEAVES, compute_layers, compute_merkleproof_for, merkleroot
+from raiden.transfer.merkle_tree import LEAVES, compute_layers, merkleroot
 from raiden.transfer.state import (
     CHANNEL_STATE_CLOSED,
     CHANNEL_STATE_CLOSING,
@@ -60,7 +60,6 @@ from raiden.transfer.state import (
     TransactionExecutionStatus,
     TransactionOrder,
     UnlockPartialProofState,
-    UnlockProofState,
     make_empty_merkle_tree,
     message_identifier_from_prng,
 )
@@ -1035,15 +1034,6 @@ def set_settled(channel_state: NettingChannelState, block_number: BlockNumber) -
 def update_contract_balance(end_state: NettingChannelEndState, contract_balance: Balance) -> None:
     if contract_balance > end_state.contract_balance:
         end_state.contract_balance = contract_balance
-
-
-def compute_proof_for_lock(
-    end_state: NettingChannelEndState, secret: Secret, lock: HashTimeLockState
-) -> UnlockProofState:
-    # forcing bytes because ethereum.abi doesn't work with bytearray
-    merkle_proof = compute_merkleproof_for(end_state.merkletree, Keccak256(lock.lockhash))
-
-    return UnlockProofState(merkle_proof, lock.encoded, secret)
 
 
 def compute_merkletree_with(

--- a/raiden/transfer/merkle_tree.py
+++ b/raiden/transfer/merkle_tree.py
@@ -64,46 +64,6 @@ def compute_layers(elements: List[Keccak256]) -> List[List[Keccak256]]:
     return tree
 
 
-def compute_merkleproof_for(merkletree: "MerkleTreeState", element: Keccak256) -> List[Keccak256]:
-    """ Containment proof for element.
-
-    The proof contains only the entries that are sufficient to recompute the
-    merkleroot, from the leaf `element` up to `root`.
-
-    Raises:
-        IndexError: If the element is not part of the merkletree.
-    """
-    idx = merkletree.layers[LEAVES].index(element)
-
-    proof = []
-    for layer in merkletree.layers:
-        if idx % 2:
-            pair = idx - 1
-        else:
-            pair = idx + 1
-
-        # with an odd number of elements the rightmost one does not have a pair.
-        if pair < len(layer):
-            proof.append(layer[pair])
-
-        # the tree is binary and balanced
-        idx = idx // 2
-
-    return proof
-
-
-def validate_proof(proof: List[Keccak256], root: Keccak256, leaf_element: Keccak256) -> bool:
-    """ Checks that `leaf_element` was contained in the tree represented by
-    `merkleroot`.
-    """
-
-    hash_ = leaf_element
-    for pair in proof:
-        hash_ = hash_pair(hash_, pair)
-
-    return hash_ == root
-
-
 def merkleroot(merkletree: "MerkleTreeState") -> Locksroot:
     """ Return the root element of the merkle tree. """
     assert merkletree.layers, "the merkle tree layers are empty"


### PR DESCRIPTION
Task 3 of #3993 

Test formerly untested branches of channel.py and remove some dead code paths.

**Edit**: now at 90% https://codecov.io/gh/raiden-network/raiden/pull/4014/src/raiden/transfer/channel.py?before=raiden/transfer/channel.py *phew*
