### PR TITLE
More unit test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ jobs:
           name: Prepare coverage
           command: |
             mkdir -p ${COVERAGE_DIR}
-            rm ${COVERAGE_DIR}/.coverage* || true
+            rm ${COVERAGE_DIR}/.coverage.* || true
       - run:
           name: Select tests
           command: |
@@ -376,7 +376,7 @@ jobs:
       - run:
           name: Store coverage
           command: |
-            mv .coverage* ${COVERAGE_DIR}
+            mv .coverage.* ${COVERAGE_DIR}
 
       - persist_to_workspace:
           root: "~"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[report]
+exclude_lines =
+	pragma: no cover
+	if TYPE_CHECKING:
+	def __repr__
+
+[run]
+include =
+	raiden/*.py
+	raiden/**/*.py
+omit =
+	raiden/tests/**

--- a/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
@@ -5,6 +5,14 @@ import pytest
 from raiden.constants import EMPTY_MERKLE_ROOT
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.state import MediationPairState
+from raiden.transfer.mediated_transfer.state_change import (
+    ActionInitInitiator,
+    ActionInitMediator,
+    ActionInitTarget,
+    ReceiveTransferRefund,
+    ReceiveTransferRefundCancelRoute,
+)
+from raiden.transfer.state import RouteState
 
 
 def test_invalid_instantiation_locked_transfer_state():
@@ -34,9 +42,9 @@ def test_invalid_instantiation_locked_transfer_state():
 
 def test_invalid_instantiation_mediation_pair_state():
     valid = MediationPairState(
-        payer_transfer = factories.create(factories.LockedTransferSignedStateProperties()),
-        payee_address = factories.make_address(),
-        payee_transfer = factories.create(factories.LockedTransferUnsignedStateProperties()),
+        payer_transfer=factories.create(factories.LockedTransferSignedStateProperties()),
+        payee_address=factories.make_address(),
+        payee_transfer=factories.create(factories.LockedTransferUnsignedStateProperties()),
     )
 
     unsigned_transfer = factories.create(factories.LockedTransferUnsignedStateProperties())
@@ -50,3 +58,63 @@ def test_invalid_instantiation_mediation_pair_state():
     hex_instead_of_binary = factories.make_checksum_address()
     with pytest.raises(ValueError):
         replace(valid, payee_address=hex_instead_of_binary)
+
+
+def test_invalid_instantiation_action_init_initiator():
+    wrong_type_transfer = factories.create(factories.LockedTransferSignedStateProperties())
+    with pytest.raises(ValueError):
+        ActionInitInitiator(transfer=wrong_type_transfer, routes=list())
+
+
+@pytest.fixture
+def additional_args():
+    sender = factories.UNIT_TRANSFER_SENDER
+    balance_proof = factories.create(factories.BalanceProofSignedStateProperties())
+    return dict(sender=sender, balance_proof=balance_proof)
+
+
+def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
+    route_state = RouteState(
+        node_address=factories.make_address(),
+        channel_identifier=factories.make_channel_identifier(),
+    )
+    not_a_route_state = object()
+    valid_transfer = factories.create(factories.LockedTransferSignedStateProperties())
+    wrong_type_transfer = factories.create(factories.TransferDescriptionProperties())
+    routes = list()
+
+    with pytest.raises(ValueError):
+        ActionInitMediator(
+            from_transfer=wrong_type_transfer,
+            from_route=route_state,
+            routes=routes,
+            **additional_args,
+        )
+
+    with pytest.raises(ValueError):
+        ActionInitMediator(
+            from_transfer=valid_transfer,
+            from_route=not_a_route_state,
+            routes=routes,
+            **additional_args,
+        )
+
+    with pytest.raises(ValueError):
+        ActionInitTarget(transfer=wrong_type_transfer, route=route_state, **additional_args)
+
+    with pytest.raises(ValueError):
+        ActionInitTarget(transfer=valid_transfer, route=not_a_route_state, **additional_args)
+
+
+def test_invalid_instantiation_receive_transfer_refund(additional_args):
+    wrong_type_transfer = factories.create(factories.TransferDescriptionProperties())
+    routes = list()
+    secret = factories.UNIT_SECRET
+
+    with pytest.raises(ValueError):
+        ReceiveTransferRefund(transfer=wrong_type_transfer, routes=routes, **additional_args)
+
+    with pytest.raises(ValueError):
+        ReceiveTransferRefundCancelRoute(
+            transfer=wrong_type_transfer, routes=routes, secret=secret, **additional_args
+        )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
@@ -1,0 +1,52 @@
+from dataclasses import replace
+
+import pytest
+
+from raiden.constants import EMPTY_MERKLE_ROOT
+from raiden.tests.utils import factories
+from raiden.transfer.mediated_transfer.state import MediationPairState
+
+
+def test_invalid_instantiation_locked_transfer_state():
+    valid_unsigned = factories.create(factories.LockedTransferUnsignedStateProperties())
+    valid_signed = factories.create(factories.LockedTransferSignedStateProperties())
+
+    # neither class can be instantiated with an empty locksroot
+    for valid in (valid_unsigned, valid_signed):
+        empty_balance_proof = replace(valid.balance_proof, locksroot=EMPTY_MERKLE_ROOT)
+        with pytest.raises(ValueError):
+            replace(valid, balance_proof=empty_balance_proof)
+
+    # an unsigned locked transfer state cannot be instantiated with a signed balance proof
+    with pytest.raises(ValueError):
+        replace(valid_unsigned, balance_proof=valid_signed.balance_proof)
+
+    # and vice versa
+    with pytest.raises(ValueError):
+        replace(valid_signed, balance_proof=valid_unsigned.balance_proof)
+
+    # lock is typechecked
+    wrong_type_lock = object()
+    for valid in (valid_unsigned, valid_signed):
+        with pytest.raises(ValueError):
+            replace(valid, lock=wrong_type_lock)
+
+
+def test_invalid_instantiation_mediation_pair_state():
+    valid = MediationPairState(
+        payer_transfer = factories.create(factories.LockedTransferSignedStateProperties()),
+        payee_address = factories.make_address(),
+        payee_transfer = factories.create(factories.LockedTransferUnsignedStateProperties()),
+    )
+
+    unsigned_transfer = factories.create(factories.LockedTransferUnsignedStateProperties())
+    with pytest.raises(ValueError):
+        replace(valid, payer_transfer=unsigned_transfer)
+
+    signed_transfer = factories.create(factories.LockedTransferSignedStateProperties())
+    with pytest.raises(ValueError):
+        replace(valid, payee_transfer=signed_transfer)
+
+    hex_instead_of_binary = factories.make_checksum_address()
+    with pytest.raises(ValueError):
+        replace(valid, payee_address=hex_instead_of_binary)

--- a/raiden/tests/unit/transfer/test_events.py
+++ b/raiden/tests/unit/transfer/test_events.py
@@ -1,0 +1,20 @@
+import pytest
+
+from raiden.constants import UINT256_MAX
+from raiden.tests.utils import factories
+from raiden.transfer.events import EventPaymentReceivedSuccess
+
+
+def test_invalid_instantiation_event_payment_received_success():
+    kwargs = dict(
+        payment_network_address=factories.UNIT_PAYMENT_NETWORK_IDENTIFIER,
+        token_network_address=factories.UNIT_TOKEN_NETWORK_ADDRESS,
+        identifier=factories.UNIT_TRANSFER_IDENTIFIER,
+        initiator=factories.make_address(),
+    )
+
+    with pytest.raises(ValueError):
+        EventPaymentReceivedSuccess(amount=UINT256_MAX + 1, **kwargs)
+
+    with pytest.raises(ValueError):
+        EventPaymentReceivedSuccess(amount=-5, **kwargs)


### PR DESCRIPTION
Test runtime type checks and argument sanity checks in three modules and ignore all `if TYPE_CHECKING` blocks and `repr` methods in coverage reports.

Unit test coverage improvement:
`raiden.transfer.events` from 87% to 91%
`raiden.transfer.mediated_transfer.state` from 86% to 100%
`raiden.transfer.mediated_transfer.state_change` from 87% to 100%

Closes #3907
Closes #3950 
Closes #3951 