### PR TITLE
Some unit tests for miscellaneous modules

### DIFF
--- a/raiden/encoding/format.py
+++ b/raiden/encoding/format.py
@@ -61,7 +61,7 @@ def namedbuffer(buffer_name, fields_spec):  # noqa (ignore ciclomatic complexity
     if any(field.size_bytes < 0 for field in fields):
         raise ValueError("negative size_bytes")
 
-    if any(len(field.name) < 0 for field in fields):
+    if any(len(field.name) == 0 for field in fields):
         raise ValueError("field missing name")
 
     names_fields = {field.name: field for field in fields}

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -3,6 +3,7 @@ import structlog
 from raiden.constants import UINT64_MAX, UINT256_MAX
 from raiden.encoding.encoders import integer
 from raiden.encoding.format import make_field, namedbuffer, pad
+from raiden.exceptions import InvalidProtocolMessage
 
 
 def cmdid(id_):
@@ -289,7 +290,7 @@ def wrap(data):
 
     try:
         message = message_type(data)
-    except ValueError:
+    except (InvalidProtocolMessage, ValueError):
         log.error("trying to decode invalid message")
         return None
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -67,17 +67,17 @@ class SnapshotRecord(NamedTuple):
     data: Any
 
 
-def assert_sqlite_version() -> bool:
+def assert_sqlite_version() -> bool:  # pragma: no unittest
     if sqlite3.sqlite_version_info < SQLITE_MIN_REQUIRED_VERSION:
         return False
     return True
 
 
 def _sanitize_limit_and_offset(limit: int = None, offset: int = None) -> Tuple[int, int]:
-    if limit is not None and (not isinstance(limit, int) or limit < 0):
+    if limit is not None and (not isinstance(limit, int) or limit < 0):  # pragma: no unittest
         raise InvalidNumberInput("limit must be a positive integer")
 
-    if offset is not None and (not isinstance(offset, int) or offset < 0):
+    if offset is not None and (not isinstance(offset, int) or offset < 0):  # pragma: no unittest
         raise InvalidNumberInput("offset must be a positive integer")
 
     limit = -1 if limit is None else limit
@@ -304,7 +304,9 @@ class SQLiteStorage:
     ) -> Optional[SnapshotRecord]:
         """ Get snapshots earlier than state_change with provided ID. """
 
-        if not (state_change_identifier == "latest" or isinstance(state_change_identifier, int)):
+        if not (
+            state_change_identifier == "latest" or isinstance(state_change_identifier, int)
+        ):  # pragma: no unittest
             raise ValueError("from_identifier must be an integer or 'latest'")
 
         cursor = self.conn.cursor()
@@ -480,7 +482,9 @@ class SQLiteStorage:
         if not (from_identifier == "latest" or isinstance(from_identifier, T_StateChangeID)):
             raise ValueError("from_identifier must be an integer or 'latest'")
 
-        if not (to_identifier == "latest" or isinstance(to_identifier, T_StateChangeID)):
+        if not (
+            to_identifier == "latest" or isinstance(to_identifier, T_StateChangeID)
+        ):  # pragma: no unittest
             raise ValueError("to_identifier must be an integer or 'latest'")
 
         cursor = self.conn.cursor()
@@ -651,7 +655,7 @@ class SerializedSQLiteStorage:
         self.database = SQLiteStorage(database_path)
         self.serializer = serializer
 
-    def update_version(self) -> None:
+    def update_version(self) -> None:  # pragma: no unittest
         self.database.update_version()
 
     def count_state_changes(self) -> int:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -25,6 +25,7 @@ from raiden.utils.typing import (
     T_StateChangeID,
     Tuple,
     Union,
+    typecheck,
 )
 
 
@@ -477,10 +478,9 @@ class SQLiteStorage:
         self.maybe_commit()
 
     def get_statechanges_by_identifier(
-        self, from_identifier: Union[StateChangeID, str], to_identifier: Union[StateChangeID, str]
+        self, from_identifier: StateChangeID, to_identifier: Union[StateChangeID, str]
     ) -> List[str]:
-        if not (from_identifier == "latest" or isinstance(from_identifier, T_StateChangeID)):
-            raise ValueError("from_identifier must be an integer or 'latest'")
+        typecheck(from_identifier, T_StateChangeID)
 
         if not (
             to_identifier == "latest" or isinstance(to_identifier, T_StateChangeID)
@@ -488,12 +488,6 @@ class SQLiteStorage:
             raise ValueError("to_identifier must be an integer or 'latest'")
 
         cursor = self.conn.cursor()
-
-        if from_identifier == "latest":
-            assert to_identifier is None
-
-            cursor.execute("SELECT identifier FROM state_changes ORDER BY identifier DESC LIMIT 1")
-            from_identifier = cursor.fetchone()
 
         if to_identifier == "latest":
             cursor.execute(
@@ -746,7 +740,7 @@ class SerializedSQLiteStorage:
         return state_change
 
     def get_statechanges_by_identifier(
-        self, from_identifier: Union[StateChangeID, str], to_identifier: Union[StateChangeID, str]
+        self, from_identifier: StateChangeID, to_identifier: Union[StateChangeID, str]
     ) -> List[StateChange]:
         state_changes = self.database.get_statechanges_by_identifier(
             from_identifier, to_identifier

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -54,7 +54,7 @@ def _do_check_version(current_version: Tuple[str, ...]):
     return True
 
 
-def check_version(current_version: str):
+def check_version(current_version: str):  # pragma: no unittest
     """ Check periodically for a new release """
     app_version = parse_version(current_version)
     while True:
@@ -95,7 +95,7 @@ def check_gas_reserve(raiden):  # pragma: no unittest
         gevent.sleep(CHECK_GAS_RESERVE_INTERVAL)
 
 
-def check_rdn_deposits(raiden, user_deposit_proxy: UserDeposit):
+def check_rdn_deposits(raiden, user_deposit_proxy: UserDeposit):  # pragma: no unittest
     """ Check periodically for RDN deposits in the user-deposits contract """
     while True:
         rei_balance = user_deposit_proxy.effective_balance(raiden.address, "latest")

--- a/raiden/tests/unit/storage/test_serialization.py
+++ b/raiden/tests/unit/storage/test_serialization.py
@@ -1,4 +1,10 @@
-from raiden.storage.serialization.fields import OptionalIntegerToStringField, QueueIdentifierField
+import pytest
+
+from raiden.storage.serialization.fields import (
+    BytesField,
+    OptionalIntegerToStringField,
+    QueueIdentifierField,
+)
 from raiden.tests.utils import factories
 from raiden.transfer.identifiers import QueueIdentifier
 
@@ -8,15 +14,37 @@ def assert_roundtrip(field, value):
     assert field._deserialize(serialized, None, None) == value
 
 
-def test_queue_identifier_field_roundtrip():
-    queue_identifier = QueueIdentifier(
+@pytest.fixture()
+def queue_identifier():
+    return QueueIdentifier(
         recipient=factories.make_address(),
         canonical_identifier=factories.make_canonical_identifier(),
     )
+
+
+def test_queue_identifier_field_roundtrip(queue_identifier):
     assert_roundtrip(QueueIdentifierField(), queue_identifier)
+
+
+def test_queue_identifier_field_invalid_inputs(queue_identifier):
+    serialized = QueueIdentifierField()._serialize(queue_identifier, None, None)
+    wrong_delimiter = serialized.replace("|", ":")
+
+    # TODO check for address and chain/channel id validity in QueueIdentifier too, add tests here
+
+    for string in (wrong_delimiter,):
+        with pytest.raises(ValueError):
+            QueueIdentifierField()._deserialize(string, None, None)
 
 
 def test_optional_integer_to_string_field_roundtrip():
     field = OptionalIntegerToStringField()
     assert_roundtrip(field, 42)
+    assert_roundtrip(field, None)
+
+
+def test_bytes_field_roundtrip():
+    field = BytesField()
+    assert_roundtrip(field, b"foo")
+    assert_roundtrip(field, b"")
     assert_roundtrip(field, None)

--- a/raiden/tests/unit/test_encoding.py
+++ b/raiden/tests/unit/test_encoding.py
@@ -1,0 +1,59 @@
+import pytest
+
+from raiden.encoding.encoders import integer
+from raiden.encoding.format import Field, make_field, namedbuffer
+from raiden.encoding.messages import SECRETREQUEST, SecretRequest, wrap
+
+
+def test_integer_encoder():
+    encoder = integer(minimum=10, maximum=100)
+    for value in (10, 11, 50, 100):
+        encoder.validate(value)
+        assert encoder.decode(encoder.encode(value, 8)) == value
+    for value in (9, 101, 1000):
+        with pytest.raises(ValueError):
+            encoder.validate(value)
+
+
+def test_make_field_invalid_input():
+    with pytest.raises(ValueError):
+        make_field(name="name", size_bytes=-5, format_string="{}")
+
+
+def test_named_buffer_invalid_input():
+    valid_field = make_field("valid", 4, "{}")
+    invalid_field1 = Field("invalid", -5, "{}", None)
+    invalid_field2 = Field("", 4, "{}", None)
+    field_named_data = make_field("data", 4, "{}")
+    with pytest.raises(ValueError):
+        namedbuffer("", [valid_field])
+    with pytest.raises(ValueError):
+        namedbuffer("has_a_name_but_no_fields", [])
+    with pytest.raises(ValueError):
+        namedbuffer("has_invalid_field", [valid_field, invalid_field1])
+    with pytest.raises(ValueError):
+        namedbuffer("has_nameless_field", [valid_field, invalid_field2])
+    with pytest.raises(ValueError):
+        namedbuffer("field_named_data", [field_named_data, valid_field])
+    with pytest.raises(ValueError):
+        namedbuffer("repeated_field_name", [valid_field, valid_field])
+
+
+def test_wrap_invalid():
+    assert wrap(data=[]) is None
+    assert wrap(data=[10000]) is None, "Unknown cmdid"
+    assert wrap(data=[SECRETREQUEST]) is None, "Length not equal to SecretRequest.size"
+
+
+def test_wrap_and_namedbuffer():
+    valid = [SECRETREQUEST]
+    valid.extend([0] * (SecretRequest.size - 1))
+    message = wrap(data=valid)
+    assert type(message) == SecretRequest
+    assert message.amount == 0
+    assert message.message_identifier == 0
+    assert len(message) == SecretRequest.size
+    message.secrethash = b"\1"
+    assert message.secrethash[-1] == 1
+    with pytest.raises(ValueError):  # too many bytes
+        message.secrethash = b"\1" * 50

--- a/raiden/tests/unit/test_waiting.py
+++ b/raiden/tests/unit/test_waiting.py
@@ -1,0 +1,46 @@
+from random import shuffle
+from unittest.mock import Mock, patch
+
+import gevent
+
+from raiden.tests.utils.factories import make_chain_state
+from raiden.transfer.state import CHANNEL_STATE_CLOSED, TransactionExecutionStatus
+from raiden.waiting import wait_for_channel_in_states
+
+
+def test_wait_for_channel_in_states():
+    """
+    wait_for_channel_in_states should wait until all watched channels are
+    deleted or in one of the target states.
+    """
+    container = make_chain_state(number_of_channels=4)
+    raiden_mock = Mock(alarm=True)
+    raiden_mock.wal.state_manager.current_state = container.chain_state
+
+    channel_ids = [
+        channel.canonical_identifier.channel_identifier for channel in container.channels
+    ]
+    shuffle(channel_ids)
+
+    def sleeper_task():
+        wait_for_channel_in_states(
+            raiden=raiden_mock,
+            payment_network_address=container.payment_network_address,
+            token_address=container.token_address,
+            channel_ids=channel_ids,
+            retry_timeout=0.01,
+            target_states=[CHANNEL_STATE_CLOSED],
+        )
+
+    with patch("raiden.transfer.views.state_from_raiden", return_value=container.chain_state):
+        sleeper = gevent.spawn(sleeper_task)
+        for channel_id in channel_ids:
+            assert sleeper
+            if channel_id % 2 or True:
+                del container.token_network.channelidentifiers_to_channels[channel_id]
+            else:
+                channel = container.token_network.channelidentifiers_to_channels[channel_id]
+                close = TransactionExecutionStatus(result=TransactionExecutionStatus.SUCCESS)
+                channel.close_transaction = close
+            gevent.sleep(0.03)
+        assert not sleeper

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -15,7 +15,7 @@ from raiden.messages import (
     Unlock,
     lockedtransfersigned_from_message,
 )
-from raiden.transfer import channel, token_network
+from raiden.transfer import channel, token_network, views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.state import (
     HashTimeLockState,
@@ -1093,6 +1093,12 @@ class ContainerForChainStateTests:
     @property
     def channels(self):
         return self.channel_set.channels
+
+    @property
+    def token_network(self):
+        return views.get_token_network_by_address(
+            chain_state=self.chain_state, token_network_address=self.token_network_address
+        )
 
 
 def make_chain_state(


### PR DESCRIPTION
Coverage increase: Total unit test coverage 74% to 75%
`raiden.encoding.encoders` 82% to 100%
`raiden.encoding.format` 77% to 95%
`raiden.encoding.messages` 81% to 100%
`raiden.storage.restore` 79% to 100%
`raiden.storage.serialization.fields` 78% to 100%
`raiden.waiting` 33% to 100%

Closes #3878
Closes #3918
Closes #3919
Closes #3920 