### PR TITLE
Take privacy into account when sending feedback

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -519,6 +519,7 @@ def query_paths(
 
 
 def post_pfs_feedback(
+    routing_mode: RoutingMode,
     pfs_config: PFSConfig,
     token_network_address: TokenNetworkAddress,
     route: List[Address],
@@ -526,8 +527,8 @@ def post_pfs_feedback(
     succesful: bool,
 ) -> None:
 
-    # PFS not enabled
-    if pfs_config is None:
+    feedback_disabled = routing_mode == RoutingMode.PRIVATE or pfs_config is None
+    if feedback_disabled:
         return
 
     hex_route = [to_checksum_address(address) for address in route]

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -677,6 +677,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
                 feedback_token=feedback_token,
             )
             post_pfs_feedback(
+                routing_mode=raiden.routing_mode,
                 pfs_config=pfs_config,
                 token_network_address=route_failed_event.token_network_address,
                 route=route_failed_event.route,
@@ -700,6 +701,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
                 feedback_token=feedback_token,
             )
             post_pfs_feedback(
+                routing_mode=raiden.routing_mode,
                 pfs_config=pfs_config,
                 token_network_address=payment_sent_success_event.token_network_address,
                 route=payment_sent_success_event.route,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -13,6 +13,7 @@ from eth_utils import (
     to_checksum_address,
 )
 
+from raiden.constants import RoutingMode
 from raiden.exceptions import ServiceRequestFailed, ServiceRequestIOURejected
 from raiden.network.pathfinding import (
     IOU,
@@ -831,11 +832,12 @@ def test_post_pfs_feedback(query_paths_args):
 
     with patch.object(requests, "post", return_value=request_mock()) as feedback:
         post_pfs_feedback(
+            routing_mode=RoutingMode.PFS,
+            pfs_config=query_paths_args["pfs_config"],
             token_network_address=token_network_address,
             route=route,
             token=feedback_token,
             succesful=True,
-            pfs_config=query_paths_args["pfs_config"],
         )
 
         assert feedback.called
@@ -848,11 +850,12 @@ def test_post_pfs_feedback(query_paths_args):
 
     with patch.object(requests, "post", return_value=request_mock()) as feedback:
         post_pfs_feedback(
+            routing_mode=RoutingMode.PFS,
+            pfs_config=query_paths_args["pfs_config"],
             token_network_address=token_network_address,
             route=route,
             token=feedback_token,
             succesful=False,
-            pfs_config=query_paths_args["pfs_config"],
         )
 
         assert feedback.called
@@ -865,11 +868,12 @@ def test_post_pfs_feedback(query_paths_args):
 
     with patch.object(requests, "post", return_value=request_mock()) as feedback:
         post_pfs_feedback(
+            routing_mode=RoutingMode.PRIVATE,
+            pfs_config=query_paths_args["pfs_config"],
             token_network_address=token_network_address,
             route=route,
             token=feedback_token,
             succesful=False,
-            pfs_config=None,
         )
 
         assert not feedback.called


### PR DESCRIPTION
Only send routing feedback when the routing mode is not `PRIVATE`