### PR TITLE
Handle feedback token from PFS

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -33,7 +33,7 @@ log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class MessageHandler:
-    def on_message(self, raiden: RaidenService, message: Message):
+    def on_message(self, raiden: RaidenService, message: Message) -> None:
         # pylint: disable=unidiomatic-typecheck
 
         if type(message) == SecretRequest:
@@ -71,7 +71,7 @@ class MessageHandler:
             log.error("Unknown message cmdid {}".format(message.cmdid))
 
     @staticmethod
-    def handle_message_secretrequest(raiden: RaidenService, message: SecretRequest):
+    def handle_message_secretrequest(raiden: RaidenService, message: SecretRequest) -> None:
         secret_request = ReceiveSecretRequest(
             message.payment_identifier,
             message.amount,
@@ -82,12 +82,12 @@ class MessageHandler:
         raiden.handle_and_track_state_change(secret_request)
 
     @staticmethod
-    def handle_message_revealsecret(raiden: RaidenService, message: RevealSecret):
+    def handle_message_revealsecret(raiden: RaidenService, message: RevealSecret) -> None:
         state_change = ReceiveSecretReveal(message.secret, message.sender)
         raiden.handle_and_track_state_change(state_change)
 
     @staticmethod
-    def handle_message_unlock(raiden: RaidenService, message: Unlock):
+    def handle_message_unlock(raiden: RaidenService, message: Unlock) -> None:
         balance_proof = balanceproof_from_envelope(message)
         state_change = ReceiveUnlock(
             message_identifier=message.message_identifier,
@@ -97,7 +97,7 @@ class MessageHandler:
         raiden.handle_and_track_state_change(state_change)
 
     @staticmethod
-    def handle_message_lockexpired(raiden: RaidenService, message: LockExpired):
+    def handle_message_lockexpired(raiden: RaidenService, message: LockExpired) -> None:
         balance_proof = balanceproof_from_envelope(message)
         state_change = ReceiveLockExpired(
             balance_proof=balance_proof,
@@ -107,12 +107,11 @@ class MessageHandler:
         raiden.handle_and_track_state_change(state_change)
 
     @staticmethod
-    def handle_message_refundtransfer(raiden: RaidenService, message: RefundTransfer):
+    def handle_message_refundtransfer(raiden: RaidenService, message: RefundTransfer) -> None:
         token_network_address = message.token_network_address
         from_transfer = lockedtransfersigned_from_message(message)
         chain_state = views.state_from_raiden(raiden)
 
-        # FIXME: add return types
         # FIXME: Shouldn't request routes here
         routes, _ = get_best_routes(
             chain_state=chain_state,
@@ -148,7 +147,7 @@ class MessageHandler:
         raiden.handle_and_track_state_change(state_change)
 
     @staticmethod
-    def handle_message_lockedtransfer(raiden: RaidenService, message: LockedTransfer):
+    def handle_message_lockedtransfer(raiden: RaidenService, message: LockedTransfer) -> None:
         secrethash = message.lock.secrethash
         # We must check if the secret was registered against the latest block,
         # even if the block is forked away and the transaction that registers
@@ -175,11 +174,11 @@ class MessageHandler:
             raiden.mediate_mediated_transfer(message)
 
     @staticmethod
-    def handle_message_processed(raiden: RaidenService, message: Processed):
+    def handle_message_processed(raiden: RaidenService, message: Processed) -> None:
         processed = ReceiveProcessed(message.sender, message.message_identifier)
         raiden.handle_and_track_state_change(processed)
 
     @staticmethod
-    def handle_message_delivered(raiden: RaidenService, message: Delivered):
+    def handle_message_delivered(raiden: RaidenService, message: Delivered) -> None:
         delivered = ReceiveDelivered(message.sender, message.delivered_message_identifier)
         raiden.handle_and_track_state_change(delivered)

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -112,7 +112,9 @@ class MessageHandler:
         from_transfer = lockedtransfersigned_from_message(message)
         chain_state = views.state_from_raiden(raiden)
 
-        routes = get_best_routes(
+        # FIXME: add return types
+        # FIXME: Shouldn't request routes here
+        routes, _ = get_best_routes(
             chain_state=chain_state,
             token_network_id=TokenNetworkID(token_network_address),
             from_address=InitiatorAddress(raiden.address),

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -138,7 +138,7 @@ def initiator_init(
         secrethash=transfer_secrethash,
     )
     previous_address = None
-    routes = routing.get_best_routes(
+    routes, _ = routing.get_best_routes(
         chain_state=views.state_from_raiden(raiden),
         token_network_id=token_network_identifier,
         from_address=InitiatorAddress(raiden.address),
@@ -153,7 +153,8 @@ def initiator_init(
 
 def mediator_init(raiden, transfer: LockedTransfer) -> ActionInitMediator:
     from_transfer = lockedtransfersigned_from_message(transfer)
-    routes = routing.get_best_routes(
+    # Feedback token not used here, will be removed with source routing
+    routes, _ = routing.get_best_routes(
         chain_state=views.state_from_raiden(raiden),
         token_network_id=TokenNetworkID(from_transfer.balance_proof.token_network_identifier),
         from_address=raiden.address,

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -151,7 +151,7 @@ def run_test_participant_selection(raiden_network, token_addresses):
         for target in raiden_network:
             if target.raiden.address == app.raiden.address:
                 continue
-            routes = routing.get_best_routes(
+            routes, _ = routing.get_best_routes(
                 chain_state=node_state,
                 token_network_id=network_state.address,
                 from_address=app.raiden.address,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -17,6 +17,7 @@ from raiden.transfer import views
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
 from raiden.transfer.state_change import ActionChannelSetFee
 from raiden.utils import sha3
+from raiden.utils.typing import TokenAmount
 from raiden.waiting import wait_for_block
 
 
@@ -342,7 +343,7 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
         chain_state, payment_network_id, token_address
     )
 
-    with patch("raiden.routing.query_paths", return_value=[]) as patched:
+    with patch("raiden.routing.query_paths", return_value=([], None)) as patched:
 
         app0.raiden.start_mediated_transfer_with_secret(
             token_network_identifier=token_network_id,
@@ -372,7 +373,7 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
 
             locked_transfer = factories.create(
                 factories.LockedTransferProperties(
-                    amount=5,
+                    amount=TokenAmount(5),
                     initiator=factories.HOP1,
                     target=factories.HOP2,
                     sender=factories.HOP1,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -444,7 +444,7 @@ def test_routing_mocked_pfs_unavailable_peer(chain_state, token_network_state, o
                 "fees": 0,
             }
         ],
-        "feedback_token": "381e4a005a4d4687ac200fa1acd15c6f",
+        "feedback_token": DEFAULT_FEEDBACK_TOKEN.hex,
     }
 
     # test routing with node 2 unavailable
@@ -469,7 +469,7 @@ def test_routing_mocked_pfs_unavailable_peer(chain_state, token_network_state, o
         # is over address2, the internal routing does not provide
         assert routes[0].node_address == address2
         assert routes[0].channel_identifier == channel_state2.identifier
-        assert feedback_token is not None
+        assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
 
 def test_get_and_update_iou():
@@ -720,7 +720,7 @@ def query_paths_args(token_network_state, our_address, pfs_max_fee):
 
 @pytest.fixture
 def valid_response_json():
-    return dict(result="some result", feedback_token="381e4a005a4d4687ac200fa1acd15c6f")
+    return dict(result="some result", feedback_token=DEFAULT_FEEDBACK_TOKEN.hex)
 
 
 def test_query_paths_with_second_try(query_paths_args, valid_response_json):

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -768,7 +768,7 @@ def test_routing_issue2663(chain_state, token_network_state, our_address):
         address4: NODE_NETWORK_REACHABLE,
     }
 
-    routes1 = get_best_routes(
+    routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_id=token_network_state.address,
         from_address=our_address,
@@ -789,7 +789,7 @@ def test_routing_issue2663(chain_state, token_network_state, our_address):
         address4: NODE_NETWORK_REACHABLE,
     }
 
-    routes1 = get_best_routes(
+    routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_id=token_network_state.address,
         from_address=our_address,
@@ -810,7 +810,7 @@ def test_routing_issue2663(chain_state, token_network_state, our_address):
         address4: NODE_NETWORK_REACHABLE,
     }
 
-    routes1 = get_best_routes(
+    routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_id=token_network_state.address,
         from_address=our_address,
@@ -831,7 +831,7 @@ def test_routing_issue2663(chain_state, token_network_state, our_address):
         address4: NODE_NETWORK_REACHABLE,
     }
 
-    routes1 = get_best_routes(
+    routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_id=token_network_state.address,
         from_address=our_address,
@@ -990,7 +990,7 @@ def test_routing_priority(chain_state, token_network_state, our_address):
         address3: NODE_NETWORK_REACHABLE,
     }
 
-    routes = get_best_routes(
+    routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_id=token_network_state.address,
         from_address=our_address,
@@ -1011,7 +1011,7 @@ def test_routing_priority(chain_state, token_network_state, our_address):
         address4: NODE_NETWORK_REACHABLE,
     }
 
-    routes = get_best_routes(
+    routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_id=token_network_state.address,
         from_address=our_address,


### PR DESCRIPTION
This commit adds handling for the feedback token returned from the PFS
and adapts the tests accordingly.

Part of #3996 