### PR TITLE
Avoid test warning by doing pytest rewrite first

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -3,6 +3,19 @@ from gevent import monkey  # isort:skip # noqa
 
 monkey.patch_all()  # isort:skip # noqa
 
+import pytest  # isort:skip
+
+# Execute these before the other imports because rewrites can't work after the
+# module has been imported.
+pytest.register_assert_rewrite("raiden.tests.utils.eth_node")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.factories")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.messages")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.network")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.protocol")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.smartcontracts")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.smoketest")  # isort:skip
+pytest.register_assert_rewrite("raiden.tests.utils.transfer")  # isort:skip
+
 import datetime
 import os
 import re
@@ -11,7 +24,6 @@ import tempfile
 from pathlib import Path
 
 import gevent
-import pytest
 from _pytest.pathlib import LOCK_TIMEOUT, ensure_reset_dir, make_numbered_dir_with_cleanup
 from _pytest.tmpdir import get_user
 
@@ -21,15 +33,6 @@ from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
-
-pytest.register_assert_rewrite("raiden.tests.utils.eth_node")
-pytest.register_assert_rewrite("raiden.tests.utils.factories")
-pytest.register_assert_rewrite("raiden.tests.utils.messages")
-pytest.register_assert_rewrite("raiden.tests.utils.network")
-pytest.register_assert_rewrite("raiden.tests.utils.protocol")
-pytest.register_assert_rewrite("raiden.tests.utils.smartcontracts")
-pytest.register_assert_rewrite("raiden.tests.utils.smoketest")
-pytest.register_assert_rewrite("raiden.tests.utils.transfer")
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
When modules are already imported, pytest can't rewrite their
assertions. To avoid this, just do the rewrite before all imports.