### PR TITLE
mypy decreasing error report

### DIFF
--- a/.circleci/enforce_decreasing_lint_errors.sh
+++ b/.circleci/enforce_decreasing_lint_errors.sh
@@ -3,9 +3,31 @@
 set -e
 set -x
 
-function compare_reports() {
+# For the first build the PR's base branch will work as a baseline,
+# subsequent reports will be against the PR itself. Because of
+# this, it is possible for a PR to undo linting fixes from another.
+# Example:
+#
+# 1. PR1 is opened, it does not fix any linting errors
+# 2. PR2 is opened against the same base branch, and merged, it
+#    fixes linting errors
+# 3. PR1 is rebased on the base branch. This may introduce as many
+#    errors as PR2 fixed without failling the build (because the
+#    baseline is outdated).
+# 4. PR1 is merged.
+#
+# This is fine, at least the number of errors doesn't increase.
+# Additionally, because on step 4 above PR1 was merged, the base
+# branch itself got more linting errors, for this reason topic
+# branches (e.g. master or develop) should not break if linting
+# errors increase.
+if [[ ! -e ~/.local/BASE_COMMIT ]]; then
+    exit 0
+fi
+
+function compare_pylint_reports() {
     if [[ $# -ne 2 ]]; then
-        echo "compare_reports was not properly called, it requires two arguments, $# given"
+        echo "compare_pylint_reports was not properly called, it requires two arguments, $# given"
         exit 1
     fi
 
@@ -13,7 +35,7 @@ function compare_reports() {
     old=$2
 
     if [[ ! -e "${new}" ]]; then
-        echo "compare_reports was not properly called, new report ${new} is missing."
+        echo "compare_pylint_reports was not properly called, new report ${new} is missing."
         exit 1
     fi
 
@@ -24,28 +46,6 @@ function compare_reports() {
         if [[ $new_error_count -gt $previous_error_count ]]; then
             diff ${old} ${new}
 
-            # For the first build the PR's base branch will work as a baseline,
-            # subsequent reports will be against the PR itself. Because of
-            # this, it is possible for a PR to undo linting fixes from another.
-            # Example:
-            #
-            # 1. PR1 is opened, it does not fix any linting errors
-            # 2. PR2 is opened against the same base branch, and merged, it
-            #    fixes linting errors
-            # 3. PR1 is rebased on the base branch. This may introduce as many
-            #    errors as PR2 fixed without failling the build (because the
-            #    baseline is outdated).
-            # 4. PR1 is merged.
-            #
-            # This is fine, at least the number of errors doesn't increase.
-            # Additionally, because on step 4 above PR1 was merged, the base
-            # branch itself got more linting errors, for this reason topic
-            # branches (e.g. master or develop) should not break if linting
-            # errors increase.
-            if [[ ! -e ~/.local/BASE_COMMIT ]]; then
-                return 1
-            fi
-
             # DO NOT overwrite the old report in the cache, we want to keep the
             # version with the lower number of errors
         else
@@ -54,7 +54,36 @@ function compare_reports() {
             mv ${new} ${old}
         fi
     else
-        # First run, save the report to compare on subsequent runs
+        # Save the report to compare on subsequent runs
+        mv ${new} ${old}
+    fi
+}
+
+function compare_mypy_reports() {
+    if [[ $# -ne 2 ]]; then
+        echo "compare_mypy_reports was not properly called, it requires two arguments, $# given"
+        exit 1
+    fi
+
+    new=$1
+    old=$2
+
+    if [[ ! -e "${new}" ]]; then
+        echo "compare_mypy_reports was not properly called, new report ${new} is missing."
+        exit 1
+    fi
+
+    if [[ -e "${old}" ]]; then
+        if ! ./.circleci/lint_report.py ${old} ${new}; then
+            # DO NOT overwrite the old report in the cache, we want to keep the
+            # version with the lower number of errors
+            #
+            # If this PR fixed errors, move the new report over the old one to
+            # enforce a new lower bound on the number of errors
+            mv ${new} ${old}
+        fi
+    else
+        # Save the report to compare on subsequent runs
         mv ${new} ${old}
     fi
 }
@@ -77,11 +106,11 @@ mypy --config-file /dev/null --strict --disallow-subclassing-any \
 
 exit_code=0
 
-if ! compare_reports "${new_report_pylint}" "${old_report_pylint}"; then
+if ! compare_pylint_reports "${new_report_pylint}" "${old_report_pylint}"; then
     exit_code=1
 fi
 
-if ! compare_reports "${new_report_mypy}" "${old_report_mypy}"; then
+if ! compare_mypy_reports "${new_report_mypy}" "${old_report_mypy}"; then
     exit_code=1
 fi
 

--- a/.circleci/lint_report.py
+++ b/.circleci/lint_report.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+""" Utility to compare to report the number of increased errors in the same
+code.
+
+The exit code of the tool will be 0 if the number of reported errors stayed the
+same *or decreased*. Otherwise it will be number of additional errors reported.
+
+This utility assumes both reports are produced by the *same version of Mypy*,
+and that *the generated report has stable messages*, otherwise the errors
+results are not stable.
+"""
+import re
+import sys
+from collections import defaultdict
+from itertools import groupby
+from typing import Dict, Iterator, NamedTuple, Optional, Tuple
+
+MYPY_LINE = re.compile(
+    r"^"
+    r"(?P<filename>([^:]|\\:)+):"
+    r"((?P<linenum>([0-9]+)):)?"
+    r"(?P<level>([^:]|\\:)+):"
+    r"(?P<message>.+$)"
+)
+
+
+class FileErrorType(NamedTuple):
+    filename: str
+    errortype: str
+
+
+class Error(NamedTuple):
+    filename: str
+    linenum: str
+    level: str
+    message: str
+
+
+NewErrorCountPerFile = Dict[FileErrorType, int]
+UNKNOWN_REPORT_LINE = "Unrecognized line format"
+
+
+def compare_errors(error_old: Error, error_new: Error) -> int:
+    # Errors for `filename` have been fixed according to the new report.
+    if error_old.filename < error_new.filename:
+        return -1
+
+    # Assuming stable output.
+    message_old = (error_old.level, error_old.message)
+    message_new = (error_new.level, error_new.message)
+
+    # The error `(level, message)` is fixed according to the new report
+    if message_old < message_new:
+        return -1
+
+    if message_old == message_new:
+        return 0
+
+    # Do not compare line numbers. If the error moved around it does not
+    # matter, only new and fixed bugs.
+    #
+    # Input has to be sorted. Because the character `:` is larger then numbers,
+    # lines without number will always be last.
+    # linenum_old = error_old["linenum"] or float("inf")
+    # linenum_new = error_new["linenum"] or float("inf")
+    # if linenum_old < linenum_new:
+    #     return -1
+
+    return 1
+
+
+def next_error(f: Iterator[Error]) -> Optional[Error]:
+    try:
+        return next(f)
+    except StopIteration:
+        return None
+
+
+def get_errors(previous_report: str) -> Iterator[Error]:
+    with open(previous_report, "r") as file:
+        for line in file:
+            match = MYPY_LINE.match(line)
+            assert match, UNKNOWN_REPORT_LINE
+
+            error = Error(
+                filename=match["filename"],
+                linenum=match["linenum"],
+                level=match["level"],
+                message=match["message"],
+            )
+            yield error
+
+
+def sort_by_filename_level_error(error):
+    return error.filename, error.level, error.message
+
+
+def compare_reports(previous_report: str, new_report: str) -> Tuple[NewErrorCountPerFile, int]:
+    previous_errors_unsorted = get_errors(previous_report)
+    new_errors_unsorted = get_errors(new_report)
+
+    previous_errors = sorted(previous_errors_unsorted, key=sort_by_filename_level_error)
+    new_errors = sorted(new_errors_unsorted, key=sort_by_filename_level_error)
+
+    previous_errors_it = iter(previous_errors)
+    new_errors_it = iter(new_errors)
+
+    new_errors_count = 0
+    error_count: NewErrorCountPerFile = defaultdict(int)
+
+    previous_error = next_error(previous_errors_it)
+    new_error = next_error(new_errors_it)
+
+    while previous_error is not None and new_error is not None:
+        compare = compare_errors(previous_error, new_error)
+
+        # The new report has a new error
+        if compare > 0:
+            new_errors_count += 1
+            error_count[FileErrorType(new_error.filename, new_error.message)] += 1
+
+        if compare < 0:
+            previous_error = next_error(previous_errors_it)
+        elif compare == 0:
+            previous_error = next_error(previous_errors_it)
+            new_error = next_error(new_errors_it)
+        else:
+            new_error = next_error(new_errors_it)
+
+    # Extra lines in the new report are new errors
+    while new_error is not None:
+        new_errors_count += 1
+        error_count[FileErrorType(new_error.filename, new_error.message)] += 1
+
+        new_error = next_error(new_errors_it)
+
+    return error_count, new_errors_count
+
+
+def print_changes(report: NewErrorCountPerFile) -> None:
+    error_types_grouped_by_filename = groupby(sorted(report), key=lambda k: k.filename)
+
+    for filename, error_types_it in error_types_grouped_by_filename:
+        error_types = list(error_types_it)
+        total_errors_for_file = sum(report[error] for error in error_types)
+
+        print(f"{filename} :: +{total_errors_for_file}")
+        for error in error_types:
+            print(f"   +{report[error]} :: {error.errortype}")
+        print()
+        print()
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("previous_report")
+    parser.add_argument("new_report")
+    args = parser.parse_args()
+
+    report, changes = compare_reports(args.previous_report, args.new_report)
+
+    if changes > 0:
+        print_changes(report)
+        sys.exit(changes)
+
+
+if __name__ == "__main__":
+    main()

--- a/.circleci/lint_report.py
+++ b/.circleci/lint_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 """ Utility to compare to report the number of increased errors in the same
 code.
 
@@ -58,13 +58,6 @@ def compare_errors(error_old: Error, error_new: Error) -> int:
 
     # Do not compare line numbers. If the error moved around it does not
     # matter, only new and fixed bugs.
-    #
-    # Input has to be sorted. Because the character `:` is larger then numbers,
-    # lines without number will always be last.
-    # linenum_old = error_old["linenum"] or float("inf")
-    # linenum_new = error_new["linenum"] or float("inf")
-    # if linenum_old < linenum_new:
-    #     return -1
 
     return 1
 
@@ -91,7 +84,7 @@ def get_errors(previous_report: str) -> Iterator[Error]:
             yield error
 
 
-def sort_by_filename_level_error(error):
+def sort_by_filename_level_error(error: Error) -> Tuple:
     return error.filename, error.level, error.message
 
 
@@ -151,7 +144,7 @@ def print_changes(report: NewErrorCountPerFile) -> None:
         print()
 
 
-def main():
+def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
The line number should not interfere in the status of the report, only
the type and quantity of errors.

This also groups the same type of error per file.