### PR TITLE
Mark code to be omitted in unit test coverage report

### DIFF
--- a/.unittest-coveragerc
+++ b/.unittest-coveragerc
@@ -5,6 +5,8 @@ exclude_lines =
 	if TYPE_CHECKING:
 	def __repr__
 	raise NotImplementedError
+	assert not isinstance
+	typecheck
 
 [run]
 branch = True

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -130,7 +130,7 @@ def get_transfer_from_task(
             transfer = transfer_task.mediator_state.waiting_transfer.transfer
     elif isinstance(transfer_task, TargetTask):
         transfer = transfer_task.target_state.transfer
-    else:
+    else:  # pragma: no unittest
         raise ValueError("get_tranfer_from_task for a non TransferTask argument")
 
     return transfer, role
@@ -160,9 +160,8 @@ def transfer_tasks_view(
     return view
 
 
-class RaidenAPI:
+class RaidenAPI:  # pragma: no unittest
     # pylint: disable=too-many-public-methods
-    # pragma: no unittest
 
     def __init__(self, raiden):
         self.raiden = raiden
@@ -729,7 +728,7 @@ class RaidenAPI:
         current_state = views.state_from_raiden(self.raiden)
         payment_network_address = self.raiden.default_registry.address
 
-        if not isinstance(amount, int):
+        if not isinstance(amount, int):  # pragma: no unittest
             raise InvalidAmount("Amount not a number")
 
         if amount <= 0:

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -162,6 +162,7 @@ def transfer_tasks_view(
 
 class RaidenAPI:
     # pylint: disable=too-many-public-methods
+    # pragma: no unittest
 
     def __init__(self, raiden):
         self.raiden = raiden

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -277,7 +277,7 @@ def restapi_setup_type_converters(flask_app, names_to_converters):
         flask_app.url_map.converters[key] = value
 
 
-class APIServer(Runnable):
+class APIServer(Runnable):  # pragma: no unittest
     """
     Runs the API-server that routes the endpoint to the resources.
     The API is wrapped in multiple layers, and the Server should be invoked this way::
@@ -475,7 +475,7 @@ class APIServer(Runnable):
         return api_error([str(exception)], HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
-class RestAPI:
+class RestAPI:  # pragma: no unittest
     """
     This wraps around the actual RaidenAPI in api/python.
     It will provide the additional, neccessary RESTful logic and

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -86,7 +86,7 @@ def get_token_network_registry_events(
     events: Optional[List[str]] = ALL_EVENTS,
     from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
     to_block: BlockSpecification = "latest",
-) -> List[Dict]:
+) -> List[Dict]:  # pragma: no unittest
     """ Helper to get all events of the Registry contract at `registry_address`. """
     return get_contract_events(
         chain=chain,
@@ -105,7 +105,7 @@ def get_token_network_events(
     events: Optional[List[str]] = ALL_EVENTS,
     from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
     to_block: BlockSpecification = "latest",
-) -> List[Dict]:
+) -> List[Dict]:  # pragma: no unittest
     """ Helper to get all events of the ChannelManagerContract at `token_address`. """
 
     return get_contract_events(
@@ -125,7 +125,7 @@ def get_all_netting_channel_events(
     contract_manager: ContractManager,
     from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
     to_block: BlockSpecification = "latest",
-) -> List[Dict]:
+) -> List[Dict]:  # pragma: no unittest
     """ Helper to get all events of a NettingChannelContract. """
 
     filter_args = get_filter_args_for_all_events_from_channel(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -449,7 +449,7 @@ def handle_secret_revealed(raiden: "RaidenService", event: Event):
     raiden.handle_and_track_state_change(registeredsecret_state_change)
 
 
-def on_blockchain_event(raiden: "RaidenService", event: Event):
+def on_blockchain_event(raiden: "RaidenService", event: Event):  # pragma: no unittest
     data = event.event_data
     log.debug(
         "Blockchain event",

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -56,7 +56,7 @@ def log_open_channels(raiden, registry_address, token_address, funds):
         )
 
 
-class ConnectionManager:
+class ConnectionManager:  # pragma: no unittest
     """The ConnectionManager provides a high level abstraction for connecting to a
     Token network.
 

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -33,7 +33,7 @@ RECOVERABLE_ERRORS = (
 )
 
 
-def log_open_channels(raiden, registry_address, token_address, funds):
+def log_open_channels(raiden, registry_address, token_address, funds):  # pragma: no unittest
     chain_state = views.state_from_raiden(raiden)
     open_channels = views.get_channelstate_open(
         chain_state=chain_state,

--- a/raiden/encoding/encoders.py
+++ b/raiden/encoding/encoders.py
@@ -1,3 +1,5 @@
+from raiden.utils.typing import typecheck
+
 __all__ = ("integer",)
 
 
@@ -10,8 +12,7 @@ class integer:  # pylint: disable=invalid-name
 
     def validate(self, value: int):
         """ Validates the integer is in the value range. """
-        if not isinstance(value, int):
-            raise ValueError("value is not an integer")
+        typecheck(value, int)
 
         if self.minimum > value or self.maximum < value:
             msg = ("{} is outside the valide range [{},{}]").format(

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -65,6 +65,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
     Type,
+    typecheck,
 )
 
 __all__ = (
@@ -796,10 +797,7 @@ class SignedBlindedBalanceProof:
     def from_balance_proof_signed_state(
         cls, balance_proof: BalanceProofSignedState
     ) -> "SignedBlindedBalanceProof":
-        if not isinstance(balance_proof, BalanceProofSignedState):
-            raise ValueError(
-                "balance_proof is not an instance of the type BalanceProofSignedState"
-            )
+        typecheck(balance_proof, BalanceProofSignedState)
 
         # pylint: disable=unexpected-keyword-arg
         return cls(
@@ -852,11 +850,7 @@ class RequestMonitoring(SignedMessage):
     non_closing_signature: Optional[Signature] = None
 
     def __post_init__(self):
-        if self.balance_proof is None:
-            raise ValueError("no balance proof given")
-
-        if not isinstance(self.balance_proof, SignedBlindedBalanceProof):
-            raise ValueError("onchain_balance_proof is not a SignedBlindedBalanceProof")
+        typecheck(self.balance_proof, SignedBlindedBalanceProof)
 
     @classmethod
     def from_balance_proof_signed_state(
@@ -865,10 +859,7 @@ class RequestMonitoring(SignedMessage):
         reward_amount: TokenAmount,
         monitoring_service_contract_address: Address,
     ) -> "RequestMonitoring":
-        if not isinstance(balance_proof, BalanceProofSignedState):
-            raise ValueError(
-                "balance_proof is not an instance of the type BalanceProofSignedState"
-            )
+        typecheck(balance_proof, BalanceProofSignedState)
 
         onchain_balance_proof = SignedBlindedBalanceProof.from_balance_proof_signed_state(
             balance_proof=balance_proof

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -23,6 +23,7 @@ from raiden.utils.typing import (
     TokenAddress,
     TokenNetworkAddress,
     Tuple,
+    typecheck,
 )
 from raiden_contracts.contract_manager import ContractManager
 
@@ -199,8 +200,7 @@ class BlockChainService:
 
         if not is_binary_address(token_network_address):
             raise ValueError("address must be a valid address")
-        if not isinstance(channel_id, T_ChannelID):
-            raise ValueError("channel identifier must be of type T_ChannelID")
+        typecheck(channel_id, T_ChannelID)
 
         with self._payment_channel_creation_lock:
             dict_key = (token_network_address, channel_id)

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -71,6 +71,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
     Tuple,
     cast,
+    typecheck,
 )
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
@@ -420,7 +421,7 @@ class TokenNetwork:
                 participant2=participant2,
                 block_identifier=block_identifier,
             )
-        elif not isinstance(channel_identifier, T_ChannelID):
+        elif not isinstance(channel_identifier, T_ChannelID):  # pragma: no unittest
             raise InvalidChannelID("channel_identifier must be of type T_ChannelID")
         elif channel_identifier <= 0 or channel_identifier > UINT256_MAX:
             raise InvalidChannelID(
@@ -464,7 +465,7 @@ class TokenNetwork:
                 participant2=participant2,
                 block_identifier=block_identifier,
             )
-        elif not isinstance(channel_identifier, T_ChannelID):
+        elif not isinstance(channel_identifier, T_ChannelID):  # pragma: no unittest
             raise InvalidChannelID("channel_identifier must be of type T_ChannelID")
         elif channel_identifier <= 0 or channel_identifier > UINT256_MAX:
             raise InvalidChannelID(
@@ -703,8 +704,7 @@ class TokenNetwork:
             RuntimeError: If the token address is empty.
             ValueError: If an argument is of the invalid type.
         """
-        if not isinstance(total_deposit, int):
-            raise ValueError("total_deposit needs to be an integer number.")
+        typecheck(total_deposit, int)
 
         with self.channel_operations_lock[partner], self.deposit_lock:
             previous_total_deposit = self._detail_participant(
@@ -1840,8 +1840,7 @@ class TokenNetwork:
             channel_identifier=channel_identifier,
         )
 
-        if not isinstance(channel_data.state, T_ChannelState):
-            raise ValueError("channel state must be of type ChannelState")
+        typecheck(channel_data.state, T_ChannelState)
 
         return channel_data.state
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -35,6 +35,7 @@ from raiden.utils.typing import (
     T_TargetAddress,
     TokenAddress,
     TokenAmount,
+    typecheck,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED
 from raiden_contracts.contract_manager import ContractManager
@@ -82,8 +83,7 @@ class TokenNetworkRegistry:
         """ Return the token network address for the given token or None if
         there is no correspoding address.
         """
-        if not isinstance(token_address, T_TargetAddress):
-            raise ValueError("token_address must be an address")
+        typecheck(token_address, T_TargetAddress)
 
         address = self.proxy.contract.functions.token_to_token_networks(
             to_checksum_address(token_address)

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -21,6 +21,7 @@ from raiden.utils.typing import (
     TokenAddress,
     TokenAmount,
     Tuple,
+    typecheck,
 )
 from raiden_contracts.constants import CONTRACT_USER_DEPOSIT, GAS_REQUIRED_FOR_UDC_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager
@@ -158,8 +159,7 @@ class UserDeposit:
         token: Token,
         block_identifier: BlockSpecification,
     ) -> Tuple[TokenAmount, Dict]:
-        if not isinstance(total_deposit, int):
-            raise ValueError("total_deposit needs to be an integer number.")
+        typecheck(total_deposit, int)
 
         previous_total_deposit = self.get_total_deposit(
             address=beneficiary, block_identifier=block_identifier

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -78,7 +78,7 @@ def unlock(
     sender: Address,
     receiver: Address,
     given_block_identifier: BlockSpecification,
-) -> None:
+) -> None:  # pragma: no unittest
     merkle_tree_locks = get_batch_unlock(end_state)
     assert merkle_tree_locks, "merkle tree is missing"
 
@@ -97,7 +97,9 @@ class EventHandler(ABC):
 
 
 class RaidenEventHandler(EventHandler):
-    def on_raiden_event(self, raiden: "RaidenService", chain_state: ChainState, event: Event):
+    def on_raiden_event(
+        self, raiden: "RaidenService", chain_state: ChainState, event: Event
+    ):  # pragma: no unittest
         # pylint: disable=too-many-branches
         if type(event) == SendLockExpired:
             assert isinstance(event, SendLockExpired), MYPY_ANNOTATION
@@ -150,7 +152,9 @@ class RaidenEventHandler(EventHandler):
             log.error("Unknown event", event_type=str(type(event)), node=pex(raiden.address))
 
     @staticmethod
-    def handle_send_lockexpired(raiden: "RaidenService", send_lock_expired: SendLockExpired):
+    def handle_send_lockexpired(
+        raiden: "RaidenService", send_lock_expired: SendLockExpired
+    ):  # pragma: no unittest
         lock_expired_message = message_from_sendevent(send_lock_expired)
         raiden.sign(lock_expired_message)
         raiden.transport.send_async(send_lock_expired.queue_identifier, lock_expired_message)
@@ -158,7 +162,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_lockedtransfer(
         raiden: "RaidenService", send_locked_transfer: SendLockedTransfer
-    ):
+    ):  # pragma: no unittest
         mediated_transfer_message = message_from_sendevent(send_locked_transfer)
         raiden.sign(mediated_transfer_message)
         raiden.transport.send_async(
@@ -166,13 +170,17 @@ class RaidenEventHandler(EventHandler):
         )
 
     @staticmethod
-    def handle_send_secretreveal(raiden: "RaidenService", reveal_secret_event: SendSecretReveal):
+    def handle_send_secretreveal(
+        raiden: "RaidenService", reveal_secret_event: SendSecretReveal
+    ):  # pragma: no unittest
         reveal_secret_message = message_from_sendevent(reveal_secret_event)
         raiden.sign(reveal_secret_message)
         raiden.transport.send_async(reveal_secret_event.queue_identifier, reveal_secret_message)
 
     @staticmethod
-    def handle_send_balanceproof(raiden: "RaidenService", balance_proof_event: SendBalanceProof):
+    def handle_send_balanceproof(
+        raiden: "RaidenService", balance_proof_event: SendBalanceProof
+    ):  # pragma: no unittest
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)
         raiden.transport.send_async(balance_proof_event.queue_identifier, unlock_message)
@@ -180,7 +188,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_secretrequest(
         raiden: "RaidenService", secret_request_event: SendSecretRequest
-    ):
+    ):  # pragma: no unittest
         if reveal_secret_with_resolver(raiden, secret_request_event):
             return
 
@@ -191,7 +199,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_refundtransfer(
         raiden: "RaidenService", refund_transfer_event: SendRefundTransfer
-    ):
+    ):  # pragma: no unittest
         refund_transfer_message = message_from_sendevent(refund_transfer_event)
         raiden.sign(refund_transfer_message)
         raiden.transport.send_async(
@@ -199,7 +207,9 @@ class RaidenEventHandler(EventHandler):
         )
 
     @staticmethod
-    def handle_send_processed(raiden: "RaidenService", processed_event: SendProcessed):
+    def handle_send_processed(
+        raiden: "RaidenService", processed_event: SendProcessed
+    ):  # pragma: no unittest
         processed_message = message_from_sendevent(processed_event)
         raiden.sign(processed_message)
         raiden.transport.send_async(processed_event.queue_identifier, processed_message)
@@ -233,7 +243,9 @@ class RaidenEventHandler(EventHandler):
             payment_status.payment_done.set(payment_sent_failed_event)
 
     @staticmethod
-    def handle_unlockfailed(raiden: "RaidenService", unlock_failed_event: EventUnlockFailed):
+    def handle_unlockfailed(
+        raiden: "RaidenService", unlock_failed_event: EventUnlockFailed
+    ):  # pragma: no unittest
         # pylint: disable=unused-argument
         log.error(
             "UnlockFailed!",
@@ -245,7 +257,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_contract_send_secretreveal(
         raiden: "RaidenService", channel_reveal_secret_event: ContractSendSecretReveal
-    ):
+    ):  # pragma: no unittest
         raiden.default_secret_registry.register_secret(secret=channel_reveal_secret_event.secret)
 
     @staticmethod
@@ -572,7 +584,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
 
     def on_raiden_event(
         self, raiden: "RaidenService", chain_state: ChainState, event: Event
-    ) -> None:
+    ) -> None:  # pragma: no unittest
         if type(event) == EventRouteFailed:
             assert isinstance(event, EventRouteFailed), MYPY_ANNOTATION
             self.handle_routefailed(raiden, event)
@@ -584,8 +596,10 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
         self.wrapped.on_raiden_event(raiden, chain_state, event)
 
     @staticmethod
-    def handle_routefailed(raiden: "RaidenService", route_failed_event: EventRouteFailed) -> None:
-        feedback_token = raiden.route_to_feedback_token.get(tuple(route_failed_event.route))
+    def handle_routefailed(
+        raiden: "RaidenService", route_failed_event: EventRouteFailed
+    ) -> None:  # pragma: no unittest
+        feedback_token = raiden.route_to_feeback_token.get(tuple(route_failed_event.route))
 
         if feedback_token:
             log.debug(
@@ -605,7 +619,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
     @staticmethod
     def handle_paymentsentsuccess(
         raiden: "RaidenService", payment_sent_success_event: EventPaymentSentSuccess
-    ) -> None:
+    ) -> None:  # pragma: no unittest
         feedback_token = raiden.route_to_feedback_token.get(
             tuple(payment_sent_success_event.route)
         )

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -26,7 +26,7 @@ def channel_state_until_state_change(
     raiden: "RaidenService",
     canonical_identifier: CanonicalIdentifier,
     state_change_identifier: Union[StateChangeID, str],
-) -> Optional[NettingChannelState]:
+) -> Optional[NettingChannelState]:  # pragma: no unittest
     """ Go through WAL state changes until a certain balance hash is found. """
     assert raiden.wal, "Raiden has not been started yet"
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -71,7 +71,7 @@ def check_version(current_version: str):
             gevent.sleep(CHECK_VERSION_INTERVAL)
 
 
-def check_gas_reserve(raiden):
+def check_gas_reserve(raiden):  # pragma: no unittest
     """ Check periodically for gas reserve in the account """
     while True:
         has_enough_balance, estimated_required_balance = gas_reserve.has_enough_gas_reserve(
@@ -116,7 +116,7 @@ def check_rdn_deposits(raiden, user_deposit_proxy: UserDeposit):
         gevent.sleep(CHECK_RDN_MIN_DEPOSIT_INTERVAL)
 
 
-def check_network_id(network_id, web3: Web3):
+def check_network_id(network_id, web3: Web3):  # pragma: no unittest
     """ Check periodically if the underlying ethereum client's network id has changed"""
     while True:
         current_id = int(web3.version.network)

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -44,6 +44,7 @@ from raiden.utils.typing import (
     TokenAddress,
     TokenAmount,
     TokenNetworkAddress,
+    typecheck,
 )
 
 
@@ -513,8 +514,7 @@ def make_receive_transfer_mediated(
     chain_id: Optional[ChainID] = None,
 ) -> LockedTransferSignedState:
 
-    if not isinstance(lock, HashTimeLockState):
-        raise ValueError("lock must be of type HashTimeLockState")
+    typecheck(lock, HashTimeLockState)
 
     signer = LocalSigner(privkey)
     address = signer.address
@@ -584,8 +584,7 @@ def make_receive_expired_lock(
     chain_id: ChainID = None,
 ) -> ReceiveLockExpired:
 
-    if not isinstance(lock, HashTimeLockState):
-        raise ValueError("lock must be of type HashTimeLockState")
+    typecheck(lock, HashTimeLockState)
 
     signer = LocalSigner(privkey)
     address = signer.address

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -34,6 +34,7 @@ from raiden.utils.typing import (
     TransactionHash,
     Tuple,
     TypeVar,
+    typecheck,
 )
 
 # Quick overview
@@ -159,8 +160,7 @@ class ContractSendEvent(Event):
     triggered_by_block_hash: BlockHash
 
     def __post_init__(self) -> None:
-        if not isinstance(self.triggered_by_block_hash, T_BlockHash):
-            raise ValueError("triggered_by_block_hash must be of type block_hash")
+        typecheck(self.triggered_by_block_hash, T_BlockHash)
 
 
 @dataclass
@@ -181,10 +181,8 @@ class ContractReceiveStateChange(StateChange):
     block_hash: BlockHash
 
     def __post_init__(self) -> None:
-        if not isinstance(self.block_number, T_BlockNumber):
-            raise ValueError("block_number must be of type block_number")
-        if not isinstance(self.block_hash, T_BlockHash):
-            raise ValueError("block_hash must be of type block_hash")
+        typecheck(self.block_number, T_BlockNumber)
+        typecheck(self.block_hash, T_BlockHash)
 
 
 ST = TypeVar("ST", bound=State)
@@ -208,7 +206,7 @@ class StateManager(Generic[ST]):
             state_transition: function that can apply a StateChange message.
             current_state: current application state.
         """
-        if not callable(state_transition):
+        if not callable(state_transition):  # pragma: no unittest
             raise ValueError("state_transition must be a callable")
 
         self.state_transition = state_transition
@@ -291,17 +289,10 @@ class BalanceProofUnsignedState(State):
     balance_hash: BalanceHash = field(default=EMPTY_BALANCE_HASH)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.nonce, int):
-            raise ValueError("nonce must be int")
-
-        if not isinstance(self.transferred_amount, T_TokenAmount):
-            raise ValueError("transferred_amount must be a token_amount instance")
-
-        if not isinstance(self.locked_amount, T_TokenAmount):
-            raise ValueError("locked_amount must be a token_amount instance")
-
-        if not isinstance(self.locksroot, T_Keccak256):
-            raise ValueError("locksroot must be a keccak256 instance")
+        typecheck(self.nonce, int)
+        typecheck(self.transferred_amount, T_TokenAmount)
+        typecheck(self.locked_amount, T_TokenAmount)
+        typecheck(self.locksroot, T_Keccak256)
 
         if self.nonce <= 0:
             raise ValueError("nonce cannot be zero or negative")
@@ -356,26 +347,13 @@ class BalanceProofSignedState(State):
     balance_hash: BalanceHash = field(default=EMPTY_BALANCE_HASH)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.nonce, int):
-            raise ValueError("nonce must be int")
-
-        if not isinstance(self.transferred_amount, T_TokenAmount):
-            raise ValueError("transferred_amount must be a token_amount instance")
-
-        if not isinstance(self.locked_amount, T_TokenAmount):
-            raise ValueError("locked_amount must be a token_amount instance")
-
-        if not isinstance(self.locksroot, T_Keccak256):
-            raise ValueError("locksroot must be a keccak256 instance")
-
-        if not isinstance(self.message_hash, T_Keccak256):
-            raise ValueError("message_hash must be a keccak256 instance")
-
-        if not isinstance(self.signature, T_Signature):
-            raise ValueError("signature must be a signature instance")
-
-        if not isinstance(self.sender, T_Address):
-            raise ValueError("sender must be an address instance")
+        typecheck(self.nonce, int)
+        typecheck(self.transferred_amount, T_TokenAmount)
+        typecheck(self.locked_amount, T_TokenAmount)
+        typecheck(self.locksroot, T_Keccak256)
+        typecheck(self.message_hash, T_Keccak256)
+        typecheck(self.signature, T_Signature)
+        typecheck(self.sender, T_Address)
 
         if self.nonce <= 0:
             raise ValueError("nonce cannot be zero or negative")

--- a/raiden/transfer/identifiers.py
+++ b/raiden/transfer/identifiers.py
@@ -9,6 +9,7 @@ from raiden.utils.typing import (
     T_ChainID,
     T_ChannelID,
     TokenNetworkAddress,
+    typecheck,
 )
 
 
@@ -19,14 +20,9 @@ class CanonicalIdentifier:
     channel_identifier: ChannelID
 
     def validate(self) -> None:
-        if not isinstance(self.token_network_address, T_Address):
-            raise ValueError("token_network_address must be an address instance")
-
-        if not isinstance(self.channel_identifier, T_ChannelID):
-            raise ValueError("channel_identifier must be an ChannelID instance")
-
-        if not isinstance(self.chain_identifier, T_ChainID):
-            raise ValueError("chain_id must be a ChainID instance")
+        typecheck(self.chain_identifier, T_ChainID)
+        typecheck(self.token_network_address, T_Address)
+        typecheck(self.channel_identifier, T_ChannelID)
 
         if self.channel_identifier < 0 or self.channel_identifier > constants.UINT256_MAX:
             raise ValueError("channel id is invalid")

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -16,6 +16,7 @@ from raiden.utils.typing import (
     SecretHash,
     TokenAddress,
     TokenNetworkAddress,
+    typecheck,
 )
 
 
@@ -44,8 +45,7 @@ class SendLockedTransfer(SendMessageEvent):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.transfer, LockedTransferUnsignedState):
-            raise ValueError("transfer must be a LockedTransferUnsignedState instance")
+        typecheck(self.transfer, LockedTransferUnsignedState)
 
     @property
     def balance_proof(self) -> BalanceProofUnsignedState:

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -30,6 +30,7 @@ from raiden.utils.typing import (
     TargetAddress,
     TokenAddress,
     TokenNetworkAddress,
+    typecheck,
 )
 
 if TYPE_CHECKING:
@@ -56,11 +57,9 @@ class LockedTransferUnsignedState(LockedTransferState):
     target: TargetAddress
 
     def __post_init__(self) -> None:
-        if not isinstance(self.lock, HashTimeLockState):
-            raise ValueError("lock must be a HashTimeLockState instance")
 
-        if not isinstance(self.balance_proof, BalanceProofUnsignedState):
-            raise ValueError("balance_proof must be a BalanceProofUnsignedState instance")
+        typecheck(self.lock, HashTimeLockState)
+        typecheck(self.balance_proof, BalanceProofUnsignedState)
 
         # At least the lock for this transfer must be in the locksroot, so it
         # must not be empty
@@ -83,11 +82,8 @@ class LockedTransferSignedState(LockedTransferState):
     target: TargetAddress
 
     def __post_init__(self) -> None:
-        if not isinstance(self.lock, HashTimeLockState):
-            raise ValueError("lock must be a HashTimeLockState instance")
-
-        if not isinstance(self.balance_proof, BalanceProofSignedState):
-            raise ValueError("balance_proof must be a BalanceProofSignedState instance")
+        typecheck(self.lock, HashTimeLockState)
+        typecheck(self.balance_proof, BalanceProofSignedState)
 
         # At least the lock for this transfer must be in the locksroot, so it
         # must not be empty
@@ -199,14 +195,9 @@ class MediationPairState(State):
     )
 
     def __post_init__(self) -> None:
-        if not isinstance(self.payer_transfer, LockedTransferSignedState):
-            raise ValueError("payer_transfer must be a LockedTransferSignedState instance")
-
-        if not isinstance(self.payee_address, T_Address):
-            raise ValueError("payee_address must be an address")
-
-        if not isinstance(self.payee_transfer, LockedTransferUnsignedState):
-            raise ValueError("payee_transfer must be a LockedTransferUnsignedState instance")
+        typecheck(self.payer_transfer, LockedTransferSignedState)
+        typecheck(self.payee_address, T_Address)
+        typecheck(self.payee_transfer, LockedTransferUnsignedState)
 
     @property
     def payer_address(self) -> Address:

--- a/raiden/transfer/mediated_transfer/state_change.py
+++ b/raiden/transfer/mediated_transfer/state_change.py
@@ -20,6 +20,7 @@ from raiden.utils.typing import (
     PaymentID,
     Secret,
     SecretHash,
+    typecheck,
 )
 
 
@@ -33,8 +34,7 @@ class ActionInitInitiator(StateChange):
     routes: List[RouteState]
 
     def __post_init__(self) -> None:
-        if not isinstance(self.transfer, TransferDescriptionWithSecretState):
-            raise ValueError("transfer must be an TransferDescriptionWithSecretState instance.")
+        typecheck(self.transfer, TransferDescriptionWithSecretState)
 
 
 @dataclass
@@ -53,11 +53,8 @@ class ActionInitMediator(BalanceProofStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.from_hop, HopState):
-            raise ValueError("from_route must be a HopState instance")
-
-        if not isinstance(self.from_transfer, LockedTransferSignedState):
-            raise ValueError("from_transfer must be a LockedTransferSignedState instance")
+        typecheck(self.from_hop, HopState)
+        typecheck(self.from_transfer, LockedTransferSignedState)
 
 
 @dataclass
@@ -74,12 +71,8 @@ class ActionInitTarget(BalanceProofStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-
-        if not isinstance(self.from_hop, HopState):
-            raise ValueError("route must be a RouteState instance")
-
-        if not isinstance(self.transfer, LockedTransferSignedState):
-            raise ValueError("transfer must be a LockedTransferSignedState instance")
+        typecheck(self.from_hop, HopState)
+        typecheck(self.transfer, LockedTransferSignedState)
 
 
 @dataclass
@@ -125,8 +118,7 @@ class ReceiveTransferRefundCancelRoute(BalanceProofStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.transfer, LockedTransferSignedState):
-            raise ValueError("transfer must be an instance of LockedTransferSignedState")
+        typecheck(self.transfer, LockedTransferSignedState)
 
         self.secrethash = SecretHash(sha256(self.secret).digest())
 
@@ -140,5 +132,4 @@ class ReceiveTransferRefund(BalanceProofStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.transfer, LockedTransferSignedState):
-            raise ValueError("transfer must be an instance of LockedTransferSignedState")
+        typecheck(self.transfer, LockedTransferSignedState)

--- a/raiden/transfer/secret_registry.py
+++ b/raiden/transfer/secret_registry.py
@@ -6,7 +6,7 @@ from raiden.transfer.state import (
     CHANNEL_STATES_PRIOR_TO_CLOSED,
     NettingChannelState,
 )
-from raiden.utils.typing import BlockExpiration, BlockHash, List, Secret, T_Secret
+from raiden.utils.typing import BlockExpiration, BlockHash, List, Secret, T_Secret, typecheck
 
 
 def events_for_onchain_secretreveal(
@@ -17,8 +17,7 @@ def events_for_onchain_secretreveal(
 ) -> List[Event]:
     events: List[Event] = list()
 
-    if not isinstance(secret, T_Secret):
-        raise ValueError("secret must be a Secret instance")
+    typecheck(secret, T_Secret)
 
     if get_status(channel_state) in CHANNEL_STATES_PRIOR_TO_CLOSED + (CHANNEL_STATE_CLOSED,):
         reveal_event = ContractSendSecretReveal(

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -61,6 +61,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
     Union,
+    typecheck,
 )
 
 if TYPE_CHECKING:
@@ -172,8 +173,7 @@ class HopState(State):
     channel_identifier: ChannelID
 
     def __post_init__(self) -> None:
-        if not isinstance(self.node_address, T_Address):
-            raise ValueError("node_address must be an address instance")
+        typecheck(self.node_address, T_Address)
 
 
 @dataclass
@@ -201,14 +201,9 @@ class HashTimeLockState(State):
     lockhash: LockHash = field(repr=False, default=EMPTY_LOCK_HASH)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.amount, T_PaymentWithFeeAmount):
-            raise ValueError("amount must be a PaymentWithFeeAmount instance")
-
-        if not isinstance(self.expiration, T_BlockNumber):
-            raise ValueError("expiration must be a BlockNumber instance")
-
-        if not isinstance(self.secrethash, T_Secret):
-            raise ValueError("secrethash must be a Secret instance")
+        typecheck(self.amount, T_PaymentWithFeeAmount)
+        typecheck(self.expiration, T_BlockNumber)
+        typecheck(self.secrethash, T_Secret)
 
         packed = messages.Lock(buffer_for(messages.Lock))
         # pylint: disable=assigning-non-slot
@@ -234,11 +229,8 @@ class UnlockPartialProofState(State):
     lockhash: LockHash = field(repr=False, default=EMPTY_LOCK_HASH)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.lock, HashTimeLockState):
-            raise ValueError("lock must be a HashTimeLockState instance")
-
-        if not isinstance(self.secret, T_Secret):
-            raise ValueError("secret must be a secret instance")
+        typecheck(self.lock, HashTimeLockState)
+        typecheck(self.secret, T_Secret)
 
         self.amount = self.lock.amount
         self.expiration = self.lock.expiration
@@ -291,14 +283,9 @@ class TransactionChannelNewBalance(State):
     deposit_block_number: BlockNumber
 
     def __post_init__(self) -> None:
-        if not isinstance(self.participant_address, T_Address):
-            raise ValueError("participant_address must be of type address")
-
-        if not isinstance(self.contract_balance, T_TokenAmount):
-            raise ValueError("contract_balance must be of type token_amount")
-
-        if not isinstance(self.deposit_block_number, T_BlockNumber):
-            raise ValueError("deposit_block_number must be of type block_number")
+        typecheck(self.participant_address, T_Address)
+        typecheck(self.contract_balance, T_TokenAmount)
+        typecheck(self.deposit_block_number, T_BlockNumber)
 
 
 @dataclass(order=True)
@@ -335,11 +322,8 @@ class NettingChannelEndState(State):
     onchain_locksroot: Locksroot = EMPTY_MERKLE_ROOT
 
     def __post_init__(self) -> None:
-        if not isinstance(self.address, T_Address):
-            raise ValueError("address must be an address instance")
-
-        if not isinstance(self.contract_balance, T_TokenAmount):
-            raise ValueError("balance must be a token_amount isinstance")
+        typecheck(self.address, T_Address)
+        typecheck(self.contract_balance, T_TokenAmount)
 
 
 @dataclass
@@ -364,22 +348,21 @@ class NettingChannelState(State):
         if self.reveal_timeout >= self.settle_timeout:
             raise ValueError("reveal_timeout must be smaller than settle_timeout")
 
-        if not isinstance(self.reveal_timeout, int) or self.reveal_timeout <= 0:
+        typecheck(self.reveal_timeout, int)
+        typecheck(self.settle_timeout, int)
+        typecheck(self.open_transaction, TransactionExecutionStatus)
+        typecheck(self.canonical_identifier.channel_identifier, T_ChannelID)
+
+        if self.reveal_timeout <= 0:
             raise ValueError("reveal_timeout must be a positive integer")
 
-        if not isinstance(self.settle_timeout, int) or self.settle_timeout <= 0:
+        if self.settle_timeout <= 0:
             raise ValueError("settle_timeout must be a positive integer")
-
-        if not isinstance(self.open_transaction, TransactionExecutionStatus):
-            raise ValueError("open_transaction must be a TransactionExecutionStatus instance")
 
         if self.open_transaction.result != TransactionExecutionStatus.SUCCESS:
             raise ValueError(
                 "Cannot create a NettingChannelState with a non successfull open_transaction"
             )
-
-        if not isinstance(self.canonical_identifier.channel_identifier, T_ChannelID):
-            raise ValueError("channel identifier must be of type T_ChannelID")
 
         if (
             self.canonical_identifier.channel_identifier < 0
@@ -439,11 +422,8 @@ class TokenNetworkState(State):
     )
 
     def __post_init__(self) -> None:
-        if not isinstance(self.address, T_Address):
-            raise ValueError("address must be an address instance")
-
-        if not isinstance(self.token_address, T_Address):
-            raise ValueError("token_address must be an address instance")
+        typecheck(self.address, T_Address)
+        typecheck(self.token_address, T_Address)
 
         self.partneraddresses_to_channelidentifiers = defaultdict(
             list, self.partneraddresses_to_channelidentifiers
@@ -464,8 +444,7 @@ class PaymentNetworkState(State):
     )
 
     def __post_init__(self) -> None:
-        if not isinstance(self.address, T_Address):
-            raise ValueError("address must be an address instance")
+        typecheck(self.address, T_Address)
 
         if not self.tokennetworkaddresses_to_tokennetworks:
             self.tokennetworkaddresses_to_tokennetworks: Dict[
@@ -507,14 +486,9 @@ class ChainState(State):
     ] = field(repr=False, default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.block_number, T_BlockNumber):
-            raise ValueError("block_number must be of BlockNumber type")
-
-        if not isinstance(self.block_hash, T_BlockHash):
-            raise ValueError("block_hash must be of BlockHash type")
-
-        if not isinstance(self.chain_id, T_ChainID):
-            raise ValueError("chain_id must be of ChainID type")
+        typecheck(self.block_number, T_BlockNumber)
+        typecheck(self.block_hash, T_BlockHash)
+        typecheck(self.chain_id, T_ChainID)
 
     def __repr__(self):
         return (

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -41,6 +41,7 @@ from raiden.utils.typing import (
     T_SecretRegistryAddress,
     TokenAmount,
     TokenNetworkAddress,
+    typecheck,
 )
 
 
@@ -51,8 +52,7 @@ class BalanceProofStateChange(AuthenticatedSenderStateChange):
     balance_proof: BalanceProofSignedState
 
     def __post_init__(self):
-        if not isinstance(self.balance_proof, BalanceProofSignedState):
-            raise ValueError("balance_proof must be an instance of BalanceProofSignedState")
+        typecheck(self.balance_proof, BalanceProofSignedState)
 
 
 @dataclass
@@ -67,8 +67,7 @@ class Block(StateChange):
     block_hash: BlockHash
 
     def __post_init__(self) -> None:
-        if not isinstance(self.block_number, T_BlockNumber):
-            raise ValueError("block_number must be of type block_number")
+        typecheck(self.block_number, T_BlockNumber)
 
 
 @dataclass
@@ -161,14 +160,9 @@ class ActionInitChain(StateChange):
     chain_id: ChainID
 
     def __post_init__(self) -> None:
-        if not isinstance(self.block_number, T_BlockNumber):
-            raise ValueError("block_number must be of type BlockNumber")
-
-        if not isinstance(self.block_hash, T_BlockHash):
-            raise ValueError("block_hash must be of type BlockHash")
-
-        if not isinstance(self.chain_id, int):
-            raise ValueError("chain_id must be int")
+        typecheck(self.block_number, T_BlockNumber)
+        typecheck(self.block_hash, T_BlockHash)
+        typecheck(self.chain_id, int)
 
 
 @dataclass
@@ -181,8 +175,7 @@ class ActionNewTokenNetwork(StateChange):
     token_network: TokenNetworkState
 
     def __post_init__(self) -> None:
-        if not isinstance(self.token_network, TokenNetworkState):
-            raise ValueError("token_network must be a TokenNetworkState instance.")
+        typecheck(self.token_network, TokenNetworkState)
 
 
 @dataclass
@@ -233,8 +226,7 @@ class ActionChangeNodeNetworkState(StateChange):
     network_state: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.node_address, T_Address):
-            raise ValueError("node_address must be an address instance")
+        typecheck(self.node_address, T_Address)
 
 
 @dataclass
@@ -247,8 +239,7 @@ class ContractReceiveNewPaymentNetwork(ContractReceiveStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.payment_network, PaymentNetworkState):
-            raise ValueError("payment_network must be a PaymentNetworkState instance")
+        typecheck(self.payment_network, PaymentNetworkState)
 
 
 @dataclass
@@ -260,8 +251,7 @@ class ContractReceiveNewTokenNetwork(ContractReceiveStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.token_network, TokenNetworkState):
-            raise ValueError("token_network must be a TokenNetworkState instance")
+        typecheck(self.token_network, TokenNetworkState)
 
 
 @dataclass
@@ -274,12 +264,9 @@ class ContractReceiveSecretReveal(ContractReceiveStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.secret_registry_address, T_SecretRegistryAddress):
-            raise ValueError("secret_registry_address must be of type SecretRegistryAddress")
-        if not isinstance(self.secrethash, T_SecretHash):
-            raise ValueError("secrethash must be of type SecretHash")
-        if not isinstance(self.secret, T_Secret):
-            raise ValueError("secret must be of type Secret")
+        typecheck(self.secret_registry_address, T_SecretRegistryAddress)
+        typecheck(self.secrethash, T_SecretHash)
+        typecheck(self.secret, T_Secret)
 
 
 @dataclass
@@ -303,11 +290,8 @@ class ContractReceiveChannelBatchUnlock(ContractReceiveStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.receiver, T_Address):
-            raise ValueError("receiver must be of type address")
-
-        if not isinstance(self.sender, T_Address):
-            raise ValueError("sender must be of type address")
+        typecheck(self.receiver, T_Address)
+        typecheck(self.sender, T_Address)
 
     @property
     def token_network_address(self) -> TokenNetworkAddress:
@@ -324,11 +308,8 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if not isinstance(self.participant1, T_Address):
-            raise ValueError("participant1 must be of type address")
-
-        if not isinstance(self.participant2, T_Address):
-            raise ValueError("participant2 must be of type address")
+        typecheck(self.participant1, T_Address)
+        typecheck(self.participant2, T_Address)
 
     @property
     def channel_identifier(self) -> ChannelID:

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -76,11 +76,11 @@ def count_token_network_channels(
     return count
 
 
-def state_from_raiden(raiden) -> ChainState:
+def state_from_raiden(raiden) -> ChainState:  # pragma: no unittest
     return raiden.wal.state_manager.current_state
 
 
-def state_from_app(app) -> ChainState:
+def state_from_app(app) -> ChainState:  # pragma: no unittest
     return app.raiden.wal.state_manager.current_state
 
 

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -22,7 +22,7 @@ log = structlog.get_logger(__name__)
 TRANSFER_MEMORY = 4096
 
 
-class EchoNode:
+class EchoNode:  # pragma: no unittest
     def __init__(self, api, token_address):
         assert isinstance(api, RaidenAPI)
         self.ready = Event()

--- a/raiden/utils/timeout.py
+++ b/raiden/utils/timeout.py
@@ -5,7 +5,7 @@ from raiden.utils.typing import BlockNumber, Callable
 from raiden.waiting import wait_for_block
 
 
-def _timeout_task(
+def _timeout_task(  # pragma: no unittest
     throw: Callable,
     exception_to_throw: Exception,
     raiden: RaidenService,
@@ -16,7 +16,7 @@ def _timeout_task(
     throw(exception_to_throw)
 
 
-class BlockTimeout:
+class BlockTimeout:  # pragma: no unittest
     def __init__(
         self,
         exception_to_throw,

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -22,6 +22,12 @@ if TYPE_CHECKING:
 
 MYPY_ANNOTATION = "This assert is used to tell mypy what is the type of the variable"
 
+
+def typecheck(value: Any, expected: Type):
+    if not isinstance(value, expected):
+        raise ValueError(f"Expected a value of type {expected}")
+
+
 ABI = List[Dict[str, Any]]
 
 T_Address = bytes

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -34,7 +34,7 @@ TRANSPORT_ERROR_MSG = "Waiting for protocol messags requires a running transport
 
 def wait_for_block(
     raiden: "RaidenService", block_number: BlockNumber, retry_timeout: float
-) -> None:
+) -> None:  # pragma: no unittest
     while raiden.get_block_number() < block_number:
         assert raiden, ALARM_TASK_ERROR_MSG
         assert raiden.alarm, ALARM_TASK_ERROR_MSG
@@ -48,7 +48,7 @@ def wait_for_newchannel(
     token_address: TokenAddress,
     partner_address: Address,
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until the channel with partner_address is registered.
 
     Note:
@@ -79,7 +79,7 @@ def wait_for_participant_newbalance(
     target_address: Address,
     target_balance: TokenAmount,
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until a given channels balance exceeds the target balance.
 
     Note:
@@ -117,7 +117,7 @@ def wait_for_payment_balance(
     target_address: Address,
     target_balance: TokenAmount,
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until a given channel's balance exceeds the target balance.
 
     Note:
@@ -223,7 +223,7 @@ def wait_for_close(
     token_address: TokenAddress,
     channel_ids: List[ChannelID],
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until all channels are closed.
 
     Note:
@@ -244,7 +244,7 @@ def wait_for_payment_network(
     payment_network_address: PaymentNetworkAddress,
     token_address: TokenAddress,
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     token_network = views.get_token_network_by_token_address(
         views.state_from_raiden(raiden), payment_network_address, token_address
     )
@@ -264,7 +264,7 @@ def wait_for_settle(
     token_address: TokenAddress,
     channel_ids: List[ChannelID],
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until all channels are settled.
 
     Note:
@@ -282,7 +282,7 @@ def wait_for_settle(
 
 def wait_for_network_state(
     raiden: "RaidenService", node_address: Address, network_state: str, retry_timeout: float
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until `node_address` becomes healthy.
 
     Note:
@@ -298,7 +298,9 @@ def wait_for_network_state(
         network_statuses = views.get_networkstatuses(views.state_from_raiden(raiden))
 
 
-def wait_for_healthy(raiden: "RaidenService", node_address: Address, retry_timeout: float) -> None:
+def wait_for_healthy(
+    raiden: "RaidenService", node_address: Address, retry_timeout: float
+) -> None:  # pragma: no unittest
     """Wait until `node_address` becomes healthy.
 
     Note:
@@ -313,7 +315,7 @@ def wait_for_transfer_success(
     payment_identifier: PaymentID,
     amount: PaymentAmount,
     retry_timeout: float,
-) -> None:
+) -> None:  # pragma: no unittest
     """Wait until a transfer with a specific identifier and amount
     is seen in the WAL.
 


### PR DESCRIPTION
Adds the following parts of the code to be omitted in unit test coverage measurement:

- runtime typechecks (Introduces a `typecheck` function too to reduce the amount of boilderplate code and be able to find the checks in the code)
- classes that have a direct or indirect attribute of type `RaidenService`
- functions that take arguments of a complex type and are too small to be split (mainly wrappers and dispatchers, more of these wil be omitted in the following pull requests.)

Coverage increase: 64% to 72%.