### PR TITLE
Feature/3863 permissive source routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage.xml
 *,cover
 .pytest_cache/
 mypy-out.txt
+.hypothesis/
 
 # Pyenv
 .python-version

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -137,6 +137,12 @@ class UnknownAddress(RaidenError):
     pass
 
 
+class UnresolvableRoute(RaidenError):
+    """ Raised when the next hop of a route can not be resolved to a channel"""
+
+    pass
+
+
 class UnknownTokenAddress(RaidenError):
     """ Raised when the token address in unknown. """
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -137,12 +137,6 @@ class UnknownAddress(RaidenError):
     pass
 
 
-class UnresolvableRoute(RaidenError):
-    """ Raised when the next hop of a route can not be resolved to a channel"""
-
-    pass
-
-
 class UnknownTokenAddress(RaidenError):
     """ Raised when the token address in unknown. """
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -161,8 +161,8 @@ class MessageHandler:
     @staticmethod
     def handle_message_refundtransfer(raiden: RaidenService, message: RefundTransfer) -> None:
         token_network_address = message.token_network_address
-        from_transfer = lockedtransfersigned_from_message(message)
         chain_state = views.state_from_raiden(raiden)
+        from_transfer = lockedtransfersigned_from_message(message=message)
 
         # FIXME: Shouldn't request routes here
         routes, _ = get_best_routes(

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -48,6 +48,7 @@ from raiden.utils.typing import (
     ClassVar,
     Dict,
     InitiatorAddress,
+    List,
     Locksroot,
     MessageID,
     Nonce,
@@ -83,6 +84,7 @@ __all__ = (
     "RefundTransfer",
     "RequestMonitoring",
     "RevealSecret",
+    "RouteMetadata",
     "SecretRequest",
     "SignedBlindedBalanceProof",
     "SignedMessage",
@@ -909,6 +911,15 @@ class LockExpired(EnvelopeMessage):
             secrethash=event.secrethash,
             signature=EMPTY_SIGNATURE,
         )
+
+
+@dataclass(frozen=True)
+class RouteMetadata:
+    routes: List[Address]
+
+    @property
+    def hash(self):
+        return sha3(rlp.encode(self.routes))
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -713,7 +713,7 @@ class Metadata:
         return sha3(rlp.encode([r.hash for r in self.routes]))
 
     def __repr__(self):
-        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.routes])}"
+        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.route])}"
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -693,14 +693,14 @@ class Lock:
 
 @dataclass(frozen=True)
 class RouteMetadata:
-    routes: List[Address]
+    route: List[Address]
 
     @property
     def hash(self):
-        return sha3(rlp.encode(self.routes))
+        return sha3(rlp.encode(self.route))
 
     def __repr__(self):
-        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.routes])}"
+        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.route])}"
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 
 import rlp
 from cachetools import LRUCache, cached
-from eth_utils import big_endian_to_int, to_hex
+from eth_utils import big_endian_to_int, to_checksum_address, to_hex
 
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX, UINT256_MAX
 from raiden.encoding import messages
@@ -33,7 +33,7 @@ from raiden.transfer.state import (
     balanceproof_from_envelope,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import ishash, pex, sha3
+from raiden.utils import ishash, sha3
 from raiden.utils.packing import pack_balance_proof, pack_balance_proof_update, pack_reward_proof
 from raiden.utils.signer import Signer, recover
 from raiden.utils.signing import pack_data
@@ -701,7 +701,7 @@ class RouteMetadata:
         return sha3(rlp.encode(self.route))
 
     def __repr__(self):
-        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.route])}"
+        return f"RouteMetadata: {' -> '.join([to_checksum_address(a) for a in self.route])}"
 
 
 @dataclass(frozen=True)
@@ -795,7 +795,7 @@ class LockedTransfer(LockedTransferBase):
 
     @property
     def message_hash(self):
-        metadata_hash = (self.metadata and self.metadata.hash) or sha3(b"")
+        metadata_hash = (self.metadata and self.metadata.hash) or b""
         packed = self.packed()
         klass = type(packed)
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -699,6 +699,9 @@ class RouteMetadata:
     def hash(self):
         return sha3(rlp.encode(self.routes))
 
+    def __repr__(self):
+        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.routes])}"
+
 
 @dataclass(repr=False, eq=False)
 class LockedTransferBase(EnvelopeMessage):

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -778,7 +778,7 @@ class LockedTransfer(LockedTransferBase):
     fee: int
     metadata: Metadata
 
-    route_metadata: Optional[RouteMetadata] = field(default=None)
+    route_metadata: RouteMetadata
 
     def __post_init__(self):
         super().__post_init__()

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -48,6 +48,7 @@ from raiden.utils.typing import (
     ClassVar,
     Dict,
     InitiatorAddress,
+    List,
     Locksroot,
     MessageID,
     Nonce,
@@ -712,7 +713,7 @@ class Metadata:
         return sha3(rlp.encode([r.hash for r in self.routes]))
 
     def __repr__(self):
-        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.routes])}"
+        return f"Metadata: routes: {[repr(route) for route in self.routes]}"
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -894,7 +894,7 @@ class RefundTransfer(LockedTransfer):
             initiator=transfer.initiator,
             fee=fee,
             signature=EMPTY_SIGNATURE,
-            route_metadata=transfer.route_state.route,
+            route_metadata=RouteMetadata(routes=transfer.route_state.route),
         )
 
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -713,7 +713,7 @@ class Metadata:
         return sha3(rlp.encode([r.hash for r in self.routes]))
 
     def __repr__(self):
-        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.route])}"
+        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.routes])}"
 
 
 @dataclass(repr=False, eq=False)
@@ -780,8 +780,6 @@ class LockedTransfer(LockedTransferBase):
     initiator: InitiatorAddress
     fee: int
     metadata: Metadata
-
-    route_metadata: RouteMetadata
 
     def __post_init__(self):
         super().__post_init__()

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -778,7 +778,7 @@ class LockedTransfer(LockedTransferBase):
     fee: int
     metadata: Metadata
 
-    route_metadata: Optional[RouteMetadata] = None
+    route_metadata: Optional[RouteMetadata] = field(default=None)
 
     def __post_init__(self):
         super().__post_init__()

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -913,7 +913,9 @@ class RefundTransfer(LockedTransfer):
             initiator=transfer.initiator,
             fee=fee,
             signature=EMPTY_SIGNATURE,
-            route_metadata=RouteMetadata(routes=transfer.route_state.route),
+            metadata=Metadata(
+                routes=[RouteMetadata(route=r.route) for r in transfer.route_states]
+            ),
         )
 
 

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -764,7 +764,7 @@ class LockedTransfer(LockedTransferBase):
     initiator: InitiatorAddress
     fee: int
 
-    route_metadata: Optional[RouteMetadata] = None
+    route_metadata: Optional[RouteMetadata] = field(default=None)
 
     def __post_init__(self):
         super().__post_init__()
@@ -777,6 +777,21 @@ class LockedTransfer(LockedTransferBase):
 
         if self.fee > UINT256_MAX:
             raise ValueError("fee is too large")
+
+    @property
+    def message_hash(self):
+        route_metadata_hash = (self.route_metadata and self.route_metadata.hash) or sha3(b"")
+        packed = self.packed()
+        klass = type(packed)
+
+        field = klass.fields_spec[-1]
+        assert field.name == "signature", "signature is not the last field"
+
+        data = packed.data
+        message_data = data[: -field.size_bytes]
+        message_hash = sha3(message_data + route_metadata_hash)
+
+        return message_hash
 
     def pack(self, packed) -> None:
         packed.chain_id = self.chain_id

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -778,6 +778,8 @@ class LockedTransfer(LockedTransferBase):
     fee: int
     metadata: Metadata
 
+    route_metadata: Optional[RouteMetadata] = None
+
     def __post_init__(self):
         super().__post_init__()
 
@@ -953,15 +955,6 @@ class LockExpired(EnvelopeMessage):
             secrethash=event.secrethash,
             signature=EMPTY_SIGNATURE,
         )
-
-
-@dataclass(frozen=True)
-class RouteMetadata:
-    routes: List[Address]
-
-    @property
-    def hash(self):
-        return sha3(rlp.encode(self.routes))
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -703,6 +703,15 @@ class RouteMetadata:
         return f"RouteMetadata: {' -> '.join([pex(address) for address in self.route])}"
 
 
+@dataclass(frozen=True)
+class Metadata:
+    routes: List[RouteMetadata]
+
+    @property
+    def hash(self):
+        return sha3(rlp.encode([r.hash for r in self.routes]))
+
+
 @dataclass(repr=False, eq=False)
 class LockedTransferBase(EnvelopeMessage):
     """ A transfer which signs that the partner can claim `locked_amount` if

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -48,7 +48,6 @@ from raiden.utils.typing import (
     ClassVar,
     Dict,
     InitiatorAddress,
-    List,
     Locksroot,
     MessageID,
     Nonce,
@@ -1260,20 +1259,20 @@ class FeeUpdate(SignedMessage):
         )
 
 
-def lockedtransfersigned_from_message(message: LockedTransfer) -> "LockedTransferSignedState":
+def lockedtransfersigned_from_message(message: LockedTransfer) -> LockedTransferSignedState:
     """ Create LockedTransferSignedState from a LockedTransfer message. """
     balance_proof = balanceproof_from_envelope(message)
 
     lock = HashTimeLockState(message.lock.amount, message.lock.expiration, message.lock.secrethash)
-
     transfer_state = LockedTransferSignedState(
-        message.message_identifier,
-        message.payment_identifier,
-        message.token,
-        balance_proof,
-        lock,
-        message.initiator,
-        message.target,
+        message_identifier=message.message_identifier,
+        payment_identifier=message.payment_identifier,
+        token=message.token,
+        balance_proof=balance_proof,
+        lock=lock,
+        initiator=message.initiator,
+        target=message.target,
+        routes=[r.route for r in message.metadata.routes],
     )
 
     return transfer_state
@@ -1295,22 +1294,3 @@ CMDID_TO_CLASS: Dict[int, Type[Message]] = {
 
 CLASSNAME_TO_CLASS = {klass.__name__: klass for klass in CMDID_TO_CLASS.values()}
 CLASSNAME_TO_CLASS["Secret"] = Unlock
-
-
-def lockedtransfersigned_from_message(message: LockedTransfer) -> LockedTransferSignedState:
-    """ Create LockedTransferSignedState from a LockedTransfer message. """
-    balance_proof = balanceproof_from_envelope(message)
-
-    lock = HashTimeLockState(message.lock.amount, message.lock.expiration, message.lock.secrethash)
-    transfer_state = LockedTransferSignedState(
-        message_identifier=message.message_identifier,
-        payment_identifier=message.payment_identifier,
-        token=message.token,
-        balance_proof=balance_proof,
-        lock=lock,
-        initiator=message.initiator,
-        target=message.target,
-        routes=[r.route for r in message.metadata.routes],
-    )
-
-    return transfer_state

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -712,6 +712,9 @@ class Metadata:
     def hash(self):
         return sha3(rlp.encode([r.hash for r in self.routes]))
 
+    def __repr__(self):
+        return f"RouteMetadata: {' -> '.join([pex(address) for address in self.routes])}"
+
 
 @dataclass(repr=False, eq=False)
 class LockedTransferBase(EnvelopeMessage):

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -955,6 +955,15 @@ class LockExpired(EnvelopeMessage):
         )
 
 
+@dataclass(frozen=True)
+class RouteMetadata:
+    routes: List[Address]
+
+    @property
+    def hash(self):
+        return sha3(rlp.encode(self.routes))
+
+
 @dataclass(repr=False, eq=False)
 class SignedBlindedBalanceProof:
     """Message sub-field `onchain_balance_proof` for `RequestMonitoring`.

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -33,7 +33,7 @@ from raiden.transfer.state import (
     balanceproof_from_envelope,
 )
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import ishash, sha3
+from raiden.utils import ishash, pex, sha3
 from raiden.utils.packing import pack_balance_proof, pack_balance_proof_update, pack_reward_proof
 from raiden.utils.signer import Signer, recover
 from raiden.utils.signing import pack_data

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -691,6 +691,15 @@ class Lock:
         )
 
 
+@dataclass(frozen=True)
+class RouteMetadata:
+    routes: List[Address]
+
+    @property
+    def hash(self):
+        return sha3(rlp.encode(self.routes))
+
+
 @dataclass(repr=False, eq=False)
 class LockedTransferBase(EnvelopeMessage):
     """ A transfer which signs that the partner can claim `locked_amount` if
@@ -754,6 +763,8 @@ class LockedTransfer(LockedTransferBase):
     target: TargetAddress
     initiator: InitiatorAddress
     fee: int
+
+    route_metadata: Optional[RouteMetadata] = None
 
     def __post_init__(self):
         super().__post_init__()
@@ -911,15 +922,6 @@ class LockExpired(EnvelopeMessage):
             secrethash=event.secrethash,
             signature=EMPTY_SIGNATURE,
         )
-
-
-@dataclass(frozen=True)
-class RouteMetadata:
-    routes: List[Address]
-
-    @property
-    def hash(self):
-        return sha3(rlp.encode(self.routes))
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -33,7 +33,6 @@ from raiden.exceptions import (
     PaymentConflict,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
-    UnresolvableRoute,
 )
 from raiden.messages import (
     LockedTransfer,
@@ -171,30 +170,16 @@ def mediator_init(
         # pylint: disable=E1101
         from_transfer.balance_proof.channel_identifier,
     )
-    try:
-
-        route_state = routing.resolve_route(
-            route_metadata=transfer.route_metadata,
-            # pylint: disable=E1101
-            token_network_address=from_transfer.balance_proof.token_network_address,
-            chain_state=views.state_from_raiden(raiden),
-        )
-    except UnresolvableRoute as exc:
-        log.warn(
-            str(exc),
-            sender=pex(transfer.sender),
-            message_identifier=transfer.message_identifier,
-            # pylint: disable=E1101
-            channel_identifier=from_transfer.balance_proof.canonical_identifier.channel_identifier,
-            # pylint: disable=E1101
-            token_network_address=pex(from_transfer.balance_proof.token_network_address),
-            node=pex(raiden.address),
-        )
-        return None
+    route_states = routing.resolve_routes(
+        routes=transfer.metadata.routes,
+        # pylint: disable=E1101
+        token_network_address=from_transfer.balance_proof.token_network_address,
+        chain_state=views.state_from_raiden(raiden),
+    )
 
     init_mediator_statechange = ActionInitMediator(
         from_hop=from_hop,
-        route_state=route_state,
+        route_states=route_states,
         from_transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -33,6 +33,7 @@ from raiden.exceptions import (
     PaymentConflict,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
+    UnresolvableRoute,
 )
 from raiden.messages import (
     LockedTransfer,
@@ -168,12 +169,27 @@ def mediator_init(raiden: "RaidenService", transfer: LockedTransfer) -> ActionIn
         # pylint: disable=E1101
         from_transfer.balance_proof.channel_identifier,
     )
-    route_state = routing.resolve_route(
-        route_metadata=transfer.route_metadata,
-        # pylint: disable=E1101
-        token_network_address=from_transfer.balance_proof.token_network_address,
-        chain_state=views.state_from_raiden(raiden),
-    )
+    try:
+
+        route_state = routing.resolve_route(
+            route_metadata=transfer.route_metadata,
+            # pylint: disable=E1101
+            token_network_address=from_transfer.balance_proof.token_network_address,
+            chain_state=views.state_from_raiden(raiden),
+        )
+    except UnresolvableRoute as exc:
+        log.warn(
+            str(exc),
+            sender=pex(transfer.sender),
+            message_identifier=transfer.message_identifier,
+            # pylint: disable=E1101
+            channel_identifier=from_transfer.balance_proof.canonical_identifier.channel_identifier,
+            # pylint: disable=E1101
+            token_network_address=pex(from_transfer.balance_proof.token_network_address),
+            node=pex(raiden.address),
+        )
+        return None
+
     init_mediator_statechange = ActionInitMediator(
         from_hop=from_hop,
         route_state=route_state,
@@ -1052,7 +1068,8 @@ class RaidenService(Runnable):
 
     def mediate_mediated_transfer(self, transfer: LockedTransfer) -> None:
         init_mediator_statechange = mediator_init(self, transfer)
-        self.handle_and_track_state_change(init_mediator_statechange)
+        if init_mediator_statechange is not None:
+            self.handle_and_track_state_change(init_mediator_statechange)
 
     def target_mediated_transfer(self, transfer: LockedTransfer) -> None:
         self.start_health_check_for(Address(transfer.initiator))

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -33,7 +33,6 @@ from raiden.exceptions import (
     PaymentConflict,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
-    UnresolvableRoute,
 )
 from raiden.messages import (
     LockedTransfer,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -162,7 +162,6 @@ def initiator_init(
 
 def mediator_init(raiden: "RaidenService", transfer: LockedTransfer) -> ActionInitMediator:
     from_transfer = lockedtransfersigned_from_message(transfer)
-    # Feedback token not used here, will be removed with source routing
     from_hop = HopState(
         transfer.sender,
         # pylint: disable=E1101

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1052,8 +1052,8 @@ class RaidenService(Runnable):
 
     def mediate_mediated_transfer(self, transfer: LockedTransfer) -> None:
         init_mediator_statechange = mediator_init(self, transfer)
-        if init_mediator_statechange is not None:
-            self.handle_and_track_state_change(init_mediator_statechange)
+
+        self.handle_and_track_state_change(init_mediator_statechange)
 
     def target_mediated_transfer(self, transfer: LockedTransfer) -> None:
         self.start_health_check_for(Address(transfer.initiator))

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -161,7 +161,9 @@ def initiator_init(
     return ActionInitInitiator(transfer_state, routes)
 
 
-def mediator_init(raiden: "RaidenService", transfer: LockedTransfer) -> ActionInitMediator:
+def mediator_init(
+    raiden: "RaidenService", transfer: LockedTransfer
+) -> Optional[ActionInitMediator]:
     from_transfer = lockedtransfersigned_from_message(transfer)
     # Feedback token not used here, will be removed with source routing
     from_hop = HopState(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -33,6 +33,7 @@ from raiden.exceptions import (
     PaymentConflict,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
+    UnresolvableRoute,
 )
 from raiden.messages import (
     LockedTransfer,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -160,9 +160,7 @@ def initiator_init(
     return ActionInitInitiator(transfer_state, routes)
 
 
-def mediator_init(
-    raiden: "RaidenService", transfer: LockedTransfer
-) -> Optional[ActionInitMediator]:
+def mediator_init(raiden: "RaidenService", transfer: LockedTransfer) -> ActionInitMediator:
     from_transfer = lockedtransfersigned_from_message(transfer)
     # Feedback token not used here, will be removed with source routing
     from_hop = HopState(

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -6,11 +6,12 @@ import networkx
 import structlog
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.exceptions import ServiceRequestFailed
+from raiden.exceptions import ServiceRequestFailed, UnresolvableRoute
 from raiden.messages import RouteMetadata
 from raiden.network.pathfinding import query_paths
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, RouteState
+from raiden.utils import pex
 from raiden.utils.typing import (
     Address,
     ChannelID,
@@ -297,7 +298,8 @@ def resolve_route(
         partner_address=route_metadata.routes[1],
     )
 
-    assert channel_state is not None, "Channel state needs to exist"
+    if channel_state is None:
+        raise UnresolvableRoute(f"no channel for {route_metadata} on {pex(token_network_address)}")
 
     return RouteState(
         route=route_metadata.routes,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -292,8 +292,6 @@ def resolve_routes(
     """ resolve the forward_channel_id for a given route """
 
     resolvable = []
-    unresolvable = []
-
     for route_metadata in routes:
         channel_state = views.get_channelstate_by_token_network_and_partner(
             chain_state=chain_state,
@@ -308,6 +306,4 @@ def resolve_routes(
                     forward_channel_id=channel_state.canonical_identifier.channel_identifier,
                 )
             )
-        else:
-            unresolvable.append(RouteState(route=route_metadata.route))
-    return resolvable + unresolvable
+    return resolvable

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -6,12 +6,11 @@ import networkx
 import structlog
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.exceptions import ServiceRequestFailed, UnresolvableRoute
+from raiden.exceptions import ServiceRequestFailed
 from raiden.messages import RouteMetadata
 from raiden.network.pathfinding import query_paths
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, RouteState
-from raiden.utils import pex
 from raiden.utils.typing import (
     Address,
     ChannelID,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -293,6 +293,9 @@ def resolve_routes(
 
     resolvable = []
     for route_metadata in routes:
+        if len(route_metadata.route) < 2:
+            continue
+
         channel_state = views.get_channelstate_by_token_network_and_partner(
             chain_state=chain_state,
             token_network_address=token_network_address,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -295,13 +295,13 @@ def resolve_route(
     channel_state = views.get_channelstate_by_token_network_and_partner(
         chain_state=chain_state,
         token_network_address=token_network_address,
-        partner_address=route_metadata.routes[1],
+        partner_address=route_metadata.route[1],
     )
 
     if channel_state is None:
         raise UnresolvableRoute(f"no channel for {route_metadata} on {pex(token_network_address)}")
 
     return RouteState(
-        route=route_metadata.routes,
+        route=route_metadata.route,
         forward_channel_id=channel_state.canonical_identifier.channel_identifier,
     )

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -6,11 +6,12 @@ import networkx
 import structlog
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.exceptions import ServiceRequestFailed
+from raiden.exceptions import ServiceRequestFailed, UnresolvableRoute
 from raiden.messages import RouteMetadata
 from raiden.network.pathfinding import query_paths
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, RouteState
+from raiden.utils import pex
 from raiden.utils.typing import (
     Address,
     ChannelID,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -7,6 +7,7 @@ import structlog
 from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.exceptions import ServiceRequestFailed
+from raiden.messages import RouteMetadata
 from raiden.network.pathfinding import query_paths
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, RouteState
@@ -281,3 +282,24 @@ def get_best_routes_pfs(
         paths.append(RouteState(canonical_path, channel_state.identifier))
 
     return True, paths, feedback_token
+
+
+def resolve_route(
+    route_metadata: RouteMetadata,
+    token_network_address: TokenNetworkAddress,
+    chain_state: ChainState,
+) -> RouteState:
+    """ resolve the forward_channel_id for a given route """
+
+    channel_state = views.get_channelstate_by_token_network_and_partner(
+        chain_state=chain_state,
+        token_network_address=token_network_address,
+        partner_address=route_metadata.routes[1],
+    )
+
+    assert channel_state is not None, "Channel state needs to exist"
+
+    return RouteState(
+        route=route_metadata.routes,
+        forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+    )

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -353,7 +353,7 @@ class InitiatorMixin:
     @rule(
         target=init_initiators,
         partner=partners,
-        payment_id=payment_id(),
+        payment_id=payment_id(),  # pylint: disable=no-value-for-parameter
         amount=integers(min_value=1, max_value=100),
         secret=secret(),  # pylint: disable=no-value-for-parameter
     )
@@ -374,7 +374,7 @@ class InitiatorMixin:
 
     @rule(
         partner=partners,
-        payment_id=payment_id(),
+        payment_id=payment_id(),  # pylint: disable=no-value-for-parameter
         excess_amount=integers(min_value=1),
         secret=secret(),  # pylint: disable=no-value-for-parameter
     )
@@ -389,7 +389,7 @@ class InitiatorMixin:
     @rule(
         previous_action=init_initiators,
         partner=partners,
-        payment_id=payment_id(),
+        payment_id=payment_id(),  # pylint: disable=no-value-for-parameter
         amount=integers(min_value=1),
     )
     def used_secret_init_initiator(self, previous_action, partner, payment_id, amount):
@@ -537,7 +537,7 @@ class MediatorMixin:
         target_channel = self.address_to_channel[transfer.target]
 
         return ActionInitMediator(
-            routes=[factories.make_route_from_channel(target_channel)],
+            route_state=factories.make_route_from_channel(target_channel),
             from_hop=factories.make_hop_to_channel(initiator_channel),
             from_transfer=transfer,
             balance_proof=transfer.balance_proof,
@@ -548,9 +548,9 @@ class MediatorMixin:
         target=init_mediators,
         initiator_address=partners,
         target_address=partners,
-        payment_id=payment_id(),
+        payment_id=payment_id(),  # pylint: disable=no-value-for-parameter
         amount=integers(min_value=1, max_value=100),
-        secret=secret(),
+        secret=secret(),  # pylint: disable=no-value-for-parameter
     )
     def valid_init_mediator(self, initiator_address, target_address, payment_id, amount, secret):
         assume(initiator_address != target_address)
@@ -597,22 +597,28 @@ class MediatorMixin:
         result = node.state_transition(self.chain_state, previous_action)
         assert not result.events
 
+    # pylint: disable=no-value-for-parameter
     @rule(previous_action=secret_requests, invalid_sender=address())
+    # pylint: enable=no-value-for-parameter
     def replay_receive_secret_reveal_scrambled_sender(self, previous_action, invalid_sender):
         action = ReceiveSecretReveal(previous_action.secret, invalid_sender)
         result = node.state_transition(self.chain_state, action)
         assert not result.events
 
+    # pylint: disable=no-value-for-parameter
     @rule(previous_action=init_mediators, secret=secret())
+    # pylint: enable=no-value-for-parameter
     def wrong_secret_receive_secret_reveal(self, previous_action, secret):
         sender = previous_action.from_transfer.target
         action = ReceiveSecretReveal(secret, sender)
         result = node.state_transition(self.chain_state, action)
         assert not result.events
 
+    # pylint: disable=no-value-for-parameter
     @rule(
         target=secret_requests, previous_action=consumes(init_mediators), invalid_sender=address()
     )
+    # pylint: enable=no-value-for-parameter
     def wrong_address_receive_secret_reveal(self, previous_action, invalid_sender):
         secret = self.secrethash_to_secret[previous_action.from_transfer.lock.secrethash]
         invalid_action = ReceiveSecretReveal(secret, invalid_sender)

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -537,7 +537,7 @@ class MediatorMixin:
         target_channel = self.address_to_channel[transfer.target]
 
         return ActionInitMediator(
-            route_state=factories.make_route_from_channel(target_channel),
+            route_states=[factories.make_route_from_channel(target_channel)],
             from_hop=factories.make_hop_to_channel(initiator_channel),
             from_transfer=transfer,
             balance_proof=transfer.balance_proof,

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -6,7 +6,7 @@ import pytest
 from eth_utils import keccak
 
 from raiden.constants import EMPTY_SIGNATURE, LOCKSROOT_OF_NO_LOCKS, UINT64_MAX
-from raiden.messages import Lock, LockedTransfer, RevealSecret, Unlock
+from raiden.messages import Lock, LockedTransfer, Metadata, RevealSecret, RouteMetadata, Unlock
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.integration.fixtures.raiden_network import CHAIN, wait_for_channels
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -186,6 +186,9 @@ def run_test_regression_multiple_revealsecret(raiden_network, token_addresses, t
         target=app1.raiden.address,
         initiator=app0.raiden.address,
         signature=EMPTY_SIGNATURE,
+        metadata=Metadata(
+            routes=[RouteMetadata(route=[app0.raiden.address, app1.raiden.address])]
+        ),
     )
     app0.raiden.sign(mediated_transfer)
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -359,6 +359,7 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
             )
             assert patched.call_count == 1
 
+            # Mediator should not re-query PFS
             locked_transfer = factories.create(
                 factories.LockedTransferProperties(
                     amount=TokenAmount(5),
@@ -373,7 +374,7 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
                 )
             )
             app0.raiden.mediate_mediated_transfer(locked_transfer)
-            assert patched.call_count == 2
+            assert patched.call_count == 1
 
 
 @pytest.mark.parametrize("channels_per_node", [CHAIN])

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -5,7 +5,7 @@ import pytest
 
 from raiden.api.python import RaidenAPI
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
-from raiden.messages import Lock, LockedTransfer
+from raiden.messages import Lock, LockedTransfer, RouteMetadata
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.factories import (
     UNIT_CHAIN_ID,
@@ -147,6 +147,7 @@ def run_test_receive_lockedtransfer_invalidnonce(
         initiator=app0.raiden.address,
         fee=0,
         signature=EMPTY_SIGNATURE,
+        route_metadata=RouteMetadata(routes=[app1.raiden.address, app2.raiden.address]),
     )
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
@@ -210,6 +211,7 @@ def run_test_receive_lockedtransfer_invalidsender(
         initiator=other_address,
         fee=0,
         signature=EMPTY_SIGNATURE,
+        route_metadata=RouteMetadata(routes=[app0.raiden.address]),
     )
 
     sign_and_inject(mediated_transfer_message, LocalSigner(other_key), app0)
@@ -264,6 +266,7 @@ def run_test_receive_lockedtransfer_invalidrecipient(
         initiator=app0.raiden.address,
         fee=0,
         signature=EMPTY_SIGNATURE,
+        route_metadata=RouteMetadata(routes=[app1.raiden.address]),
     )
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
@@ -324,6 +327,7 @@ def run_test_received_lockedtransfer_closedchannel(
         initiator=app0.raiden.address,
         fee=0,
         signature=EMPTY_SIGNATURE,
+        route_metadata=RouteMetadata(routes=[app1.raiden.address]),
     )
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -5,7 +5,7 @@ import pytest
 
 from raiden.api.python import RaidenAPI
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
-from raiden.messages import Lock, LockedTransfer, RouteMetadata
+from raiden.messages import Lock, LockedTransfer, Metadata, RouteMetadata
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.factories import (
     UNIT_CHAIN_ID,
@@ -147,7 +147,9 @@ def run_test_receive_lockedtransfer_invalidnonce(
         initiator=app0.raiden.address,
         fee=0,
         signature=EMPTY_SIGNATURE,
-        route_metadata=RouteMetadata(routes=[app1.raiden.address, app2.raiden.address]),
+        metadata=Metadata(
+            routes=[RouteMetadata(route=[app1.raiden.address, app2.raiden.address])]
+        ),
     )
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
@@ -211,7 +213,7 @@ def run_test_receive_lockedtransfer_invalidsender(
         initiator=other_address,
         fee=0,
         signature=EMPTY_SIGNATURE,
-        route_metadata=RouteMetadata(routes=[app0.raiden.address]),
+        metadata=Metadata(routes=[RouteMetadata(route=[app0.raiden.address])]),
     )
 
     sign_and_inject(mediated_transfer_message, LocalSigner(other_key), app0)
@@ -266,7 +268,7 @@ def run_test_receive_lockedtransfer_invalidrecipient(
         initiator=app0.raiden.address,
         fee=0,
         signature=EMPTY_SIGNATURE,
-        route_metadata=RouteMetadata(routes=[app1.raiden.address]),
+        metadata=Metadata(routes=[RouteMetadata(route=[app1.raiden.address])]),
     )
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
@@ -327,7 +329,7 @@ def run_test_received_lockedtransfer_closedchannel(
         initiator=app0.raiden.address,
         fee=0,
         signature=EMPTY_SIGNATURE,
-        route_metadata=RouteMetadata(routes=[app1.raiden.address]),
+        metadata=Metadata(routes=[RouteMetadata(route=[app1.raiden.address])]),
     )
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -103,7 +103,6 @@ def test_mediator_task_view():
     # pylint: disable=E1101
     transfer_state1.transfers_pair.append(
         MediationPairState(
-            route=route_state,
             payer_transfer=payer_transfer,
             payee_transfer=payee_transfer,
             payee_address=payee_transfer.target,

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -47,7 +47,9 @@ def test_initiator_task_view():
         secrethash=sha256(secret).digest(),
     )
     transfer_state = InitiatorTransferState(
-        route=factories.make_route_to_channel(),
+        route=RouteState(
+            route=[transfer.initiator, transfer.target], forward_channel_id=channel_id
+        ),
         transfer_description=transfer_description,
         channel_identifier=channel_id,
         transfer=transfer,

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -12,6 +12,7 @@ from raiden.transfer.mediated_transfer.state import (
     WaitingTransferState,
 )
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask, MediatorTask, TargetTask
+from raiden.transfer.state import RouteState
 from raiden.transfer.views import list_channelstate_for_tokennetwork
 
 
@@ -91,12 +92,16 @@ def test_mediator_task_view():
             )
         )
     )
-    routes = [factories.make_route_from_channel(initiator_channel)]
-    transfer_state1 = MediatorTransferState(secrethash=secrethash1, routes=routes)
+    route_state = RouteState(
+        route=[payee_transfer.target],
+        forward_channel_id=initiator_channel.canonical_identifier.channel_identifier,
+    )
+
+    transfer_state1 = MediatorTransferState(secrethash=secrethash1, routes=[route_state])
     # pylint: disable=E1101
     transfer_state1.transfers_pair.append(
         MediationPairState(
-            route=routes[0],
+            route=route_state,
             payer_transfer=payer_transfer,
             payee_transfer=payee_transfer,
             payee_address=payee_transfer.target,
@@ -114,7 +119,7 @@ def test_mediator_task_view():
         )
     )
     secrethash2 = transfer2.lock.secrethash
-    transfer_state2 = MediatorTransferState(secrethash=secrethash2, routes=routes)
+    transfer_state2 = MediatorTransferState(secrethash=secrethash2, routes=[route_state])
     transfer_state2.waiting_transfer = WaitingTransferState(transfer=transfer2)
     task2 = MediatorTask(
         token_network_address=factories.UNIT_TOKEN_NETWORK_ADDRESS, mediator_state=transfer_state2

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -56,6 +56,7 @@ from raiden.transfer.state import (
     NettingChannelEndState,
     NettingChannelState,
     PendingLocksState,
+    RouteState,
     TransactionChannelNewBalance,
     TransactionExecutionStatus,
     UnlockPartialProofState,
@@ -463,6 +464,11 @@ def test_channelstate_send_lockedtransfer():
         payment_identifier,
         lock_expiration,
         lock_secrethash,
+        route_state=RouteState(
+            # pylint: disable=E1101
+            route=[channel_state.partner_state.address],
+            forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+        ),
     )
 
     our_model2 = our_model1._replace(
@@ -958,6 +964,11 @@ def test_channel_never_expires_lock_with_secret_onchain():
         payment_identifier=payment_identifier,
         expiration=lock_expiration,
         secrethash=lock_secrethash,
+        route_state=RouteState(
+            # pylint: disable=E1101
+            route=[channel_state.partner_state.address],
+            forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+        ),
     )
 
     # pylint: disable=E1101
@@ -1382,12 +1393,16 @@ def test_channelstate_unlock_unlocked_onchain():
 
 
 def test_refund_transfer_matches_received():
-    same = LockedTransferSignedStateProperties(amount=30, expiration=50)
+    amount = 30
+    expiration = 50
+
+    same = LockedTransferSignedStateProperties(amount=amount, expiration=expiration)
     lower = replace(same, expiration=49)
 
     refund_lower_expiration = create(lower)
     refund_same_expiration = create(same)
-    transfer = create(same.extract(LockedTransferUnsignedStateProperties))
+
+    transfer = create(LockedTransferUnsignedStateProperties(amount=amount, expiration=expiration))
 
     assert channel.refund_transfer_matches_transfer(refund_lower_expiration, transfer) is False
     assert channel.refund_transfer_matches_transfer(refund_same_expiration, transfer) is True

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -464,11 +464,13 @@ def test_channelstate_send_lockedtransfer():
         payment_identifier,
         lock_expiration,
         lock_secrethash,
-        route_state=RouteState(
-            # pylint: disable=E1101
-            route=[channel_state.partner_state.address],
-            forward_channel_id=channel_state.canonical_identifier.channel_identifier,
-        ),
+        route_states=[
+            RouteState(
+                # pylint: disable=E1101
+                route=[channel_state.partner_state.address],
+                forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+            )
+        ],
     )
 
     our_model2 = our_model1._replace(
@@ -964,11 +966,13 @@ def test_channel_never_expires_lock_with_secret_onchain():
         payment_identifier=payment_identifier,
         expiration=lock_expiration,
         secrethash=lock_secrethash,
-        route_state=RouteState(
-            # pylint: disable=E1101
-            route=[channel_state.partner_state.address],
-            forward_channel_id=channel_state.canonical_identifier.channel_identifier,
-        ),
+        route_states=[
+            RouteState(
+                # pylint: disable=E1101
+                route=[channel_state.partner_state.address],
+                forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+            )
+        ],
     )
 
     # pylint: disable=E1101

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -185,11 +185,9 @@ def test_get_state_change_with_balance_proof():
         transfer=transfer,
         balance_proof=transfer.balance_proof,
         sender=transfer.balance_proof.sender,  # pylint: disable=no-member
-        routes=list(),
     )
     transfer = make_signed_transfer_from_counter(counter)
     transfer_refund_cancel_route = ReceiveTransferRefundCancelRoute(
-        routes=list(),
         transfer=transfer,
         balance_proof=transfer.balance_proof,
         sender=transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -198,10 +198,12 @@ def test_get_state_change_with_balance_proof():
     mediator_from_route, mediator_signed_transfer = make_from_route_from_counter(counter)
 
     action_init_mediator = ActionInitMediator(
-        route_state=RouteState(
-            route=[factories.make_address(), factories.make_address()],
-            forward_channel_id=factories.make_channel_identifier(),
-        ),
+        route_states=[
+            RouteState(
+                route=[factories.make_address(), factories.make_address()],
+                forward_channel_id=factories.make_channel_identifier(),
+            )
+        ],
         from_hop=mediator_from_route,
         from_transfer=mediator_signed_transfer,
         balance_proof=mediator_signed_transfer.balance_proof,

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -34,7 +34,7 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveTransferRefund,
     ReceiveTransferRefundCancelRoute,
 )
-from raiden.transfer.state import BalanceProofUnsignedState
+from raiden.transfer.state import BalanceProofUnsignedState, RouteState
 from raiden.transfer.state_change import Block, ReceiveUnlock
 from raiden.utils import sha3
 from raiden.utils.typing import BlockExpiration, BlockGasLimit, BlockNumber, MessageID, TokenAmount
@@ -196,8 +196,12 @@ def test_get_state_change_with_balance_proof():
         secret=sha3(factories.make_secret(next(counter))),
     )
     mediator_from_route, mediator_signed_transfer = make_from_route_from_counter(counter)
+
     action_init_mediator = ActionInitMediator(
-        routes=list(),
+        route_state=RouteState(
+            route=[factories.make_address(), factories.make_address()],
+            forward_channel_id=factories.make_channel_identifier(),
+        ),
         from_hop=mediator_from_route,
         from_transfer=mediator_signed_transfer,
         balance_proof=mediator_signed_transfer.balance_proof,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -343,7 +343,7 @@ def test_mediator_clear_pairs_after_batch_unlock(
     )
     from_hop = factories.make_hop_from_channel(channel_state)
     init_mediator = ActionInitMediator(
-        route_state=route_state,
+        route_states=[route_state],
         from_hop=from_hop,
         from_transfer=mediated_transfer,
         balance_proof=mediated_transfer.balance_proof,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -16,6 +16,7 @@ from raiden.transfer.state import (
     NODE_NETWORK_UNREACHABLE,
     HashTimeLockState,
     PendingLocksState,
+    RouteState,
     TokenNetworkGraphState,
     TokenNetworkState,
 )
@@ -336,10 +337,13 @@ def test_mediator_clear_pairs_after_batch_unlock(
         channel_state=channel_state, privkey=pkey, nonce=1, transferred_amount=0, lock=lock
     )
 
-    from_route = factories.make_route_from_channel(channel_state)
+    route_state = RouteState(
+        route=[channel_state.our_state.address, channel_state.partner_state.address],
+        forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+    )
     from_hop = factories.make_hop_from_channel(channel_state)
     init_mediator = ActionInitMediator(
-        routes=[from_route],
+        route_state=route_state,
         from_hop=from_hop,
         from_transfer=mediated_transfer,
         balance_proof=mediated_transfer.balance_proof,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -703,7 +703,14 @@ def test_init_with_maximum_pending_transfers_exceeded():
         )
     )
     channel_map = {channel1.identifier: channel1}
-    available_routes = [factories.make_route_from_channel(channel1)]
+    available_routes = [
+        RouteState(
+            # pylint: disable=E1101
+            route=[channel1.our_state.address, channel1.partner_state.address],
+            forward_channel_id=channel1.canonical_identifier.channel_identifier,
+        )
+    ]
+
     pseudo_random_generator = random.Random()
 
     transitions = list()

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -359,8 +359,8 @@ def test_state_wait_unlock_valid():
     assert search_for_item(iteration.events, EventUnlockSuccess, {})
     assert balance_proof
     assert complete
-    assert len(complete.route) == 1
-    assert complete.route[0] == balance_proof.recipient
+    assert len(complete.route) == 2
+    assert complete.route[1] == balance_proof.recipient
 
     assert balance_proof.recipient == setup.channel.partner_state.address
     assert complete.identifier == UNIT_TRANSFER_IDENTIFIER

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -155,7 +155,7 @@ def test_next_route():
     assert initiator_state.channel_identifier == channels[0].identifier, msg
     assert not state.cancelled_channels
 
-    iteration = initiator_manager.maybe_try_new_route(
+    iteration = initiator_manager.maybe_try_new_route_or_cancel(
         payment_state=state,
         initiator_state=initiator_state,
         transfer_description=initiator_state.transfer_description,
@@ -432,7 +432,6 @@ def test_refund_transfer_next_route():
     assert channels[0].partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -485,7 +484,6 @@ def test_refund_transfer_no_more_routes():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=setup.available_routes,
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1155,7 +1153,6 @@ def test_secret_reveal_cancel_other_transfers():
     assert channels[0].partner_state.address == refund_address
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1268,7 +1265,6 @@ def test_refund_after_secret_request():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=setup.available_routes,
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1331,7 +1327,6 @@ def test_clearing_payment_state_on_lock_expires_with_refunded_transfers():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,
@@ -1465,7 +1460,6 @@ def test_initiator_manager_drops_invalid_state_changes():
     transfer = factories.create(factories.LockedTransferSignedStateProperties())
     secret = factories.UNIT_SECRET
     cancel_route = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
         transfer=transfer,
         secret=secret,
         balance_proof=transfer.balance_proof,
@@ -1504,7 +1498,6 @@ def test_initiator_manager_drops_invalid_state_changes():
 
     transfer2 = factories.create(factories.LockedTransferSignedStateProperties(amount=2))
     cancel_route2 = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
         transfer=transfer2,
         balance_proof=transfer2.balance_proof,
         # pylint: disable=no-member
@@ -1557,7 +1550,6 @@ def test_regression_payment_unlock_failed_event_must_be_emitted_only_once():
     )
 
     state_change = ReceiveTransferRefundCancelRoute(
-        routes=channels.get_routes(),
         transfer=refund_transfer,
         secret=random_secret(),
         balance_proof=refund_transfer.balance_proof,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -159,7 +159,7 @@ def test_next_route():
         payment_state=state,
         initiator_state=initiator_state,
         transfer_description=initiator_state.transfer_description,
-        available_routes=channels.get_routes(),
+        candidate_route_states=channels.get_routes(),
         channelidentifiers_to_channels=channels.channel_map,
         pseudo_random_generator=prng,
         block_number=block_number,
@@ -359,7 +359,8 @@ def test_state_wait_unlock_valid():
     assert search_for_item(iteration.events, EventUnlockSuccess, {})
     assert balance_proof
     assert complete
-    assert complete.route == setup.available_routes[0].route
+    assert len(complete.route) == 1
+    assert complete.route[0] == balance_proof.recipient
 
     assert balance_proof.recipient == setup.channel.partner_state.address
     assert complete.identifier == UNIT_TRANSFER_IDENTIFIER

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -144,8 +144,8 @@ def test_is_safe_to_wait():
     assert not is_safe, "this is expiration must not be safe"
 
 
-def test_next_route_amount():
-    """ Routes that dont have enough available_balance must be ignored. """
+def test_is_channel_usable():
+    """ Check rules that determine if a channel can be used for transfers """
     reveal_timeout = 30
     timeout_blocks = reveal_timeout + 10
     amount = UNIT_TRANSFER_AMOUNT
@@ -157,61 +157,21 @@ def test_next_route_amount():
             ),
             NettingChannelStateProperties(our_state=NettingChannelEndStateProperties(balance=0)),
             NettingChannelStateProperties(
-                our_state=NettingChannelEndStateProperties(balance=amount)
+                our_state=NettingChannelEndStateProperties(),
+                reveal_timeout=timeout_blocks,
+                settle_timeout=timeout_blocks * 2,
             ),
         ]
     )
 
-    # the first available route should be used
-    chosen_channel, _ = channel.next_channel_from_routes(
-        channels.get_routes(0), channels.channel_map, amount, timeout_blocks
-    )
-    assert chosen_channel.identifier == channels[0].identifier
-
-    # additional routes do not change the order
-    chosen_channel, _ = channel.next_channel_from_routes(
-        channels.get_routes(0, 1), channels.channel_map, amount, timeout_blocks
-    )
-    assert chosen_channel.identifier == channels[0].identifier
-
-    chosen_channel, _ = channel.next_channel_from_routes(
-        channels.get_routes(2, 0), channels.channel_map, amount, timeout_blocks
-    )
-    assert chosen_channel.identifier == channels[2].identifier
+    # the first channel is usable
+    assert channel.is_channel_usable(channels[0], amount, timeout_blocks)
 
     # a channel without capacity must be skipped
-    chosen_channel, _ = channel.next_channel_from_routes(
-        channels.get_routes(1, 0), channels.channel_map, amount, timeout_blocks
-    )
-    assert chosen_channel.identifier == channels[0].identifier
+    assert not channel.is_channel_usable(channels[1], amount, timeout_blocks)
 
-
-def test_next_route_reveal_timeout():
-    """ Routes with a larger reveal timeout than timeout_blocks must be ignored. """
-    timeout_blocks = 10
-    identifiers = [make_canonical_identifier(channel_identifier=i) for i in range(1, 5)]
-
-    channels = make_channel_set(
-        [
-            NettingChannelStateProperties(
-                canonical_identifier=identifiers[0], reveal_timeout=timeout_blocks * 2
-            ),
-            NettingChannelStateProperties(
-                canonical_identifier=identifiers[1], reveal_timeout=timeout_blocks + 1
-            ),
-            NettingChannelStateProperties(
-                canonical_identifier=identifiers[2], reveal_timeout=timeout_blocks // 2
-            ),
-            NettingChannelStateProperties(
-                canonical_identifier=identifiers[3], reveal_timeout=timeout_blocks
-            ),
-        ]
-    )
-
-    chosen_channel, _ = channel.next_channel_from_routes(
-        channels.get_routes(0, 1, 2, 3), channels.channel_map, UNIT_TRANSFER_AMOUNT, timeout_blocks
-    )
-    assert chosen_channel.identifier == channels[2].identifier
+    # channels
+    assert not channel.is_channel_usable(channels[2], reveal_timeout, timeout_blocks)
 
 
 def test_next_transfer_pair():
@@ -233,12 +193,14 @@ def test_next_transfer_pair():
         ]
     )
 
+    route_state_table = channels.get_routes()
     pair, events = mediator.forward_transfer_pair(
-        payer_transfer,
-        channels.get_routes(0),
-        channels.channel_map,
-        pseudo_random_generator,
-        block_number,
+        payer_transfer=payer_transfer,
+        route_state=route_state_table[0],
+        route_state_table=route_state_table,
+        channelidentifiers_to_channels=channels.channel_map,
+        pseudo_random_generator=pseudo_random_generator,
+        block_number=block_number,
     )
 
     assert pair.payer_transfer == payer_transfer
@@ -837,21 +799,21 @@ def test_mediate_transfer():
         channels[0], LockedTransferSignedStateProperties(expiration=30)
     )
 
-    mediator_state = MediatorTransferState(
-        secrethash=UNIT_SECRETHASH, routes=channels.get_routes()
-    )
+    route_states = channels.get_routes(1)
+    mediator_state = MediatorTransferState(secrethash=UNIT_SECRETHASH, routes=route_states)
+
     iteration = mediator.mediate_transfer(
-        mediator_state,
-        channels.get_routes(1),
-        channels[0],
-        channels.channel_map,
-        channels.nodeaddresses_to_networkstates,
-        pseudo_random_generator,
-        payer_transfer,
-        block_number,
+        state=mediator_state,
+        candidate_route_states=route_states,
+        payer_channel=channels[0],
+        channelidentifiers_to_channels=channels.channel_map,
+        nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
+        pseudo_random_generator=pseudo_random_generator,
+        payer_transfer=payer_transfer,
+        block_number=block_number,
     )
 
-    assert search_for_item(
+    item = search_for_item(
         iteration.events,
         SendLockedTransfer,
         {
@@ -868,6 +830,8 @@ def test_mediate_transfer():
             },
         },
     )
+
+    assert item is not None
 
 
 def test_init_mediator():
@@ -1148,10 +1112,12 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
     }
 
     init_state_change = ActionInitMediator(
-        route_state=RouteState(
-            route=[our_state.address, attacked_channel.partner_state.address],
-            forward_channel_id=attacked_channel.canonical_identifier.channel_identifier,
-        ),
+        route_states=[
+            RouteState(
+                route=[our_state.address, attacked_channel.partner_state.address],
+                forward_channel_id=attacked_channel.canonical_identifier.channel_identifier,
+            )
+        ],
         from_hop=from_hop,
         from_transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
@@ -1425,7 +1391,7 @@ def test_mediator_lock_expired_with_new_block():
     mediator_state = MediatorTransferState(UNIT_SECRETHASH, channels.get_routes())
     iteration = mediator.mediate_transfer(
         state=mediator_state,
-        possible_routes=channels.get_routes(1),
+        candidate_route_states=channels.get_routes(0),
         payer_channel=channels[0],
         channelidentifiers_to_channels=channels.channel_map,
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
@@ -1481,7 +1447,7 @@ def test_mediator_must_not_send_lock_expired_when_channel_is_closed():
     mediator_state = MediatorTransferState(UNIT_SECRETHASH, channels.get_routes())
     iteration = mediator.mediate_transfer(
         state=mediator_state,
-        possible_routes=channels.get_routes(1),
+        candidate_route_states=channels.get_routes(1),
         payer_channel=channels[0],
         channelidentifiers_to_channels=channels.channel_map,
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
@@ -1800,7 +1766,7 @@ def test_filter_reachable_routes():
     nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP1, HOP2])
 
     filtered_routes = mediator.filter_reachable_routes(
-        routes=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
+        route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
     )
 
     assert possible_routes[0] in filtered_routes
@@ -1810,7 +1776,7 @@ def test_filter_reachable_routes():
     nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP2])
 
     filtered_routes = mediator.filter_reachable_routes(
-        routes=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
+        route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
     )
 
     assert possible_routes[0] not in filtered_routes
@@ -1820,7 +1786,7 @@ def test_filter_reachable_routes():
     nodeaddresses_to_networkstates = factories.make_node_availability_map([])
 
     filtered_routes = mediator.filter_reachable_routes(
-        routes=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
+        route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
     )
 
     assert possible_routes[0] not in filtered_routes
@@ -1922,7 +1888,8 @@ def test_next_transfer_pair_with_fees_deducted():
 
     pair, events = mediator.forward_transfer_pair(
         payer_transfer=payer_transfer,
-        available_routes=channels.get_routes(0),
+        route_state=channels.get_route(0),
+        route_state_table=channels.get_routes(),
         channelidentifiers_to_channels=channels.channel_map,
         pseudo_random_generator=random.Random(),
         block_number=2,
@@ -2022,8 +1989,8 @@ def test_sanity_check_for_refund_transfer_with_fees():
         ),
     )
 
-    assert from_transfer.route[0] == factories.UNIT_OUR_ADDRESS, "not matching"
-    assert from_transfer.route[1] == next_hop_address, "not right next hop"
+    assert from_transfer.routes[0][0] == factories.UNIT_OUR_ADDRESS, "not matching"
+    assert from_transfer.routes[0][1] == next_hop_address, "not right next hop"
 
     iteration = mediator.state_transition(
         mediator_state=None,
@@ -2077,10 +2044,7 @@ def test_receive_unlock():
     )
     payee_transfer = factories.create(factories.LockedTransferUnsignedStateProperties())
     wrong_pair = MediationPairState(
-        route=RouteState([], -1),
-        payer_transfer=payer_transfer,
-        payee_address=HOP2,
-        payee_transfer=payee_transfer,
+        payer_transfer=payer_transfer, payee_address=HOP2, payee_transfer=payee_transfer
     )
     state.transfers_pair = [wrong_pair]
     iteration = mediator.state_transition(
@@ -2090,7 +2054,6 @@ def test_receive_unlock():
 
     payer_transfer = factories.create(factories.LockedTransferSignedStateProperties())
     pair = MediationPairState(
-        route=RouteState([], -1),
         payer_transfer=payer_transfer,
         payee_address=UNIT_TRANSFER_TARGET,
         payee_transfer=payee_transfer,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
 import random
 from copy import deepcopy
+from dataclasses import replace
 
 import pytest
 
@@ -329,7 +330,7 @@ def test_events_for_refund():
     pseudo_random_generator = random.Random()
 
     our_state = factories.NettingChannelEndStateProperties(balance=amount)
-    partner_state = factories.replace(our_state, address=UNIT_TRANSFER_SENDER)
+    partner_state = replace(our_state, address=UNIT_TRANSFER_SENDER)
     refund_channel = factories.create(
         factories.NettingChannelStateProperties(our_state=our_state, partner_state=partner_state)
     )
@@ -1002,9 +1003,11 @@ def test_no_valid_routes():
         channels[0], LockedTransferSignedStateProperties(initiator=HOP1)
     )
 
+    state_change = mediator_make_init_action(channels, from_transfer)
+
     iteration = mediator.state_transition(
         mediator_state=None,
-        state_change=mediator_make_init_action(channels, from_transfer),
+        state_change=state_change,
         channelidentifiers_to_channels=channels.channel_map,
         nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=random.Random(),
@@ -1115,7 +1118,7 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
 
     # C's channel with the Attacker node A2
     our_state = factories.NettingChannelEndStateProperties(balance=amount)
-    partner_state = factories.replace(our_state, address=UNIT_TRANSFER_SENDER)
+    partner_state = replace(our_state, address=UNIT_TRANSFER_SENDER)
 
     attacked_channel = factories.create(
         factories.NettingChannelStateProperties(our_state=our_state)
@@ -1139,14 +1142,16 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
         ),
     )
 
-    available_routes = [factories.make_route_from_channel(attacked_channel)]
     channel_map = {
         bc_channel.identifier: bc_channel,
         attacked_channel.identifier: attacked_channel,
     }
 
     init_state_change = ActionInitMediator(
-        routes=available_routes,
+        route_state=RouteState(
+            route=[our_state.address, attacked_channel.partner_state.address],
+            forward_channel_id=attacked_channel.canonical_identifier.channel_identifier,
+        ),
         from_hop=from_hop,
         from_transfer=from_transfer,
         balance_proof=from_transfer.balance_proof,
@@ -1344,13 +1349,14 @@ def test_mediate_transfer_with_maximum_pending_transfers_exceeded():
         [
             NettingChannelStateProperties(
                 make_canonical_identifier(channel_identifier=1),
+                our_state=NettingChannelEndStateProperties.OUR_STATE,
                 partner_state=NettingChannelEndStateProperties(
                     balance=balance, address=UNIT_TRANSFER_SENDER
                 ),
             ),
             NettingChannelStateProperties(
                 make_canonical_identifier(channel_identifier=2),
-                our_state=NettingChannelEndStateProperties(balance=balance),
+                our_state=replace(NettingChannelEndStateProperties.OUR_STATE, balance=balance),
             ),
         ]
     )
@@ -1369,6 +1375,7 @@ def test_mediate_transfer_with_maximum_pending_transfers_exceeded():
                 canonical_identifier=factories.make_canonical_identifier(channel_identifier=2),
                 transferred_amount=0,
                 message_identifier=index,
+                route=[factories.UNIT_OUR_ADDRESS, channels.channels[1].partner_state.address],
             ),
             calculate_locksroot=True,
             allow_invalid=True,
@@ -1770,14 +1777,23 @@ def test_filter_reachable_routes():
     was unreachable and became reachable before the locked transfer expired.
     Expected result is to route the transfer through this node.
     """
+    target = factories.make_address()
     partner1 = factories.NettingChannelEndStateProperties(address=HOP1)
-    partner2 = factories.replace(partner1, address=HOP2)
+    partner2 = replace(partner1, address=HOP2)
     channel1 = factories.create(factories.NettingChannelStateProperties(partner_state=partner1))
     channel2 = factories.create(factories.NettingChannelStateProperties(partner_state=partner2))
 
     possible_routes = [
-        factories.make_route_from_channel(channel1),
-        factories.make_route_from_channel(channel2),
+        RouteState(
+            # pylint: disable=E1101
+            route=[channel1.our_state.address, partner1.address, target],
+            forward_channel_id=channel1.canonical_identifier.channel_identifier,
+        ),
+        RouteState(
+            # pylint: disable=E1101
+            route=[channel1.our_state.address, partner2.address, target],
+            forward_channel_id=channel2.canonical_identifier.channel_identifier,
+        ),
     ]
 
     # Both nodes are online
@@ -1827,9 +1843,7 @@ def test_node_change_network_state_reachable_node():
     )
     setup.channels.channels.append(payer_channel)
 
-    possible_routes = [
-        factories.make_route_from_channel(channel) for channel in setup.channel_map.values()
-    ]
+    possible_routes = setup.channels.get_routes()
 
     lock_expiration = UNIT_REVEAL_TIMEOUT * 2
     received_transfer = factories.create(
@@ -1929,7 +1943,7 @@ def test_backward_transfer_pair_with_fees_deducted():
     fee = 5
 
     end_state = factories.NettingChannelEndStateProperties(balance=amount + fee)
-    partner_state = factories.replace(end_state, address=UNIT_TRANSFER_SENDER)
+    partner_state = replace(end_state, address=UNIT_TRANSFER_SENDER)
     refund_channel = factories.create(
         factories.NettingChannelStateProperties(our_state=end_state, partner_state=partner_state)
     )
@@ -1978,25 +1992,38 @@ def test_sanity_check_for_refund_transfer_with_fees():
             NettingChannelStateProperties(
                 mediation_fee=UNIT_TRANSFER_FEE,
                 canonical_identifier=make_canonical_identifier(channel_identifier=1),
+                our_state=NettingChannelEndStateProperties.OUR_STATE,
                 partner_state=NettingChannelEndStateProperties(
                     balance=UNIT_TRANSFER_AMOUNT + UNIT_TRANSFER_FEE, address=UNIT_TRANSFER_SENDER
                 ),
             ),
             NettingChannelStateProperties(
                 make_canonical_identifier(channel_identifier=2),
-                our_state=NettingChannelEndStateProperties(balance=UNIT_TRANSFER_AMOUNT - 1),
+                our_state=replace(
+                    NettingChannelEndStateProperties.OUR_STATE, balance=UNIT_TRANSFER_AMOUNT - 1
+                ),
             ),
             NettingChannelStateProperties(
                 make_canonical_identifier(channel_identifier=3),
-                our_state=NettingChannelEndStateProperties(balance=0),
+                our_state=replace(NettingChannelEndStateProperties.OUR_STATE, balance=0),
             ),
         ]
     )
+
+    next_hop_address = channels[1].partner_state.address
+
     from_transfer_amount = UNIT_TRANSFER_AMOUNT + UNIT_TRANSFER_FEE
     from_transfer = factories.make_signed_transfer_for(
-        channels[0],
-        LockedTransferSignedStateProperties(initiator=HOP1, amount=from_transfer_amount),
+        channel_state=channels[0],
+        properties=LockedTransferSignedStateProperties(
+            initiator=UNIT_TRANSFER_SENDER,
+            amount=from_transfer_amount,
+            route=[factories.UNIT_OUR_ADDRESS, next_hop_address, factories.UNIT_TRANSFER_TARGET],
+        ),
     )
+
+    assert from_transfer.route[0] == factories.UNIT_OUR_ADDRESS, "not matching"
+    assert from_transfer.route[1] == next_hop_address, "not right next hop"
 
     iteration = mediator.state_transition(
         mediator_state=None,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -316,7 +316,7 @@ def test_regression_mediator_task_no_routes():
 
     init_state_change = ActionInitMediator(
         from_hop=channels.get_hop(0),
-        route_state=channels.get_routes()[0],
+        route_states=channels.get_routes(),
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
         sender=payer_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -406,7 +406,7 @@ def test_regression_mediator_not_update_payer_state_twice():
 
     init_state_change = ActionInitMediator(
         from_hop=payer_route,
-        route_state=pair.get_route(1),
+        route_states=pair.get_routes(),
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
         sender=payer_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -137,9 +137,7 @@ def test_regression_send_refund():
     pseudo_random_generator = random.Random()
     setup = factories.make_transfers_pair(3)
 
-    mediator_state = MediatorTransferState(
-        secrethash=UNIT_SECRETHASH, routes=setup.channels.get_hops()
-    )
+    mediator_state = MediatorTransferState(secrethash=UNIT_SECRETHASH, routes=[])
     mediator_state.transfers_pair = setup.transfers_pair
 
     last_pair = setup.transfers_pair[-1]

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -315,8 +315,8 @@ def test_regression_mediator_task_no_routes():
     )
 
     init_state_change = ActionInitMediator(
-        routes=channels.get_routes(),
         from_hop=channels.get_hop(0),
+        route_state=channels.get_routes()[0],
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
         sender=payer_transfer.balance_proof.sender,  # pylint: disable=no-member
@@ -404,10 +404,9 @@ def test_regression_mediator_not_update_payer_state_twice():
     payer_route = factories.make_hop_from_channel(payer_channel)
     payer_transfer = factories.make_signed_transfer_for(payer_channel, LONG_EXPIRATION)
 
-    available_routes = [factories.make_route_from_channel(payee_channel)]
     init_state_change = ActionInitMediator(
-        routes=available_routes,
         from_hop=payer_route,
+        route_state=pair.get_route(1),
         from_transfer=payer_transfer,
         balance_proof=payer_transfer.balance_proof,
         sender=payer_transfer.balance_proof.sender,  # pylint: disable=no-member

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -156,13 +156,10 @@ def test_regression_send_refund():
     )
 
     # All three channels have been used
-    routes = []
-
     refund_state_change = ReceiveTransferRefund(
         transfer=received_transfer,
         balance_proof=received_transfer.balance_proof,
         sender=received_transfer.balance_proof.sender,  # pylint: disable=no-member
-        routes=routes,
     )
 
     iteration = mediator.handle_refundtransfer(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
@@ -112,13 +112,12 @@ def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
 
 def test_invalid_instantiation_receive_transfer_refund(additional_args):
     wrong_type_transfer = factories.create(factories.TransferDescriptionProperties())
-    routes = list()
     secret = factories.UNIT_SECRET
 
     with pytest.raises(ValueError):
-        ReceiveTransferRefund(transfer=wrong_type_transfer, routes=routes, **additional_args)
+        ReceiveTransferRefund(transfer=wrong_type_transfer, **additional_args)
 
     with pytest.raises(ValueError):
         ReceiveTransferRefundCancelRoute(
-            transfer=wrong_type_transfer, routes=routes, secret=secret, **additional_args
+            transfer=wrong_type_transfer, secret=secret, **additional_args
         )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
@@ -79,21 +79,28 @@ def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
         node_address=factories.make_address(),
         channel_identifier=factories.make_channel_identifier(),
     )
+
+    route_state = RouteState(
+        route=[factories.make_address()], forward_channel_id=factories.make_channel_identifier()
+    )
+
     not_a_route_state = object()
     valid_transfer = factories.create(factories.LockedTransferSignedStateProperties())
     wrong_type_transfer = factories.create(factories.TransferDescriptionProperties())
-    routes = list()
 
     with pytest.raises(ValueError):
         ActionInitMediator(
-            from_transfer=wrong_type_transfer, from_hop=hop_state, routes=routes, **additional_args
+            from_transfer=wrong_type_transfer,
+            from_hop=hop_state,
+            route_state=route_state,
+            **additional_args,
         )
 
     with pytest.raises(ValueError):
         ActionInitMediator(
             from_transfer=valid_transfer,
             from_hop=not_a_route_state,
-            routes=routes,
+            route_state=route_state,
             **additional_args,
         )
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_state_and_state_change.py
@@ -42,7 +42,6 @@ def test_invalid_instantiation_locked_transfer_state():
 
 def test_invalid_instantiation_mediation_pair_state():
     valid = MediationPairState(
-        route=RouteState([], -1),
         payer_transfer=factories.create(factories.LockedTransferSignedStateProperties()),
         payee_address=factories.make_address(),
         payee_transfer=factories.create(factories.LockedTransferUnsignedStateProperties()),
@@ -92,7 +91,7 @@ def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
         ActionInitMediator(
             from_transfer=wrong_type_transfer,
             from_hop=hop_state,
-            route_state=route_state,
+            route_states=[route_state],
             **additional_args,
         )
 
@@ -100,7 +99,7 @@ def test_invalid_instantiation_action_init_mediator_and_target(additional_args):
         ActionInitMediator(
             from_transfer=valid_transfer,
             from_hop=not_a_route_state,
-            route_state=route_state,
+            route_states=[route_state],
             **additional_args,
         )
 

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -1,4 +1,5 @@
 from raiden.messages import LockedTransfer, RouteMetadata
+from raiden.routing import resolve_route
 from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils import factories
 from raiden.utils.signer import LocalSigner, recover
@@ -79,3 +80,28 @@ def test_can_round_trip_serialize_locked_transfer():
 
     as_dict = DictSerializer.serialize(locked_transfer)
     assert DictSerializer.deserialize(as_dict) == locked_transfer
+
+
+def test_resolve_route(netting_channel_state, chain_state, token_network_state):
+    route_metadata = factories.create(
+        factories.RouteMetadataProperties(
+            routes=[
+                netting_channel_state.our_state.address,
+                netting_channel_state.partner_state.address,
+            ]
+        )
+    )
+
+    route_state = resolve_route(
+        route_metadata=route_metadata,
+        token_network_address=token_network_state.address,
+        chain_state=chain_state,
+    )
+
+    msg = "route resolved with wrong channel id"
+    channel_id = netting_channel_state.canonical_identifier.channel_identifier
+    assert route_state.forward_channel_id == channel_id, msg
+
+
+def test_mediator_forwards_pruned_route():
+    pass

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -1,4 +1,4 @@
-from raiden.messages import LockedTransfer, RouteMetadata
+from raiden.messages import LockedTransfer, Metadata, RouteMetadata
 from raiden.routing import resolve_route
 from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils import factories
@@ -25,6 +25,30 @@ def test_route_metadata_hashing():
     )
 
     inverted_route_hash = inverted_route_metadata.hash
+
+    assert one_hash != inverted_route_hash, "route metadata with inverted routes still match"
+
+
+def test_metadata_hashing():
+    properties = factories.MetadataProperties()
+    one_metadata = factories.create(properties)
+    assert isinstance(one_metadata, Metadata)
+    one_hash = one_metadata.hash
+
+    another_metadata = factories.create(properties)
+    another_hash = another_metadata.hash
+
+    assert one_hash == another_hash, "route metadata with same routes do not match"
+
+    inverted_route_metadata = factories.create(
+        factories.RouteMetadataProperties(route=[factories.HOP2, factories.HOP1])
+    )
+
+    metadata_with_inverted_route = factories.create(
+        factories.MetadataProperties(routes=[inverted_route_metadata])
+    )
+
+    inverted_route_hash = metadata_with_inverted_route.hash
 
     assert one_hash != inverted_route_hash, "route metadata with inverted routes still match"
 

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -1,4 +1,4 @@
-from raiden.messages import RouteMetadata
+from raiden.messages import LockedTransfer, RouteMetadata
 from raiden.tests.utils import factories
 from raiden.utils.signer import LocalSigner
 
@@ -25,3 +25,11 @@ def test_route_metadata_hashing():
     inverted_route_hash = inverted_route_metadata.hash
 
     assert one_hash != inverted_route_hash, "route metadata with inverted routes still match"
+
+
+def test_locked_transfer_with_route_metadata():
+    locked_transfer = factories.create(factories.LockedTransferProperties())
+    assert isinstance(locked_transfer, LockedTransfer)
+    assert isinstance(locked_transfer.route_metadata, RouteMetadata)
+
+    assert locked_transfer.route_metadata.routes == [factories.HOP1, factories.HOP2]

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -32,4 +32,20 @@ def test_locked_transfer_with_route_metadata():
     assert isinstance(locked_transfer, LockedTransfer)
     assert isinstance(locked_transfer.route_metadata, RouteMetadata)
 
+    # pylint: disable=E1101
     assert locked_transfer.route_metadata.routes == [factories.HOP1, factories.HOP2]
+
+
+def test_locked_transfer_additional_hash_contains_route_metadata_hash():
+    one_locked_transfer = factories.create(factories.LockedTransferProperties())
+    another_locked_transfer = factories.create(
+        factories.LockedTransferProperties(
+            route_metadata=factories.create(
+                factories.RouteMetadataProperties(routes=[factories.HOP2, factories.HOP1])
+            )
+        )
+    )
+
+    assert (
+        one_locked_transfer.message_hash != another_locked_transfer.message_hash
+    ), "LockedTransfers with different routes should have different message hashes"

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -21,7 +21,7 @@ def test_route_metadata_hashing():
     assert one_hash == another_hash, "route metadata with same routes do not match"
 
     inverted_route_metadata = factories.create(
-        factories.RouteMetadataProperties(routes=[factories.HOP2, factories.HOP1])
+        factories.RouteMetadataProperties(route=[factories.HOP2, factories.HOP1])
     )
 
     inverted_route_hash = inverted_route_metadata.hash
@@ -35,7 +35,7 @@ def test_locked_transfer_with_route_metadata():
     assert isinstance(locked_transfer.route_metadata, RouteMetadata)
 
     # pylint: disable=E1101
-    assert locked_transfer.route_metadata.routes == [factories.HOP1, factories.HOP2]
+    assert locked_transfer.route_metadata.route == [factories.HOP1, factories.HOP2]
 
 
 def test_locked_transfer_additional_hash_contains_route_metadata_hash():
@@ -43,7 +43,7 @@ def test_locked_transfer_additional_hash_contains_route_metadata_hash():
     another_locked_transfer = factories.create(
         factories.LockedTransferProperties(
             route_metadata=factories.create(
-                factories.RouteMetadataProperties(routes=[factories.HOP2, factories.HOP1])
+                factories.RouteMetadataProperties(route=[factories.HOP2, factories.HOP1])
             )
         )
     )
@@ -59,7 +59,7 @@ def test_changing_route_metadata_will_invalidate_lock_transfer_signature():
     )
 
     new_route_metadata = factories.create(
-        factories.RouteMetadataProperties(routes=[factories.HOP2, factories.HOP1])
+        factories.RouteMetadataProperties(route=[factories.HOP2, factories.HOP1])
     )
 
     assert ADDRESS == recover(
@@ -85,7 +85,7 @@ def test_can_round_trip_serialize_locked_transfer():
 def test_resolve_route(netting_channel_state, chain_state, token_network_state):
     route_metadata = factories.create(
         factories.RouteMetadataProperties(
-            routes=[
+            route=[
                 netting_channel_state.our_state.address,
                 netting_channel_state.partner_state.address,
             ]

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -1,4 +1,4 @@
-from raiden.messages import LockedTransfer, Metadata, RouteMetadata
+from raiden.messages import LockedTransfer, Metadata, RefundTransfer, RouteMetadata
 from raiden.routing import resolve_routes
 from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils import factories
@@ -7,6 +7,15 @@ from raiden.utils.signer import LocalSigner, recover
 PARTNER_PRIVKEY, PARTNER_ADDRESS = factories.make_privkey_address()
 PRIVKEY, ADDRESS = factories.make_privkey_address()
 signer = LocalSigner(PRIVKEY)
+
+
+def test_can_create_refund_transfer_messages():
+    refund_transfer = factories.create(factories.RefundTransferProperties())
+
+    assert refund_transfer is not None
+    assert isinstance(refund_transfer, RefundTransfer)
+    assert isinstance(refund_transfer.metadata, Metadata)
+    assert len(refund_transfer.metadata.routes) == 1
 
 
 def test_route_metadata_hashing():

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -1,4 +1,5 @@
 from raiden.messages import LockedTransfer, RouteMetadata
+from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils import factories
 from raiden.utils.signer import LocalSigner, recover
 
@@ -69,3 +70,12 @@ def test_changing_route_metadata_will_invalidate_lock_transfer_signature():
     assert ADDRESS != recover(
         one_locked_transfer._data_to_sign(), one_locked_transfer.signature
     ), "signature should not be valid after data being altered"
+
+
+def test_can_round_trip_serialize_locked_transfer():
+    locked_transfer = factories.create(
+        factories.LockedTransferProperties(sender=ADDRESS, pkey=PRIVKEY)
+    )
+
+    as_dict = DictSerializer.serialize(locked_transfer)
+    assert DictSerializer.deserialize(as_dict) == locked_transfer

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -1,0 +1,27 @@
+from raiden.messages import RouteMetadata
+from raiden.tests.utils import factories
+from raiden.utils.signer import LocalSigner
+
+PARTNER_PRIVKEY, PARTNER_ADDRESS = factories.make_privkey_address()
+PRIVKEY, ADDRESS = factories.make_privkey_address()
+signer = LocalSigner(PRIVKEY)
+
+
+def test_route_metadata_hashing():
+    properties = factories.RouteMetadataProperties()
+    one_route_metadata = factories.create(properties)
+    assert isinstance(one_route_metadata, RouteMetadata)
+    one_hash = one_route_metadata.hash
+
+    another_route_metadata = factories.create(properties)
+    another_hash = another_route_metadata.hash
+
+    assert one_hash == another_hash, "route metadata with same routes do not match"
+
+    inverted_route_metadata = factories.create(
+        factories.RouteMetadataProperties(routes=[factories.HOP2, factories.HOP1])
+    )
+
+    inverted_route_hash = inverted_route_metadata.hash
+
+    assert one_hash != inverted_route_hash, "route metadata with inverted routes still match"

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1092,9 +1092,9 @@ def mediator_make_init_action(
     channels: ChannelSet, transfer: LockedTransferSignedState
 ) -> ActionInitMediator:
     def get_forward_channel(route: List[Address]) -> Optional[ChannelID]:
-        for candidate_channel in channels.channels:
-            if route[1] == candidate_channel.partner_state.address:
-                return candidate_channel.identifier
+        for channel_state in channels.channels:
+            if route[1] == channel_state.partner_state.address:
+                return channel_state.identifier
         return None
 
     forwards = [get_forward_channel(route) for route in transfer.routes]

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1276,6 +1276,13 @@ def make_node_availability_map(nodes):
     return {node: NODE_NETWORK_REACHABLE for node in nodes}
 
 
+def make_route_from_channel(channel: NettingChannelState) -> RouteState:
+    return RouteState(
+        route=[channel.our_state.address, channel.partner_state.address],
+        forward_channel_id=channel.canonical_identifier.channel_identifier,
+    )
+
+
 @dataclass(frozen=True)
 class RouteProperties(Properties):
     address1: Address

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -715,16 +715,17 @@ def _(properties, defaults=None) -> LockedTransferUnsignedState:
     netting_channel_state = create(
         NettingChannelStateProperties(canonical_identifier=balance_proof.canonical_identifier)
     )
+
     route_state = RouteState(
         # pylint: disable=E1101
-        route=[netting_channel_state.partner_state.address],
+        route=[netting_channel_state.partner_state.address, transfer.target],
         forward_channel_id=netting_channel_state.canonical_identifier.channel_identifier,
     )
 
     return LockedTransferUnsignedState(
         balance_proof=balance_proof,
         lock=lock,
-        route_state=route_state,
+        route_states=[route_state],
         **transfer.partial_dict("initiator", "target", "payment_identifier", "token"),
     )
 
@@ -785,12 +786,12 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
     route = params.pop("route")
     # pylint: disable=E1101
     route_metadata = [transfer.recipient, transfer.target] if route == EMPTY else route
-    params["route_metadata"] = RouteMetadata(route=route_metadata)
+    params["metadata"] = Metadata(routes=[RouteMetadata(route=route_metadata)])
 
     locked_transfer = LockedTransfer(lock=lock, **params, signature=EMPTY_SIGNATURE)
     locked_transfer.sign(signer)
 
-    assert locked_transfer.route_metadata
+    assert locked_transfer.metadata
     assert locked_transfer.sender == sender
 
     balance_proof = balanceproof_from_envelope(locked_transfer)
@@ -809,20 +810,20 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
         lock=lock,
         initiator=locked_transfer.initiator,
         target=locked_transfer.target,
-        route=locked_transfer.route_metadata.route,
+        routes=[rm.route for rm in locked_transfer.metadata.routes],
     )
 
 
 @dataclass(frozen=True)
 class LockedTransferProperties(LockedTransferSignedStateProperties):
     fee: FeeAmount = EMPTY
-    route_metadata: RouteMetadata = EMPTY
+    metadata: Metadata = EMPTY
     TARGET_TYPE = LockedTransfer
 
 
 LockedTransferProperties.DEFAULTS = LockedTransferProperties(
     **replace(LockedTransferSignedStateProperties.DEFAULTS, locksroot=GENERATE).__dict__,
-    route_metadata=GENERATE,
+    metadata=GENERATE,
     fee=0,
 )
 
@@ -841,8 +842,8 @@ def prepare_locked_transfer(properties, defaults):
     params["signature"] = EMPTY_SIGNATURE
 
     params.pop("route")
-    if params["route_metadata"] == GENERATE:
-        params["route_metadata"] = create(RouteMetadataProperties())
+    if params["metadata"] == GENERATE:
+        params["metadata"] = create(MetadataProperties())
 
     return params, LocalSigner(params.pop("pkey")), params.pop("sender")
 
@@ -1014,10 +1015,13 @@ class ChannelSet:
         return [self.get_hop(index) for index in (args or range(len(self.channels)))]
 
     def get_route(self, channel_index: int) -> RouteState:
+        """ Creates an *outbound* RouteState, based on channel our/partner addresses. """
+
         channel = self.channels[channel_index]
+        route = [channel.our_state.address, channel.partner_state.address]
+
         return RouteState(
-            route=[channel.our_state.address, channel.partner_state.address],
-            forward_channel_id=channel.canonical_identifier.channel_identifier,
+            route=route, forward_channel_id=channel.canonical_identifier.channel_identifier
         )
 
     def get_routes(self, *args) -> List[RouteState]:
@@ -1086,13 +1090,14 @@ def mediator_make_init_action(
     channels: ChannelSet, transfer: LockedTransferSignedState
 ) -> ActionInitMediator:
 
-    route_state = RouteState(
-        route=transfer.route, forward_channel_id=channels.get_hop(1).channel_identifier
-    )
+    route_states = [
+        RouteState(route=route, forward_channel_id=channels.get_hop(1).channel_identifier)
+        for route in transfer.routes
+    ]
 
     return ActionInitMediator(
         from_hop=channels.get_hop(0),
-        route_state=route_state,
+        route_states=route_states,
         from_transfer=transfer,
         balance_proof=transfer.balance_proof,
         sender=transfer.balance_proof.sender,
@@ -1162,6 +1167,13 @@ def make_transfers_pair(
         assert is_valid, msg
 
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
+        route_states = [
+            RouteState(
+                route=channels[payer_index:],
+                forward_channel_id=channels[payee_index].canonical_identifier.channel_identifier,
+            )
+        ]
+
         lockedtransfer_event = channel.send_lockedtransfer(
             channel_state=channels[payee_index],
             initiator=UNIT_TRANSFER_INITIATOR,
@@ -1171,10 +1183,7 @@ def make_transfers_pair(
             payment_identifier=UNIT_TRANSFER_IDENTIFIER,
             expiration=lock_expiration,
             secrethash=UNIT_SECRETHASH,
-            route_state=RouteState(
-                route=channels[payer_index:],
-                forward_channel_id=channels[payee_index].canonical_identifier.channel_identifier,
-            ),
+            route_states=route_states,
         )
         assert lockedtransfer_event
 
@@ -1187,7 +1196,6 @@ def make_transfers_pair(
         sent_transfer = lockedtransfer_event.transfer
 
         pair = MediationPairState(
-            route=RouteState([], 0),
             payer_transfer=received_transfer,
             payee_address=lockedtransfer_event.recipient,
             payee_transfer=sent_transfer,

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -14,7 +14,6 @@ from raiden.messages import (
     RefundTransfer,
     RouteMetadata,
     Unlock,
-    lockedtransfersigned_from_message,
 )
 from raiden.transfer import channel, token_network, views
 from raiden.transfer.channel import compute_locksroot
@@ -41,6 +40,7 @@ from raiden.transfer.state import (
     RouteState,
     TokenNetworkState,
     TransactionExecutionStatus,
+    balanceproof_from_envelope,
     message_identifier_from_prng,
 )
 from raiden.transfer.state_change import ContractReceiveChannelNew, ContractReceiveRouteNew
@@ -266,19 +266,6 @@ def make_hop_to_channel(channel_state: NettingChannelState = EMPTY) -> HopState:
     return HopState(channel_state.our_state.address, channel_state.identifier)
 
 
-def make_route_from_channel(channel_state: NettingChannelState = EMPTY) -> RouteState:
-    channel_state = if_empty(channel_state, create(NettingChannelStateProperties()))
-    return RouteState(
-        [channel_state.our_state.address, channel_state.partner_state.address],
-        channel_state.identifier,
-    )
-
-
-def make_route_to_channel(channel_state: NettingChannelState = EMPTY) -> RouteState:
-    channel_state = if_empty(channel_state, create(NettingChannelStateProperties()))
-    return RouteState([channel_state.our_state.address], channel_state.identifier)
-
-
 # CONSTANTS
 # In this module constants are in the bottom because we need some of the
 # factories.
@@ -298,6 +285,9 @@ UNIT_CANONICAL_ID = CanonicalIdentifier(
     token_network_address=UNIT_TOKEN_NETWORK_ADDRESS,
     channel_identifier=UNIT_CHANNEL_ID,
 )
+UNIT_OUR_KEY = b"ourourourourourourourourourourou"
+UNIT_OUR_ADDRESS = privatekey_to_address(UNIT_OUR_KEY)
+
 UNIT_PAYMENT_NETWORK_IDENTIFIER = b"paymentnetworkidentifier"
 UNIT_TRANSFER_IDENTIFIER = 37
 UNIT_TRANSFER_INITIATOR = b"initiatorinitiatorin"
@@ -406,6 +396,14 @@ class NettingChannelEndStateProperties(Properties):
 
 NettingChannelEndStateProperties.DEFAULTS = NettingChannelEndStateProperties(
     address=None, privatekey=None, balance=100, pending_locks=None
+)
+
+NettingChannelEndStateProperties.OUR_STATE = NettingChannelEndStateProperties(
+    address=UNIT_OUR_ADDRESS,
+    privatekey=UNIT_OUR_KEY,
+    balance=100,
+    merkletree_leaves=None,
+    merkletree_width=0,
 )
 
 
@@ -672,6 +670,8 @@ class LockedTransferUnsignedStateProperties(BalanceProofProperties):
     payment_identifier: PaymentID = EMPTY
     token: TokenAddress = EMPTY
     secret: Secret = EMPTY
+    route_state: RouteState = EMPTY
+
     TARGET_TYPE = LockedTransferUnsignedState
 
 
@@ -701,24 +701,51 @@ def _(properties, defaults=None) -> LockedTransferUnsignedState:
     if transfer.locksroot == LOCKSROOT_OF_NO_LOCKS:
         transfer = replace(transfer, locksroot=keccak(lock.encoded))
 
+    balance_proof = create(transfer.extract(BalanceProofProperties))
+    netting_channel_state = create(
+        NettingChannelStateProperties(canonical_identifier=balance_proof.canonical_identifier)
+    )
+    route_state = RouteState(
+        # pylint: disable=E1101
+        route=[netting_channel_state.partner_state.address],
+        forward_channel_id=netting_channel_state.canonical_identifier.channel_identifier,
+    )
+
     return LockedTransferUnsignedState(
-        balance_proof=create(transfer.extract(BalanceProofProperties)),
+        balance_proof=balance_proof,
         lock=lock,
+        route_state=route_state,
         **transfer.partial_dict("initiator", "target", "payment_identifier", "token"),
     )
 
 
 @dataclass(frozen=True)
-class LockedTransferSignedStateProperties(LockedTransferUnsignedStateProperties):
+class LockedTransferSignedStateProperties(BalanceProofProperties):
+    amount: TokenAmount = EMPTY
+    expiration: BlockExpiration = EMPTY
+    initiator: InitiatorAddress = EMPTY
+    target: TargetAddress = EMPTY
+    payment_identifier: PaymentID = EMPTY
+    token: TokenAddress = EMPTY
+    secret: Secret = EMPTY
     sender: Address = EMPTY
     recipient: Address = EMPTY
     pkey: bytes = EMPTY
     message_identifier: MessageID = EMPTY
+    route: List[Address] = EMPTY
+
     TARGET_TYPE = LockedTransferSignedState
 
 
+# `route_state` is only present in LockedTransferUnsignedState, therefore we cut it out
+LOCKED_TRANSFER_BASE_DEFAULTS = {
+    k: v
+    for k, v in LockedTransferUnsignedStateProperties.DEFAULTS.__dict__.items()
+    if k not in ["route_state"]
+}
+
 LockedTransferSignedStateProperties.DEFAULTS = LockedTransferSignedStateProperties(
-    **LockedTransferUnsignedStateProperties.DEFAULTS.__dict__,
+    **LOCKED_TRANSFER_BASE_DEFAULTS,
     sender=UNIT_TRANSFER_SENDER,
     recipient=UNIT_TRANSFER_TARGET,
     pkey=UNIT_TRANSFER_PKEY,
@@ -744,12 +771,36 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
         params["locksroot"] = keccak(lock.as_bytes)
     params["fee"] = 0
 
+    # Dancing with parameters for different LockedState and LockedTransfer classes
+    route = params.pop("route")
+    # pylint: disable=E1101
+    route_metadata = [transfer.recipient, transfer.target] if route == EMPTY else route
+    params["route_metadata"] = RouteMetadata(routes=route_metadata)
+
     locked_transfer = LockedTransfer(lock=lock, **params, signature=EMPTY_SIGNATURE)
     locked_transfer.sign(signer)
 
+    assert locked_transfer.route_metadata
     assert locked_transfer.sender == sender
 
-    return lockedtransfersigned_from_message(locked_transfer)
+    balance_proof = balanceproof_from_envelope(locked_transfer)
+
+    lock = HashTimeLockState(
+        locked_transfer.lock.amount,
+        locked_transfer.lock.expiration,
+        locked_transfer.lock.secrethash,
+    )
+
+    return LockedTransferSignedState(
+        message_identifier=locked_transfer.message_identifier,
+        payment_identifier=locked_transfer.payment_identifier,
+        token=locked_transfer.token,
+        balance_proof=balance_proof,
+        lock=lock,
+        initiator=locked_transfer.initiator,
+        target=locked_transfer.target,
+        route=locked_transfer.route_metadata.routes,
+    )
 
 
 @dataclass(frozen=True)
@@ -761,8 +812,8 @@ class LockedTransferProperties(LockedTransferSignedStateProperties):
 
 LockedTransferProperties.DEFAULTS = LockedTransferProperties(
     **replace(LockedTransferSignedStateProperties.DEFAULTS, locksroot=GENERATE).__dict__,
-    fee=0,
     route_metadata=GENERATE,
+    fee=0,
 )
 
 
@@ -779,6 +830,7 @@ def prepare_locked_transfer(properties, defaults):
 
     params["signature"] = EMPTY_SIGNATURE
 
+    params.pop("route")
     if params["route_metadata"] == GENERATE:
         params["route_metadata"] = create(RouteMetadataProperties())
 
@@ -788,6 +840,7 @@ def prepare_locked_transfer(properties, defaults):
 @create.register(LockedTransferProperties)
 def _(properties, defaults=None) -> LockedTransfer:
     params, signer, expected_sender = prepare_locked_transfer(properties, defaults)
+
     transfer = LockedTransfer(**params)
     transfer.sign(signer)
     assert transfer.sender == expected_sender
@@ -837,11 +890,14 @@ def make_signed_transfer_for(
         ok = channel_state.reveal_timeout < properties.expiration < channel_state.settle_timeout
         assert ok, "Expiration must be between reveal_timeout and settle_timeout."
 
+    # pylint: disable=E1101
     assert privatekey_to_address(properties.pkey) == properties.sender
 
     if properties.sender == channel_state.our_state.address:
+        # pylint: disable=E1101
         recipient = channel_state.partner_state.address
     elif properties.sender == channel_state.partner_state.address:
+        # pylint: disable=E1101
         recipient = channel_state.our_state.address
     else:
         raise RuntimeError("Given sender does not participate in given channel.")
@@ -868,6 +924,9 @@ def make_signed_transfer_for(
         transfer_properties = LockedTransferUnsignedStateProperties(
             locksroot=locksroot, canonical_identifier=channel_state.canonical_identifier
         )
+
+    transfer_properties.__dict__.pop("route_state")
+
     transfer = create(
         LockedTransferSignedStateProperties(recipient=recipient, **transfer_properties.__dict__),
         defaults=properties,
@@ -945,7 +1004,11 @@ class ChannelSet:
         return [self.get_hop(index) for index in (args or range(len(self.channels)))]
 
     def get_route(self, channel_index: int) -> RouteState:
-        return make_route_from_channel(self.channels[channel_index])
+        channel = self.channels[channel_index]
+        return RouteState(
+            route=[channel.our_state.address, channel.partner_state.address],
+            forward_channel_id=channel.canonical_identifier.channel_identifier,
+        )
 
     def get_routes(self, *args) -> List[RouteState]:
         return [self.get_route(index) for index in (args or range(len(self.channels)))]
@@ -1012,9 +1075,14 @@ def mediator_make_channel_pair(
 def mediator_make_init_action(
     channels: ChannelSet, transfer: LockedTransferSignedState
 ) -> ActionInitMediator:
+
+    route_state = RouteState(
+        route=transfer.route, forward_channel_id=channels.get_hop(1).channel_identifier
+    )
+
     return ActionInitMediator(
-        routes=channels.get_routes(1),
         from_hop=channels.get_hop(0),
+        route_state=route_state,
         from_transfer=transfer,
         balance_proof=transfer.balance_proof,
         sender=transfer.balance_proof.sender,
@@ -1093,6 +1161,10 @@ def make_transfers_pair(
             payment_identifier=UNIT_TRANSFER_IDENTIFIER,
             expiration=lock_expiration,
             secrethash=UNIT_SECRETHASH,
+            route_state=RouteState(
+                route=channels[payer_index:],
+                forward_channel_id=channels[payee_index].canonical_identifier.channel_identifier,
+            ),
         )
         assert lockedtransfer_event
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1324,15 +1324,6 @@ def route_properties_to_channel(route: RouteProperties) -> NettingChannelState:
     return channel  # type: ignore
 
 
-@dataclass(frozen=True)
-class RouteMetadataProperties(Properties):
-    routes: List[Address] = EMPTY
-    TARGET_TYPE = RouteMetadata
-
-
-RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(routes=[HOP1, HOP2])
-
-
 def create_network(
     token_network_state: TokenNetworkState,
     our_address: Address,

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -680,7 +680,7 @@ class LockedTransferUnsignedStateProperties(BalanceProofProperties):
     payment_identifier: PaymentID = EMPTY
     token: TokenAddress = EMPTY
     secret: Secret = EMPTY
-    route_state: RouteState = EMPTY
+    route_states: List[RouteState] = EMPTY
 
     TARGET_TYPE = LockedTransferUnsignedState
 
@@ -752,7 +752,7 @@ class LockedTransferSignedStateProperties(BalanceProofProperties):
 LOCKED_TRANSFER_BASE_DEFAULTS = {
     k: v
     for k, v in LockedTransferUnsignedStateProperties.DEFAULTS.__dict__.items()
-    if k not in ["route_state"]
+    if k not in ["route_states"]
 }
 
 LockedTransferSignedStateProperties.DEFAULTS = LockedTransferSignedStateProperties(
@@ -936,7 +936,7 @@ def make_signed_transfer_for(
             locksroot=locksroot, canonical_identifier=channel_state.canonical_identifier
         )
 
-    transfer_properties.__dict__.pop("route_state")
+    transfer_properties.__dict__.pop("route_states", None)
 
     transfer = create(
         LockedTransferSignedStateProperties(recipient=recipient, **transfer_properties.__dict__),

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -401,11 +401,7 @@ NettingChannelEndStateProperties.DEFAULTS = NettingChannelEndStateProperties(
 )
 
 NettingChannelEndStateProperties.OUR_STATE = NettingChannelEndStateProperties(
-    address=UNIT_OUR_ADDRESS,
-    privatekey=UNIT_OUR_KEY,
-    balance=100,
-    merkletree_leaves=None,
-    merkletree_width=0,
+    address=UNIT_OUR_ADDRESS, privatekey=UNIT_OUR_KEY, balance=100
 )
 
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1324,6 +1324,15 @@ def route_properties_to_channel(route: RouteProperties) -> NettingChannelState:
     return channel  # type: ignore
 
 
+@dataclass(frozen=True)
+class RouteMetadataProperties(Properties):
+    routes: List[Address] = EMPTY
+    TARGET_TYPE = RouteMetadata
+
+
+RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(routes=[HOP1, HOP2])
+
+
 def create_network(
     token_network_state: TokenNetworkState,
     our_address: Address,

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -11,6 +11,7 @@ from raiden.messages import (
     Lock,
     LockedTransfer,
     LockExpired,
+    Metadata,
     RefundTransfer,
     RouteMetadata,
     Unlock,
@@ -431,6 +432,15 @@ class RouteMetadataProperties(Properties):
 
 
 RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(route=[HOP1, HOP2])
+
+
+@dataclass(frozen=True)
+class MetadataProperties(Properties):
+    routes: List[RouteMetadata] = EMPTY
+    TARGET_TYPE = Metadata
+
+
+MetadataProperties.DEFAULTS = MetadataProperties(routes=[RouteMetadata(route=[HOP1, HOP2])])
 
 
 @dataclass(frozen=True)

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -12,6 +12,7 @@ from raiden.messages import (
     LockedTransfer,
     LockExpired,
     RefundTransfer,
+    RouteMetadata,
     Unlock,
     lockedtransfersigned_from_message,
 )
@@ -1207,6 +1208,15 @@ def route_properties_to_channel(route: RouteProperties) -> NettingChannelState:
         )
     )
     return channel  # type: ignore
+
+
+@dataclass(frozen=True)
+class RouteMetadataProperties(Properties):
+    routes: List[Address] = EMPTY
+    TARGET_TYPE = RouteMetadata
+
+
+RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(routes=[HOP1, HOP2])
 
 
 def create_network(

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -426,11 +426,11 @@ def _(properties, defaults=None) -> NettingChannelEndState:
 
 @dataclass(frozen=True)
 class RouteMetadataProperties(Properties):
-    routes: List[Address] = EMPTY
+    route: List[Address] = EMPTY
     TARGET_TYPE = RouteMetadata
 
 
-RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(routes=[HOP1, HOP2])
+RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(route=[HOP1, HOP2])
 
 
 @dataclass(frozen=True)
@@ -775,7 +775,7 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
     route = params.pop("route")
     # pylint: disable=E1101
     route_metadata = [transfer.recipient, transfer.target] if route == EMPTY else route
-    params["route_metadata"] = RouteMetadata(routes=route_metadata)
+    params["route_metadata"] = RouteMetadata(route=route_metadata)
 
     locked_transfer = LockedTransfer(lock=lock, **params, signature=EMPTY_SIGNATURE)
     locked_transfer.sign(signer)
@@ -799,7 +799,7 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
         lock=lock,
         initiator=locked_transfer.initiator,
         target=locked_transfer.target,
-        route=locked_transfer.route_metadata.routes,
+        route=locked_transfer.route_metadata.route,
     )
 
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -540,7 +540,7 @@ def make_receive_transfer_mediated(
     chain_id = chain_id or channel_state.chain_id
 
     transfer_route_metadata = RouteMetadata(
-        routes=[channel_state.our_state.address, transfer_target]
+        route=[channel_state.our_state.address, transfer_target]
     )
 
     mediated_transfer_msg = LockedTransfer(
@@ -574,7 +574,7 @@ def make_receive_transfer_mediated(
         target=transfer_target,
         message_identifier=random.randint(0, UINT64_MAX),
         balance_proof=balance_proof,
-        route=transfer_route_metadata.routes,
+        route=transfer_route_metadata.route,
     )
 
     return receive_lockedtransfer

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -10,7 +10,7 @@ from gevent.timeout import Timeout
 from raiden.app import App
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
 from raiden.message_handler import MessageHandler
-from raiden.messages import LockedTransfer, LockExpired, Message, RouteMetadata, Unlock
+from raiden.messages import LockedTransfer, LockExpired, Message, Metadata, RouteMetadata, Unlock
 from raiden.tests.utils.factories import make_address, make_secret
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.transfer import channel, views
@@ -539,8 +539,8 @@ def make_receive_transfer_mediated(
     transfer_initiator = make_address()
     chain_id = chain_id or channel_state.chain_id
 
-    transfer_route_metadata = RouteMetadata(
-        route=[channel_state.our_state.address, transfer_target]
+    transfer_metadata = Metadata(
+        routes=[RouteMetadata(route=[channel_state.our_state.address, transfer_target])]
     )
 
     mediated_transfer_msg = LockedTransfer(
@@ -560,7 +560,7 @@ def make_receive_transfer_mediated(
         initiator=transfer_initiator,
         signature=EMPTY_SIGNATURE,
         fee=0,
-        route_metadata=transfer_route_metadata,
+        metadata=transfer_metadata,
     )
     mediated_transfer_msg.sign(signer)
 
@@ -574,7 +574,7 @@ def make_receive_transfer_mediated(
         target=transfer_target,
         message_identifier=random.randint(0, UINT64_MAX),
         balance_proof=balance_proof,
-        route=transfer_route_metadata.route,
+        routes=transfer_metadata.routes,
     )
 
     return receive_lockedtransfer

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -152,7 +152,13 @@ def get_receiver_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
 def prune_route_table(
     route_state_table: List[RouteState], selected_route: RouteState
 ) -> List[RouteState]:
+    """ Takes a selected route and places it on top of the route table,
+    with the current node address removed.
 
+    The idea is that the current node is the first address on the route
+    state entry, so this address needs to be removed from the table when
+    passing it to the next hop.
+    """
     pruned_route_table = [rs for rs in route_state_table if rs.route != selected_route.route]
 
     pruned_route_table.insert(
@@ -1331,14 +1337,14 @@ def send_lockedtransfer(
     route_states: List[RouteState],
 ) -> SendLockedTransfer:
     send_locked_transfer_event, pending_locks = create_sendlockedtransfer(
-        channel_state,
-        initiator,
-        target,
-        amount,
-        message_identifier,
-        payment_identifier,
-        expiration,
-        secrethash,
+        channel_state=channel_state,
+        initiator=initiator,
+        target=target,
+        amount=amount,
+        message_identifier=message_identifier,
+        payment_identifier=payment_identifier,
+        expiration=expiration,
+        secrethash=secrethash,
         route_states=route_states,
     )
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -495,12 +495,12 @@ def is_valid_lockedtransfer(
     receiver_state: NettingChannelEndState,
 ) -> PendingLocksStateOrError:
     return valid_lockedtransfer_check(
-        channel_state,
-        sender_state,
-        receiver_state,
-        "LockedTransfer",
-        transfer_state.balance_proof,
-        transfer_state.lock,
+        channel_state=channel_state,
+        sender_state=sender_state,
+        receiver_state=receiver_state,
+        message_name="LockedTransfer",
+        received_balance_proof=transfer_state.balance_proof,
+        lock=transfer_state.lock,
     )
 
 
@@ -1223,6 +1223,7 @@ def create_sendlockedtransfer(
     payment_identifier: PaymentID,
     expiration: BlockExpiration,
     secrethash: SecretHash,
+    route_state: "RouteState",
 ) -> Tuple[SendLockedTransfer, PendingLocksState]:
     our_state = channel_state.our_state
     partner_state = channel_state.partner_state
@@ -1266,7 +1267,13 @@ def create_sendlockedtransfer(
     )
 
     locked_transfer = LockedTransferUnsignedState(
-        payment_identifier, token, balance_proof, lock, initiator, target
+        payment_identifier=payment_identifier,
+        token=token,
+        balance_proof=balance_proof,
+        lock=lock,
+        initiator=initiator,
+        target=target,
+        route_state=route_state,
     )
 
     lockedtransfer = SendLockedTransfer(
@@ -1345,6 +1352,7 @@ def send_lockedtransfer(
     payment_identifier: PaymentID,
     expiration: BlockExpiration,
     secrethash: SecretHash,
+    route_state: "RouteState",
 ) -> SendLockedTransfer:
     send_locked_transfer_event, pending_locks = create_sendlockedtransfer(
         channel_state,
@@ -1355,6 +1363,7 @@ def send_lockedtransfer(
         payment_identifier,
         expiration,
         secrethash,
+        route_state=route_state,
     )
 
     transfer = send_locked_transfer_event.transfer
@@ -1376,6 +1385,7 @@ def send_refundtransfer(
     payment_identifier: PaymentID,
     expiration: BlockExpiration,
     secrethash: SecretHash,
+    route_state: "RouteState",
 ) -> SendRefundTransfer:
     msg = "Refunds are only valid for *known and pending* transfers"
     assert secrethash in channel_state.partner_state.secrethashes_to_lockedlocks, msg
@@ -1384,14 +1394,15 @@ def send_refundtransfer(
     assert get_status(channel_state) == CHANNEL_STATE_OPENED, msg
 
     send_mediated_transfer, pending_locks = create_sendlockedtransfer(
-        channel_state,
-        initiator,
-        target,
-        amount,
-        message_identifier,
-        payment_identifier,
-        expiration,
-        secrethash,
+        channel_state=channel_state,
+        initiator=initiator,
+        target=target,
+        amount=amount,
+        message_identifier=message_identifier,
+        payment_identifier=payment_identifier,
+        expiration=expiration,
+        secrethash=secrethash,
+        route_state=route_state,
     )
 
     mediated_transfer = send_mediated_transfer.transfer

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -152,22 +152,15 @@ def get_receiver_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
 def prune_route_table(
     route_state_table: List[RouteState], selected_route: RouteState
 ) -> List[RouteState]:
-    """ Takes a selected route and places it on top of the route table,
-    with the current node address removed.
-
-    The idea is that the current node is the first address on the route
-    state entry, so this address needs to be removed from the table when
-    passing it to the next hop.
+    """ Given a selected route, returns a filtered route table that
+    contains only routes using the same forward channel and removes our own
+    address in the process.
     """
-    pruned_route_table = [rs for rs in route_state_table if rs.route != selected_route.route]
-
-    pruned_route_table.insert(
-        0,
-        RouteState(
-            route=selected_route.route[1:], forward_channel_id=selected_route.forward_channel_id
-        ),
-    )
-    return pruned_route_table
+    return [
+        RouteState(route=rs.route[1:], forward_channel_id=selected_route.forward_channel_id)
+        for rs in route_state_table
+        if rs.forward_channel_id == selected_route.forward_channel_id
+    ]
 
 
 def is_channel_usable(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -152,6 +152,7 @@ def get_receiver_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
 def prune_route_table(
     route_state_table: List[RouteState], selected_route: RouteState
 ) -> List[RouteState]:
+
     pruned_route_table = [rs for rs in route_state_table if rs.route != selected_route.route]
 
     pruned_route_table.insert(

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -197,17 +197,17 @@ def try_new_route(
 
     for candidate_route_state in candidate_route_states:
         forward_channel_id = candidate_route_state.forward_channel_id
+
         candidate_channel_state = forward_channel_id and channelidentifiers_to_channels.get(
             forward_channel_id
         )
 
-        if (
-            forward_channel_id
-            and candidate_channel_state
-            and channel.is_channel_usable(
-                candidate_channel_state=candidate_channel_state, transfer_amount=amount_with_fee
-            )
-        ):
+        assert isinstance(candidate_channel_state, NettingChannelState)
+
+        is_usable_route = channel.is_channel_usable(
+            candidate_channel_state=candidate_channel_state, transfer_amount=amount_with_fee
+        )
+        if is_usable_route:
             channel_state = candidate_channel_state
             route_state = candidate_route_state
             break

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -211,18 +211,19 @@ def try_new_route(
         initiator_state = None
 
     else:
-        channel_state, route = route_infos
+        channel_state, route_state = route_infos
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
         lockedtransfer_event = send_lockedtransfer(
             transfer_description=transfer_description,
             channel_state=channel_state,
             message_identifier=message_identifier,
             block_number=block_number,
+            route_state=route_state,
         )
         assert lockedtransfer_event
 
         initiator_state = InitiatorTransferState(
-            route=route,
+            route=route_state,
             transfer_description=transfer_description,
             channel_identifier=channel_state.identifier,
             transfer=lockedtransfer_event.transfer,
@@ -237,6 +238,7 @@ def send_lockedtransfer(
     channel_state: NettingChannelState,
     message_identifier: MessageID,
     block_number: BlockNumber,
+    route_state: RouteState,
 ) -> SendLockedTransfer:
     """ Create a mediated transfer using channel. """
     assert channel_state.token_network_address == transfer_description.token_network_address
@@ -259,6 +261,7 @@ def send_lockedtransfer(
         payment_identifier=transfer_description.payment_identifier,
         expiration=lock_expiration,
         secrethash=transfer_description.secrethash,
+        route_state=route_state,
     )
     return lockedtransfer_event
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -180,21 +180,42 @@ def get_initial_lock_expiration(
 
 def try_new_route(
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
-    available_routes: List[RouteState],
+    candidate_route_states: List[RouteState],
     transfer_description: TransferDescriptionWithSecretState,
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
 ) -> TransitionResult[Optional[InitiatorTransferState]]:
 
-    route_infos = channel.next_channel_from_routes(
-        available_routes=available_routes,
-        channelidentifiers_to_channels=channelidentifiers_to_channels,
-        transfer_amount=PaymentWithFeeAmount(transfer_description.amount),
+    initiator_state = None
+    events: List[Event] = list()
+    amount_with_fee: PaymentWithFeeAmount = PaymentWithFeeAmount(
+        transfer_description.amount + transfer_description.allocated_fee
     )
 
-    events: List[Event] = list()
-    if route_infos is None:
-        if not available_routes:
+    channel_state = None
+    route_state = None
+
+    for candidate_route_state in candidate_route_states:
+        forward_channel_id = candidate_route_state.forward_channel_id
+        candidate_channel_state = forward_channel_id and channelidentifiers_to_channels.get(
+            forward_channel_id
+        )
+
+        if (
+            forward_channel_id
+            and candidate_channel_state
+            and channel.is_channel_usable(
+                candidate_channel_state=candidate_channel_state, transfer_amount=amount_with_fee
+            )
+        ):
+            channel_state = candidate_channel_state
+            route_state = RouteState(
+                route=candidate_route_state.route[1:], forward_channel_id=forward_channel_id
+            )
+            break
+
+    if route_state is None:
+        if not candidate_route_states:
             reason = "there is no route available"
         else:
             reason = "none of the available routes could be used"
@@ -211,7 +232,8 @@ def try_new_route(
         initiator_state = None
 
     else:
-        channel_state, route_state = route_infos
+        assert channel_state is not None
+
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
         lockedtransfer_event = send_lockedtransfer(
             transfer_description=transfer_description,
@@ -219,6 +241,7 @@ def try_new_route(
             message_identifier=message_identifier,
             block_number=block_number,
             route_state=route_state,
+            route_states=candidate_route_states,
         )
         assert lockedtransfer_event
 
@@ -239,6 +262,7 @@ def send_lockedtransfer(
     message_identifier: MessageID,
     block_number: BlockNumber,
     route_state: RouteState,
+    route_states: List[RouteState],
 ) -> SendLockedTransfer:
     """ Create a mediated transfer using channel. """
     assert channel_state.token_network_address == transfer_description.token_network_address
@@ -261,7 +285,9 @@ def send_lockedtransfer(
         payment_identifier=transfer_description.payment_identifier,
         expiration=lock_expiration,
         secrethash=transfer_description.secrethash,
-        route_state=route_state,
+        route_states=channel.prune_route_table(
+            route_state_table=route_states, selected_route=route_state
+        ),
     )
     return lockedtransfer_event
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -209,9 +209,7 @@ def try_new_route(
             )
         ):
             channel_state = candidate_channel_state
-            route_state = RouteState(
-                route=candidate_route_state.route[1:], forward_channel_id=forward_channel_id
-            )
+            route_state = candidate_route_state
             break
 
     if route_state is None:

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -111,9 +111,14 @@ def maybe_try_new_route_or_cancel(
         if not is_reroute_allowed:
             return TransitionResult(payment_state, events)
 
+        filtered_route_states = [
+            route
+            for route in candidate_route_states
+            if route.forward_channel_id not in payment_state.cancelled_channels
+        ]
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels=channelidentifiers_to_channels,
-            candidate_route_states=candidate_route_states,
+            candidate_route_states=filtered_route_states,
             transfer_description=transfer_description,
             pseudo_random_generator=pseudo_random_generator,
             block_number=block_number,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -96,7 +96,7 @@ def maybe_try_new_route(
     payment_state: InitiatorPaymentState,
     initiator_state: InitiatorTransferState,
     transfer_description: TransferDescriptionWithSecretState,
-    available_routes: List[RouteState],
+    candidate_route_states: List[RouteState],
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
@@ -107,7 +107,7 @@ def maybe_try_new_route(
 
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels=channelidentifiers_to_channels,
-            available_routes=available_routes,
+            candidate_route_states=candidate_route_states,
             transfer_description=transfer_description,
             pseudo_random_generator=pseudo_random_generator,
             block_number=block_number,
@@ -204,7 +204,7 @@ def handle_init(
     if payment_state is None:
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels=channelidentifiers_to_channels,
-            available_routes=state_change.routes,
+            candidate_route_states=state_change.routes,
             transfer_description=state_change.transfer,
             pseudo_random_generator=pseudo_random_generator,
             block_number=block_number,
@@ -323,7 +323,7 @@ def handle_transferrefundcancelroute(
         payment_state=payment_state,
         initiator_state=initiator_state,
         transfer_description=transfer_description,
-        available_routes=state_change.routes,
+        candidate_route_states=state_change.routes,
         channelidentifiers_to_channels=channelidentifiers_to_channels,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1189,6 +1189,10 @@ def handle_refundtransfer(
             if route.forward_channel_id != payer_channel.canonical_identifier.channel_identifier
         ]
 
+        # To avoid duplicated attempts at an already-tried route, we
+        # remove the unusable routes from the state.routes
+        mediator_state.routes = candidate_route_states
+
         iteration = mediate_transfer(
             state=mediator_state,
             candidate_route_states=candidate_route_states,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1402,8 +1402,6 @@ def handle_node_change_network_state(
     if mediator_state.waiting_transfer is None:
         return TransitionResult(mediator_state, list())
 
-    assert route.forward_channel_id
-
     transfer = mediator_state.waiting_transfer.transfer
     payer_channel_identifier = transfer.balance_proof.channel_identifier
     payer_channel = channelidentifiers_to_channels.get(payer_channel_identifier)

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -397,6 +397,7 @@ def forward_transfer_pair(
             payment_identifier=payer_transfer.payment_identifier,
             expiration=lock.expiration,
             secrethash=lock.secrethash,
+            route_state=route_state,
         )
         assert lockedtransfer_event
 
@@ -445,6 +446,12 @@ def backward_transfer_pair(
     # do anything and wait for the received lock to expire.
     if channel.is_channel_usable(backward_channel, lock.amount, lock_timeout):
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
+
+        backward_route_state = RouteState(
+            route=[backward_channel.partner_state.address],
+            forward_channel_id=backward_channel.canonical_identifier.channel_identifier,
+        )
+
         refund_transfer = channel.send_refundtransfer(
             channel_state=backward_channel,
             initiator=payer_transfer.initiator,
@@ -454,11 +461,11 @@ def backward_transfer_pair(
             payment_identifier=payer_transfer.payment_identifier,
             expiration=lock.expiration,
             secrethash=lock.secrethash,
+            route_state=backward_route_state,
         )
 
-        backward_path = RouteState([], ChannelID(-1))
         transfer_pair = MediationPairState(
-            route=backward_path,
+            route=backward_route_state,
             payer_transfer=payer_transfer,
             payee_address=backward_channel.partner_state.address,
             payee_transfer=refund_transfer.transfer,
@@ -1046,11 +1053,11 @@ def handle_init(
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
 ) -> TransitionResult[Optional[MediatorTransferState]]:
-    routes = state_change.routes
-
     from_hop = state_change.from_hop
     from_transfer = state_change.from_transfer
     payer_channel = channelidentifiers_to_channels.get(from_hop.channel_identifier)
+
+    routes = [state_change.route_state]
 
     # There is no corresponding channel for the message, ignore it
     if not payer_channel:
@@ -1166,14 +1173,14 @@ def handle_refundtransfer(
             return TransitionResult(mediator_state, channel_events)
 
         iteration = mediate_transfer(
-            mediator_state,
-            mediator_state_change.routes,
-            payer_channel,
-            channelidentifiers_to_channels,
-            nodeaddresses_to_networkstates,
-            pseudo_random_generator,
-            payer_transfer,
-            block_number,
+            state=mediator_state,
+            possible_routes=mediator_state_change.routes,
+            payer_channel=payer_channel,
+            channelidentifiers_to_channels=channelidentifiers_to_channels,
+            nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
+            pseudo_random_generator=pseudo_random_generator,
+            payer_transfer=payer_transfer,
+            block_number=block_number,
         )
 
         events.extend(channel_events)

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -371,6 +371,11 @@ def forward_transfer_pair(
     lock_timeout = BlockTimeout(payer_transfer.lock.expiration - block_number)
 
     payee_channel = channelidentifiers_to_channels.get(route_state.forward_channel_id)
+
+    route_states = channel.prune_route_table(
+        route_state_table=route_state_table, selected_route=route_state
+    )
+
     is_payee_channel_usable = payee_channel is not None and channel.is_channel_usable(
         candidate_channel_state=payee_channel,
         transfer_amount=payer_transfer.lock.amount,
@@ -392,9 +397,7 @@ def forward_transfer_pair(
             payment_identifier=payer_transfer.payment_identifier,
             expiration=lock.expiration,
             secrethash=lock.secrethash,
-            route_states=channel.prune_route_table(
-                route_state_table=route_state_table, selected_route=route_state
-            ),
+            route_states=route_states,
         )
         assert lockedtransfer_event
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1182,9 +1182,16 @@ def handle_refundtransfer(
         if not is_valid:
             return TransitionResult(mediator_state, channel_events)
 
+        # We remove all routes where the sender of the refund is our forward hop
+        candidate_route_states = [
+            route
+            for route in mediator_state.routes
+            if route.forward_channel_id != payer_channel.canonical_identifier.channel_identifier
+        ]
+
         iteration = mediate_transfer(
             state=mediator_state,
-            candidate_route_states=mediator_state_change.routes,
+            candidate_route_states=candidate_route_states,
             payer_channel=payer_channel,
             channelidentifiers_to_channels=channelidentifiers_to_channels,
             nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -59,7 +59,7 @@ class LockedTransferUnsignedState(LockedTransferState):
     """
 
     balance_proof: BalanceProofUnsignedState
-    route_states: List[RouteState]
+    route_states: List[RouteState] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -59,7 +59,7 @@ class LockedTransferUnsignedState(LockedTransferState):
     """
 
     balance_proof: BalanceProofUnsignedState
-    route_state: RouteState
+    route_states: List[RouteState]
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -81,7 +81,7 @@ class LockedTransferSignedState(LockedTransferState):
 
     message_identifier: MessageID
     balance_proof: BalanceProofSignedState = field(repr=False)
-    route: List[Address]
+    routes: List[List[Address]]
 
     def __post_init__(self) -> None:
         typecheck(self.lock, HashTimeLockState)
@@ -154,11 +154,10 @@ class InitiatorPaymentState(State):
 class MediationPairState(State):
     """ State for a mediated transfer.
     A mediator will pay payee node knowing that there is a payer node to cover
-    the token expenses. This state keeps track of the routes and transfer for
+    the token expenses. This state keeps track of transfers for
     the payer and payee, and the current state of the payment.
     """
 
-    route: RouteState
     payer_transfer: LockedTransferSignedState
     payee_address: Address
     payee_transfer: LockedTransferUnsignedState

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -89,6 +89,7 @@ class LockedTransferSignedState(LockedTransferState):
 
         # At least the lock for this transfer must be in the locksroot, so it
         # must not be empty
+        # pylint: disable=E1101
         if self.balance_proof.locksroot == LOCKSROOT_OF_NO_LOCKS:
             raise ValueError("balance_proof must not be empty")
 

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -114,12 +114,16 @@ class ReceiveSecretReveal(AuthenticatedSenderStateChange):
 class ReceiveTransferRefundCancelRoute(BalanceProofStateChange):
     """ A RefundTransfer message received by the initiator will cancel the current
     route.
+
+    Args:
+        is_reroute_allowed: indicates if the payment type allows for re-routing.
+            E.g, for token swaps, this should not be allowed.
     """
 
-    routes: List[RouteState] = field(repr=False)
     transfer: LockedTransferSignedState
     secret: Secret = field(repr=False)
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
+    is_reroute_allowed: bool = field(default=True)
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -133,7 +137,6 @@ class ReceiveTransferRefund(BalanceProofStateChange):
     """ A RefundTransfer message received. """
 
     transfer: LockedTransferSignedState
-    routes: List[RouteState] = field(repr=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -48,12 +48,12 @@ class ActionInitMediator(BalanceProofStateChange):
 
     Args:
         from_hop: The payee route.
-        route_state: The forward route state.
+        route_states: list of forward route states.
         from_transfer: The payee transfer.
     """
 
     from_hop: HopState
-    route_state: RouteState = field(repr=False)
+    route_states: List[RouteState]
     from_transfer: LockedTransferSignedState
 
     def __post_init__(self) -> None:

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -47,13 +47,13 @@ class ActionInitMediator(BalanceProofStateChange):
     """ Initial state for a new mediator.
 
     Args:
-        routes: A list of possible routes provided by a routing service.
         from_hop: The payee route.
+        route_state: The forward route state.
         from_transfer: The payee transfer.
     """
 
-    routes: List[RouteState] = field(repr=False)
     from_hop: HopState
+    route_state: RouteState = field(repr=False)
     from_transfer: LockedTransferSignedState
 
     def __post_init__(self) -> None:

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -6,7 +6,7 @@ from random import Random
 from typing import TYPE_CHECKING, Tuple
 
 import networkx
-from eth_utils import to_hex
+from eth_utils import to_checksum_address, to_hex
 
 from raiden.constants import EMPTY_SECRETHASH, LOCKSROOT_OF_NO_LOCKS, UINT64_MAX, UINT256_MAX
 from raiden.encoding import messages
@@ -21,7 +21,7 @@ from raiden.transfer.architecture import (
 )
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.mediation_fee import FeeScheduleState
-from raiden.utils import lpex, pex
+from raiden.utils import lpex
 from raiden.utils.typing import (
     Address,
     Any,
@@ -172,7 +172,7 @@ class RouteState(State):
 
     # TODO: Add timestamp
     route: List[Address]
-    forward_channel_id: Optional[ChannelID] = None
+    forward_channel_id: ChannelID
 
     @property
     def next_hop_address(self) -> Address:
@@ -181,7 +181,7 @@ class RouteState(State):
 
     def __repr__(self):
         return "RouteState ({}), channel_id: {}".format(
-            " -> ".join([pex(a) for a in self.route]), self.forward_channel_id
+            " -> ".join(to_checksum_address(addr) for addr in self.route), self.forward_channel_id
         )
 
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -172,11 +172,11 @@ class RouteState(State):
 
     # TODO: Add timestamp
     route: List[Address]
-    forward_channel_id: ChannelID
+    forward_channel_id: Optional[ChannelID] = None
 
     @property
     def next_hop_address(self) -> Address:
-        assert len(self.route) >= 2
+        assert len(self.route) >= 1
         return self.route[1]
 
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -179,6 +179,11 @@ class RouteState(State):
         assert len(self.route) >= 1
         return self.route[1]
 
+    def __repr__(self):
+        return "RouteState ({}), channel_id: {}".format(
+            " -> ".join([pex(a) for a in self.route]), self.forward_channel_id
+        )
+
 
 @dataclass
 class HashTimeLockState(State):

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -21,7 +21,7 @@ from raiden.transfer.architecture import (
 )
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.mediation_fee import FeeScheduleState
-from raiden.utils import lpex
+from raiden.utils import lpex, pex
 from raiden.utils.typing import (
     Address,
     Any,


### PR DESCRIPTION
Fixes #3863 
Resolves #4142 

Introduces the concept of permissive source routing, where the initiator nodes send not one single route for mediators, but a list of candidate routes. This information is sent/managed by the `RouteState` type, which defines an ordered list of addresses (from starting point to end point) and an optional `forward_channel_id`, which can be used as a hint for which hop to take.

Also adds new container fields for Transfer-related messages: `Metadata` contains a list of `RouteMetadata` fields, where each RouteMetadata is a simple list of addresses. 
