### PR TITLE
Clearify PFS interaction code

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -1,7 +1,7 @@
 import json
 import random
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum, unique
 from uuid import UUID
@@ -59,7 +59,7 @@ class PFSInfo:
 
 
 @dataclass
-class PFSConfiguration:
+class PFSConfig:
     info: PFSInfo
     maximum_fee: TokenAmount
     iou_timeout: BlockNumber
@@ -313,7 +313,7 @@ def get_last_iou(
 
 
 def make_iou(
-    pfs_config: PFSConfiguration,
+    pfs_config: PFSConfig,
     our_address: Address,
     one_to_n_address: Address,
     privkey: bytes,
@@ -369,7 +369,7 @@ def update_iou(
 
 
 def create_current_iou(
-    pfs_config: PFSConfiguration,
+    pfs_config: PFSConfig,
     token_network_address: TokenNetworkAddress,
     one_to_n_address: Address,
     our_address: Address,
@@ -452,7 +452,7 @@ def post_pfs_paths(
 
 
 def query_paths(
-    pfs_config: PFSConfiguration,
+    pfs_config: PFSConfig,
     our_address: Address,
     privkey: bytes,
     current_block_number: BlockNumber,
@@ -490,7 +490,7 @@ def query_paths(
             offered_fee=offered_fee,
             scrap_existing_iou=scrap_existing_iou,
         )
-        payload["iou"] = asdict(new_iou)
+        payload["iou"] = new_iou.as_json()
 
         log.info(
             "Requesting paths from Pathfinding Service",
@@ -521,7 +521,7 @@ def query_paths(
 
 
 def post_pfs_feedback(
-    pfs_config: PFSConfiguration,
+    pfs_config: PFSConfig,
     token_network_address: TokenNetworkAddress,
     route: List[Address],
     token: UUID,

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -223,44 +223,42 @@ def configure_pfs_or_exit(
         )
         sys.exit(1)
 
-    price = pathfinding_service_info.price
-    message = pathfinding_service_info.message
-    operator = pathfinding_service_info.operator
-    version = pathfinding_service_info.version
-    pfs_chain_id = pathfinding_service_info.chain_id
-    pfs_payment_address = pathfinding_service_info.payment_address
-    pfs_token_network_address = pathfinding_service_info.token_network_registry_address
-
-    if price > 0 and not pfs_payment_address:
+    if pathfinding_service_info.price > 0 and not pathfinding_service_info.payment_address:
         click.secho(
             f"The pathfinding service at {pfs_url} did not provide an eth address "
             f"to pay it. Raiden will shut down. Please try a different PFS."
         )
         sys.exit(1)
 
-    if not node_network_id == pfs_chain_id:
+    if not node_network_id == pathfinding_service_info.chain_id:
         click.secho(f"Invalid reply from pathfinding service {pfs_url}", fg="red")
         click.secho(
             f"PFS is not operating on the same network "
-            f"({pfs_chain_id}) as your node is ({node_network_id}).\n"
+            f"({pathfinding_service_info.chain_id}) as your node is ({node_network_id}).\n"
             f"Raiden will shut down. Please choose a different PFS."
         )
         sys.exit(1)
 
-    if not is_same_address(pfs_token_network_address, token_network_registry_address):
+    if not is_same_address(
+        pathfinding_service_info.token_network_registry_address, token_network_registry_address
+    ):
         click.secho(f"Invalid reply from pathfinding service {pfs_url}", fg="red")
         click.secho(
             f"PFS is not operating on the same Token Network Registry "
-            f"({to_checksum_address(pfs_token_network_address)}) as your node is "
-            f"({to_checksum_address(token_network_registry_address)}).\n"
+            f"({to_checksum_address(pathfinding_service_info.token_network_registry_address)})"
+            f" as your node is ({to_checksum_address(token_network_registry_address)}).\n"
             f"Raiden will shut down. Please choose a different PFS."
         )
         sys.exit(1)
 
     click.secho(
-        f"{message} - You have chosen the pathfinding service at {pfs_url}. "
-        f"Operator: {operator}, running version: {version}, chain_id: {pfs_chain_id}. "
-        f"Fees will be paid to {pfs_payment_address}. For each request we will pay {price}."
+        f"You have chosen the pathfinding service at {pfs_url}.\n"
+        f"Operator: {pathfinding_service_info.operator}, "
+        f"running version: {pathfinding_service_info.version}, "
+        f"chain_id: {pathfinding_service_info.chain_id}.\n"
+        f"Fees will be paid to {pathfinding_service_info.payment_address}. "
+        f"For each request costs {pathfinding_service_info.price}.\n"
+        f"Message from the PFS:\n{pathfinding_service_info.message}"
     )
 
     log.info("Using PFS", pfs_info=pathfinding_service_info)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -666,8 +666,9 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
         raiden: "RaidenService", route_failed_event: EventRouteFailed
     ) -> None:  # pragma: no unittest
         feedback_token = raiden.route_to_feeback_token.get(tuple(route_failed_event.route))
+        pfs_config = raiden.config.get("pfs_config")
 
-        if feedback_token:
+        if feedback_token and pfs_config:
             log.debug(
                 "Received event for failed route",
                 route=route_failed_event.route,
@@ -675,11 +676,11 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
                 feedback_token=feedback_token,
             )
             post_pfs_feedback(
+                pfs_config=pfs_config,
                 token_network_address=route_failed_event.token_network_address,
                 route=route_failed_event.route,
                 token=feedback_token,
                 succesful=False,
-                service_config=raiden.config.get("services"),
             )
 
     @staticmethod
@@ -689,17 +690,18 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
         feedback_token = raiden.route_to_feedback_token.get(
             tuple(payment_sent_success_event.route)
         )
+        pfs_config = raiden.config.get("pfs_config")
 
-        if feedback_token:
+        if feedback_token and pfs_config:
             log.debug(
                 "Received payment success event",
                 route=payment_sent_success_event.route,
                 feedback_token=feedback_token,
             )
             post_pfs_feedback(
+                pfs_config=pfs_config,
                 token_network_address=payment_sent_success_event.token_network_address,
                 route=payment_sent_success_event.route,
                 token=feedback_token,
                 succesful=True,
-                service_config=raiden.config.get("services"),
             )

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -8,7 +8,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 
 from raiden.exceptions import ServiceRequestFailed
 from raiden.messages import RouteMetadata
-from raiden.network.pathfinding import PFSConfiguration, query_paths
+from raiden.network.pathfinding import PFSConfig, query_paths
 from raiden.transfer import channel, views
 from raiden.transfer.state import CHANNEL_STATE_OPENED, ChainState, RouteState
 from raiden.utils.typing import (
@@ -221,7 +221,7 @@ def get_best_routes_pfs(
     to_address: TargetAddress,
     amount: PaymentAmount,
     previous_address: Optional[Address],
-    pfs_config: PFSConfiguration,
+    pfs_config: PFSConfig,
     privkey: bytes,
 ) -> Tuple[bool, List[RouteState], Optional[UUID]]:
     try:

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -74,6 +74,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             pfs_url="",
             routing_mode=RoutingMode.LOCAL,
             service_registry=service_proxy,
+            node_network_id=chain_id,
             token_network_registry_address=token_network_registry_address_test_default,
         )
 

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -105,7 +105,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
         )
     assert config.url == given_address
     assert config.eth_address == json_data["payment_address"]
-    assert config.fee == json_data["price_info"]
+    assert config.price == json_data["price_info"]
 
     # Bad address, should exit the program
     response = Mock()

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -92,7 +92,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             token_network_registry_address=token_network_registry_address_test_default,
         )
     assert config.url in urls
-    assert is_checksum_address(config.eth_address)
+    assert is_checksum_address(config.payment_address)
 
     # Configuring a given address
     given_address = "http://ourgivenaddress"

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -2,13 +2,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 import requests
-from eth_utils import is_checksum_address, to_checksum_address
+from eth_utils import is_canonical_address, is_same_address, to_checksum_address
 
 from raiden.constants import RoutingMode
-from raiden.network.pathfinding import configure_pfs_or_exit, get_random_service
+from raiden.network.pathfinding import configure_pfs_or_exit, get_random_pfs
 from raiden.tests.utils.factories import HOP1
 from raiden.tests.utils.smartcontracts import deploy_service_registry_and_set_urls
 from raiden.utils import privatekey_to_address
+from raiden.utils.typing import ChainID
 
 token_network_registry_address_test_default = "0xB9633dd9a9a71F22C933bF121d7a22008f66B908"
 
@@ -39,10 +40,11 @@ def test_service_registry_random_pfs(
     assert not c1_service_proxy.get_service_address("latest", 9999)
 
     # Test that getting a random service from the proxy works
-    assert get_random_service(c1_service_proxy, "latest") in urls
+    assert get_random_pfs(c1_service_proxy, "latest") in urls
 
 
 def test_configure_pfs(service_registry_address, private_keys, web3, contract_manager):
+    chain_id = ChainID(int(web3.net.version))
     service_proxy, urls = deploy_service_registry_and_set_urls(
         private_keys=private_keys,
         web3=web3,
@@ -52,12 +54,13 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     json_data = {
         "price_info": 0,
         "network_info": {
-            "chain_id": 1,
+            "chain_id": chain_id,
             "registry_address": token_network_registry_address_test_default,
         },
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",
         "version": "0.0.1",
+        "settings": "",
         "payment_address": "0x2222222222222222222222222222222222222222",
     }
 
@@ -80,6 +83,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             pfs_url="",
             routing_mode=RoutingMode.PRIVATE,
             service_registry=service_proxy,
+            node_network_id=chain_id,
             token_network_registry_address=token_network_registry_address_test_default,
         )
 
@@ -89,10 +93,11 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             pfs_url="auto",
             routing_mode=RoutingMode.PFS,
             service_registry=service_proxy,
+            node_network_id=chain_id,
             token_network_registry_address=token_network_registry_address_test_default,
         )
     assert config.url in urls
-    assert is_checksum_address(config.payment_address)
+    assert is_canonical_address(config.payment_address)
 
     # Configuring a given address
     given_address = "http://ourgivenaddress"
@@ -101,10 +106,11 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             pfs_url=given_address,
             routing_mode=RoutingMode.PFS,
             service_registry=service_proxy,
+            node_network_id=chain_id,
             token_network_registry_address=token_network_registry_address_test_default,
         )
     assert config.url == given_address
-    assert config.eth_address == json_data["payment_address"]
+    assert is_same_address(config.payment_address, json_data["payment_address"])
     assert config.price == json_data["price_info"]
 
     # Bad address, should exit the program
@@ -118,6 +124,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
                 pfs_url=bad_address,
                 routing_mode=RoutingMode.PFS,
                 service_registry=service_proxy,
+                node_network_id=chain_id,
                 token_network_registry_address=token_network_registry_address_test_default,
             )
 
@@ -131,5 +138,20 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
                 pfs_url="adad",
                 routing_mode=RoutingMode.PFS,
                 service_registry=Mock(),
+                node_network_id=chain_id,
+                token_network_registry_address="0x2222222222222222222222222222222222222221",
+            )
+
+    # ChainIDs of pfs and client conflic, should exit the client
+    response.configure_mock(status_code=200)
+    response.json = Mock(return_value=json_data)
+
+    with pytest.raises(SystemExit):
+        with patch.object(requests, "get", return_value=response):
+            configure_pfs_or_exit(
+                pfs_url="adad",
+                routing_mode=RoutingMode.PFS,
+                service_registry=Mock(),
+                node_network_id=chain_id + 1,
                 token_network_registry_address="0x2222222222222222222222222222222222222221",
             )

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -112,17 +112,7 @@ PFS_CONFIG = PFSConfig(
     iou_timeout=BlockNumber(100),
     max_paths=5,
 )
-CONFIG = {
-    "services": {
-        "pathfinding_service_address": "my-pfs",
-        "pathfinding_eth_address": factories.make_checksum_address(),
-        "pathfinding_max_paths": 3,
-        "pathfinding_iou_timeout": 10,
-        "pathfinding_max_fee": 50,
-        "pathfinding_fee": 5,
-    },
-    "pfs_config": PFS_CONFIG,
-}
+CONFIG = {"pfs_config": PFS_CONFIG}
 
 PRIVKEY = b"privkeyprivkeyprivkeyprivkeypriv"
 

--- a/raiden/tests/unit/test_startup.py
+++ b/raiden/tests/unit/test_startup.py
@@ -232,7 +232,13 @@ def test_setup_proxies_no_service_registry_but_pfs():
     """
 
     network_id = 42
-    config = {"environment_type": Environment.DEVELOPMENT, "chain_id": network_id, "services": {}}
+    config = {
+        "environment_type": Environment.DEVELOPMENT,
+        "chain_id": network_id,
+        "services": dict(
+            pathfinding_max_fee=100, pathfinding_iou_timeout=500, pathfinding_max_paths=5
+        ),
+    }
     contracts = {}
     blockchain_service = MockChain(network_id=network_id, node_address=make_address())
 

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -192,13 +192,14 @@ def patched_get_for_succesful_pfs_info():
     json_data = {
         "price_info": 5,
         "network_info": {
-            "chain_id": 1,
+            "chain_id": 42,
             "registry_address": token_network_registry_address_test_default,
         },
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",
         "version": "0.0.1",
         "payment_address": "0x2222222222222222222222222222222222222222",
+        "settings": "",
     }
 
     response = Mock()

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -4,7 +4,7 @@ from typing import Any, List, Tuple
 from solc import compile_files
 
 from raiden.network.blockchain_service import BlockChainService
-from raiden.network.pathfinding import get_random_service
+from raiden.network.pathfinding import get_random_pfs
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
@@ -97,7 +97,7 @@ def deploy_service_registry_and_set_urls(
     )
 
     # Test that getting a random service for an empty registry returns None
-    pfs_address = get_random_service(c1_service_proxy, "latest")
+    pfs_address = get_random_pfs(c1_service_proxy, "latest")
     assert pfs_address is None
 
     # Test that setting the urls works

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -154,11 +154,9 @@ def run_app(
     check_ethereum_client_is_supported(web3)
     check_ethereum_network_id(network_id, web3)
 
-    (address, privatekey_bin) = get_account_and_private_key(
-        account_manager, address, password_file
-    )
+    address, privatekey_bin = get_account_and_private_key(account_manager, address, password_file)
 
-    (api_host, api_port) = split_endpoint(api_address)
+    api_host, api_port = split_endpoint(api_address)
 
     config["console"] = console
     config["rpc"] = rpc

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -7,7 +7,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 from raiden.constants import Environment, RoutingMode
 from raiden.exceptions import AddressWithoutCode, AddressWrongContract, ContractVersionMismatch
 from raiden.network.blockchain_service import BlockChainService
-from raiden.network.pathfinding import PFSConfiguration, configure_pfs_or_exit
+from raiden.network.pathfinding import PFSConfig, configure_pfs_or_exit
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
@@ -225,7 +225,7 @@ def setup_proxies_or_exit(
         msg = "Eth address of selected pathfinding service is unknown."
         assert pfs_info.payment_address is not None, msg
 
-        config["pfs_config"] = PFSConfiguration(
+        config["pfs_config"] = PFSConfig(
             info=pfs_info,
             maximum_fee=config["services"]["pathfinding_max_fee"],
             iou_timeout=config["services"]["pathfinding_iou_timeout"],

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -7,7 +7,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 from raiden.constants import Environment, RoutingMode
 from raiden.exceptions import AddressWithoutCode, AddressWrongContract, ContractVersionMismatch
 from raiden.network.blockchain_service import BlockChainService
-from raiden.network.pathfinding import configure_pfs_or_exit
+from raiden.network.pathfinding import PFSConfiguration, configure_pfs_or_exit
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
@@ -133,16 +133,15 @@ def setup_proxies_or_exit(
     environment_type = config["environment_type"]
 
     check_smart_contract_addresses(
-        environment_type,
-        node_network_id,
-        tokennetwork_registry_contract_address,
-        secret_registry_contract_address,
-        contracts,
+        environment_type=environment_type,
+        node_network_id=node_network_id,
+        tokennetwork_registry_contract_address=tokennetwork_registry_contract_address,
+        secret_registry_contract_address=secret_registry_contract_address,
+        contracts=contracts,
     )
     try:
-        registered_address: Address
         if tokennetwork_registry_contract_address is not None:
-            registered_address = Address(tokennetwork_registry_contract_address)
+            registered_address: Address = Address(tokennetwork_registry_contract_address)
         else:
             registered_address = to_canonical_address(
                 contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]["address"]
@@ -210,23 +209,30 @@ def setup_proxies_or_exit(
 
     if routing_mode == RoutingMode.PFS:
         check_pfs_configuration(
-            routing_mode, environment_type, service_registry, pathfinding_service_address
+            routing_mode=routing_mode,
+            environment_type=environment_type,
+            service_registry=service_registry,
+            pathfinding_service_address=pathfinding_service_address,
         )
 
-        pfs_config = configure_pfs_or_exit(
+        pfs_info = configure_pfs_or_exit(
             pfs_url=pathfinding_service_address,
             routing_mode=routing_mode,
             service_registry=service_registry,
+            node_network_id=node_network_id,
             token_network_registry_address=Address(token_network_registry.address),
         )
         msg = "Eth address of selected pathfinding service is unknown."
-        assert pfs_config.eth_address is not None, msg
-        config["services"]["pathfinding_service_address"] = pfs_config.url
-        config["services"]["pathfinding_eth_address"] = pfs_config.eth_address
-        config["services"]["pathfinding_fee"] = pfs_config.fee
+        assert pfs_info.payment_address is not None, msg
+
+        config["pfs_config"] = PFSConfiguration(
+            info=pfs_info,
+            maximum_fee=config["services"]["pathfinding_max_fee"],
+            iou_timeout=config["services"]["pathfinding_iou_timeout"],
+            max_paths=config["services"]["pathfinding_max_paths"],
+        )
     else:
-        config["services"]["pathfinding_service_address"] = None
-        config["services"]["pathfinding_eth_address"] = None
+        config["pfs_config"] = None
 
     proxies = Proxies(
         token_network_registry=token_network_registry,


### PR DESCRIPTION
This PR introduces dataclasses for bits of data that are handled together when interacting with the PFS. Besides better readability (in my opinion) this also gives us better type checking (before there was a weird mix of hex and canonical address for example)
- `PFSInfo` includes all the info the PFS returns
- `PFSConfig` includes all client side PFS settings as well as the currently known settings of the PFS (which will be required in the future)
- `IOU` collects all information needed for a PFS payment, as well as some signing and serialisation code.


The rest of the changes are test updates.


Part of https://github.com/raiden-network/raiden/issues/3735
Prerequisite for https://github.com/raiden-network/raiden/issues/4100