### PR TITLE
Fix typo prunning vs pruning

### DIFF
--- a/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
@@ -6,7 +6,7 @@ from raiden.utils import safe_gas_limit
 pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
 
 # set very low values to force the client to prune old state
-STATE_PRUNNING = {
+STATE_PRUNING = {
     "pruning": "fast",
     "pruning-history": 1,
     "pruning-memory": 1,
@@ -17,7 +17,7 @@ STATE_PRUNNING = {
 }
 
 
-@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNNING])
+@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNING])
 def test_parity_request_prunned_data_raises_an_exception(deploy_client):
     """ Interacting with an old block identifier with a pruning client throws. """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -12,7 +12,7 @@ from raiden.utils import safe_gas_limit
 pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
 
 # set very low values to force the client to prune old state
-STATE_PRUNNING = {
+STATE_PRUNING = {
     "pruning": "fast",
     "pruning-history": 1,
     "pruning-memory": 1,
@@ -24,7 +24,7 @@ STATE_PRUNNING = {
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNNING])
+@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNING])
 def test_locksroot_loading_during_channel_settle_handling(
     raiden_chain, deploy_client, token_addresses
 ):


### PR DESCRIPTION
There were a few instances where it read `PRUNNING` instead of `PRUNING`...