### PR TITLE
use blocks instead of seconds for wait in ms scenarios

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -29,20 +29,20 @@ scenario:
       - open_channel: {from: 0, to: 1, total_deposit: 1000}
       - transfer: {from: 0, to: 1, amount: 500, expected_http_status: 200}
       ## Wait for Monitor Request to be sent
-      - wait: 10
+      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
       ## Wait for channel to be closed
-      - wait: 50
+      - wait_blocks: 1
       - assert: {from: 0 ,to: 1, total_deposit: 1000, balance: 500, state: "closed"}
       - assert_events: {contract_name: "TokenNetwork", event_name: "ChannelClosed", num_events: 1}
 
-      ## Current blocktime Kovan 15s, so monitoring service reacts after 0.3 * 500 * 15 seconds
-      - wait: 3000
+      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
+      - wait_blocks: 401
       - assert_events: {contract_name: "TokenNetwork", event_name: "NonClosingBalanceProofUpdated", num_events: 1}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500 blocks -> 500 * 15s in Kovan = 7500s
-      - wait: 8000
+      ## Settlement timeout is 500, but we've already waited 400 blocks.
+      - wait_blocks: 100
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -29,17 +29,17 @@ scenario:
       - open_channel: {from: 0, to: 1, total_deposit: 1000}
       - transfer: {from: 0, to: 1, amount: 500, expected_http_status: 200}
       ## Wait for Monitor Request to be sent
-      - wait: 10
+      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
       ## Wait for channel to be closed
-      - wait: 50
+      - wait_blocks: 10
       - assert: {from: 0 ,to: 1, total_deposit: 1000, balance: 500, state: "closed"}
       - assert_events: {contract_name: "TokenNetwork", event_name: "ChannelClosed", num_events: 1}
 
-      ## Current blocktime Kovan 15s, so monitoring service reacts after 0.3 * 500 * 15 seconds
-      - wait: 3000
+      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
+      - wait_blocks: 401
       - assert_events: {contract_name: "TokenNetwork", event_name: "NonClosingBalanceProofUpdated", num_events: 1}
 
       ## Node1 gets back online after the MS has reacted.
@@ -47,6 +47,6 @@ scenario:
       - start_node: 1
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500 blocks -> 500 * 15s in Kovan = 7500s
-      - wait: 8000
+      ## Settlement timeout is 500, but we've already waited 400 blocks.
+      - wait_blocks: 100
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -20,8 +20,9 @@ nodes:
     environment-type: development
     enable-monitoring: true
 
-# This is the MS2 scenario. A channel between two nodes is opened, a transfer is made. Then, node 1 goes offline
-# and node 0 closes the channel. After the monitoring trigger block is passed node1 gets back online.
+# This is the MS3 scenario. A channel between two nodes is opened, a transfer is made. Then, node 1 goes offline
+# and node 0 closes the channel. Before the monitoring trigger block is passed node1 gets back online.
+# Node1 should be able to call close itself and no reward for the ms
 
 scenario:
   serial:
@@ -29,26 +30,27 @@ scenario:
       - open_channel: {from: 0, to: 1, total_deposit: 1000}
       - transfer: {from: 0, to: 1, amount: 500, expected_http_status: 200}
       ## Wait for Monitor Request to be sent
-      - wait: 10
+      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
       ## Wait for channel to be closed
-      - wait: 50
+      - wait_blocks: 1
       - assert: {from: 0 ,to: 1, total_deposit: 1000, balance: 500, state: "closed"}
       - assert_events: {contract_name: "TokenNetwork", event_name: "ChannelClosed", num_events: 1}
 
       ## node1 gets back online before the MS reacts
       ## node1 should call updateNonClosingBalanceProof in this case and the MS wont react
-      - wait: 20
+      - wait_blocks: 20
       - start_node: 1
 
-      ## Current blocktime Kovan 15s, so monitoring service reacts after 0.3 * 500 * 15 seconds
+      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
       ## But we just need to check for the event from node1 before the monitoring service reacts
-      - wait: 50
+      - wait_blocks: 20
       - assert_events: {contract_name: "TokenNetwork", event_name: "NonClosingBalanceProofUpdated", num_events: 1}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
       ## Settlement timeout is 500 blocks -> 500 * 15s in Kovan = 7500s
-      - wait: 8000
+      - wait_blocks: 461
+      # will fail for now since channel was closed by node1. We should add functionality to assert a fail
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}


### PR DESCRIPTION
To avoid flakiness if blocktimes increase and to optimize the time it takes to run the scenarios