### PR TITLE
Add and emit EventRouteFailed

### DIFF
--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1291,8 +1291,8 @@ def test_refund_transfer_matches_received():
     refund_same_expiration = factories.create(same)
     transfer = create(same.extract(factories.LockedTransferUnsignedStateProperties))
 
-    assert channel.refund_transfer_matches_received(refund_lower_expiration, transfer) is False
-    assert channel.refund_transfer_matches_received(refund_same_expiration, transfer) is True
+    assert channel.refund_transfer_matches_transfer(refund_lower_expiration, transfer) is False
+    assert channel.refund_transfer_matches_transfer(refund_same_expiration, transfer) is True
 
 
 def test_refund_transfer_does_not_match_received():
@@ -1309,7 +1309,7 @@ def test_refund_transfer_does_not_match_received():
         factories.LockedTransferSignedStateProperties(amount=amount, expiration=expiration - 1)
     )
     # target cannot refund
-    assert not channel.refund_transfer_matches_received(refund_from_target, transfer)
+    assert not channel.refund_transfer_matches_transfer(refund_from_target, transfer)
 
 
 def test_action_close_must_change_the_channel_state():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -380,12 +380,12 @@ def test_state_wait_unlock_valid():
     )
 
     assert len(iteration.events) == 3
-    assert any(isinstance(e, SendBalanceProof) for e in iteration.events)
-    assert any(isinstance(e, EventPaymentSentSuccess) for e in iteration.events)
-    assert any(isinstance(e, EventUnlockSuccess) for e in iteration.events)
 
-    balance_proof = next(e for e in iteration.events if isinstance(e, SendBalanceProof))
-    complete = next(e for e in iteration.events if isinstance(e, EventPaymentSentSuccess))
+    balance_proof = search_for_item(iteration.events, SendBalanceProof, {})
+    complete = search_for_item(iteration.events, EventPaymentSentSuccess, {})
+    assert search_for_item(iteration.events, EventUnlockSuccess, {})
+    assert balance_proof
+    assert complete
 
     assert balance_proof.recipient == setup.channel.partner_state.address
     assert complete.identifier == UNIT_TRANSFER_IDENTIFIER
@@ -487,9 +487,9 @@ def test_refund_transfer_next_route():
     )
     assert iteration.new_state is not None
 
-    route_cancelled = next(e for e in iteration.events if isinstance(e, EventUnlockFailed))
-    route_failed = next(e for e in iteration.events if isinstance(e, EventRouteFailed))
-    new_transfer = next(e for e in iteration.events if isinstance(e, SendLockedTransfer))
+    route_cancelled = search_for_item(iteration.events, EventUnlockFailed, {})
+    route_failed = search_for_item(iteration.events, EventRouteFailed, {})
+    new_transfer = search_for_item(iteration.events, SendLockedTransfer, {})
 
     assert route_cancelled, "The previous transfer must be cancelled"
     assert route_failed, "Must emit event that the first route failed"
@@ -540,9 +540,9 @@ def test_refund_transfer_no_more_routes():
     # more routes, but we have to wait for the lock expiration
     assert iteration.new_state is not None
 
-    unlocked_failed = next(e for e in iteration.events if isinstance(e, EventUnlockFailed))
-    route_failed = next(e for e in iteration.events if isinstance(e, EventRouteFailed))
-    sent_failed = next(e for e in iteration.events if isinstance(e, EventPaymentSentFailed))
+    unlocked_failed = search_for_item(iteration.events, EventUnlockFailed, {})
+    route_failed = search_for_item(iteration.events, EventRouteFailed, {})
+    sent_failed = search_for_item(iteration.events, EventPaymentSentFailed, {})
 
     assert unlocked_failed
     assert route_failed, "Must emit event that the first route failed"
@@ -657,11 +657,8 @@ def test_cancel_transfer():
     assert iteration.new_state is not None
     assert len(iteration.events) == 2
 
-    unlocked_failed = next(e for e in iteration.events if isinstance(e, EventUnlockFailed))
-    sent_failed = next(e for e in iteration.events if isinstance(e, EventPaymentSentFailed))
-
-    assert unlocked_failed
-    assert sent_failed
+    assert search_for_item(iteration.events, EventUnlockFailed, {})
+    assert search_for_item(iteration.events, EventPaymentSentFailed, {})
 
 
 def test_cancelpayment():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -618,6 +618,8 @@ def test_refund_transfer_no_more_routes():
         current_state, state_change, setup.channel_map, setup.prng, expiry_block
     )
     assert search_for_item(iteration.events, SendLockExpired, {}) is not None
+    # The lock expired, so the route failed
+    assert search_for_item(iteration.events, EventRouteFailed, {}) is not None
     # Since there was a refund transfer the payment task must not have been deleted
     assert iteration.new_state is not None
 
@@ -696,6 +698,8 @@ def test_cancelpayment():
         pseudo_random_generator=setup.prng,
         block_number=expiry_block,
     )
+    # The lock expired, so the route failed
+    assert search_for_item(iteration.events, EventRouteFailed, {}) is not None
     assert not iteration.new_state, "payment task should be deleted at this block"
 
 
@@ -861,6 +865,8 @@ def test_initiator_lock_expired():
         },
     )
     assert lock_expired is not None
+    # The lock expired, so the route failed
+    assert search_for_item(iteration.events, EventRouteFailed, {}) is not None
 
     assert search_for_item(iteration.events, EventUnlockFailed, {})
 
@@ -963,6 +969,8 @@ def test_initiator_lock_expired_must_not_be_sent_if_channel_is_closed():
         setup.current_state, block, channel_map, setup.prng, expiration_block_number
     )
     assert search_for_item(iteration.events, SendLockExpired, {}) is None
+    # The lock expired, so the route failed
+    assert search_for_item(iteration.events, EventRouteFailed, {}) is not None
 
 
 def test_initiator_handle_contract_receive_secret_reveal():

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -634,26 +634,26 @@ def valid_lockedtransfer_check(
     return result
 
 
-def refund_transfer_matches_received(
-    refund_transfer: LockedTransferSignedState, received_transfer: LockedTransferUnsignedState
+def refund_transfer_matches_transfer(
+    refund_transfer: LockedTransferSignedState, transfer: LockedTransferUnsignedState
 ) -> bool:
     refund_transfer_sender = refund_transfer.balance_proof.sender
     # Ignore a refund from the target
-    if refund_transfer_sender == received_transfer.target:
+    if refund_transfer_sender == transfer.target:
         return False
 
     return (
-        received_transfer.payment_identifier == refund_transfer.payment_identifier
-        and received_transfer.lock.amount == refund_transfer.lock.amount
-        and received_transfer.lock.secrethash == refund_transfer.lock.secrethash
-        and received_transfer.target == refund_transfer.target
-        and received_transfer.lock.expiration == refund_transfer.lock.expiration
+        transfer.payment_identifier == refund_transfer.payment_identifier
+        and transfer.lock.amount == refund_transfer.lock.amount
+        and transfer.lock.secrethash == refund_transfer.lock.secrethash
+        and transfer.target == refund_transfer.target
+        and transfer.lock.expiration == refund_transfer.lock.expiration
         and
         # The refund transfer is not tied to the other direction of the same
         # channel, it may reach this node through a different route depending
         # on the path finding strategy
         # original_receiver == refund_transfer_sender and
-        received_transfer.token == refund_transfer.token
+        transfer.token == refund_transfer.token
     )
 
 
@@ -676,7 +676,7 @@ def is_valid_refund(
     if not is_valid_locked_transfer:
         return False, msg, None
 
-    if not refund_transfer_matches_received(refund.transfer, received_transfer):
+    if not refund_transfer_matches_transfer(refund.transfer, received_transfer):
         return False, "Refund transfer did not match the received transfer", None
 
     return True, "", merkletree

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -671,3 +671,31 @@ class EventUnexpectedSecretReveal(Event):
         )
 
         return restored
+
+
+class EventRouteFailed(Event):
+    """ Event emitted when a route failed.
+
+    A route fails, when a RefundTransfer reaches the initator.
+    """
+
+    def __init__(self, secrethash: SecretHash):
+        self.secrethash = secrethash
+
+    def __repr__(self):
+        return f"<" f"EventRouteFailed " f"secrethash:{pex(self.secrethash)} " f">"
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, EventUnexpectedSecretReveal) and self.secrethash == other.secrethash
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"secrethash": serialize_bytes(self.secrethash)}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "EventRouteFailed":
+        return cls(secrethash=deserialize_secret_hash(data["secrethash"]))

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -676,14 +676,23 @@ class EventUnexpectedSecretReveal(Event):
 class EventRouteFailed(Event):
     """ Event emitted when a route failed.
 
-    A route fails, when a RefundTransfer reaches the initator.
+    As a payment can try different routes to reach the intended target
+    some of the routes can fail. This event is emitted when a route failed.
+
+    This means that multiple EventRouteFailed for a given payment and it's
+    therefore different to EventPaymentSentFailed.
+
+    A route can fail for two reasons:
+    - A refund transfer reaches the initiator (it's not important if this
+        refund transfer is unlocked or not)
+    - A lock expires
     """
 
     def __init__(self, secrethash: SecretHash):
         self.secrethash = secrethash
 
     def __repr__(self):
-        return f"<" f"EventRouteFailed " f"secrethash:{pex(self.secrethash)} " f">"
+        return f"<EventRouteFailed secrethash:{pex(self.secrethash)}>"
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -7,6 +7,7 @@ from raiden.transfer.architecture import Event, TransitionResult
 from raiden.transfer.events import EventPaymentSentFailed, EventPaymentSentSuccess
 from raiden.transfer.mediated_transfer.events import (
     CHANNEL_IDENTIFIER_GLOBAL_QUEUE,
+    EventRouteFailed,
     EventUnlockFailed,
     EventUnlockSuccess,
     SendLockedTransfer,
@@ -144,6 +145,7 @@ def handle_block(
             target=transfer_description.target,
             reason=reason,
         )
+        route_failed = EventRouteFailed(secrethash=secrethash)
         unlock_failed = EventUnlockFailed(
             identifier=payment_identifier,
             secrethash=initiator_state.transfer_description.secrethash,
@@ -159,7 +161,7 @@ def handle_block(
             # task around to wait for the LockExpired messages to sync.
             # Check https://github.com/raiden-network/raiden/issues/3183
             initiator_state if lock_exists else None,
-            events + [payment_failed, unlock_failed],
+            events + [payment_failed, route_failed, unlock_failed],
         )
     else:
         return TransitionResult(initiator_state, events)

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -283,8 +283,7 @@ def handle_transferrefundcancelroute(
         and refund_transfer.lock.expiration == original_transfer.lock.expiration
     )
 
-    # Weird naming, what do others think?
-    is_valid_refund = channel.refund_transfer_matches_received(refund_transfer, original_transfer)
+    is_valid_refund = channel.refund_transfer_matches_transfer(refund_transfer, original_transfer)
 
     events = list()
     if not is_valid_lock or not is_valid_refund:


### PR DESCRIPTION
Part of #3996 

This adds a new event `EventRouteFailed` and emits it when a `RefundTransfer` reaches the initiator and therefore a route didn't work.

This will be used to trigger route feedback to the PFS.

The second commit renames `refund_transfer_matches_received` to `refund_transfer_matches_transfer` which fits usage better.