### PR TITLE
Assumption tests for bad output

### DIFF
--- a/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
@@ -1,5 +1,6 @@
 import pytest
 from eth_utils import decode_hex, to_checksum_address
+from web3.exceptions import BadFunctionCallOutput
 
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract, get_test_contract
 
@@ -55,8 +56,26 @@ def test_call_with_a_block_number_before_smart_contract_deployed(deploy_client):
     deploy_block = receipt["blockNumber"]
     assert contract_proxy.contract.functions.ret().call(block_identifier=deploy_block) == 1
 
-    with pytest.raises(Exception):
+    with pytest.raises(BadFunctionCallOutput):
         contract_proxy.contract.functions.ret().call(block_identifier=deploy_block - 1)
+
+
+def test_call_works_with_blockhash(deploy_client):
+    """ A JSON RPC call works with a block number or blockhash. """
+    contract_path, contracts = get_test_contract("RpcTest.sol")
+    contract_proxy, receipt = deploy_client.deploy_solidity_contract(
+        "RpcTest",
+        contracts,
+        libraries=dict(),
+        constructor_parameters=None,
+        contract_path=contract_path,
+    )
+
+    deploy_blockhash = receipt["blockHash"]
+    assert contract_proxy.contract.functions.ret().call(block_identifier=deploy_blockhash) == 1
+
+    deploy_block = receipt["blockNumber"]
+    assert contract_proxy.contract.functions.ret().call(block_identifier=deploy_block) == 1
 
 
 def test_call_throws(deploy_client):

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
@@ -60,6 +60,27 @@ def test_call_with_a_block_number_before_smart_contract_deployed(deploy_client):
         contract_proxy.contract.functions.ret().call(block_identifier=deploy_block - 1)
 
 
+def test_call_which_returns_a_string_before_smart_contract_deployed(deploy_client):
+    """ A JSON RPC call using a block number where the smart contract was not
+    yet deployed should raise, even if the ABI of the function returns an empty
+    string.
+    """
+    contract_path, contracts = get_test_contract("RpcTest.sol")
+    contract_proxy, receipt = deploy_client.deploy_solidity_contract(
+        "RpcTest",
+        contracts,
+        libraries=dict(),
+        constructor_parameters=None,
+        contract_path=contract_path,
+    )
+
+    deploy_block = receipt["blockNumber"]
+    assert contract_proxy.contract.functions.ret_str().call(block_identifier=deploy_block) == ""
+
+    with pytest.raises(BadFunctionCallOutput):
+        contract_proxy.contract.functions.ret_str().call(block_identifier=deploy_block - 1)
+
+
 def test_call_works_with_blockhash(deploy_client):
     """ A JSON RPC call works with a block number or blockhash. """
     contract_path, contracts = get_test_contract("RpcTest.sol")

--- a/raiden/tests/smart_contracts/RpcTest.sol
+++ b/raiden/tests/smart_contracts/RpcTest.sol
@@ -9,6 +9,10 @@ contract RpcTest {
         return 1;
     }
 
+    function ret_str() pure public returns (string memory) {
+        return "";
+    }
+
     function loop(uint reps) pure public returns (uint) {
         uint result = 0;
         for (uint i=0; i<reps; i++) {


### PR DESCRIPTION
An exception must be raised if the smart was not deployed at the given block.