### PR TITLE
 Add `EventRouteFailed` to UNEVENTFUL_EVENTS

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -83,6 +83,7 @@ UNEVENTFUL_EVENTS = (
     EventInvalidReceivedUnlock,
     EventInvalidReceivedWithdrawRequest,
     EventInvalidReceivedWithdraw,
+    EventRouteFailed,
 )
 
 


### PR DESCRIPTION
Otherwise a log message about unknown events is thrown.