### PR TITLE
Disable calls to send_refundtransfer messages

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -63,7 +63,7 @@ class MessageHandler:
             assert isinstance(message, LockExpired), MYPY_ANNOTATION
             self.handle_message_lockexpired(raiden, message)
 
-        elif type(message) == RefundTransfer:
+        elif type(message) == RefundTransfer and raiden.config.get("enable_refund_transfers"):
             assert isinstance(message, RefundTransfer), MYPY_ANNOTATION
             self.handle_message_refundtransfer(raiden, message)
 

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -34,6 +34,7 @@ from raiden.transfer.views import state_from_raiden
 from raiden.waiting import wait_for_block, wait_for_settle
 
 
+@pytest.mark.skip("refund transfers are disabled")
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("settle_timeout", [50])
@@ -107,6 +108,7 @@ def run_test_refund_messages(raiden_chain, token_addresses, deposit, network_wai
         )
 
 
+@pytest.mark.skip("refund transfers are disabled")
 @pytest.mark.parametrize("privatekey_seed", ["test_refund_transfer:{}"])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
@@ -311,6 +313,7 @@ def run_test_refund_transfer(
     assert secrethash not in state_from_raiden(app1.raiden).payment_mapping.secrethashes_to_task
 
 
+@pytest.mark.skip("refund transfers are disabled")
 @pytest.mark.parametrize("privatekey_seed", ["test_different_view_of_last_bp_during_unlock:{}"])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
@@ -541,6 +544,7 @@ def run_test_different_view_of_last_bp_during_unlock(
     assert final_balance1 - deposit - initial_balance1 == 1
 
 
+@pytest.mark.skip("refund transfers are disabled")
 @pytest.mark.parametrize("privatekey_seed", ["test_refund_transfer:{}"])
 @pytest.mark.parametrize("number_of_nodes", [4])
 @pytest.mark.parametrize("number_of_tokens", [1])

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
 import random
 
+import pytest
 from eth_utils import keccak
 
 from raiden.messages import message_from_sendevent
@@ -121,6 +122,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
     )
 
 
+@pytest.mark.skip("refund transfers are disabled")
 def test_regression_send_refund():
     """Regression test for discarded refund transfer.
 

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -7,7 +7,7 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.events import search_for_item
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer import mediator
-from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendRefundTransfer
+from raiden.transfer.mediated_transfer.events import SendLockedTransfer
 from raiden.transfer.mediated_transfer.state_change import (
     ReceiveTransferRefund,
     ReceiveTransferRefundCancelRoute,
@@ -386,6 +386,7 @@ def test_mediator_skips_used_routes():
     assert mediator_state is not None
     assert events
 
-    # no other routes available, so refund HOP1
-    assert isinstance(events[-1], SendRefundTransfer)
-    assert events[-1].recipient == factories.HOP1
+    # FIXME: refund transfers are disabled.
+    # # no other routes available, so refund HOP1
+    # assert isinstance(events[-1], SendRefundTransfer)
+    # assert events[-1].recipient == factories.HOP1

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -442,46 +442,41 @@ def backward_transfer_pair(
     transfer_pair = None
     events: List[Event] = list()
 
-    # FIXME: we want to disable sending of refund transfers for the
-    # moment. This is the one point in the client that such a message is ever
-    # sent. So let's make this function effectively a no-op until we find out
-    # if we will restore refunds or go through with removing it.
-
-    # lock = payer_transfer.lock
-    # lock_timeout = BlockTimeout(lock.expiration - block_number)
+    lock = payer_transfer.lock
+    lock_timeout = BlockTimeout(lock.expiration - block_number)
 
     # Ensure the refund transfer's lock has a safe expiration, otherwise don't
     # do anything and wait for the received lock to expire.
-    # if channel.is_channel_usable(backward_channel, lock.amount, lock_timeout):
-    #     message_identifier = message_identifier_from_prng(pseudo_random_generator)
+    if channel.is_channel_usable(backward_channel, lock.amount, lock_timeout):
+        message_identifier = message_identifier_from_prng(pseudo_random_generator)
 
-    #     backward_route_state = RouteState(
-    #         route=[backward_channel.our_state.address],
-    #         forward_channel_id=backward_channel.canonical_identifier.channel_identifier,
-    #     )
+        backward_route_state = RouteState(
+            route=[backward_channel.our_state.address],
+            forward_channel_id=backward_channel.canonical_identifier.channel_identifier,
+        )
 
-    #     refund_transfer = channel.send_refundtransfer(
-    #         channel_state=backward_channel,
-    #         initiator=payer_transfer.initiator,
-    #         target=payer_transfer.target,
-    #         # `amount` should be `get_lock_amount_after_fees(...)`, but fees
-    #         # for refunds are currently not defined, so we assume fee=0 to keep
-    #         # it simple, for now.
-    #         amount=lock.amount,
-    #         message_identifier=message_identifier,
-    #         payment_identifier=payer_transfer.payment_identifier,
-    #         expiration=lock.expiration,
-    #         secrethash=lock.secrethash,
-    #         route_state=backward_route_state,
-    #     )
+        refund_transfer = channel.send_refundtransfer(
+            channel_state=backward_channel,
+            initiator=payer_transfer.initiator,
+            target=payer_transfer.target,
+            # `amount` should be `get_lock_amount_after_fees(...)`, but fees
+            # for refunds are currently not defined, so we assume fee=0 to keep
+            # it simple, for now.
+            amount=lock.amount,
+            message_identifier=message_identifier,
+            payment_identifier=payer_transfer.payment_identifier,
+            expiration=lock.expiration,
+            secrethash=lock.secrethash,
+            route_state=backward_route_state,
+        )
 
-    #     transfer_pair = MediationPairState(
-    #         payer_transfer=payer_transfer,
-    #         payee_address=backward_channel.partner_state.address,
-    #         payee_transfer=refund_transfer.transfer,
-    #     )
+        transfer_pair = MediationPairState(
+            payer_transfer=payer_transfer,
+            payee_address=backward_channel.partner_state.address,
+            payee_transfer=refund_transfer.transfer,
+        )
 
-    #     events.append(refund_transfer)
+        events.append(refund_transfer)
 
     return transfer_pair, events
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -417,10 +417,10 @@ def forward_transfer_pair(
 
 
 def backward_transfer_pair(
-    backward_channel: NettingChannelState,
-    payer_transfer: LockedTransferSignedState,
-    pseudo_random_generator: random.Random,
-    block_number: BlockNumber,
+    backward_channel: NettingChannelState,  # pylint: disable=unused-argument
+    payer_transfer: LockedTransferSignedState,  # pylint: disable=unused-argument
+    pseudo_random_generator: random.Random,  # pylint: disable=unused-argument
+    block_number: BlockNumber,  # pylint: disable=unused-argument
 ) -> Tuple[Optional[MediationPairState], List[Event]]:
     """ Sends a transfer backwards, allowing the previous hop to try a new
     route.
@@ -442,41 +442,46 @@ def backward_transfer_pair(
     transfer_pair = None
     events: List[Event] = list()
 
-    lock = payer_transfer.lock
-    lock_timeout = BlockTimeout(lock.expiration - block_number)
+    # FIXME: we want to disable sending of refund transfers for the
+    # moment. This is the one point in the client that such a message is ever
+    # sent. So let's make this function effectively a no-op until we find out
+    # if we will restore refunds or go through with removing it.
+
+    # lock = payer_transfer.lock
+    # lock_timeout = BlockTimeout(lock.expiration - block_number)
 
     # Ensure the refund transfer's lock has a safe expiration, otherwise don't
     # do anything and wait for the received lock to expire.
-    if channel.is_channel_usable(backward_channel, lock.amount, lock_timeout):
-        message_identifier = message_identifier_from_prng(pseudo_random_generator)
+    # if channel.is_channel_usable(backward_channel, lock.amount, lock_timeout):
+    #     message_identifier = message_identifier_from_prng(pseudo_random_generator)
 
-        backward_route_state = RouteState(
-            route=[backward_channel.our_state.address],
-            forward_channel_id=backward_channel.canonical_identifier.channel_identifier,
-        )
+    #     backward_route_state = RouteState(
+    #         route=[backward_channel.our_state.address],
+    #         forward_channel_id=backward_channel.canonical_identifier.channel_identifier,
+    #     )
 
-        refund_transfer = channel.send_refundtransfer(
-            channel_state=backward_channel,
-            initiator=payer_transfer.initiator,
-            target=payer_transfer.target,
-            # `amount` should be `get_lock_amount_after_fees(...)`, but fees
-            # for refunds are currently not defined, so we assume fee=0 to keep
-            # it simple, for now.
-            amount=lock.amount,
-            message_identifier=message_identifier,
-            payment_identifier=payer_transfer.payment_identifier,
-            expiration=lock.expiration,
-            secrethash=lock.secrethash,
-            route_state=backward_route_state,
-        )
+    #     refund_transfer = channel.send_refundtransfer(
+    #         channel_state=backward_channel,
+    #         initiator=payer_transfer.initiator,
+    #         target=payer_transfer.target,
+    #         # `amount` should be `get_lock_amount_after_fees(...)`, but fees
+    #         # for refunds are currently not defined, so we assume fee=0 to keep
+    #         # it simple, for now.
+    #         amount=lock.amount,
+    #         message_identifier=message_identifier,
+    #         payment_identifier=payer_transfer.payment_identifier,
+    #         expiration=lock.expiration,
+    #         secrethash=lock.secrethash,
+    #         route_state=backward_route_state,
+    #     )
 
-        transfer_pair = MediationPairState(
-            payer_transfer=payer_transfer,
-            payee_address=backward_channel.partner_state.address,
-            payee_transfer=refund_transfer.transfer,
-        )
+    #     transfer_pair = MediationPairState(
+    #         payer_transfer=payer_transfer,
+    #         payee_address=backward_channel.partner_state.address,
+    #         payee_transfer=refund_transfer.transfer,
+    #     )
 
-        events.append(refund_transfer)
+    #     events.append(refund_transfer)
 
     return transfer_pair, events
 
@@ -1225,6 +1230,9 @@ def handle_offchain_secretreveal(
         state_change=mediator_state_change, transfer_secrethash=mediator_state.secrethash
     )
     is_secret_unknown = mediator_state.secret is None
+
+    if not mediator_state.transfers_pair:
+        return TransitionResult(mediator_state, list())
 
     # a SecretReveal should be rejected if the payer transfer
     # has expired. To check for this, we use the last

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -132,6 +132,7 @@ def run_app(
     pathfinding_service_address: str,
     pathfinding_max_paths: int,
     enable_monitoring: bool,
+    enable_refund_transfers: bool,
     resolver_endpoint: str,
     routing_mode: RoutingMode,
     config: Dict[str, Any],
@@ -173,6 +174,7 @@ def run_app(
     config["chain_id"] = network_id
     config["default_fee_schedule"] = FeeScheduleState(flat=flat_fee, proportional=proportional_fee)
     config["use_imbalance_penalty"] = True
+    config["enable_refund_transfers"] = enable_refund_transfers
 
     setup_environment(config, environment_type)
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -287,6 +287,12 @@ def options(func):
                 help="Enable broadcasting of balance proofs to the monitoring services.",
                 is_flag=True,
             ),
+            option(
+                "--enable-refund-transfers",
+                help="Enable refund transfer mechanism",
+                is_flag=True,
+                hidden=True,
+            ),
         ),
         option_group(
             "Matrix Transport Options",


### PR DESCRIPTION
Resolves #4288 
The following PR contains the changes necessary to stop the client of sending `RefundTransfer` messages. The unit and integrations tests that are specific to testing this functionality are now marked to be skipped, and the tests that depended on this message (as part of the protocol) have been slightly altered to keep its basic functionality test.

