### PR TITLE
Remove --pathfinding-eth-address option

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -75,7 +75,6 @@ class App:  # pylint: disable=too-few-public-methods
         "shutdown_timeout": DEFAULT_SHUTDOWN_TIMEOUT,
         "services": {
             "pathfinding_service_address": None,
-            "pathfinding_eth_address": None,
             "pathfinding_max_paths": DEFAULT_PATHFINDING_MAX_PATHS,
             "pathfinding_max_fee": DEFAULT_PATHFINDING_MAX_FEE,
             "pathfinding_iou_timeout": DEFAULT_PATHFINDING_IOU_TIMEOUT,

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -100,7 +100,7 @@ def get_random_service(
 
 class PFSConfiguration(NamedTuple):
     url: str
-    eth_address: str
+    eth_address: Optional[str]
     fee: int
 
 
@@ -118,7 +118,9 @@ def configure_pfs_message(info: Dict[str, Any], url: str, eth_address: str) -> s
 
 
 def configure_pfs_or_exit(
-    pfs_address: Optional[str], routing_mode: RoutingMode, service_registry
+    pfs_address: Optional[str],
+    routing_mode: RoutingMode,
+    service_registry: Optional[ServiceRegistry],
 ) -> PFSConfiguration:
     """
     Take in the given pfs_address argument, the service registry and find out a
@@ -157,17 +159,19 @@ def configure_pfs_or_exit(
         )
         sys.exit(1)
     else:
-        if "payment_address" not in pathfinding_service_info:
+        fee = pathfinding_service_info.get("price_info", 0)
+        pfs_eth_address = pathfinding_service_info.get("payment_address", None)
+        if fee > 0 and not pfs_eth_address:
             click.secho(
                 f"The pathfinding service at {pfs_address} did not provide an eth address "
-                f"to pay it. Raiden will shut down."
+                f"to pay it. Raiden will shut down. Please try a different PFS."
             )
             sys.exit(1)
-        pfs_eth_address = pathfinding_service_info["payment_address"]
-        if not is_checksum_address(pfs_eth_address):
+        if fee > 0 and not is_checksum_address(pfs_eth_address):
             click.secho(
                 f"Invalid reply from pathfinding service {pfs_address}: Payment address "
-                f"'{pfs_eth_address}' is not a valid EIP55 address. Raiden will shut down."
+                f"'{pfs_eth_address}' is not a valid EIP55 address. Raiden will shut "
+                f"down. Please choose a different PFS."
             )
             sys.exit(1)
         msg = configure_pfs_message(
@@ -176,11 +180,7 @@ def configure_pfs_or_exit(
         click.secho(msg)
         log.info("Using PFS", pfs_info=pathfinding_service_info)
 
-    return PFSConfiguration(
-        url=pfs_address,
-        eth_address=pfs_eth_address,
-        fee=pathfinding_service_info.get("price_info", 0),
-    )
+    return PFSConfiguration(url=pfs_address, eth_address=pfs_eth_address, fee=fee)
 
 
 def get_last_iou(

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -7,7 +7,7 @@ from enum import IntEnum, unique
 import click
 import requests
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address, to_hex
+from eth_utils import is_checksum_address, to_canonical_address, to_checksum_address, to_hex
 from web3 import Web3
 
 from raiden.constants import DEFAULT_HTTP_REQUEST_TIMEOUT, ZERO_TOKENS, RoutingMode
@@ -120,7 +120,6 @@ def configure_pfs_message(info: Dict[str, Any], url: str, eth_address: str) -> s
 
 def configure_pfs_or_exit(
     pfs_address: Optional[str],
-    pfs_eth_address: Optional[str],
     routing_mode: RoutingMode,
     service_registry,
 ) -> PFSConfiguration:
@@ -143,7 +142,7 @@ def configure_pfs_or_exit(
     if pfs_address == "auto":
         assert service_registry, "Should not get here without a service registry"
         block_hash = service_registry.client.get_confirmed_blockhash()
-        pfs_address, pfs_eth_address = get_random_service(
+        pfs_address, _ = get_random_service(
             service_registry=service_registry, block_identifier=block_hash
         )
         if pfs_address is None:
@@ -153,7 +152,6 @@ def configure_pfs_or_exit(
             )
             sys.exit(1)
 
-    assert pfs_eth_address, "At this point pfs_eth_address can't be none"
     pathfinding_service_info = get_pfs_info(pfs_address)
     if not pathfinding_service_info:
         click.secho(
@@ -162,6 +160,19 @@ def configure_pfs_or_exit(
         )
         sys.exit(1)
     else:
+        if 'payment_address' not in pathfinding_service_info:
+            click.secho(
+                f"The pathfinding service at {pfs_address} did not provide an eth address "
+                f"to pay it. Raiden will shut down."
+            )
+            sys.exit(1)
+        pfs_eth_address = pathfinding_service_info['payment_address']
+        if not is_checksum_address(pfs_eth_address):
+            click.secho(
+                f"Invalid reply from pathfinding service {pfs_address}: Payment address "
+                f"'{pfs_eth_address}' is not a valid EIP55 address. Raiden will shut down."
+            )
+            sys.exit(1)
         msg = configure_pfs_message(
             info=pathfinding_service_info, url=pfs_address, eth_address=pfs_eth_address
         )

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -29,7 +29,6 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
     TokenNetworkID,
-    Tuple,
     Union,
 )
 from raiden_contracts.utils.proofs import sign_one_to_n_iou
@@ -78,7 +77,7 @@ def get_pfs_info(url: str) -> Optional[Dict]:
 
 def get_random_service(
     service_registry: ServiceRegistry, block_identifier: BlockSpecification
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Optional[str]:
     """Selects a random PFS from service_registry.
 
     Returns a tuple of the chosen services url and eth address.
@@ -86,7 +85,7 @@ def get_random_service(
     """
     count = service_registry.service_count(block_identifier=block_identifier)
     if count == 0:
-        return None, None
+        return None
     index = random.SystemRandom().randint(0, count - 1)
     address = service_registry.get_service_address(block_identifier=block_identifier, index=index)
     # We are using the same blockhash for both blockchain queries so the address
@@ -96,7 +95,7 @@ def get_random_service(
     url = service_registry.get_service_url(
         block_identifier=block_identifier, service_hex_address=address
     )
-    return url, address
+    return url
 
 
 class PFSConfiguration(NamedTuple):
@@ -119,9 +118,7 @@ def configure_pfs_message(info: Dict[str, Any], url: str, eth_address: str) -> s
 
 
 def configure_pfs_or_exit(
-    pfs_address: Optional[str],
-    routing_mode: RoutingMode,
-    service_registry,
+    pfs_address: Optional[str], routing_mode: RoutingMode, service_registry
 ) -> PFSConfiguration:
     """
     Take in the given pfs_address argument, the service registry and find out a
@@ -142,7 +139,7 @@ def configure_pfs_or_exit(
     if pfs_address == "auto":
         assert service_registry, "Should not get here without a service registry"
         block_hash = service_registry.client.get_confirmed_blockhash()
-        pfs_address, _ = get_random_service(
+        pfs_address = get_random_service(
             service_registry=service_registry, block_identifier=block_hash
         )
         if pfs_address is None:
@@ -160,13 +157,13 @@ def configure_pfs_or_exit(
         )
         sys.exit(1)
     else:
-        if 'payment_address' not in pathfinding_service_info:
+        if "payment_address" not in pathfinding_service_info:
             click.secho(
                 f"The pathfinding service at {pfs_address} did not provide an eth address "
                 f"to pay it. Raiden will shut down."
             )
             sys.exit(1)
-        pfs_eth_address = pathfinding_service_info['payment_address']
+        pfs_eth_address = pathfinding_service_info["payment_address"]
         if not is_checksum_address(pfs_eth_address):
             click.secho(
                 f"Invalid reply from pathfinding service {pfs_address}: Payment address "

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -37,7 +37,7 @@ def test_service_registry_random_pfs(
     assert not c1_service_proxy.get_service_address("latest", 9999)
 
     # Test that getting a random service from the proxy works
-    assert get_random_service(c1_service_proxy, "latest") in zip(urls, addresses)
+    assert get_random_service(c1_service_proxy, "latest") in urls
 
 
 def test_configure_pfs(service_registry_address, private_keys, web3, contract_manager):
@@ -66,39 +66,31 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     # With basic routing configure pfs should raise assertion
     with pytest.raises(AssertionError):
         config = configure_pfs_or_exit(
-            pfs_address=None,
-            routing_mode=RoutingMode.BASIC,
-            service_registry=service_proxy,
+            pfs_address=None, routing_mode=RoutingMode.BASIC, service_registry=service_proxy
         )
 
     # Asking for auto address
     with patch.object(requests, "get", return_value=response):
         config = configure_pfs_or_exit(
-            pfs_address="auto",
-            routing_mode=RoutingMode.PFS,
-            service_registry=service_proxy,
+            pfs_address="auto", routing_mode=RoutingMode.PFS, service_registry=service_proxy
         )
     assert config.url in urls
     assert is_checksum_address(config.eth_address)
 
     # Configuring a given address
     given_address = "http://ourgivenaddress"
-    given_eth_address = "0x22222222222222222222"
     with patch.object(requests, "get", return_value=response):
         config = configure_pfs_or_exit(
-            pfs_address=given_address,
-            routing_mode=RoutingMode.PFS,
-            service_registry=service_proxy,
+            pfs_address=given_address, routing_mode=RoutingMode.PFS, service_registry=service_proxy
         )
     assert config.url == given_address
-    assert config.eth_address == json_data['payment_address']
+    assert config.eth_address == json_data["payment_address"]
     assert config.fee == json_data["price_info"]
 
     # Bad address, should exit the program
     response = Mock()
     response.configure_mock(status_code=400)
     bad_address = "http://badaddress"
-    pfs_eth_address = "0x22222222222222222222"
     with pytest.raises(SystemExit):
         with patch.object(requests, "get", side_effect=requests.RequestException()):
             # Configuring a given address

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -56,6 +56,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",
         "version": "0.0.1",
+        "payment_address": "0x2222222222222222222222222222222222222222",
     }
 
     response = Mock()
@@ -66,7 +67,6 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     with pytest.raises(AssertionError):
         config = configure_pfs_or_exit(
             pfs_address=None,
-            pfs_eth_address=None,
             routing_mode=RoutingMode.BASIC,
             service_registry=service_proxy,
         )
@@ -75,7 +75,6 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     with patch.object(requests, "get", return_value=response):
         config = configure_pfs_or_exit(
             pfs_address="auto",
-            pfs_eth_address=None,
             routing_mode=RoutingMode.PFS,
             service_registry=service_proxy,
         )
@@ -88,12 +87,11 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     with patch.object(requests, "get", return_value=response):
         config = configure_pfs_or_exit(
             pfs_address=given_address,
-            pfs_eth_address=given_eth_address,
             routing_mode=RoutingMode.PFS,
             service_registry=service_proxy,
         )
     assert config.url == given_address
-    assert config.eth_address == given_eth_address
+    assert config.eth_address == json_data['payment_address']
     assert config.fee == json_data["price_info"]
 
     # Bad address, should exit the program
@@ -106,7 +104,6 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             # Configuring a given address
             config = configure_pfs_or_exit(
                 pfs_address=bad_address,
-                pfs_eth_address=pfs_eth_address,
                 routing_mode=RoutingMode.PFS,
                 service_registry=service_proxy,
             )

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -24,7 +24,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS1 scenario. It creates a network with topology A <-> B <-> C <-> D and checks

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -24,7 +24,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS1 scenario. It creates a network with topology A <-> B <-> C <-> D and checks

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -24,7 +24,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS3 scenario. It creates a network with topology A <-> B <-> C <-> D and A <-> E <-> D

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -24,7 +24,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS4 scenario. It creates a network with topology A <-> B <-> C <-> D and A <-> E <-> D

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -24,7 +24,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS5 scenario. It creates a network with topology A <-> B <-> C <-> D and A <-> E <-> D

--- a/raiden/tests/scenarios/pfs6_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs6_low_capacity.yaml
@@ -25,7 +25,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS6 scenario. It creates a network with topology A <-> B <-> C <-> D and A <-> E <-> D

--- a/raiden/tests/scenarios/pfs7_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs7_simple_path_rewards.yaml
@@ -24,7 +24,6 @@ nodes:
     environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-eth-address: "0x0bae0289aaa26845224f528f9b9defe69e01606e"
     pathfinding-max-fee: 10
 
 ## This is the PFS7 scenario. It creates a network with topology A <-> B <-> C <-> D and

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -13,7 +13,6 @@ from raiden.utils.ethereum_clients import is_supported_client
 # The tuples define the inverse values for the depended-on options
 _OPTION_DEPENDENCY_TEST_VALUES = {
     "pathfinding-service-address": "https://example.com",
-    "pathfinding-eth-address": "0x22222222222222222222",
     "pathfinding-max-paths": 5,
     "pathfinding-max-fee": 1,
     "pathfinding-iou-timeout": 200,

--- a/raiden/tests/unit/test_startup.py
+++ b/raiden/tests/unit/test_startup.py
@@ -7,7 +7,7 @@ from gevent import server
 from raiden.app import App
 from raiden.constants import Environment, RoutingMode
 from raiden.network.transport import UDPTransport
-from raiden.tests.utils.factories import make_address, make_checksum_address
+from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.mocks import MockChain, MockWeb3, patched_get_for_succesful_pfs_info
 from raiden.ui.checks import check_ethereum_network_id
 from raiden.ui.startup import (
@@ -168,7 +168,6 @@ def test_setup_proxies_raiden_addresses_are_given():
         contracts=contracts,
         routing_mode=RoutingMode.BASIC,
         pathfinding_service_address=None,
-        pathfinding_eth_address=None,
     )
     assert proxies
     assert proxies.token_network_registry
@@ -200,7 +199,6 @@ def test_setup_proxies_all_addresses_are_given(routing_mode):
             contracts=contracts,
             routing_mode=routing_mode,
             pathfinding_service_address="my-pfs",
-            pathfinding_eth_address=make_checksum_address(),
         )
     assert proxies
     assert proxies.token_network_registry
@@ -232,7 +230,6 @@ def test_setup_proxies_all_addresses_are_known(routing_mode):
             contracts=contracts,
             routing_mode=routing_mode,
             pathfinding_service_address="my-pfs",
-            pathfinding_eth_address=make_checksum_address(),
         )
     assert proxies
     assert proxies.token_network_registry
@@ -266,7 +263,6 @@ def test_setup_proxies_no_service_registry_but_pfs():
             contracts=contracts,
             routing_mode=RoutingMode.PFS,
             pathfinding_service_address="my-pfs",
-            pathfinding_eth_address=make_checksum_address(),
         )
     assert proxies
 
@@ -295,7 +291,6 @@ def test_setup_proxies_no_service_registry_and_no_pfs_address_but_requesting_pfs
                 contracts=contracts,
                 routing_mode=RoutingMode.PFS,
                 pathfinding_service_address=None,
-                pathfinding_eth_address=None,
             )
 
 

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -192,6 +192,7 @@ def patched_get_for_succesful_pfs_info():
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",
         "version": "0.0.1",
+        "payment_address": "0x2222222222222222222222222222222222222222",
     }
 
     response = Mock()

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -96,9 +96,8 @@ def deploy_service_registry_and_set_urls(
     )
 
     # Test that getting a random service for an empty registry returns None
-    pfs_address, pfs_eth_address = get_random_service(c1_service_proxy, "latest")
+    pfs_address = get_random_service(c1_service_proxy, "latest")
     assert pfs_address is None
-    assert pfs_eth_address is None
 
     # Test that setting the urls works
     c1_service_proxy.set_url(urls[0])

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -137,7 +137,6 @@ def run_app(
     environment_type: Environment,
     unrecoverable_error_should_crash: bool,
     pathfinding_service_address: str,
-    pathfinding_eth_address: str,
     pathfinding_max_paths: int,
     enable_monitoring: bool,
     resolver_endpoint: str,
@@ -222,7 +221,6 @@ def run_app(
         contracts=contracts,
         routing_mode=routing_mode,
         pathfinding_service_address=pathfinding_service_address,
-        pathfinding_eth_address=pathfinding_eth_address,
     )
 
     database_path = os.path.join(

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -48,7 +48,6 @@ log = structlog.get_logger(__name__)
 
 OPTION_DEPENDENCIES: Dict[str, List[Tuple[str, Any]]] = {
     "pathfinding-service-address": [("transport", "matrix"), ("routing-mode", RoutingMode.PFS)],
-    "pathfinding-eth-address": [("transport", "matrix"), ("routing-mode", RoutingMode.PFS)],
     "pathfinding-max-paths": [("transport", "matrix"), ("routing-mode", RoutingMode.PFS)],
     "pathfinding-max-fee": [("transport", "matrix"), ("routing-mode", RoutingMode.PFS)],
     "pathfinding-iou-timeout": [("transport", "matrix"), ("routing-mode", RoutingMode.PFS)],
@@ -249,17 +248,6 @@ def options(func):
                 default="auto",
                 type=str,
                 show_default=True,
-            ),
-            option(
-                "--pathfinding-eth-address",
-                help=(
-                    "Ethereum address to which to pay the fees of the path finding service.\n"
-                    "If the path finding service is chosen from the service registry contract, "
-                    "this option will be ignored. If the path finding service is configured "
-                    'manually, i. e. "--pathfinding-service-address" set to a value other than '
-                    '"auto", this argument must be set to a valid EIP55 address.'
-                ),
-                type=str,
             ),
             option(
                 "--pathfinding-max-paths",

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -224,7 +224,6 @@ def setup_proxies_or_exit(
 
         pfs_config = configure_pfs_or_exit(
             pfs_address=pathfinding_service_address,
-            pfs_eth_address=pathfinding_eth_address,
             routing_mode=routing_mode,
             service_registry=service_registry,
         )

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -125,7 +125,6 @@ def setup_proxies_or_exit(
     contracts: Dict[str, Any],
     routing_mode: RoutingMode,
     pathfinding_service_address: str,
-    pathfinding_eth_address: str,
 ) -> Proxies:
     """
     Initialize and setup the contract proxies.

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -15,7 +15,6 @@ import requests
 from click import BadParameter, Choice
 from click._compat import term_len
 from click.formatting import iter_rows, measure_table, wrap_text
-from eth_utils import is_checksum_address
 from pytoml import TomlError, load
 from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_price_strategy
 
@@ -443,17 +442,6 @@ def get_matrix_servers(url: str) -> List[str]:
     return available_servers
 
 
-def validate_pfs_options(options):
-    eth_address = options.get("pathfinding-eth-address")
-    if options.get("pathfinding-service-address") not in ("auto", None) and eth_address is None:
-        raise BadParameter(
-            '"--pathfinding-service-address" set manually '
-            'but no "--pathfinding-eth-address" given.'
-        )
-    if eth_address is not None and not is_checksum_address(eth_address):
-        raise BadParameter('"--pathfinding-eth-address" value is not a valid EIP55 address.')
-
-
 def validate_option_dependencies(
     command_function: Union[click.Command, click.Group],
     ctx,
@@ -486,8 +474,6 @@ def validate_option_dependencies(
                     ctx,
                     param,
                 )
-
-    validate_pfs_options(cli_params)
 
 
 ADDRESS_TYPE = AddressType()


### PR DESCRIPTION
Now that the PFS includes its eth address in the `/info` endpoint response, we don't need a cli and config option to configure it anymore.

Closes #4054 