### PR TITLE
Forcing the storage to be `close`d manually

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -574,6 +574,7 @@ class RaidenService(Runnable):
         # Close storage DB to release internal DB lock
         assert self.wal, "The Service must have been started before it can be stopped"
         self.wal.storage.close()
+        self.wal = None
 
         if self.db_lock is not None:
             self.db_lock.release()

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -566,10 +566,20 @@ class SQLiteStorage:
             self.in_transaction = False
 
     def close(self):
+        if not hasattr(self, "conn"):
+            raise RuntimeError("The database connection was closed already.")
+
         self.conn.close()
         del self.conn
 
     def __del__(self):
+        if hasattr(self, "conn"):
+            raise RuntimeError("The database connection was not closed.")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):  # pylint: disable=unused-arguments
         self.close()
 
 
@@ -691,6 +701,3 @@ class SerializedSQLiteStorage:
 
     def close(self):
         self.database.close()
-
-    def __del__(self):
-        del self.database


### PR DESCRIPTION
This fixes the following error:

```python
Exception ignored in: <function SQLiteStorage.__del__ at 0x7f1b809158c8>                                                                                                                                                                                      
Traceback (most recent call last):                                                                                                                                                                                                                            
  File "/home/karl/raiden/raiden/storage/sqlite.py", line 573, in __del__                                                                                                                                                                                     
  File "/home/karl/raiden/raiden/storage/sqlite.py", line 569, in close                                                                                                                                                                                       
AttributeError: 'SQLiteStorage' object has no attribute 'conn'
```

And makes the manual call to `close` mandatory.