### PR TITLE
Make pylint pick up all settings by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint: mypy mypy-all
 	flake8 raiden/ tools/
 	isort $(ISORT_PARAMS) --diff --check-only
 	black --check $(BLACK_PATHS)
-	pylint --load-plugins=tools.pylint.gevent_checker --rcfile .pylint.rc $(LINT_PATHS)
+	pylint $(LINT_PATHS)
 	python setup.py check --restructuredtext --strict
 
 isort:

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,7 @@ jobs=4
 persistent=yes
 suggestion-mode=yes
 unsafe-load-any-extension=no
+load-plugins=tools.pylint.gevent_checker
 
 # Blacklist files or directories (basenames, not paths)
 ignore=


### PR DESCRIPTION
Pylint now uses all intended settings even when run without command line
arguments. This is done by:
* renaming .pylint.rc to pylintrc (the default config file name)
* adding the gevent checker in the config file