### PR TITLE
Simplify smoketest

### DIFF
--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -13,9 +13,7 @@ from raiden.tests.utils.smoketest import setup_raiden, setup_testchain
 @pytest.fixture(scope="session")
 def testchain_provider(blockchain_type, port_generator):
     eth_client = EthClient(blockchain_type)
-    chain_manager = setup_testchain(
-        eth_client=eth_client, print_step=lambda x: None, free_port_generator=port_generator
-    )
+    chain_manager = setup_testchain(eth_client=eth_client, free_port_generator=port_generator)
 
     with chain_manager as testchain:
         yield testchain

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -37,8 +37,14 @@ def raiden_testchain(testchain_provider, cli_tests_contracts_version):
         matrix_server="auto",
         print_step=lambda x: None,
         contracts_version=cli_tests_contracts_version,
-        testchain_setup=testchain_provider,
+        eth_client=testchain_provider["eth_client"],
+        eth_rpc_endpoint=testchain_provider["eth_rpc_endpoint"],
+        web3=testchain_provider["web3"],
+        base_datadir=testchain_provider["base_datadir"],
+        keystore=testchain_provider["keystore"],
     )
+    result["ethereum_nodes"] = testchain_provider["node_executors"]
+
     args = result["args"]
     # The setup of the testchain returns a TextIOWrapper but
     # for the tests we need a filename

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from http import HTTPStatus
-from typing import Any, Callable, ContextManager, List
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, List
 
 import click
 import requests
@@ -59,6 +59,10 @@ from raiden_contracts.constants import (
     TEST_SETTLE_TIMEOUT_MIN,
 )
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from raiden.network.transport.matrix import ParsedURL  # noqa: F401
 
 # the smoketest will assert that a different endpoint got successfully registered
 TEST_ENDPOINT = Endpoint("9.9.9.9:9999")
@@ -204,6 +208,18 @@ def setup_testchain(
             node_executors=node_executors,
             web3=web3,
         )
+
+
+@contextmanager
+def setup_matrix_for_smoketest(
+    print_step: Callable, free_port_generator: Iterable[Port]
+) -> ContextManager[List["ParsedURL"]]:
+    from raiden.tests.utils.transport import matrix_server_starter
+
+    print_step("Starting Matrix transport")
+
+    with matrix_server_starter(free_port_generator=free_port_generator) as ctx:
+        yield ctx
 
 
 def setup_raiden(

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -2,7 +2,6 @@ import contextlib
 import os
 import random
 import shutil
-import signal
 import sys
 import tempfile
 import traceback
@@ -10,7 +9,6 @@ from contextlib import contextmanager
 from copy import deepcopy
 from http import HTTPStatus
 from io import StringIO
-from subprocess import TimeoutExpired
 from typing import Any, Callable, ContextManager, List
 
 import click
@@ -372,7 +370,6 @@ def run_smoketest(
     contract_addresses: List[Address],
     token: ContractProxy,
     debug: bool,
-    ethereum_nodes: List[HTTPExecutor],
 ):
     print_step("Starting Raiden")
 
@@ -438,19 +435,5 @@ def run_smoketest(
             if app is not None:
                 app.stop()
                 app.raiden.get()
-            node_executor = ethereum_nodes[0]
-            node = node_executor.process
-            node.send_signal(signal.SIGINT)
-            try:
-                node.wait(10)
-            except TimeoutExpired:
-                print_step("Ethereum node shutdown unclean, check log!", error=True)
-                node.kill()
-
-            if isinstance(node_executor.stdio, tuple):
-                logfile = node_executor.stdio[1]
-                logfile.flush()
-                logfile.seek(0)
-                append_report("Ethereum Node log output", logfile.read())
     append_report("Raiden Node stdout", raiden_stdout.getvalue())
     return success

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -302,6 +302,7 @@ def run_smoketest(
     print_step("Starting Raiden")
 
     app = None
+    api_server = None
     try:
         app = run_app(**args)
         raiden_api = RaidenAPI(app.raiden)
@@ -370,6 +371,10 @@ def run_smoketest(
         assert response_json[0]["state"] == "opened"
         assert response_json[0]["balance"] > 0
     finally:
+        if api_server is not None:
+            api_server.stop()
+            api_server.get()
+
         if app is not None:
             app.stop()
             app.raiden.get()

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -219,24 +219,8 @@ def get_private_key(keystore):
 
 
 @contextmanager
-def setup_testchain_and_raiden(
-    transport: str,
-    eth_client: EthClient,
-    matrix_server: str,
-    contracts_version: str,
-    print_step: Callable,
-    free_port_generator: Iterable[Port],
-):
-    testchain_manager = setup_testchain(
-        eth_client=eth_client, print_step=print_step, free_port_generator=free_port_generator
-    )
-    with testchain_manager as testchain:
-        yield setup_raiden(transport, matrix_server, print_step, contracts_version, testchain)
-
-
-@contextmanager
 def setup_testchain(
-    eth_client: EthClient, print_step: Callable, free_port_generator: Iterator[int]
+    eth_client: EthClient, print_step: Callable, free_port_generator: Iterable[Port]
 ) -> ContextManager[Dict[str, Any]]:
     print_step("Starting Ethereum node")
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -206,19 +206,25 @@ def setup_testchain(
         )
 
 
-def setup_raiden(transport, matrix_server, print_step, contracts_version, testchain_setup):
+def setup_raiden(
+    transport,
+    matrix_server,
+    print_step,
+    contracts_version,
+    eth_client,
+    eth_rpc_endpoint,
+    web3,
+    base_datadir,
+    keystore,
+):
     print_step("Deploying Raiden contracts")
 
-    if testchain_setup["eth_client"] is EthClient.PARITY:
+    if eth_client is EthClient.PARITY:
         client = JSONRPCClient(
-            testchain_setup["web3"],
-            get_private_key(testchain_setup["keystore"]),
-            gas_estimate_correction=lambda gas: gas * 2,
+            web3, get_private_key(keystore), gas_estimate_correction=lambda gas: gas * 2
         )
     else:
-        client = JSONRPCClient(
-            testchain_setup["web3"], get_private_key(testchain_setup["keystore"])
-        )
+        client = JSONRPCClient(web3, get_private_key(keystore))
     contract_manager = ContractManager(contracts_precompiled_path(contracts_version))
 
     token = deploy_token(
@@ -265,14 +271,14 @@ def setup_raiden(transport, matrix_server, print_step, contracts_version, testch
 
     args = {
         "address": to_checksum_address(TEST_ACCOUNT_ADDRESS),
-        "datadir": testchain_setup["keystore"],
+        "datadir": keystore,
         "endpoint_registry_contract_address": endpoint_registry_contract_address,
-        "eth_rpc_endpoint": testchain_setup["eth_rpc_endpoint"],
+        "eth_rpc_endpoint": eth_rpc_endpoint,
         "gas_price": "fast",
-        "keystore_path": testchain_setup["keystore"],
+        "keystore_path": keystore,
         "matrix_server": matrix_server,
         "network_id": str(NETWORKNAME_TO_ID["smoketest"]),
-        "password_file": click.File()(os.path.join(testchain_setup["base_datadir"], "pw")),
+        "password_file": click.File()(os.path.join(base_datadir, "pw")),
         "tokennetwork_registry_contract_address": tokennetwork_registry_contract_address,
         "secret_registry_contract_address": secret_registry_contract_address,
         "sync_check": False,
@@ -285,12 +291,7 @@ def setup_raiden(transport, matrix_server, print_step, contracts_version, testch
         )
         args["service_registry_contract_address"] = service_registry_contract_address
 
-    return {
-        "args": args,
-        "contract_addresses": contract_addresses,
-        "ethereum_nodes": testchain_setup["node_executors"],
-        "token": token,
-    }
+    return {"args": args, "contract_addresses": contract_addresses, "token": token}
 
 
 def run_smoketest(

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -453,8 +453,4 @@ def run_smoketest(
                 logfile.seek(0)
                 append_report("Ethereum Node log output", logfile.read())
     append_report("Raiden Node stdout", raiden_stdout.getvalue())
-    if success:
-        print_step(f"Smoketest successful")
-    else:
-        print_step(f"Smoketest had errors", error=True)
     return success

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -4,7 +4,6 @@ import shutil
 import sys
 import tempfile
 from contextlib import contextmanager
-from copy import deepcopy
 from http import HTTPStatus
 from typing import Any, Callable, ContextManager, List
 
@@ -23,14 +22,12 @@ from web3.middleware import geth_poa_middleware
 from raiden.accounts import AccountManager
 from raiden.api.python import RaidenAPI
 from raiden.api.rest import APIServer, RestAPI
-from raiden.app import App
 from raiden.connection_manager import ConnectionManager
 from raiden.constants import (
     RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
     RED_EYES_PER_TOKEN_NETWORK_LIMIT,
     UINT256_MAX,
     EthClient,
-    RoutingMode,
 )
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.rpc.client import JSONRPCClient
@@ -303,15 +300,6 @@ def run_smoketest(
     token: ContractProxy,
 ):
     print_step("Starting Raiden")
-
-    config = deepcopy(App.DEFAULT_CONFIG)
-    args["config"] = config
-    # Should use basic routing in the smoke test for now
-    # TODO: If we ever utilize a PFS in the smoke test we
-    #     need to use the deployed service registry, register the
-    #     PFS service there and then change this argument.
-    args["routing_mode"] = RoutingMode.BASIC
-    args["one_to_n_contract_address"] = None
 
     app = None
     try:

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -152,9 +152,8 @@ def get_private_key(keystore):
 
 @contextmanager
 def setup_testchain(
-    eth_client: EthClient, print_step: Callable, free_port_generator: Iterable[Port]
+    eth_client: EthClient, free_port_generator: Iterable[Port]
 ) -> ContextManager[Dict[str, Any]]:
-    print_step("Starting Ethereum node")
 
     ensure_executable(eth_client.value)
 
@@ -219,6 +218,16 @@ def setup_matrix_for_smoketest(
     print_step("Starting Matrix transport")
 
     with matrix_server_starter(free_port_generator=free_port_generator) as ctx:
+        yield ctx
+
+
+@contextmanager
+def setup_testchain_for_smoketest(
+    eth_client: EthClient, print_step: Callable, free_port_generator: Iterable[Port]
+) -> ContextManager[Dict[str, Any]]:
+    print_step("Starting Ethereum node")
+
+    with setup_testchain(eth_client=eth_client, free_port_generator=free_port_generator) as ctx:
         yield ctx
 
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -497,10 +497,10 @@ def version(short):
 def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str]):
     """ Test, that the raiden installation is sane. """
     from raiden.tests.utils.smoketest import (
-        setup_testchain,
         setup_raiden,
         run_smoketest,
         setup_matrix_for_smoketest,
+        setup_testchain_for_smoketest,
     )
     from raiden.tests.utils.transport import make_requests_insecure
     from raiden.utils.debugging import enable_gevent_monitoring_signal
@@ -566,7 +566,7 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         free_port_generator = get_free_port()
         ethereum_nodes = None
 
-        testchain_manager: ContextManager[Dict[str, Any]] = setup_testchain(
+        testchain_manager: ContextManager[Dict[str, Any]] = setup_testchain_for_smoketest(
             eth_client=eth_client, print_step=print_step, free_port_generator=free_port_generator
         )
         matrix_manager: ContextManager[List[ParsedURL]] = setup_matrix_for_smoketest(

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -579,12 +579,20 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         ethereum_nodes = None
         with stdout_manager, testchain_manager as testchain, matrix_manager as server_urls:
             result = setup_raiden(
-                transport, matrix_server, print_step, contracts_version, testchain
+                transport=transport,
+                matrix_server=matrix_server,
+                print_step=print_step,
+                contracts_version=contracts_version,
+                eth_client=testchain["eth_client"],
+                eth_rpc_endpoint=testchain["eth_rpc_endpoint"],
+                web3=testchain["web3"],
+                base_datadir=testchain["base_datadir"],
+                keystore=testchain["keystore"],
             )
 
             args = result["args"]
             contract_addresses = result["contract_addresses"]
-            ethereum_nodes = result["ethereum_nodes"]
+            ethereum_nodes = testchain["node_executors"]
             token = result["token"]
 
             port = next(free_port_generator)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -595,9 +595,8 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
             args["extra_config"] = {"transport": {"matrix": {"available_servers": server_urls}}}
 
             try:
-                success = run_smoketest(
+                run_smoketest(
                     print_step=print_step,
-                    append_report=append_report,
                     args=args,
                     contract_addresses=contract_addresses,
                     token=token,
@@ -628,6 +627,8 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         append_report("Smoketest execution error", error)
         print_step("Smoketest execution error", error=True)
         success = False
+    else:
+        success = True
 
     append_report("Raiden Node stdout", raiden_stdout.getvalue())
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -600,7 +600,10 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         )
         success = False
 
-    if not success:
+    if success:
+        print_step(f"Smoketest successful")
+    else:
+        print_step(f"Smoketest had errors", error=True)
         sys.exit(1)
 
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -491,7 +491,7 @@ def version(short):
 @click.pass_context
 def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str]):
     """ Test, that the raiden installation is sane. """
-    from raiden.tests.utils.smoketest import setup_testchain_and_raiden, run_smoketest
+    from raiden.tests.utils.smoketest import setup_testchain, setup_raiden, run_smoketest
     from raiden.tests.utils.transport import make_requests_insecure, matrix_server_starter
     from raiden.utils.debugging import enable_gevent_monitoring_signal
 
@@ -546,14 +546,14 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         ctx.parent.params["environment_type"]
     )
 
-    with setup_testchain_and_raiden(
-        transport=ctx.parent.params["transport"],
-        eth_client=eth_client,
-        matrix_server=ctx.parent.params["matrix_server"],
-        contracts_version=contracts_version,
-        print_step=print_step,
-        free_port_generator=free_port_generator,
-    ) as result:
+    transport = ctx.parent.params["transport"]
+    matrix_server = ctx.parent.params["matrix_server"]
+
+    with setup_testchain(
+        eth_client=eth_client, print_step=print_step, free_port_generator=free_port_generator
+    ) as testchain:
+        result = setup_raiden(transport, matrix_server, print_step, contracts_version, testchain)
+
         args = result["args"]
         contract_addresses = result["contract_addresses"]
         token = result["token"]


### PR DESCRIPTION
This PR:

1. Expands the block covered by the debug flag for smoketests
1. removed code that only made sense when udp was a transport
1. Passes some arguments explicitly instead of using a dictionary
1. flattens the logical depth of a smoketest.

Instead of:

- raiden.ui.cli:smoketest
- setup_testchain_and_raiden / setup_testchain / setup_raiden
- matrix_server_starter
- run_smoketest
- redirect_stdout
- smoketest_perform_tests

it does:

- raiden.ui.cli:smoketest
- redirect_stdout / setup_testchain / matrix_server_starter
- run_smoketest

Which should a bit easier to follow