### PR TITLE
Separate debug log for each test

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -31,6 +31,7 @@ from raiden.constants import EthClient
 from raiden.log_config import configure_logging
 from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
+from raiden.tests.utils.ci import get_artifacts_storage
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
@@ -109,9 +110,9 @@ def enable_greenlet_debugger(request):
         hub.handle_error = debugger
 
 
-@pytest.fixture(autouse=True, scope="session")
-def logging_level(request):
-    """ Configure the structlog level.
+@pytest.fixture(autouse=True)
+def logging_level(request, tmpdir):
+    """ Configure the structlog level for each test run.
 
     For integration tests this also sets the geth verbosity.
     """
@@ -135,8 +136,12 @@ def logging_level(request):
     else:
         logging_levels = {"": level}
 
+    base_dir = get_artifacts_storage(request.node.name) or str(tmpdir)
+    os.makedirs(base_dir, exist_ok=True)
+
     time = datetime.datetime.utcnow().isoformat()
-    debug_path = os.path.join(tempfile.gettempdir(), f"raiden-debug_{time}.log")
+    debug_path = os.path.join(base_dir, f"raiden-debug_{time}.log")
+
     configure_logging(
         logging_levels,
         colorize=not request.config.option.plain_log,

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -29,7 +29,7 @@ def raiden_testchain(blockchain_type, port_generator, cli_tests_contracts_versio
     base_datadir = str(tmpdir)
 
     # Save the Ethereum node's logs, if needed for debugging
-    base_logdir = os.path.join(get_artifacts_storage(str(tmpdir)), blockchain_type)
+    base_logdir = os.path.join(get_artifacts_storage() or str(tmpdir), blockchain_type)
     os.makedirs(base_logdir, exist_ok=True)
 
     with setup_testchain(
@@ -84,7 +84,7 @@ def cli_args(request, tmpdir, raiden_testchain, removed_args, changed_args, envi
 
     # This assumes that there is only one Raiden instance per CLI test
     base_logfile = os.path.join(
-        get_artifacts_storage(str(tmpdir)), request.node.name, "raiden_nodes", "cli_test.log"
+        get_artifacts_storage(request.node.name) or str(tmpdir), "raiden_nodes", "cli_test.log"
     )
     os.makedirs(os.path.dirname(base_logfile), exist_ok=True)
 

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -71,7 +71,7 @@ def web3(
 
     # Save the Ethereum node's log, if needed for debugging
     base_logdir = os.path.join(
-        get_artifacts_storage(base_datadir), request.node.name, blockchain_type
+        get_artifacts_storage(request.node.name) or base_datadir, blockchain_type
     )
 
     genesis_description = GenesisDescription(

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -60,7 +60,7 @@ def raiden_chain(
     )
 
     base_datadir = os.path.join(
-        get_artifacts_storage(str(tmpdir)), request.node.name, "raiden_nodes"
+        get_artifacts_storage(request.node.name) or str(tmpdir), "raiden_nodes"
     )
 
     service_registry_address = None
@@ -162,7 +162,7 @@ def raiden_network(
         service_registry_address = blockchain_services.service_registry.address
 
     base_datadir = os.path.join(
-        get_artifacts_storage(str(tmpdir)), request.node.name, "raiden_nodes"
+        get_artifacts_storage(request.node.name) or str(tmpdir), "raiden_nodes"
     )
 
     raiden_apps = create_apps(

--- a/raiden/tests/utils/ci.py
+++ b/raiden/tests/utils/ci.py
@@ -1,5 +1,12 @@
 import os
 
+from raiden.utils.typing import Optional
 
-def get_artifacts_storage(default):
-    return os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR", default)
+
+def get_artifacts_storage(*parts) -> Optional[str]:
+    artifact_dir = os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR")
+
+    if artifact_dir:
+        os.path.join(artifact_dir, *parts)
+
+    return None


### PR DESCRIPTION
This also fixed a bug in the get_artifacts_storage usage, which added
the test name twice in local runs.

fixes #4234