### PR TITLE
ci: grouped logs into a single folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ jobs:
     environment:
       RAIDEN_TESTS_SYNAPSE_BASE_DIR: /home/circleci/.cache/synapse
       RAIDEN_TESTS_SYNAPSE_LOGS_DIR: /tmp/synapse-logs
-      RAIDEN_TESTS_ETH_LOGSDIR: /tmp/eth/logs
+      RAIDEN_TESTS_LOGSDIR: /tmp/tests/logs
       COVERAGE_DIR: /home/circleci/raiden/coverage
 
     parallelism: << parameters.parallelism >>

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -31,9 +31,8 @@ from raiden.constants import EthClient
 from raiden.log_config import configure_logging
 from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
-from raiden.tests.utils.ci import get_artifacts_storage
+from raiden.tests.utils.ci import shortned_artifacts_storage
 from raiden.tests.utils.transport import make_requests_insecure
-from raiden.utils import pex
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
 
@@ -137,13 +136,7 @@ def logging_level(request, tmpdir):
     else:
         logging_levels = {"": level}
 
-    # The test name including the arguments cannot be used because of the path
-    # length. Some tests will have a path longer than 300 characters.
-    original_name = request.node.originalname
-    shorted_arguments = pex(request.node.name.encode("utf8"))
-    shortened_test_name = f"{original_name}-{shorted_arguments}"
-
-    base_dir = get_artifacts_storage(shortened_test_name) or str(tmpdir)
+    base_dir = shortned_artifacts_storage(request.node) or str(tmpdir)
     os.makedirs(base_dir, exist_ok=True)
 
     time = datetime.datetime.utcnow().isoformat()

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -31,7 +31,7 @@ from raiden.constants import EthClient
 from raiden.log_config import configure_logging
 from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
-from raiden.tests.utils.ci import shortned_artifacts_storage
+from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
@@ -136,7 +136,7 @@ def logging_level(request, tmpdir):
     else:
         logging_levels = {"": level}
 
-    base_dir = shortned_artifacts_storage(request.node) or str(tmpdir)
+    base_dir = shortened_artifacts_storage(request.node) or str(tmpdir)
     os.makedirs(base_dir, exist_ok=True)
 
     time = datetime.datetime.utcnow().isoformat()

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -31,7 +31,6 @@ from raiden.constants import EthClient
 from raiden.log_config import configure_logging
 from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
-from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
@@ -111,7 +110,7 @@ def enable_greenlet_debugger(request):
 
 
 @pytest.fixture(autouse=True)
-def logging_level(request, tmpdir):
+def logging_level(request, logs_storage):
     """ Configure the structlog level for each test run.
 
     For integration tests this also sets the geth verbosity.
@@ -136,11 +135,11 @@ def logging_level(request, tmpdir):
     else:
         logging_levels = {"": level}
 
-    base_dir = shortened_artifacts_storage(request.node) or str(tmpdir)
-    os.makedirs(base_dir, exist_ok=True)
+    # configure_logging requires the path to exist
+    os.makedirs(logs_storage, exist_ok=True)
 
     time = datetime.datetime.utcnow().isoformat()
-    debug_path = os.path.join(base_dir, f"raiden-debug_{time}.log")
+    debug_path = os.path.join(logs_storage, f"raiden-debug_{time}.log")
 
     configure_logging(
         logging_levels,

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -9,7 +9,9 @@ from raiden.constants import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT, Environment
 from raiden.network.utils import get_free_port
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, DEFAULT_RETRY_TIMEOUT
 from raiden.tests.fixtures.constants import DEFAULT_BALANCE
+from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
+from raiden.tests.utils.tests import unique_path
 from raiden.utils import sha3
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
 
@@ -103,6 +105,23 @@ def random_marker():
     """
     random_hex = hex(random.getrandbits(100))
     return remove_0x_prefix(random_hex)
+
+
+@pytest.fixture
+def logs_storage(request, tmpdir):
+    """Returns the path where debugging data should be saved.
+
+    Use this to preserve the databases and logs necessary to debug test
+    failures on the CI system.
+    """
+    # A shortened path is necessary because some system have limits on the path
+    # length
+    short_path = shortened_artifacts_storage(request.node) or str(tmpdir)
+
+    # A unique path is necssary because flaky tests are executed multiple
+    # times, and the state of the previous run must not interfere with the new
+    # run.
+    return unique_path(short_path)
 
 
 @pytest.fixture

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from raiden.constants import Environment, EthClient
 from raiden.settings import PRODUCTION_CONTRACT_VERSION
-from raiden.tests.utils.ci import get_artifacts_storage, shortned_artifacts_storage
+from raiden.tests.utils.ci import get_artifacts_storage, shortened_artifacts_storage
 from raiden.tests.utils.smoketest import setup_raiden, setup_testchain
 
 
@@ -84,7 +84,7 @@ def cli_args(request, tmpdir, raiden_testchain, removed_args, changed_args, envi
 
     # This assumes that there is only one Raiden instance per CLI test
     base_logfile = os.path.join(
-        shortned_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes", "cli_test.log"
+        shortened_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes", "cli_test.log"
     )
 
     os.makedirs(os.path.dirname(base_logfile), exist_ok=True)

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 from raiden.constants import Environment, EthClient
 from raiden.settings import PRODUCTION_CONTRACT_VERSION
-from raiden.tests.utils.ci import get_artifacts_storage
+from raiden.tests.utils.ci import get_artifacts_storage, shortned_artifacts_storage
 from raiden.tests.utils.smoketest import setup_raiden, setup_testchain
 
 
@@ -84,8 +84,9 @@ def cli_args(request, tmpdir, raiden_testchain, removed_args, changed_args, envi
 
     # This assumes that there is only one Raiden instance per CLI test
     base_logfile = os.path.join(
-        get_artifacts_storage(request.node.name) or str(tmpdir), "raiden_nodes", "cli_test.log"
+        shortned_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes", "cli_test.log"
     )
+
     os.makedirs(os.path.dirname(base_logfile), exist_ok=True)
 
     args = [

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -6,7 +6,6 @@ from web3 import HTTPProvider, Web3
 from raiden.constants import EthClient
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.eth_node import (
     AccountDescription,
     EthNodeDescription,
@@ -34,6 +33,7 @@ def web3(
     request,
     tmpdir,
     chain_id,
+    logs_storage,
 ):
     """ Starts a private chain with accounts funded. """
     # include the deploy key in the list of funded accounts
@@ -75,9 +75,7 @@ def web3(
     base_datadir = str(tmpdir)
 
     # Save the Ethereum node's log for debugging
-    base_logdir = os.path.join(
-        shortened_artifacts_storage(request.node) or base_datadir, blockchain_type
-    )
+    base_logdir = os.path.join(logs_storage, blockchain_type)
 
     genesis_description = GenesisDescription(
         prefunded_accounts=accounts_to_fund, chain_id=chain_id, random_marker=random_marker

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -6,7 +6,7 @@ from web3 import HTTPProvider, Web3
 from raiden.constants import EthClient
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.tests.utils.ci import get_artifacts_storage
+from raiden.tests.utils.ci import shortned_artifacts_storage
 from raiden.tests.utils.eth_node import (
     AccountDescription,
     EthNodeDescription,
@@ -74,9 +74,9 @@ def web3(
     # The private chain data is always discarded on the CI
     base_datadir = str(tmpdir)
 
-    # Save the Ethereum node's log, if needed for debugging
+    # Save the Ethereum node's log for debugging
     base_logdir = os.path.join(
-        get_artifacts_storage(request.node.name) or base_datadir, blockchain_type
+        shortned_artifacts_storage(request.node) or base_datadir, blockchain_type
     )
 
     genesis_description = GenesisDescription(

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -6,7 +6,7 @@ from web3 import HTTPProvider, Web3
 from raiden.constants import EthClient
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.tests.utils.ci import shortned_artifacts_storage
+from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.eth_node import (
     AccountDescription,
     EthNodeDescription,
@@ -76,7 +76,7 @@ def web3(
 
     # Save the Ethereum node's log for debugging
     base_logdir = os.path.join(
-        shortned_artifacts_storage(request.node) or base_datadir, blockchain_type
+        shortened_artifacts_storage(request.node) or base_datadir, blockchain_type
     )
 
     genesis_description = GenesisDescription(

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -4,7 +4,7 @@ import gevent
 import pytest
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
-from raiden.tests.utils.ci import shortned_artifacts_storage
+from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.network import (
     CHAIN,
     create_all_channels_for_network,
@@ -60,7 +60,7 @@ def raiden_chain(
     )
 
     base_datadir = os.path.join(
-        shortned_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
+        shortened_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
     )
 
     service_registry_address = None
@@ -162,7 +162,7 @@ def raiden_network(
         service_registry_address = blockchain_services.service_registry.address
 
     base_datadir = os.path.join(
-        shortned_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
+        shortened_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
     )
 
     raiden_apps = create_apps(

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -4,7 +4,6 @@ import gevent
 import pytest
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
-from raiden.tests.utils.ci import shortened_artifacts_storage
 from raiden.tests.utils.network import (
     CHAIN,
     create_all_channels_for_network,
@@ -47,8 +46,7 @@ def raiden_chain(
     user_deposit_address,
     monitoring_service_contract_address,
     global_rooms,
-    tmpdir,
-    request,
+    logs_storage,
 ):
 
     if len(token_addresses) != 1:
@@ -59,9 +57,7 @@ def raiden_chain(
         "with 0, 1 or 2 channels"
     )
 
-    base_datadir = os.path.join(
-        shortened_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
-    )
+    base_datadir = os.path.join(logs_storage, "raiden_nodes")
 
     service_registry_address = None
     if blockchain_services.service_registry:
@@ -154,16 +150,13 @@ def raiden_network(
     user_deposit_address,
     monitoring_service_contract_address,
     global_rooms,
-    tmpdir,
-    request,
+    logs_storage,
 ):
     service_registry_address = None
     if blockchain_services.service_registry:
         service_registry_address = blockchain_services.service_registry.address
 
-    base_datadir = os.path.join(
-        shortened_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
-    )
+    base_datadir = os.path.join(logs_storage, "raiden_nodes")
 
     raiden_apps = create_apps(
         chain_id=chain_id,

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -4,7 +4,7 @@ import gevent
 import pytest
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
-from raiden.tests.utils.ci import get_artifacts_storage
+from raiden.tests.utils.ci import shortned_artifacts_storage
 from raiden.tests.utils.network import (
     CHAIN,
     create_all_channels_for_network,
@@ -60,7 +60,7 @@ def raiden_chain(
     )
 
     base_datadir = os.path.join(
-        get_artifacts_storage(request.node.name) or str(tmpdir), "raiden_nodes"
+        shortned_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
     )
 
     service_registry_address = None
@@ -162,7 +162,7 @@ def raiden_network(
         service_registry_address = blockchain_services.service_registry.address
 
     base_datadir = os.path.join(
-        get_artifacts_storage(request.node.name) or str(tmpdir), "raiden_nodes"
+        shortned_artifacts_storage(request.node) or str(tmpdir), "raiden_nodes"
     )
 
     raiden_apps = create_apps(

--- a/raiden/tests/utils/ci.py
+++ b/raiden/tests/utils/ci.py
@@ -8,7 +8,7 @@ def get_artifacts_storage() -> Optional[str]:
     return os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR")
 
 
-def shortned_artifacts_storage(test_node, *parts: str) -> Optional[str]:
+def shortened_artifacts_storage(test_node, *parts: str) -> Optional[str]:
     """Return a pathname based on the test details.
 
     Some platforms have a limit to the length of a file path. This function
@@ -24,8 +24,8 @@ def shortned_artifacts_storage(test_node, *parts: str) -> Optional[str]:
 
     if len(path) >= 286:
         original_name = test_node.originalname
-        shortned_args = pex(test_node.name.encode("utf8"))
-        path = os.path.join(artifacts_dir, f"{original_name}-{shortned_args}", *parts)
+        shortened_args = pex(test_node.name.encode("utf8"))
+        path = os.path.join(artifacts_dir, f"{original_name}-{shortened_args}", *parts)
 
     msg = (
         "Trimming the tests arguments didn't result in a path short enough, the "

--- a/raiden/tests/utils/ci.py
+++ b/raiden/tests/utils/ci.py
@@ -22,6 +22,7 @@ def shortened_artifacts_storage(test_node, *parts: str) -> Optional[str]:
 
     path = os.path.join(artifacts_dir, test_node.name, *parts)
 
+    # Paths longer than 286 will be reject on CircleCI
     if len(path) >= 286:
         original_name = test_node.originalname
         shortened_args = pex(test_node.name.encode("utf8"))

--- a/raiden/tests/utils/ci.py
+++ b/raiden/tests/utils/ci.py
@@ -5,7 +5,7 @@ from raiden.utils import pex
 
 
 def get_artifacts_storage() -> Optional[str]:
-    return os.environ.get("RAIDEN_TESTS_ETH_LOGSDIR")
+    return os.environ.get("RAIDEN_TESTS_LOGSDIR")
 
 
 def shortened_artifacts_storage(test_node, *parts: str) -> Optional[str]:

--- a/raiden/tests/utils/tests.py
+++ b/raiden/tests/utils/tests.py
@@ -1,7 +1,21 @@
 import gc
-from itertools import chain, combinations, product
+import os
+from itertools import chain, combinations, count, product
 
 import gevent
+
+
+def unique_path(initial_path: str) -> str:
+    proposed_path = initial_path
+
+    counter = count()
+    while os.path.exists(proposed_path):
+        # Adding ## before the number to differenciate from the tests
+        # parametrized arguments
+        number = f"##{next(counter)}"
+        proposed_path = f"{initial_path[:-len(number)]}{number}"
+
+    return proposed_path
 
 
 def cleanup_tasks():


### PR DESCRIPTION
cb2558342318f11aaee75db0ce5715519e28bc4a fixed the path name for the unit tests but broke it for the integration tests. This adds a tool to compute a shortened path, if necessary, and uses it consistently.