### PR TITLE
Add `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+# How to use this:
+# 1) Install https://pre-commit.com/ `pip install --user pre-commit`
+# 2) Execute `pre-commit install -c .pre-commit-config.yaml`
+# 3) Every commit now goes through linting, mypy, etc.
+# 4) If you ever need to commit without passing checks, run `git commit --no-verify`
+exclude: '^$'
+fail_fast: false
+repos:
+  - repo: git://github.com/pre-commit/mirrors-isort
+    rev: v4.3.20
+    hooks:
+      - id: isort
+        args: ["--ignore-whitespace", "--settings-path", "./", "--recursive"]
+  - repo: https://github.com/python/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+        language_version: python3.7
+
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: python -m pylint.__main__ --rcfile pylintrc raiden
+        language: system
+        types: [python]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.2
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      # - id: double-quote-string-fixer
+      - id: end-of-file-fixer
+      - id: flake8
+        args: ["--config=setup.cfg"]
+        additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer",]
+      - id: mixed-line-ending
+      - id: trailing-whitespace


### PR DESCRIPTION
This adds a configuration file for https://pre-commit.com/ to be used with Raiden. 

It respects all linting/styling preferences shared in the repository, and can be used voluntarily. 

If installed (see header of `.pre-commit-config.yaml`), every commit will be ensured to pass CI-side linting.