### PR TITLE
Maintaining vim's backup file around

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ clean-build:
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
 clean-test:


### PR DESCRIPTION
The clean-pyc rule should not touch vim's backup files. [skip ci]