### PR TITLE
Add docstring to `EnvelopeMessage`

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -302,6 +302,13 @@ class SignedRetrieableMessage(SignedMessage, RetrieableMessage):
 
 @dataclass(repr=False, eq=False)
 class EnvelopeMessage(SignedRetrieableMessage):
+    """ Contains an on-chain message and shares its signature.
+
+    For performance reasons envelope messages share the signature with the
+    blockchain message. The same signature is used for authenticating for both
+    the client and the smart contract.
+    """
+
     chain_id: ChainID
     nonce: Nonce
     transferred_amount: TokenAmount


### PR DESCRIPTION
If found @hackaugusto's comment at https://github.com/raiden-network/raiden/issues/4297 informative, so I added it to the docstring.

[skip tests]