### PR TITLE
Stricter rules for pending greenlets on tests

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -37,6 +37,7 @@ enable=
     no-self-use,
     import-self,
     gevent-joinall,
+    gevent-killall,
     useless-object-inheritance,
     unused-argument,
     unexpected-keyword-arg,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -423,7 +423,7 @@ class MatrixTransport(Runnable):
             # children crashes should throw an exception here
         except gevent.GreenletExit:  # killed without exception
             self._stop_event.set()
-            gevent.killall(self.greenlets)  # kill children
+            gevent.killall(self.greenlets, timeout=10)  # kill children
             raise  # re-raise to keep killed status
         except Exception:
             self.stop()  # ensure cleanup and wait on subtasks

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -455,7 +455,7 @@ class RaidenService(Runnable):
             self.stop_event.wait()
         except gevent.GreenletExit:  # killed without exception
             self.stop_event.set()
-            gevent.killall([self.alarm, self.transport])  # kill children
+            gevent.killall([self.alarm, self.transport], timeout=10)  # kill children
             raise  # re-raise to keep killed status
         except Exception:
             self.stop()

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -40,6 +40,7 @@ from raiden.constants import (
 )
 from raiden.log_config import configure_logging
 from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
+from raiden.tests.fixtures.cleanup import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType

--- a/raiden/tests/fixtures/cleanup.py
+++ b/raiden/tests/fixtures/cleanup.py
@@ -20,7 +20,7 @@ def cleanup_tasks() -> None:
     ]
 
     if tasks:
-        gevent.util.print_run_info()
+        log.debug("Pending greenlets", tracebacks="\n".join(gevent.util.format_run_info()))
 
         # Kill the pending greenlets hoping that the next tests will run
         # without interference

--- a/raiden/tests/fixtures/cleanup.py
+++ b/raiden/tests/fixtures/cleanup.py
@@ -26,6 +26,8 @@ def print_tracebacks(tasks: List[Greenlet]) -> None:
 
 @pytest.fixture(autouse=True)
 def cleanup_tasks() -> None:
+    yield
+
     log.debug("cleanup_tasks started")
 
     tasks = [

--- a/raiden/tests/fixtures/cleanup.py
+++ b/raiden/tests/fixtures/cleanup.py
@@ -1,0 +1,35 @@
+import gc
+
+import gevent
+import pytest
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_tasks():
+    log.debug("cleanup_tasks started")
+
+    tasks = [
+        running_task
+        for running_task in gc.get_objects()
+        if isinstance(running_task, gevent.Greenlet) and not running_task.dead
+    ]
+
+    if tasks:
+        # Kill the pending greenlets hoping that the next tests will run
+        # without interference
+        gevent.killall(tasks, timeout=10)
+
+        # Fail the insulting test because it has to be fixed
+        msg = (
+            "The test finished and left running greenlets behind. This improper "
+            "cleanup will cause flakiness in the build. E.g.: Two tests in "
+            "sequence could run a server on the same port, a hanging greenlet "
+            "from the previous tests could send packet to the new server and "
+            "mess things up. Kill all greenlets to make sure that no left-over "
+            "state from a previous test interferes with a new one. Please make "
+            "sure all greenlets are stopped before the test ends."
+        )
+        raise AssertionError(msg)

--- a/raiden/tests/fixtures/cleanup.py
+++ b/raiden/tests/fixtures/cleanup.py
@@ -1,27 +1,10 @@
 import gc
-import traceback
 
 import gevent
 import pytest
 import structlog
-from gevent import Greenlet
-
-from raiden.utils.typing import List
 
 log = structlog.get_logger(__name__)
-
-
-def print_tracebacks(tasks: List[Greenlet]) -> None:
-    header = (
-        "--------------------------------------------------\n"
-        "--------------- Pending Greenlets ----------------\n"
-        "--------------------------------------------------\n"
-    )
-
-    print(header)
-    for task in tasks:
-        formated_traceback = "".join(traceback.format_stack(task.gr_frame))
-        print(f"\n{task.name}\n\nTraceback:\n{formated_traceback}")
 
 
 @pytest.fixture(autouse=True)
@@ -37,7 +20,7 @@ def cleanup_tasks() -> None:
     ]
 
     if tasks:
-        print_tracebacks(tasks)
+        gevent.util.print_run_info()
 
         # Kill the pending greenlets hoping that the next tests will run
         # without interference

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -73,7 +73,15 @@ def changed_args():
 
 
 @pytest.fixture()
-def cli_args(logs_storage, raiden_testchain, removed_args, changed_args, environment_type):
+def cli_args(
+    logs_storage,
+    raiden_testchain,
+    removed_args,
+    changed_args,
+    environment_type,
+    cleanup_tasks,  # pylint: disable=unused-argument
+):
+
     initial_args = raiden_testchain.copy()
 
     if removed_args is not None:
@@ -116,7 +124,7 @@ def cli_args(logs_storage, raiden_testchain, removed_args, changed_args, environ
 
 
 @pytest.fixture
-def raiden_spawner(tmp_path, request):
+def raiden_spawner(tmp_path, request, cleanup_tasks):  # pylint: disable=unused-argument
     def spawn_raiden(args):
         # Remove any possibly defined `RAIDEN_*` environment variables from outer scope
         new_env = {k: copy(v) for k, v in os.environ.items() if not k.startswith("RAIDEN")}

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -13,7 +13,6 @@ from raiden.tests.utils.eth_node import (
     run_private_blockchain,
 )
 from raiden.tests.utils.network import jsonrpc_services
-from raiden.tests.utils.tests import cleanup_tasks
 from raiden.utils import privatekey_to_address
 
 # pylint: disable=redefined-outer-name,too-many-arguments,unused-argument,too-many-locals
@@ -34,6 +33,7 @@ def web3(
     tmpdir,
     chain_id,
     logs_storage,
+    cleanup_tasks,  # pylint: disable=unused-argument
 ):
     """ Starts a private chain with accounts funded. """
     # include the deploy key in the list of funded accounts
@@ -90,8 +90,6 @@ def web3(
     )
     with eth_node_runner:
         yield web3
-
-    cleanup_tasks()
 
 
 @pytest.fixture

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -2,6 +2,7 @@ import os
 
 import gevent
 import pytest
+import structlog
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.tests.utils.network import (
@@ -15,6 +16,18 @@ from raiden.tests.utils.network import (
     wait_for_channels,
     wait_for_token_networks,
 )
+
+log = structlog.get_logger(__name__)
+
+
+def _stop_apps(raiden_apps):
+    log.debug("Stopping apps")
+
+    for app in raiden_apps:
+        app.stop()
+
+    for app in raiden_apps:
+        app.raiden.get()
 
 
 def timeout(blockchain_type: str):
@@ -119,8 +132,7 @@ def raiden_chain(
 
     yield raiden_apps
 
-    for app in raiden_apps:
-        app.stop()
+    _stop_apps(raiden_apps)
 
 
 @pytest.fixture
@@ -216,5 +228,4 @@ def raiden_network(
 
     yield raiden_apps
 
-    for app in raiden_apps:
-        app.stop()
+    _stop_apps(raiden_apps)

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -26,8 +26,9 @@ def _stop_apps(raiden_apps):
     for app in raiden_apps:
         app.stop()
 
-    for app in raiden_apps:
-        app.raiden.get()
+    # Because of tests that force failure on the nodes, this cannot be done
+    # for app in raiden_apps:
+    #     app.raiden.get()
 
 
 def timeout(blockchain_type: str):

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -15,7 +15,6 @@ from raiden.tests.utils.network import (
     wait_for_channels,
     wait_for_token_networks,
 )
-from raiden.tests.utils.tests import shutdown_apps_and_cleanup_tasks
 
 
 def timeout(blockchain_type: str):
@@ -120,7 +119,8 @@ def raiden_chain(
 
     yield raiden_apps
 
-    shutdown_apps_and_cleanup_tasks(raiden_apps)
+    for app in raiden_apps:
+        app.stop()
 
 
 @pytest.fixture
@@ -216,4 +216,5 @@ def raiden_network(
 
     yield raiden_apps
 
-    shutdown_apps_and_cleanup_tasks(raiden_apps)
+    for app in raiden_apps:
+        app.stop()

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -28,7 +28,12 @@ def matrix_server_count():
 
 @pytest.fixture
 def local_matrix_servers(
-    request, transport_protocol, matrix_server_count, synapse_config_generator, port_generator
+    request,
+    transport_protocol,
+    matrix_server_count,
+    synapse_config_generator,
+    port_generator,
+    cleanup_tasks,  # pylint: disable=unused-argument
 ):
     if transport_protocol is not TransportProtocol.MATRIX:
         yield [None]

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -240,3 +240,5 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
         RANGE_ALL_STATE_CHANGES
     )
     assert search_for_item(restarted_state_changes, ContractReceiveChannelClosed, {})
+
+    app0_restart.stop()

--- a/raiden/tests/utils/tests.py
+++ b/raiden/tests/utils/tests.py
@@ -1,8 +1,5 @@
-import gc
 import os
 from itertools import chain, combinations, count, product
-
-import gevent
 
 
 def unique_path(initial_path: str) -> str:
@@ -36,27 +33,6 @@ def unique_path(initial_path: str) -> str:
         pass
 
     return proposed_path
-
-
-def cleanup_tasks():
-    tasks = [
-        running_task
-        for running_task in gc.get_objects()
-        if isinstance(running_task, gevent.Greenlet)
-    ]
-    gevent.killall(tasks)
-    gevent.hub.reinit()
-
-
-def shutdown_apps_and_cleanup_tasks(raiden_apps):
-    for app in raiden_apps:
-        app.stop()
-
-    # Two tests in sequence could run a server on the same port, a hanging
-    # greenlet from the previous tests could send packet to the new server and
-    # mess things up. Kill all greenlets to make sure that no left-over state
-    # from a previous test interferes with a new one.
-    cleanup_tasks()
 
 
 def all_combinations(values):


### PR DESCRIPTION
Some of the tests are currently flaky, the test_api_withdraw is a good
example. The logs show that the test finished executing successfully,
but got stuck during the fixture cleanup.

It is not clear at which point during the fixture cleanup the test is
hanging, however it is after the call to `app.stop()` (There are logs
for sucessfull stop of the apps).

This adds an extra pylint rule ensure that the `killall` is not the
culprit, and also makes the rule for cleaning up stricter (instead of
just killing any pending greenlets, now the test will also fail).