### PR TITLE
Stricter type for TransitionResult

### DIFF
--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1725,7 +1725,7 @@ def handle_action_withdraw(
 
 def handle_receive_withdraw_request(
     channel_state: NettingChannelState, withdraw_request: ReceiveWithdrawRequest
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     events: List[Event] = list()
 
     is_valid, msg = is_valid_withdraw_request(
@@ -1758,7 +1758,7 @@ def handle_receive_withdraw_request(
 
 def handle_receive_withdraw(
     channel_state: NettingChannelState, withdraw: ReceiveWithdraw, block_hash: BlockHash
-) -> TransitionResult:
+) -> TransitionResult[NettingChannelState]:
     events: List[Event] = list()
 
     is_valid, msg = is_valid_withdraw_confirmation(channel_state=channel_state, withdraw=withdraw)
@@ -2028,7 +2028,7 @@ def handle_channel_updated_transfer(
 
 def handle_channel_settled(
     channel_state: NettingChannelState, state_change: ContractReceiveChannelSettled
-) -> TransitionResult[NettingChannelState]:
+) -> TransitionResult[Optional[NettingChannelState]]:
     events: List[Event] = list()
 
     if state_change.channel_identifier == channel_state.identifier:
@@ -2102,7 +2102,7 @@ def handle_channel_withdraw(
 
 def handle_channel_batch_unlock(
     channel_state: NettingChannelState, state_change: ContractReceiveChannelBatchUnlock
-) -> TransitionResult[NettingChannelState]:
+) -> TransitionResult[Optional[NettingChannelState]]:
     events: List[Event] = list()
 
     new_channel_state: Optional[NettingChannelState] = channel_state
@@ -2136,11 +2136,13 @@ def state_transition(
     block_number: BlockNumber,
     block_hash: BlockHash,
     pseudo_random_generator: random.Random,
-) -> TransitionResult[NettingChannelState]:
+) -> TransitionResult[Optional[NettingChannelState]]:
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 
     events: List[Event] = list()
-    iteration: TransitionResult[NettingChannelState] = TransitionResult(channel_state, events)
+    iteration: TransitionResult[Optional[NettingChannelState]] = TransitionResult(
+        channel_state, events
+    )
 
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -35,7 +35,9 @@ from raiden.utils.typing import (
 )
 
 
-def clear_if_finalized(iteration: TransitionResult,) -> TransitionResult[InitiatorPaymentState]:
+def clear_if_finalized(
+    iteration: TransitionResult
+) -> TransitionResult[Optional[InitiatorPaymentState]]:
     """ Clear the initiator payment task if all transfers have been finalized
     or expired. """
     state = cast(InitiatorPaymentState, iteration.new_state)
@@ -134,7 +136,7 @@ def subdispatch_to_initiatortransfer(
     state_change: StateChange,
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
-) -> TransitionResult[InitiatorTransferState]:
+) -> TransitionResult[Optional[InitiatorTransferState]]:
     channel_identifier = initiator_state.channel_identifier
     channel_state = channelidentifiers_to_channels.get(channel_identifier)
     if not channel_state:
@@ -197,7 +199,7 @@ def handle_init(
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
-) -> TransitionResult[InitiatorPaymentState]:
+) -> TransitionResult[Optional[InitiatorPaymentState]]:
     events: List[Event] = list()
     if payment_state is None:
         sub_iteration = initiator.try_new_route(
@@ -465,8 +467,10 @@ def state_transition(
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
-) -> TransitionResult[InitiatorPaymentState]:
+) -> TransitionResult[Optional[InitiatorPaymentState]]:
     # pylint: disable=unidiomatic-typecheck
+    iteration: TransitionResult[Optional[InitiatorPaymentState]]
+
     if type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION
         assert payment_state, "Block state changes should be accompanied by a valid payment state"

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -319,7 +319,7 @@ def sanity_check(
 def clear_if_finalized(
     iteration: TransitionResult,
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
-) -> TransitionResult[MediatorTransferState]:
+) -> TransitionResult[Optional[MediatorTransferState]]:
     """Clear the mediator task if all the locks have been finalized.
 
     A lock is considered finalized if it has been removed from the merkle tree
@@ -1045,7 +1045,7 @@ def handle_init(
     nodeaddresses_to_networkstates: NodeNetworkStateMap,
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
-) -> TransitionResult[MediatorTransferState]:
+) -> TransitionResult[Optional[MediatorTransferState]]:
     routes = state_change.routes
 
     from_hop = state_change.from_hop
@@ -1410,7 +1410,7 @@ def state_transition(
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
     block_hash: BlockHash,
-) -> TransitionResult[MediatorTransferState]:
+) -> TransitionResult[Optional[MediatorTransferState]]:
     """ State machine for a node mediating a transfer. """
     # pylint: disable=too-many-branches
     # Notes:

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -90,8 +90,9 @@ def handle_inittarget(
     channel_state: NettingChannelState,
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
-) -> TransitionResult[TargetTransferState]:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """ Handles an ActionInitTarget state change. """
+    iteration: TransitionResult[Optional[TargetTransferState]]
     transfer = state_change.transfer
     route = state_change.from_hop
 
@@ -221,7 +222,7 @@ def handle_unlock(
     target_state: TargetTransferState,
     state_change: ReceiveUnlock,
     channel_state: NettingChannelState,
-) -> TransitionResult[TargetTransferState]:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """ Handles a ReceiveUnlock state change. """
     balance_proof_sender = state_change.balance_proof.sender
 
@@ -299,7 +300,7 @@ def handle_lock_expired(
     state_change: ReceiveLockExpired,
     channel_state: NettingChannelState,
     block_number: BlockNumber,
-) -> TransitionResult[TargetTransferState]:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """Remove expired locks from channel states."""
     result = channel.handle_receive_lock_expired(
         channel_state=channel_state, state_change=state_change, block_number=block_number
@@ -325,7 +326,7 @@ def state_transition(
     channel_state: NettingChannelState,
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
-) -> TransitionResult[TargetTransferState]:
+) -> TransitionResult[Optional[TargetTransferState]]:
     """ State machine for the target node of a mediated transfer. """
     # pylint: disable=too-many-branches,unidiomatic-typecheck
 

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -181,9 +181,9 @@ def subdispatch_to_paymenttask(
     if sub_task:
         pseudo_random_generator = chain_state.pseudo_random_generator
         sub_iteration: Union[
-            TransitionResult[InitiatorPaymentState],
-            TransitionResult[MediatorTransferState],
-            TransitionResult[TargetTransferState],
+            TransitionResult[Optional[InitiatorPaymentState]],
+            TransitionResult[Optional[MediatorTransferState]],
+            TransitionResult[Optional[TargetTransferState]],
         ]
 
         if isinstance(sub_task, InitiatorTask):


### PR DESCRIPTION
This moves the `Optional` out of the description in `TransitionResult`. The idea here is that `node.transition_result` must not return `None`, while some of the state transitions for the initiator/mediator/target may. 