### PR TITLE
PR - Better handling of async_result (payment_done)

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -988,8 +988,7 @@ class RestAPI:
 
         if isinstance(result, EventPaymentSentFailed):
             return api_error(
-                errors="Payment couldn't be completed "
-                "(insufficient funds, no route to target or target offline). " + result.reason,
+                errors=f"Payment couldn't be completed because: {result.reason}",
                 status_code=HTTPStatus.CONFLICT,
             )
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -215,7 +215,7 @@ class RaidenEventHandler(EventHandler):
         # With the introduction of the lock we should always get
         # here only once per identifier so payment_status should always exist
         # see: https://github.com/raiden-network/raiden/pull/3191
-        payment_status.payment_done.set(payment_sent_success_event.secret)
+        payment_status.payment_done.set(payment_sent_success_event)
 
     @staticmethod
     def handle_paymentsentfailed(
@@ -230,7 +230,7 @@ class RaidenEventHandler(EventHandler):
         # but the lock expiration will generate a second
         # EventPaymentSentFailed message which we can ignore here
         if payment_status:
-            payment_status.payment_done.set(False)
+            payment_status.payment_done.set(payment_sent_failed_event)
 
     @staticmethod
     def handle_unlockfailed(raiden: "RaidenService", unlock_failed_event: EventUnlockFailed):

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -27,7 +27,11 @@ from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.smartcontracts import deploy_contract_web3
 from raiden.tests.utils.transfer import assert_synced_channel_state, get_channelstate, transfer
 from raiden.transfer import views
-from raiden.transfer.events import EventPaymentReceivedSuccess, EventPaymentSentSuccess
+from raiden.transfer.events import (
+    EventPaymentReceivedSuccess,
+    EventPaymentSentFailed,
+    EventPaymentSentSuccess,
+)
 from raiden.transfer.state_change import ContractReceiveNewTokenNetwork
 from raiden.utils import create_default_identifier
 from raiden.utils.gas_reserve import (
@@ -385,7 +389,7 @@ def run_test_insufficient_funds(raiden_network, token_addresses, deposit):
         deposit + 1,
         target=app1.raiden.address,
     )
-    assert not result.payment_done.get()
+    assert isinstance(result.payment_done.get(), EventPaymentSentFailed)
 
 
 @pytest.mark.parametrize("number_of_nodes", [3])

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -22,6 +22,7 @@ from raiden.tests.utils.transfer import (
     wait_assert,
 )
 from raiden.transfer import views
+from raiden.transfer.events import EventPaymentSentFailed
 from raiden.utils.signer import LocalSigner
 
 
@@ -54,7 +55,7 @@ def run_test_failsfast_lockedtransfer_exceeding_distributable(
         token_network_address, deposit * 2, app1.raiden.address, identifier=1
     )
 
-    assert payment_status.payment_done.get(timeout=5) is False
+    assert isinstance(payment_status.payment_done.get(timeout=5), EventPaymentSentFailed)
     assert payment_status.payment_done.successful()
 
     assert_synced_channel_state(token_network_address, app0, deposit, [], app1, deposit, [])
@@ -84,7 +85,7 @@ def run_test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
     payment_status = app0.raiden.mediated_transfer_async(
         token_network_address, amount, app1.raiden.address, identifier=1
     )
-    assert payment_status.payment_done.wait() is False
+    assert isinstance(payment_status.payment_done.get(), EventPaymentSentFailed)
 
 
 @pytest.mark.parametrize("number_of_nodes", [3])

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -21,7 +21,7 @@ from raiden.tests.utils.transfer import (
     wait_assert,
 )
 from raiden.transfer import channel, views
-from raiden.transfer.events import ContractSendChannelUpdateTransfer
+from raiden.transfer.events import ContractSendChannelUpdateTransfer, EventPaymentSentFailed
 from raiden.transfer.mediated_transfer.events import (
     SendLockedTransfer,
     SendLockExpired,
@@ -74,7 +74,7 @@ def run_test_refund_messages(raiden_chain, token_addresses, deposit, network_wai
         token_network_address, refund_amount, app2.raiden.address, identifier
     )
     msg = "Must fail, there are no routes available"
-    assert payment_status.payment_done.wait() is False, msg
+    assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
 
     # The transfer from app0 to app2 failed, so the balances did change.
     # Since the refund is not unlocked both channels have the corresponding
@@ -202,7 +202,7 @@ def run_test_refund_transfer(
         token_network_address, amount_refund, app2.raiden.address, identifier_refund
     )
     msg = "there is no path with capacity, the transfer must fail"
-    assert payment_status.payment_done.wait() is False, msg
+    assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
 
     gevent.sleep(0.2)
 
@@ -414,7 +414,7 @@ def run_test_different_view_of_last_bp_during_unlock(
         token_network_address, amount_refund, app2.raiden.address, identifier_refund
     )
     msg = "there is no path with capacity, the transfer must fail"
-    assert payment_status.payment_done.wait() is False, msg
+    assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
 
     gevent.sleep(0.2)
 
@@ -640,7 +640,7 @@ def run_test_refund_transfer_after_2nd_hop(
         token_network_address, amount_refund, app3.raiden.address, identifier_refund
     )
     msg = "there is no path with capacity, the transfer must fail"
-    assert payment_status.payment_done.wait() is False, msg
+    assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
 
     gevent.sleep(0.2)
 


### PR DESCRIPTION
the raiden_event_handler now returns to the payment rest layer an instance of EventPaymentSentFailed or EventPaymentSentSuccess. Better handling for error situation and allow the failure reason to be provided back to the caller.