### PR TITLE
Add 10 blocks wait for MS scenarios

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -43,6 +43,7 @@ scenario:
       - assert_events: {contract_name: "TokenNetwork", event_name: "NonClosingBalanceProofUpdated", num_events: 1}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500, but we've already waited 400 blocks.
-      - wait_blocks: 100
+      ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
+      ## To make sure the transactions gets mined in time, 10 additional blocks are added
+      - wait_blocks: 110
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -47,6 +47,7 @@ scenario:
       - start_node: 1
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500, but we've already waited 400 blocks.
-      - wait_blocks: 100
+      ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
+      ## To make sure the transactions gets mined in time, 10 additional blocks are added
+      - wait_blocks: 110
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}


### PR DESCRIPTION
It works without, but we don't want to test if transactions are mined in short time.