### PR TITLE
Improve typing in `tools`

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -42,6 +42,7 @@ from raiden.utils.typing import (
     BlockSpecification,
     CompiledContract,
     Nonce,
+    PrivateKey,
     TransactionHash,
 )
 
@@ -383,7 +384,7 @@ class JSONRPCClient:
     def __init__(
         self,
         web3: Web3,
-        privkey: bytes,
+        privkey: Optional[PrivateKey],
         gas_price_strategy: Callable = rpc_gas_price_strategy,
         gas_estimate_correction: Callable = lambda gas: gas,
         block_num_confirmations: int = 0,

--- a/tools/gas_cost_measures.py
+++ b/tools/gas_cost_measures.py
@@ -12,7 +12,15 @@ from raiden.transfer.balance_proof import pack_balance_proof
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils.signer import LocalSigner
-from raiden.utils.typing import ChainID, ChannelID, Dict, Locksroot, Nonce, TokenAmount
+from raiden.utils.typing import (
+    AdditionalHash,
+    ChainID,
+    ChannelID,
+    Dict,
+    Locksroot,
+    Nonce,
+    TokenAmount,
+)
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_contracts.utils.pending_transfers import get_pending_transfers_tree
 
@@ -73,7 +81,7 @@ class ContractTester:
         # return self.web3.eth.getTransactionReceipt(tx_hash)
 
 
-def find_max_pending_transfers(gas_limit):
+def find_max_pending_transfers(gas_limit) -> None:
     """Measure gas consumption of TokenNetwork.unlock() depending on number of
     pending transfers and find the maximum number of pending transfers so
     gas_limit is not exceeded."""
@@ -112,7 +120,7 @@ def find_max_pending_transfers(gas_limit):
         settle_timeout=150,
     )
 
-    channel_identifier = int(encode_hex(receipt["logs"][0]["topics"][1]), 16)
+    channel_identifier = ChannelID(int(encode_hex(receipt["logs"][0]["topics"][1]), 16))
 
     tester.call_transaction(
         "HumanStandardToken",
@@ -154,8 +162,8 @@ def find_max_pending_transfers(gas_limit):
     enough = 0
     too_much = 1024
 
-    nonce = 10
-    additional_hash = urandom(32)
+    nonce = Nonce(10)
+    additional_hash = AdditionalHash(urandom(32))
     token_network_address = tester.contract_address("TokenNetwork")
 
     while enough + 1 < too_much:

--- a/tools/startcluster.py
+++ b/tools/startcluster.py
@@ -2,6 +2,7 @@
 import random
 import signal
 import tempfile
+from typing import ContextManager
 
 from eth_utils import remove_0x_prefix
 from web3 import HTTPProvider, Web3
@@ -12,6 +13,7 @@ from raiden.tests.utils.eth_node import (
     run_private_blockchain,
 )
 from raiden.utils import privatekey_to_address, sha3
+from raiden.utils.typing import ChainID, Port
 from raiden_contracts.constants import NETWORKNAME_TO_ID
 
 NUM_GETH_NODES = 3
@@ -27,15 +29,15 @@ DEFAULT_ACCOUNTS_KEYS = [sha3(seed) for seed in DEFAULT_ACCOUNTS_SEEDS]
 DEFAULT_ACCOUNTS = [privatekey_to_address(key) for key in DEFAULT_ACCOUNTS_KEYS]
 
 
-def main():
+def main() -> None:
     tmpdir = tempfile.mkdtemp()
 
     geth_nodes = []
     for i in range(NUM_GETH_NODES):
         is_miner = i == 0
         node_key = sha3(f"node:{i}".encode())
-        p2p_port = START_PORT + i
-        rpc_port = START_RPCPORT + i
+        p2p_port = Port(START_PORT + i)
+        rpc_port = Port(START_RPCPORT + i)
 
         description = EthNodeDescription(
             private_key=node_key,
@@ -55,14 +57,14 @@ def main():
     genesis_description = GenesisDescription(
         prefunded_accounts=DEFAULT_ACCOUNTS,
         random_marker=random_marker,
-        chain_id=NETWORKNAME_TO_ID["smoketest"],
+        chain_id=ChainID(NETWORKNAME_TO_ID["smoketest"]),
     )
-    private_chain = run_private_blockchain(  # NOQA
+    private_chain: ContextManager = run_private_blockchain(  # NOQA
         web3=web3,
         eth_nodes=geth_nodes,
         base_datadir=tmpdir,
         log_dir=tmpdir,
-        verbosity=verbosity,
+        verbosity=str(verbosity),
         genesis_description=genesis_description,
     )
 

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -18,7 +18,7 @@ WEI_TO_ETH = 10 ** 18
 @click.option("--rpc-url", default="http://localhost:8545")
 @click.argument("eth-amount", type=int)
 @click.argument("targets_file", type=click.File())
-def main(keystore_file, password, rpc_url, eth_amount, targets_file):
+def main(keystore_file, password, rpc_url, eth_amount, targets_file) -> None:
     web3 = Web3(HTTPProvider(rpc_url))
     with open(keystore_file, "r") as keystore:
         account = Account(json.load(keystore), password, keystore_file)


### PR DESCRIPTION
I did this because I got the following linting error from
.circleci/enforce_decreasing_lint_errors.sh in CI:

```
> tools/gas_cost_measures.py:179: error: Argument "additional_hash" to
"pack_balance_proof" has incompatible type "bytes"; expected
"AdditionalHash"
> tools/startcluster.py:40: error: Argument "rpc_port" to
"EthNodeDescription" has incompatible type "int"; expected "Port"
> tools/startcluster.py:40: error: Argument "p2p_port" to
"EthNodeDescription" has incompatible type "int"; expected "Port"
> tools/startcluster.py:55: error: Argument "chain_id" to
"GenesisDescription" has incompatible type "int"; expected "ChainID"
> tools/startcluster.py:60: error: Argument "verbosity" to
"run_private_blockchain" has incompatible type "int"; expected "str"
> tools/startcluster.py:60: error: Need type annotation for
'private_chain'
1a8
> tools/transfer_eth.py:26: error: Argument 2 to "JSONRPCClient" has
incompatible type "Optional[PrivateKey]"; expected "bytes"
```

I don't know why mypy actually checked these (the functions were
untyped), but fixing the typing errors is helpful anyway and will
hopefully resolve the CI problem.