### PR TITLE
Dataclasses - Remove some disable E1101

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -158,7 +158,6 @@ def mediator_init(raiden, transfer: LockedTransfer) -> ActionInitMediator:
     # Feedback token not used here, will be removed with source routing
     routes, _ = routing.get_best_routes(
         chain_state=views.state_from_raiden(raiden),
-        # pylint: disable=E1101
         token_network_address=from_transfer.balance_proof.token_network_address,
         one_to_n_address=raiden.default_one_to_n_address,
         from_address=raiden.address,
@@ -168,11 +167,7 @@ def mediator_init(raiden, transfer: LockedTransfer) -> ActionInitMediator:
         config=raiden.config,
         privkey=raiden.privkey,
     )
-    from_route = RouteState(
-        transfer.sender,
-        # pylint: disable=E1101
-        from_transfer.balance_proof.channel_identifier,
-    )
+    from_route = RouteState(transfer.sender, from_transfer.balance_proof.channel_identifier)
     init_mediator_statechange = ActionInitMediator(
         routes=routes,
         from_route=from_route,
@@ -187,7 +182,6 @@ def target_init(transfer: LockedTransfer) -> ActionInitTarget:
     from_transfer = lockedtransfersigned_from_message(transfer)
     from_route = RouteState(
         node_address=transfer.sender,
-        # pylint: disable=E1101
         channel_identifier=from_transfer.balance_proof.channel_identifier,
     )
     init_target_statechange = ActionInitTarget(

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -992,7 +992,6 @@ def test_regression_must_update_balanceproof_remove_expired_lock():
     lock_expired = make_receive_expired_lock(
         channel_state,
         privkey2,
-        # pylint: disable=E1101
         receive_lockedtransfer.balance_proof.nonce + 1,
         transferred_amount,
         lock,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_events.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_events.py
@@ -16,6 +16,4 @@ def test_send_refund_transfer_contains_balance_proof():
     )
 
     assert hasattr(event, "balance_proof")
-    # pylint: disable=E1101
-
     assert JSONSerializer.deserialize(JSONSerializer.serialize(event)) == event

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -76,7 +76,7 @@ class LockedTransferSignedState(LockedTransferState):
     message_identifier: MessageID
     payment_identifier: PaymentID
     token: TokenAddress
-    balance_proof: BalanceProofSignedState = field(repr=False)
+    balance_proof: BalanceProofSignedState
     lock: HashTimeLockState
     initiator: InitiatorAddress
     target: TargetAddress
@@ -90,13 +90,11 @@ class LockedTransferSignedState(LockedTransferState):
 
         # At least the lock for this transfer must be in the locksroot, so it
         # must not be empty
-        # pylint: disable=E1101
         if self.balance_proof.locksroot == EMPTY_MERKLE_ROOT:
             raise ValueError("balance_proof must not be empty")
 
     @property
     def payer_address(self) -> Address:
-        # pylint: disable=E1101
         return self.balance_proof.sender
 
 


### PR DESCRIPTION
As commented here: https://github.com/raiden-network/raiden/pull/3969#discussion_r285510704

> I checked this point out. Most of the disable=E1101 were added because partner_state and our_state are defined as field(repr=False). However, i would argue that setting them to be included in repr would be a bit too much because of the amount of data that will end up being logged.
Do you think we should accept this and remove field assignment to those attributes?

@hackaugusto 