### PR TITLE
 Include DB version number in `version` subcommand output 

### DIFF
--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -21,6 +21,7 @@ def test_cli_version(cli_runner):
     result_json = json.loads(result.output)
     result_expected_keys = {
         "raiden",
+        "raiden_db_version",
         "python_implementation",
         "python_version",
         "system",

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -65,6 +65,7 @@ def options(func):
     # Until https://github.com/pallets/click/issues/926 is fixed the options need to be re-defined
     # for every use
     options_ = [
+        option("--version", hidden=True, is_flag=True, allow_from_autoenv=False),
         option(
             "--datadir",
             help="Directory for storing raiden data.",
@@ -394,6 +395,15 @@ def options(func):
 @click.pass_context
 def run(ctx, **kwargs):
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+
+    if kwargs.pop("version", False):
+        click.echo(
+            click.style("Hint: Use ", fg="green")
+            + click.style(f"'{os.path.basename(sys.argv[0])} version'", fg="yellow")
+            + click.style(" instead", fg="green")
+        )
+        ctx.invoke(version, short=True)
+        return
 
     if kwargs["config_file"]:
         apply_config_file(run, kwargs, ctx)

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -130,7 +130,7 @@ def get_relative_path(file_name: str) -> str:
     return file_name.replace(prefix + "/", "")
 
 
-def get_system_spec() -> Dict[str, str]:
+def get_system_spec() -> Dict[str, Any]:
     """Collect information about the system and installation.
     """
     import pkg_resources
@@ -156,6 +156,7 @@ def get_system_spec() -> Dict[str, str]:
 
     system_spec = {
         "raiden": version,
+        "raiden_db_version": constants.RAIDEN_DB_VERSION,
         "python_implementation": platform.python_implementation(),
         "python_version": platform.python_version(),
         "system": system_info,


### PR DESCRIPTION
Useful for debugging as well as for the the scenario player.

(Also adds a hidden convenience `--version` flag to the cli)