### PR TITLE
use local venv instead of nightlies [skip tests]

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -14,6 +14,7 @@ token:
 nodes:
   mode: managed
   count: 2
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -14,6 +14,7 @@ token:
 nodes:
   mode: managed
   count: 2
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -14,6 +14,7 @@ token:
 nodes:
   mode: managed
   count: 2
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -16,6 +16,7 @@ token:
 nodes:
   mode: managed
   count: 4
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -16,7 +16,7 @@ token:
 nodes:
   mode: managed
   count: 4
-  ## add path to Raiden virtual env
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -16,6 +16,7 @@ token:
 nodes:
   mode: managed
   count: 5
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -16,6 +16,7 @@ token:
 nodes:
   mode: managed
   count: 5
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -16,7 +16,7 @@ token:
 nodes:
   mode: managed
   count: 5
-  ## add path to Raiden virtual env
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs6_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs6_low_capacity.yaml
@@ -17,7 +17,7 @@ token:
 nodes:
   mode: managed
   count: 5
-  ## add path to Raiden virtual env
+  raiden_version: local
 
   default_options:
     gas-price: fast

--- a/raiden/tests/scenarios/pfs7_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs7_simple_path_rewards.yaml
@@ -16,7 +16,7 @@ token:
 nodes:
   mode: managed
   count: 5
-  ## add path to Raiden virtual env
+  raiden_version: local
 
   default_options:
     gas-price: fast


### PR DESCRIPTION
This allows for the scenarios to use a local venv installation instead of relying on the nightlies to build.