### PR TITLE
Parallel tests with xdist

### DIFF
--- a/.unittest-coveragerc
+++ b/.unittest-coveragerc
@@ -20,3 +20,4 @@ omit =
 	raiden/ui/**
 	raiden/network/proxies/**
 	raiden/network/transport/**
+concurrency = gevent

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -67,6 +67,7 @@ pytest-cov==2.5.1
 pytest-random==0.2
 pytest-select==0.1.2
 pytest-timeout==1.3.3
+pytest-xdist==1.27.0
 pytest==4.1.1
 python-dateutil==2.7.5
 PyYAML==5.1

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -1,7 +1,7 @@
 # pylint: disable=wrong-import-position,redefined-outer-name,unused-wildcard-import,wildcard-import
 from gevent import monkey  # isort:skip # noqa
 
-monkey.patch_all()  # isort:skip # noqa
+monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
 
 import pytest  # isort:skip
 

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -231,9 +231,14 @@ def blockchain_private_keys(blockchain_number_of_nodes, blockchain_key_seed):
 
 
 @pytest.fixture(scope="session")
-def port_generator(request):
+def port_generator(request, worker_id):
     """ count generator used to get a unique port number. """
-    return get_free_port(request.config.getoption("base_port"))
+    if worker_id == "master":
+        # xdist is not in use to run parallel tests
+        port_offset = 0
+    else:
+        port_offset = int(worker_id.replace("gw", "")) * 1000
+    return get_free_port(request.config.getoption("base_port") + port_offset)
 
 
 @pytest.fixture

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from random import randint
 from unittest.mock import patch
 from uuid import UUID
 
@@ -11,7 +12,10 @@ from raiden.accounts import Account, AccountManager
 from raiden.ui.prompt import unlock_account_with_passwordfile
 from raiden.utils import get_project_root, privatekey_to_address, privatekey_to_publickey
 
-KEYFILE_INACCESSIBLE = "UTC--2017-06-20T16-33-00.000000000Z--inaccessible"
+# use random file name so tests can run in parallel
+KEYFILE_INACCESSIBLE = "UTC--2017-06-20T16-33-00.{:09d}Z--inaccessible".format(
+    randint(0, 999999999)
+)
 KEYFILE_INVALID = "UTC--2017-06-20T16-06-00.000000000Z--invalid"
 
 

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -2,17 +2,18 @@ import logging
 import os
 import re
 import shutil
-import subprocess
 import sys
 from binascii import unhexlify
 from contextlib import ExitStack, contextmanager
 from datetime import datetime
 from pathlib import Path
+from subprocess import DEVNULL, STDOUT
 from tempfile import mkdtemp
 from typing import ContextManager, List
 from urllib.parse import urljoin, urlsplit
 
 import requests
+from gevent import subprocess
 from twisted.internet import defer
 
 from raiden.utils.http import HTTPExecutor
@@ -154,8 +155,8 @@ def generate_synapse_config() -> ContextManager:
                 cwd=server_dir,
                 timeout=30,
                 check=True,
-                stderr=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
+                stderr=DEVNULL,
+                stdout=DEVNULL,
             )
         return server_name, config_file
 
@@ -183,7 +184,7 @@ def matrix_server_starter(
             server_url = ParsedURL(f"https://{server_name}")
             server_urls.append(server_url)
 
-            synapse_io = subprocess.DEVNULL
+            synapse_io = DEVNULL
             # Used in CI to capture the logs for failure analysis
             if _SYNAPSE_LOGS_PATH:
                 log_file_path = Path(_SYNAPSE_LOGS_PATH).joinpath(f"{server_name}.log")
@@ -198,7 +199,7 @@ def matrix_server_starter(
                 log_file.write(f"{header:=^100}\n")
                 log_file.flush()
 
-                synapse_io = subprocess.DEVNULL, log_file, subprocess.STDOUT
+                synapse_io = DEVNULL, log_file, STDOUT
 
             exit_stack.enter_context(
                 HTTPExecutor(

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -3,7 +3,6 @@ import os
 import platform
 import socket
 import ssl
-import subprocess
 import time
 from http.client import HTTPSConnection
 from json import JSONDecodeError
@@ -12,6 +11,7 @@ from typing import IO, Any, Callable, List, Optional, Tuple, Union
 from urllib.parse import urlunparse
 
 import structlog
+from gevent import subprocess
 from mirakuru.base import ENV_UUID
 from mirakuru.exceptions import AlreadyRunning, ProcessExitedWithError
 from mirakuru.http import HTTPConnection, HTTPException, HTTPExecutor as MiHTTPExecutor

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ pytest-cov==2.5.1
 pytest-random==0.02
 pytest-timeout==1.3.3
 pytest-select==0.1.2
+pytest-xdist==1.27.0
 grequests==0.3.0
 pexpect==4.6.0
 


### PR DESCRIPTION
Use pytest-xdist for parallel test execution instead of tools/parallel_tests.sh. The only reason we didn't do this before was that gevent monkeypatching broke xdist. This is avoided by reducing monkeypatching.

We should be able to leverage this in CircleCI to cut both our runtime and our costs significantly, but I had problems with some tests which I couldn't reproduce locally as well as problems with the coverage generation. So the xdist is for local execution only at this point.