### PR TITLE
Store smoketest artifacts on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,11 @@ jobs:
             set -x
       - run:
           name: Running Raiden Smoketest with << parameters.transport-layer >>, environment << parameters.environment-type >> on ethereum client << parameters.blockchain-type >>
-          command: raiden --environment-type=<< parameters.environment-type >> --transport=<< parameters.transport-layer >> smoketest --eth-client << parameters.blockchain-type >> << parameters.additional-args >>
+          command: raiden --environment-type=<< parameters.environment-type >> --transport=<< parameters.transport-layer >> smoketest --eth-client << parameters.blockchain-type >> << parameters.additional-args >> --report-path /tmp/smoketest.log
+
+      - store_artifacts:
+          path: /tmp/smoketest.log
+          destination: smoketest-logs
 
   test:
     parameters:

--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -9,7 +9,7 @@ from time import sleep
 import psutil
 import requests
 
-from raiden.utils.typing import Iterable, Optional, Port
+from raiden.utils.typing import Iterator, Optional, Port
 
 LOOPBACK = "127.0.0.1"
 
@@ -17,7 +17,7 @@ LOOPBACK = "127.0.0.1"
 # root access
 if sys.platform == "darwin":  # pragma: no cover
 
-    def _unused_ports(initial_port: Optional[int]) -> Iterable[Port]:
+    def _unused_ports(initial_port: Optional[int]) -> Iterator[Port]:
         socket_kind: SocketKind = SocketKind.SOCK_STREAM
 
         if not initial_port:
@@ -58,7 +58,7 @@ if sys.platform == "darwin":  # pragma: no cover
 
 else:
 
-    def _unused_ports(initial_port: Optional[int]) -> Iterable[Port]:
+    def _unused_ports(initial_port: Optional[int]) -> Iterator[Port]:
         initial_port = initial_port or 27854
 
         for port in count(initial_port):
@@ -74,7 +74,7 @@ else:
                 yield Port(port)
 
 
-def get_free_port(initial_port: Optional[int] = None) -> Iterable[Port]:
+def get_free_port(initial_port: Optional[int] = None) -> Iterator[Port]:
     """Find an unused TCP port.
 
     If `initial_port` is passed the function will try to find a port as close as possible.

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -57,7 +57,16 @@ from raiden.transfer.state import CHANNEL_STATE_OPENED
 from raiden.ui.app import run_app
 from raiden.utils import privatekey_to_address, split_endpoint
 from raiden.utils.http import HTTPExecutor
-from raiden.utils.typing import Address, AddressHex, ChainID, Dict, Endpoint, Iterator
+from raiden.utils.typing import (
+    Address,
+    AddressHex,
+    ChainID,
+    Dict,
+    Endpoint,
+    Iterable,
+    Iterator,
+    Port,
+)
 from raiden.waiting import wait_for_block
 from raiden_contracts.constants import (
     CONTRACT_ENDPOINT_REGISTRY,
@@ -216,7 +225,7 @@ def setup_testchain_and_raiden(
     matrix_server: str,
     contracts_version: str,
     print_step: Callable,
-    free_port_generator: Iterator[int],
+    free_port_generator: Iterable[Port],
 ):
     testchain_manager = setup_testchain(
         eth_client=eth_client, print_step=print_step, free_port_generator=free_port_generator

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -9,7 +9,7 @@ from contextlib import ExitStack, contextmanager
 from datetime import datetime
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import ContextManager, Iterator
+from typing import ContextManager, List
 from urllib.parse import urljoin, urlsplit
 
 import requests
@@ -17,6 +17,7 @@ from twisted.internet import defer
 
 from raiden.utils.http import HTTPExecutor
 from raiden.utils.signer import recover
+from raiden.utils.typing import Iterable, Port
 
 _SYNAPSE_BASE_DIR_VAR_NAME = "RAIDEN_TESTS_SYNAPSE_BASE_DIR"
 _SYNAPSE_LOGS_PATH = os.environ.get("RAIDEN_TESTS_SYNAPSE_LOGS_DIR", False)
@@ -167,16 +168,16 @@ def generate_synapse_config() -> ContextManager:
 
 @contextmanager
 def matrix_server_starter(
-    free_port_generator: Iterator[int],
+    free_port_generator: Iterable[Port],
     *,
     count: int = 1,
     config_generator: ContextManager = None,
     log_context: str = None,
-) -> ContextManager:
+) -> ContextManager[List[ParsedURL]]:
     with ExitStack() as exit_stack:
         if config_generator is None:
             config_generator = exit_stack.enter_context(generate_synapse_config())
-        server_urls = []
+        server_urls: List[ParsedURL] = []
         for _, port in zip(range(count), free_port_generator):
             server_name, config_file = config_generator(port)
             server_url = ParsedURL(f"https://{server_name}")

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -21,6 +21,7 @@ from raiden.settings import (
     DEFAULT_PATHFINDING_MAX_FEE,
     DEFAULT_PATHFINDING_MAX_PATHS,
 )
+from raiden.tests.utils.transport import ParsedURL
 from raiden.ui.startup import environment_type_to_contracts_version
 from raiden.utils import get_system_spec
 from raiden.utils.cli import (
@@ -488,7 +489,7 @@ def version(short):
     help="Which Ethereum client to run for the smoketests",
 )
 @click.pass_context
-def smoketest(ctx, debug, eth_client, report_path):
+def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str]):
     """ Test, that the raiden installation is sane. """
     from raiden.tests.utils.smoketest import setup_testchain_and_raiden, run_smoketest
     from raiden.tests.utils.transport import make_requests_insecure, matrix_server_starter
@@ -572,6 +573,7 @@ def smoketest(ctx, debug, eth_client, report_path):
         if args["transport"] == "matrix":
             print_step("Starting Matrix transport")
             try:
+                server_urls: List[ParsedURL]
                 with matrix_server_starter(free_port_generator=free_port_generator) as server_urls:
                     # Disable TLS verification so we can connect to the self signed certificate
                     make_requests_insecure()

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -474,6 +474,11 @@ def version(short):
 
 
 @run.command()
+@option(
+    "--report-path",
+    help="Store report at this location instead of a temp file.",
+    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+)
 @option("--debug", is_flag=True, help="Drop into pdb on errors.")
 @option(
     "--eth-client",
@@ -483,7 +488,7 @@ def version(short):
     help="Which Ethereum client to run for the smoketests",
 )
 @click.pass_context
-def smoketest(ctx, debug, eth_client):
+def smoketest(ctx, debug, eth_client, report_path):
     """ Test, that the raiden installation is sane. """
     from raiden.tests.utils.smoketest import setup_testchain_and_raiden, run_smoketest
     from raiden.tests.utils.transport import make_requests_insecure, matrix_server_starter
@@ -491,7 +496,10 @@ def smoketest(ctx, debug, eth_client):
 
     enable_gevent_monitoring_signal()
 
-    report_file = mktemp(suffix=".log")
+    if report_path is None:
+        report_file = mktemp(suffix=".log")
+    else:
+        report_file = report_path
     configure_logging(
         logger_level_config={"": "DEBUG"},
         log_file=report_file,


### PR DESCRIPTION
This adds the option `--report-path` to the `raiden smoketest` command. It allows to optionally configure a path for the report file.

We use this option, to store the smoketest artifacts on CircleCI runs.

This fixes #4051 

