### PR TITLE
Remove `unpack` method from messages

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -86,7 +86,6 @@ __all__ = (
     "ToDevice",
     "Unlock",
     "UpdatePFS",
-    "decode",
     "from_dict",
     "message_from_sendevent",
 )
@@ -144,14 +143,6 @@ def assert_transfer_values(payment_identifier, token, recipient):
 
     if len(recipient) != 20:
         raise ValueError("recipient is an invalid address")
-
-
-def decode(data: bytes) -> "Message":
-    try:
-        klass = CMDID_TO_CLASS[data[0]]
-    except KeyError:
-        raise InvalidProtocolMessage("Invalid message type (CMDID = {})".format(hex(data[0])))
-    return klass.decode(data)
 
 
 def from_dict(data: dict) -> "Message":
@@ -221,11 +212,6 @@ class Message:
         packed = self.packed()
         return sha3(packed.data)
 
-    @classmethod
-    def decode(cls, data):
-        packed = messages.wrap(data)
-        return cls.unpack(packed)
-
     def encode(self) -> bytes:
         packed = self.packed()
         return bytes(packed.data)
@@ -238,10 +224,6 @@ class Message:
         self.pack(packed)
 
         return packed
-
-    @classmethod
-    def unpack(cls, packed):
-        raise NotImplementedError("Method needs to be implemented in a subclass.")
 
     def pack(self, packed) -> None:
         raise NotImplementedError("Method needs to be implemented in a subclass.")
@@ -292,15 +274,6 @@ class SignedMessage(AuthenticatedMessage):
         except InvalidSignature:
             address = None
         return address
-
-    @classmethod
-    def decode(cls, data):
-        packed = messages.wrap(data)
-
-        if packed is None:
-            return None
-
-        return cls.unpack(packed)
 
 
 @dataclass(repr=False, eq=False)
@@ -378,12 +351,6 @@ class Processed(SignedRetrieableMessage):
 
     message_identifier: MessageID
 
-    @classmethod
-    def unpack(cls, packed):
-        # pylint: disable=unexpected-keyword-arg
-        processed = cls(message_identifier=packed.message_identifier, signature=packed.signature)
-        return processed
-
     def pack(self, packed) -> None:
         packed.message_identifier = self.message_identifier
         packed.signature = self.signature
@@ -405,12 +372,6 @@ class ToDevice(SignedMessage):
 
     message_identifier: MessageID
 
-    @classmethod
-    def unpack(cls, packed):
-        # pylint: disable=unexpected-keyword-arg
-        to_device = cls(message_identifier=packed.message_identifier, signature=packed.signature)
-        return to_device
-
     def pack(self, packed) -> None:
         packed.message_identifier = self.message_identifier
         packed.signature = self.signature
@@ -426,15 +387,6 @@ class Delivered(SignedMessage):
 
     delivered_message_identifier: MessageID
 
-    @classmethod
-    def unpack(cls, packed):
-        # pylint: disable=unexpected-keyword-arg
-        delivered = cls(
-            delivered_message_identifier=packed.delivered_message_identifier,
-            signature=packed.signature,
-        )
-        return delivered
-
     def pack(self, packed) -> None:
         packed.delivered_message_identifier = self.delivered_message_identifier
         packed.signature = self.signature
@@ -447,11 +399,6 @@ class Pong(SignedMessage):
     cmdid: ClassVar[int] = messages.PONG
 
     nonce: Nonce
-
-    @staticmethod
-    def unpack(packed):
-        pong = Pong(nonce=packed.nonce, signature=packed.signature)
-        return pong
 
     def pack(self, packed) -> None:
         packed.nonce = self.nonce
@@ -466,16 +413,6 @@ class Ping(SignedMessage):
 
     nonce: Nonce
     current_protocol_version: RaidenProtocolVersion
-
-    @classmethod
-    def unpack(cls, packed):
-        # pylint: disable=unexpected-keyword-arg
-        ping = cls(
-            nonce=packed.nonce,
-            current_protocol_version=packed.current_protocol_version,
-            signature=packed.signature,
-        )
-        return ping
 
     def pack(self, packed) -> None:
         packed.nonce = self.nonce
@@ -493,18 +430,6 @@ class SecretRequest(SignedRetrieableMessage):
     secrethash: SecretHash
     amount: PaymentAmount
     expiration: BlockExpiration
-
-    @classmethod
-    def unpack(cls, packed):
-        secret_request = cls(
-            message_identifier=packed.message_identifier,
-            payment_identifier=packed.payment_identifier,
-            secrethash=packed.secrethash,
-            amount=packed.amount,
-            expiration=packed.expiration,
-            signature=packed.signature,
-        )
-        return secret_request
 
     def pack(self, packed) -> None:
         packed.message_identifier = self.message_identifier
@@ -557,24 +482,6 @@ class Unlock(EnvelopeMessage):
     def secrethash(self):
         return sha3(self.secret)
 
-    @classmethod
-    def unpack(cls, packed):
-        # pylint: disable=unexpected-keyword-arg
-        secret = cls(
-            chain_id=packed.chain_id,
-            message_identifier=packed.message_identifier,
-            payment_identifier=packed.payment_identifier,
-            nonce=packed.nonce,
-            token_network_address=packed.token_network_address,
-            channel_identifier=packed.channel_identifier,
-            transferred_amount=packed.transferred_amount,
-            locked_amount=packed.locked_amount,
-            locksroot=packed.locksroot,
-            secret=packed.secret,
-            signature=packed.signature,
-        )
-        return secret
-
     def pack(self, packed) -> None:
         packed.chain_id = self.chain_id
         packed.message_identifier = self.message_identifier
@@ -625,15 +532,6 @@ class RevealSecret(SignedRetrieableMessage):
     @cached(_hashes_cache, key=attrgetter("secret"))
     def secrethash(self):
         return sha3(self.secret)
-
-    @classmethod
-    def unpack(cls, packed):
-        reveal_secret = RevealSecret(
-            message_identifier=packed.message_identifier,
-            secret=packed.secret,
-            signature=packed.signature,
-        )
-        return reveal_secret
 
     def pack(self, packed) -> None:
         packed.message_identifier = self.message_identifier
@@ -738,30 +636,6 @@ class LockedTransferBase(EnvelopeMessage):
         super().__post_init__()
         assert_transfer_values(self.payment_identifier, self.token, self.recipient)
 
-    @classmethod
-    def unpack(cls, packed):
-        lock = Lock(
-            amount=packed.amount, expiration=packed.expiration, secrethash=packed.secrethash
-        )
-
-        # pylint: disable=unexpected-keyword-arg
-        locked_transfer = cls(
-            chain_id=packed.chain_id,
-            message_identifier=packed.message_identifier,
-            payment_identifier=packed.payment_identifier,
-            nonce=packed.nonce,
-            token_network_address=packed.token_network_address,
-            token=packed.token,
-            channel_identifier=packed.channel_identifier,
-            transferred_amount=packed.transferred_amount,
-            recipient=packed.recipient,
-            locked_amount=packed.locked_amount,
-            locksroot=packed.locksroot,
-            lock=lock,
-            signature=packed.signature,
-        )
-        return locked_transfer
-
     def pack(self, packed) -> None:
         packed.chain_id = self.chain_id
         packed.message_identifier = self.message_identifier
@@ -821,33 +695,6 @@ class LockedTransfer(LockedTransferBase):
 
         if self.fee > UINT256_MAX:
             raise ValueError("fee is too large")
-
-    @classmethod
-    def unpack(cls, packed):
-        lock = Lock(
-            amount=packed.amount, expiration=packed.expiration, secrethash=packed.secrethash
-        )
-
-        # pylint: disable=unexpected-keyword-arg
-        mediated_transfer = cls(
-            chain_id=packed.chain_id,
-            message_identifier=packed.message_identifier,
-            payment_identifier=packed.payment_identifier,
-            nonce=packed.nonce,
-            token_network_address=packed.token_network_address,
-            token=packed.token,
-            channel_identifier=packed.channel_identifier,
-            transferred_amount=packed.transferred_amount,
-            locked_amount=packed.locked_amount,
-            recipient=packed.recipient,
-            locksroot=packed.locksroot,
-            lock=lock,
-            target=packed.target,
-            initiator=packed.initiator,
-            fee=packed.fee,
-            signature=packed.signature,
-        )
-        return mediated_transfer
 
     def pack(self, packed) -> None:
         packed.chain_id = self.chain_id
@@ -914,33 +761,6 @@ class RefundTransfer(LockedTransfer):
     cmdid: ClassVar[int] = messages.REFUNDTRANSFER
 
     @classmethod
-    def unpack(cls, packed):
-        lock = Lock(
-            amount=packed.amount, expiration=packed.expiration, secrethash=packed.secrethash
-        )
-
-        # pylint: disable=unexpected-keyword-arg
-        locked_transfer = cls(
-            chain_id=packed.chain_id,
-            message_identifier=packed.message_identifier,
-            payment_identifier=packed.payment_identifier,
-            nonce=packed.nonce,
-            token_network_address=packed.token_network_address,
-            token=packed.token,
-            channel_identifier=packed.channel_identifier,
-            transferred_amount=packed.transferred_amount,
-            locked_amount=packed.locked_amount,
-            recipient=packed.recipient,
-            locksroot=packed.locksroot,
-            lock=lock,
-            target=packed.target,
-            initiator=packed.initiator,
-            fee=packed.fee,
-            signature=packed.signature,
-        )
-        return locked_transfer
-
-    @classmethod
     def from_event(cls, event):
         transfer = event.transfer
         balance_proof = transfer.balance_proof
@@ -982,25 +802,6 @@ class LockExpired(EnvelopeMessage):
 
     recipient: Address
     secrethash: SecretHash
-
-    @classmethod
-    def unpack(cls, packed):
-        # pylint: disable=unexpected-keyword-arg
-        transfer = cls(
-            chain_id=packed.chain_id,
-            nonce=packed.nonce,
-            message_identifier=packed.message_identifier,
-            token_network_address=packed.token_network_address,
-            channel_identifier=packed.channel_identifier,
-            transferred_amount=packed.transferred_amount,
-            recipient=packed.recipient,
-            locked_amount=packed.locked_amount,
-            locksroot=packed.locksroot,
-            secrethash=packed.secrethash,
-            signature=packed.signature,
-        )
-
-        return transfer
 
     def pack(self, packed) -> None:
         packed.chain_id = self.chain_id
@@ -1187,26 +988,6 @@ class RequestMonitoring(SignedMessage):
         packed.reward_amount = self.reward_amount
         packed.reward_proof_signature = self.reward_proof_signature
 
-    @classmethod
-    def unpack(cls, packed) -> "RequestMonitoring":
-        onchain_balance_proof = SignedBlindedBalanceProof(
-            nonce=packed.nonce,
-            chain_id=packed.chain_id,
-            token_network_address=packed.token_network_address,
-            channel_identifier=packed.channel_identifier,
-            balance_hash=packed.balance_hash,
-            additional_hash=packed.additional_hash,
-            signature=packed.signature,
-        )
-        # pylint: disable=unexpected-keyword-arg
-        monitoring_request = cls(
-            balance_proof=onchain_balance_proof,
-            non_closing_signature=packed.non_closing_signature,
-            reward_amount=packed.reward_amount,
-            signature=packed.reward_proof_signature,
-        )
-        return monitoring_request
-
     def verify_request_monitoring(
         self, partner_address: Address, requesting_address: Address
     ) -> bool:
@@ -1311,26 +1092,6 @@ class UpdatePFS(SignedMessage):
         packed.reveal_timeout = self.reveal_timeout
         packed.fee = self.mediation_fee
         packed.signature = self.signature
-
-    @classmethod
-    def unpack(cls, packed) -> "UpdatePFS":
-        # pylint: disable=unexpected-keyword-arg
-        return cls(
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=packed.chain_id,
-                token_network_address=packed.token_network_address,
-                channel_identifier=packed.channel_identifier,
-            ),
-            updating_participant=packed.updating_participant,
-            other_participant=packed.other_participant,
-            updating_nonce=packed.updating_nonce,
-            other_nonce=packed.other_nonce,
-            updating_capacity=packed.other_capacity,
-            other_capacity=packed.other_capacity,
-            reveal_timeout=packed.reveal_timeout,
-            mediation_fee=packed.fee,
-            signature=packed.signature,
-        )
 
 
 def lockedtransfersigned_from_message(message: LockedTransfer) -> "LockedTransferSignedState":

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -212,10 +212,6 @@ class Message:
         packed = self.packed()
         return sha3(packed.data)
 
-    def encode(self) -> bytes:
-        packed = self.packed()
-        return bytes(packed.data)
-
     def packed(self):
         klass = messages.CMDID_MESSAGE[self.cmdid]
         data = buffer_for(klass)

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -554,8 +554,6 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
         )
         return []
 
-    assert not data.startswith("0x")
-
     for line in data.splitlines():
         line = line.strip()
         if not line:
@@ -572,7 +570,7 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
             continue
         except InvalidProtocolMessage as ex:
             log.warning(
-                "Message data JSON are not a valid Message",
+                "Message data JSON is not a valid Message",
                 message_data=line,
                 peer_address=to_checksum_address(peer_address),
                 _exc=ex,

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -35,7 +35,7 @@ from gevent.lock import Semaphore
 from matrix_client.errors import MatrixError, MatrixRequestError
 
 from raiden.exceptions import InvalidProtocolMessage, InvalidSignature, TransportError
-from raiden.messages import Message, SignedMessage, decode as message_from_bytes
+from raiden.messages import Message, SignedMessage
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.utils import get_http_rtt
 from raiden.storage.serialization import JSONSerializer
@@ -544,7 +544,7 @@ def make_room_alias(chain_id: ChainID, *suffixes: str) -> str:
 
 
 def validate_and_parse_message(data, peer_address) -> List[Message]:
-    messages = list()
+    messages: List[Message] = list()
 
     if not isinstance(data, str):
         log.warning(
@@ -554,69 +554,46 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
         )
         return []
 
-    if data.startswith("0x"):
+    assert not data.startswith("0x")
+
+    for line in data.splitlines():
+        line = line.strip()
+        if not line:
+            continue
         try:
-            message = message_from_bytes(decode_hex(data))
-            if not message:
-                raise InvalidProtocolMessage
-        except (DecodeError, AssertionError) as ex:
+            message = JSONSerializer.deserialize(line)
+        except (UnicodeDecodeError, json.JSONDecodeError) as ex:
             log.warning(
-                "Can't parse Message binary data",
-                message_data=data,
+                "Can't parse Message data JSON",
+                message_data=line,
                 peer_address=to_checksum_address(peer_address),
                 _exc=ex,
             )
-            return []
+            continue
         except InvalidProtocolMessage as ex:
             log.warning(
-                "Received Message binary data is not a valid message",
-                message_data=data,
+                "Message data JSON are not a valid Message",
+                message_data=line,
                 peer_address=to_checksum_address(peer_address),
                 _exc=ex,
             )
-            return []
-        else:
-            messages.append(message)
-
-    else:
-        for line in data.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                message = JSONSerializer.deserialize(line)
-            except (UnicodeDecodeError, json.JSONDecodeError) as ex:
-                log.warning(
-                    "Can't parse Message data JSON",
-                    message_data=line,
-                    peer_address=to_checksum_address(peer_address),
-                    _exc=ex,
-                )
-                continue
-            except InvalidProtocolMessage as ex:
-                log.warning(
-                    "Message data JSON are not a valid Message",
-                    message_data=line,
-                    peer_address=to_checksum_address(peer_address),
-                    _exc=ex,
-                )
-                continue
-            if not isinstance(message, SignedMessage):
-                log.warning(
-                    "Message not a SignedMessage!",
-                    message=message,
-                    peer_address=to_checksum_address(peer_address),
-                )
-                continue
-            if message.sender != peer_address:
-                log.warning(
-                    "Message not signed by sender!",
-                    message=message,
-                    signer=message.sender,
-                    peer_address=to_checksum_address(peer_address),
-                )
-                continue
-            messages.append(message)
+            continue
+        if not isinstance(message, SignedMessage):
+            log.warning(
+                "Message not a SignedMessage!",
+                message=message,
+                peer_address=to_checksum_address(peer_address),
+            )
+            continue
+        if message.sender != peer_address:
+            log.warning(
+                "Message not signed by sender!",
+                message=message,
+                signer=message.sender,
+                peer_address=to_checksum_address(peer_address),
+            )
+            continue
+        messages.append(message)
 
     return messages
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -186,7 +186,7 @@ def skip_userid_validation(monkeypatch):
     )
 
 
-def make_message(convert_to_hex: bool = False, overwrite_data=None):
+def make_message(overwrite_data=None):
     room = Room(None, "!roomID:server")
     if not overwrite_data:
         message = SecretRequest(
@@ -198,11 +198,7 @@ def make_message(convert_to_hex: bool = False, overwrite_data=None):
             signature=EMPTY_SIGNATURE,
         )
         message.sign(LocalSigner(factories.HOP1_KEY))
-        data = message.encode()
-        if convert_to_hex:
-            data = "0x" + data.hex()
-        else:
-            data = JSONSerializer.serialize(message)
+        data = JSONSerializer.serialize(message)
     else:
         data = overwrite_data
 
@@ -216,7 +212,7 @@ def test_normal_processing_json(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation
 ):
     m = mock_matrix
-    room, event = make_message(convert_to_hex=False)
+    room, event = make_message()
     assert m._handle_message(room, event)
 
 
@@ -225,7 +221,7 @@ def test_processing_invalid_json(  # pylint: disable=unused-argument
 ):
     m = mock_matrix
     invalid_json = '{"foo": 1,'
-    room, event = make_message(convert_to_hex=False, overwrite_data=invalid_json)
+    room, event = make_message(overwrite_data=invalid_json)
     assert not m._handle_message(room, event)
 
 
@@ -242,7 +238,7 @@ def test_processing_invalid_message_json(  # pylint: disable=unused-argument
 ):
     m = mock_matrix
     invalid_message = '{"this": 1, "message": 5, "is": 3, "not_valid": 5}'
-    room, event = make_message(convert_to_hex=False, overwrite_data=invalid_message)
+    room, event = make_message(overwrite_data=invalid_message)
     assert not m._handle_message(room, event)
 
 
@@ -251,7 +247,7 @@ def test_processing_invalid_message_cmdid_json(  # pylint: disable=unused-argume
 ):
     m = mock_matrix
     invalid_message = '{"type": "NonExistentMessage", "is": 3, "not_valid": 5}'
-    room, event = make_message(convert_to_hex=False, overwrite_data=invalid_message)
+    room, event = make_message(overwrite_data=invalid_message)
     assert not m._handle_message(room, event)
 
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -212,14 +212,6 @@ def make_message(convert_to_hex: bool = False, overwrite_data=None):
     return room, event
 
 
-def test_normal_processing_hex(  # pylint: disable=unused-argument
-    mock_matrix, skip_userid_validation
-):
-    m = mock_matrix
-    room, event = make_message(convert_to_hex=True)
-    assert m._handle_message(room, event)
-
-
 def test_normal_processing_json(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation
 ):
@@ -260,36 +252,6 @@ def test_processing_invalid_message_cmdid_json(  # pylint: disable=unused-argume
     m = mock_matrix
     invalid_message = '{"type": "NonExistentMessage", "is": 3, "not_valid": 5}'
     room, event = make_message(convert_to_hex=False, overwrite_data=invalid_message)
-    assert not m._handle_message(room, event)
-
-
-def test_processing_invalid_hex(  # pylint: disable=unused-argument
-    mock_matrix, skip_userid_validation
-):
-    m = mock_matrix
-    room, event = make_message(convert_to_hex=True)
-    old_data = event["content"]["body"]
-    event["content"]["body"] = old_data[:-1]
-    assert not m._handle_message(room, event)
-
-
-def test_processing_invalid_message_hex(  # pylint: disable=unused-argument
-    mock_matrix, skip_userid_validation
-):
-    m = mock_matrix
-    room, event = make_message(convert_to_hex=True)
-    old_data = event["content"]["body"]
-    event["content"]["body"] = old_data[:-4]
-    assert not m._handle_message(room, event)
-
-
-def test_processing_invalid_message_cmdid_hex(  # pylint: disable=unused-argument
-    mock_matrix, skip_userid_validation
-):
-    m = mock_matrix
-    room, event = make_message(convert_to_hex=True)
-    old_data = event["content"]["body"]
-    event["content"]["body"] = "0xff" + old_data[4:]
     assert not m._handle_message(room, event)
 
 

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -86,7 +86,7 @@ def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, trans
             fee=fee,
         )
     )
-    mediated_transfer.packed()
+    mediated_transfer.packed()  # Just test that packing works without exceptions.
 
 
 @pytest.mark.parametrize("amount", [0, constants.UINT256_MAX])
@@ -102,4 +102,4 @@ def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_
             transferred_amount=transferred_amount,
         )
     )
-    refund_transfer.packed()
+    refund_transfer.packed()  # Just test that packing works without exceptions.

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -68,10 +68,7 @@ def test_processed():
     )
     processed_message.sign(signer)
     assert processed_message.sender == ADDRESS
-
     assert processed_message.message_identifier == message_identifier
-
-    processed_message.encode()
 
 
 @pytest.mark.parametrize("amount", [0, constants.UINT256_MAX])
@@ -89,7 +86,7 @@ def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, trans
             fee=fee,
         )
     )
-    mediated_transfer.encode()
+    mediated_transfer.packed()
 
 
 @pytest.mark.parametrize("amount", [0, constants.UINT256_MAX])
@@ -105,4 +102,4 @@ def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_
             transferred_amount=transferred_amount,
         )
     )
-    refund_transfer.encode()
+    refund_transfer.packed()

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -4,9 +4,8 @@ import pytest
 
 from raiden import constants
 from raiden.exceptions import InvalidSignature
-from raiden.messages import Ping, Processed, decode
+from raiden.messages import Ping, Processed
 from raiden.tests.utils import factories
-from raiden.utils import sha3
 from raiden.utils.signer import LocalSigner, recover
 
 PRIVKEY, ADDRESS = factories.make_privkey_address()
@@ -50,13 +49,7 @@ def test_encoding():
         signature=constants.EMPTY_SIGNATURE,
     )
     ping.sign(signer)
-    decoded_ping = decode(ping.encode())
-    assert isinstance(decoded_ping, Ping)
-    assert decoded_ping.sender == ADDRESS == ping.sender
-    assert ping.nonce == decoded_ping.nonce
-    assert ping.signature == decoded_ping.signature
-    assert ping.cmdid == decoded_ping.cmdid
-    assert ping.hash == decoded_ping.hash
+    assert ping.sender == ADDRESS
 
 
 def test_hash():
@@ -66,10 +59,6 @@ def test_hash():
         signature=constants.EMPTY_SIGNATURE,
     )
     ping.sign(signer)
-    data = ping.encode()
-    msghash = sha3(data)
-    decoded_ping = decode(data)
-    assert sha3(decoded_ping.encode()) == msghash
 
 
 def test_processed():
@@ -82,13 +71,7 @@ def test_processed():
 
     assert processed_message.message_identifier == message_identifier
 
-    data = processed_message.encode()
-    decoded_processed_message = decode(data)
-
-    assert decoded_processed_message.message_identifier == message_identifier
-    assert processed_message.message_identifier == message_identifier
-    assert decoded_processed_message.sender == processed_message.sender
-    assert sha3(decoded_processed_message.encode()) == sha3(data)
+    processed_message.encode()
 
 
 @pytest.mark.parametrize("amount", [0, constants.UINT256_MAX])
@@ -106,7 +89,7 @@ def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, trans
             fee=fee,
         )
     )
-    assert decode(mediated_transfer.encode()) == mediated_transfer
+    mediated_transfer.encode()
 
 
 @pytest.mark.parametrize("amount", [0, constants.UINT256_MAX])
@@ -122,4 +105,4 @@ def test_refund_transfer_min_max(amount, payment_identifier, nonce, transferred_
             transferred_amount=transferred_amount,
         )
     )
-    assert decode(refund_transfer.encode()) == refund_transfer
+    refund_transfer.encode()

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -37,9 +37,6 @@ def test_request_monitoring():
     request_monitoring.sign(signer)
     as_dict = DictSerializer.serialize(request_monitoring)
     assert DictSerializer.deserialize(as_dict) == request_monitoring
-    request_monitoring_packed = request_monitoring.packed()
-    request_monitoring.pack(request_monitoring_packed)
-    assert RequestMonitoring.unpack(request_monitoring_packed) == request_monitoring
     # RequestMonitoring can be created directly from BalanceProofSignedState
     direct_created = RequestMonitoring.from_balance_proof_signed_state(
         balance_proof, reward_amount=55


### PR DESCRIPTION
Also remove the corresponding tests and the support for hex-encoded
messages in the matrix transport.