### PR TITLE
Improvements to mediated_transfer unit tests

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -160,7 +160,7 @@ def test_next_route():
     )
 
     # HOP3 should be ignored because it doesn't have enough balance
-    assert iteration.new_state.cancelled_channels == [channel1.identifier]
+    assert iteration.new_state.cancelled_channels == [channels[0].identifier]
 
 
 def test_init_with_usable_routes():

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -760,7 +760,7 @@ class ChannelSet:
         return make_route_from_channel(self.channels[channel_index])
 
     def get_routes(self, *args) -> List[RouteState]:
-        return [self.get_route(channel_index) for channel_index in args]
+        return [self.get_route(index) for index in (args or range(len(self.channels)))]
 
     def __getitem__(self, item: int) -> NettingChannelState:
         return self.channels[item]
@@ -788,6 +788,14 @@ def make_channel_set(
         channels.append(create(properties[i], defaults))
 
     return ChannelSet(channels, our_pkeys, partner_pkeys)
+
+
+def make_channel_set_from_amounts(amounts: List[typing.TokenAmount]) -> ChannelSet:
+    properties = [
+        NettingChannelStateProperties(our_state=NettingChannelEndStateProperties(balance=amount))
+        for amount in amounts
+    ]
+    return make_channel_set(properties)
 
 
 def mediator_make_channel_pair(

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -66,6 +66,7 @@ from raiden.utils.typing import (
     PaymentID,
     PaymentNetworkID,
     Secret,
+    SecretHash,
     Signature,
     TargetAddress,
     TokenAddress,
@@ -254,7 +255,7 @@ def make_merkletree_leaves(width: int) -> List[Keccak256]:
     return [make_secret() for _ in range(width)]
 
 
-def make_merkletree(leaves: List[typing.SecretHash]) -> MerkleTreeState:
+def make_merkletree(leaves: List[SecretHash]) -> MerkleTreeState:
     return MerkleTreeState(compute_layers(leaves))
 
 
@@ -794,7 +795,7 @@ def make_channel_set(
     return ChannelSet(channels, our_pkeys, partner_pkeys)
 
 
-def make_channel_set_from_amounts(amounts: List[typing.TokenAmount]) -> ChannelSet:
+def make_channel_set_from_amounts(amounts: List[TokenAmount]) -> ChannelSet:
     properties = [
         NettingChannelStateProperties(our_state=NettingChannelEndStateProperties(balance=amount))
         for amount in amounts

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -254,6 +254,10 @@ def make_merkletree_leaves(width: int) -> List[Keccak256]:
     return [make_secret() for _ in range(width)]
 
 
+def make_merkletree(leaves: List[typing.SecretHash]) -> MerkleTreeState:
+    return MerkleTreeState(compute_layers(leaves))
+
+
 @singledispatch
 def create(properties: Any, defaults: Optional[Properties] = None) -> Any:
     """Create objects from their associated property class.

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -12,6 +12,7 @@ from raiden.messages import LockedTransfer, LockExpired, Message, Unlock
 from raiden.tests.utils.factories import make_address, make_secret
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.transfer import channel, views
+from raiden.transfer.architecture import TransitionResult
 from raiden.transfer.mediated_transfer.events import SendSecretRequest
 from raiden.transfer.mediated_transfer.state import LockedTransferSignedState
 from raiden.transfer.mediated_transfer.state_change import ReceiveLockExpired
@@ -27,6 +28,7 @@ from raiden.transfer.state import (
 from raiden.utils import lpex, pex, random_secret, sha3
 from raiden.utils.signer import LocalSigner, Signer
 from raiden.utils.typing import (
+    Any,
     Balance,
     Callable,
     ChainID,
@@ -492,6 +494,12 @@ def assert_balance(
         f"did not equal the balance ({balance})"
     )
     assert balance == locked + distributable, msg
+
+
+def assert_dropped(iteration: TransitionResult, old_state: Any, reason: Optional[str] = None):
+    msg = f"State change expected to be dropped ({reason or 'reason unknown'})."
+    assert iteration.new_state is None or iteration.new_state == old_state, msg
+    assert not iteration.events, msg
 
 
 def make_receive_transfer_mediated(


### PR DESCRIPTION
- Remove duplicated setup code in `test_initiatorstate.py`
- Test hitherto untested paths in initiator and mediator modules

Closes #3953