### PR TITLE
Increase unit test coverage of small modules in raiden/transfer/

### DIFF
--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -25,7 +25,9 @@ from raiden.transfer.state import BalanceProofUnsignedState
 from raiden.transfer.state_change import ReceiveUnlock
 from raiden.transfer.utils import (
     get_event_with_balance_proof_by_balance_hash,
+    get_event_with_balance_proof_by_locksroot,
     get_state_change_with_balance_proof_by_balance_hash,
+    get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.utils import sha3
 
@@ -216,6 +218,14 @@ def test_get_state_change_with_balance_proof():
         )
         assert state_change_record.data == state_change
 
+        state_change_record = get_state_change_with_balance_proof_by_locksroot(
+            storage=storage,
+            canonical_identifier=balance_proof.canonical_identifier,
+            sender=balance_proof.sender,
+            locksroot=balance_proof.locksroot,
+        )
+        assert state_change_record.data == state_change
+
 
 def test_get_event_with_balance_proof():
     """ All events which contain a balance proof must be found by when
@@ -275,6 +285,15 @@ def test_get_event_with_balance_proof():
             balance_hash=balance_proof.balance_hash,
         )
         assert event_record.data == event
+
+        event_record = get_event_with_balance_proof_by_locksroot(
+            storage=storage,
+            canonical_identifier=balance_proof.canonical_identifier,
+            recipient=event.recipient,
+            locksroot=balance_proof.locksroot,
+        )
+        assert event_record.data == event
+
         # Checking that balance proof attribute can be accessed for all events.
         # Issue https://github.com/raiden-network/raiden/issues/3179
         assert event_record.data.balance_proof == event.balance_proof

--- a/raiden/tests/unit/transfer/test_utils.py
+++ b/raiden/tests/unit/transfer/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from eth_utils import decode_hex
+from eth_utils import decode_hex, to_checksum_address
 
 from raiden.constants import EMPTY_HASH, EMPTY_MERKLE_ROOT
 from raiden.tests.utils import factories
@@ -43,3 +43,23 @@ def test_events_for_onchain_secretreveal_typechecks_secret():
     block_hash = factories.make_block_hash()
     with pytest.raises(ValueError):
         events_for_onchain_secretreveal(channel, "This is an invalid secret", 10, block_hash)
+
+
+def test_canonical_identifier_validation():
+    invalid_chain_id = factories.make_canonical_identifier(chain_identifier="337")
+    with pytest.raises(ValueError):
+        invalid_chain_id.validate()
+
+    wrong_type_channel_id = factories.make_canonical_identifier(channel_identifier="1")
+    with pytest.raises(ValueError):
+        wrong_type_channel_id.validate()
+
+    negative_channel_id = factories.make_canonical_identifier(channel_identifier=-5)
+    with pytest.raises(ValueError):
+        negative_channel_id.validate()
+
+    wrong_format_token_network_address = factories.make_canonical_identifier(
+        token_network_address=to_checksum_address(factories.UNIT_TOKEN_NETWORK_ADDRESS)
+    )
+    with pytest.raises(ValueError):
+        wrong_format_token_network_address.validate()


### PR DESCRIPTION
Some additional unit tests to increase the coverage some small modules:

- `transfer.utils` to 92%
- `transfer.secret_registry` to 100%
- `transfer.identifiers` to 81% 

The still uncovered statements in `transfer.identifiers` will mostly be removed with the switch to dataclasses.

Closes #3910.