### PR TITLE
Fix variable name typo

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -585,7 +585,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
 
     @staticmethod
     def handle_routefailed(raiden: "RaidenService", route_failed_event: EventRouteFailed) -> None:
-        feedback_token = raiden.route_to_feeback_token.get(tuple(route_failed_event.route))
+        feedback_token = raiden.route_to_feedback_token.get(tuple(route_failed_event.route))
 
         if feedback_token:
             log.debug(
@@ -606,7 +606,9 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
     def handle_paymentsentsuccess(
         raiden: "RaidenService", payment_sent_success_event: EventPaymentSentSuccess
     ) -> None:
-        feedback_token = raiden.route_to_feeback_token.get(tuple(payment_sent_success_event.route))
+        feedback_token = raiden.route_to_feedback_token.get(
+            tuple(payment_sent_success_event.route)
+        )
 
         if feedback_token:
             log.debug(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -158,7 +158,7 @@ def initiator_init(
     # Only prepare feedback when token is available
     if feedback_token is not None:
         for route_state in routes:
-            raiden.route_to_feeback_token[tuple(route_state.route)] = feedback_token
+            raiden.route_to_feedback_token[tuple(route_state.route)] = feedback_token
 
     return ActionInitInitiator(transfer_state, routes)
 
@@ -402,7 +402,7 @@ class RaidenService(Runnable):
         self.payment_identifier_lock = gevent.lock.Semaphore()
 
         # A list is not hashable, so use tuple as key here
-        self.route_to_feeback_token: Dict[Tuple[Address, ...], UUID] = dict()
+        self.route_to_feedback_token: Dict[Tuple[Address, ...], UUID] = dict()
 
         # Flag used to skip the processing of all Raiden events during the
         # startup.

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1609,7 +1609,7 @@ def test_initiator_init():
     with patch(
         "raiden.routing.get_best_routes", return_value=(route_states, feedback_token)
     ) as best_routes:
-        assert len(service.route_to_feeback_token) == 0
+        assert len(service.route_to_feedback_token) == 0
 
         state = initiator_init(
             raiden=service,
@@ -1623,7 +1623,7 @@ def test_initiator_init():
         )
 
         assert best_routes.called
-        assert len(service.route_to_feeback_token) == 1
-        assert service.route_to_feeback_token[tuple(route_states[0].route)] == feedback_token
+        assert len(service.route_to_feedback_token) == 1
+        assert service.route_to_feedback_token[tuple(route_states[0].route)] == feedback_token
 
         assert state.routes == route_states

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -127,7 +127,7 @@ class MockRaidenService:
         self.default_registry.address = factories.make_address()
         self.default_one_to_n_address = factories.make_address()
 
-        self.route_to_feeback_token = {}
+        self.route_to_feedback_token = {}
 
         if state_transition is None:
             state_transition = node.state_transition


### PR DESCRIPTION
`s/route_to_feeback_token/route_to_feedback_token/`