### PR TITLE
Use `FeeSchedule` for incoming channel

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -25,7 +25,6 @@ from raiden.tests.utils.factories import (
     UNIT_SETTLE_TIMEOUT,
     UNIT_TOKEN_NETWORK_ADDRESS,
     UNIT_TRANSFER_AMOUNT,
-    UNIT_TRANSFER_FEE,
     UNIT_TRANSFER_IDENTIFIER,
     UNIT_TRANSFER_SENDER,
     UNIT_TRANSFER_TARGET,
@@ -1920,7 +1919,7 @@ def test_next_transfer_pair_with_fees_deducted():
 
 def test_backward_transfer_pair_with_fees_deducted():
     amount = 10
-    fee = FeeAmount(5)
+    fee = FeeAmount(0)  # Fee handling for refunds is currently undefined, so set it to 0 for now.
 
     end_state = factories.NettingChannelEndStateProperties(balance=amount + fee)
     partner_state = replace(end_state, address=UNIT_TRANSFER_SENDER)
@@ -1967,14 +1966,15 @@ def test_backward_transfer_pair_with_fees_deducted():
 
 
 def test_sanity_check_for_refund_transfer_with_fees():
+    fee = FeeAmount(0)  # Fee handling for refunds is currently undefined, so set it to 0 for now.
     channels = make_channel_set(
         [
             NettingChannelStateProperties(
-                fee_schedule=FeeScheduleStateProperties(flat=UNIT_TRANSFER_FEE, proportional=0),
+                fee_schedule=FeeScheduleStateProperties(flat=fee, proportional=0),
                 canonical_identifier=make_canonical_identifier(channel_identifier=1),
                 our_state=NettingChannelEndStateProperties.OUR_STATE,
                 partner_state=NettingChannelEndStateProperties(
-                    balance=UNIT_TRANSFER_AMOUNT + UNIT_TRANSFER_FEE, address=UNIT_TRANSFER_SENDER
+                    balance=UNIT_TRANSFER_AMOUNT + fee, address=UNIT_TRANSFER_SENDER
                 ),
             ),
             NettingChannelStateProperties(
@@ -1992,7 +1992,7 @@ def test_sanity_check_for_refund_transfer_with_fees():
 
     next_hop_address = channels[1].partner_state.address
 
-    from_transfer_amount = UNIT_TRANSFER_AMOUNT + UNIT_TRANSFER_FEE
+    from_transfer_amount = UNIT_TRANSFER_AMOUNT + fee
     from_transfer = factories.make_signed_transfer_for(
         channel_state=channels[0],
         properties=LockedTransferSignedStateProperties(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1890,22 +1890,24 @@ def test_node_change_network_state_unreachable_node():
 
 def test_next_transfer_pair_with_fees_deducted():
     balance = 10
-    fee = 5
+    fee_in = 1
+    fee_out = 2
 
     payer_transfer = create(
         LockedTransferSignedStateProperties(
-            amount=balance + fee, initiator=HOP1, target=ADDR, expiration=50
+            amount=balance + fee_in + fee_out, initiator=HOP1, target=ADDR, expiration=50
         )
     )
 
     channels = make_channel_set(
         [
             NettingChannelStateProperties(
-                our_state=NettingChannelEndStateProperties(balance=balance)
+                our_state=NettingChannelEndStateProperties(balance=balance),
+                fee_schedule=FeeScheduleState(flat=fee_in),
             ),
             NettingChannelStateProperties(
                 our_state=NettingChannelEndStateProperties(balance=balance),
-                fee_schedule=FeeScheduleState(flat=fee),
+                fee_schedule=FeeScheduleState(flat=fee_out),
             ),
         ]
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -205,13 +205,17 @@ def test_next_transfer_pair():
         [
             NettingChannelStateProperties(
                 our_state=NettingChannelEndStateProperties(balance=balance)
-            )
+            ),
+            NettingChannelStateProperties(
+                our_state=NettingChannelEndStateProperties(balance=balance)
+            ),
         ]
     )
 
-    route_state_table = channels.get_routes()
+    route_state_table = channels.get_routes(1)
     pair, events = mediator.forward_transfer_pair(
         payer_transfer=payer_transfer,
+        payer_channel=channels[0],
         route_state=route_state_table[0],
         route_state_table=route_state_table,
         channelidentifiers_to_channels=channels.channel_map,
@@ -220,7 +224,7 @@ def test_next_transfer_pair():
     )
 
     assert pair.payer_transfer == payer_transfer
-    assert pair.payee_address == channels[0].partner_state.address
+    assert pair.payee_address == channels[1].partner_state.address
     assert pair.payee_transfer.lock.expiration == pair.payer_transfer.lock.expiration
 
     assert search_for_item(
@@ -1897,15 +1901,19 @@ def test_next_transfer_pair_with_fees_deducted():
     channels = make_channel_set(
         [
             NettingChannelStateProperties(
+                our_state=NettingChannelEndStateProperties(balance=balance)
+            ),
+            NettingChannelStateProperties(
                 our_state=NettingChannelEndStateProperties(balance=balance),
                 fee_schedule=FeeScheduleState(flat=fee),
-            )
+            ),
         ]
     )
 
     pair, events = mediator.forward_transfer_pair(
         payer_transfer=payer_transfer,
-        route_state=channels.get_route(0),
+        payer_channel=channels[0],
+        route_state=channels.get_route(1),
         route_state_table=channels.get_routes(),
         channelidentifiers_to_channels=channels.channel_map,
         pseudo_random_generator=random.Random(),

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -449,7 +449,10 @@ def backward_transfer_pair(
             channel_state=backward_channel,
             initiator=payer_transfer.initiator,
             target=payer_transfer.target,
-            amount=get_lock_amount_after_fees(lock, backward_channel),
+            # `amount` should be `get_lock_amount_after_fees(...)`, but fees
+            # for refunds are currently not defined, so we assume fee=0 to keep
+            # it simple, for now.
+            amount=lock.amount,
             message_identifier=message_identifier,
             payment_identifier=payer_transfer.payment_identifier,
             expiration=lock.expiration,


### PR DESCRIPTION
The flexible mediation fees are meant to be calculated for both the incoming and the outgoing channel. Previously, we only cared for the outgoing channel.

Closes https://github.com/raiden-network/raiden/issues/3542.