### PR TITLE
Mark and retry flaky tests

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -69,6 +69,7 @@ pytest-select==0.1.2
 pytest-timeout==1.3.3
 pytest-xdist==1.27.0
 pytest==4.1.1
+flaky==3.5.3
 python-dateutil==2.7.5
 PyYAML==5.1
 readme-renderer==21.0

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -35,6 +35,7 @@ def run_test_token_addresses(raiden_network, token_addresses):
     assert set(api.get_tokens_list(registry_address)) == set(token_addresses)
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, retry_timeout):

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -204,6 +204,7 @@ def test_payload_with_address_invalid_length(api_server_test_instance):
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_payload_with_address_not_eip55(api_server_test_instance):
@@ -269,6 +270,7 @@ def test_api_get_channel_list(api_server_test_instance, token_addresses, reveal_
     assert "token_network_address" in channel_info
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_channel_status_channel_nonexistant(api_server_test_instance, token_addresses):
@@ -448,6 +450,7 @@ def test_api_open_and_deposit_channel(api_server_test_instance, token_addresses,
     assert "The account balance is below the estimated amount" in response["errors"]
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_close_and_settle_channel(
@@ -957,6 +960,7 @@ def test_api_payments_with_secret_no_hash(
     assert secret == response["secret"]
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_hash_no_secret(
     api_server_test_instance, raiden_network, token_addresses
@@ -993,6 +997,7 @@ def test_api_payments_with_hash_no_secret(
     assert payment == payment
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_secret_and_hash(
     api_server_test_instance, raiden_network, token_addresses
@@ -1091,6 +1096,7 @@ def test_api_payments_conflicts(api_server_test_instance, raiden_network, token_
     assert all(response.status_code == HTTPStatus.OK for response in responses)
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_tokens", [0])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -1307,6 +1313,7 @@ def test_connect_insufficient_reserve(api_server_test_instance, token_addresses)
     assert "The account balance is below the estimated amount" in response["errors"]
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_network_events(api_server_test_instance, token_addresses):
@@ -1370,6 +1377,7 @@ def test_token_events(api_server_test_instance, token_addresses):
     assert len(response.json()) > 0
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_events(api_server_test_instance, token_addresses):
@@ -1492,6 +1500,7 @@ def test_api_deposit_limit(api_server_test_instance, token_addresses, reveal_tim
     )
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_payment_events_endpoints(api_server_test_instance, raiden_network, token_addresses):
     app0, app1, app2 = raiden_network
@@ -1780,6 +1789,7 @@ def test_channel_events_raiden(api_server_test_instance, raiden_network, token_a
     assert_proper_response(response)
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_pending_transfers_endpoint(raiden_network, token_addresses):

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -159,6 +159,7 @@ def wait_both_channel_deposit(
     )
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_new(raiden_chain, retry_timeout, token_addresses):
@@ -191,6 +192,7 @@ def run_test_channel_new(raiden_chain, retry_timeout, token_addresses):
     assert channelcount0 + 1 == channelcount1
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("privatekey_seed", ["event_new_channel:{}"])
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -242,6 +244,7 @@ def run_test_channel_deposit(raiden_chain, deposit, retry_timeout, token_address
     assert_synced_channel_state(token_network_address, app0, deposit, [], app1, deposit, [])
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_query_events(
@@ -442,6 +445,7 @@ def run_test_query_events(
     assert must_have_event(all_netting_channel_events, settled_event)
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_secret_revealed_on_chain(

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -46,6 +46,7 @@ def wait_for_batch_unlock(app, token_network_address, receiver, sender):
         )
 
 
+@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_settle_is_automatically_called(raiden_network, token_addresses):
     raise_on_failure(
@@ -253,6 +254,7 @@ def run_test_lock_expiry(raiden_network, token_addresses, deposit):
     assert transfer_2_secrethash in bob_channel_state.partner_state.secrethashes_to_lockedlocks
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_batch_unlock(
     raiden_network, token_addresses, secret_registry_address, deposit, blockchain_type
@@ -405,6 +407,7 @@ def run_test_batch_unlock(
     assert token_proxy.balance_of(bob_app.raiden.address) == bob_new_balance
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_settled_lock(token_addresses, raiden_network, deposit):
@@ -504,6 +507,7 @@ def run_test_settled_lock(token_addresses, raiden_network, deposit):
     assert token_proxy.balance_of(address1) == expected_balance1
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_automatic_secret_registration(raiden_chain, token_addresses):
@@ -682,6 +686,7 @@ def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
     assert hub_contract.participants[app1.raiden.address]["netted"] == deposit - amount
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_automatic_dispute(raiden_network, deposit, token_addresses):
     raise_on_failure(
@@ -765,6 +770,7 @@ def run_test_automatic_dispute(raiden_network, deposit, token_addresses):
     assert token_proxy.balance_of(app1.raiden.address) == expected_balance1
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_batch_unlock_after_restart(raiden_network, token_addresses, deposit):
     raise_on_failure(

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -320,6 +320,7 @@ def assert_channels(raiden_network, token_network_address, deposit):
         )
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [2])

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -60,6 +60,7 @@ def saturated_count(connection_managers, registry_address, token_address):
     ].count(True)
 
 
+@pytest.mark.flaky(max_runs=4)
 # TODO: add test scenarios for
 # - subsequent `connect()` calls with different `funds` arguments
 # - `connect()` calls with preexisting channels

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -102,6 +102,7 @@ def test_register_secret_batch_happy_path(secret_registry_proxy):
     secret_registry_batch_happy_path(secret_registry_proxy)
 
 
+@pytest.mark.flaky
 def test_register_secret_batch_with_pruned_block(
     secret_registry_proxy, web3, private_keys, contract_manager
 ):

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -42,6 +42,7 @@ def test_service_registry_random_pfs(
     assert get_random_service(c1_service_proxy, "latest") in urls
 
 
+@pytest.mark.flaky
 def test_configure_pfs(service_registry_address, private_keys, web3, contract_manager):
     service_proxy, urls = deploy_service_registry_and_set_urls(
         private_keys=private_keys,

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -30,6 +30,7 @@ from raiden_contracts.constants import (
 SIGNATURE_SIZE_IN_BITS = 520
 
 
+@pytest.mark.flaky
 def test_token_network_deposit_race(
     token_network_proxy, private_keys, token_proxy, web3, contract_manager
 ):
@@ -627,6 +628,7 @@ def test_token_network_proxy_update_transfer(
         assert "getChannelIdentifier returned 0" in str(exc)
 
 
+@pytest.mark.flaky
 def test_query_pruned_state(token_network_proxy, private_keys, web3, contract_manager):
     """A test for https://github.com/raiden-network/raiden/issues/3566
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -316,6 +316,7 @@ def test_matrix_message_sync(matrix_transports):
         assert any(getattr(m, "message_identifier", -1) == i for m in received_messages)
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.skipif(getattr(pytest, "config").getvalue("usepdb"), reason="test fails with pdb")
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
@@ -704,6 +705,7 @@ def test_pfs_global_messages(
     transport.get()
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule",
     [
@@ -761,6 +763,7 @@ def test_matrix_invite_private_room_happy_case(matrix_transports, expected_join_
     assert join_rule1 == expected_join_rule
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule0, expected_join_rule1",
     [
@@ -820,6 +823,7 @@ def test_matrix_invite_private_room_unhappy_case1(
     assert join_rule1 == expected_join_rule1
 
 
+@pytest.mark.flaky(max_runs=10)
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule0, expected_join_rule1",
     [
@@ -892,6 +896,7 @@ def test_matrix_invite_private_room_unhappy_case_2(
     assert join_rule1 == expected_join_rule1
 
 
+@pytest.mark.flaky(max_runs=8)
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule",
     [
@@ -946,6 +951,7 @@ def test_matrix_invite_private_room_unhappy_case_3(matrix_transports, expected_j
     assert join_rule1 == expected_join_rule
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("matrix_server_count", [3])
 @pytest.mark.parametrize("number_of_transports", [3])
 def test_matrix_user_roaming(matrix_transports):

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -1,3 +1,4 @@
+import pytest
 from eth_utils import to_checksum_address
 
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
@@ -5,6 +6,7 @@ from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 SSTORE_COST = 20000
 
 
+@pytest.mark.flaky
 def test_estimate_gas_fail(deploy_client):
     """ A JSON RPC estimate gas call for a throwing transaction returns None"""
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -1,3 +1,4 @@
+import pytest
 from eth_utils import to_checksum_address
 
 from raiden.network.rpc.transactions import check_transaction_threw
@@ -21,6 +22,7 @@ def test_transact_opcode(deploy_client):
     assert check_transaction_threw(deploy_client, transaction) is None, "must be empty"
 
 
+@pytest.mark.flaky
 def test_transact_throws_opcode(deploy_client):
     """ The receipt status field of a transaction that threw is 0x0 """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")

--- a/raiden/tests/integration/rpc/test_client.py
+++ b/raiden/tests/integration/rpc/test_client.py
@@ -1,9 +1,11 @@
 import gevent
+import pytest
 
 from raiden.network.rpc.client import geth_discover_next_available_nonce
 from raiden.tests.utils.factories import make_address
 
 
+@pytest.mark.flaky
 def test_geth_discover_next_available_nonce(
     deploy_client, skip_if_parity  # pylint: disable=unused-argument
 ):

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -12,6 +12,7 @@ from raiden.transfer import views
 from raiden.transfer.state_change import ContractReceiveChannelSettled
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
@@ -99,6 +100,7 @@ def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
     )
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -5,6 +5,7 @@ from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.transfer import views
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_with_self(raiden_network, settle_timeout, token_addresses):

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -145,6 +145,7 @@ def run_test_register_token_insufficient_eth(raiden_network, token_amount, contr
         )
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -429,6 +430,7 @@ def run_test_funds_check_for_openchannel(raiden_network, token_addresses):
         gevent.joinall(greenlets, raise_error=True)
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("reveal_timeout", [8])
@@ -478,6 +480,7 @@ def run_test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=
         assert not greenlet.value
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("privatekey_seed", ["test_set_deposit_limit_crash:{}"])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -546,6 +549,7 @@ def run_test_set_deposit_limit_crash(
         )
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -19,6 +19,7 @@ from raiden.tests.utils.transfer import transfer
 from raiden.transfer.state_change import Block
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -96,6 +96,7 @@ def test_recovery_happy_case(
     )
 
 
+@pytest.mark.flaky(max_runs=4)
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
@@ -181,6 +182,7 @@ def test_recovery_unhappy_case(
     )
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -39,6 +39,7 @@ def open_and_wait_for_channels(app_channels, registry_address, token, deposit, s
     wait_for_channels(app_channels, registry_address, [token], deposit)
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("number_of_nodes", [5])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("settle_timeout", [64])  # default settlement is too low for 3 hops
@@ -242,6 +243,7 @@ def test_regression_register_secret_once(secret_registry_address, deploy_service
     assert previous_nonce == deploy_service.client._available_nonce
 
 
+@pytest.mark.flaky
 @pytest.mark.skip("issue #3915")
 @pytest.mark.parametrize("number_of_nodes", [5])
 def test_regression_payment_complete_after_refund_to_the_initiator(

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -20,6 +20,7 @@ from raiden.transfer.mediated_transfer.events import SendSecretReveal
 from raiden.utils import BlockNumber
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -157,6 +157,7 @@ def run_test_locked_transfer_secret_registered_onchain(
     assert not transfer_statechange_dispatched
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer_with_entire_deposit(
@@ -211,6 +212,7 @@ def run_test_mediated_transfer_with_entire_deposit(
         )
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer_messages_out_of_order(  # pylint: disable=unused-argument
@@ -375,6 +377,7 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
             assert patched.call_count == 2
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [4])
 def test_mediated_transfer_with_allocated_fee(

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -88,6 +88,7 @@ def run_test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
     assert isinstance(payment_status.payment_done.get(), EventPaymentSentFailed)
 
 
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_receive_lockedtransfer_invalidnonce(

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -310,6 +310,7 @@ def run_test_refund_transfer(
     assert secrethash not in state_from_raiden(app1.raiden).payment_mapping.secrethashes_to_task
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("privatekey_seed", ["test_different_view_of_last_bp_during_unlock:{}"])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])

--- a/raiden/tests/unit/blockchain/test_events.py
+++ b/raiden/tests/unit/blockchain/test_events.py
@@ -1,9 +1,11 @@
 from unittest.mock import Mock
 
+import pytest
 from hexbytes import HexBytes
 
 from raiden.blockchain.events import BlockchainEvents
 from raiden.tests.utils.events import check_dict_nested_attrs
+from raiden.tests.utils.tests import delay_rerun
 from raiden.utils.filters import StatelessFilter
 
 
@@ -55,19 +57,22 @@ event_logs = [
 ]
 
 
+@pytest.mark.flaky(max_runs=20, rerun_filter=delay_rerun)
 def test_blockchain_events(contract_manager):
     # TODO Expand this test: multiple listeners, removed listeners, multiple/missed events.
     # As it is now it only covers the classès helper functions in raiden.utils.filters properly.
     blockchain_events = BlockchainEvents()
     abi = contract_manager.get_contract_abi("TokenNetwork")
 
-    filter = StatelessFilter(web3=stub_web3(event_logs), filter_params=dict(toBlock="pending"))
-    blockchain_events.add_event_listener(event_name="Block", eth_filter=filter, abi=abi)
+    stateless_filter = StatelessFilter(
+        web3=stub_web3(event_logs), filter_params=dict(toBlock="pending")
+    )
+    blockchain_events.add_event_listener(event_name="Block", eth_filter=stateless_filter, abi=abi)
 
     events = list(blockchain_events.poll_blockchain_events(block_number=235))
 
     assert len(events) == 1
-    assert len(filter.get_all_entries(235)) == 1
+    assert len(stateless_filter.get_all_entries(235)) == 1
     assert check_dict_nested_attrs(events[0].event_data, event1)
 
     blockchain_events.uninstall_all_event_listeners()

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -16,6 +16,7 @@ def cli_runner(tmp_path):
         yield partial(runner.invoke, env={"HOME": str(tmp_path)})
 
 
+@pytest.mark.flaky
 def test_cli_version(cli_runner):
     result = cli_runner(run, ["version"])
     result_json = json.loads(result.output)

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -94,6 +94,7 @@ def test_log_filter():
     assert filter_.should_log("other", "WARN") is True
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize("module", ["", "raiden", "raiden.network"])
 @pytest.mark.parametrize("level", ["DEBUG", "WARNING"])
 @pytest.mark.parametrize("logger", ["test", "raiden", "raiden.network"])

--- a/raiden/tests/utils/tests.py
+++ b/raiden/tests/utils/tests.py
@@ -1,4 +1,5 @@
 import gc
+import time
 from itertools import chain, combinations, product
 
 import gevent
@@ -75,3 +76,8 @@ def fixture_all_combinations(invalid_values):
 
         for instance in invalid_instances:
             yield dict(instance)
+
+
+def delay_rerun(*_args):
+    time.sleep(1)
+    return True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ pytest-random==0.02
 pytest-timeout==1.3.3
 pytest-select==0.1.2
 pytest-xdist==1.27.0
+flaky==3.5.3
 grequests==0.3.0
 pexpect==4.6.0
 


### PR DESCRIPTION
Use https://github.com/box/flaky to retry all tests marked as flay once.
I've executed the tests using `pytest -Wignore raiden/tests/ -n 20
--show-capture=no` and marked failing tests as flaky until executing the
test suite 5 times in a row succeeded.

This should give us a reasonably usable test suite and makes the
knowledge which tests are flaky easily accessible.

Using `--count` (via pytest-repeat) and  `--random` seemed to increase
the failure rate. Also the number of retries and the retry delay are not
applied very uniformly as I switched back and forth between different
options. If push this PR just in case it is already helpful.
If it's not, just don't merge and give me more time to get the details
right.