### PR TITLE
Track feedback token for routes, add PFSFeedbackEventHandler

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -131,7 +131,6 @@ class MessageHandler:
             chain_state=chain_state, secrethash=from_transfer.lock.secrethash
         )
 
-        state_change: StateChange
         if role == "initiator":
             old_secret = views.get_transfer_secret(chain_state, from_transfer.lock.secrethash)
             # We currently don't allow multi routes if the initiator does not
@@ -141,7 +140,7 @@ class MessageHandler:
                 routes = list()
 
             secret = random_secret()
-            state_change = ReceiveTransferRefundCancelRoute(
+            state_change: StateChange = ReceiveTransferRefundCancelRoute(
                 routes=routes,
                 transfer=from_transfer,
                 balance_proof=from_transfer.balance_proof,

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -448,7 +448,7 @@ def post_pfs_feedback(
 
     url = service_config["pathfinding_service_address"]
     hex_route = [to_checksum_address(address) for address in route]
-    payload = dict(token=token.hex, path=hex_route, status="success" if succesful else "failure")
+    payload = dict(token=token.hex, path=hex_route, success=succesful)
 
     log.info(
         "Sending routing feedback to Pathfinding Service",

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -152,6 +152,7 @@ def initiator_init(
         privkey=raiden.privkey,
     )
 
+    # Only prepare feedback when token is available
     if feedback_token is not None:
         for route_state in routes:
             raiden.route_to_feeback_token[tuple(route_state.route)] = feedback_token

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -45,7 +45,10 @@ def test_initiator_task_view():
         secrethash=sha3(secret),
     )
     transfer_state = InitiatorTransferState(
-        transfer_description=transfer_description, channel_identifier=channel_id, transfer=transfer
+        route=factories.make_route_to_channel(),
+        transfer_description=transfer_description,
+        channel_identifier=channel_id,
+        transfer=transfer,
     )
     payment_state = InitiatorPaymentState(
         routes=[], initiator_transfers={secrethash: transfer_state}

--- a/raiden/tests/unit/api/test_api_events.py
+++ b/raiden/tests/unit/api/test_api_events.py
@@ -49,6 +49,7 @@ def test_v1_event_payment_sent_failed_schema():
 
 def test_event_filter_for_payments():
     token_network_address = factories.make_address()
+    secret = factories.make_secret()
     payment_network_address = factories.make_payment_network_address()
     identifier = 1
     target = factories.make_address()
@@ -58,6 +59,8 @@ def test_event_filter_for_payments():
         identifier=identifier,
         amount=5,
         target=target,
+        secret=secret,
+        route=[],
     )
     assert event_filter_for_payments(event, token_network_address, None)
     assert event_filter_for_payments(event, token_network_address, target)

--- a/raiden/tests/unit/test_operators.py
+++ b/raiden/tests/unit/test_operators.py
@@ -41,10 +41,10 @@ def test_transfer_statechange_operators():
 
 
 def test_event_operators():
-    a = EventPaymentSentSuccess(1, 4, 2, 5, sha3(b"target"))
-    b = EventPaymentSentSuccess(1, 4, 2, 5, sha3(b"target"))
-    c = EventPaymentSentSuccess(2, 7, 3, 4, sha3(b"target"))
-    d = EventPaymentSentSuccess(2, 7, 3, 4, sha3(b"differenttarget"))
+    a = EventPaymentSentSuccess(1, 4, 2, 5, sha3(b"target"), b"0", [])
+    b = EventPaymentSentSuccess(1, 4, 2, 5, sha3(b"target"), b"0", [])
+    c = EventPaymentSentSuccess(2, 7, 3, 4, sha3(b"target"), b"0", [])
+    d = EventPaymentSentSuccess(2, 7, 3, 4, sha3(b"differenttarget"), b"0", [])
 
     # pylint: disable=unneeded-not
     assert a == b

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -853,7 +853,7 @@ def test_post_pfs_feedback(query_paths_args):
 
         payload = feedback.call_args[1]["json"]
         assert payload["token"] == feedback_token.hex
-        assert payload["status"] == "success"
+        assert payload["success"] is True
         assert payload["path"] == [to_checksum_address(addr) for addr in route]
 
     with patch.object(requests, "post", return_value=request_mock()) as feedback:
@@ -870,7 +870,7 @@ def test_post_pfs_feedback(query_paths_args):
 
         payload = feedback.call_args[1]["json"]
         assert payload["token"] == feedback_token.hex
-        assert payload["status"] == "failure"
+        assert payload["success"] is False
         assert payload["path"] == [to_checksum_address(addr) for addr in route]
 
     with patch.object(requests, "post", return_value=request_mock()) as feedback:

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1472,9 +1472,10 @@ def test_initiator_manager_drops_invalid_state_changes():
         assert_dropped(iteration, state, "no matching initiator_state")
 
         initiator_state = InitiatorTransferState(
-            factories.UNIT_TRANSFER_DESCRIPTION,
-            channels[0].canonical_identifier.channel_identifier,
-            transfer,
+            route=factories.make_route_from_channel(channels[0]),
+            transfer_description=factories.UNIT_TRANSFER_DESCRIPTION,
+            channel_identifier=channels[0].canonical_identifier.channel_identifier,
+            transfer=transfer,
         )
         state = InitiatorPaymentState(
             routes=[], initiator_transfers={factories.UNIT_SECRETHASH: initiator_state}

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -170,6 +170,10 @@ def make_checksum_address() -> AddressHex:
     return to_checksum_address(make_address())
 
 
+def make_token_network_address() -> TokenNetworkAddress:
+    return TokenNetworkAddress(make_address())
+
+
 def make_additional_hash() -> AdditionalHash:
     return AdditionalHash(make_32bytes())
 

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -109,19 +109,25 @@ class MockChainState:
 
 
 class MockRaidenService:
-    def __init__(self, message_handler=None, state_transition=None, private_key=None):
+    def __init__(self, message_handler=None, state_transition=None, private_key=None, config=None):
         if private_key is None:
-            self.private_key, self.address = factories.make_privkey_address()
+            self.privkey, self.address = factories.make_privkey_address()
         else:
-            self.private_key = private_key
+            self.privkey = private_key
             self.address = privatekey_to_address(private_key)
 
         self.chain = MockChain(network_id=17, node_address=self.address)
-        self.signer = LocalSigner(self.private_key)
+        self.signer = LocalSigner(self.privkey)
 
         self.message_handler = message_handler
+        self.config = config
 
         self.user_deposit = Mock()
+        self.default_registry = Mock()
+        self.default_registry.address = factories.make_address()
+        self.default_one_to_n_address = factories.make_address()
+
+        self.route_to_feeback_token = {}
 
         if state_transition is None:
             state_transition = node.state_transition

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -14,6 +14,7 @@ from raiden.utils.typing import (
     Address,
     ChannelID,
     InitiatorAddress,
+    List,
     Optional,
     PaymentAmount,
     PaymentID,
@@ -135,7 +136,8 @@ class EventPaymentSentSuccess(Event):
     identifier: PaymentID
     amount: PaymentAmount
     target: TargetAddress
-    secret: Optional[Secret] = None
+    secret: Secret
+    route: List[Address]
 
 
 @dataclass

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -16,6 +16,7 @@ from raiden.utils.typing import (
     Secret,
     SecretHash,
     TokenAddress,
+    TokenNetworkAddress,
 )
 
 # According to the smart contracts as of 07/08:
@@ -211,3 +212,4 @@ class EventRouteFailed(Event):
 
     secrethash: SecretHash
     route: List[Address]
+    token_network_address: TokenNetworkAddress

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -7,8 +7,10 @@ from raiden.transfer.mediated_transfer.state import LockedTransferUnsignedState
 from raiden.transfer.state import BalanceProofUnsignedState
 from raiden.utils import sha3
 from raiden.utils.typing import (
+    Address,
     BlockExpiration,
     ChannelID,
+    List,
     PaymentID,
     PaymentWithFeeAmount,
     Secret,
@@ -208,3 +210,4 @@ class EventRouteFailed(Event):
     """
 
     secrethash: SecretHash
+    route: List[Address]

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -73,6 +73,7 @@ def events_for_unlock_lock(
         amount=transfer_description.amount,
         target=transfer_description.target,
         secret=secret,
+        route=initiator_state.route.route,
     )
 
     unlock_success = EventUnlockSuccess(
@@ -143,7 +144,7 @@ def handle_block(
             target=transfer_description.target,
             reason=reason,
         )
-        route_failed = EventRouteFailed(secrethash=secrethash)
+        route_failed = EventRouteFailed(secrethash=secrethash, route=initiator_state.route.route)
         unlock_failed = EventUnlockFailed(
             identifier=payment_identifier,
             secrethash=initiator_state.transfer_description.secrethash,
@@ -206,7 +207,7 @@ def try_new_route(
         initiator_state = None
 
     else:
-        channel_state, _ = route_infos
+        channel_state, route = route_infos
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
         lockedtransfer_event = send_lockedtransfer(
             transfer_description=transfer_description,
@@ -217,6 +218,7 @@ def try_new_route(
         assert lockedtransfer_event
 
         initiator_state = InitiatorTransferState(
+            route=route,
             transfer_description=transfer_description,
             channel_identifier=channel_state.identifier,
             transfer=lockedtransfer_event.transfer,

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -144,7 +144,11 @@ def handle_block(
             target=transfer_description.target,
             reason=reason,
         )
-        route_failed = EventRouteFailed(secrethash=secrethash, route=initiator_state.route.route)
+        route_failed = EventRouteFailed(
+            secrethash=secrethash,
+            route=initiator_state.route.route,
+            token_network_address=transfer_description.token_network_address,
+        )
         unlock_failed = EventUnlockFailed(
             identifier=payment_identifier,
             secrethash=initiator_state.transfer_description.secrethash,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -295,7 +295,11 @@ def handle_transferrefundcancelroute(
     if not is_valid:
         return TransitionResult(payment_state, list())
 
-    route_failed_event = EventRouteFailed(secrethash=original_transfer.lock.secrethash)
+    transfer_secrethash = original_transfer.lock.secrethash
+    route_failed_event = EventRouteFailed(
+        secrethash=transfer_secrethash,
+        route=payment_state.initiator_transfers[transfer_secrethash].route.route,
+    )
     events.append(route_failed_event)
 
     old_description = initiator_state.transfer_description

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -296,9 +296,11 @@ def handle_transferrefundcancelroute(
         return TransitionResult(payment_state, list())
 
     transfer_secrethash = original_transfer.lock.secrethash
+    transfer_state = payment_state.initiator_transfers[transfer_secrethash]
     route_failed_event = EventRouteFailed(
         secrethash=transfer_secrethash,
-        route=payment_state.initiator_transfers[transfer_secrethash].route.route,
+        route=transfer_state.route.route,
+        token_network_address=transfer_state.transfer_description.token_network_address,
     )
     events.append(route_failed_event)
 

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -130,6 +130,7 @@ class WaitingTransferState(State):
 class InitiatorTransferState(State):
     """ State of a transfer for the initiator node. """
 
+    route: RouteState
     transfer_description: TransferDescriptionWithSecretState = field(repr=False)
     channel_identifier: ChannelID
     transfer: LockedTransferUnsignedState

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -22,7 +22,7 @@ from raiden.message_handler import MessageHandler
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.transport import MatrixTransport
-from raiden.raiden_event_handler import RaidenEventHandler
+from raiden.raiden_event_handler import EventHandler, PFSFeedbackEventHandler, RaidenEventHandler
 from raiden.settings import DEFAULT_MATRIX_KNOWN_SERVERS, DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.ui.checks import (
     check_ethereum_client_is_supported,
@@ -219,7 +219,10 @@ def run_app(
     else:
         raise RuntimeError(f'Unknown transport type "{transport}" given')
 
-    raiden_event_handler = RaidenEventHandler()
+    event_handler: EventHandler = RaidenEventHandler()
+
+    if routing_mode == RoutingMode.PFS:
+        event_handler = PFSFeedbackEventHandler(event_handler)
 
     message_handler = MessageHandler()
 
@@ -237,7 +240,7 @@ def run_app(
             default_secret_registry=proxies.secret_registry,
             default_service_registry=proxies.service_registry,
             transport=transport,
-            raiden_event_handler=raiden_event_handler,
+            raiden_event_handler=event_handler,
             message_handler=message_handler,
             user_deposit=proxies.user_deposit,
         )


### PR DESCRIPTION
Final pieces of the client side routing feedback.

This adds:
- A mapping `route_to_feeback_token` to the `RaidenService` in which the feedback token for routes are stored (only when the PFS is used)
- The `PFSFeedbackEventHandler`, which handles PFS feedback (only enabled when PFS is enabled).
- A function `post_pfs_feedback` which sends feedback to the PFS


Fixes #3996 