### PR TITLE
Remove EMPTY_SECRET

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -11,7 +11,6 @@ from raiden.utils.typing import (
     LockHash,
     Locksroot,
     RaidenProtocolVersion,
-    Secret,
     SecretHash,
     Signature,
     TokenAmount,
@@ -51,7 +50,6 @@ EMPTY_MESSAGE_HASH = AdditionalHash(bytes(32))
 EMPTY_HASH_KECCAK = keccak(EMPTY_HASH)
 EMPTY_SIGNATURE = Signature(bytes(65))
 EMPTY_MERKLE_ROOT = Locksroot(bytes(32))
-EMPTY_SECRET = Secret(b"")
 EMPTY_SECRETHASH = SecretHash(bytes(32))
 ZERO_TOKENS = TokenAmount(0)
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -1,6 +1,5 @@
 import structlog
 
-from raiden.constants import EMPTY_SECRET
 from raiden.messages import (
     Delivered,
     LockedTransfer,
@@ -137,7 +136,7 @@ class MessageHandler:
             # We currently don't allow multi routes if the initiator does not
             # hold the secret. In such case we remove all other possible routes
             # which allow the API call to return with with an error message.
-            if old_secret == EMPTY_SECRET:
+            if old_secret is None:
                 routes = list()
 
             secret = random_secret()

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -1,6 +1,5 @@
 import random
 
-from raiden.constants import EMPTY_SECRET
 from raiden.settings import DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
 from raiden.transfer import channel
 from raiden.transfer.architecture import Event, TransitionResult
@@ -288,7 +287,7 @@ def handle_secretrequest(
         state_change.amount <= lock.amount
         and state_change.amount >= initiator_state.transfer_description.amount
         and state_change.expiration == lock.expiration
-        and initiator_state.transfer_description.secret != EMPTY_SECRET
+        and initiator_state.transfer_description.secret
     )
 
     if already_received_secret_request and is_message_from_target:


### PR DESCRIPTION
Unlike other constants named `EMPTY_*`, `EMPTY_SECRET` had no bytes in it.
`EMPTY_SECRET` was of type Secret but it was not useful onchain as a secret
because every secret needs to be 32 bytes.

This commit removes EMPTY_SECRET and instead uses None as the absence of secret.