### PR TITLE
State pruning in TokenNetwork.new_netting_channel

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -393,8 +393,11 @@ class TokenNetwork:
 
                 raise RaidenRecoverableError("Creating new channel failed.")
 
+        receipt = self.client.get_transaction_receipt(transaction_hash)
         channel_identifier: ChannelID = self._detail_channel(
-            participant1=self.node_address, participant2=partner, block_identifier="latest"
+            participant1=self.node_address,
+            participant2=partner,
+            block_identifier=encode_hex(receipt["blockHash"]),
         ).channel_identifier
 
         return channel_identifier

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -350,7 +350,7 @@ class TokenNetwork:
             if self.safety_deprecation_switch(block_identifier=failed_at_blockhash):
                 raise RaidenRecoverableError("This token network is deprecated.")
 
-            raise RaidenUnrecoverableError(
+            raise RaidenRecoverableError(
                 "Creating a new channel will fail - Gas estimation failed for unknown reason."
             )
         else:
@@ -391,7 +391,7 @@ class TokenNetwork:
                 if self.safety_deprecation_switch(block_identifier=failed_at_blockhash):
                     raise RaidenRecoverableError("This token network is deprecated.")
 
-                raise RaidenUnrecoverableError("Creating new channel failed.")
+                raise RaidenRecoverableError("Creating new channel failed.")
 
         channel_identifier: ChannelID = self._detail_channel(
             participant1=self.node_address, participant2=partner, block_identifier="latest"

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -704,14 +704,14 @@ class TokenNetwork:
         - If Acc2's transaction is mined first, then Acc1 token supply is left intact.
         - If Acc1's transaction is mined first, then Acc2 will only move 3 tokens.
 
-        Races for the same account don't have any unexpeted side-effect.
+        Races for the same account don't have any unexpected side-effect.
 
         Raises:
             DepositMismatch: If the new request total deposit is lower than the
                 existing total deposit on-chain for the `given_block_identifier`.
             RaidenRecoverableError: If the channel was closed meanwhile the
                 deposit was in transit.
-            RaidenUnrecoverableError: If the transaction was sucessful and the
+            RaidenUnrecoverableError: If the transaction was successful and the
                 deposit_amount is not as large as the requested value.
             RuntimeError: If the token address is empty.
             ValueError: If an argument is of the invalid type.
@@ -852,7 +852,7 @@ class TokenNetwork:
         checking_block = self.client.get_checking_block()
         amount_to_deposit = TokenAmount(total_deposit - previous_total_deposit)
 
-        # If there are channels being set up concurrenlty either the
+        # If there are channels being set up concurrently either the
         # allowance must be accumulated *or* the calls to `approve` and
         # `setTotalDeposit` must be serialized. This is necessary otherwise
         # the deposit will fail.
@@ -867,7 +867,7 @@ class TokenNetwork:
         # - setTotalDeposit
         # - setTotalDeposit
         #
-        # in which case  the second `approve` will overwrite the first,
+        # in which case the second `approve` will overwrite the first,
         # and the first `setTotalDeposit` will consume the allowance,
         # making the second deposit fail.
         self.token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
@@ -1426,7 +1426,7 @@ class TokenNetwork:
         Raises:
             RaidenRecoverableError: If the close call failed but it is not
                 critical.
-            RaidenUnrecoverableError: If the operation was ilegal at the
+            RaidenUnrecoverableError: If the operation was illegal at the
                 `given_block_identifier` or if the channel changes in a way that
                 cannot be recovered.
         """

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -114,12 +114,12 @@ def test_token_network_proxy(
 
     # instantiating a new channel - test basic assumptions
     assert (
-        c1_token_network_proxy._channel_exists_and_not_settled(
+        c1_token_network_proxy.get_channel_identifier_or_none(
             participant1=c1_client.address,
             participant2=c2_client.address,
             block_identifier="latest",
         )
-        is False
+        is None
     )
 
     msg = "Hex encoded addresses are not supported, an exception must be raised"
@@ -222,13 +222,12 @@ def test_token_network_proxy(
         )
 
     assert (
-        c1_token_network_proxy._channel_exists_and_not_settled(
+        c1_token_network_proxy.get_channel_identifier_or_none(
             participant1=c1_client.address,
             participant2=c2_client.address,
-            channel_identifier=channel_identifier,
             block_identifier="latest",
         )
-        is True
+        is not None
     )
 
     assert (
@@ -330,13 +329,12 @@ def test_token_network_proxy(
         is True
     )
     assert (
-        c1_token_network_proxy._channel_exists_and_not_settled(
+        c1_token_network_proxy.get_channel_identifier_or_none(
             participant1=c1_client.address,
             participant2=c2_client.address,
-            channel_identifier=channel_identifier,
             block_identifier="latest",
         )
-        is True
+        is not None
     )
 
     msg = (
@@ -412,13 +410,12 @@ def test_token_network_proxy(
         given_block_identifier="latest",
     )
     assert (
-        c1_token_network_proxy._channel_exists_and_not_settled(
+        c1_token_network_proxy.get_channel_identifier_or_none(
             participant1=c1_client.address,
             participant2=c2_client.address,
-            channel_identifier=channel_identifier,
             block_identifier="latest",
         )
-        is False
+        is None
     )
     assert token_proxy.balance_of(c1_client.address) == (initial_balance_c1 - transferred_amount)
     assert token_proxy.balance_of(c2_client.address) == (initial_balance_c2 + transferred_amount)
@@ -766,13 +763,12 @@ def test_token_network_actions_at_pruned_blocks(
         is True
     )
     assert (
-        c1_token_network_proxy._channel_exists_and_not_settled(
+        c1_token_network_proxy.get_channel_identifier_or_none(
             participant1=c1_client.address,
             participant2=c2_client.address,
-            channel_identifier=channel_identifier,
             block_identifier="latest",
         )
-        is True
+        is not None
     )
 
     c1_chain.wait_until_block(target_block_number=close_pruned_number + STATE_PRUNING_AFTER_BLOCKS)


### PR DESCRIPTION
Catch possible `ValueError` due to missing block when checking the precondition. Other than that the error handling in `new_netting_channel` is already up to date.

Closes #4199