### PR TITLE
Store complete routes in Initiator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -62,8 +62,8 @@ from raiden.transfer.state import (
     BalanceProofSignedState,
     BalanceProofUnsignedState,
     ChainState,
+    HopState,
     PaymentNetworkState,
-    RouteState,
 )
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
@@ -167,10 +167,18 @@ def mediator_init(raiden, transfer: LockedTransfer) -> ActionInitMediator:
         config=raiden.config,
         privkey=raiden.privkey,
     )
+<<<<<<< HEAD
     from_route = RouteState(transfer.sender, from_transfer.balance_proof.channel_identifier)
+=======
+    from_hop = HopState(
+        transfer.sender,
+        # pylint: disable=E1101
+        from_transfer.balance_proof.channel_identifier,
+    )
+>>>>>>> Give states more intuitive names
     init_mediator_statechange = ActionInitMediator(
         routes=routes,
-        from_route=from_route,
+        from_hop=from_hop,
         from_transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -180,12 +188,12 @@ def mediator_init(raiden, transfer: LockedTransfer) -> ActionInitMediator:
 
 def target_init(transfer: LockedTransfer) -> ActionInitTarget:
     from_transfer = lockedtransfersigned_from_message(transfer)
-    from_route = RouteState(
+    from_hop = HopState(
         node_address=transfer.sender,
         channel_identifier=from_transfer.balance_proof.channel_identifier,
     )
     init_target_statechange = ActionInitTarget(
-        route=from_route,
+        from_hop=from_hop,
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -167,15 +167,11 @@ def mediator_init(raiden, transfer: LockedTransfer) -> ActionInitMediator:
         config=raiden.config,
         privkey=raiden.privkey,
     )
-<<<<<<< HEAD
-    from_route = RouteState(transfer.sender, from_transfer.balance_proof.channel_identifier)
-=======
     from_hop = HopState(
         transfer.sender,
         # pylint: disable=E1101
         from_transfer.balance_proof.channel_identifier,
     )
->>>>>>> Give states more intuitive names
     init_mediator_statechange = ActionInitMediator(
         routes=routes,
         from_hop=from_hop,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -54,7 +54,7 @@ def get_best_routes(
         )
 
         for route_state in internal_routes:
-            if to_address == route_state.route[1] and (
+            if to_address == route_state.next_hop_address and (
                 channel_state
                 # other conditions about e.g. channel state are checked in best routes internal
                 and channel.get_distributable(

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -196,7 +196,7 @@ def get_best_routes_internal(
     while neighbors_heap:
         neighbour = heappop(neighbors_heap)
         # The complete route includes the initiator, add it to the beginning
-        complete_route = [from_address] + neighbour.route
+        complete_route = [Address(from_address)] + neighbour.route
 
         available_routes.append(PathState(complete_route, neighbour.channelid))
 

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -9,7 +9,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 from raiden.exceptions import ServiceRequestFailed
 from raiden.network.pathfinding import query_paths
 from raiden.transfer import channel, views
-from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, PathState
+from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, RouteState
 from raiden.utils.typing import (
     Address,
     ChannelID,
@@ -34,7 +34,7 @@ def get_best_routes(
     previous_address: Optional[Address],
     config: Dict[str, Any],
     privkey: bytes,
-) -> Tuple[List[PathState], Optional[UUID]]:
+) -> Tuple[List[RouteState], Optional[UUID]]:
     services_config = config.get("services", None)
 
     # the pfs should not be requested when the target is linked via a direct channel
@@ -120,7 +120,7 @@ def get_best_routes_internal(
     to_address: TargetAddress,
     amount: int,
     previous_address: Optional[Address],
-) -> List[PathState]:
+) -> List[RouteState]:
     """ Returns a list of channels that can be used to make a transfer.
 
     This will filter out channels that are not open and don't have enough
@@ -198,7 +198,7 @@ def get_best_routes_internal(
         # The complete route includes the initiator, add it to the beginning
         complete_route = [Address(from_address)] + neighbour.route
 
-        available_routes.append(PathState(complete_route, neighbour.channelid))
+        available_routes.append(RouteState(complete_route, neighbour.channelid))
 
     return available_routes
 
@@ -213,7 +213,7 @@ def get_best_routes_pfs(
     previous_address: Optional[Address],
     config: Dict[str, Any],
     privkey: bytes,
-) -> Tuple[bool, List[PathState], Optional[UUID]]:
+) -> Tuple[bool, List[RouteState], Optional[UUID]]:
     try:
         pfs_routes, feedback_token = query_paths(
             service_config=config,
@@ -265,6 +265,6 @@ def get_best_routes_pfs(
             )
             continue
 
-        paths.append(PathState(canonical_path, channel_state.identifier))
+        paths.append(RouteState(canonical_path, channel_state.identifier))
 
     return True, paths, feedback_token

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -298,7 +298,7 @@ class InitiatorMixin:
         channel = self.address_to_channel[transfer.target]
         if transfer.secrethash not in self.expected_expiry:
             self.expected_expiry[transfer.secrethash] = self.block_number + 10
-        return ActionInitInitiator(transfer, [factories.make_route_from_channel(channel)])
+        return ActionInitInitiator(transfer, [factories.make_path_from_channel(channel)])
 
     def _receive_secret_request(self, transfer: TransferDescriptionWithSecretState):
         secrethash = sha3(transfer.secret)
@@ -534,7 +534,7 @@ class MediatorMixin:
         target_channel = self.address_to_channel[transfer.target]
 
         return ActionInitMediator(
-            routes=[factories.make_route_from_channel(target_channel)],
+            routes=[factories.make_path_from_channel(target_channel)],
             from_route=factories.make_route_to_channel(initiator_channel),
             from_transfer=transfer,
             balance_proof=transfer.balance_proof,

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -298,7 +298,7 @@ class InitiatorMixin:
         channel = self.address_to_channel[transfer.target]
         if transfer.secrethash not in self.expected_expiry:
             self.expected_expiry[transfer.secrethash] = self.block_number + 10
-        return ActionInitInitiator(transfer, [factories.make_path_from_channel(channel)])
+        return ActionInitInitiator(transfer, [factories.make_route_from_channel(channel)])
 
     def _receive_secret_request(self, transfer: TransferDescriptionWithSecretState):
         secrethash = sha3(transfer.secret)
@@ -534,8 +534,8 @@ class MediatorMixin:
         target_channel = self.address_to_channel[transfer.target]
 
         return ActionInitMediator(
-            routes=[factories.make_path_from_channel(target_channel)],
-            from_route=factories.make_route_to_channel(initiator_channel),
+            routes=[factories.make_route_from_channel(target_channel)],
+            from_hop=factories.make_hop_to_channel(initiator_channel),
             from_transfer=transfer,
             balance_proof=transfer.balance_proof,
             sender=transfer.balance_proof.sender,

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -10,7 +10,6 @@ from raiden.transfer.mediated_transfer.state import (
     WaitingTransferState,
 )
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask, MediatorTask, TargetTask
-from raiden.transfer.state import PathState
 from raiden.transfer.views import list_channelstate_for_tokennetwork
 from raiden.utils import sha3
 
@@ -91,7 +90,7 @@ def test_mediator_task_view():
     # pylint: disable=E1101
     transfer_state1.transfers_pair.append(
         MediationPairState(
-            path=PathState([], -1),
+            route=routes[0],
             payer_transfer=payer_transfer,
             payee_transfer=payee_transfer,
             payee_address=payee_transfer.target,
@@ -142,7 +141,7 @@ def test_target_task_view():
             partner_state=factories.NettingChannelEndStateProperties(address=mediator, balance=100)
         )
     )
-    transfer_state = TargetTransferState(route=None, transfer=transfer, secret=secret)
+    transfer_state = TargetTransferState(from_hop=None, transfer=transfer, secret=secret)
     task = TargetTask(
         canonical_identifier=mediator_channel.canonical_identifier, target_state=transfer_state
     )

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -47,7 +47,9 @@ def test_initiator_task_view():
     transfer_state = InitiatorTransferState(
         transfer_description=transfer_description, channel_identifier=channel_id, transfer=transfer
     )
-    payment_state = InitiatorPaymentState({secrethash: transfer_state})
+    payment_state = InitiatorPaymentState(
+        routes=[], initiator_transfers={secrethash: transfer_state}
+    )
     task = InitiatorTask(
         token_network_address=factories.UNIT_TOKEN_NETWORK_ADDRESS, manager_state=payment_state
     )

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -10,6 +10,7 @@ from raiden.transfer.mediated_transfer.state import (
     WaitingTransferState,
 )
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask, MediatorTask, TargetTask
+from raiden.transfer.state import PathState
 from raiden.transfer.views import list_channelstate_for_tokennetwork
 from raiden.utils import sha3
 
@@ -90,6 +91,7 @@ def test_mediator_task_view():
     # pylint: disable=E1101
     transfer_state1.transfers_pair.append(
         MediationPairState(
+            path=PathState([], -1),
             payer_transfer=payer_transfer,
             payee_transfer=payee_transfer,
             payee_address=payee_transfer.target,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -201,7 +201,7 @@ def test_routing_mocked_pfs_happy_path(happy_path_fixture, one_to_n_address, our
 
     assert_checksum_address_in_url(patched.call_args[0][0])
 
-    assert routes[0].route[1] == address2
+    assert routes[0].next_hop_address == address2
     assert routes[0].forward_channel_id == channel_state2.identifier
     assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
@@ -249,7 +249,7 @@ def test_routing_mocked_pfs_happy_path_with_updated_iou(
 
     assert_checksum_address_in_url(patched.call_args[0][0])
 
-    assert routes[0].route[1] == address2
+    assert routes[0].next_hop_address == address2
     assert routes[0].forward_channel_id == channel_state2.identifier
     assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
@@ -291,9 +291,9 @@ def test_routing_mocked_pfs_request_error(
         # PFS doesn't work, so internal routing is used, so two possible routes are returned,
         # whereas the path via address1 is shorter
         # (even if the route is not possible from a global perspective)
-        assert routes[0].route[1] == address1
+        assert routes[0].next_hop_address == address1
         assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].route[1] == address2
+        assert routes[1].next_hop_address == address2
         assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
@@ -346,9 +346,9 @@ def test_routing_mocked_pfs_bad_http_code(
         # whereas the path via address1 is shorter (
         # even if the route is not possible from a global perspective)
         # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].route[1] == address1
+        assert routes[0].next_hop_address == address1
         assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].route[1] == address2
+        assert routes[1].next_hop_address == address2
         assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
@@ -386,9 +386,9 @@ def test_routing_mocked_pfs_invalid_json(
         # whereas the path via address1 is shorter (
         # even if the route is not possible from a global perspective)
         # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].route[1] == address1
+        assert routes[0].next_hop_address == address1
         assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].route[1] == address2
+        assert routes[1].next_hop_address == address2
         assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
@@ -426,9 +426,9 @@ def test_routing_mocked_pfs_invalid_json_structure(
         # whereas the path via address1 is shorter (
         # even if the route is not possible from a global perspective)
         # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].route[1] == address1
+        assert routes[0].next_hop_address == address1
         assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].route[1] == address2
+        assert routes[1].next_hop_address == address2
         assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
@@ -478,7 +478,7 @@ def test_routing_mocked_pfs_unavailable_peer(
         )
         # Node with address2 is not reachable, so even if the only route sent by the PFS
         # is over address2, the internal routing does not provide
-        assert routes[0].route[1] == address2
+        assert routes[0].next_hop_address == address2
         assert routes[0].forward_channel_id == channel_state2.identifier
         assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
@@ -707,7 +707,7 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
             config=CONFIG,
             privkey=PRIVKEY,
         )
-        assert routes[0].route[1] == address1
+        assert routes[0].next_hop_address == address1
         assert routes[0].forward_channel_id == channel_state1.identifier
         assert not pfs_request.called
 

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -71,7 +71,7 @@ def create_square_network_topology(
         token_network_state=token_network_state,
         our_address=our_address,
         routes=routes,
-        block_number=10,
+        block_number=factories.make_block_number(),
     )
 
     return new_state, [address1, address2, address3, address4], channels
@@ -201,8 +201,8 @@ def test_routing_mocked_pfs_happy_path(happy_path_fixture, one_to_n_address, our
 
     assert_checksum_address_in_url(patched.call_args[0][0])
 
-    assert routes[0].node_address == address2
-    assert routes[0].channel_identifier == channel_state2.identifier
+    assert routes[0].route[1] == address2
+    assert routes[0].forward_channel_id == channel_state2.identifier
     assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
     # Check for iou arguments in request payload
@@ -249,8 +249,8 @@ def test_routing_mocked_pfs_happy_path_with_updated_iou(
 
     assert_checksum_address_in_url(patched.call_args[0][0])
 
-    assert routes[0].node_address == address2
-    assert routes[0].channel_identifier == channel_state2.identifier
+    assert routes[0].route[1] == address2
+    assert routes[0].forward_channel_id == channel_state2.identifier
     assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
     # Check for iou arguments in request payload
@@ -291,10 +291,10 @@ def test_routing_mocked_pfs_request_error(
         # PFS doesn't work, so internal routing is used, so two possible routes are returned,
         # whereas the path via address1 is shorter
         # (even if the route is not possible from a global perspective)
-        assert routes[0].node_address == address1
-        assert routes[0].channel_identifier == channel_state1.identifier
-        assert routes[1].node_address == address2
-        assert routes[1].channel_identifier == channel_state2.identifier
+        assert routes[0].route[1] == address1
+        assert routes[0].forward_channel_id == channel_state1.identifier
+        assert routes[1].route[1] == address2
+        assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
 
@@ -346,10 +346,10 @@ def test_routing_mocked_pfs_bad_http_code(
         # whereas the path via address1 is shorter (
         # even if the route is not possible from a global perspective)
         # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].node_address == address1
-        assert routes[0].channel_identifier == channel_state1.identifier
-        assert routes[1].node_address == address2
-        assert routes[1].channel_identifier == channel_state2.identifier
+        assert routes[0].route[1] == address1
+        assert routes[0].forward_channel_id == channel_state1.identifier
+        assert routes[1].route[1] == address2
+        assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
 
@@ -386,10 +386,10 @@ def test_routing_mocked_pfs_invalid_json(
         # whereas the path via address1 is shorter (
         # even if the route is not possible from a global perspective)
         # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].node_address == address1
-        assert routes[0].channel_identifier == channel_state1.identifier
-        assert routes[1].node_address == address2
-        assert routes[1].channel_identifier == channel_state2.identifier
+        assert routes[0].route[1] == address1
+        assert routes[0].forward_channel_id == channel_state1.identifier
+        assert routes[1].route[1] == address2
+        assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
 
@@ -426,10 +426,10 @@ def test_routing_mocked_pfs_invalid_json_structure(
         # whereas the path via address1 is shorter (
         # even if the route is not possible from a global perspective)
         # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].node_address == address1
-        assert routes[0].channel_identifier == channel_state1.identifier
-        assert routes[1].node_address == address2
-        assert routes[1].channel_identifier == channel_state2.identifier
+        assert routes[0].route[1] == address1
+        assert routes[0].forward_channel_id == channel_state1.identifier
+        assert routes[1].route[1] == address2
+        assert routes[1].forward_channel_id == channel_state2.identifier
         assert feedback_token is None
 
 
@@ -478,8 +478,8 @@ def test_routing_mocked_pfs_unavailable_peer(
         )
         # Node with address2 is not reachable, so even if the only route sent by the PFS
         # is over address2, the internal routing does not provide
-        assert routes[0].node_address == address2
-        assert routes[0].channel_identifier == channel_state2.identifier
+        assert routes[0].route[1] == address2
+        assert routes[0].forward_channel_id == channel_state2.identifier
         assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
 
@@ -707,8 +707,8 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
             config=CONFIG,
             privkey=PRIVKEY,
         )
-        assert routes[0].node_address == address1
-        assert routes[0].channel_identifier == channel_state1.identifier
+        assert routes[0].route[1] == address1
+        assert routes[0].forward_channel_id == channel_state1.identifier
         assert not pfs_request.called
 
     # with the transfer of 51 the direct channel should not be returned,

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -124,7 +124,7 @@ def make_from_route_from_counter(counter):
             ),
         )
     )
-    from_route = factories.make_route_from_channel(from_channel)
+    from_hop = factories.make_hop_from_channel(from_channel)
 
     expiration = factories.UNIT_REVEAL_TIMEOUT + 1
 
@@ -145,7 +145,7 @@ def make_from_route_from_counter(counter):
             pkey=factories.HOP1_KEY,
         ),
     )
-    return from_route, from_transfer
+    return from_hop, from_transfer
 
 
 def test_get_state_change_with_balance_proof():
@@ -190,14 +190,14 @@ def test_get_state_change_with_balance_proof():
     mediator_from_route, mediator_signed_transfer = make_from_route_from_counter(counter)
     action_init_mediator = ActionInitMediator(
         routes=list(),
-        from_route=mediator_from_route,
+        from_hop=mediator_from_route,
         from_transfer=mediator_signed_transfer,
         balance_proof=mediator_signed_transfer.balance_proof,
         sender=mediator_signed_transfer.balance_proof.sender,  # pylint: disable=no-member
     )
     target_from_route, target_signed_transfer = make_from_route_from_counter(counter)
     action_init_target = ActionInitTarget(
-        route=target_from_route,
+        from_hop=target_from_route,
         transfer=target_signed_transfer,
         balance_proof=target_signed_transfer.balance_proof,
         sender=target_signed_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -803,8 +803,8 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         config={},
         privkey=b"",  # not used if pfs is not configured
     )
-    assert routes1[0].route[1] == address1
-    assert routes1[1].route[1] == address2
+    assert routes1[0].next_hop_address == address1
+    assert routes1[1].next_hop_address == address2
 
     # test routing with node 2 offline
     chain_state.nodeaddresses_to_networkstates = {
@@ -825,7 +825,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         config={},
         privkey=b"",
     )
-    assert routes1[0].route[1] == address1
+    assert routes1[0].next_hop_address == address1
 
     # test routing with node 3 offline
     # the routing doesn't care as node 3 is not directly connected
@@ -847,8 +847,8 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         config={},
         privkey=b"",
     )
-    assert routes1[0].route[1] == address1
-    assert routes1[1].route[1] == address2
+    assert routes1[0].next_hop_address == address1
+    assert routes1[1].next_hop_address == address2
 
     # test routing with node 1 offline
     chain_state.nodeaddresses_to_networkstates = {
@@ -870,7 +870,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         privkey=b"",
     )
     # right now the channel to 1 gets filtered out as it is offline
-    assert routes1[0].route[1] == address2
+    assert routes1[0].next_hop_address == address2
 
 
 def test_routing_priority(chain_state, token_network_state, one_to_n_address, our_address):
@@ -1029,8 +1029,8 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         config={},
         privkey=b"",
     )
-    assert routes[0].route[1] == address1
-    assert routes[1].route[1] == address2
+    assert routes[0].next_hop_address == address1
+    assert routes[1].next_hop_address == address2
 
     # number of hops overwrites refunding capacity (route over node 2 involves less hops)
     chain_state.nodeaddresses_to_networkstates = {
@@ -1051,5 +1051,5 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         config={},
         privkey=b"",
     )
-    assert routes[0].route[1] == address2
-    assert routes[1].route[1] == address1
+    assert routes[0].next_hop_address == address2
+    assert routes[1].next_hop_address == address1

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -311,9 +311,10 @@ def test_mediator_clear_pairs_after_batch_unlock(
         channel_state=channel_state, privkey=pkey, nonce=1, transferred_amount=0, lock=lock
     )
 
+    from_path = factories.make_path_from_channel(channel_state)
     from_route = factories.make_route_from_channel(channel_state)
     init_mediator = ActionInitMediator(
-        routes=[from_route],
+        routes=[from_path],
         from_route=from_route,
         from_transfer=mediated_transfer,
         balance_proof=mediated_transfer.balance_proof,
@@ -802,8 +803,8 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         config={},
         privkey=b"",  # not used if pfs is not configured
     )
-    assert routes1[0].node_address == address1
-    assert routes1[1].node_address == address2
+    assert routes1[0].route[1] == address1
+    assert routes1[1].route[1] == address2
 
     # test routing with node 2 offline
     chain_state.nodeaddresses_to_networkstates = {
@@ -824,7 +825,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         config={},
         privkey=b"",
     )
-    assert routes1[0].node_address == address1
+    assert routes1[0].route[1] == address1
 
     # test routing with node 3 offline
     # the routing doesn't care as node 3 is not directly connected
@@ -846,8 +847,8 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         config={},
         privkey=b"",
     )
-    assert routes1[0].node_address == address1
-    assert routes1[1].node_address == address2
+    assert routes1[0].route[1] == address1
+    assert routes1[1].route[1] == address2
 
     # test routing with node 1 offline
     chain_state.nodeaddresses_to_networkstates = {
@@ -869,11 +870,11 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         privkey=b"",
     )
     # right now the channel to 1 gets filtered out as it is offline
-    assert routes1[0].node_address == address2
+    assert routes1[0].route[1] == address2
 
 
 def test_routing_priority(chain_state, token_network_state, one_to_n_address, our_address):
-    open_block_number = 10
+    open_block_number = factories.make_block_number()
     open_block_number_hash = factories.make_block_hash()
     address1 = factories.make_address()
     address2 = factories.make_address()
@@ -1028,8 +1029,8 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         config={},
         privkey=b"",
     )
-    assert routes[0].node_address == address1
-    assert routes[1].node_address == address2
+    assert routes[0].route[1] == address1
+    assert routes[1].route[1] == address2
 
     # number of hops overwrites refunding capacity (route over node 2 involves less hops)
     chain_state.nodeaddresses_to_networkstates = {
@@ -1050,5 +1051,5 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         config={},
         privkey=b"",
     )
-    assert routes[0].node_address == address2
-    assert routes[1].node_address == address1
+    assert routes[0].route[1] == address2
+    assert routes[1].route[1] == address1

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -197,11 +197,11 @@ def test_channel_data_removed_after_unlock(
         channel_state=channel_state, privkey=pkey, nonce=1, transferred_amount=0, lock=lock
     )
 
-    from_route = factories.make_route_from_channel(channel_state)
+    from_hop = factories.make_hop_from_channel(channel_state)
     init_target = ActionInitTarget(
         sender=mediated_transfer.balance_proof.sender,  # pylint: disable=no-member
         balance_proof=mediated_transfer.balance_proof,
-        route=from_route,
+        from_hop=from_hop,
         transfer=mediated_transfer,
     )
 
@@ -311,11 +311,11 @@ def test_mediator_clear_pairs_after_batch_unlock(
         channel_state=channel_state, privkey=pkey, nonce=1, transferred_amount=0, lock=lock
     )
 
-    from_path = factories.make_path_from_channel(channel_state)
     from_route = factories.make_route_from_channel(channel_state)
+    from_hop = factories.make_hop_from_channel(channel_state)
     init_mediator = ActionInitMediator(
-        routes=[from_path],
-        from_route=from_route,
+        routes=[from_route],
+        from_hop=from_hop,
         from_transfer=mediated_transfer,
         balance_proof=mediated_transfer.balance_proof,
         sender=mediated_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -428,9 +428,9 @@ def test_multiple_channel_states(chain_state, token_network_state, channel_prope
         channel_state=channel_state, privkey=pkey, nonce=1, transferred_amount=0, lock=lock
     )
 
-    from_route = factories.make_route_from_channel(channel_state)
+    from_hop = factories.make_hop_from_channel(channel_state)
     init_target = ActionInitTarget(
-        route=from_route,
+        from_hop=from_hop,
         transfer=mediated_transfer,
         balance_proof=mediated_transfer.balance_proof,
         sender=mediated_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -73,7 +73,7 @@ def make_initiator_manager_state(
 ):
     init = ActionInitInitiator(
         transfer=transfer_description or factories.UNIT_TRANSFER_DESCRIPTION,
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
     )
     initial_state = None
     iteration = initiator_manager.state_transition(
@@ -128,7 +128,7 @@ def setup_initiator_tests(
         block_number=block_number,
         channel=channels[0],
         channel_map=channels.channel_map,
-        available_routes=channels.get_routes(),
+        available_routes=channels.get_paths(),
         prng=prng,
         lock=lock,
     )
@@ -154,7 +154,7 @@ def test_next_route():
         payment_state=state,
         initiator_state=initiator_state,
         transfer_description=initiator_state.transfer_description,
-        available_routes=channels.get_routes(),
+        available_routes=channels.get_paths(),
         channelidentifiers_to_channels=channels.channel_map,
         pseudo_random_generator=prng,
         block_number=block_number,
@@ -172,7 +172,7 @@ def test_init_with_usable_routes():
     pseudo_random_generator = random.Random()
 
     init_state_change = ActionInitInitiator(
-        factories.UNIT_TRANSFER_DESCRIPTION, channels.get_routes()
+        factories.UNIT_TRANSFER_DESCRIPTION, channels.get_paths()
     )
 
     block_number = 1
@@ -423,7 +423,7 @@ def test_refund_transfer_next_route():
     assert channels[0].partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -695,7 +695,7 @@ def test_init_with_maximum_pending_transfers_exceeded():
         )
     )
     channel_map = {channel1.identifier: channel1}
-    available_routes = [factories.make_route_from_channel(channel1)]
+    available_routes = [factories.make_path_from_channel(channel1)]
     pseudo_random_generator = random.Random()
 
     transitions = list()
@@ -1134,7 +1134,7 @@ def test_secret_reveal_cancel_other_transfers():
     assert channels[0].partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1310,7 +1310,7 @@ def test_clearing_payment_state_on_lock_expires_with_refunded_transfers():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1444,7 +1444,7 @@ def test_initiator_manager_drops_invalid_state_changes():
     transfer = factories.create(factories.LockedTransferSignedStateProperties())
     secret = factories.UNIT_SECRET
     cancel_route = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         transfer=transfer,
         secret=secret,
         balance_proof=transfer.balance_proof,
@@ -1482,7 +1482,7 @@ def test_initiator_manager_drops_invalid_state_changes():
 
     transfer2 = factories.create(factories.LockedTransferSignedStateProperties(amount=2))
     cancel_route2 = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         transfer=transfer2,
         balance_proof=transfer2.balance_proof,
         # pylint: disable=no-member
@@ -1535,7 +1535,7 @@ def test_regression_payment_unlock_failed_event_must_be_emitted_only_once():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -184,6 +184,8 @@ def test_init_with_usable_routes():
     assert transition.events, "we have a valid route, the mediated transfer event must be emitted"
 
     payment_state = transition.new_state
+    assert len(payment_state.routes) == 1
+
     initiator_state = get_transfer_at_index(payment_state, 0)
     assert initiator_state.transfer_description == factories.UNIT_TRANSFER_DESCRIPTION
 
@@ -1463,7 +1465,7 @@ def test_initiator_manager_drops_invalid_state_changes():
     prng = random.Random()
 
     for state_change in (cancel_route, lock_expired):
-        state = InitiatorPaymentState(initiator_transfers=dict())
+        state = InitiatorPaymentState(routes=[], initiator_transfers=dict())
         iteration = initiator_manager.state_transition(
             state, state_change, channels.channel_map, prng, 1
         )
@@ -1475,7 +1477,7 @@ def test_initiator_manager_drops_invalid_state_changes():
             transfer,
         )
         state = InitiatorPaymentState(
-            initiator_transfers={factories.UNIT_SECRETHASH: initiator_state}
+            routes=[], initiator_transfers={factories.UNIT_SECRETHASH: initiator_state}
         )
         iteration = initiator_manager.state_transition(state, state_change, dict(), prng, 1)
         assert_dropped(iteration, state, "unknown channel identifier")

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -45,8 +45,8 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state import (
     HashTimeLockState,
+    HopState,
     NettingChannelState,
-    RouteState,
     message_identifier_from_prng,
 )
 from raiden.transfer.state_change import (
@@ -73,7 +73,7 @@ def make_initiator_manager_state(
 ):
     init = ActionInitInitiator(
         transfer=transfer_description or factories.UNIT_TRANSFER_DESCRIPTION,
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
     )
     initial_state = None
     iteration = initiator_manager.state_transition(
@@ -87,7 +87,7 @@ class InitiatorSetup(NamedTuple):
     block_number: typing.BlockNumber
     channel: NettingChannelState
     channel_map: typing.Dict[typing.ChannelID, NettingChannelState]
-    available_routes: typing.List[RouteState]
+    available_routes: typing.List[HopState]
     prng: random.Random
     lock: HashTimeLockState
 
@@ -128,7 +128,7 @@ def setup_initiator_tests(
         block_number=block_number,
         channel=channels[0],
         channel_map=channels.channel_map,
-        available_routes=channels.get_paths(),
+        available_routes=channels.get_routes(),
         prng=prng,
         lock=lock,
     )
@@ -154,7 +154,7 @@ def test_next_route():
         payment_state=state,
         initiator_state=initiator_state,
         transfer_description=initiator_state.transfer_description,
-        available_routes=channels.get_paths(),
+        available_routes=channels.get_routes(),
         channelidentifiers_to_channels=channels.channel_map,
         pseudo_random_generator=prng,
         block_number=block_number,
@@ -172,7 +172,7 @@ def test_init_with_usable_routes():
     pseudo_random_generator = random.Random()
 
     init_state_change = ActionInitInitiator(
-        factories.UNIT_TRANSFER_DESCRIPTION, channels.get_paths()
+        factories.UNIT_TRANSFER_DESCRIPTION, channels.get_routes()
     )
 
     block_number = 1
@@ -423,7 +423,7 @@ def test_refund_transfer_next_route():
     assert channels[0].partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -695,7 +695,7 @@ def test_init_with_maximum_pending_transfers_exceeded():
         )
     )
     channel_map = {channel1.identifier: channel1}
-    available_routes = [factories.make_path_from_channel(channel1)]
+    available_routes = [factories.make_route_from_channel(channel1)]
     pseudo_random_generator = random.Random()
 
     transitions = list()
@@ -1134,7 +1134,7 @@ def test_secret_reveal_cancel_other_transfers():
     assert channels[0].partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1310,7 +1310,7 @@ def test_clearing_payment_state_on_lock_expires_with_refunded_transfers():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1444,7 +1444,7 @@ def test_initiator_manager_drops_invalid_state_changes():
     transfer = factories.create(factories.LockedTransferSignedStateProperties())
     secret = factories.UNIT_SECRET
     cancel_route = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
         transfer=transfer,
         secret=secret,
         balance_proof=transfer.balance_proof,
@@ -1482,7 +1482,7 @@ def test_initiator_manager_drops_invalid_state_changes():
 
     transfer2 = factories.create(factories.LockedTransferSignedStateProperties(amount=2))
     cancel_route2 = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
         transfer=transfer2,
         balance_proof=transfer2.balance_proof,
         # pylint: disable=no-member
@@ -1535,7 +1535,7 @@ def test_regression_payment_unlock_failed_event_must_be_emitted_only_once():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_paths(),
+        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -45,8 +45,8 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state import (
     HashTimeLockState,
-    HopState,
     NettingChannelState,
+    RouteState,
     message_identifier_from_prng,
 )
 from raiden.transfer.state_change import (
@@ -87,7 +87,7 @@ class InitiatorSetup(NamedTuple):
     block_number: typing.BlockNumber
     channel: NettingChannelState
     channel_map: typing.Dict[typing.ChannelID, NettingChannelState]
-    available_routes: typing.List[HopState]
+    available_routes: typing.List[RouteState]
     prng: random.Random
     lock: HashTimeLockState
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -309,7 +309,7 @@ def test_regression_mediator_task_no_routes():
     )
 
     init_state_change = ActionInitMediator(
-        routes=channels.get_routes(),
+        routes=channels.get_paths(),
         from_route=channels.get_route(0),
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
@@ -398,7 +398,7 @@ def test_regression_mediator_not_update_payer_state_twice():
     payer_route = factories.make_route_from_channel(payer_channel)
     payer_transfer = factories.make_signed_transfer_for(payer_channel, LONG_EXPIRATION)
 
-    available_routes = [factories.make_route_from_channel(payee_channel)]
+    available_routes = [factories.make_path_from_channel(payee_channel)]
     init_state_change = ActionInitMediator(
         routes=available_routes,
         from_route=payer_route,
@@ -426,9 +426,7 @@ def test_regression_mediator_not_update_payer_state_twice():
     block_expiration_number = channel.get_sender_expiration_threshold(transfer.lock)
 
     block = Block(
-        block_number=block_expiration_number,
-        gas_limit=1,
-        block_hash=factories.make_transaction_hash(),
+        block_number=block_expiration_number, gas_limit=1, block_hash=factories.make_block_hash()
     )
     iteration = mediator.state_transition(
         mediator_state=current_state,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -136,7 +136,7 @@ def test_regression_send_refund():
     setup = factories.make_transfers_pair(3)
 
     mediator_state = MediatorTransferState(
-        secrethash=UNIT_SECRETHASH, routes=setup.channels.get_routes()
+        secrethash=UNIT_SECRETHASH, routes=setup.channels.get_hops()
     )
     mediator_state.transfers_pair = setup.transfers_pair
 
@@ -309,8 +309,8 @@ def test_regression_mediator_task_no_routes():
     )
 
     init_state_change = ActionInitMediator(
-        routes=channels.get_paths(),
-        from_route=channels.get_route(0),
+        routes=channels.get_routes(),
+        from_hop=channels.get_hop(0),
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
         sender=payer_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -395,13 +395,13 @@ def test_regression_mediator_not_update_payer_state_twice():
 
     pair = factories.mediator_make_channel_pair()
     payer_channel, payee_channel = pair.channels
-    payer_route = factories.make_route_from_channel(payer_channel)
+    payer_route = factories.make_hop_from_channel(payer_channel)
     payer_transfer = factories.make_signed_transfer_for(payer_channel, LONG_EXPIRATION)
 
-    available_routes = [factories.make_path_from_channel(payee_channel)]
+    available_routes = [factories.make_route_from_channel(payee_channel)]
     init_state_change = ActionInitMediator(
         routes=available_routes,
-        from_route=payer_route,
+        from_hop=payer_route,
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
         sender=payer_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
@@ -12,7 +12,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveTransferRefund,
     ReceiveTransferRefundCancelRoute,
 )
-from raiden.transfer.state import RouteState
+from raiden.transfer.state import HopState, RouteState
 
 
 def test_invalid_instantiation_locked_transfer_state():
@@ -42,6 +42,7 @@ def test_invalid_instantiation_locked_transfer_state():
 
 def test_invalid_instantiation_mediation_pair_state():
     valid = MediationPairState(
+        route=RouteState([], -1),
         payer_transfer=factories.create(factories.LockedTransferSignedStateProperties()),
         payee_address=factories.make_address(),
         payee_transfer=factories.create(factories.LockedTransferUnsignedStateProperties()),
@@ -74,7 +75,7 @@ def additional_args():
 
 
 def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
-    route_state = RouteState(
+    hop_state = HopState(
         node_address=factories.make_address(),
         channel_identifier=factories.make_channel_identifier(),
     )
@@ -85,25 +86,22 @@ def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
 
     with pytest.raises(ValueError):
         ActionInitMediator(
-            from_transfer=wrong_type_transfer,
-            from_route=route_state,
-            routes=routes,
-            **additional_args,
+            from_transfer=wrong_type_transfer, from_hop=hop_state, routes=routes, **additional_args
         )
 
     with pytest.raises(ValueError):
         ActionInitMediator(
             from_transfer=valid_transfer,
-            from_route=not_a_route_state,
+            from_hop=not_a_route_state,
             routes=routes,
             **additional_args,
         )
 
     with pytest.raises(ValueError):
-        ActionInitTarget(transfer=wrong_type_transfer, route=route_state, **additional_args)
+        ActionInitTarget(transfer=wrong_type_transfer, from_hop=hop_state, **additional_args)
 
     with pytest.raises(ValueError):
-        ActionInitTarget(transfer=valid_transfer, route=not_a_route_state, **additional_args)
+        ActionInitTarget(transfer=valid_transfer, from_hop=not_a_route_state, **additional_args)
 
 
 def test_invalid_instantiation_receive_transfer_refund(additional_args):

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -88,7 +88,7 @@ def make_target_state(
     from_transfer = make_target_transfer(channels[0], amount, expiration, initiator)
 
     state_change = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -140,7 +140,7 @@ def test_events_for_onchain_secretreveal():
     safe_to_wait = expiration - channels[0].reveal_timeout - 1
     unsafe_to_wait = expiration - channels[0].reveal_timeout
 
-    state = TargetTransferState(channels.get_route(0), from_transfer)
+    state = TargetTransferState(channels.get_hop(0), from_transfer)
     events = target.events_for_onchain_secretreveal(
         target_state=state,
         channel_state=channels[0],
@@ -185,7 +185,7 @@ def test_handle_inittarget():
     from_transfer = create(transfer_properties)
 
     state_change = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -220,7 +220,7 @@ def test_handle_inittarget_bad_expiration():
     channel.handle_receive_lockedtransfer(channels[0], from_transfer)
 
     state_change = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -251,7 +251,7 @@ def test_handle_offchain_secretreveal():
 
     assert iteration.new_state.state == "reveal_secret"
     assert reveal.secret == UNIT_SECRET
-    assert reveal.recipient == setup.new_state.route.node_address
+    assert reveal.recipient == setup.new_state.from_hop.node_address
 
     # if we get an empty hash secret make sure it's rejected
     secret = EMPTY_HASH
@@ -451,7 +451,7 @@ def test_state_transition():
     from_transfer = make_target_transfer(channels[0], amount=lock_amount, initiator=initiator)
 
     init = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -465,7 +465,7 @@ def test_state_transition():
         block_number=block_number,
     )
     assert init_transition.new_state is not None
-    assert init_transition.new_state.route == channels.get_route(0)
+    assert init_transition.new_state.from_hop == channels.get_hop(0)
     assert init_transition.new_state.transfer == from_transfer
 
     first_new_block = Block(
@@ -508,7 +508,7 @@ def test_state_transition():
             locked_amount=0,
             canonical_identifier=factories.make_canonical_identifier(
                 token_network_address=channels[0].token_network_address,
-                channel_identifier=channels.get_route(0).channel_identifier,
+                channel_identifier=channels.get_hop(0).channel_identifier,
             ),
             locksroot=EMPTY_MERKLE_ROOT,
             message_hash=b"\x00" * 32,  # invalid
@@ -552,7 +552,7 @@ def test_target_reject_keccak_empty_hash():
     )
 
     init = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -581,7 +581,7 @@ def test_target_receive_lock_expired():
     )
 
     init = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -595,7 +595,7 @@ def test_target_receive_lock_expired():
         block_number=block_number,
     )
     assert init_transition.new_state is not None
-    assert init_transition.new_state.route == channels.get_route(0)
+    assert init_transition.new_state.from_hop == channels.get_hop(0)
     assert init_transition.new_state.transfer == from_transfer
 
     balance_proof = create(
@@ -646,7 +646,7 @@ def test_target_lock_is_expired_if_secret_is_not_registered_onchain():
     from_transfer = make_target_transfer(channels[0], amount=lock_amount, block_number=1)
 
     init = ActionInitTarget(
-        route=channels.get_route(0),
+        from_hop=channels.get_hop(0),
         transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -116,7 +116,7 @@ from raiden.utils.typing import (
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from raiden.transfer.state import PathState  # noqa: F401
+    from raiden.transfer.state import RouteState  # noqa: F401
 
 # This should be changed to `Union[str, MerkleTreeState]`
 MerkletreeOrError = Tuple[bool, Optional[str], Optional[MerkleTreeState]]
@@ -150,11 +150,11 @@ def get_receiver_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
 
 
 def next_channel_from_routes(
-    available_routes: List["PathState"],
+    available_routes: List["RouteState"],
     channelidentifiers_to_channels: Dict,
     transfer_amount: PaymentWithFeeAmount,
     lock_timeout: BlockTimeout = None,
-) -> Optional[Tuple[NettingChannelState, "PathState"]]:
+) -> Optional[Tuple[NettingChannelState, "RouteState"]]:
     """ Returns the first route that may be used to mediated the transfer.
     The routing service can race with local changes, so the recommended routes
     must be validated.
@@ -172,7 +172,7 @@ def next_channel_from_routes(
         The next route.
     """
     for route in available_routes:
-        channel_state = channelidentifiers_to_channels.get(route.channel_identifier)
+        channel_state = channelidentifiers_to_channels.get(route.forward_channel_id)
 
         if not channel_state:
             continue

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -116,7 +116,7 @@ from raiden.utils.typing import (
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from raiden.transfer.state import RouteState  # noqa: F401
+    from raiden.transfer.state import PathState  # noqa: F401
 
 # This should be changed to `Union[str, MerkleTreeState]`
 MerkletreeOrError = Tuple[bool, Optional[str], Optional[MerkleTreeState]]
@@ -150,11 +150,11 @@ def get_receiver_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
 
 
 def next_channel_from_routes(
-    available_routes: List["RouteState"],
+    available_routes: List["PathState"],
     channelidentifiers_to_channels: Dict,
     transfer_amount: PaymentWithFeeAmount,
     lock_timeout: BlockTimeout = None,
-) -> Optional[NettingChannelState]:
+) -> Optional[Tuple[NettingChannelState, "PathState"]]:
     """ Returns the first route that may be used to mediated the transfer.
     The routing service can race with local changes, so the recommended routes
     must be validated.
@@ -178,7 +178,7 @@ def next_channel_from_routes(
             continue
 
         if is_channel_usable(channel_state, transfer_amount, lock_timeout):
-            return channel_state
+            return channel_state, route
 
     return None
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -24,7 +24,7 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.state import (
     CHANNEL_STATE_OPENED,
     NettingChannelState,
-    RouteState,
+    PathState,
     message_identifier_from_prng,
 )
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, StateChange
@@ -175,13 +175,13 @@ def get_initial_lock_expiration(
 
 def try_new_route(
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
-    available_routes: List[RouteState],
+    available_routes: List[PathState],
     transfer_description: TransferDescriptionWithSecretState,
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
 ) -> TransitionResult[InitiatorTransferState]:
 
-    channel_state = channel.next_channel_from_routes(
+    channel_state, _ = channel.next_channel_from_routes(
         available_routes=available_routes,
         channelidentifiers_to_channels=channelidentifiers_to_channels,
         transfer_amount=PaymentWithFeeAmount(transfer_description.amount),

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -213,7 +213,8 @@ def handle_init(
             payment_state = InitiatorPaymentState(
                 initiator_transfers={
                     sub_iteration.new_state.transfer.lock.secrethash: sub_iteration.new_state
-                }
+                },
+                routes=state_change.routes,
             )
 
     return TransitionResult(payment_state, events)

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -21,7 +21,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretReveal,
     ReceiveTransferRefundCancelRoute,
 )
-from raiden.transfer.state import NettingChannelState, PathState
+from raiden.transfer.state import NettingChannelState, RouteState
 from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
@@ -94,7 +94,7 @@ def maybe_try_new_route(
     payment_state: InitiatorPaymentState,
     initiator_state: InitiatorTransferState,
     transfer_description: TransferDescriptionWithSecretState,
-    available_routes: List[PathState],
+    available_routes: List[RouteState],
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -21,7 +21,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveSecretReveal,
     ReceiveTransferRefundCancelRoute,
 )
-from raiden.transfer.state import NettingChannelState, RouteState
+from raiden.transfer.state import NettingChannelState, PathState
 from raiden.transfer.state_change import ActionCancelPayment, Block, ContractReceiveSecretReveal
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
@@ -94,7 +94,7 @@ def maybe_try_new_route(
     payment_state: InitiatorPaymentState,
     initiator_state: InitiatorTransferState,
     transfer_description: TransferDescriptionWithSecretState,
-    available_routes: List[RouteState],
+    available_routes: List[PathState],
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -167,7 +167,7 @@ def filter_reachable_routes(
 
     for route in routes:
         node_network_state = nodeaddresses_to_networkstates.get(
-            route.route[1], NODE_NETWORK_UNREACHABLE
+            route.next_hop_address, NODE_NETWORK_UNREACHABLE
         )
 
         if node_network_state == NODE_NETWORK_REACHABLE:
@@ -190,7 +190,7 @@ def filter_used_routes(
     This function will return routes as provided in their original order.
     """
     channelid_to_route = {r.forward_channel_id: r for r in routes}
-    routes_order = {route.route[1]: index for index, route in enumerate(routes)}
+    routes_order = {route.next_hop_address: index for index, route in enumerate(routes)}
 
     for pair in transfers_pair:
         channelid = pair.payer_transfer.balance_proof.channel_identifier
@@ -201,7 +201,9 @@ def filter_used_routes(
         if channelid in channelid_to_route:
             del channelid_to_route[channelid]
 
-    return sorted(channelid_to_route.values(), key=lambda route: routes_order[route.route[1]])
+    return sorted(
+        channelid_to_route.values(), key=lambda route: routes_order[route.next_hop_address]
+    )
 
 
 def get_payee_channel(
@@ -1369,7 +1371,9 @@ def handle_node_change_network_state(
 
     try:
         route = next(
-            route for route in mediator_state.routes if route.route[1] == state_change.node_address
+            route
+            for route in mediator_state.routes
+            if route.next_hop_address == state_change.node_address
         )
     except StopIteration:
         return TransitionResult(mediator_state, list())

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -147,6 +147,7 @@ class InitiatorPaymentState(State):
     different secrethash.
     """
 
+    routes: List[RouteState]
     initiator_transfers: Dict[SecretHash, InitiatorTransferState]
     cancelled_channels: List[ChannelID] = field(repr=False, default_factory=list)
 

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -7,7 +7,7 @@ from raiden.transfer.state import (
     BalanceProofSignedState,
     BalanceProofUnsignedState,
     HashTimeLockState,
-    PathState,
+    HopState,
     RouteState,
 )
 from raiden.utils import sha3
@@ -159,7 +159,7 @@ class MediationPairState(State):
     the payer and payee, and the current state of the payment.
     """
 
-    path: PathState
+    route: RouteState
     payer_transfer: LockedTransferSignedState
     payee_address: Address
     payee_transfer: LockedTransferUnsignedState
@@ -223,7 +223,7 @@ class MediatorTransferState(State):
     """
 
     secrethash: SecretHash
-    routes: List[PathState]
+    routes: List[RouteState]
     secret: Optional[Secret] = field(default=None)
     transfers_pair: List[MediationPairState] = field(default_factory=list)
     waiting_transfer: Optional[WaitingTransferState] = field(default=None)
@@ -247,7 +247,7 @@ class TargetTransferState(State):
         SECRET_REQUEST,
     )
 
-    route: RouteState = field(repr=False)
+    from_hop: HopState = field(repr=False)
     transfer: LockedTransferSignedState
     secret: Optional[Secret] = field(repr=False, default=None)
     state: str = field(default="secret_request")

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -7,6 +7,7 @@ from raiden.transfer.state import (
     BalanceProofSignedState,
     BalanceProofUnsignedState,
     HashTimeLockState,
+    PathState,
     RouteState,
 )
 from raiden.utils import sha3
@@ -158,6 +159,7 @@ class MediationPairState(State):
     the payer and payee, and the current state of the payment.
     """
 
+    path: PathState
     payer_transfer: LockedTransferSignedState
     payee_address: Address
     payee_transfer: LockedTransferUnsignedState
@@ -221,7 +223,7 @@ class MediatorTransferState(State):
     """
 
     secrethash: SecretHash
-    routes: List[RouteState]
+    routes: List[PathState]
     secret: Optional[Secret] = field(default=None)
     transfers_pair: List[MediationPairState] = field(default_factory=list)
     waiting_transfer: Optional[WaitingTransferState] = field(default=None)

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -54,7 +54,7 @@ class ActionInitMediator(BalanceProofStateChange):
     def __post_init__(self) -> None:
         super().__post_init__()
         if not isinstance(self.from_hop, HopState):
-            raise ValueError("from_route must be a RouteState instance")
+            raise ValueError("from_route must be a HopState instance")
 
         if not isinstance(self.from_transfer, LockedTransferSignedState):
             raise ValueError("from_transfer must be a LockedTransferSignedState instance")

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -8,7 +8,7 @@ from raiden.transfer.mediated_transfer.state import (
     LockedTransferSignedState,
     TransferDescriptionWithSecretState,
 )
-from raiden.transfer.state import PathState, RouteState
+from raiden.transfer.state import HopState, RouteState
 from raiden.transfer.state_change import BalanceProofStateChange
 from raiden.utils import sha3
 from raiden.utils.typing import (
@@ -30,7 +30,7 @@ class ActionInitInitiator(StateChange):
     """ Initial state of a new mediated transfer. """
 
     transfer: TransferDescriptionWithSecretState
-    routes: List[PathState]
+    routes: List[RouteState]
 
     def __post_init__(self) -> None:
         if not isinstance(self.transfer, TransferDescriptionWithSecretState):
@@ -43,17 +43,17 @@ class ActionInitMediator(BalanceProofStateChange):
 
     Args:
         routes: A list of possible routes provided by a routing service.
-        from_route: The payee route.
+        from_hop: The payee route.
         from_transfer: The payee transfer.
     """
 
-    routes: List[PathState] = field(repr=False)
-    from_route: RouteState
+    routes: List[RouteState] = field(repr=False)
+    from_hop: HopState
     from_transfer: LockedTransferSignedState
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.from_route, RouteState):
+        if not isinstance(self.from_hop, HopState):
             raise ValueError("from_route must be a RouteState instance")
 
         if not isinstance(self.from_transfer, LockedTransferSignedState):
@@ -65,17 +65,17 @@ class ActionInitTarget(BalanceProofStateChange):
     """ Initial state for a new target.
 
     Args:
-        route: The payee route.
+        from_hop: The payee route.
         transfer: The payee transfer.
     """
 
-    route: RouteState
+    from_hop: HopState
     transfer: LockedTransferSignedState
 
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        if not isinstance(self.route, RouteState):
+        if not isinstance(self.from_hop, HopState):
             raise ValueError("route must be a RouteState instance")
 
         if not isinstance(self.transfer, LockedTransferSignedState):
@@ -118,7 +118,7 @@ class ReceiveTransferRefundCancelRoute(BalanceProofStateChange):
     route.
     """
 
-    routes: List[PathState] = field(repr=False)
+    routes: List[RouteState] = field(repr=False)
     transfer: LockedTransferSignedState
     secret: Secret = field(repr=False)
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
@@ -136,7 +136,7 @@ class ReceiveTransferRefund(BalanceProofStateChange):
     """ A RefundTransfer message received. """
 
     transfer: LockedTransferSignedState
-    routes: List[PathState] = field(repr=False)
+    routes: List[RouteState] = field(repr=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -8,7 +8,7 @@ from raiden.transfer.mediated_transfer.state import (
     LockedTransferSignedState,
     TransferDescriptionWithSecretState,
 )
-from raiden.transfer.state import RouteState
+from raiden.transfer.state import PathState, RouteState
 from raiden.transfer.state_change import BalanceProofStateChange
 from raiden.utils import sha3
 from raiden.utils.typing import (
@@ -27,15 +27,10 @@ from raiden.utils.typing import (
 # useful work, ie. there must /not/ be an event for requesting new data.
 @dataclass
 class ActionInitInitiator(StateChange):
-    """ Initial state of a new mediated transfer.
-
-    Args:
-        transfer_description: A state object containing the transfer details.
-        routes: A list of possible routes provided by a routing service.
-    """
+    """ Initial state of a new mediated transfer. """
 
     transfer: TransferDescriptionWithSecretState
-    routes: List[RouteState]
+    routes: List[PathState]
 
     def __post_init__(self) -> None:
         if not isinstance(self.transfer, TransferDescriptionWithSecretState):
@@ -52,7 +47,7 @@ class ActionInitMediator(BalanceProofStateChange):
         from_transfer: The payee transfer.
     """
 
-    routes: List[RouteState] = field(repr=False)
+    routes: List[PathState] = field(repr=False)
     from_route: RouteState
     from_transfer: LockedTransferSignedState
 
@@ -123,7 +118,7 @@ class ReceiveTransferRefundCancelRoute(BalanceProofStateChange):
     route.
     """
 
-    routes: List[RouteState] = field(repr=False)
+    routes: List[PathState] = field(repr=False)
     transfer: LockedTransferSignedState
     secret: Secret = field(repr=False)
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
@@ -141,7 +136,7 @@ class ReceiveTransferRefund(BalanceProofStateChange):
     """ A RefundTransfer message received. """
 
     transfer: LockedTransferSignedState
-    routes: List[RouteState] = field(repr=False)
+    routes: List[PathState] = field(repr=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -93,7 +93,7 @@ def handle_inittarget(
 ) -> TransitionResult[TargetTransferState]:
     """ Handles an ActionInitTarget state change. """
     transfer = state_change.transfer
-    route = state_change.route
+    route = state_change.from_hop
 
     assert channel_state.identifier == transfer.balance_proof.channel_identifier
     is_valid, channel_events, errormsg = channel.handle_receive_lockedtransfer(
@@ -173,7 +173,7 @@ def handle_offchain_secretreveal(
             secrethash=state_change.secrethash,
         )
 
-        route = target_state.route
+        route = target_state.from_hop
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
         target_state.state = TargetTransferState.OFFCHAIN_SECRET_REVEAL
         target_state.secret = state_change.secret

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -186,6 +186,11 @@ class RouteState(State):
     route: List[Address]
     forward_channel_id: ChannelID
 
+    @property
+    def next_hop_address(self) -> Address:
+        assert len(self.route) >= 2
+        return self.route[1]
+
 
 @dataclass
 class HashTimeLockState(State):

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -167,8 +167,8 @@ class TokenNetworkGraphState(State):
 
 
 @dataclass
-class RouteState(State):
-    """ A possible route provided by a routing service. """
+class HopState(State):
+    """ Information about the next hop. """
 
     node_address: Address
     channel_identifier: ChannelID
@@ -179,7 +179,7 @@ class RouteState(State):
 
 
 @dataclass
-class PathState(State):
+class RouteState(State):
     """ A possible route for a payment to a given target. """
 
     # TODO: Add timestamp

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -168,12 +168,7 @@ class TokenNetworkGraphState(State):
 
 @dataclass
 class RouteState(State):
-    """ A possible route provided by a routing service.
-
-    Args:
-        node_address: The address of the next_hop.
-        channel_identifier: The channel identifier.
-    """
+    """ A possible route provided by a routing service. """
 
     node_address: Address
     channel_identifier: ChannelID
@@ -181,6 +176,15 @@ class RouteState(State):
     def __post_init__(self) -> None:
         if not isinstance(self.node_address, T_Address):
             raise ValueError("node_address must be an address instance")
+
+
+@dataclass
+class PathState(State):
+    """ A possible route for a payment to a given target. """
+
+    # TODO: Add timestamp
+    route: List[Address]
+    forward_channel_id: ChannelID
 
 
 @dataclass


### PR DESCRIPTION
This PR adds a new state that stores complete routes for a payment. This is used for the initiator and mediator and will be used for source routing and routing feedback.

The new state is called `RouteState`  and stores a list of addresses, from initiator/mediator to the target. A different state that was used before to track state linked to a specific channel was renamed to `HopState` in the hope that this is more intuitive.