### PR TITLE
Fix macOS nightly build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,9 @@ install: check-pip-tools clean-pyc
 	cd requirements; pip-sync requirements.txt _raiden.txt
 
 install-dev: check-pip-tools clean-pyc
-	cd requirements; touch requirements-local.txt; pip-sync requirements-dev.txt _raiden-dev.txt requirements-local.txt
+	touch requirements/requirements-local.txt
+	cd requirements; pip-sync requirements-dev.txt _raiden-dev.txt
+	pip install -c requirements/requirements-dev.txt -r requirements/requirements-local.txt
 
 ARCHIVE_TAG_ARG=
 ifdef ARCHIVE_TAG

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -110,7 +110,7 @@ pip-tools==3.8.0
 pluggy==0.12.0
 prometheus-client==0.3.1
 psutil==5.6.3
-psycopg2==2.8.3
+psycopg2==2.7.7
 ptyprocess==0.6.0
 py-ecc==1.4.7
 py-geth==2.1.0

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -42,3 +42,8 @@ bump2version
 
 # Test support
 matrix-synapse==0.33.9
+
+# Pin psycopg2 to prevent having to compile the c-extension
+# (see https://github.com/raiden-network/raiden/issues/3745)
+# can be removed once https://github.com/raiden-network/raiden/issues/3387
+psycopg2<2.8

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -106,7 +106,7 @@ pip-tools==3.8.0
 pluggy==0.12.0            # via pytest
 prometheus-client==0.3.1  # via matrix-synapse
 psutil==5.6.3
-psycopg2==2.8.3           # via matrix-synapse
+psycopg2==2.7.7
 ptyprocess==0.6.0
 py-ecc==1.4.7
 py-geth==2.1.0


### PR DESCRIPTION
Due to an unintentional dependency upgrade of psycopg2 our nightly macOS builds failed 
(see #3745 for details).

Drive-by fix: Developer local requirements from `requirements-local.txt` could be mangled with repeated runs of `make install-dev`.