### PR TITLE
`pack_data` takes tuples instead of two lists

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1227,26 +1227,14 @@ class FeeUpdate(SignedMessage):
 
     def _data_to_sign(self) -> bytes:
         return pack_data(
-            [
-                "uint256",  # canonical_identifier
-                "address",
-                "uint256",
-                "address",  # updating participant
-                "uint256",  # fees
-                "uint256",
-                "bytes",
-                "string",  # timestamp
-            ],
-            [
-                self.canonical_identifier.chain_identifier,
-                self.canonical_identifier.token_network_address,
-                self.canonical_identifier.channel_identifier,
-                self.updating_participant,
-                self.fee_schedule.flat,
-                self.fee_schedule.proportional,
-                rlp.encode(self.fee_schedule.imbalance_penalty or 0),
-                DictSerializer.serialize(self)["timestamp"],
-            ],
+            (self.canonical_identifier.chain_identifier, "uint256"),
+            (self.canonical_identifier.token_network_address, "address"),
+            (self.canonical_identifier.channel_identifier, "uint256"),
+            (self.updating_participant, "address"),
+            (self.fee_schedule.flat, "uint256"),
+            (self.fee_schedule.proportional, "uint256"),
+            (rlp.encode(self.fee_schedule.imbalance_penalty or 0), "bytes"),
+            (DictSerializer.serialize(self)["timestamp"], "string"),
         )
 
     @classmethod

--- a/raiden/tests/integration/network/proxies/__init__.py
+++ b/raiden/tests/integration/network/proxies/__init__.py
@@ -55,16 +55,13 @@ class BalanceProof:
 
     def serialize_bin(self, msg_type: MessageTypeId = MessageTypeId.BALANCE_PROOF):
         return pack_data(
-            ["address", "uint256", "uint256", "uint256", "bytes32", "uint256", "bytes32"],
-            [
-                self.token_network_address,
-                self.chain_id,
-                msg_type.value,
-                self.channel_identifier,
-                decode_hex(self.balance_hash),
-                self.nonce,
-                decode_hex(self.additional_hash),
-            ],
+            (self.token_network_address, "address"),
+            (self.chain_id, "uint256"),
+            (msg_type.value, "uint256"),
+            (self.channel_identifier, "uint256"),
+            (decode_hex(self.balance_hash), "bytes32"),
+            (self.nonce, "uint256"),
+            (decode_hex(self.additional_hash), "bytes32"),
         )
 
     @property

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -96,10 +96,10 @@ def test_get_http_rtt():
 
 
 def test_pack_data():
-    assert pack_data(["string", "uint32"], ["Test", 49]) == b"Test\x00\x00\x001"
+    assert pack_data(("Test", "string"), (49, "uint32")) == b"Test\x00\x00\x001"
 
     with pytest.raises(ValueError):
-        pack_data(["uint256", "address"], [13])
+        pack_data((13, "uint256"), ("address"))
 
     with pytest.raises(TypeError):
-        pack_data(["uint256", "uint256"], [256, "This is not a uint256"])
+        pack_data((256, "uint256"), ("This is not a uint256", "uint256"))

--- a/raiden/utils/packing.py
+++ b/raiden/utils/packing.py
@@ -25,16 +25,13 @@ def pack_balance_proof(
     contracts expect the signed data to have.
     """
     return pack_data(
-        ["address", "uint256", "uint256", "uint256", "bytes32", "uint256", "bytes32"],
-        [
-            canonical_identifier.token_network_address,
-            canonical_identifier.chain_identifier,
-            msg_type,
-            canonical_identifier.channel_identifier,
-            balance_hash,
-            nonce,
-            additional_hash,
-        ],
+        (canonical_identifier.token_network_address, "address"),
+        (canonical_identifier.chain_identifier, "uint256"),
+        (msg_type, "uint256"),
+        (canonical_identifier.channel_identifier, "uint256"),
+        (balance_hash, "bytes32"),
+        (nonce, "uint256"),
+        (additional_hash, "bytes32"),
     )
 
 
@@ -72,16 +69,13 @@ def pack_reward_proof(
     token_network_address = canonical_identifier.token_network_address
     chain_id = canonical_identifier.chain_identifier
     return pack_data(
-        ["address", "uint256", "uint256", "uint256", "uint256", "address", "uint256"],
-        [
-            monitoring_service_contract_address,
-            chain_id,
-            MessageTypeId.MSReward,
-            channel_identifier,
-            reward_amount,
-            token_network_address,
-            nonce,
-        ],
+        (monitoring_service_contract_address, "address"),
+        (chain_id, "uint256"),
+        (MessageTypeId.MSReward, "uint256"),
+        (channel_identifier, "uint256"),
+        (reward_amount, "uint256"),
+        (token_network_address, "address"),
+        (nonce, "uint256"),
     )
 
 
@@ -100,13 +94,10 @@ def pack_withdraw(
     total_withdraw
     """
     return pack_data(
-        ["address", "uint256", "uint256", "uint256", "address", "uint256"],
-        [
-            canonical_identifier.token_network_address,
-            canonical_identifier.chain_identifier,
-            MessageTypeId.WITHDRAW,
-            canonical_identifier.channel_identifier,
-            participant,
-            total_withdraw,
-        ],
+        (canonical_identifier.token_network_address, "address"),
+        (canonical_identifier.chain_identifier, "uint256"),
+        (MessageTypeId.WITHDRAW, "uint256"),
+        (canonical_identifier.channel_identifier, "uint256"),
+        (participant, "address"),
+        (total_withdraw, "uint256"),
     )

--- a/raiden/utils/signing.py
+++ b/raiden/utils/signing.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, Tuple
 
 from eth_utils import decode_hex, keccak, remove_0x_prefix
 from web3.utils.abi import map_abi_data
@@ -8,14 +8,9 @@ from web3.utils.normalizers import abi_address_to_hex
 sha3 = keccak
 
 
-def pack_data(abi_types: List[str], values: List[Any]) -> bytes:
+def pack_data(*args: Tuple[Any, str]) -> bytes:
     """Normalize data and pack them into a byte array"""
-    if len(abi_types) != len(values):
-        raise ValueError(
-            "Length mismatch between provided abi types and values.  Got "
-            "{} types and {} values.".format(len(abi_types), len(values))
-        )
-
+    values, abi_types = zip(*args)
     normalized_values = map_abi_data([abi_address_to_hex], abi_types, values)
 
     return decode_hex(


### PR DESCRIPTION
This allows
* easier matching between value and type
* more concise code
* easier editing