### PR TITLE
Rename EMPTY_SECRET into ABSENT_SECRET

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -51,9 +51,10 @@ EMPTY_MESSAGE_HASH = AdditionalHash(bytes(32))
 EMPTY_HASH_KECCAK = keccak(EMPTY_HASH)
 EMPTY_SIGNATURE = Signature(bytes(65))
 EMPTY_MERKLE_ROOT = Locksroot(bytes(32))
-EMPTY_SECRET = Secret(b"")
 EMPTY_SECRETHASH = SecretHash(bytes(32))
 ZERO_TOKENS = TokenAmount(0)
+
+ABSENT_SECRET = Secret(b"")
 
 SECRET_LENGTH = 32
 SECRETHASH_LENGTH = 32

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -1,6 +1,6 @@
 import structlog
 
-from raiden.constants import EMPTY_SECRET
+from raiden.constants import ABSENT_SECRET
 from raiden.messages import (
     Delivered,
     LockedTransfer,
@@ -137,7 +137,7 @@ class MessageHandler:
             # We currently don't allow multi routes if the initiator does not
             # hold the secret. In such case we remove all other possible routes
             # which allow the API call to return with with an error message.
-            if old_secret == EMPTY_SECRET:
+            if old_secret == ABSENT_SECRET:
                 routes = list()
 
             secret = random_secret()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -16,7 +16,7 @@ from raiden.blockchain.events import BlockchainEvents
 from raiden.blockchain_events_handler import on_blockchain_event
 from raiden.connection_manager import ConnectionManager
 from raiden.constants import (
-    EMPTY_SECRET,
+    ABSENT_SECRET,
     GENESIS_BLOCK_NUMBER,
     SECRET_LENGTH,
     SNAPSHOT_STATE_CHANGES_COUNT,
@@ -1039,7 +1039,7 @@ class RaidenService(Runnable):
             if secrethash is None:
                 secret = random_secret()
             else:
-                secret = EMPTY_SECRET
+                secret = ABSENT_SECRET
 
         payment_status = self.start_mediated_transfer_with_secret(
             token_network_address=token_network_address,

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -1,6 +1,6 @@
 import random
 
-from raiden.constants import EMPTY_SECRET
+from raiden.constants import ABSENT_SECRET
 from raiden.settings import DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
 from raiden.transfer import channel
 from raiden.transfer.architecture import Event, TransitionResult
@@ -288,7 +288,7 @@ def handle_secretrequest(
         state_change.amount <= lock.amount
         and state_change.amount >= initiator_state.transfer_description.amount
         and state_change.expiration == lock.expiration
-        and initiator_state.transfer_description.secret != EMPTY_SECRET
+        and initiator_state.transfer_description.secret != ABSENT_SECRET
     )
 
     if already_received_secret_request and is_message_from_target:

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -411,7 +411,7 @@ def role_from_transfer_task(transfer_task: TransferTask) -> str:
 def secret_from_transfer_task(
     transfer_task: Optional[TransferTask], secrethash: SecretHash
 ) -> Optional[Secret]:
-    """Return the secret for the transfer, None on EMPTY_SECRET."""
+    """Return the secret for the transfer, None on ABSENT_SECRET."""
     assert isinstance(transfer_task, InitiatorTask)
 
     transfer_state = transfer_task.manager_state.initiator_transfers[secrethash]


### PR DESCRIPTION
All other constants that are named EMPTY_* have non-zero length and
have zeros in it. I also want an EMPTY_SECRET that has 32 bytes of
zeros.

So I rename EMPTY_SECRET = b"" into ABSENT_SECRET.  This value is
currently being used to indicate the absense of the secret.

https://github.com/raiden-network/raiden/issues/3944 keeps track of
replacing ABSENT_SECRET with None.