### PR TITLE
Remove unnecessary second test run

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1869,7 +1869,7 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-@pytest.mark.parametrize("deposit", [1000, 1000])
+@pytest.mark.parametrize("deposit", [1000])
 def test_api_withdraw(api_server_test_instance, raiden_network, token_addresses):
     _, app1 = raiden_network
     token_address = token_addresses[0]


### PR DESCRIPTION
This is a blind shot at fixing the flakyness of 
```
raiden/tests/integration/api/test_restapi.py::test_api_withdraw[matrix-False-10001-2] Too long with no output (exceeded 10m0s)
```

In the test parametrization, there were two runs with `deposit=1000` configured (the intended meaning probably was a deposit of `1000` for both of the `number_of_nodes=2` nodes).

I removed the second `1000`, so this test will run only once -- this should at least reduce flakyism by 50% :tada: 