### PR TITLE
Recalc imbalance fees after balance change

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -29,7 +29,7 @@ from raiden.transfer.state import (
     TransactionChannelNewBalance,
 )
 from raiden.transfer.state_change import (
-    ActionChannelSetFee,
+    ActionChannelUpdateFee,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
     ContractReceiveChannelNew,
@@ -282,14 +282,14 @@ def handle_channel_new_balance(raiden: "RaidenService", event: Event):  # pragma
         participant_address = args["participant"]
         total_deposit = args["total_deposit"]
 
-        update_fees_statechange = ActionChannelSetFee(
+        update_fee_statechange = ActionChannelUpdateFee(
             canonical_identifier=previous_channel_state.canonical_identifier,
             flat_fee=previous_channel_state.fee_schedule.flat,
             proportional_fee=previous_channel_state.fee_schedule.proportional,
             use_imbalance_penalty=previous_channel_state.fee_schedule.imbalance_penalty
             is not None,
         )
-        raiden.handle_and_track_state_change(update_fees_statechange)
+        raiden.handle_and_track_state_change(update_fee_statechange)
 
         if balance_was_zero and participant_address != raiden.address:
             connection_manager = raiden.connection_manager_for_token_network(token_network_address)
@@ -341,14 +341,14 @@ def handle_channel_withdraw(raiden: "RaidenService", event: Event):
         msg = "Failed to find channel state after withdraw"
         assert channel_state is not None, msg
 
-        update_fees_statechange = ActionChannelSetFee(
+        update_fee_statechange = ActionChannelUpdateFee(
             canonical_identifier=previous_channel_state.canonical_identifier,
             flat_fee=previous_channel_state.fee_schedule.flat,
             proportional_fee=previous_channel_state.fee_schedule.proportional,
             use_imbalance_penalty=previous_channel_state.fee_schedule.imbalance_penalty
             is not None,
         )
-        raiden.handle_and_track_state_change(update_fees_statechange)
+        raiden.handle_and_track_state_change(update_fee_statechange)
 
         update_path_finding_service_from_channel_state(raiden=raiden, channel_state=channel_state)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -69,7 +69,7 @@ from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.transfer.state import ChainState, HopState, PaymentNetworkState
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
-    ActionChannelSetFee,
+    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ActionInitChain,
     Block,
@@ -909,8 +909,7 @@ class RaidenService(Runnable):
                     proportional_fee=default_fee_schedule.proportional,
                 )
 
-                # FIXME: this should trigger an update of rebalancing fees
-                state_change = ActionChannelSetFee(
+                state_change = ActionChannelUpdateFee(
                     canonical_identifier=channel.canonical_identifier,
                     flat_fee=default_fee_schedule.flat,
                     proportional_fee=default_fee_schedule.proportional,

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -10,7 +10,7 @@ from raiden.settings import MONITORING_MIN_CAPACITY, MONITORING_REWARD
 from raiden.transfer import channel, views
 from raiden.transfer.architecture import BalanceProofSignedState, BalanceProofUnsignedState
 from raiden.transfer.identifiers import CanonicalIdentifier
-from raiden.transfer.state import ChainState, NettingChannelState
+from raiden.transfer.state import ChainState
 from raiden.utils import to_rdn
 from raiden.utils.typing import TYPE_CHECKING, Address
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -21,10 +21,7 @@ from raiden.messages import Delivered, PFSFeeUpdate, Processed, SecretRequest, T
 from raiden.network.transport.matrix import AddressReachability, MatrixTransport, _RetryQueue
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import make_room_alias
-from raiden.services import (
-    update_monitoring_service_from_balance_proof,
-    update_path_finding_service_from_balance_proof,
-)
+from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
 from raiden.storage.serialization import JSONSerializer
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
@@ -681,9 +678,7 @@ def test_pfs_global_messages(
         "get_channelstate_by_canonical_identifier",
         lambda *a, **kw: channel_state,
     )
-    update_path_finding_service_from_balance_proof(
-        raiden=raiden_service, chain_state=None, new_balance_proof=balance_proof
-    )
+    send_pfs_update(raiden=raiden_service, canonical_identifier=balance_proof.canonical_identifier)
     gevent.idle()
     with gevent.Timeout(2):
         while pfs_room.send_text.call_count < 1:

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -18,7 +18,7 @@ from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import assert_synced_channel_state, transfer, wait_assert
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
-from raiden.transfer.state_change import ActionChannelSetFee
+from raiden.transfer.state_change import ActionChannelUpdateFee
 from raiden.utils import sha3
 from raiden.utils.typing import BlockNumber, FeeAmount, PaymentAmount, TokenAmount
 from raiden.waiting import wait_for_block
@@ -470,14 +470,14 @@ def run_test_mediated_transfer_with_allocated_fee(
     )
 
     # Let app1 consume all of the allocated mediation fee
-    action_set_fee = ActionChannelSetFee(
+    action_update_fee = ActionChannelUpdateFee(
         canonical_identifier=app1_app2_channel_state.canonical_identifier,
         flat_fee=fee,
         proportional_fee=0,
         use_imbalance_penalty=False,
     )
 
-    app1.raiden.handle_state_changes(state_changes=[action_set_fee])
+    app1.raiden.handle_state_changes(state_changes=[action_update_fee])
 
     transfer(
         initiator_app=app0,
@@ -567,14 +567,14 @@ def run_test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
     )
 
     # Let app1 consume all of the allocated mediation fee
-    action_set_fee = ActionChannelSetFee(
+    action_update_fee = ActionChannelUpdateFee(
         canonical_identifier=app1_app2_channel_state.canonical_identifier,
         flat_fee=FeeAmount(fee * 2),
         proportional_fee=0,
         use_imbalance_penalty=False,
     )
 
-    app1.raiden.handle_state_changes(state_changes=[action_set_fee])
+    app1.raiden.handle_state_changes(state_changes=[action_update_fee])
 
     secret = factories.make_secret(0)
     secrethash = sha256(secret).digest()

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -4,7 +4,7 @@ from raiden.transfer.mediated_transfer.mediation_fee import (
     NUM_DISCRETISATION_POINTS,
     FeeScheduleState,
     Interpolate,
-    calculate_rebalancing_fees,
+    calculate_imbalance_fees,
     linspace,
 )
 from raiden.utils.typing import Balance, FeeAmount as FA, PaymentAmount, TokenAmount as TA
@@ -71,12 +71,12 @@ def test_linspace():
 
 
 def test_rebalancing_fee_calculation():
-    sample = calculate_rebalancing_fees(Balance(100), Balance(100))
+    sample = calculate_imbalance_fees(Balance(100), Balance(100))
     assert len(sample) == NUM_DISCRETISATION_POINTS
     assert max(x for x, _ in sample) == 200
     assert max(y for _, y in sample) == 10 ** 18
 
-    sample = calculate_rebalancing_fees(Balance(0), Balance(10))
+    sample = calculate_imbalance_fees(Balance(0), Balance(10))
     assert len(sample) == 10
     assert max(x for x, _ in sample) == 10
     assert max(y for _, y in sample) == 10 ** 18

--- a/raiden/tests/unit/transfer/test_channel.py
+++ b/raiden/tests/unit/transfer/test_channel.py
@@ -17,7 +17,7 @@ from raiden.transfer.channel import (
     get_batch_unlock_gain,
     get_secret,
     get_status,
-    handle_action_set_fee,
+    handle_action_update_fee,
     handle_block,
     handle_receive_lockedtransfer,
     is_balance_proof_usable_onchain,
@@ -35,7 +35,7 @@ from raiden.transfer.state import (
     UnlockPartialProofState,
 )
 from raiden.transfer.state_change import (
-    ActionChannelSetFee,
+    ActionChannelUpdateFee,
     Block,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelSettled,
@@ -329,13 +329,13 @@ def test_handle_action_set_fee():
     state = factories.create(factories.NettingChannelStateProperties())
     flat_fee = 130
     proportional_fee = 1000
-    action = ActionChannelSetFee(
+    action = ActionChannelUpdateFee(
         canonical_identifier=state.canonical_identifier,
         flat_fee=flat_fee,
         proportional_fee=proportional_fee,
         use_imbalance_penalty=False,
     )
-    result = handle_action_set_fee(state, action)
+    result = handle_action_update_fee(state, action)
     assert result.new_state.fee_schedule.flat == flat_fee
     assert result.new_state.fee_schedule.proportional == proportional_fee
     assert not result.new_state.fee_schedule.imbalance_penalty

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -93,7 +93,7 @@ def linspace(start: TokenAmount, stop: TokenAmount, num: int) -> List[TokenAmoun
     return result
 
 
-def calculate_rebalancing_fees(
+def calculate_imbalance_fees(
     our_balance: Balance, partner_balance: Balance
 ) -> List[Tuple[TokenAmount, FeeAmount]]:
     """ Calculates a quadratic rebalancing curve.

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -41,7 +41,7 @@ from raiden.transfer.state import ChainState, PaymentNetworkState, TokenNetworkS
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
     ActionChannelClose,
-    ActionChannelSetFee,
+    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ActionInitChain,
     ActionNewTokenNetwork,
@@ -771,8 +771,8 @@ def handle_state_change(
     elif type(state_change) == ActionChannelClose:
         assert isinstance(state_change, ActionChannelClose), MYPY_ANNOTATION
         iteration = handle_token_network_action(chain_state, state_change)
-    elif type(state_change) == ActionChannelSetFee:
-        assert isinstance(state_change, ActionChannelSetFee), MYPY_ANNOTATION
+    elif type(state_change) == ActionChannelUpdateFee:
+        assert isinstance(state_change, ActionChannelUpdateFee), MYPY_ANNOTATION
         iteration = subdispatch_by_canonical_id(
             chain_state=chain_state,
             canonical_identifier=state_change.canonical_identifier,

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -125,7 +125,7 @@ class ActionChannelWithdraw(StateChange):
 
 
 @dataclass
-class ActionChannelSetFee(StateChange):
+class ActionChannelUpdateFee(StateChange):
     canonical_identifier: CanonicalIdentifier
     flat_fee: FeeAmount
     proportional_fee: int  # as micros, e.g. 1% = 0.01e6

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -5,7 +5,7 @@ from raiden.transfer.architecture import Event, StateChange, TransitionResult
 from raiden.transfer.state import TokenNetworkState
 from raiden.transfer.state_change import (
     ActionChannelClose,
-    ActionChannelSetFee,
+    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -25,7 +25,7 @@ from raiden.utils.typing import MYPY_ANNOTATION, BlockHash, BlockNumber, List, U
 # that contains channel IDs and other specific channel attributes
 StateChangeWithChannelID = Union[
     ActionChannelClose,
-    ActionChannelSetFee,
+    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ContractReceiveChannelClosed,
     ContractReceiveChannelNewBalance,
@@ -346,8 +346,8 @@ def state_transition(
             block_hash=block_hash,
             pseudo_random_generator=pseudo_random_generator,
         )
-    elif type(state_change) == ActionChannelSetFee:
-        assert isinstance(state_change, ActionChannelSetFee), MYPY_ANNOTATION
+    elif type(state_change) == ActionChannelUpdateFee:
+        assert isinstance(state_change, ActionChannelUpdateFee), MYPY_ANNOTATION
         iteration = subdispatch_to_channel_by_id(
             token_network_state=token_network_state,
             state_change=state_change,


### PR DESCRIPTION
This PR updates the balance fees after a deposit or withdraw for the channel has been received. This is done by emitting `ActionChannelUpdateFee` (renamed from `ActionChannelSetFee`) state changes when such a blockchain event is received.

Part of #3542