### PR TITLE
Check partner's network availability when initiating mediated transfers

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -42,7 +42,7 @@ from raiden.tests.utils.factories import (
     mediator_make_init_action,
 )
 from raiden.tests.utils.transfer import assert_dropped
-from raiden.transfer import channel
+from raiden.transfer import channel, routes
 from raiden.transfer.events import (
     ContractSendChannelClose,
     ContractSendSecretReveal,
@@ -1782,7 +1782,7 @@ def test_filter_reachable_routes():
     # Both nodes are online
     nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP1, HOP2])
 
-    filtered_routes = mediator.filter_reachable_routes(
+    filtered_routes = routes.filter_reachable_routes(
         route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
     )
 
@@ -1792,7 +1792,7 @@ def test_filter_reachable_routes():
     # Only HOP2 is online
     nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP2])
 
-    filtered_routes = mediator.filter_reachable_routes(
+    filtered_routes = routes.filter_reachable_routes(
         route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
     )
 
@@ -1802,7 +1802,7 @@ def test_filter_reachable_routes():
     # None of the route nodes are available
     nodeaddresses_to_networkstates = factories.make_node_availability_map([])
 
-    filtered_routes = mediator.filter_reachable_routes(
+    filtered_routes = routes.filter_reachable_routes(
         route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
     )
 

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -342,8 +342,7 @@ def test_mediator_skips_used_routes():
     events = transition_result.events
     assert mediator_state is not None
     assert events
-    assert len(mediator_state.routes) == 1
-    assert mediator_state.routes[0].route[1] == charlie
+    assert mediator_state.transfers_pair[-1].payee_address == charlie
 
     # now we should have a forward transfer to HOP3
     assert isinstance(events[-1], SendLockedTransfer)
@@ -387,8 +386,6 @@ def test_mediator_skips_used_routes():
     assert mediator_state is not None
     assert events
 
-    assert len(mediator_state.routes) == 0
     # no other routes available, so refund HOP1
-
     assert isinstance(events[-1], SendRefundTransfer)
     assert events[-1].recipient == factories.HOP1

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1318,6 +1318,10 @@ def make_chain_state(
     chain_state.tokennetworkaddresses_to_paymentnetworkaddresses[
         token_network_address
     ] = payment_network_address
+
+    chain_state.nodeaddresses_to_networkstates = make_node_availability_map(
+        [channel.partner_state.address for channel in channel_set.channels]
+    )
     return ContainerForChainStateTests(
         chain_state=chain_state,
         our_address=our_address,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -145,20 +145,6 @@ def get_receiver_expiration_threshold(lock: HashTimeLockState) -> BlockNumber:
     return BlockNumber(lock.expiration + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS)
 
 
-def prune_route_table(
-    route_state_table: List[RouteState], selected_route: RouteState
-) -> List[RouteState]:
-    """ Given a selected route, returns a filtered route table that
-    contains only routes using the same forward channel and removes our own
-    address in the process.
-    """
-    return [
-        RouteState(route=rs.route[1:], forward_channel_id=selected_route.forward_channel_id)
-        for rs in route_state_table
-        if rs.forward_channel_id == selected_route.forward_channel_id
-    ]
-
-
 def is_channel_usable(
     candidate_channel_state: NettingChannelState,
     transfer_amount: PaymentWithFeeAmount,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -113,8 +113,9 @@ def maybe_try_new_route_or_cancel(
         if not is_reroute_allowed:
             return TransitionResult(payment_state, events)
 
-        filtered_route_states = routes.exclude_routes_from_channels(
-            route_states=candidate_route_states, channel_ids=payment_state.cancelled_channels
+        filtered_route_states = routes.filter_acceptable_routes(
+            route_states=candidate_route_states,
+            blacklisted_channel_ids=payment_state.cancelled_channels,
         )
         sub_iteration = initiator.try_new_route(
             channelidentifiers_to_channels=channelidentifiers_to_channels,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1005,8 +1005,8 @@ def mediate_transfer(
         nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
     )
 
-    candidate_route_states = routes.exclude_routes_from_channels(
-        route_states=candidate_route_states, channel_ids=state.refunded_channels
+    candidate_route_states = routes.filter_acceptable_routes(
+        route_states=candidate_route_states, blacklisted_channel_ids=state.refunded_channels
     )
 
     for route_state in candidate_route_states:

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -214,10 +214,13 @@ class MediatorTransferState(State):
     channels will be used for the same transfer (not for different payments).
     Args:
         secrethash: The secrethash used for this transfer.
+        routes: list of all routes given for this transfer
+        refunded_channels: list of channel identifiers that sent refunds
     """
 
     secrethash: SecretHash
     routes: List[RouteState]
+    refunded_channels: List[ChannelID] = field(repr=False, default_factory=list)
     secret: Optional[Secret] = field(default=None)
     transfers_pair: List[MediationPairState] = field(default_factory=list)
     waiting_transfer: Optional[WaitingTransferState] = field(default=None)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -192,13 +192,16 @@ def subdispatch_to_paymenttask(
         if isinstance(sub_task, InitiatorTask):
             token_network_address = sub_task.token_network_address
             token_network_state = get_token_network_by_address(chain_state, token_network_address)
+
             if token_network_state:
+                channel_identifier_map = token_network_state.channelidentifiers_to_channels
                 sub_iteration = initiator_manager.state_transition(
-                    sub_task.manager_state,
-                    state_change,
-                    token_network_state.channelidentifiers_to_channels,
-                    pseudo_random_generator,
-                    block_number,
+                    payment_state=sub_task.manager_state,
+                    state_change=state_change,
+                    channelidentifiers_to_channels=channel_identifier_map,
+                    nodeaddresses_to_networkstates=chain_state.nodeaddresses_to_networkstates,
+                    pseudo_random_generator=pseudo_random_generator,
+                    block_number=block_number,
                 )
                 events = sub_iteration.events
 
@@ -285,6 +288,7 @@ def subdispatch_initiatortask(
                 payment_state=manager_state,
                 state_change=state_change,
                 channelidentifiers_to_channels=token_network_state.channelidentifiers_to_channels,
+                nodeaddresses_to_networkstates=chain_state.nodeaddresses_to_networkstates,
                 pseudo_random_generator=pseudo_random_generator,
                 block_number=block_number,
             )

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -14,12 +14,14 @@ def filter_reachable_routes(
     ]
 
 
-def exclude_routes_from_channels(
-    route_states: List[RouteState], channel_ids: List[ChannelID]
+def filter_acceptable_routes(
+    route_states: List[RouteState], blacklisted_channel_ids: List[ChannelID]
 ) -> List[RouteState]:
-    """ Keeps only routes whose forward_channel is not in the given list. """
+    """ Keeps only routes whose forward_channel is not in the list of blacklisted channels """
 
-    return [route for route in route_states if route.forward_channel_id not in channel_ids]
+    return [
+        route for route in route_states if route.forward_channel_id not in blacklisted_channel_ids
+    ]
 
 
 def prune_route_table(

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -1,0 +1,36 @@
+from raiden.transfer.state import NODE_NETWORK_REACHABLE, RouteState
+from raiden.utils.typing import ChannelID, List, NodeNetworkStateMap
+
+
+def filter_reachable_routes(
+    route_states: List[RouteState], nodeaddresses_to_networkstates: NodeNetworkStateMap
+) -> List[RouteState]:
+    """ This function makes sure we use reachable routes only. """
+
+    return [
+        route
+        for route in route_states
+        if nodeaddresses_to_networkstates.get(route.next_hop_address) == NODE_NETWORK_REACHABLE
+    ]
+
+
+def exclude_routes_from_channels(
+    route_states: List[RouteState], channel_ids: List[ChannelID]
+) -> List[RouteState]:
+    """ Keeps only routes whose forward_channel is not in the given list. """
+
+    return [route for route in route_states if route.forward_channel_id not in channel_ids]
+
+
+def prune_route_table(
+    route_states: List[RouteState], selected_route: RouteState
+) -> List[RouteState]:
+    """ Given a selected route, returns a filtered route table that
+    contains only routes using the same forward channel and removes our own
+    address in the process.
+    """
+    return [
+        RouteState(route=rs.route[1:], forward_channel_id=selected_route.forward_channel_id)
+        for rs in route_states
+        if rs.forward_channel_id == selected_route.forward_channel_id
+    ]


### PR DESCRIPTION
Resolves #4036 
Resolves #4254 
Resolves #4255 

When looking for routes to use for initiating a mediated transfer, we now check the status of the partner's node (if it is online, if it is has not been part of a refunded transfer, etc). 

The `MediatedTransferState` now includes information for a list of `refunded_channels`, which gets updated as part of the handling of a refund transfer. This information can then be used by the `mediate_transfer` function in determining which route to use.

The PR also does some refactoring related to functions that calculate/filter routes, and is located on `raiden.transfer.routes.py`. These functions are then used by all initiator- and mediator-related functions that need to define routes to be used.