### PR TITLE
Submit code coverage for different test types with flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,6 @@ jobs:
       RAIDEN_TESTS_SYNAPSE_BASE_DIR: /home/circleci/.cache/synapse
       RAIDEN_TESTS_SYNAPSE_LOGS_DIR: /tmp/synapse-logs
       RAIDEN_TESTS_ETH_LOGSDIR: /tmp/eth/logs
-      COVERAGE_DIR: /home/circleci/raiden/coverage
 
     parallelism: << parameters.parallelism >>
 
@@ -331,12 +330,6 @@ jobs:
           keys:
             - synapse-keys-v1
             - synapse-keys-
-      # Remove any existing .coverage files so we don't persist them again, causing a conflict.
-      - run:
-          name: Prepare coverage
-          command: |
-            mkdir -p ${COVERAGE_DIR}
-            rm ${COVERAGE_DIR}/.coverage* || true
       - run:
           name: Select tests
           command: |
@@ -374,14 +367,9 @@ jobs:
               << parameters.additional-args >>
 
       - run:
-          name: Store coverage
+          name: Report coverage
           command: |
-            mv .coverage* ${COVERAGE_DIR}
-
-      - persist_to_workspace:
-          root: "~"
-          paths:
-            - "./raiden/coverage"
+            bash <(curl -s https://codecov.io/bash) -c -F << parameters.test-type >>
 
       - save_cache:
           key: ethash-{{ checksum "~/.local/bin/geth" }}
@@ -421,12 +409,7 @@ jobs:
       - conditional-skip
       - config-path
       - run:
-          name: Report to Codecov
-          command: |
-            pip install codecov
-            cd ~/raiden
-            coverage combine coverage
-            codecov
+          command: "true"
 
   build-binary-linux:
     parameters:


### PR DESCRIPTION
This seems to work in general, however there is some strange behavior:
The codecov website shows 100% coverage for each flag (unit, fuzz or integration test), but the overall coverage is fine. I'm not sure if this just happens because it's the first time this is measured or something is wrong with this PR


I'm not sure either if we need the finalize step, but I guess it's needed for the later tasks.