### PR TITLE
Introducing ULIDs

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -447,7 +447,9 @@ def handle_channel_batch_unlock(raiden: "RaidenService", event: Event):
                 sender=partner,
             )
             if state_change_record is not None:
-                canonical_identifier = state_change_record.data.balance_proof.canonical_identifier
+                canonical_identifier = (
+                    state_change_record.data.balance_proof.canonical_identifier  # type: ignore
+                )
                 break
         elif partner == args["receiver"]:
             event_record = get_event_with_balance_proof_by_locksroot(
@@ -461,7 +463,9 @@ def handle_channel_batch_unlock(raiden: "RaidenService", event: Event):
                 recipient=partner,
             )
             if event_record is not None:
-                canonical_identifier = event_record.data.balance_proof.canonical_identifier
+                canonical_identifier = (
+                    event_record.data.balance_proof.canonical_identifier  # type: ignore
+                )
                 break
 
     msg = (

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -594,7 +594,7 @@ class RaidenEventHandler(EventHandler):
                     "Our balance proof could not be found in the database"
                 )
 
-            our_balance_proof = event_record.data.balance_proof
+            our_balance_proof = event_record.data.balance_proof  # type: ignore
             our_transferred_amount = our_balance_proof.transferred_amount
             our_locked_amount = our_balance_proof.locked_amount
             our_locksroot = our_balance_proof.locksroot
@@ -616,7 +616,7 @@ class RaidenEventHandler(EventHandler):
                     "Partner balance proof could not be found in the database"
                 )
 
-            partner_balance_proof = state_change_record.data.balance_proof
+            partner_balance_proof = state_change_record.data.balance_proof  # type: ignore
             partner_transferred_amount = partner_balance_proof.transferred_amount
             partner_locked_amount = partner_balance_proof.locked_amount
             partner_locksroot = partner_balance_proof.locksroot

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -341,7 +341,7 @@ class RaidenService(Runnable):
         self.wal = wal.restore_to_state_change(
             transition_function=node.state_transition,
             storage=storage,
-            state_change_identifier=sqlite.LAST_STATECHANGE_ULID,
+            state_change_identifier=sqlite.HIGH_STATECHANGE_ULID,
         )
 
         if self.wal.state_manager.current_state is None:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -341,7 +341,7 @@ class RaidenService(Runnable):
         self.wal = wal.restore_to_state_change(
             transition_function=node.state_transition,
             storage=storage,
-            state_change_identifier=sqlite.StateChangeID(sqlite.LAST_ULID),
+            state_change_identifier=sqlite.StateChangeID(sqlite.LAST_STATECHANGE_ULID),
         )
 
         if self.wal.state_manager.current_state is None:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -341,7 +341,7 @@ class RaidenService(Runnable):
         self.wal = wal.restore_to_state_change(
             transition_function=node.state_transition,
             storage=storage,
-            state_change_identifier=sqlite.StateChangeID(sqlite.LAST_STATECHANGE_ULID),
+            state_change_identifier=sqlite.LAST_STATECHANGE_ULID,
         )
 
         if self.wal.state_manager.current_state is None:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -341,7 +341,7 @@ class RaidenService(Runnable):
         self.wal = wal.restore_to_state_change(
             transition_function=node.state_transition,
             storage=storage,
-            state_change_identifier="latest",
+            state_change_identifier=sqlite.StateChangeID(sqlite.LAST_ULID),
         )
 
         if self.wal.state_manager.current_state is None:

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -22,7 +22,6 @@ from raiden.utils.typing import (
     List,
     Locksroot,
     Optional,
-    Union,
 )
 
 if TYPE_CHECKING:
@@ -32,7 +31,7 @@ if TYPE_CHECKING:
 def channel_state_until_state_change(
     raiden: "RaidenService",
     canonical_identifier: CanonicalIdentifier,
-    state_change_identifier: Union[StateChangeID, str],
+    state_change_identifier: StateChangeID,
 ) -> Optional[NettingChannelState]:  # pragma: no unittest
     """ Go through WAL state changes until a certain balance hash is found. """
     assert raiden.wal, "Raiden has not been started yet"

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -6,6 +6,7 @@ from raiden.storage.sqlite import (
     FilteredDBQuery,
     Operator,
     SerializedSQLiteStorage,
+    StateChangeID,
     StateChangeRecord,
 )
 from raiden.storage.wal import restore_to_state_change
@@ -21,7 +22,6 @@ from raiden.utils.typing import (
     List,
     Locksroot,
     Optional,
-    StateChangeID,
     Union,
 )
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -556,7 +556,7 @@ class SQLiteStorage:
         )
         self.maybe_commit()
 
-    def get_statechanges_by_range(
+    def get_statechanges_records_by_range(
         self, db_range: Range[StateChangeID]
     ) -> List[StateChangeEncodedRecord]:
         if not isinstance(db_range, Range):  # pragma: no unittest
@@ -821,14 +821,22 @@ class SerializedSQLiteStorage:
 
         return state_change
 
-    def get_statechanges_by_range(self, db_range: Range[StateChangeID]) -> List[StateChangeRecord]:
-        state_changes = self.database.get_statechanges_by_range(db_range=db_range)
+    def get_statechanges_records_by_range(
+        self, db_range: Range[StateChangeID]
+    ) -> List[StateChangeRecord]:
+        state_changes = self.database.get_statechanges_records_by_range(db_range=db_range)
         return [
             StateChangeRecord(
                 state_change_identifier=state_change.state_change_identifier,
                 data=self.serializer.deserialize(state_change.data),
             )
             for state_change in state_changes
+        ]
+
+    def get_statechanges_by_range(self, db_range: Range[StateChangeID]) -> List[StateChange]:
+        return [
+            state_change_record.data
+            for state_change_record in self.get_statechanges_records_by_range(db_range=db_range)
         ]
 
     def get_events_with_timestamps(

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -49,9 +49,9 @@ class Range(Generic[ID]):
             raise ValueError("last must be larger or equal to first")
 
 
-FIRST_STATECHANGE_ULID = StateChangeID(ULID((0).to_bytes(16, "big")))
-LAST_STATECHANGE_ULID = StateChangeID(ULID((2 ** 128 - 1).to_bytes(16, "big")))
-RANGE_ALL_STATE_CHANGES = Range(FIRST_STATECHANGE_ULID, LAST_STATECHANGE_ULID)
+LOW_STATECHANGE_ULID = StateChangeID(ULID((0).to_bytes(16, "big")))
+HIGH_STATECHANGE_ULID = StateChangeID(ULID((2 ** 128 - 1).to_bytes(16, "big")))
+RANGE_ALL_STATE_CHANGES = Range(LOW_STATECHANGE_ULID, HIGH_STATECHANGE_ULID)
 
 
 class Operator(Enum):
@@ -811,13 +811,13 @@ class SerializedSQLiteStorage:
     ) -> Optional[StateChangeRecord]:
         """ Return all state changes filtered by a named field and value."""
 
-        state_change_encoded = self.database.get_latest_state_change_by_data_field(query)
+        encoded_state_change = self.database.get_latest_state_change_by_data_field(query)
 
         state_change = None
-        if state_change_encoded is not None:
+        if encoded_state_change is not None:
             state_change = StateChangeRecord(
-                state_change_identifier=state_change_encoded.state_change_identifier,
-                data=self.serializer.deserialize(state_change_encoded.data),
+                state_change_identifier=encoded_state_change.state_change_identifier,
+                data=self.serializer.deserialize(encoded_state_change.data),
             )
 
         return state_change

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -248,7 +248,7 @@ class SQLiteStorage:
         would be error prone (it would depend on configuration of which tables
         have an ULID), this is not done.
         """
-        assert table_name not in (None, ""), "A table name must be provided"
+        assert table_name, "A table name must be provided"
 
         factory = self._ulid_factories.get(table_name)
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -330,25 +330,6 @@ class SQLiteStorage:
         )
         self.maybe_commit()
 
-    def get_latest_state_snapshot(self) -> Optional[SnapshotRecord]:
-        """ Return the tuple of (last_applied_state_change_id, snapshot) or None"""
-        cursor = self.conn.execute(
-            "SELECT identifier, statechange_id, data "
-            "FROM state_snapshot "
-            "ORDER BY identifier "
-            "DESC LIMIT 1"
-        )
-        rows = cursor.fetchall()
-
-        if rows:
-            assert len(rows) == 1
-            snapshot_state_id = rows[0][0]
-            last_applied_state_change_id = rows[0][1]
-            snapshot_state = rows[0][2]
-            return SnapshotRecord(snapshot_state_id, last_applied_state_change_id, snapshot_state)
-
-        return None
-
     def get_snapshot_closest_to_state_change(
         self, state_change_identifier: Union[StateChangeID, str]
     ) -> Optional[SnapshotRecord]:
@@ -767,16 +748,6 @@ class SerializedSQLiteStorage:
             for event in events
         ]
         return self.database.write_events(events_data)
-
-    def get_latest_state_snapshot(self) -> Optional[SnapshotRecord]:
-        """ Return the tuple of (last_applied_state_change_id, snapshot) or None"""
-        row = self.database.get_latest_state_snapshot()
-
-        if row:
-            snapshot_state = self.serializer.deserialize(row.data)
-            return SnapshotRecord(row.identifier, row.state_change_identifier, snapshot_state)
-
-        return None
 
     def get_snapshot_closest_to_state_change(
         self, state_change_identifier: Union[StateChangeID, str]

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
+from typing_extensions import Literal
+
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.serialization import SerializationBase
@@ -201,7 +203,7 @@ def _query_to_string(query: FilteredDBQuery) -> Tuple[str, List[str]]:
 
 
 class SQLiteStorage:
-    def __init__(self, database_path: Path):
+    def __init__(self, database_path: Union[Path, Literal[":memory:"]]):
         sqlite3.register_adapter(ULID, adapt_ulid_identifier)
         sqlite3.register_converter("ULID", convert_ulid_identifier)
 
@@ -321,7 +323,7 @@ class SQLiteStorage:
 
         return int(result[0][0])
 
-    def write_state_change(self, state_change: StateChange, timestamp: datetime) -> StateChangeID:
+    def write_state_change(self, state_change: str, timestamp: datetime) -> StateChangeID:
         state_change_id = self._ulid_factory(StateChangeID).new()
 
         self.conn.execute(
@@ -729,7 +731,9 @@ class SerializedSQLiteStorage:
     applied the automatic encoding/deconding will not work.
     """
 
-    def __init__(self, database_path: Path, serializer: SerializationBase) -> None:
+    def __init__(
+        self, database_path: Union[Path, Literal[":memory:"]], serializer: SerializationBase
+    ) -> None:
         self.database = SQLiteStorage(database_path)
         self.serializer = serializer
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -44,8 +44,9 @@ class Range(Generic[ID]):
     last: ID
 
     def __post_init__(self) -> None:
+        # Because the range is inclusive, the values can be equal
         if self.first > self.last:
-            raise ValueError("last must be larger then first")
+            raise ValueError("last must be larger or equal to first")
 
 
 FIRST_STATECHANGE_ULID = StateChangeID(ULID((0).to_bytes(16, "big")))

--- a/raiden/storage/ulid.py
+++ b/raiden/storage/ulid.py
@@ -89,7 +89,7 @@ class ULIDMonotonicFactory(Generic[ID]):
             self._previous_timestamp = timestamp
 
         rnd = random.getrandbits(64)
-        identifier = timestamp.to_bytes(8, "big") + rnd.to_bytes(8, "big")
+        identifier = ULID(timestamp.to_bytes(8, "big") + rnd.to_bytes(8, "big"))
 
         return cast(ID, identifier)
 

--- a/raiden/storage/ulid.py
+++ b/raiden/storage/ulid.py
@@ -36,7 +36,7 @@ ID = TypeVar("ID", bound=ULID)
 
 
 class ULIDMonotonicFactory(Generic[ID]):
-    """Monotonic ULID factory that guarantees new ULIDs will not be decrease.
+    """Monotonic ULID factory that guarantees new ULIDs will not decrease.
 
     This factory does not follow the SPEC. The timestamp is not walltime and
     the precision was increased from ms to ns to guarantee total order.

--- a/raiden/storage/ulid.py
+++ b/raiden/storage/ulid.py
@@ -1,0 +1,100 @@
+import random
+from dataclasses import dataclass
+from time import get_clock_info, monotonic_ns, time_ns
+
+from gevent.lock import Semaphore
+
+from raiden.utils.typing import Any, Iterable, Iterator, List, Tuple
+
+
+@dataclass(frozen=True, order=True)
+class ULID:
+    """An ULID.
+
+    The generated IDs are lexicographically sorted, however the timestamps are
+    *not* representative of wall time.
+
+    SPEC: https://github.com/ulid/spec
+    """
+
+    identifier: bytes
+
+    def __post_init__(self):
+        assert len(self.identifier) == 16, "id_ must be 16 bytes long"
+
+    @property
+    def timestamp(self):
+        """Aproximated timestamp of the database entry.
+
+        There is no lower bound for the skew in time.
+        """
+        timestamp_bytes = self.identifier[:8]
+        return int.from_bytes(timestamp_bytes, "big")
+
+
+class ULIDMonotonicFactory:
+    """Monotonic ULID factory that guarantees new ULIDs will not be decrease.
+
+    This factory does not follow the SPEC. The timestamp is not walltime and
+    the precision was increased from ms to ns to guarantee total order.
+
+    time.time() can not be used because it is not monotonic.  The clock can be
+    reset by the user, a NTPD daemon, adjusted because of TZ changes, adjusted
+    because of leap seconds, etc. Therefore a monotonic clock must be used.
+    """
+
+    def __init__(self, start: int) -> None:
+        monotonic_info = get_clock_info("monotonic")
+
+        msg = (
+            "The monotonic clock must not be adjustable. A monotonic clock is "
+            "*necessary* for safe operation, otherwise database entries may get "
+            "swapped around and the queries can return the wrong values."
+        )
+        assert monotonic_info.adjustable is False, msg
+
+        msg = (
+            "The monotonic clock must have nanosecond resolution. This is "
+            "necessary because multiple state changes can be written on the same "
+            "millisecond."
+        )
+        assert monotonic_info.resolution <= 0.000_000_001, msg
+
+        current_time = time_ns()
+
+        if start is None or start < current_time:
+            start = current_time
+
+        self._previous_timestamp = start
+        self._previous_monotonic = monotonic_ns()
+        self._lock = Semaphore()
+
+    def new(self) -> ULID:
+        timestamp: int
+
+        with self._lock:
+            new_monotonic = monotonic_ns()
+
+            msg = (
+                "A monotonic clock with ns precision must not return the same "
+                "value twice, looking up the time itself should take more then 1ns, "
+                "https://www.python.org/dev/peps/pep-0564/#annex-clocks-resolution-in-python."
+            )
+            assert new_monotonic > self._previous_monotonic, msg
+
+            delta = new_monotonic - self._previous_monotonic
+            timestamp = self._previous_timestamp + delta
+
+            self._previous_monotonic = new_monotonic
+            self._previous_timestamp = timestamp
+
+        rnd = random.getrandbits(64)
+        identifier = timestamp.to_bytes(8, "big") + rnd.to_bytes(8, "big")
+
+        return ULID(identifier)
+
+    def prepend_and_save_ids(self, ids: List[ULID], items: Iterable[Tuple[Any, ...]]) -> Iterator:
+        for item in items:
+            next_id = self.new()
+            ids.append(next_id)
+            yield (next_id, *item)

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -17,7 +17,7 @@ The primary key is *not* auto-increment because the IDs are populated with
 ULIDs [7]. ULIDs are necessary because the application must know the ID of
 elements inserted in bulk, and this cannot be know reliably if auto increment
 is used, even with synchronizaiton over `lastrowid`. Additionally random IDs
-are less likely to collide with is useful to detect programming errors. Typos
+are less likely to collide, which is useful to detect programming errors. Typos
 are a good example that can have catastrophic results, where REPLACE/DELETE
 queries can operate on the wrong table or column and with the possibility of
 collision change the wrong data.
@@ -29,7 +29,7 @@ based on rowid will prevent large rewrites of the DB's tables, using ULIDs
 prevent rewrites of the PK Index.
 
 Manifest typing [4] is used for the ULIDs instead PARSE_COLNAMES [5] because
-of the easy of convertion.
+of the easy of conversion.
 
 1- https://www.sqlite.org/lang_createtable.html#constraints
 2- https://www.sqlite.org/withoutrowid.html

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -14,19 +14,19 @@ are too few to fit a well ordered ID with nanosecond precision and a random
 tag.
 
 The primary key is *not* auto-increment because the IDs are populated with
-ULIDs [7]. ULIDs are used mainly to avoid collisions and contain programming
-errors. Typos are a good example that can have catastrophic results, where
-REPLACE/DELETE queries can operate on the wrong table or column and with the
-possibility of collision change the wrong data.
+ULIDs [7]. ULIDs are necessary because the application must know the ID of
+elements inserted in bulk, and this cannot be know reliably if auto increment
+is used, even with synchronizaiton over `lastrowid`. Additionally random IDs
+are less likely to collide with is useful to detect programming errors. Typos
+are a good example that can have catastrophic results, where REPLACE/DELETE
+queries can operate on the wrong table or column and with the possibility of
+collision change the wrong data.
 
-ULIDs and are prefered over UUIDs because they are lexicographically sortable
-by design. Even though the implicit clustered index based on rowid will
-prevent large rewrites of the DB's tables, using ULIDs prevent rewrites of
-the PK Index.
-
-Using ULIDs has the additional benefit of removing the need for
-synchronization around the connection `lastrowid`, because IDs are now
-application controlled.
+ULIDs are necessary over UUIDs because they are lexicographically sortable by
+design, and state changes must be saved in order. This has the additional
+benefit of being a good write pattren, even though the implicit clustered index
+based on rowid will prevent large rewrites of the DB's tables, using ULIDs
+prevent rewrites of the PK Index.
 
 Manifest typing [4] is used for the ULIDs instead PARSE_COLNAMES [5] because
 of the easy of convertion.

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -1,3 +1,44 @@
+"""
+Notes:
+
+Every primary key *MUST* also have *NOT NULL* specified [1].
+
+`WITHOUT ROWID` [2] was considered, in order to force sqlite3 to use "proper"
+clustered indexes and to enforce the NOT NULL constraint for primary keys.
+However the write/read pattern for Raiden does not fall under the recommended
+categories, and some important features of the database won't work with that
+flag. Instead of `WITHOUT ROWID` the implicit rowid column is used.
+
+Using an explicit `INTEGER PRIMARY KEY` [3] was considered, however 64 bits
+are too few to fit a well ordered ID with nanosecond precision and a random
+tag.
+
+The primary key is *not* auto-increment because the IDs are populated with
+ULIDs [7]. ULIDs are used mainly to avoid collisions and contain programming
+errors. Typos are a good example that can have catastrophic results, where
+REPLACE/DELETE queries can operate on the wrong table or column and with the
+possibility of collision change the wrong data.
+
+ULIDs and are prefered over UUIDs because they are lexicographically sortable
+by design. Even though the implicit clustered index based on rowid will
+prevent large rewrites of the DB's tables, using ULIDs prevent rewrites of
+the PK Index.
+
+Using ULIDs has the additional benefit of removing the need for
+synchronization around the connection `lastrowid`, because IDs are now
+application controlled.
+
+Manifest typing [4] is used for the ULIDs instead PARSE_COLNAMES [5] because
+of the easy of convertion.
+
+1- https://www.sqlite.org/lang_createtable.html#constraints
+2- https://www.sqlite.org/withoutrowid.html
+3- https://www.sqlite.org/lang_createtable.html#rowid
+4- https://www.sqlite.org/different.html#typing
+5- https://docs.python.org/3/library/sqlite3.html#sqlite3.PARSE_COLNAMES
+6- https://tools.ietf.org/html/rfc4122.html
+7- https://github.com/ulid/spec
+"""
 from collections import namedtuple
 
 
@@ -8,34 +49,35 @@ class TimestampedEvent(namedtuple("TimestampedEvent", "wrapped_event log_time"))
 
 DB_CREATE_SETTINGS = """
 CREATE TABLE IF NOT EXISTS settings (
-    name VARCHAR[24] NOT NULL PRIMARY KEY,
+    name VARCHAR[24] UNIQUE PRIMARY KEY NOT NULL,
     value TEXT
 );
 """
 
 DB_CREATE_STATE_CHANGES = """
 CREATE TABLE IF NOT EXISTS state_changes (
-    identifier INTEGER PRIMARY KEY AUTOINCREMENT,
+    identifier ULID PRIMARY KEY NOT NULL,
     data JSON,
-    log_time TIMESTAMP
+    timestamp TIMESTAMP NOT NULL
 );
 """
 
 DB_CREATE_SNAPSHOT = """
 CREATE TABLE IF NOT EXISTS state_snapshot (
-    identifier INTEGER PRIMARY KEY,
-    statechange_id INTEGER,
+    identifier ULID PRIMARY KEY NOT NULL,
+    statechange_id ULID NOT NULL,
     data JSON,
+    timestamp TIMESTAMP NOT NULL,
     FOREIGN KEY(statechange_id) REFERENCES state_changes(identifier)
 );
 """
 
 DB_CREATE_STATE_EVENTS = """
 CREATE TABLE IF NOT EXISTS state_events (
-    identifier INTEGER PRIMARY KEY,
-    source_statechange_id INTEGER NOT NULL,
-    log_time TIMESTAMP,
+    identifier ULID PRIMARY KEY NOT NULL,
+    source_statechange_id ULID NOT NULL,
     data JSON,
+    timestamp TIMESTAMP NOT NULL,
     FOREIGN KEY(source_statechange_id) REFERENCES state_changes(identifier)
 );
 """

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -52,7 +52,7 @@ def restore_to_state_change(
 
     log.debug("Replaying state changes", num_state_changes=len(unapplied_state_changes))
     for state_change in unapplied_state_changes:
-        wal.state_manager.dispatch(state_change.data)
+        wal.state_manager.dispatch(state_change)
 
     return wal
 

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -3,9 +3,14 @@ from datetime import datetime
 import gevent.lock
 import structlog
 
-from raiden.storage.sqlite import FIRST_STATECHANGE_ULID, Range, SerializedSQLiteStorage, StateChangeID
+from raiden.storage.sqlite import (
+    FIRST_STATECHANGE_ULID,
+    Range,
+    SerializedSQLiteStorage,
+    StateChangeID,
+)
 from raiden.transfer.architecture import Event, State, StateChange, StateManager
-from raiden.utils.typing import Callable, Generic, List, RaidenDBVersion, Tuple, TypeVar
+from raiden.utils.typing import Callable, Generic, List, Optional, RaidenDBVersion, Tuple, TypeVar
 
 log = structlog.get_logger(__name__)
 
@@ -15,6 +20,7 @@ def restore_to_state_change(
     storage: SerializedSQLiteStorage,
     state_change_identifier: StateChangeID,
 ) -> "WriteAheadLog":
+    chain_state: Optional[State]
     from_identifier: StateChangeID
 
     snapshot = storage.get_snapshot_before_state_change(

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -4,7 +4,7 @@ import gevent.lock
 import structlog
 
 from raiden.storage.sqlite import (
-    FIRST_STATECHANGE_ULID,
+    LOW_STATECHANGE_ULID,
     Range,
     SerializedSQLiteStorage,
     StateChangeID,
@@ -40,7 +40,7 @@ def restore_to_state_change(
             "No snapshot found, replaying all state changes",
             to_state_change_id=state_change_identifier,
         )
-        from_identifier = FIRST_STATECHANGE_ULID
+        from_identifier = LOW_STATECHANGE_ULID
         chain_state = None
 
     unapplied_state_changes = storage.get_statechanges_by_range(

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import gevent.lock
 import structlog
 
-from raiden.storage.sqlite import FIRST_ULID, Range, SerializedSQLiteStorage, StateChangeID
+from raiden.storage.sqlite import FIRST_STATECHANGE_ULID, Range, SerializedSQLiteStorage, StateChangeID
 from raiden.transfer.architecture import Event, State, StateChange, StateManager
 from raiden.utils.typing import Callable, Generic, List, RaidenDBVersion, Tuple, TypeVar
 
@@ -34,7 +34,7 @@ def restore_to_state_change(
             "No snapshot found, replaying all state changes",
             to_state_change_id=state_change_identifier,
         )
-        from_identifier = StateChangeID(FIRST_ULID)
+        from_identifier = FIRST_STATECHANGE_ULID
         chain_state = None
 
     unapplied_state_changes = storage.get_statechanges_by_range(

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -162,8 +162,10 @@ def run_test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposi
         node1.raiden,
         ContractReceiveChannelSettled,
         {
-            "token_network_address": token_network_address,
-            "channel_identifier": channel12.identifier,
+            "canonical_identifier": {
+                "token_network_address": token_network_address,
+                "channel_identifier": channel12.identifier,
+            }
         },
         retry_timeout,
     )

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -12,7 +12,7 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.messages import LockedTransfer, LockExpired, RevealSecret, Unlock
 from raiden.storage.restore import channel_state_until_state_change
-from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
+from raiden.storage.sqlite import LAST_STATECHANGE_ULID, RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
@@ -341,7 +341,7 @@ def run_test_batch_unlock(
     restored_channel_state = channel_state_until_state_change(
         raiden=alice_app.raiden,
         canonical_identifier=alice_bob_channel_state.canonical_identifier,
-        state_change_identifier="latest",
+        state_change_identifier=LAST_STATECHANGE_ULID,
     )
 
     our_restored_balance_proof = restored_channel_state.our_state.balance_proof

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -12,7 +12,7 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.messages import LockedTransfer, LockExpired, RevealSecret, Unlock
 from raiden.storage.restore import channel_state_until_state_change
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
@@ -34,7 +34,7 @@ def wait_for_batch_unlock(app, token_network_address, receiver, sender):
     while not unlock_event:
         gevent.sleep(1)
 
-        state_changes = app.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+        state_changes = app.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
 
         unlock_event = search_for_item(
             state_changes,
@@ -111,7 +111,7 @@ def run_test_settle_is_automatically_called(raiden_network, token_addresses):
         not in token_network.partneraddresses_to_channelidentifiers[app1.raiden.address]
     )
 
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
 
     assert search_for_item(
         state_changes,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -34,7 +34,7 @@ def wait_for_batch_unlock(app, token_network_address, receiver, sender):
         gevent.sleep(1)
 
         state_changes = app.raiden.wal.storage.get_statechanges_by_identifier(
-            from_identifier=0, to_identifier="latest"
+            from_identifier="earliest", to_identifier="latest"
         )
 
         unlock_event = search_for_item(
@@ -113,7 +113,7 @@ def run_test_settle_is_automatically_called(raiden_network, token_addresses):
     )
 
     state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
 
     assert search_for_item(

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -12,7 +12,7 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.messages import LockedTransfer, LockExpired, RevealSecret, Unlock
 from raiden.storage.restore import channel_state_until_state_change
-from raiden.storage.sqlite import LAST_STATECHANGE_ULID, RANGE_ALL_STATE_CHANGES
+from raiden.storage.sqlite import HIGH_STATECHANGE_ULID, RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
@@ -341,7 +341,7 @@ def run_test_batch_unlock(
     restored_channel_state = channel_state_until_state_change(
         raiden=alice_app.raiden,
         canonical_identifier=alice_bob_channel_state.canonical_identifier,
-        state_change_identifier=LAST_STATECHANGE_ULID,
+        state_change_identifier=HIGH_STATECHANGE_ULID,
     )
 
     our_restored_balance_proof = restored_channel_state.our_state.balance_proof

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -12,6 +12,7 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.messages import LockedTransfer, LockExpired, RevealSecret, Unlock
 from raiden.storage.restore import channel_state_until_state_change
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
@@ -33,9 +34,7 @@ def wait_for_batch_unlock(app, token_network_address, receiver, sender):
     while not unlock_event:
         gevent.sleep(1)
 
-        state_changes = app.raiden.wal.storage.get_statechanges_by_identifier(
-            from_identifier="earliest", to_identifier="latest"
-        )
+        state_changes = app.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
 
         unlock_event = search_for_item(
             state_changes,
@@ -112,9 +111,7 @@ def run_test_settle_is_automatically_called(raiden_network, token_addresses):
         not in token_network.partneraddresses_to_channelidentifiers[app1.raiden.address]
     )
 
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier="earliest", to_identifier="latest"
-    )
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
 
     assert search_for_item(
         state_changes,

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -4,6 +4,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.constants import EMPTY_HASH, EMPTY_SIGNATURE
 from raiden.network.proxies.token_network import TokenNetwork
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
@@ -89,9 +90,7 @@ def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
         channel_ids=[channel_identifier],
         retry_timeout=app0.raiden.alarm.sleep_time,
     )
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier="earliest", to_identifier="latest"
-    )
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
     assert search_for_item(
         state_changes,
         ContractReceiveChannelSettled,
@@ -166,9 +165,7 @@ def run_test_node_can_settle_if_partner_does_not_call_update_transfer(
         channel_ids=[channel_identifier],
         retry_timeout=app0.raiden.alarm.sleep_time,
     )
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier="earliest", to_identifier="latest"
-    )
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
     assert search_for_item(
         state_changes,
         ContractReceiveChannelSettled,

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -4,7 +4,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.constants import EMPTY_HASH, EMPTY_SIGNATURE
 from raiden.network.proxies.token_network import TokenNetwork
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
@@ -90,7 +90,7 @@ def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
         channel_ids=[channel_identifier],
         retry_timeout=app0.raiden.alarm.sleep_time,
     )
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     assert search_for_item(
         state_changes,
         ContractReceiveChannelSettled,
@@ -165,7 +165,7 @@ def run_test_node_can_settle_if_partner_does_not_call_update_transfer(
         channel_ids=[channel_identifier],
         retry_timeout=app0.raiden.alarm.sleep_time,
     )
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     assert search_for_item(
         state_changes,
         ContractReceiveChannelSettled,

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -90,7 +90,7 @@ def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
         retry_timeout=app0.raiden.alarm.sleep_time,
     )
     state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
     assert search_for_item(
         state_changes,
@@ -167,7 +167,7 @@ def run_test_node_can_settle_if_partner_does_not_call_update_transfer(
         retry_timeout=app0.raiden.alarm.sleep_time,
     )
     state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
     assert search_for_item(
         state_changes,

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -47,7 +47,7 @@ def run_test_regression_filters_must_be_installed_from_confirmed_block(raiden_ne
     target_block_num = latest_block["number"]
 
     app0_state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
 
     assert search_for_item(

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.app import App
 from raiden.constants import (
     DISCOVERY_DEFAULT_ROOM,
@@ -46,8 +47,8 @@ def run_test_regression_filters_must_be_installed_from_confirmed_block(raiden_ne
     app0.raiden._callback_new_block(latest_block=latest_block)
     target_block_num = latest_block["number"]
 
-    app0_state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier="earliest", to_identifier="latest"
+    app0_state_changes = app0.raiden.wal.storage.get_statechanges_by_range(
+        RANGE_ALL_ELEMENTS
     )
 
     assert search_for_item(

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.app import App
 from raiden.constants import (
     DISCOVERY_DEFAULT_ROOM,
@@ -13,6 +12,7 @@ from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
@@ -47,9 +47,7 @@ def run_test_regression_filters_must_be_installed_from_confirmed_block(raiden_ne
     app0.raiden._callback_new_block(latest_block=latest_block)
     target_block_num = latest_block["number"]
 
-    app0_state_changes = app0.raiden.wal.storage.get_statechanges_by_range(
-        RANGE_ALL_ELEMENTS
-    )
+    app0_state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
 
     assert search_for_item(
         app0_state_changes,

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -7,6 +7,7 @@ from raiden.app import App
 from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
@@ -167,9 +168,7 @@ def test_recovery_unhappy_case(
     del app0  # from here on the app0_restart should be used
     app0_restart.start()
 
-    state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier="earliest", to_identifier="latest"
-    )
+    state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
 
     assert search_for_item(
         state_changes,
@@ -231,7 +230,7 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
     # wait for the nodes' healthcheck to update the network statuses
     waiting.wait_for_healthy(app0_restart.raiden, app1.raiden.address, network_wait)
     waiting.wait_for_healthy(app1.raiden, app0_restart.raiden.address, network_wait)
-    restarted_state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_identifier(
-        "earliest", "latest"
+    restarted_state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_range(
+        RANGE_ALL_ELEMENTS
     )
     assert search_for_item(restarted_state_changes, ContractReceiveChannelClosed, {})

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -168,7 +168,7 @@ def test_recovery_unhappy_case(
     app0_restart.start()
 
     state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
 
     assert search_for_item(
@@ -232,6 +232,6 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
     waiting.wait_for_healthy(app0_restart.raiden, app1.raiden.address, network_wait)
     waiting.wait_for_healthy(app1.raiden, app0_restart.raiden.address, network_wait)
     restarted_state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_identifier(
-        0, "latest"
+        "earliest", "latest"
     )
     assert search_for_item(restarted_state_changes, ContractReceiveChannelClosed, {})

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -7,7 +7,7 @@ from raiden.app import App
 from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
@@ -168,7 +168,9 @@ def test_recovery_unhappy_case(
     del app0  # from here on the app0_restart should be used
     app0_restart.start()
 
-    state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_range(
+        RANGE_ALL_STATE_CHANGES
+    )
 
     assert search_for_item(
         state_changes,
@@ -231,6 +233,6 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
     waiting.wait_for_healthy(app0_restart.raiden, app1.raiden.address, network_wait)
     waiting.wait_for_healthy(app1.raiden, app0_restart.raiden.address, network_wait)
     restarted_state_changes = app0_restart.raiden.wal.storage.get_statechanges_by_range(
-        RANGE_ALL_ELEMENTS
+        RANGE_ALL_STATE_CHANGES
     )
     assert search_for_item(restarted_state_changes, ContractReceiveChannelClosed, {})

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -8,6 +8,7 @@ from raiden.exceptions import RaidenUnrecoverableError
 from raiden.message_handler import MessageHandler
 from raiden.messages import LockedTransfer, RevealSecret, SecretRequest
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
@@ -150,7 +151,7 @@ def run_test_locked_transfer_secret_registered_onchain(
     message_handler = MessageHandler()
     message_handler.handle_message_lockedtransfer(app0.raiden, locked_transfer)
 
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier("earliest", "latest")
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
     transfer_statechange_dispatched = search_for_item(
         state_changes, ActionInitMediator, {}
     ) or search_for_item(state_changes, ActionInitTarget, {})

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -8,7 +8,7 @@ from raiden.exceptions import RaidenUnrecoverableError
 from raiden.message_handler import MessageHandler
 from raiden.messages import LockedTransfer, RevealSecret, SecretRequest
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
@@ -151,7 +151,7 @@ def run_test_locked_transfer_secret_registered_onchain(
     message_handler = MessageHandler()
     message_handler.handle_message_lockedtransfer(app0.raiden, locked_transfer)
 
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     transfer_statechange_dispatched = search_for_item(
         state_changes, ActionInitMediator, {}
     ) or search_for_item(state_changes, ActionInitTarget, {})

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -150,7 +150,7 @@ def run_test_locked_transfer_secret_registered_onchain(
     message_handler = MessageHandler()
     message_handler.handle_message_lockedtransfer(app0.raiden, locked_transfer)
 
-    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(0, "latest")
+    state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier("earliest", "latest")
     transfer_statechange_dispatched = search_for_item(
         state_changes, ActionInitMediator, {}
     ) or search_for_item(state_changes, ActionInitTarget, {})

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -2,7 +2,7 @@ import gevent
 import pytest
 
 from raiden.api.python import RaidenAPI
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import (
     raiden_events_search_for_item,
@@ -271,7 +271,7 @@ def run_test_refund_transfer(
         )
         assert send_lock_expired
         # make sure that app0 never got it
-        state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+        state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
         assert not search_for_item(state_changes, ReceiveLockExpired, {"secrethash": secrethash})
 
     # Out of the handicapped app0 transport.

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -2,6 +2,7 @@ import gevent
 import pytest
 
 from raiden.api.python import RaidenAPI
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import (
     raiden_events_search_for_item,
@@ -270,9 +271,7 @@ def run_test_refund_transfer(
         )
         assert send_lock_expired
         # make sure that app0 never got it
-        state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
-            "earliest", "latest"
-        )
+        state_changes = app0.raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
         assert not search_for_item(state_changes, ReceiveLockExpired, {"secrethash": secrethash})
 
     # Out of the handicapped app0 transport.

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -270,7 +270,9 @@ def run_test_refund_transfer(
         )
         assert send_lock_expired
         # make sure that app0 never got it
-        state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(0, "latest")
+        state_changes = app0.raiden.wal.storage.get_statechanges_by_identifier(
+            "earliest", "latest"
+        )
         assert not search_for_item(state_changes, ReceiveLockExpired, {"secrethash": secrethash})
 
     # Out of the handicapped app0 transport.

--- a/raiden/tests/unit/storage/test_ulid.py
+++ b/raiden/tests/unit/storage/test_ulid.py
@@ -1,0 +1,27 @@
+import heapq
+
+from raiden.constants import UINT64_MAX
+from raiden.storage.ulid import ULID, ULIDMonotonicFactory
+
+
+def test_ulid_factory():
+    factory = ULIDMonotonicFactory(start=None)
+
+    entries = [factory.new()]
+
+    # Do a few iteration to test monotonic clock, every new entry must be
+    # larger than the previous
+    for _ in range(100):
+        new_ulid = factory.new()
+        prevous_largest = heapq.nlargest(1, entries)[0]
+        assert new_ulid > prevous_largest, "monotonicity property is broken"
+        heapq.heappush(entries, new_ulid)
+
+
+def test_ulid_timestamp():
+    timestamp_values = [0, 1558988971814002421, UINT64_MAX]
+    rnd = 42
+
+    for timestamp in timestamp_values:
+        identifier = timestamp.to_bytes(8, "big") + rnd.to_bytes(8, "big")
+        assert ULID(identifier).timestamp == timestamp

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -15,7 +15,12 @@ from raiden.storage.restore import (
     get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS, Range, SerializedSQLiteStorage, SQLiteStorage
+from raiden.storage.sqlite import (
+    RANGE_ALL_STATE_CHANGES,
+    Range,
+    SerializedSQLiteStorage,
+    SQLiteStorage,
+)
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.events import (
     SendBalanceProof,
@@ -225,7 +230,7 @@ def test_get_state_change_with_balance_proof():
     assert storage.count_state_changes() == len(statechanges_balanceproofs)
 
     # Make sure state changes are returned in the correct order in which they were stored
-    stored_statechanges = storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    stored_statechanges = storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     assert len(stored_statechanges) == 6
     assert isinstance(stored_statechanges[0].data, ReceiveLockExpired)
     assert isinstance(stored_statechanges[1].data, ReceiveUnlock)

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -498,8 +498,7 @@ def test_update_event_get_event():
     state_changes_data = json.loads(state_changes_file.read_text())
     for state_change_record in state_changes_data:
         storage.write_state_change(
-            state_change=json.dumps(state_change_record[1]),
-            timestamp=datetime.utcnow().isoformat(timespec="milliseconds"),
+            state_change=json.dumps(state_change_record[1]), timestamp=datetime.utcnow()
         )
 
 
@@ -512,7 +511,7 @@ def test_storage_get_and_update(storage):
 
 
 def test_storage_close():
-    storage = SerializedSQLiteStorage(":memory:", JSONSerializer)
+    storage = SerializedSQLiteStorage(":memory:", JSONSerializer())
     storage.close()
     with pytest.raises(RuntimeError):  # attempt to close an already closed database
         storage.close()

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -157,7 +157,7 @@ def make_from_route_from_counter(counter):
 
 
 def test_get_state_change_with_balance_proof():
-    """ All state changes which contain a balance proof must be found by when
+    """ All state changes which contain a balance proof must be found when
     querying the database.
     """
     serializer = JSONSerializer()

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -15,7 +15,7 @@ from raiden.storage.restore import (
     get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import SerializedSQLiteStorage, SQLiteStorage
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS, Range, SerializedSQLiteStorage, SQLiteStorage
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.events import (
     SendBalanceProof,
@@ -225,7 +225,8 @@ def test_get_state_change_with_balance_proof():
     assert storage.count_state_changes() == len(statechanges_balanceproofs)
 
     # Make sure state changes are returned in the correct order in which they were stored
-    stored_statechanges = storage.get_statechanges_by_identifier("earliest", "latest")
+    stored_statechanges = storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    assert len(stored_statechanges) == 6
     assert isinstance(stored_statechanges[0].data, ReceiveLockExpired)
     assert isinstance(stored_statechanges[1].data, ReceiveUnlock)
     assert isinstance(stored_statechanges[2].data, ReceiveTransferRefund)
@@ -234,10 +235,14 @@ def test_get_state_change_with_balance_proof():
     assert isinstance(stored_statechanges[5].data, ActionInitTarget)
 
     # Make sure state changes are returned in the correct order in which they were stored
-    stored_statechanges = storage.get_statechanges_by_identifier(
-        stored_statechanges[1].state_change_identifier,
-        stored_statechanges[2].state_change_identifier,
+    stored_statechanges = storage.get_statechanges_by_range(
+        Range(
+            stored_statechanges[1].state_change_identifier,
+            stored_statechanges[2].state_change_identifier,
+        )
     )
+
+    assert len(stored_statechanges) == 2
     assert isinstance(stored_statechanges[0].data, ReceiveUnlock)
     assert isinstance(stored_statechanges[1].data, ReceiveTransferRefund)
 

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -230,26 +230,28 @@ def test_get_state_change_with_balance_proof():
     assert storage.count_state_changes() == len(statechanges_balanceproofs)
 
     # Make sure state changes are returned in the correct order in which they were stored
-    stored_statechanges = storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
-    assert len(stored_statechanges) == 6
-    assert isinstance(stored_statechanges[0].data, ReceiveLockExpired)
-    assert isinstance(stored_statechanges[1].data, ReceiveUnlock)
-    assert isinstance(stored_statechanges[2].data, ReceiveTransferRefund)
-    assert isinstance(stored_statechanges[3].data, ReceiveTransferRefundCancelRoute)
-    assert isinstance(stored_statechanges[4].data, ActionInitMediator)
-    assert isinstance(stored_statechanges[5].data, ActionInitTarget)
+    stored_statechanges_records = storage.get_statechanges_records_by_range(
+        RANGE_ALL_STATE_CHANGES
+    )
+    assert len(stored_statechanges_records) == 6
+    assert isinstance(stored_statechanges_records[0].data, ReceiveLockExpired)
+    assert isinstance(stored_statechanges_records[1].data, ReceiveUnlock)
+    assert isinstance(stored_statechanges_records[2].data, ReceiveTransferRefund)
+    assert isinstance(stored_statechanges_records[3].data, ReceiveTransferRefundCancelRoute)
+    assert isinstance(stored_statechanges_records[4].data, ActionInitMediator)
+    assert isinstance(stored_statechanges_records[5].data, ActionInitTarget)
 
     # Make sure state changes are returned in the correct order in which they were stored
     stored_statechanges = storage.get_statechanges_by_range(
         Range(
-            stored_statechanges[1].state_change_identifier,
-            stored_statechanges[2].state_change_identifier,
+            stored_statechanges_records[1].state_change_identifier,
+            stored_statechanges_records[2].state_change_identifier,
         )
     )
 
     assert len(stored_statechanges) == 2
-    assert isinstance(stored_statechanges[0].data, ReceiveUnlock)
-    assert isinstance(stored_statechanges[1].data, ReceiveTransferRefund)
+    assert isinstance(stored_statechanges[0], ReceiveUnlock)
+    assert isinstance(stored_statechanges[1], ReceiveTransferRefund)
 
     for state_change, balance_proof in statechanges_balanceproofs:
         state_change_record = get_state_change_with_balance_proof_by_balance_hash(

--- a/raiden/tests/unit/test_upgrade.py
+++ b/raiden/tests/unit/test_upgrade.py
@@ -90,8 +90,7 @@ def test_upgrade_manager_restores_backup(tmp_path, monkeypatch):
         )
         action_init_chain_data = JSONSerializer.serialize(state_change)
         storage.write_state_change(
-            state_change=action_init_chain_data,
-            log_time=datetime.utcnow().isoformat(timespec="milliseconds"),
+            state_change=action_init_chain_data, timestamp=datetime.utcnow()
         )
         storage.update_version()
 

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -8,7 +8,11 @@ import pytest
 from raiden.constants import RAIDEN_DB_VERSION
 from raiden.exceptions import InvalidDBData
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import LAST_ULID, RANGE_ALL_STATE_CHANGES, SerializedSQLiteStorage
+from raiden.storage.sqlite import (
+    LAST_STATECHANGE_ULID,
+    RANGE_ALL_STATE_CHANGES,
+    SerializedSQLiteStorage,
+)
 from raiden.storage.utils import TimestampedEvent
 from raiden.storage.wal import WriteAheadLog, restore_to_state_change
 from raiden.tests.utils import factories
@@ -183,7 +187,7 @@ def test_restore_without_snapshot():
     newwal = restore_to_state_change(
         transition_function=state_transtion_acc,
         storage=wal.storage,
-        state_change_identifier=LAST_ULID,
+        state_change_identifier=LAST_STATECHANGE_ULID,
     )
 
     aggregate = newwal.state_manager.current_state
@@ -205,5 +209,5 @@ def test_get_snapshot_before_state_change():
     wal.log_and_dispatch(block3)
     wal.snapshot()
 
-    snapshot = wal.storage.get_snapshot_before_state_change(LAST_ULID)
+    snapshot = wal.storage.get_snapshot_before_state_change(LAST_STATECHANGE_ULID)
     assert snapshot.data == AccState([block1, block2, block3])

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -8,7 +8,7 @@ import pytest
 from raiden.constants import RAIDEN_DB_VERSION
 from raiden.exceptions import InvalidDBData
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import LAST_ULID, RANGE_ALL_ELEMENTS, SerializedSQLiteStorage
+from raiden.storage.sqlite import LAST_ULID, RANGE_ALL_STATE_CHANGES, SerializedSQLiteStorage
 from raiden.storage.utils import TimestampedEvent
 from raiden.storage.wal import WriteAheadLog, restore_to_state_change
 from raiden.tests.utils import factories
@@ -90,18 +90,18 @@ def test_write_read_log():
         block_hash=block_hash,
     )
 
-    state_changes1 = wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes1 = wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     count1 = len(state_changes1)
 
     wal.log_and_dispatch(block)
 
-    state_changes2 = wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes2 = wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     count2 = len(state_changes2)
     assert count1 + 1 == count2
 
     wal.log_and_dispatch(contract_receive_unlock)
 
-    state_changes3 = wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS)
+    state_changes3 = wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     count3 = len(state_changes3)
     assert count2 + 1 == count3
 

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -110,15 +110,15 @@ def test_write_read_log():
     assert count2 + 1 == count3
 
     result1, result2 = state_changes3[-2:]
-    assert isinstance(result1.data, Block)
-    assert result1.data.block_number == block_number
+    assert isinstance(result1, Block)
+    assert result1.block_number == block_number
 
-    assert isinstance(result2.data, ContractReceiveChannelBatchUnlock)
-    assert result2.data.receiver == participant
-    assert result2.data.sender == partner
-    assert result2.data.locksroot == locksroot
-    assert result2.data.unlocked_amount == unlocked_amount
-    assert result2.data.returned_tokens == returned_amount
+    assert isinstance(result2, ContractReceiveChannelBatchUnlock)
+    assert result2.receiver == participant
+    assert result2.sender == partner
+    assert result2.locksroot == locksroot
+    assert result2.unlocked_amount == unlocked_amount
+    assert result2.returned_tokens == returned_amount
 
     # Make sure state snapshot can only go for corresponding state change ids
     with pytest.raises(sqlite3.IntegrityError):

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -9,7 +9,7 @@ from raiden.constants import RAIDEN_DB_VERSION
 from raiden.exceptions import InvalidDBData
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import (
-    LAST_STATECHANGE_ULID,
+    HIGH_STATECHANGE_ULID,
     RANGE_ALL_STATE_CHANGES,
     SerializedSQLiteStorage,
 )
@@ -187,7 +187,7 @@ def test_restore_without_snapshot():
     newwal = restore_to_state_change(
         transition_function=state_transtion_acc,
         storage=wal.storage,
-        state_change_identifier=LAST_STATECHANGE_ULID,
+        state_change_identifier=HIGH_STATECHANGE_ULID,
     )
 
     aggregate = newwal.state_manager.current_state
@@ -209,5 +209,5 @@ def test_get_snapshot_before_state_change():
     wal.log_and_dispatch(block3)
     wal.snapshot()
 
-    snapshot = wal.storage.get_snapshot_before_state_change(LAST_STATECHANGE_ULID)
+    snapshot = wal.storage.get_snapshot_before_state_change(HIGH_STATECHANGE_ULID)
     assert snapshot.data == AccState([block1, block2, block3])

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -126,19 +126,6 @@ def test_write_read_log():
     with pytest.raises(sqlite3.IntegrityError):
         wal.storage.write_state_snapshot(34, "AAAA", datetime.now())
 
-    # Make sure we can only have a single state snapshot
-    assert wal.storage.get_latest_state_snapshot() is None
-
-    wal.storage.write_state_snapshot(1, "AAAA")
-    snapshot = wal.storage.get_latest_state_snapshot()
-    assert snapshot.state_change_identifier == 1
-    assert snapshot.data == "AAAA"
-
-    wal.storage.write_state_snapshot(2, "BBBB")
-    snapshot = wal.storage.get_latest_state_snapshot()
-    assert snapshot.state_change_identifier == 2
-    assert snapshot.data == "BBBB"
-
 
 def test_timestamped_event():
     event = EventPaymentSentFailed(

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -91,14 +91,14 @@ def test_write_read_log():
     )
 
     state_changes1 = wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
     count1 = len(state_changes1)
 
     wal.log_and_dispatch(block)
 
     state_changes2 = wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
     count2 = len(state_changes2)
     assert count1 + 1 == count2
@@ -106,25 +106,25 @@ def test_write_read_log():
     wal.log_and_dispatch(contract_receive_unlock)
 
     state_changes3 = wal.storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
     count3 = len(state_changes3)
     assert count2 + 1 == count3
 
     result1, result2 = state_changes3[-2:]
-    assert isinstance(result1, Block)
-    assert result1.block_number == block_number
+    assert isinstance(result1.data, Block)
+    assert result1.data.block_number == block_number
 
-    assert isinstance(result2, ContractReceiveChannelBatchUnlock)
-    assert result2.receiver == participant
-    assert result2.sender == partner
-    assert result2.locksroot == locksroot
-    assert result2.unlocked_amount == unlocked_amount
-    assert result2.returned_tokens == returned_amount
+    assert isinstance(result2.data, ContractReceiveChannelBatchUnlock)
+    assert result2.data.receiver == participant
+    assert result2.data.sender == partner
+    assert result2.data.locksroot == locksroot
+    assert result2.data.unlocked_amount == unlocked_amount
+    assert result2.data.returned_tokens == returned_amount
 
     # Make sure state snapshot can only go for corresponding state change ids
     with pytest.raises(sqlite3.IntegrityError):
-        wal.storage.write_state_snapshot(34, "AAAA")
+        wal.storage.write_state_snapshot(34, "AAAA", datetime.now())
 
     # Make sure we can only have a single state snapshot
     assert wal.storage.get_latest_state_snapshot() is None

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -97,7 +97,9 @@ def raiden_state_changes_search_for_item(
     `attributes` are compared using the utility `check_nested_attrs`.
     """
     return search_for_item(
-        raiden.wal.storage.get_statechanges_by_identifier(0, "latest"), item_type, attributes
+        raiden.wal.storage.get_statechanges_by_identifier("earliest", "latest"),
+        item_type,
+        attributes,
     )
 
 

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -1,20 +1,22 @@
-from collections import Mapping
+from collections.abc import Mapping
 
 import gevent
 
 from raiden.raiden_service import RaidenService
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.transfer.architecture import Event, StateChange
-from raiden.utils.typing import Any, Dict, List, Optional
+from raiden.utils.typing import Any, Iterable, List, Optional, Type, TypeVar
 
 NOVALUE = object()
+T = TypeVar("T")
+TM = TypeVar("TM", bound=Mapping)
 
 
-def check_dict_nested_attrs(item: Dict, dict_data: Dict) -> bool:
+def check_dict_nested_attrs(item: Mapping, dict_data: Mapping) -> bool:
     """ Checks the values from `dict_data` are contained in `item`
 
     >>> d = {'a': 1, 'b': {'c': 2}}
-    >>> check_dict_nested_attrs(d, {'a': 1)
+    >>> check_dict_nested_attrs(d, {'a': 1})
     True
     >>> check_dict_nested_attrs(d, {'b': {'c': 2}})
     True
@@ -36,7 +38,7 @@ def check_dict_nested_attrs(item: Dict, dict_data: Dict) -> bool:
     return True
 
 
-def check_nested_attrs(item: Any, attributes: Dict) -> bool:
+def check_nested_attrs(item: Any, attributes: Mapping) -> bool:
     """ Checks the attributes from `item` match the values defined in `attributes`.
 
     >>> from collections import namedtuple
@@ -65,7 +67,9 @@ def check_nested_attrs(item: Any, attributes: Dict) -> bool:
     return True
 
 
-def search_for_item(item_list: List, item_type: Any, attributes: Dict) -> Optional[Any]:
+def search_for_item(
+    item_list: Iterable[T], item_type: Type[T], attributes: Mapping
+) -> Optional[T]:
     """ Search for the first item of type `item_type` with `attributes` in
     `item_list`.
 
@@ -79,39 +83,44 @@ def search_for_item(item_list: List, item_type: Any, attributes: Dict) -> Option
 
 
 def raiden_events_search_for_item(
-    raiden: RaidenService, item_type: Event, attributes: Dict
+    raiden: RaidenService, item_type: Type[Event], attributes: Mapping
 ) -> Optional[Event]:
     """ Search for the first event of type `item_type` with `attributes` in the
     `raiden` database.
 
     `attributes` are compared using the utility `check_nested_attrs`.
     """
+    assert raiden.wal, "RaidenService must be started"
     return search_for_item(raiden.wal.storage.get_events(), item_type, attributes)
 
 
 def raiden_state_changes_search_for_item(
-    raiden: RaidenService, item_type: StateChange, attributes: Dict
+    raiden: RaidenService, item_type: Type[StateChange], attributes: Mapping
 ) -> Optional[StateChange]:
     """ Search for the first event of type `item_type` with `attributes` in the
     `raiden` database.
 
     `attributes` are compared using the utility `check_nested_attrs`.
     """
-    return search_for_item(
-        raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES),
-        item_type,
-        attributes,
+    assert raiden.wal, "RaidenService must be started"
+
+    state_changes = (
+        state_change_record.data
+        for state_change_record in raiden.wal.storage.get_statechanges_by_range(
+            RANGE_ALL_STATE_CHANGES
+        )
     )
+    return search_for_item(state_changes, item_type, attributes)
 
 
-def must_have_event(event_list: List, dict_data: Dict):
+def must_have_event(event_list: Iterable[TM], dict_data: TM) -> Optional[TM]:
     for item in event_list:
         if isinstance(item, Mapping) and check_dict_nested_attrs(item, dict_data):
             return item
     return None
 
 
-def must_have_events(event_list: List, *args) -> bool:
+def must_have_events(event_list: List[TM], *args) -> bool:
     for dict_data in args:
         item = must_have_event(event_list, dict_data)
         if not item:
@@ -121,8 +130,8 @@ def must_have_events(event_list: List, *args) -> bool:
 
 
 def wait_for_raiden_event(
-    raiden: RaidenService, item_type: Event, attributes: Dict, retry_timeout: float
-) -> Event:
+    raiden: RaidenService, item_type: Type[Event], attributes: Mapping, retry_timeout: float
+) -> Optional[Event]:
     """Wait until an event is seen in the WAL events
 
     Note:
@@ -136,8 +145,8 @@ def wait_for_raiden_event(
 
 
 def wait_for_state_change(
-    raiden: RaidenService, item_type: StateChange, attributes: Dict, retry_timeout: float
-) -> StateChange:
+    raiden: RaidenService, item_type: Type[StateChange], attributes: Mapping, retry_timeout: float
+) -> Optional[StateChange]:
     """Wait until a state change is seen in the WAL
 
     Note:

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -104,13 +104,11 @@ def raiden_state_changes_search_for_item(
     """
     assert raiden.wal, "RaidenService must be started"
 
-    state_changes = (
-        state_change_record.data
-        for state_change_record in raiden.wal.storage.get_statechanges_by_range(
-            RANGE_ALL_STATE_CHANGES
-        )
+    return search_for_item(
+        raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES),
+        item_type,
+        attributes,
     )
-    return search_for_item(state_changes, item_type, attributes)
 
 
 def must_have_event(event_list: Iterable[TM], dict_data: TM) -> Optional[TM]:

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -3,7 +3,7 @@ from collections import Mapping
 import gevent
 
 from raiden.raiden_service import RaidenService
-from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.transfer.architecture import Event, StateChange
 from raiden.utils.typing import Any, Dict, List, Optional
 
@@ -98,7 +98,9 @@ def raiden_state_changes_search_for_item(
     `attributes` are compared using the utility `check_nested_attrs`.
     """
     return search_for_item(
-        raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS), item_type, attributes
+        raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES),
+        item_type,
+        attributes,
     )
 
 

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -3,6 +3,7 @@ from collections import Mapping
 import gevent
 
 from raiden.raiden_service import RaidenService
+from raiden.storage.sqlite import RANGE_ALL_ELEMENTS
 from raiden.transfer.architecture import Event, StateChange
 from raiden.utils.typing import Any, Dict, List, Optional
 
@@ -97,9 +98,7 @@ def raiden_state_changes_search_for_item(
     `attributes` are compared using the utility `check_nested_attrs`.
     """
     return search_for_item(
-        raiden.wal.storage.get_statechanges_by_identifier("earliest", "latest"),
-        item_type,
-        attributes,
+        raiden.wal.storage.get_statechanges_by_range(RANGE_ALL_ELEMENTS), item_type, attributes
     )
 
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -147,6 +147,10 @@ def make_uint64() -> int:
     return random.randint(0, UINT64_MAX)
 
 
+def make_payment_id() -> PaymentID:
+    return random.randint(0, UINT64_MAX)
+
+
 def make_balance() -> Balance:
     return Balance(random.randint(0, UINT256_MAX))
 
@@ -171,8 +175,20 @@ def make_address() -> Address:
     return Address(make_20bytes())
 
 
+def make_initiator_address() -> InitiatorAddress:
+    return InitiatorAddress(make_20bytes())
+
+
+def make_target_address() -> TargetAddress:
+    return TargetAddress(make_20bytes())
+
+
 def make_checksum_address() -> AddressHex:
     return to_checksum_address(make_address())
+
+
+def make_token_address() -> TokenAddress:
+    return make_20bytes()
 
 
 def make_token_network_address() -> TokenNetworkAddress:
@@ -210,6 +226,13 @@ def make_keccak_hash() -> Keccak256:
 def make_secret(i: int = EMPTY) -> Secret:
     if i is not EMPTY:
         return format(i, ">032").encode()
+    else:
+        return make_32bytes()
+
+
+def make_secret_hash(i: int = EMPTY) -> SecretHash:
+    if i is not EMPTY:
+        return sha256(format(i, ">032").encode()).digest()
     else:
         return make_32bytes()
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -120,15 +120,6 @@ RaidenProtocolVersion = NewType("RaidenProtocolVersion", T_RaidenProtocolVersion
 T_RaidenDBVersion = int
 RaidenDBVersion = NewType("RaidenDBVersion", T_RaidenDBVersion)
 
-T_StateChangeID = int
-StateChangeID = NewType("StateChangeID", T_StateChangeID)
-
-T_SnapshotID = int
-SnapshotID = NewType("SnapshotID", T_SnapshotID)
-
-T_EventID = int
-EventID = NewType("EventID", T_EventID)
-
 T_ChainID = int
 ChainID = NewType("ChainID", T_ChainID)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ requests==2.20.0
 structlog==18.2.0
 web3==4.9.1
 webargs==5.3.1
+typing_extensions==3.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,6 @@ warn_unused_ignores = True
 
 [mypy-raiden.tests.*]
 ignore_errors = True
+
+[mypy-raiden.tests.utils.events]
+ignore_errors = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,6 @@ ignore_errors = True
 
 [mypy-raiden.tests.utils.events]
 ignore_errors = False
+
+[mypy-raiden.tests.unit.test_sqlite]
+ignore_errors = False

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -127,7 +127,7 @@ class Translator(dict):
 
 
 def replay_wal(storage, token_network_address, partner_address, translator=None):
-    all_state_changes = storage.get_statechanges_by_identifier(
+    all_state_changes = storage.get_statechanges_by_range(
         from_identifier="earliest", to_identifier="latest"
     )
 

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -13,8 +13,8 @@ import re
 import click
 from eth_utils import encode_hex, to_canonical_address
 
-from raiden.storage import sqlite
 from raiden.storage.serialization import JSONSerializer
+from raiden.storage.sqlite import NULL_ULID, SerializedSQLiteStorage
 from raiden.storage.wal import WriteAheadLog
 from raiden.transfer import node, views
 from raiden.transfer.architecture import StateManager
@@ -128,7 +128,7 @@ class Translator(dict):
 
 def replay_wal(storage, token_network_address, partner_address, translator=None):
     all_state_changes = storage.get_statechanges_by_identifier(
-        from_identifier=0, to_identifier="latest"
+        from_identifier="earliest", to_identifier="latest"
     )
 
     state_manager = StateManager(state_transition=node.state_transition, current_state=None)
@@ -184,7 +184,7 @@ def main(db_file, token_network_address, partner_address, names_translator):
         translator = None
 
     replay_wal(
-        storage=sqlite.SerializedSQLiteStorage(db_file, JSONSerializer()),
+        storage=SerializedSQLiteStorage(db_file, JSONSerializer()),
         token_network_address=token_network_address,
         partner_address=partner_address,
         translator=translator,

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -14,7 +14,7 @@ import click
 from eth_utils import encode_hex, to_canonical_address
 
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import NULL_ULID, SerializedSQLiteStorage
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.storage.wal import WriteAheadLog
 from raiden.transfer import node, views
 from raiden.transfer.architecture import StateManager

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -14,7 +14,7 @@ import click
 from eth_utils import encode_hex, to_canonical_address
 
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.sqlite import SerializedSQLiteStorage
+from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES, SerializedSQLiteStorage
 from raiden.storage.wal import WriteAheadLog
 from raiden.transfer import node, views
 from raiden.transfer.architecture import StateManager
@@ -127,9 +127,7 @@ class Translator(dict):
 
 
 def replay_wal(storage, token_network_address, partner_address, translator=None):
-    all_state_changes = storage.get_statechanges_by_range(
-        from_identifier="earliest", to_identifier="latest"
-    )
+    all_state_changes = storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
 
     state_manager = StateManager(state_transition=node.state_transition, current_state=None)
     wal = WriteAheadLog(state_manager, storage)


### PR DESCRIPTION
This PR ended being a bigger than what I wanted. Here is what it does:

- Remove the dependency on `lastrowid` [example](https://github.com/raiden-network/raiden/blob/0ae7627d8e484c78b35f37e3b2f5d660b5ca670d/raiden/storage/sqlite.py#L146), which [requires synchronization](https://github.com/raiden-network/raiden/blob/0ae7627d8e484c78b35f37e3b2f5d660b5ca670d/raiden/storage/sqlite.py#L89-L102) and [does not work with `executemany`](https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.lastrowid).
  - This removed some race conditions, which on the current code base were unlikely to be hit. ([Inserts that are not protected by the write lock](https://github.com/raiden-network/raiden/blob/0ae7627d8e484c78b35f37e3b2f5d660b5ca670d/raiden/storage/sqlite.py#L113-L118) which may result in the wrong `lastrowid` being used)
- Without `lastrowid` a new method to determine the IDs of the insert rows is necessary. This moves the ID generation from the database to the APP. This PR implements the IDs with ULIDs.
- ULIDs are used over UUID because Raiden requires total order for the entries [on restarts](https://github.com/raiden-network/raiden/blob/0ae7627d8e484c78b35f37e3b2f5d660b5ca670d/raiden/storage/wal.py#L19-L21), otherwise recovery is not deterministic.
- Because of the above our implementation requires a monotonic clock, and the wall time cannot be used. To handle this the `ULIDMonotonicFactory` was introduced, which deviates from the `ULID` spec by using `ns` resolution instead of `ms` (An alternative is to add a monotonic counter for the IDs generated on the same ms).
- Moved the `TIMESTAMP` generation to the database, since there is not many reasons to have Raiden providing it. The column was added to all WAL related tables. The timestamp was maintained because the ULID uses the monotonic clock which has no relation to wall time.
- I also did a review of SQLite's clustered IDs found some documented bugs that were not handled. Namely the `NOT NULL` constraint must always be added for non clustered indexes (everything but `INTEGER PRIMARY KEY` or tables with `WITHOUT ROWID`).

Review after: #4143