### PR TITLE
Save cli tests logs

### DIFF
--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -7,6 +7,7 @@ from raiden.constants import Environment, EthClient
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.settings import DEVELOPMENT_CONTRACT_VERSION, RED_EYES_CONTRACT_VERSION
+from raiden.tests.utils.ci import get_artifacts_storage
 from raiden.tests.utils.eth_node import (
     EthNodeDescription,
     GenesisDescription,
@@ -18,8 +19,6 @@ from raiden.utils import privatekey_to_address
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 
 # pylint: disable=redefined-outer-name,too-many-arguments,unused-argument,too-many-locals
-
-_ETH_LOGDIR = os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR")
 
 
 @pytest.fixture
@@ -69,12 +68,13 @@ def web3(
 
     accounts_to_fund = [privatekey_to_address(key) for key in keys_to_fund]
 
+    # The private chain data is always discarded on the CI
     base_datadir = str(tmpdir)
 
-    if _ETH_LOGDIR:
-        base_logdir = os.path.join(_ETH_LOGDIR, request.node.name, blockchain_type)
-    else:
-        base_logdir = os.path.join(base_datadir, "logs")
+    # Save the Ethereum node's log, if needed for debugging
+    base_logdir = os.path.join(
+        get_artifacts_storage(base_datadir), request.node.name, blockchain_type
+    )
 
     genesis_description = GenesisDescription(
         prefunded_accounts=accounts_to_fund, chain_id=chain_id, random_marker=random_marker

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -4,6 +4,7 @@ import gevent
 import pytest
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
+from raiden.tests.utils.ci import get_artifacts_storage
 from raiden.tests.utils.network import (
     CHAIN,
     create_all_channels_for_network,
@@ -16,8 +17,6 @@ from raiden.tests.utils.network import (
     wait_for_token_networks,
 )
 from raiden.tests.utils.tests import shutdown_apps_and_cleanup_tasks
-
-_ETH_LOGDIR = os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR")
 
 
 def timeout(blockchain_type: str):
@@ -59,10 +58,9 @@ def raiden_chain(
         "with 0, 1 or 2 channels"
     )
 
-    if _ETH_LOGDIR:
-        base_datadir = os.path.join(_ETH_LOGDIR, request.node.name, "raiden_nodes")
-    else:
-        base_datadir = os.path.join(tmpdir.strpath, "raiden_nodes")
+    base_datadir = os.path.join(
+        get_artifacts_storage(str(tmpdir)), request.node.name, "raiden_nodes"
+    )
 
     service_registry_address = None
     if blockchain_services.service_registry:
@@ -155,10 +153,9 @@ def raiden_network(
     if blockchain_services.service_registry:
         service_registry_address = blockchain_services.service_registry.address
 
-    if _ETH_LOGDIR:
-        base_datadir = os.path.join(_ETH_LOGDIR, request.node.name, "raiden_nodes")
-    else:
-        base_datadir = os.path.join(tmpdir.strpath, "raiden_nodes")
+    base_datadir = os.path.join(
+        get_artifacts_storage(str(tmpdir)), request.node.name, "raiden_nodes"
+    )
 
     raiden_apps = create_apps(
         chain_id=chain_id,

--- a/raiden/tests/utils/ci.py
+++ b/raiden/tests/utils/ci.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_artifacts_storage(default):
+    return os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR", default)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -148,7 +148,7 @@ def get_private_key(keystore):
 
 @contextmanager
 def setup_testchain(
-    eth_client: EthClient, free_port_generator: Iterable[Port], base_datadir, base_logdir: str
+    eth_client: EthClient, free_port_generator: Iterable[Port], base_datadir: str, base_logdir: str
 ) -> ContextManager[Dict[str, Any]]:
 
     ensure_executable(eth_client.value)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -8,7 +8,7 @@ import traceback
 from copy import deepcopy
 from io import StringIO
 from subprocess import TimeoutExpired
-from tempfile import mktemp
+from tempfile import mkdtemp, mktemp
 from typing import Any, AnyStr, ContextManager, Dict, List, Optional, Tuple
 
 import click
@@ -310,10 +310,15 @@ def options(func):
                 "--log-file",
                 help="file path for logging to file",
                 default=None,
-                type=str,
+                type=click.Path(dir_okay=False, writable=True, resolve_path=True),
                 show_default=True,
             ),
             option("--log-json", help="Output log lines in JSON format", is_flag=True),
+            option(
+                "--debug-logfile-name",
+                help=("The debug logfile name."),
+                type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+            ),
             option(
                 "--disable-debug-logfile",
                 help=(
@@ -567,8 +572,13 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         free_port_generator = get_free_port()
         ethereum_nodes = None
 
+        datadir = mkdtemp()
         testchain_manager: ContextManager[Dict[str, Any]] = setup_testchain_for_smoketest(
-            eth_client=eth_client, print_step=print_step, free_port_generator=free_port_generator
+            eth_client=eth_client,
+            print_step=print_step,
+            free_port_generator=free_port_generator,
+            base_datadir=datadir,
+            base_logdir=datadir,
         )
         matrix_manager: ContextManager[List[ParsedURL]] = setup_matrix_for_smoketest(
             print_step=print_step, free_port_generator=free_port_generator

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -65,6 +65,7 @@ class NodeRunner:
             log_json=self._options["log_json"],
             log_file=self._options["log_file"],
             disable_debug_logfile=self._options["disable_debug_logfile"],
+            debug_log_file_name=self._options["debug_logfile_name"],
         )
 
         log.info("Starting Raiden", **get_system_spec())


### PR DESCRIPTION
Saving the logs of the ethereum node and the raiden nodes to figure out why some tests are flaky. 

Example: https://circleci.com/gh/raiden-network/raiden/52357#tests/containers/16