### PR TITLE
Fix token_network registry check

### DIFF
--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -72,7 +72,7 @@ class MockChain:
     def token_network_registry(  # pylint: disable=unused-argument, no-self-use
         self, address: Address
     ):
-        return object()
+        return Mock(address=address)
 
     def secret_registry(self, address: Address):  # pylint: disable=unused-argument, no-self-use
         return object()

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -219,7 +219,7 @@ def setup_proxies_or_exit(
             pfs_address=pathfinding_service_address,
             routing_mode=routing_mode,
             service_registry=service_registry,
-            token_network_registry_address=tokennetwork_registry_contract_address,
+            token_network_registry_address=Address(token_network_registry.address),
         )
         msg = "Eth address of selected pathfinding service is unknown."
         assert pfs_config.eth_address is not None, msg


### PR DESCRIPTION
In #4141 we added a check between the raiden and PFS token network
registry settings. The check only worked for the case where
`tokennetwork_registry_contract_address` was explicitly given.