### PR TITLE
Use PFS routing by default

### DIFF
--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -88,7 +88,14 @@ def cli_args(request, tmpdir, raiden_testchain, removed_args, changed_args, envi
     )
     os.makedirs(os.path.dirname(base_logfile), exist_ok=True)
 
-    args = ["--gas-price", "1000000000", "--no-sync-check", f"--debug-logfile-name={base_logfile}"]
+    args = [
+        "--gas-price",
+        "1000000000",
+        "--no-sync-check",
+        f"--debug-logfile-name={base_logfile}",
+        "--routing-mode",
+        "local",
+    ]
 
     if environment_type == Environment.DEVELOPMENT.value:
         args += ["--environment-type", environment_type]

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -246,7 +246,7 @@ def options(func):
                     '"private": use local routing and don\'t send updates to the PFS\n'
                 ),
                 type=EnumChoiceType(RoutingMode),
-                default=RoutingMode.LOCAL.value,
+                default=RoutingMode.PFS.value,
                 show_default=True,
             ),
             option(


### PR DESCRIPTION
Since the internal routing is deprecated, we want to use PFS routing by default.