### PR TITLE
Removed parity geth account import

### DIFF
--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -63,10 +63,12 @@ else:
         initial_port = initial_port or 27854
 
         for port in count(initial_port):
+            # Because it is not know which interface the socket will bind to,
+            # if there is any socket in the target port it must be skiped.
             connect_using_port = (
                 conn
                 for conn in psutil.net_connections()
-                if hasattr(conn, "laddr") and conn.laddr[0] == LOOPBACK and conn.laddr[1] == port
+                if hasattr(conn, "laddr") and conn.laddr[1] == port
             )
 
             if not any(connect_using_port):

--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -63,7 +63,7 @@ else:
         initial_port = initial_port or 27854
 
         for port in count(initial_port):
-            # Because it is not know which interface the socket will bind to,
+            # Because it is not known which interface the socket will bind to,
             # if there is any socket in the target port it must be skiped.
             connect_using_port = (
                 conn


### PR DESCRIPTION
This removes the calls to geth and parity import. This was done because parity account import hangs every so often and makes our CI flaky.

I did this because another build failed with a hanging account import: https://circleci.com/gh/raiden-network/raiden/48224#tests/containers/2