### PR TITLE
Matrix .db methods

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1054,9 +1054,7 @@ class MatrixTransport(Runnable):
 
     def _get_private_room(self, invitees: List[User]):
         """ Create an anonymous, private room and invite peers """
-        room = self._client.create_room(
-            None, invitees=[user.user_id for user in invitees], is_public=False
-        )
+        room = self._client.create_room(None, invitees=[user.user_id for user in invitees])
         self.log.debug("Creating private room", room=room, invitees=invitees)
         return room
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -552,9 +552,7 @@ class MatrixTransport(Runnable):
 
             if self.storage:
                 self.storage.write_matrix_userids_for_address(
-                    node_address,
-                    list(user_ids),
-                    datetime.utcnow().isoformat(timespec="milliseconds"),
+                    node_address, user_ids, datetime.utcnow()
                 )
 
             # Ensure network state is updated in case we already know about the user presences
@@ -1058,9 +1056,7 @@ class MatrixTransport(Runnable):
         self._address_mgr.add_userids_for_address(address, {user.user_id for user in peers})
         if self.storage:
             self.storage.write_matrix_userids_for_address(
-                address,
-                [user.user_id for user in peers],
-                datetime.utcnow().isoformat(timespec="milliseconds"),
+                address, {user.user_id for user in peers}, datetime.utcnow()
             )
         self._set_room_id_for_address(address, room.room_id)
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1,6 +1,7 @@
 import json
 import time
 from collections import defaultdict
+from datetime import datetime
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -40,6 +41,7 @@ from raiden.network.transport.matrix.utils import (
 from raiden.network.transport.utils import timeout_exponential_backoff
 from raiden.raiden_service import RaidenService
 from raiden.storage.serialization import JSONSerializer
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, QueueIdentifier
 from raiden.transfer.state import (
@@ -343,6 +345,7 @@ class MatrixTransport(Runnable):
         self._account_data_lock = Semaphore()
 
         self._message_handler: Optional[MessageHandler] = None
+        self._storage: Optional[SerializedSQLiteStorage] = None
 
     def __repr__(self):
         if self._raiden_service is not None:
@@ -364,8 +367,12 @@ class MatrixTransport(Runnable):
         self._stop_event.clear()
         self._starting = True
         self._raiden_service = raiden_service
+        if self._raiden_service.wal:
+            self._storage = self._raiden_service.wal.storage
+            self._address_mgr._address_to_userids = (
+                self._storage.get_matrix_userids_and_addresses()
+            )
         self._message_handler = message_handler
-
         prev_user_id: Optional[str]
         prev_access_token: Optional[str]
         if prev_auth_data and prev_auth_data.count("/") == 1:
@@ -542,6 +549,10 @@ class MatrixTransport(Runnable):
                 if validate_userid_signature(user) == node_address
             }
             self._address_mgr.add_userids_for_address(node_address, user_ids)
+
+            self._storage.write_matrix_userids_for_address(
+                node_address, list(user_ids), datetime.utcnow().isoformat(timespec="milliseconds")
+            )
 
             # Ensure network state is updated in case we already know about the user presences
             # representing the target node
@@ -1042,6 +1053,12 @@ class MatrixTransport(Runnable):
                     )
 
         self._address_mgr.add_userids_for_address(address, {user.user_id for user in peers})
+        if self._storage:
+            self._storage.write_matrix_userids_for_address(
+                address,
+                [user.user_id for user in peers],
+                datetime.utcnow().isoformat(timespec="milliseconds"),
+            )
         self._set_room_id_for_address(address, room.room_id)
 
         if not room.listeners:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1,7 +1,6 @@
 import json
 import time
 from collections import defaultdict
-from datetime import datetime
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -345,7 +344,6 @@ class MatrixTransport(Runnable):
         self._account_data_lock = Semaphore()
 
         self._message_handler: Optional[MessageHandler] = None
-        self.storage: Optional[MatrixStorage] = None
 
     def __repr__(self):
         if self._raiden_service is not None:
@@ -368,10 +366,6 @@ class MatrixTransport(Runnable):
         self._stop_event.clear()
         self._starting = True
         self._raiden_service = raiden_service
-        if storage:
-            self.storage = storage
-            stored_userids_and_addresses = self.storage.get_matrix_user_ids_for_addresses()
-            self._address_mgr.recover_userids(stored_userids_and_addresses)
         self._message_handler = message_handler
         prev_user_id: Optional[str]
         prev_access_token: Optional[str]
@@ -380,7 +374,7 @@ class MatrixTransport(Runnable):
         else:
             prev_user_id = prev_access_token = None
 
-        self._address_mgr.start()
+        self._address_mgr.start(storage)
         login_or_register(
             client=self._client,
             signer=self._raiden_service.signer,
@@ -528,11 +522,6 @@ class MatrixTransport(Runnable):
                 if validate_userid_signature(user) == node_address
             }
             self._address_mgr.add_userids_for_address(node_address, user_ids)
-
-            if self.storage:
-                self.storage.write_matrix_user_ids_for_address(
-                    node_address, user_ids, datetime.utcnow()
-                )
 
             # Ensure network state is updated in case we already know about the user presences
             # representing the target node
@@ -1033,10 +1022,8 @@ class MatrixTransport(Runnable):
                     )
 
         self._address_mgr.add_userids_for_address(address, {user.user_id for user in peers})
-        if self.storage:
-            self.storage.write_matrix_user_ids_for_address(
-                address, {user.user_id for user in peers}, datetime.utcnow()
-            )
+        for member_id in member_ids:
+            self._address_mgr.add_room_id_for_user_id(member_id, room.room_id)
         self._set_room_id_for_address(address, room.room_id)
 
         if not room.listeners:
@@ -1240,28 +1227,34 @@ class MatrixTransport(Runnable):
         If filter_private=None, filter according to self._private_rooms
         """
         address_hex: AddressHex = to_checksum_address(address)
-        with self._account_data_lock:
-            room_ids = self._client.account_data.get("network.raiden.rooms", {}).get(address_hex)
-            self.log.debug("Room ids for address", for_address=address_hex, room_ids=room_ids)
-            if not room_ids:  # None or empty
-                room_ids = list()
-            if not isinstance(room_ids, list):  # old version, single room
-                room_ids = [room_ids]
+        user_ids = self._address_mgr.get_userids_for_address(address)
+        room_ids = [
+            _RoomID(self._address_mgr.get_room_id_for_user_id(user_id)) for user_id in user_ids]
+        if not room_ids:
+            with self._account_data_lock:
+                room_ids = self._client.account_data.get("network.raiden.rooms", {}).get(
+                    address_hex
+                )
+        self.log.debug("Room ids for address", for_address=address_hex, room_ids=room_ids)
+        if not room_ids:  # None or empty
+            room_ids = list()
+        if not isinstance(room_ids, list):  # old version, single room
+            room_ids = [room_ids]
 
-            if filter_private is None:
-                filter_private = self._private_rooms
-            if not filter_private:
-                # existing rooms
-                room_ids = [room_id for room_id in room_ids if room_id in self._client.rooms]
-            else:
-                # existing and private rooms
-                room_ids = [
-                    room_id
-                    for room_id in room_ids
-                    if room_id in self._client.rooms and self._client.rooms[room_id].invite_only
-                ]
+        if filter_private is None:
+            filter_private = self._private_rooms
+        if not filter_private:
+            # existing rooms
+            room_ids = [room_id for room_id in room_ids if room_id in self._client.rooms]
+        else:
+            # existing and private rooms
+            room_ids = [
+                room_id
+                for room_id in room_ids
+                if room_id in self._client.rooms and self._client.rooms[room_id].invite_only
+            ]
 
-            return room_ids
+        return room_ids
 
     def _leave_unused_rooms(self, _address_to_room_ids: Dict[AddressHex, List[_RoomID]]):
         """

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -370,7 +370,7 @@ class MatrixTransport(Runnable):
         self._raiden_service = raiden_service
         if storage:
             self.storage = storage
-            stored_userids_and_addresses = self.storage.get_matrix_userids_and_addresses()
+            stored_userids_and_addresses = self.storage.get_matrix_user_ids_for_addresses()
             self._address_mgr.recover_userids(stored_userids_and_addresses)
         self._message_handler = message_handler
         prev_user_id: Optional[str]
@@ -530,7 +530,7 @@ class MatrixTransport(Runnable):
             self._address_mgr.add_userids_for_address(node_address, user_ids)
 
             if self.storage:
-                self.storage.write_matrix_userids_for_address(
+                self.storage.write_matrix_user_ids_for_address(
                     node_address, user_ids, datetime.utcnow()
                 )
 
@@ -1034,7 +1034,7 @@ class MatrixTransport(Runnable):
 
         self._address_mgr.add_userids_for_address(address, {user.user_id for user in peers})
         if self.storage:
-            self.storage.write_matrix_userids_for_address(
+            self.storage.write_matrix_user_ids_for_address(
                 address, {user.user_id for user in peers}, datetime.utcnow()
             )
         self._set_room_id_for_address(address, room.room_id)

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -41,7 +41,7 @@ from raiden.network.transport.matrix.utils import (
 from raiden.network.transport.utils import timeout_exponential_backoff
 from raiden.raiden_service import RaidenService
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import MatrixStorage, SerializedSQLiteStorage
+from raiden.storage.sqlite import MatrixStorage
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, QueueIdentifier
 from raiden.transfer.state import (
@@ -345,6 +345,7 @@ class MatrixTransport(Runnable):
         self._account_data_lock = Semaphore()
 
         self._message_handler: Optional[MessageHandler] = None
+        self.storage: Optional[MatrixStorage] = None
 
     def __repr__(self):
         if self._raiden_service is not None:
@@ -369,7 +370,8 @@ class MatrixTransport(Runnable):
         self._raiden_service = raiden_service
         if storage:
             self.storage = storage
-            self._address_mgr._address_to_userids = self.storage.get_matrix_userids_and_addresses()
+            stored_userids_and_addresses = self.storage.get_matrix_userids_and_addresses()
+            self._address_mgr.recover_userids(stored_userids_and_addresses)
         self._message_handler = message_handler
         prev_user_id: Optional[str]
         prev_access_token: Optional[str]

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1227,34 +1227,28 @@ class MatrixTransport(Runnable):
         If filter_private=None, filter according to self._private_rooms
         """
         address_hex: AddressHex = to_checksum_address(address)
-        user_ids = self._address_mgr.get_userids_for_address(address)
-        room_ids = [
-            _RoomID(self._address_mgr.get_room_id_for_user_id(user_id)) for user_id in user_ids]
-        if not room_ids:
-            with self._account_data_lock:
-                room_ids = self._client.account_data.get("network.raiden.rooms", {}).get(
-                    address_hex
-                )
-        self.log.debug("Room ids for address", for_address=address_hex, room_ids=room_ids)
-        if not room_ids:  # None or empty
-            room_ids = list()
-        if not isinstance(room_ids, list):  # old version, single room
-            room_ids = [room_ids]
+        with self._account_data_lock:
+            room_ids = self._client.account_data.get("network.raiden.rooms", {}).get(address_hex)
+            self.log.debug("Room ids for address", for_address=address_hex, room_ids=room_ids)
+            if not room_ids:  # None or empty
+                room_ids = list()
+            if not isinstance(room_ids, list):  # old version, single room
+                room_ids = [room_ids]
 
-        if filter_private is None:
-            filter_private = self._private_rooms
-        if not filter_private:
-            # existing rooms
-            room_ids = [room_id for room_id in room_ids if room_id in self._client.rooms]
-        else:
-            # existing and private rooms
-            room_ids = [
-                room_id
-                for room_id in room_ids
-                if room_id in self._client.rooms and self._client.rooms[room_id].invite_only
-            ]
+            if filter_private is None:
+                filter_private = self._private_rooms
+            if not filter_private:
+                # existing rooms
+                room_ids = [room_id for room_id in room_ids if room_id in self._client.rooms]
+            else:
+                # existing and private rooms
+                room_ids = [
+                    room_id
+                    for room_id in room_ids
+                    if room_id in self._client.rooms and self._client.rooms[room_id].invite_only
+                ]
 
-        return room_ids
+            return room_ids
 
     def _leave_unused_rooms(self, _address_to_room_ids: Dict[AddressHex, List[_RoomID]]):
         """

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -305,6 +305,7 @@ class UserAddressManager:
         return validate_userid_signature(user)
 
     def recover_userids(self, address_to_userids: defaultdict) -> None:
+        """Restores the mapping address: userids for all known addresses"""
         self._address_to_userids = address_to_userids
 
     @property

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -304,6 +304,9 @@ class UserAddressManager:
     def _validate_userid_signature(user: User) -> Optional[Address]:
         return validate_userid_signature(user)
 
+    def recover_userids(self, address_to_userids: defaultdict) -> None:
+        self._address_to_userids = address_to_userids
+
     @property
     def log(self) -> BoundLoggerLazyProxy:
         if not self._log:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -55,6 +55,7 @@ from raiden.services import (
 from raiden.settings import MEDIATION_FEE
 from raiden.storage import sqlite, wal
 from raiden.storage.serialization import DictSerializer, JSONSerializer
+from raiden.storage.utils import make_db_connection
 from raiden.storage.wal import WriteAheadLog
 from raiden.tasks import AlarmTask
 from raiden.transfer import node, views
@@ -323,10 +324,8 @@ class RaidenService(Runnable):
             assert self.db_lock.is_locked, f"Database not locked. node:{self!r}"
 
         self.maybe_upgrade_db()
-
-        storage = sqlite.SerializedSQLiteStorage(
-            database_path=self.database_path, serializer=JSONSerializer()
-        )
+        conn = make_db_connection(self.database_path)
+        storage = sqlite.SerializedSQLiteStorage(conn)
         storage.update_version()
         storage.log_run()
         self.wal = wal.restore_to_state_change(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -54,7 +54,7 @@ from raiden.services import (
 )
 from raiden.settings import MEDIATION_FEE
 from raiden.storage import sqlite, wal
-from raiden.storage.serialization import DictSerializer, JSONSerializer
+from raiden.storage.serialization import DictSerializer
 from raiden.storage.utils import make_db_connection
 from raiden.storage.wal import WriteAheadLog
 from raiden.tasks import AlarmTask

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -4,13 +4,10 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
-
-from typing_extensions import Literal
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
-from raiden.storage.serialization import SerializationBase
+from raiden.storage.serialization import JSONSerializer, SerializationBase
 from raiden.storage.ulid import ULID, ULIDMonotonicFactory
 from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.transfer.architecture import Event, State, StateChange
@@ -769,9 +766,9 @@ class SerializedSQLiteStorage:
     applied the automatic encoding/deconding will not work.
     """
 
-    def __init__(self, connection, serializer: SerializationBase) -> None:
+    def __init__(self, connection, serializer: SerializationBase = None) -> None:
         self.database = SQLiteStorage(connection)
-        self.serializer = serializer
+        self.serializer = JSONSerializer() if serializer is None else serializer
 
     def update_version(self) -> None:  # pragma: no unittest
         self.database.update_version()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -219,7 +219,7 @@ class SQLiteStorage:
         # References:
         # https://sqlite.org/atomiccommit.html#_exclusive_access_mode
         # https://sqlite.org/pragma.html#pragma_locking_mode
-        conn.execute("PRAGMA locking_mode=EXCLUSIVE")
+        conn.execute("PRAGMA locking_mode=NORMAL")
 
         # Keep the journal around and skip inode updates.
         # References:
@@ -583,10 +583,11 @@ class SQLiteStorage:
         ]
 
     def write_matrix_room_ids_for_address(self, room_id_data):
-        # FIXME
-        self.conn.execute(
+        cursor = self.conn.cursor()
+        cursor.execute(
             "INSERT OR REPLACE INTO matrix_room_ids_and_aliases VALUES(?, ?, ?, ?)", room_id_data
         )
+        self.maybe_commit()
 
     def get_matrix_room_ids_aliases_for_address(self, address_identifier):
         cursor = self.conn.cursor()
@@ -600,10 +601,9 @@ class SQLiteStorage:
         return room_ids_to_aliases, stored_address
 
     def write_matrix_user_ids_for_address(self, user_id_data):
-        # FIXME
-        self.conn.execute(
-            "INSERT OR REPLACE INTO matrix_user_ids VALUES(?, ?, ?, ?) ", user_id_data
-        )
+        cursor = self.conn.cursor()
+        cursor.execute("INSERT OR REPLACE INTO matrix_user_ids VALUES(?, ?, ?, ?) ", user_id_data)
+        self.maybe_commit()
 
     def get_matrix_address_to_userids(self):
         cursor = self.conn.cursor()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -908,6 +908,8 @@ class SerializedSQLiteStorage:
     def close(self) -> None:
         self.database.close()
 
+
+class MatrixStorage(SerializedSQLiteStorage):
     def write_matrix_roomids_for_address(
         self, address: Address, room_ids_to_aliases: Dict[str, Any], log_time
     ):

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+
 import simplejson as json
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -597,7 +597,8 @@ class SQLiteStorage:
             (address_identifier,),
         )
         rows = cursor.fetchall()
-        room_ids_to_aliases, stored_address = rows[0][0], rows[0][1]
+        room_ids_to_aliases = rows[0][0] if rows else None
+        stored_address = rows[0][1] if rows else None
         return room_ids_to_aliases, stored_address
 
     def write_matrix_user_ids_for_address(self, user_id_data):
@@ -608,10 +609,7 @@ class SQLiteStorage:
     def get_matrix_address_to_userids(self):
         cursor = self.conn.cursor()
         cursor.execute("SELECT address, userids FROM matrix_user_ids")
-        address_to_userids = {}
-        for row in cursor.fetchall():
-            address_to_userids[row[0]] = row[1]
-        return address_to_userids
+        return {row[0]: row[1] for row in cursor.fetchall()}
 
     def _query_events(
         self,
@@ -947,5 +945,5 @@ class MatrixStorage(SerializedSQLiteStorage):
         room_ids_aliases, stored_address = self.database.get_matrix_room_ids_aliases_for_address(
             address_identifier
         )
-        assert stored_address == address
+        assert stored_address == address or stored_address is None
         return self.serializer.deserialize(room_ids_aliases)

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -1,10 +1,12 @@
 import sqlite3
+from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
+from eth_utils import remove_0x_prefix, to_normalized_address
 from typing_extensions import Literal
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
@@ -15,6 +17,7 @@ from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
 from raiden.transfer.architecture import Event, State, StateChange
 from raiden.utils import get_system_spec
 from raiden.utils.typing import (
+    Address,
     Any,
     Dict,
     Generic,
@@ -579,6 +582,38 @@ class SQLiteStorage:
             for entry in cursor
         ]
 
+    def _write_matrix_room_ids_for_address(self, room_id_data):
+        with self.write_lock, self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO matrix_room_ids_and_aliases VALUES(?, ?, ?, ?)",
+                room_id_data,
+            )
+
+    def _get_matrix_room_ids_aliases_for_address(self, address_identifier):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT room_ids_to_aliases, address FROM matrix_room_ids_and_aliases "
+            "WHERE address_identifier = ?",
+            (address_identifier,),
+        )
+        rows = cursor.fetchall()
+        room_ids_to_aliases, stored_address = rows[0][0], rows[0][1]
+        return room_ids_to_aliases, stored_address
+
+    def _write_matrix_user_ids_for_address(self, user_id_data):
+        with self.write_lock, self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO matrix_user_ids VALUES(?, ?, ?, ?) ", user_id_data
+            )
+
+    def _get_matrix_address_to_userids(self):
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT address, userids FROM matrix_user_ids")
+        address_to_userids = {}
+        for row in cursor.fetchall():
+            address_to_userids[row[0]] = row[1]
+        return address_to_userids
+
     def _query_events(
         self,
         limit: int = None,
@@ -873,3 +908,43 @@ class SerializedSQLiteStorage:
 
     def close(self) -> None:
         self.database.close()
+
+    def write_matrix_roomids_for_address(
+        self, address: Address, room_ids_to_aliases: Dict[str, Any], log_time
+    ):
+        """Save currently known matrix user_ids for an address
+        Shorten the address and int to 60bit identifier."""
+        # FIXME Error handling in case of precomputation attack,
+        #  writing room_ids for a node with the same shortened address crashes the db
+        #  address field can be removed then
+        address_short = remove_0x_prefix(to_normalized_address(address))[:15]
+        address_identifier = int(address_short, base=16)
+        serialized_room_ids_to_aliases = self.serializer.serialize(room_ids_to_aliases)
+        room_id_data = (address_identifier, address, serialized_room_ids_to_aliases, log_time)
+        return super()._write_matrix_room_ids_for_address(room_id_data)
+
+    def write_matrix_userids_for_address(self, address: Address, user_ids: List[str], log_time):
+        """Save currently known matrix room_ids for an address. Assumes the caller has verified."""
+        # FIXME -"-
+        address_short = remove_0x_prefix(to_normalized_address(address))[:15]
+        address_identifier = int(address_short, base=16)
+        serialized_userids = self.serializer.serialize(user_ids)
+        user_id_data = (address_identifier, address, serialized_userids, log_time)
+        return super()._write_matrix_user_ids_for_address(user_id_data)
+
+    def get_matrix_userids_and_addresses(self):
+        # Fixme: Type handling and conversion
+        address_to_userids = super()._get_matrix_address_to_userids()
+        returned_default_dict = defaultdict(set)
+        for address, user_ids in address_to_userids.items():
+            returned_default_dict[address] = set(self.serializer.deserialize(user_ids))
+        return returned_default_dict
+
+    def get_matrix_roomids_for_address(self, address: Address):
+        address_short = remove_0x_prefix(to_normalized_address(address))[:15]
+        address_identifier = int(address_short, base=16)
+        room_ids_to_aliases, stored_address = super()._get_matrix_room_ids_aliases_for_address(
+            address_identifier
+        )
+        assert stored_address == address
+        return self.serializer.deserialize(room_ids_to_aliases)

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -6,10 +6,14 @@ from datetime import datetime
 from enum import Enum
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
-from raiden.exceptions import InvalidNumberInput
+from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.serialization import JSONSerializer, SerializationBase
 from raiden.storage.ulid import ULID, ULIDMonotonicFactory
-from raiden.storage.utils import TimestampedEvent
+from raiden.storage.utils import (
+    DB_SCRIPT_CREATE_MATRIX_TABLES,
+    DB_SCRIPT_CREATE_TABLES,
+    TimestampedEvent,
+)
 from raiden.transfer.architecture import Event, State, StateChange
 from raiden.utils import get_system_spec
 from raiden.utils.typing import (
@@ -207,6 +211,30 @@ class SQLiteStorage:
     def __init__(self, conn: sqlite3.Connection):
         sqlite3.register_adapter(ULID, adapt_ulid_identifier)
         sqlite3.register_converter("ULID", convert_ulid_identifier)
+        conn.text_factory = str
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        # Skip the acquire/release cycle for the exclusive write lock.
+        # References:
+        # https://sqlite.org/atomiccommit.html#_exclusive_access_mode
+        # https://sqlite.org/pragma.html#pragma_locking_mode
+        conn.execute("PRAGMA locking_mode=EXCLUSIVE")
+
+        # Keep the journal around and skip inode updates.
+        # References:
+        # https://sqlite.org/atomiccommit.html#_persistent_rollback_journals
+        # https://sqlite.org/pragma.html#pragma_journal_mode
+        try:
+            conn.execute("PRAGMA journal_mode=PERSIST")
+        except sqlite3.DatabaseError:
+            raise InvalidDBData(
+                # FIXME get db path
+                f"Existing DB was found to be corrupt at Raiden startup. "
+                f"Manual user intervention required. Bailing."
+            )
+
+        with conn:
+            conn.executescript(DB_SCRIPT_CREATE_TABLES)
         self.conn = conn
         self.in_transaction = False
 
@@ -553,32 +581,6 @@ class SQLiteStorage:
             for entry in cursor
         ]
 
-    def write_matrix_room_ids_for_address(self, room_id_data) -> None:
-        cursor = self.conn.cursor()
-        cursor.execute(
-            "INSERT OR REPLACE INTO matrix_room_ids_and_aliases VALUES(?, ?, ?)", room_id_data
-        )
-        self.maybe_commit()
-
-    def get_matrix_room_ids_aliases_for_address(self, address) -> str:
-        cursor = self.conn.cursor()
-        cursor.execute(
-            "SELECT room_ids_to_aliases FROM matrix_room_ids_and_aliases " "WHERE address = ?",
-            (address,),
-        )
-        rows = cursor.fetchall()
-        return rows[0][0] if rows else "{}"
-
-    def write_matrix_user_ids_for_address(self, user_id_data: Tuple[Address, Any, str]) -> None:
-        cursor = self.conn.cursor()
-        cursor.execute("INSERT OR REPLACE INTO matrix_user_ids VALUES(?, ?, ?) ", user_id_data)
-        self.maybe_commit()
-
-    def get_matrix_address_to_userids(self) -> Dict[Address, str]:
-        cursor = self.conn.cursor()
-        cursor.execute("SELECT address, userids FROM matrix_user_ids")
-        return {row[0]: row[1] for row in cursor.fetchall()}
-
     def _query_events(
         self,
         limit: int = None,
@@ -875,12 +877,94 @@ class SerializedSQLiteStorage:
         self.database.close()
 
 
+class MatrixSQLiteStorage:
+    def __init__(self, conn: sqlite3.Connection):
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA locking_mode=EXCLUSIVE")
+        try:
+            conn.execute("PRAGMA journal_mode=PERSIST")
+        except sqlite3.DatabaseError:
+            raise InvalidDBData(
+                f"Existing MatrixDB was found to be corrupt at Raiden startup. "
+                f"Manual user intervention required. Bailing."
+            )
+
+        with conn:
+            conn.executescript(DB_SCRIPT_CREATE_MATRIX_TABLES)
+        self.conn = conn
+        self.in_transaction = False
+
+    def write_matrix_room_ids_for_address(self, room_id_data) -> None:
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "INSERT OR REPLACE INTO matrix_room_ids_and_aliases VALUES(?, ?, ?)", room_id_data
+        )
+        self.maybe_commit()
+
+    def get_matrix_room_ids_aliases_for_address(self, address) -> str:
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT room_ids_to_aliases FROM matrix_room_ids_and_aliases " "WHERE address = ?",
+            (address,),
+        )
+        rows = cursor.fetchall()
+        return rows[0][0] if rows else "{}"
+
+    def write_matrix_user_ids_for_address(self, user_id_data: Tuple[Address, Any, str]) -> None:
+        cursor = self.conn.cursor()
+        cursor.execute("INSERT OR REPLACE INTO matrix_user_ids VALUES(?, ?, ?) ", user_id_data)
+        self.maybe_commit()
+
+    def get_matrix_address_to_userids(self) -> Dict[Address, str]:
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT address, userids FROM matrix_user_ids")
+        return {row[0]: row[1] for row in cursor.fetchall()}
+
+    def maybe_commit(self) -> None:
+        if not self.in_transaction:
+            self.conn.commit()
+
+    @contextmanager
+    def transaction(self):
+        cursor = self.conn.cursor()
+        self.in_transaction = True
+        try:
+            cursor.execute("BEGIN")
+            yield
+            cursor.execute("COMMIT")
+        except:  # noqa
+            cursor.execute("ROLLBACK")
+            raise
+        finally:
+            self.in_transaction = False
+
+    def close(self) -> None:
+        if not hasattr(self, "conn"):
+            raise RuntimeError("The database connection was closed already.")
+
+        self.conn.close()
+        del self.conn
+
+    def __del__(self):
+        if hasattr(self, "conn"):
+            raise RuntimeError("The database connection was not closed.")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):  # pylint: disable=unused-arguments
+        self.close()
+
+
 class MatrixStorage:
     def __init__(
         self, connection: sqlite3.Connection, serializer: SerializationBase = None
     ) -> None:
-        self.database = SQLiteStorage(connection)
-        self.serializer = JSONSerializer() if serializer is None else serializer
+        self.database = MatrixSQLiteStorage(connection)
+        self.serializer = JSONSerializer() if not serializer else serializer
+
+    def close(self) -> None:
+        self.database.close()
 
     def write_matrix_roomids_for_address(
         self, address: Address, room_ids_to_aliases: Dict[str, Any], timestamp: datetime
@@ -913,6 +997,3 @@ class MatrixStorage:
     def get_matrix_roomids_for_address(self, address: Address) -> List[str]:
         room_ids_aliases = self.database.get_matrix_room_ids_aliases_for_address(address)
         return self.serializer.deserialize(room_ids_aliases)
-
-    def close(self) -> None:
-        self.database.close()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -968,7 +968,7 @@ class MatrixStorage:
 
     def write_matrix_room_id_for_user_id(self, user_id: str, room_id: str, timestamp: datetime):
         # FIXME Docstrings
-        room_id_data = (user_id, room_id, timestamp.isoformat(timespec="milliseconds"))
+        room_id_data = (str(user_id), str(room_id), timestamp.isoformat(timespec="milliseconds"))
         return self.database.write_matrix_room_id_for_user_id(room_id_data)
 
     def write_matrix_user_ids_for_address(

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from enum import Enum
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
-from raiden.exceptions import InvalidDBData, InvalidNumberInput
+from raiden.exceptions import InvalidNumberInput
 from raiden.storage.serialization import JSONSerializer, SerializationBase
 from raiden.storage.ulid import ULID, ULIDMonotonicFactory
-from raiden.storage.utils import DB_SCRIPT_CREATE_TABLES, TimestampedEvent
+from raiden.storage.utils import TimestampedEvent
 from raiden.transfer.architecture import Event, State, StateChange
 from raiden.utils import get_system_spec
 from raiden.utils.typing import (
@@ -23,6 +23,7 @@ from raiden.utils.typing import (
     NewType,
     Optional,
     RaidenDBVersion,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -206,31 +207,6 @@ class SQLiteStorage:
     def __init__(self, conn: sqlite3.Connection):
         sqlite3.register_adapter(ULID, adapt_ulid_identifier)
         sqlite3.register_converter("ULID", convert_ulid_identifier)
-        conn.text_factory = str
-        conn.execute("PRAGMA foreign_keys=ON")
-
-        # Skip the acquire/release cycle for the exclusive write lock.
-        # References:
-        # https://sqlite.org/atomiccommit.html#_exclusive_access_mode
-        # https://sqlite.org/pragma.html#pragma_locking_mode
-        conn.execute("PRAGMA locking_mode=EXCLUSIVE")
-
-        # Keep the journal around and skip inode updates.
-        # References:
-        # https://sqlite.org/atomiccommit.html#_persistent_rollback_journals
-        # https://sqlite.org/pragma.html#pragma_journal_mode
-        try:
-            conn.execute("PRAGMA journal_mode=PERSIST")
-        except sqlite3.DatabaseError:
-            raise InvalidDBData(
-                # FIXME get db path
-                f"Existing DB was found to be corrupt at Raiden startup. "
-                f"Manual user intervention required. Bailing."
-            )
-
-        with conn:
-            conn.executescript(DB_SCRIPT_CREATE_TABLES)
-
         self.conn = conn
         self.in_transaction = False
 
@@ -577,28 +553,28 @@ class SQLiteStorage:
             for entry in cursor
         ]
 
-    def write_matrix_room_ids_for_address(self, room_id_data):
+    def write_matrix_room_ids_for_address(self, room_id_data) -> None:
         cursor = self.conn.cursor()
         cursor.execute(
             "INSERT OR REPLACE INTO matrix_room_ids_and_aliases VALUES(?, ?, ?)", room_id_data
         )
         self.maybe_commit()
 
-    def get_matrix_room_ids_aliases_for_address(self, address):
+    def get_matrix_room_ids_aliases_for_address(self, address) -> str:
         cursor = self.conn.cursor()
         cursor.execute(
             "SELECT room_ids_to_aliases FROM matrix_room_ids_and_aliases " "WHERE address = ?",
             (address,),
         )
         rows = cursor.fetchall()
-        return rows[0][0] if rows else {}
+        return rows[0][0] if rows else "{}"
 
-    def write_matrix_user_ids_for_address(self, user_id_data):
+    def write_matrix_user_ids_for_address(self, user_id_data: Tuple[Address, Any, str]) -> None:
         cursor = self.conn.cursor()
         cursor.execute("INSERT OR REPLACE INTO matrix_user_ids VALUES(?, ?, ?) ", user_id_data)
         self.maybe_commit()
 
-    def get_matrix_address_to_userids(self):
+    def get_matrix_address_to_userids(self) -> Dict[Address, str]:
         cursor = self.conn.cursor()
         cursor.execute("SELECT address, userids FROM matrix_user_ids")
         return {row[0]: row[1] for row in cursor.fetchall()}
@@ -766,7 +742,9 @@ class SerializedSQLiteStorage:
     applied the automatic encoding/deconding will not work.
     """
 
-    def __init__(self, connection, serializer: SerializationBase = None) -> None:
+    def __init__(
+        self, connection: sqlite3.Connection, serializer: SerializationBase = None
+    ) -> None:
         self.database = SQLiteStorage(connection)
         self.serializer = JSONSerializer() if serializer is None else serializer
 
@@ -897,19 +875,31 @@ class SerializedSQLiteStorage:
         self.database.close()
 
 
-class MatrixStorage(SerializedSQLiteStorage):
+class MatrixStorage:
+    def __init__(
+        self, connection: sqlite3.Connection, serializer: SerializationBase = None
+    ) -> None:
+        self.database = SQLiteStorage(connection)
+        self.serializer = JSONSerializer() if serializer is None else serializer
+
     def write_matrix_roomids_for_address(
-        self, address: Address, room_ids_to_aliases: Dict[str, Any], log_time
+        self, address: Address, room_ids_to_aliases: Dict[str, Any], timestamp: datetime
     ):
         """Save currently known matrix user_ids for an address"""
         serialized_room_ids_to_aliases = self.serializer.serialize(room_ids_to_aliases)
-        room_id_data = (address, serialized_room_ids_to_aliases, log_time)
+        room_id_data = (
+            address,
+            serialized_room_ids_to_aliases,
+            timestamp.isoformat(timespec="milliseconds"),
+        )
         return self.database.write_matrix_room_ids_for_address(room_id_data)
 
-    def write_matrix_userids_for_address(self, address: Address, user_ids: List[str], log_time):
+    def write_matrix_userids_for_address(
+        self, address: Address, user_ids: Set[str], timestamp: datetime
+    ):
         """Save currently known matrix room_ids for an address. Assumes the caller has verified."""
-        serialized_userids = self.serializer.serialize(user_ids)
-        user_id_data = (address, serialized_userids, log_time)
+        serialized_userids = self.serializer.serialize(list(user_ids))
+        user_id_data = (address, serialized_userids, timestamp.isoformat(timespec="milliseconds"))
         return self.database.write_matrix_user_ids_for_address(user_id_data)
 
     def get_matrix_userids_and_addresses(self) -> defaultdict:
@@ -920,6 +910,9 @@ class MatrixStorage(SerializedSQLiteStorage):
             returned_default_dict[address] = set(self.serializer.deserialize(user_ids))
         return returned_default_dict
 
-    def get_matrix_roomids_for_address(self, address: Address):
+    def get_matrix_roomids_for_address(self, address: Address) -> List[str]:
         room_ids_aliases = self.database.get_matrix_room_ids_aliases_for_address(address)
         return self.serializer.deserialize(room_ids_aliases)
+
+    def close(self) -> None:
+        self.database.close()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -206,11 +206,9 @@ def _query_to_string(query: FilteredDBQuery) -> Tuple[str, List[str]]:
 
 
 class SQLiteStorage:
-    def __init__(self, database_path: Union[Path, Literal[":memory:"]]):
+    def __init__(self, conn: sqlite3.Connection):
         sqlite3.register_adapter(ULID, adapt_ulid_identifier)
         sqlite3.register_converter("ULID", convert_ulid_identifier)
-
-        conn = sqlite3.connect(database_path, detect_types=sqlite3.PARSE_DECLTYPES)
         conn.text_factory = str
         conn.execute("PRAGMA foreign_keys=ON")
 
@@ -218,7 +216,7 @@ class SQLiteStorage:
         # References:
         # https://sqlite.org/atomiccommit.html#_exclusive_access_mode
         # https://sqlite.org/pragma.html#pragma_locking_mode
-        conn.execute("PRAGMA locking_mode=NORMAL")
+        conn.execute("PRAGMA locking_mode=EXCLUSIVE")
 
         # Keep the journal around and skip inode updates.
         # References:
@@ -228,7 +226,8 @@ class SQLiteStorage:
             conn.execute("PRAGMA journal_mode=PERSIST")
         except sqlite3.DatabaseError:
             raise InvalidDBData(
-                f"Existing DB {database_path} was found to be corrupt at Raiden startup. "
+                # FIXME get db path
+                f"Existing DB was found to be corrupt at Raiden startup. "
                 f"Manual user intervention required. Bailing."
             )
 
@@ -770,10 +769,8 @@ class SerializedSQLiteStorage:
     applied the automatic encoding/deconding will not work.
     """
 
-    def __init__(
-        self, database_path: Union[Path, Literal[":memory:"]], serializer: SerializationBase
-    ) -> None:
-        self.database = SQLiteStorage(database_path)
+    def __init__(self, connection, serializer: SerializationBase) -> None:
+        self.database = SQLiteStorage(connection)
         self.serializer = serializer
 
     def update_version(self) -> None:  # pragma: no unittest

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -109,19 +109,23 @@ PRAGMA foreign_keys=on;
     DB_CREATE_RUNS,
 )
 
+
+"""1 to n: address: user_ids"""
 DB_CREATE_MATRIX_USER_IDS = """
-CREATE TABLE IF NOT EXISTS matrix_user_ids (
+CREATE TABLE IF NOT EXISTS matrix_user_ids_for_address (
     address BINARY PRIMARY KEY,
-    userids TEXT NOT NULL,
+    user_ids TEXT NOT NULL,
     log_time TEXT
 );
+
 """
-DB_CREATE_MATRIX_ROOM_IDS_AND_ALIASES = """
-CREATE TABLE IF NOT EXISTS matrix_room_ids_and_aliases (
-    address BINARY PRIMARY KEY,
-    room_ids_to_aliases TEXT NOT NULL,
-    log_time TEXT,
-    FOREIGN KEY(address) REFERENCES matrix_user_ids(address)
+
+"""1 to 1: user_id:room_id"""
+DB_CREATE_MATRIX_ROOM_IDS_FOR_USER_IDS = """
+CREATE TABLE IF NOT EXISTS matrix_room_ids_for_user_ids (
+    user_id TEXT PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    log_time TEXT
 );
 """
 
@@ -132,5 +136,5 @@ BEGIN TRANSACTION;
 COMMIT;
 PRAGMA foreign_keys=on;
 """.format(
-    DB_CREATE_MATRIX_USER_IDS, DB_CREATE_MATRIX_ROOM_IDS_AND_ALIASES
+    DB_CREATE_MATRIX_USER_IDS, DB_CREATE_MATRIX_ROOM_IDS_FOR_USER_IDS
 )

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -39,12 +39,17 @@ of the easy of conversion.
 6- https://tools.ietf.org/html/rfc4122.html
 7- https://github.com/ulid/spec
 """
+import sqlite3
 from collections import namedtuple
 
 
 class TimestampedEvent(namedtuple("TimestampedEvent", "wrapped_event log_time")):
     def __getattr__(self, item):
         return getattr(self.wrapped_event, item)
+
+
+def make_db_connection(database_path=":memory:") -> sqlite3.Connection:
+    return sqlite3.connect(database_path, detect_types=sqlite3.PARSE_DECLTYPES)
 
 
 DB_CREATE_SETTINGS = """

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -89,10 +89,28 @@ CREATE TABLE IF NOT EXISTS runs (
 );
 """
 
+DB_CREATE_MATRIX_USER_IDS = """
+CREATE TABLE IF NOT EXISTS matrix_user_ids (
+    address_identifier INTEGER PRIMARY KEY,
+    address BINARY NOT NULL,
+    userids TEXT NOT NULL,
+    log_time TEXT
+);
+"""
+DB_CREATE_MATRIX_ROOM_IDS_AND_ALIASES = """
+CREATE TABLE IF NOT EXISTS matrix_room_ids_and_aliases (
+    address_identifier INTEGER PRIMARY KEY,
+    address BINARY NOT NULL,
+    room_ids_to_aliases TEXT NOT NULL,
+    log_time TEXT,
+    FOREIGN KEY(address_identifier) REFERENCES matrix_user_ids(address_identifier)
+);
+"""
+
 DB_SCRIPT_CREATE_TABLES = """
 PRAGMA foreign_keys=off;
 BEGIN TRANSACTION;
-{}{}{}{}{}
+{}{}{}{}{}{}{}
 COMMIT;
 PRAGMA foreign_keys=on;
 """.format(
@@ -101,4 +119,6 @@ PRAGMA foreign_keys=on;
     DB_CREATE_SNAPSHOT,
     DB_CREATE_STATE_EVENTS,
     DB_CREATE_RUNS,
+    DB_CREATE_MATRIX_USER_IDS,
+    DB_CREATE_MATRIX_ROOM_IDS_AND_ALIASES,
 )

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -91,19 +91,17 @@ CREATE TABLE IF NOT EXISTS runs (
 
 DB_CREATE_MATRIX_USER_IDS = """
 CREATE TABLE IF NOT EXISTS matrix_user_ids (
-    address_identifier INTEGER PRIMARY KEY,
-    address BINARY NOT NULL,
+    address BINARY PRIMARY KEY,
     userids TEXT NOT NULL,
     log_time TEXT
 );
 """
 DB_CREATE_MATRIX_ROOM_IDS_AND_ALIASES = """
 CREATE TABLE IF NOT EXISTS matrix_room_ids_and_aliases (
-    address_identifier INTEGER PRIMARY KEY,
-    address BINARY NOT NULL,
+    address BINARY PRIMARY KEY,
     room_ids_to_aliases TEXT NOT NULL,
     log_time TEXT,
-    FOREIGN KEY(address_identifier) REFERENCES matrix_user_ids(address_identifier)
+    FOREIGN KEY(address) REFERENCES matrix_user_ids(address)
 );
 """
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -7,6 +7,7 @@ import pytest
 from eth_utils import to_checksum_address
 from gevent import Timeout
 from matrix_client.errors import MatrixRequestError
+from storage.sqlite import MatrixStorage
 
 import raiden
 from raiden.constants import (
@@ -22,6 +23,7 @@ from raiden.messages.synchronization import Delivered, Processed
 from raiden.network.transport.matrix import AddressReachability, MatrixTransport, _RetryQueue
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import UserPresence, make_room_alias
+from raiden.network.transport.matrix.utils import UserAddressManager, make_room_alias
 from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
@@ -1066,6 +1068,7 @@ def test_reproduce_handle_invite_send_race_issue_3588(matrix_transports):
 
     transport0.start(raiden_service0, message_handler0, "")
     transport1.start(raiden_service1, message_handler1, "")
+
     transport0.start_health_check(raiden_service1.address)
     transport1.start_health_check(raiden_service0.address)
 
@@ -1106,7 +1109,7 @@ def test_send_to_device(matrix_transports):
 
 @pytest.mark.parametrize("matrix_server_count", [1])
 @pytest.mark.parametrize("number_of_transports", [2])
-def test_matrix_userid_persistence(matrix_transports):
+def test_matrix_userid_persistence(matrix_transports, tmp_path):
     transport0, transport1 = matrix_transports
     received_messages0 = set()
     received_messages1 = set()

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1102,3 +1102,59 @@ def test_send_to_device(matrix_transports):
     transport0.send_to_device(raiden_service1.address, message)
     with gevent.Timeout(2):
         wait_assert(transport1._receive_to_device.assert_called)
+
+
+@pytest.mark.parametrize("matrix_server_count", [1])
+@pytest.mark.parametrize("number_of_transports", [2])
+def test_matrix_userid_persistence(matrix_transports):
+    transport0, transport1 = matrix_transports
+    received_messages0 = set()
+    received_messages1 = set()
+
+    message_handler0 = MessageHandler(received_messages0)
+    message_handler1 = MessageHandler(received_messages1)
+    raiden_service0 = MockRaidenService(message_handler0)
+    raiden_service1 = MockRaidenService(message_handler1)
+    raiden_service2 = MockRaidenService(message_handler0)
+    raiden_service3 = MockRaidenService(message_handler1)
+
+    transport0.start(raiden_service0, message_handler0, "")
+    transport1.start(raiden_service1, message_handler1, "")
+
+    transport1.start_health_check(raiden_service0.address)
+    transport1.start_health_check(raiden_service2.address)
+    transport1.start_health_check(raiden_service3.address)
+
+    user_ids0 = transport1._address_mgr.get_userids_for_address(raiden_service0.address)
+    user_ids2 = transport1._address_mgr.get_userids_for_address(raiden_service2.address)
+    user_ids3 = transport1._address_mgr.get_userids_for_address(raiden_service3.address)
+
+    transport1.stop()
+
+    transport1._address_mgr = UserAddressManager(
+        client=transport1._client,
+        get_user_callable=transport1._get_user,
+        address_reachability_changed_callback=transport1._address_reachability_changed,
+        user_presence_changed_callback=transport1._user_presence_changed,
+        stop_event=transport1._stop_event,
+    )
+
+    assert not (
+        transport1._address_mgr.is_address_known(raiden_service0.address)
+        or transport1._address_mgr.is_address_known(raiden_service2.address)
+        or transport1._address_mgr.is_address_known(raiden_service3.address)
+    )
+
+    transport1.start(raiden_service1, message_handler1, "")
+
+    assert (
+        transport1._address_mgr.is_address_known(raiden_service0.address)
+        and transport1._address_mgr.is_address_known(raiden_service2.address)
+        and transport1._address_mgr.is_address_known(raiden_service3.address)
+    )
+
+    assert (
+        user_ids0 == transport1._address_mgr.get_userids_for_address(raiden_service0.address)
+        and user_ids2 == transport1._address_mgr.get_userids_for_address(raiden_service2.address)
+        and user_ids3 == transport1._address_mgr.get_userids_for_address(raiden_service3.address)
+    )

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -26,6 +26,7 @@ from raiden.network.transport.matrix.utils import UserAddressManager, make_room_
 from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import MatrixStorage
+from raiden.storage.utils import make_db_connection
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.mocks import MockRaidenService
@@ -1121,10 +1122,9 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
     raiden_service1 = MockRaidenService(message_handler1, tmp_path=tmp_path)
     raiden_service2 = MockRaidenService(message_handler0)
     raiden_service3 = MockRaidenService(message_handler1)
-    transport0.start(raiden_service0, message_handler0, "")
-    transport1.start(
-        raiden_service1, message_handler1, "", storage=MatrixStorage(raiden_service1.conn)
-    )
+    transport0.start(raiden_service0, message_handler0, "")  #
+    conn = make_db_connection()
+    transport1.start(raiden_service1, message_handler1, "", storage=MatrixStorage(conn))
 
     transport1.start_health_check(raiden_service0.address)
     transport1.start_health_check(raiden_service2.address)
@@ -1162,9 +1162,7 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
         or transport1._address_mgr.is_address_known(raiden_service3.address)
     )
 
-    transport1.start(
-        raiden_service1, message_handler1, "", storage=MatrixStorage(raiden_service1.conn)
-    )
+    transport1.start(raiden_service1, message_handler1, "", storage=MatrixStorage(conn))
 
     assert (
         user_ids0 == transport1._address_mgr.get_userids_for_address(raiden_service0.address)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1132,7 +1132,6 @@ def test_matrix_userid_persistence(matrix_transports):
     user_ids0 = transport1._address_mgr.get_userids_for_address(raiden_service0.address)
     user_ids2 = transport1._address_mgr.get_userids_for_address(raiden_service2.address)
     user_ids3 = transport1._address_mgr.get_userids_for_address(raiden_service3.address)
-    gevent.sleep(10)
     # Check that user_ids and room_ids are available for all nodes
     assert user_ids0 != set() and user_ids2 != set() and user_ids3 != set()
     assert room_id0 and room_id2 and room_id3

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -7,7 +7,6 @@ import pytest
 from eth_utils import to_checksum_address
 from gevent import Timeout
 from matrix_client.errors import MatrixRequestError
-from storage.sqlite import MatrixStorage
 
 import raiden
 from raiden.constants import (
@@ -25,6 +24,8 @@ from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import UserPresence, make_room_alias
 from raiden.network.transport.matrix.utils import UserAddressManager, make_room_alias
 from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
+from raiden.storage.serialization import JSONSerializer
+from raiden.storage.sqlite import MatrixStorage
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.mocks import MockRaidenService
@@ -1117,12 +1118,16 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
     message_handler0 = MessageHandler(received_messages0)
     message_handler1 = MessageHandler(received_messages1)
     raiden_service0 = MockRaidenService(message_handler0)
-    raiden_service1 = MockRaidenService(message_handler1)
+    raiden_service1 = MockRaidenService(message_handler1, tmp_path=tmp_path)
     raiden_service2 = MockRaidenService(message_handler0)
     raiden_service3 = MockRaidenService(message_handler1)
-
+    database_path = raiden_service1.database_path
     transport0.start(raiden_service0, message_handler0, "")
-    transport1.start(raiden_service1, message_handler1, "")
+
+    serializer = JSONSerializer()
+    transport1.start(
+        raiden_service1, message_handler1, "", storage=MatrixStorage(database_path, serializer)
+    )
 
     transport1.start_health_check(raiden_service0.address)
     transport1.start_health_check(raiden_service2.address)
@@ -1131,6 +1136,18 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
     user_ids0 = transport1._address_mgr.get_userids_for_address(raiden_service0.address)
     user_ids2 = transport1._address_mgr.get_userids_for_address(raiden_service2.address)
     user_ids3 = transport1._address_mgr.get_userids_for_address(raiden_service3.address)
+
+    assert (
+        transport1._address_mgr.is_address_known(raiden_service0.address)
+        and transport1._address_mgr.is_address_known(raiden_service2.address)
+        and transport1._address_mgr.is_address_known(raiden_service3.address)
+    )
+
+    assert (
+        user_ids0 == transport1._address_mgr.get_userids_for_address(raiden_service0.address)
+        and user_ids2 == transport1._address_mgr.get_userids_for_address(raiden_service2.address)
+        and user_ids3 == transport1._address_mgr.get_userids_for_address(raiden_service3.address)
+    )
 
     transport1.stop()
 
@@ -1148,16 +1165,18 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
         or transport1._address_mgr.is_address_known(raiden_service3.address)
     )
 
-    transport1.start(raiden_service1, message_handler1, "")
-
-    assert (
-        transport1._address_mgr.is_address_known(raiden_service0.address)
-        and transport1._address_mgr.is_address_known(raiden_service2.address)
-        and transport1._address_mgr.is_address_known(raiden_service3.address)
+    transport1.start(
+        raiden_service1, message_handler1, "", storage=MatrixStorage(database_path, serializer)
     )
 
     assert (
         user_ids0 == transport1._address_mgr.get_userids_for_address(raiden_service0.address)
         and user_ids2 == transport1._address_mgr.get_userids_for_address(raiden_service2.address)
         and user_ids3 == transport1._address_mgr.get_userids_for_address(raiden_service3.address)
+    )
+
+    assert (
+        transport1._address_mgr.is_address_known(raiden_service0.address)
+        and transport1._address_mgr.is_address_known(raiden_service2.address)
+        and transport1._address_mgr.is_address_known(raiden_service3.address)
     )

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1121,12 +1121,9 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
     raiden_service1 = MockRaidenService(message_handler1, tmp_path=tmp_path)
     raiden_service2 = MockRaidenService(message_handler0)
     raiden_service3 = MockRaidenService(message_handler1)
-    database_path = raiden_service1.database_path
     transport0.start(raiden_service0, message_handler0, "")
-
-    serializer = JSONSerializer()
     transport1.start(
-        raiden_service1, message_handler1, "", storage=MatrixStorage(database_path, serializer)
+        raiden_service1, message_handler1, "", storage=MatrixStorage(raiden_service1.conn)
     )
 
     transport1.start_health_check(raiden_service0.address)
@@ -1166,7 +1163,7 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
     )
 
     transport1.start(
-        raiden_service1, message_handler1, "", storage=MatrixStorage(database_path, serializer)
+        raiden_service1, message_handler1, "", storage=MatrixStorage(raiden_service1.conn)
     )
 
     assert (

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -23,8 +23,6 @@ from raiden.network.transport.matrix import AddressReachability, MatrixTransport
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import UserPresence, make_room_alias
 from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
-from raiden.storage.sqlite import MatrixStorage
-from raiden.storage.utils import make_db_connection
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.mocks import MockRaidenService
@@ -838,12 +836,8 @@ def test_matrix_invite_private_room_unhappy_case_3(matrix_transports, expected_j
     transport0.start_health_check(raiden_service1.address)
     transport1.start_health_check(raiden_service0.address)
 
-    wait_for_peer_reachable(transport0, raiden_service1.address)
-    wait_for_peer_reachable(transport1, raiden_service0.address)
-
     assert is_reachable(transport1, raiden_service0.address)
     assert is_reachable(transport0, raiden_service1.address)
-
     transport1.stop()
 
     wait_for_peer_unreachable(transport0, raiden_service1.address)
@@ -1109,7 +1103,7 @@ def test_send_to_device(matrix_transports):
 
 @pytest.mark.parametrize("matrix_server_count", [1])
 @pytest.mark.parametrize("number_of_transports", [4])
-def test_matrix_userid_persistence(matrix_transports, tmp_path):
+def test_matrix_userid_persistence(matrix_transports):
     transport0, transport1, transport2, transport3 = matrix_transports
     raiden_service0 = MockRaidenService()
     raiden_service1 = MockRaidenService()
@@ -1125,9 +1119,7 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
     transport2.start(raiden_service2, message_handler, "")
     transport3.start(raiden_service3, message_handler, "")
 
-    conn = make_db_connection()
-
-    transport1.start(raiden_service1, message_handler, "", storage=MatrixStorage(conn))
+    transport1.start(raiden_service1, message_handler, "")
     transport0.start_health_check(raiden_service1.address)
     transport2.start_health_check(raiden_service1.address)
     transport3.start_health_check(raiden_service1.address)
@@ -1174,7 +1166,7 @@ def test_matrix_userid_persistence(matrix_transports, tmp_path):
         and "" == transport1._address_mgr.get_room_id_for_user_id(list(user_ids3)[0])
     )
 
-    transport1.start(raiden_service1, message_handler, "", storage=MatrixStorage(conn))
+    transport1.start(raiden_service1, message_handler, "")
 
     # Check that user_ids and room_ids we're properly recovered during the restart
     assert (

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -1,4 +1,6 @@
 import os.path
+from collections import defaultdict
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -103,20 +105,24 @@ def test_regression_delete_should_not_commit_the_upgrade_transaction(tmp_path, m
 def test_get_matrix_userids_for_address():
     conn = make_db_connection()
     storage = MatrixStorage(conn)
-    log_time = "2019-16-05T14:18:35.000"
+    timestamp = datetime.utcnow()
     address = make_address()
-    user_ids = [
+    user_ids = {
         "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:localhost:8500",
         "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:localhost:8501",
-    ]
+    }
+    assert storage.get_matrix_userids_and_addresses() == defaultdict(set)
+    assert storage.get_matrix_roomids_for_address(address) == {}
 
-    storage.write_matrix_userids_for_address(address=address, user_ids=user_ids, log_time=log_time)
+    storage.write_matrix_userids_for_address(
+        address=address, user_ids=user_ids, timestamp=timestamp
+    )
     room_ids_to_aliases = {
         "!EccQWEAMFrOhVqPgYt:localhost:8500": "#raiden_17_0x2af15b_0x7cfc0b:localhost:8500",
         "!lWOxcxArgnXltwsAaP:localhost:8501": "#raiden_17_0x2af15b_0x7cfc0b:localhost:8501",
     }
     storage.write_matrix_roomids_for_address(
-        address=address, room_ids_to_aliases=room_ids_to_aliases, log_time=log_time
+        address=address, room_ids_to_aliases=room_ids_to_aliases, timestamp=timestamp
     )
 
     stored_user_ids_for_address = storage.get_matrix_userids_and_addresses()
@@ -124,4 +130,4 @@ def test_get_matrix_userids_for_address():
 
     assert stored_user_ids_for_address[address] == set(user_ids)
     assert stored_room_ids_to_aliases == room_ids_to_aliases
-    storage.close()
+    storage.database.close()

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -1,6 +1,5 @@
 import os.path
 from collections import defaultdict
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -105,7 +104,6 @@ def test_regression_delete_should_not_commit_the_upgrade_transaction(tmp_path, m
 def test_get_matrix_userids_for_address():
     conn = make_db_connection()
     storage = MatrixStorage(conn)
-    timestamp = datetime.utcnow()
     address = make_address()
     user_ids = {
         "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:server0",
@@ -118,11 +116,9 @@ def test_get_matrix_userids_for_address():
     assert storage.get_matrix_user_ids_for_addresses() == defaultdict(set)
     assert storage.get_matrix_roomids_for_user_ids() == {}
 
-    storage.write_matrix_user_ids_for_address(
-        address=address, user_ids=user_ids, timestamp=timestamp
-    )
+    storage.write_matrix_user_ids_for_address(address=address, user_ids=user_ids)
     for user_id, room_id in room_ids_for_userids.items():
-        storage.write_matrix_room_id_for_user_id(user_id, room_id, timestamp=timestamp)
+        storage.write_matrix_room_id_for_user_id(user_id, room_id)
 
     stored_user_ids_for_address = storage.get_matrix_user_ids_for_addresses()
     stored_room_ids_for_userids = storage.get_matrix_roomids_for_user_ids()

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -111,23 +111,27 @@ def test_get_matrix_userids_for_address():
         "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:localhost:8500",
         "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:localhost:8501",
     }
-    assert storage.get_matrix_userids_and_addresses() == defaultdict(set)
-    assert storage.get_matrix_roomids_for_address(address) == {}
+    room_ids_for_userids = {
+        "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:localhost:8500": "!EccQWEAMFrOhVqPgYt:localhost:8500",
+        "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:localhost:8501": "!EccQWEAMFrOhVqPgYt:localhost:8500",
+    }
+    assert storage.get_matrix_user_ids_for_addresses() == defaultdict(set)
+    assert storage.get_matrix_roomids_for_user_ids() == {}
 
-    storage.write_matrix_userids_for_address(
+    storage.write_matrix_user_ids_for_address(
         address=address, user_ids=user_ids, timestamp=timestamp
     )
-    room_ids_to_aliases = {
-        "!EccQWEAMFrOhVqPgYt:localhost:8500": "#raiden_17_0x2af15b_0x7cfc0b:localhost:8500",
-        "!lWOxcxArgnXltwsAaP:localhost:8501": "#raiden_17_0x2af15b_0x7cfc0b:localhost:8501",
-    }
-    storage.write_matrix_roomids_for_address(
-        address=address, room_ids_to_aliases=room_ids_to_aliases, timestamp=timestamp
-    )
+    for user_id, room_id in room_ids_for_userids.items():
+        storage.write_matrix_room_id_for_user_id(
+            user_id,
+            room_id,
+            timestamp=timestamp,
+        )
 
-    stored_user_ids_for_address = storage.get_matrix_userids_and_addresses()
-    stored_room_ids_to_aliases = storage.get_matrix_roomids_for_address(address)
+    stored_user_ids_for_address = storage.get_matrix_user_ids_for_addresses()
+    stored_room_ids_for_userids = storage.get_matrix_roomids_for_user_ids()
 
     assert stored_user_ids_for_address[address] == set(user_ids)
-    assert stored_room_ids_to_aliases == room_ids_to_aliases
+    assert stored_room_ids_for_userids == room_ids_for_userids
+
     storage.database.close()

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import RAIDEN_DB_VERSION, SerializedSQLiteStorage, SQLiteStorage
+from raiden.storage.sqlite import RAIDEN_DB_VERSION, MatrixStorage, SQLiteStorage
 from raiden.tests.utils.factories import make_address
 from raiden.utils.upgrades import UpgradeManager, UpgradeRecord
 
@@ -90,7 +90,7 @@ def test_regression_delete_should_not_commit_the_upgrade_transaction(tmp_path, m
 
 def test_get_matrix_userids_for_address():
     serializer = JSONSerializer
-    storage = SerializedSQLiteStorage(":memory:", serializer)
+    storage = MatrixStorage(":memory:", serializer)
     log_time = "2019-16-05T14:18:35.000"
     address = make_address()
     user_ids = [

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -108,12 +108,12 @@ def test_get_matrix_userids_for_address():
     timestamp = datetime.utcnow()
     address = make_address()
     user_ids = {
-        "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:localhost:8500",
-        "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:localhost:8501",
+        "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:server0",
+        "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:server1",
     }
     room_ids_for_userids = {
-        "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:localhost:8500": "!EccQWEAMFrOhVqPgYt:localhost:8500",
-        "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:localhost:8501": "!EccQWEAMFrOhVqPgYt:localhost:8500",
+        "@0xdd2a8d3a434273289b4e9b0c20ad61b705d7d61f:server0": "!000000000000000000:server0",
+        "@0xc24acbf411290aff4e0294d956fb3e5f82af4d8e:server1": "!111111111111111111:server1",
     }
     assert storage.get_matrix_user_ids_for_addresses() == defaultdict(set)
     assert storage.get_matrix_roomids_for_user_ids() == {}
@@ -122,11 +122,7 @@ def test_get_matrix_userids_for_address():
         address=address, user_ids=user_ids, timestamp=timestamp
     )
     for user_id, room_id in room_ids_for_userids.items():
-        storage.write_matrix_room_id_for_user_id(
-            user_id,
-            room_id,
-            timestamp=timestamp,
-        )
+        storage.write_matrix_room_id_for_user_id(user_id, room_id, timestamp=timestamp)
 
     stored_user_ids_for_address = storage.get_matrix_user_ids_for_addresses()
     stored_room_ids_for_userids = storage.get_matrix_roomids_for_user_ids()

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -96,6 +96,8 @@ USER1_S1 = DummyUser(USER1_S1_ID)
 USER1_S2 = DummyUser(USER1_S2_ID)
 USER2_S1 = DummyUser(USER2_S1_ID)
 USER2_S2 = DummyUser(USER2_S2_ID)
+ROOM_ID_S1 = "!000000000000000000:server0"
+ROOM_ID_S2 = "!111111111111111111:server1"
 
 
 @pytest.fixture
@@ -321,3 +323,23 @@ def test_user_addr_mgr_populate_force(user_addr_mgr, force, result):
     user_addr_mgr.populate_userids_for_address(ADDR2, force=force)
 
     assert user_addr_mgr.get_userids_for_address(ADDR2) == result
+
+
+def test_user_addr_mgr_add_room_ids_get_room_ids(user_addr_mgr):
+    # Getting a room_id for a user_id which has not been added doesn't throw
+    assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID) == ""
+    user_addr_mgr.add_room_id_for_user_id(USER1_S1_ID, ROOM_ID_S1)
+
+    # Adding a room_id for a user_id works as expected
+    assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID) == ROOM_ID_S1
+    user_addr_mgr.add_room_id_for_user_id(USER1_S1_ID, ROOM_ID_S1)
+
+    # Adding a room_id for a user_id is idempotent
+    assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID) == ROOM_ID_S1
+
+    # Adding more than one room_id for a user_id does not work
+    user_addr_mgr.add_room_id_for_user_id(USER1_S1_ID, ROOM_ID_S2)
+    assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID) == ROOM_ID_S1
+
+    # Room_known_for_user helper does what it should
+    assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID)

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -337,9 +337,5 @@ def test_user_addr_mgr_add_room_ids_get_room_ids(user_addr_mgr):
     # Adding a room_id for a user_id is idempotent
     assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID) == ROOM_ID_S1
 
-    # Adding more than one room_id for a user_id does not work
-    user_addr_mgr.add_room_id_for_user_id(USER1_S1_ID, ROOM_ID_S2)
-    assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID) == ROOM_ID_S1
-
     # Room_known_for_user helper does what it should
     assert user_addr_mgr.get_room_id_for_user_id(USER1_S1_ID)

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -13,13 +13,13 @@ from raiden.storage.restore import (
     get_state_change_with_balance_proof_by_balance_hash,
     get_state_change_with_balance_proof_by_locksroot,
 )
-from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import (
     RANGE_ALL_STATE_CHANGES,
     Range,
     SerializedSQLiteStorage,
     SQLiteStorage,
 )
+from raiden.storage.utils import make_db_connection
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.events import (
     SendBalanceProof,
@@ -168,8 +168,8 @@ def test_get_state_change_with_balance_proof():
     """ All state changes which contain a balance proof must be found when
     querying the database.
     """
-    serializer = JSONSerializer()
-    storage = SerializedSQLiteStorage(":memory:", serializer)
+    conn = make_db_connection()
+    storage = SerializedSQLiteStorage(conn)
     counter = itertools.count()
 
     balance_proof = make_signed_balance_proof_from_counter(counter)
@@ -288,8 +288,8 @@ def test_get_event_with_balance_proof():
     """ All events which contain a balance proof must be found by when
     querying the database.
     """
-    serializer = JSONSerializer()
-    storage = SerializedSQLiteStorage(":memory:", serializer)
+    conn = make_db_connection()
+    storage = SerializedSQLiteStorage(conn)
     counter = itertools.count(1)
     partner_address = factories.make_address()
 
@@ -365,25 +365,25 @@ def test_get_event_with_balance_proof():
 def test_log_run():
     with patch("raiden.storage.sqlite.get_system_spec") as get_speck_mock:
         get_speck_mock.return_value = dict(raiden="1.2.3")
-        serializer = JSONSerializer()
-        store = SerializedSQLiteStorage(":memory:", serializer)
-        store.log_run()
-    cursor = store.database.conn.cursor()
+        conn = make_db_connection()
+        storage = SerializedSQLiteStorage(conn)
+        storage.log_run()
+    cursor = storage.database.conn.cursor()
     cursor.execute("SELECT started_at, raiden_version FROM runs")
     run = cursor.fetchone()
     now = datetime.utcnow()
     assert now - timedelta(seconds=2) <= run[0] <= now, f"{run[0]} not right before {now}"
     assert run[1] == "1.2.3"
 
-    store.close()
+    storage.close()
 
 
 @pytest.fixture
 def storage():
     state_changes_file = Path(__file__).parent / "test_data" / "db_statechanges.json"
     state_changes_data = json.loads(state_changes_file.read_text())
-
-    with SQLiteStorage(":memory:") as storage:
+    conn = make_db_connection()
+    with SQLiteStorage(conn) as storage:
         storage.write_state_changes(
             state_changes=[
                 json.dumps(state_change_record[1]) for state_change_record in state_changes_data
@@ -396,8 +396,8 @@ def storage():
 def test_batch_query_state_changes():
     state_changes_file = Path(__file__).parent / "test_data" / "db_statechanges.json"
     state_changes_data = json.loads(state_changes_file.read_text())
-
-    storage = SQLiteStorage(":memory:")
+    conn = make_db_connection()
+    storage = SQLiteStorage(conn)
     state_change_identifiers = storage.write_state_changes(
         state_changes=[
             json.dumps(state_change_record[1]) for state_change_record in state_changes_data
@@ -443,7 +443,8 @@ def test_batch_query_state_changes():
 
 
 def test_batch_query_event_records():
-    storage = SQLiteStorage(":memory:")
+    conn = make_db_connection()
+    storage = SQLiteStorage(conn)
 
     state_changes_file = Path(__file__).parent / "test_data" / "db_statechanges.json"
     state_changes_data = json.loads(state_changes_file.read_text())
@@ -496,7 +497,8 @@ def test_batch_query_event_records():
 
 
 def test_storage_get_and_update(storage):
-    other_storage = SQLiteStorage(":memory:")
+    conn = make_db_connection()
+    other_storage = SQLiteStorage(conn)
     data = storage.get_events()
     event_data = [(item, number) for number, item in enumerate(data)]
     other_storage.update_events(event_data)
@@ -504,7 +506,8 @@ def test_storage_get_and_update(storage):
 
 
 def test_storage_close():
-    storage = SerializedSQLiteStorage(":memory:", JSONSerializer())
+    conn = make_db_connection()
+    storage = SerializedSQLiteStorage(conn)
     storage.close()
     with pytest.raises(RuntimeError):  # attempt to close an already closed database
         storage.close()

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -12,7 +12,7 @@ from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state_change import ActionInitChain
-from raiden.utils import pex, privatekey_to_address
+from raiden.utils import privatekey_to_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,
@@ -111,14 +111,7 @@ class MockChainState:
 
 
 class MockRaidenService:
-    def __init__(
-        self,
-        message_handler=None,
-        state_transition=None,
-        private_key=None,
-        config=None,
-        tmp_path=None,
-    ):
+    def __init__(self, message_handler=None, state_transition=None, private_key=None, config=None):
         if private_key is None:
             self.privkey, self.address = factories.make_privkey_address()
         else:
@@ -140,16 +133,12 @@ class MockRaidenService:
 
         self.targets_to_identifiers_to_statuses = defaultdict(dict)
         self.route_to_feedback_token = {}
-        self.database_path = ":memory:"
 
         if state_transition is None:
             state_transition = node.state_transition
 
         state_manager = StateManager(state_transition, None)
-        if tmp_path:
-            self.database_path = f"{tmp_path}/mock_{pex(self.address)}.db"
-
-        self.conn = make_db_connection(self.database_path)
+        self.conn = make_db_connection()
         storage = SerializedSQLiteStorage(self.conn)
         self.wal = WriteAheadLog(state_manager, storage)
 

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -148,7 +148,7 @@ class MockRaidenService:
         serializer = JSONSerializer()
         state_manager = StateManager(state_transition, None)
         if tmp_path:
-            self.database_path = f"{tmp_path}/{pex(self.address)}.db"
+            self.database_path = f"{tmp_path}/mock_{pex(self.address)}.db"
 
         storage = SerializedSQLiteStorage(self.database_path, serializer)
         self.wal = WriteAheadLog(state_manager, storage)

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -12,7 +12,7 @@ from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state_change import ActionInitChain
-from raiden.utils import privatekey_to_address
+from raiden.utils import pex, privatekey_to_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,
@@ -148,7 +148,7 @@ class MockRaidenService:
         serializer = JSONSerializer()
         state_manager = StateManager(state_transition, None)
         if tmp_path:
-            self.database_path = f"{tmp_path}/test.db"
+            self.database_path = f"{tmp_path}/{pex(self.address)}.db"
 
         storage = SerializedSQLiteStorage(self.database_path, serializer)
         self.wal = WriteAheadLog(state_manager, storage)

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -4,8 +4,8 @@ from collections import defaultdict
 from unittest.mock import Mock, PropertyMock
 
 from raiden.constants import RoutingMode
-from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import SerializedSQLiteStorage
+from raiden.storage.utils import make_db_connection
 from raiden.storage.wal import WriteAheadLog
 from raiden.tests.utils import factories
 from raiden.transfer import node
@@ -145,12 +145,12 @@ class MockRaidenService:
         if state_transition is None:
             state_transition = node.state_transition
 
-        serializer = JSONSerializer()
         state_manager = StateManager(state_transition, None)
         if tmp_path:
             self.database_path = f"{tmp_path}/mock_{pex(self.address)}.db"
 
-        storage = SerializedSQLiteStorage(self.database_path, serializer)
+        self.conn = make_db_connection(self.database_path)
+        storage = SerializedSQLiteStorage(self.conn)
         self.wal = WriteAheadLog(state_manager, storage)
 
         state_change = ActionInitChain(

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -111,7 +111,14 @@ class MockChainState:
 
 
 class MockRaidenService:
-    def __init__(self, message_handler=None, state_transition=None, private_key=None, config=None):
+    def __init__(
+        self,
+        message_handler=None,
+        state_transition=None,
+        private_key=None,
+        config=None,
+        tmp_path=None,
+    ):
         if private_key is None:
             self.privkey, self.address = factories.make_privkey_address()
         else:
@@ -133,13 +140,17 @@ class MockRaidenService:
 
         self.targets_to_identifiers_to_statuses = defaultdict(dict)
         self.route_to_feedback_token = {}
+        self.database_path = ":memory:"
 
         if state_transition is None:
             state_transition = node.state_transition
 
-        serializer = JSONSerializer
+        serializer = JSONSerializer()
         state_manager = StateManager(state_transition, None)
-        storage = SerializedSQLiteStorage(":memory:", serializer)
+        if tmp_path:
+            self.database_path = f"{tmp_path}/test.db"
+
+        storage = SerializedSQLiteStorage(self.database_path, serializer)
         self.wal = WriteAheadLog(state_manager, storage)
 
         state_change = ActionInitChain(

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -178,8 +178,8 @@ class UpgradeManager:
             # Only instantiate `SQLiteStorage` after the copy. Otherwise
             # `_copy` will deadlock because only one connection is allowed to
             # `target_file`.
-
-            with SQLiteStorage(target_file) as storage:
+            conn = sqlite3.connect(target_file, detect_types=sqlite3.PARSE_DECLTYPES)
+            with SQLiteStorage(conn) as storage:
                 log.debug(f"Upgrading database from v{from_version} to v{RAIDEN_DB_VERSION}")
 
                 try:

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -11,7 +11,6 @@ The ignored state changes will still be applied, but they will just not be print
 """
 import json
 import re
-from contextlib import closing
 from itertools import chain
 
 import click

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -11,6 +11,7 @@ The ignored state changes will still be applied, but they will just not be print
 """
 import json
 import re
+from contextlib import closing
 from itertools import chain
 
 import click
@@ -207,13 +208,13 @@ def main(db_file, token_network_address, partner_address, names_translator):
 
     assert is_checksum_address(token_network_address), "token_network_address must be provided"
     assert is_checksum_address(partner_address), "partner_address must be provided"
-
-    replay_wal(
-        storage=SerializedSQLiteStorage(conn),
-        token_network_address=token_network_address,
-        partner_address=partner_address,
-        translator=translator,
-    )
+    with closing(SerializedSQLiteStorage(conn)) as storage:
+        replay_wal(
+            storage=storage,
+            token_network_address=token_network_address,
+            partner_address=partner_address,
+            translator=translator,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 1. Changes to SerialzedSQLiteStorage and SQLiteStorage

- Hands over sql.connection as explicit arguments to all storage classes, removes database path 
- Sets JSONSerializer as default serializer for SerialzedSQLiteStorage

### 2. MatrixStorage

- Adds MatrixSQLiteStorage base with persistence methods and tables for matrix user_ids, room_ids and aliases for 
- Adds MatrixStorage wrapper
- Adds MatrixStorage to transport.start() [Optional].
- Writes matrix user_ids in `start_healtcheck` and in `get_room_for_address`
- Adds unit test for direct write/read.
- Adds integration test for user_id write/read when a transport is stopped and restarted.
