### PR TITLE
Add `log` to the pylint allowed constant names

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -18,7 +18,7 @@ overgeneral-exceptions=Exception,RaidenUnrecoverableError
 [BASIC]
 
 bad-names=foo,bar,baz,toto,tutu,tata
-good-names=i,j,k,_
+good-names=i,j,k,_,log
 
 [LOGGING]
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -64,7 +64,7 @@ from raiden.utils.typing import (
     Tuple,
 )
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 EVENTS_PAYMENT_HISTORY_RELATED = (
     EventPaymentSentSuccess,

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -25,7 +25,7 @@ from raiden.utils import pex, typing
 from raiden.utils.typing import Address
 from raiden_contracts.contract_manager import contracts_precompiled_path
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 class App:  # pylint: disable=too-few-public-methods

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from raiden.raiden_service import RaidenService  # noqa: F401
 
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 def handle_tokennetwork_new(raiden: "RaidenService", event: Event):

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -23,7 +23,7 @@ from raiden.transfer import views
 from raiden.utils import pex, typing
 from raiden.utils.typing import Address
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 RECOVERABLE_ERRORS = (
     DepositMismatch,
     DepositOverLimit,

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -22,7 +22,6 @@ LOCKEXPIRED = 13
 TODEVICE = 14
 
 
-# pylint: disable=invalid-name
 log = structlog.get_logger(__name__)
 
 

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -29,7 +29,7 @@ from raiden.transfer.state_change import ReceiveDelivered, ReceiveProcessed, Rec
 from raiden.utils import pex, random_secret
 from raiden.utils.typing import MYPY_ANNOTATION, InitiatorAddress, PaymentAmount
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 class MessageHandler:

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -34,7 +34,7 @@ from raiden.utils.typing import (
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, EVENT_SECRET_REVEALED
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 class SecretRegistry:

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -10,7 +10,7 @@ from raiden.utils.typing import Address, AddressHex, BlockSpecification, Optiona
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 class ServiceRegistry:

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -12,7 +12,7 @@ from raiden.utils.typing import Address, Balance, BlockSpecification, TokenAddre
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 # Determined by safe_gas_limit(estimateGas(approve)) on 17/01/19 with geth 1.8.20
 GAS_REQUIRED_FOR_APPROVE = 58792

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -85,7 +85,7 @@ from raiden_contracts.constants import (
 )
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 def raise_on_call_returned_empty(given_block_identifier: BlockSpecification) -> NoReturn:

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -39,7 +39,7 @@ from raiden.utils.typing import (
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, EVENT_TOKEN_NETWORK_CREATED
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 class TokenNetworkRegistry:

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -25,7 +25,7 @@ from raiden.utils.typing import (
 from raiden_contracts.constants import CONTRACT_USER_DEPOSIT, GAS_REQUIRED_FOR_UDC_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 class UserDeposit:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -45,7 +45,7 @@ from raiden.utils.typing import (
     TransactionHash,
 )
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 def logs_blocks_sanity_check(from_block: BlockSpecification, to_block: BlockSpecification) -> None:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     # pylint: disable=unused-import
     from raiden.raiden_service import RaidenService
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 UNEVENTFUL_EVENTS = (
     EventPaymentReceivedSuccess,
     EventUnlockSuccess,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -97,7 +97,7 @@ from raiden.utils.typing import (
 from raiden.utils.upgrades import UpgradeManager
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 StatusesDict = Dict[TargetAddress, Dict[PaymentID, "PaymentStatus"]]
 ConnectionManagerDict = Dict[TokenNetworkAddress, ConnectionManager]
 

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -21,7 +21,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
 )
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 def get_best_routes(

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -17,7 +17,7 @@ from raiden.utils.typing import (
     Union,
 )
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 def restore_to_state_change(

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -27,7 +27,7 @@ from raiden.utils.runnable import Runnable
 from raiden.utils.typing import Tuple
 
 REMOVE_CALLBACK = object()
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 def _do_check_version(current_version: Tuple[str, ...]):

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -18,7 +18,7 @@ from raiden.utils import privatekey_to_address, privatekey_to_publickey
 from raiden.utils.http import JSONRPCExecutor
 from raiden.utils.typing import Address, Any, ChainID, Dict, List, NamedTuple, Port, PrivateKey
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 
 Command = List[str]

--- a/raiden/utils/filters.py
+++ b/raiden/utils/filters.py
@@ -20,7 +20,7 @@ from raiden.utils.typing import (
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
 from raiden_contracts.contract_manager import ContractManager
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 # The maximum block range to query in a single filter query
 # Helps against timeout errors that occur if you query a filter for

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -26,7 +26,7 @@ from raiden.utils.typing import (
 if TYPE_CHECKING:
     from raiden.raiden_service import RaidenService  # pylint: disable=unused-import
 
-log = structlog.get_logger(__name__)  # pylint: disable=invalid-name
+log = structlog.get_logger(__name__)
 
 ALARM_TASK_ERROR_MSG = "Waiting relies on alarm task polling to update the node's internal state."
 TRANSPORT_ERROR_MSG = "Waiting for protocol messags requires a running transport."


### PR DESCRIPTION
Pylint seems to require all constants to be uppercase. By adding `log`
to the "good names" in `pylintrc`, we can make an exception for the
logger instances.

This saves us some noise from the logger constructors, as we don't need
to disable the name check individually for every module.