### PR TITLE
Unify next_channel_from_routes for initiator and mediator

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -156,24 +156,24 @@ def test_next_route_amount():
     )
 
     # the first available route should be used
-    chosen_channel = mediator.next_channel_from_routes(
+    chosen_channel = channel.next_channel_from_routes(
         channels.get_routes(0), channels.channel_map, amount, timeout_blocks
     )
     assert chosen_channel.identifier == channels[0].identifier
 
     # additional routes do not change the order
-    chosen_channel = mediator.next_channel_from_routes(
+    chosen_channel = channel.next_channel_from_routes(
         channels.get_routes(0, 1), channels.channel_map, amount, timeout_blocks
     )
     assert chosen_channel.identifier == channels[0].identifier
 
-    chosen_channel = mediator.next_channel_from_routes(
+    chosen_channel = channel.next_channel_from_routes(
         channels.get_routes(2, 0), channels.channel_map, amount, timeout_blocks
     )
     assert chosen_channel.identifier == channels[2].identifier
 
     # a channel without capacity must be skipped
-    chosen_channel = mediator.next_channel_from_routes(
+    chosen_channel = channel.next_channel_from_routes(
         channels.get_routes(1, 0), channels.channel_map, amount, timeout_blocks
     )
     assert chosen_channel.identifier == channels[0].identifier
@@ -201,7 +201,7 @@ def test_next_route_reveal_timeout():
         ]
     )
 
-    chosen_channel = mediator.next_channel_from_routes(
+    chosen_channel = channel.next_channel_from_routes(
         channels.get_routes(0, 1, 2, 3), channels.channel_map, UNIT_TRANSFER_AMOUNT, timeout_blocks
     )
     assert chosen_channel.identifier == channels[2].identifier

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -9,7 +9,6 @@ from raiden.constants import EMPTY_MERKLE_ROOT, EMPTY_SIGNATURE, UINT64_MAX, UIN
 from raiden.messages import Lock, LockedTransfer, RefundTransfer, lockedtransfersigned_from_message
 from raiden.transfer import balance_proof, channel, token_network
 from raiden.transfer.identifiers import CanonicalIdentifier
-from raiden.transfer.mediated_transfer import mediator
 from raiden.transfer.mediated_transfer.state import (
     HashTimeLockState,
     LockedTransferSignedState,
@@ -956,7 +955,7 @@ def make_transfers_pair(
         assert lockedtransfer_event
 
         lock_timeout = lock_expiration - block_number
-        assert mediator.is_channel_usable(
+        assert channel.is_channel_usable(
             candidate_channel_state=channels[payee_index],
             transfer_amount=amount,
             lock_timeout=lock_timeout,


### PR DESCRIPTION
Both the initiator and mediator had a function next_channel_from_routes.
This commit unifies them in the channel module.