### PR TITLE
Fix and update marshmallow-dataclasses dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Flask==1.0.2
 gevent==1.3.6
 ipython<5.0.0
 marshmallow-polyfield==5.5
-marshmallow-dataclass==6.0.0c1
+marshmallow-dataclass==6.0.0rc2
 marshmallow==3.0.0rc6
 matrix-client==0.3.2
 miniupnpc==2.0.2


### PR DESCRIPTION
The version number was missing an `r` in `rc1`. Also update to `rc2`,
which includes a fix required by the services.