### PR TITLE
Increase timeout for `test_send_queued_messages`.

### DIFF
--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -107,7 +107,7 @@ def run_test_send_queued_messages(raiden_network, deposit, token_addresses, netw
             retry_timeout=network_wait,
         )
     exception = RuntimeError("Timeout while waiting for balance update for app0")
-    with gevent.Timeout(30, exception=exception):
+    with gevent.Timeout(90, exception=exception):
         waiting.wait_for_payment_balance(
             raiden=app0_restart.raiden,
             payment_network_address=payment_network_address,


### PR DESCRIPTION
I don't think this is a good idea, but it's better than blocking all PRs
because they don't get through CI.

The ticket to investigate this is https://github.com/raiden-network/raiden/issues/4312.