### PR TITLE
Consistently name PFS messages

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -14,7 +14,7 @@ from raiden.constants import (
     PATH_FINDING_BROADCASTING_ROOM,
     RoutingMode,
 )
-from raiden.messages import FeeUpdate
+from raiden.messages import PFSFeeUpdate
 from raiden.network.proxies.utils import get_onchain_locksroots
 from raiden.services import update_path_finding_service_from_channel_state
 from raiden.storage.restore import (
@@ -140,7 +140,7 @@ def handle_channel_new(raiden: "RaidenService", event: Event):
 
         # Tell PFS about fees for this channel, when not in private mode
         if raiden.routing_mode != RoutingMode.PRIVATE:
-            fee_update = FeeUpdate.from_channel_state(channel_state)
+            fee_update = PFSFeeUpdate.from_channel_state(channel_state)
             fee_update.sign(raiden.signer)
             # Appends message to queue, so it's not blocking
             raiden.transport.send_global(PATH_FINDING_BROADCASTING_ROOM, fee_update)

--- a/raiden/encoding/messages.py
+++ b/raiden/encoding/messages.py
@@ -209,7 +209,7 @@ RequestMonitoring = namedbuffer(
 )
 
 
-UpdatePFS = namedbuffer(
+PFSCapacityUpdate = namedbuffer(
     "update_pfs",
     [
         chain_id,

--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -91,7 +91,8 @@ __all__ = (
     "SignedMessage",
     "Unlock",
     "ToDevice",
-    "UpdatePFS",
+    "PFSCapacityUpdate",
+    "PFSFeeUpdate",
     "Withdraw",
     "WithdrawRequest",
     "from_dict",
@@ -1156,7 +1157,7 @@ class RequestMonitoring(SignedMessage):
 
 
 @dataclass(repr=False, eq=False)
-class UpdatePFS(SignedMessage):
+class PFSCapacityUpdate(SignedMessage):
     """ Message to inform a pathfinding service about a capacity change. """
 
     canonical_identifier: CanonicalIdentifier
@@ -1173,7 +1174,7 @@ class UpdatePFS(SignedMessage):
             self.signature = EMPTY_SIGNATURE
 
     @classmethod
-    def from_channel_state(cls, channel_state: NettingChannelState) -> "UpdatePFS":
+    def from_channel_state(cls, channel_state: NettingChannelState) -> "PFSCapacityUpdate":
         # pylint: disable=unexpected-keyword-arg
         return cls(
             canonical_identifier=channel_state.canonical_identifier,
@@ -1192,7 +1193,7 @@ class UpdatePFS(SignedMessage):
         )
 
     def packed(self) -> bytes:
-        klass = messages.UpdatePFS
+        klass = messages.PFSCapacityUpdate
         data = buffer_for(klass)
         packed = klass(data)
         self.pack(packed)
@@ -1213,7 +1214,7 @@ class UpdatePFS(SignedMessage):
 
 
 @dataclass
-class FeeUpdate(SignedMessage):
+class PFSFeeUpdate(SignedMessage):
     """Informs the PFS of mediation fees demanded by the client"""
 
     canonical_identifier: CanonicalIdentifier

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -5,7 +5,7 @@ from eth_utils import to_checksum_address
 
 from raiden import constants
 from raiden.constants import RoutingMode
-from raiden.messages import RequestMonitoring, UpdatePFS
+from raiden.messages import PFSCapacityUpdate, RequestMonitoring
 from raiden.settings import MONITORING_MIN_CAPACITY, MONITORING_REWARD
 from raiden.transfer import channel, views
 from raiden.transfer.architecture import BalanceProofSignedState, BalanceProofUnsignedState
@@ -43,7 +43,7 @@ def update_path_finding_service_from_channel_state(
     if raiden.routing_mode == RoutingMode.PRIVATE:
         return
 
-    msg = UpdatePFS.from_channel_state(channel_state)
+    msg = PFSCapacityUpdate.from_channel_state(channel_state)
     msg.sign(raiden.signer)
     raiden.transport.send_global(constants.PATH_FINDING_BROADCASTING_ROOM, msg)
     log.debug("Sent a PFS Update", message=msg, channel_state=channel_state)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -17,7 +17,7 @@ from raiden.constants import (
     RoutingMode,
 )
 from raiden.exceptions import InsufficientFunds
-from raiden.messages import Delivered, FeeUpdate, Processed, SecretRequest, ToDevice
+from raiden.messages import Delivered, PFSFeeUpdate, Processed, SecretRequest, ToDevice
 from raiden.network.transport.matrix import AddressReachability, MatrixTransport, _RetryQueue
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import make_room_alias
@@ -641,7 +641,7 @@ def test_pfs_global_messages(
     route_mode,
 ):
     """
-    Test that RaidenService sends UpdatePFS messages to global
+    Test that RaidenService sends PFSCapacityUpdate messages to global
     PATH_FINDING_BROADCASTING_ROOM room on newly received balance proofs.
     """
     transport = MatrixTransport(
@@ -671,7 +671,7 @@ def test_pfs_global_messages(
     raiden_service.transport = transport
     transport.log = MagicMock()
 
-    # send UpdatePFS
+    # send PFSCapacityUpdate
     balance_proof = factories.create(HOP1_BALANCE_PROOF)
     channel_state = factories.create(factories.NettingChannelStateProperties())
     channel_state.our_state.balance_proof = balance_proof
@@ -690,9 +690,9 @@ def test_pfs_global_messages(
             gevent.idle()
     assert pfs_room.send_text.call_count == 1
 
-    # send FeeUpdate
+    # send PFSFeeUpdate
     channel_state = factories.create(factories.NettingChannelStateProperties())
-    fee_update = FeeUpdate.from_channel_state(channel_state)
+    fee_update = PFSFeeUpdate.from_channel_state(channel_state)
     fee_update.sign(raiden_service.signer)
     raiden_service.transport.send_global(PATH_FINDING_BROADCASTING_ROOM, fee_update)
     with gevent.Timeout(2):
@@ -700,7 +700,7 @@ def test_pfs_global_messages(
             gevent.idle()
     assert pfs_room.send_text.call_count == 2
     msg_data = json.loads(pfs_room.send_text.call_args[0][0])
-    assert msg_data["_type"] == "raiden.messages.FeeUpdate"
+    assert msg_data["_type"] == "raiden.messages.PFSFeeUpdate"
 
     transport.stop()
     transport.get()

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -6,14 +6,14 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX, UINT256_MAX
 from raiden.message_handler import MessageHandler
 from raiden.messages import (
     Delivered,
-    FeeUpdate,
+    PFSCapacityUpdate,
+    PFSFeeUpdate,
     Ping,
     Processed,
     RequestMonitoring,
     RevealSecret,
     SecretRequest,
     SignedBlindedBalanceProof,
-    UpdatePFS,
 )
 from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils import factories
@@ -125,7 +125,7 @@ def test_update_pfs():
     channel_state = factories.create(factories.NettingChannelStateProperties())
     channel_state.our_state.balance_proof = balance_proof
     channel_state.partner_state.balance_proof = balance_proof
-    message = UpdatePFS.from_channel_state(channel_state=channel_state)
+    message = PFSCapacityUpdate.from_channel_state(channel_state=channel_state)
 
     assert message.signature == EMPTY_SIGNATURE
     privkey2, address2 = factories.make_privkey_address()
@@ -138,7 +138,7 @@ def test_update_pfs():
 
 def test_fee_update():
     channel_state = factories.create(factories.NettingChannelStateProperties())
-    message = FeeUpdate.from_channel_state(channel_state)
+    message = PFSFeeUpdate.from_channel_state(channel_state)
     message.sign(signer)
 
     assert message == DictSerializer.deserialize(DictSerializer.serialize(message))


### PR DESCRIPTION
This means:
`FeeUpdate` -> `PFSFeeUpdate`
`UpdatePFS` -> `PFSCapacityUpdate`