### PR TITLE
Fix test logpath size

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -33,6 +33,7 @@ from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.tests.utils.ci import get_artifacts_storage
 from raiden.tests.utils.transport import make_requests_insecure
+from raiden.utils import pex
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
 
@@ -136,7 +137,13 @@ def logging_level(request, tmpdir):
     else:
         logging_levels = {"": level}
 
-    base_dir = get_artifacts_storage(request.node.name) or str(tmpdir)
+    # The test name including the arguments cannot be used because of the path
+    # length. Some tests will have a path longer than 300 characters.
+    original_name = request.node.originalname
+    shorted_arguments = pex(request.node.name.encode("utf8"))
+    shortened_test_name = f"{original_name}-{shorted_arguments}"
+
+    base_dir = get_artifacts_storage(shortened_test_name) or str(tmpdir)
     os.makedirs(base_dir, exist_ok=True)
 
     time = datetime.datetime.utcnow().isoformat()

--- a/raiden/tests/utils/ci.py
+++ b/raiden/tests/utils/ci.py
@@ -7,6 +7,6 @@ def get_artifacts_storage(*parts) -> Optional[str]:
     artifact_dir = os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR")
 
     if artifact_dir:
-        os.path.join(artifact_dir, *parts)
+        return os.path.join(artifact_dir, *parts)
 
     return None


### PR DESCRIPTION
Fix the build. Some of the tests parametrize fixtures are very long when encoded as strings, resulting in build failures because of the path length.