### PR TITLE
Fix docker based nightly builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 dist/
 tools/testnet/.terraform/plugins
+docs/_build
+.mypy_cache
+.eggs
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,6 @@ install-dev: check-pip-tools clean-pyc
 	cd requirements; pip-sync requirements-dev.txt _raiden-dev.txt
 	pip install -c requirements/requirements-dev.txt -r requirements/requirements-local.txt
 
-ARCHIVE_TAG_ARG=
-ifdef ARCHIVE_TAG
-ARCHIVE_TAG_ARG=--build-arg ARCHIVE_TAG=$(ARCHIVE_TAG)
-else
-ARCHIVE_TAG_ARG=--build-arg ARCHIVE_TAG=v$(shell python setup.py --version)
-endif
-
-
 GITHUB_ACCESS_TOKEN_ARG=
 ifdef GITHUB_ACCESS_TOKEN
 GITHUB_ACCESS_TOKEN_ARG=--build-arg GITHUB_ACCESS_TOKEN_FRAGMENT=$(GITHUB_ACCESS_TOKEN)@
@@ -106,8 +98,9 @@ endif
 
 # architecture needs to be asked in docker because docker can be run on remote host to create binary for different architectures
 bundle-docker: ARCHITECTURE_TAG = $(shell docker run --rm python:3.7 uname -m)
+bundle-docker: ARCHIVE_TAG ?= v$(shell python setup.py --version)
 bundle-docker:
-	docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) --build-arg ARCHITECTURE_TAG=$(ARCHITECTURE_TAG) $(ARCHIVE_TAG_ARG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .
+	docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) --build-arg ARCHITECTURE_TAG=$(ARCHITECTURE_TAG) --build-arg ARCHIVE_TAG=$(ARCHIVE_TAG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .
 	-(docker rm builder)
 	docker create --name builder pyinstallerbuilder
 	mkdir -p dist/archive

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -17,8 +17,12 @@ RUN wget -nv -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && \
     rm geth.tar.gz
 
 
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
 ADD requirements/requirements.txt /tmp/
 WORKDIR /tmp
+
 
 RUN pip install -U 'pip<19.0.0' setuptools pip-tools
 RUN pip-sync requirements.txt
@@ -27,7 +31,6 @@ ADD . /raiden
 
 WORKDIR /raiden
 RUN git fetch --tags || true
-
 
 # install raiden
 RUN make install && pip install pyinstaller


### PR DESCRIPTION
With the introduction of the new deps system a check for an active v(irtual)env was introduced. 
This failed inside the bundle docker container since it didn't use a venv previously.