### PR TITLE
Fix v21-v22 migration and fix sqlite transaction model

### DIFF
--- a/raiden/storage/migrations/v21_to_v22.py
+++ b/raiden/storage/migrations/v21_to_v22.py
@@ -248,10 +248,10 @@ def _add_canonical_identifier_to_statechanges(
                     lambda obj, channel_id_=channel_id: upgrade_object(obj, chain_id, channel_id_),
                 )
 
-            walk_dicts(state_change_obj, constraint_has_canonical_identifier_or_values_removed)
-            updated_state_changes.append(
-                (json.dumps(state_change_obj), state_change_record.state_change_identifier)
-            )
+                walk_dicts(state_change_obj, constraint_has_canonical_identifier_or_values_removed)
+                updated_state_changes.append(
+                    (json.dumps(state_change_obj), state_change_record.state_change_identifier)
+                )
 
         storage.update_state_changes(updated_state_changes)
         storage.delete_state_changes(delete_state_changes)

--- a/raiden/storage/migrations/v21_to_v22.py
+++ b/raiden/storage/migrations/v21_to_v22.py
@@ -158,7 +158,7 @@ def constraint_removed_duplicated_values(obj: Dict[str, Any]) -> None:
             assert key not in obj
 
 
-def contraint_has_canonical_identifier(obj: Dict[str, Any]) -> None:
+def constraint_has_canonical_identifier(obj: Dict[str, Any]) -> None:
     _type = obj.get("_type")
     if _type in ALL_MIGRATING and _type not in ALL_REMOVE_MIGRATIONS:
         canonical_identifier = obj.get("canonical_identifier")
@@ -170,7 +170,7 @@ def contraint_has_canonical_identifier(obj: Dict[str, Any]) -> None:
 
 def constraint_has_canonical_identifier_or_values_removed(obj: Dict[str, Any]) -> None:
     constraint_removed_duplicated_values(obj)
-    contraint_has_canonical_identifier(obj)
+    constraint_has_canonical_identifier(obj)
 
 
 def walk_dicts(obj: Union[List, Dict], callback: Callable) -> None:

--- a/raiden/storage/migrations/v21_to_v22.py
+++ b/raiden/storage/migrations/v21_to_v22.py
@@ -225,7 +225,7 @@ def _add_canonical_identifier_to_statechanges(
 
     for state_change_batch in storage.batch_query_state_changes(batch_size=500):
         updated_state_changes: List[Tuple[str, int]] = list()
-        delete_state_changes: List[int] = list()
+        delete_state_changes: List[Tuple[int]] = list()
 
         for state_change_record in state_change_batch:
             state_change_obj = json.loads(state_change_record.data)
@@ -236,7 +236,7 @@ def _add_canonical_identifier_to_statechanges(
             )
 
             if should_delete:
-                delete_state_changes.append(state_change_record.state_change_identifier)
+                delete_state_changes.append((state_change_record.state_change_identifier,))
             else:
                 channel_id: Optional[int] = None
                 if is_unlock:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -183,7 +183,7 @@ class SQLiteStorage:
         """
         with self.write_lock:
             self.conn.executemany(
-                "DELETE FROM state_events WHERE identifier = ?", state_changes_to_delete
+                "DELETE FROM state_changes WHERE identifier = ?", state_changes_to_delete
             )
             self.maybe_commit()
 

--- a/raiden/tests/unit/storage/migrations/data/v21_statechanges.json
+++ b/raiden/tests/unit/storage/migrations/data/v21_statechanges.json
@@ -1803,6 +1803,23 @@
   [
     103,
     {
+      "transaction_hash": "0x559f38fb0a36581b96a212acb79432e82186a0e6fb4f4d9e52efc46f6d7368a6",
+      "token_network_identifier": "0x31F486f03875aA82781F3d1207294Cf7F4B0399F",
+      "participant": "0x999999D9b9c0c91AC009AeeBd74313D1a736A24C",
+      "partner": "0x111111e7821A0970EA79185A738BfBd3BC382AAb",
+      "locksroot": "0xd466502291daac54a7a4c34e87006bfb932dd684ac060f75dd8cbc05e7c802a0",
+      "unlocked_amount": "10",
+      "returned_tokens": "0",
+      "block_number": "121",
+      "block_hash": "0x4500be864b3f1b6e2be0d0e0eff3fdd87ec192a458420b5d13d9051be1bb2eea",
+      "_type": "raiden.transfer.state_change.Block",
+      "_type": "raiden.transfer.state_change.ContractReceiveChannelBatchUnlock",
+      "_version": 0
+    }
+  ],
+  [
+    104,
+    {
       "node_address": "0xe3B942e7821A0970EA79185A738BfBd3BC382AAb",
       "network_state": "unreachable",
       "_type": "raiden.transfer.state_change.ActionChangeNodeNetworkState",

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -1,12 +1,14 @@
+import os.path
 from unittest.mock import patch
 
 import pytest
 
 from raiden.storage.sqlite import RAIDEN_DB_VERSION, SQLiteStorage
+from raiden.utils.upgrades import UpgradeManager, UpgradeRecord
 
 
 def test_transaction_commit(tmp_path):
-    filename = f"v{RAIDEN_DB_VERSION}_db.log"
+    filename = f"v{RAIDEN_DB_VERSION}_log.db"
     storage = SQLiteStorage(f"{tmp_path}/{filename}")
 
     with storage.transaction():
@@ -17,15 +19,68 @@ def test_transaction_commit(tmp_path):
 
 
 def test_transaction_rollback(tmp_path):
-    filename = f"v{RAIDEN_DB_VERSION}_db.log"
-    storage = SQLiteStorage(f"{tmp_path}/{filename}")
+    filename = f"v{RAIDEN_DB_VERSION}_log.db"
+    db_path = os.path.join(tmp_path, filename)
+    storage = SQLiteStorage(db_path)
     storage.update_version()
 
     assert storage.get_version() == RAIDEN_DB_VERSION
 
-    with pytest.raises(KeyboardInterrupt):
+    with pytest.raises(RuntimeError):
         with storage.transaction():
             with patch("raiden.storage.sqlite.RAIDEN_DB_VERSION", new=1000):
                 storage.update_version()
-                raise KeyboardInterrupt()
+                raise RuntimeError()
     assert storage.get_version() == RAIDEN_DB_VERSION
+
+
+def test_upgrade_manager_transaction_rollback(tmp_path, monkeypatch):
+    FORMAT = os.path.join(tmp_path, "v{}_log.db")
+
+    def failure(**kwargs):  # pylint: disable=unused-argument
+        raise RuntimeError()
+
+    # Create the db to be upgraded
+    with monkeypatch.context() as m:
+        m.setattr("raiden.storage.sqlite.RAIDEN_DB_VERSION", 1)
+        storage = SQLiteStorage(FORMAT.format(1))
+        storage.update_version()
+        del storage
+
+    # This should not fail with 'OperationalError'
+    with pytest.raises(RuntimeError):
+        with monkeypatch.context() as m:
+            m.setattr("raiden.storage.sqlite.RAIDEN_DB_VERSION", 2)
+            upgrade_list = [UpgradeRecord(from_version=1, function=failure)]
+            m.setattr("raiden.utils.upgrades.UPGRADES_LIST", upgrade_list)
+            manager = UpgradeManager(FORMAT.format(2))
+            manager.run()
+
+    storage = SQLiteStorage(FORMAT.format(2))
+    assert storage.get_version() == 1, "The upgrade must have failed"
+
+
+def test_regression_delete_should_not_commit_the_upgrade_transaction(tmp_path, monkeypatch):
+    FORMAT = os.path.join(tmp_path, "v{}_log.db")
+
+    def failure(storage, **kwargs):  # pylint: disable=unused-argument
+        storage.delete_state_changes([1, 2])
+
+    # Create the db to be upgraded
+    with monkeypatch.context() as m:
+        m.setattr("raiden.storage.sqlite.RAIDEN_DB_VERSION", 1)
+        storage = SQLiteStorage(FORMAT.format(1))
+        storage.update_version()
+        del storage
+
+    with pytest.raises(ValueError):
+        # This should not fail with 'OperationalError'
+        with monkeypatch.context() as m:
+            m.setattr("raiden.storage.sqlite.RAIDEN_DB_VERSION", 2)
+            upgrade_list = [UpgradeRecord(from_version=1, function=failure)]
+            m.setattr("raiden.utils.upgrades.UPGRADES_LIST", upgrade_list)
+            manager = UpgradeManager(FORMAT.format(2))
+            manager.run()
+
+    storage = SQLiteStorage(FORMAT.format(2))
+    assert storage.get_version() == 1, "The upgrade must have failed"


### PR DESCRIPTION
This fixes several bugs that occured in the `v21_to_v22` migration:
### Constraint checking of delete queued state changes
During the migration of state changes, some `ContractReceiveBatchUnlock` instances are queued for deletion (because the user is not part of the unlock). This failed the constraint checking which previously stated that all `ContractReceiveBatchUnlock` need to have a valid canonical identifier.

This PR fixes the constraint checking by skipping deleted state changes.

### Missing testdata for deletion
I added testdata to cover the case for deleting unrelated `ContractReceiveBatchUnlock`

### Incorrect table name in delete_state_changes
The function to delete state changes incorrectly operated on the table `state_events`.

### Incorrect transaction model with sqlite storage module
Some `SQLiteStorage` manipulation functions incorrectly introduced a second transaction context. This became a problem when trying to rollback after an error.
This PR removes the extra `with self.conn` contexts, and adds a test for correct rollback behavior.

Resolves #4041 