### PR TITLE
UserDeposit proxy now uses gas.json

### DIFF
--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -24,7 +24,7 @@ from raiden.utils.typing import (
     typecheck,
 )
 from raiden_contracts.constants import CONTRACT_USER_DEPOSIT
-from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.contract_manager import ContractManager, gas_measurements
 
 log = structlog.get_logger(__name__)
 
@@ -45,11 +45,10 @@ class UserDeposit:
 
         self.client = jsonrpc_client
 
-        self.gas_measurements = gas_measurements(self.contract_manager.contracts_version)
-
         self.address = user_deposit_address
         self.node_address = self.client.address
         self.contract_manager = contract_manager
+        self.gas_measurements = gas_measurements(self.contract_manager.contracts_version)
 
         self.proxy = jsonrpc_client.new_contract_proxy(
             self.contract_manager.get_contract_abi(CONTRACT_USER_DEPOSIT),

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -23,7 +23,7 @@ from raiden.utils.typing import (
     Tuple,
     typecheck,
 )
-from raiden_contracts.constants import CONTRACT_USER_DEPOSIT, GAS_REQUIRED_FOR_UDC_DEPOSIT
+from raiden_contracts.constants import CONTRACT_USER_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager
 
 log = structlog.get_logger(__name__)
@@ -44,6 +44,8 @@ class UserDeposit:
         )
 
         self.client = jsonrpc_client
+
+        self.gas_measurements = gas_measurements(self.contract_manager.contracts_version)
 
         self.address = user_deposit_address
         self.node_address = self.client.address
@@ -129,7 +131,7 @@ class UserDeposit:
                     self.proxy.jsonrpc_client.check_for_insufficient_eth(
                         transaction_name="deposit",
                         transaction_executed=transaction_executed,
-                        required_gas=GAS_REQUIRED_FOR_UDC_DEPOSIT,
+                        required_gas=self.gas_measurements["UserDeposit.deposit"],
                         block_identifier=block,
                     )
 


### PR DESCRIPTION
because the global constants in raiden_contracts.constants are obsolete.

The change mimicks what's been done in the TokenNetwork proxy in 75d04070ef .