### PR TITLE
Remove Travis-specific part of `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,22 +205,6 @@ tests to run, just use the appropriate directory.
 For a detailed explanation of the different types of tests, see the
 [test suite section](#test-suite) below.
 
-### Testing on the CI
-
-By default whenever you make a Pull Request the linter tests, smoketests, unit tests and all the integration tests will run. This is in essence our entire test suite and at the time of writing takes around 50 mins assuming travis has enough free jobs for all the parallel jobs to run without any waiting time.
-
-This can take a lot of time and as such there are various labels you can add in the body of a commit in order to change which tests run on Travis. Following is a breakdown of those labels:
-
-- `[skip tests]`: This will skip all tests and run nothing.
-- `[ci nightly]`: This will run no tests but start a nightly release build.
-- `[no ci integration]`: This will only run the linter, smoketest and unit tests. It is rather fast.
-- `[ci integration-general]`: This will run linter, smoke, unit and only the integration tests under the `integration/` directory but no other subdirectories. This will include our slowest integration tests at the moment. At the time of writing they take around 38 mins.
-- `[ci integration-transfer]`: This will run linter, smoke, unit and only the integration tests under the `integration/transfer` directory. At the time of writing these take around 20 mins.
-- `[ci integration-long-running]`: This will run linter, smoke, unit and only the integration tests under the `integration/long-running` directory. At the time of writing these are empty so they take up only the time that is required for setting up a job. Around 2 mins.
-- `[ci integration-contracts]`: This will run linter, smoke, unit and only the integration tests under the `integration/contracts` directory. At the time of writing they take around 6 mins.
-- `[ci integration-api]`: This will run linter, smoke, unit and only the integration tests under the `integration/api` directory. At the time of writing they take around 17 mins.
-- `[ci integration-cli]`: This will run linter, smoke, unit and only the integration tests under the `integration/cli` directory. At the time of writing they take around 5 mins.
-
 ### Commiting Rules
 
 For an exhaustive guide read [this](http://chris.beams.io/posts/git-commit/)


### PR DESCRIPTION
We're not using Travis anymore and that part does not apply to CircleCI,
which only supports `[skip ci]`.