### PR TITLE
Send new UpdateFee message to PFS via matrix

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -6,6 +6,8 @@ import structlog
 from raiden.blockchain.events import Event
 from raiden.blockchain.state import get_channel_state
 from raiden.connection_manager import ConnectionManager
+from raiden.constants import PATH_FINDING_BROADCASTING_ROOM
+from raiden.messages import FeeUpdate
 from raiden.network.proxies.utils import get_onchain_locksroots
 from raiden.storage.restore import (
     get_event_with_balance_proof_by_locksroot,
@@ -125,6 +127,12 @@ def handle_channel_new(raiden: "RaidenService", event: Event):
 
         if ConnectionManager.BOOTSTRAP_ADDR != partner_address:
             raiden.start_health_check_for(partner_address)
+
+        # Tell PFS about fees for this channel
+        fee_update = FeeUpdate.from_channel_state(channel_state)
+        fee_update.sign(raiden.signer)
+        # Appends message to queue, so it's not blocking
+        raiden.transport.send_global(PATH_FINDING_BROADCASTING_ROOM, fee_update)
 
     # Raiden node is not participant of channel
     else:

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -6,6 +6,7 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX, UINT256_MAX
 from raiden.message_handler import MessageHandler
 from raiden.messages import (
     Delivered,
+    FeeUpdate,
     Ping,
     Processed,
     RequestMonitoring,
@@ -135,6 +136,14 @@ def test_update_pfs():
     signer2 = LocalSigner(privkey2)
     message.sign(signer2)
     assert recover(message._data_to_sign(), message.signature) == address2
+
+    assert message == DictSerializer.deserialize(DictSerializer.serialize(message))
+
+
+def test_fee_update():
+    channel_state = factories.create(factories.NettingChannelStateProperties())
+    message = FeeUpdate.from_channel_state(channel_state)
+    message.sign(signer)
 
     assert message == DictSerializer.deserialize(DictSerializer.serialize(message))
 


### PR DESCRIPTION
This if the first step towards using the new FeeUpdate message. The following things are left out on purpose and will follow in the next PRs:

- increasing nonce to avoid replay attacks
- using proportional or imbalance fee
- not sending the message depending on privacy settings
- removal of mediation fee from `UpdatePFS` message

Relates to https://github.com/raiden-network/raiden/issues/3542