### PR TITLE
Fix transport life-cycle handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,7 @@ jobs:
     executor:
       name: docker
       py-version: << parameters.py-version >>
+      resource: xlarge
 
     steps:
       - attach-and-link:
@@ -329,7 +330,7 @@ jobs:
       test-type:
         description: "type of test"
         type: enum
-        enum: ["integration", "unit", "fuzz"]
+        enum: ["fuzz", "integration", "mocked", "unit"]
       parallelism:
         description: "number of containers to be used in parallel for this test"
         default: 1
@@ -703,7 +704,13 @@ workflows:
           name: test-unit-3.7
           py-version: "3.7"
           test-type: "unit"
-          blockchain-type: "geth"
+          requires:
+            - lint-3.7
+
+      - test:
+          name: test-mocked-3.7
+          py-version: "3.7"
+          test-type: "mocked"
           requires:
             - lint-3.7
 
@@ -711,7 +718,6 @@ workflows:
           name: test-fuzz-3.7
           py-version: "3.7"
           test-type: "fuzz"
-          blockchain-type: "geth"
           additional-args: "--hypothesis-show-statistics"
           requires:
             - lint-3.7
@@ -730,6 +736,7 @@ workflows:
             - smoketest-matrix-development-parity-3.7
             - test-unit-3.7
             - test-fuzz-3.7
+            - test-mocked-3.7
 
       - test:
           name: test-integration-matrix-parity-3.7
@@ -745,6 +752,7 @@ workflows:
             - smoketest-matrix-development-parity-3.7
             - test-unit-3.7
             - test-fuzz-3.7
+            - test-mocked-3.7
 
       - finalize:
           requires:
@@ -903,7 +911,13 @@ workflows:
           name: test-unit-3.7
           py-version: "3.7"
           test-type: "unit"
-          blockchain-type: "geth"
+          requires:
+            - lint-3.7
+
+      - test:
+          name: test-mocked-3.7
+          py-version: "3.7"
+          test-type: "mocked"
           requires:
             - lint-3.7
 
@@ -911,7 +925,6 @@ workflows:
           name: test-fuzz-3.7
           py-version: "3.7"
           test-type: "fuzz"
-          blockchain-type: "geth"
           additional-args: "--hypothesis-show-statistics"
           requires:
             - lint-3.7
@@ -930,6 +943,7 @@ workflows:
             - smoketest-matrix-development-parity-3.7
             - test-unit-3.7
             - test-fuzz-3.7
+            - test-mocked-3.7
 
       - test:
           name: test-integration-matrix-parity-3.7
@@ -945,6 +959,7 @@ workflows:
             - smoketest-matrix-development-parity-3.7
             - test-unit-3.7
             - test-fuzz-3.7
+            - test-mocked-3.7
 
       - finalize:
           requires:

--- a/.circleci/enforce_decreasing_lint_errors.sh
+++ b/.circleci/enforce_decreasing_lint_errors.sh
@@ -96,7 +96,13 @@ old_report_mypy="${CACHE_DIR}/mypy"
 new_report_pylint=$(mktemp)
 new_report_mypy=$(mktemp)
 
-pylint --jobs=0 \
+if [[ ! -z ${CIRCLECI} ]]; then
+    JOBS=8
+else
+    JOBS=0
+fi
+
+pylint --jobs=${JOBS} \
     --load-plugins=tools.pylint.gevent_checker,tools.pylint.assert_checker \
     raiden/ tools/scenario-player/ > ${new_report_pylint} || true
 

--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,19 @@ clean-test:
 	rm -f .coverage
 	rm -fr htmlcov/
 
+# CircleCI always reports 36 CPUs, force tools to use the actual number
+JOBS_ARG=
+ifdef CIRCLECI
+JOBS_ARG=--jobs=8
+endif
 LINT_PATHS = raiden/ tools/ setup.py
 ISORT_PARAMS = --ignore-whitespace --settings-path ./ --skip-glob '*/node_modules/*' --recursive $(LINT_PATHS)
 
 lint: ISORT_CHECK_PARAMS := --diff --check-only
 lint: BLACK_CHECK_PARAMS := --check --diff
 lint: mypy mypy-all isort black
-	flake8 raiden/ tools/
-	pylint $(LINT_PATHS)
+	flake8 $(JOBS_ARG) $(LINT_PATHS)
+	pylint $(JOBS_ARG) $(LINT_PATHS)
 
 mypy:
 	mypy raiden
@@ -61,7 +66,7 @@ mypy-all:
 	mypy --config-file /dev/null raiden --ignore-missing-imports | grep error | wc -l
 
 isort:
-	isort $(ISORT_PARAMS) $(ISORT_CHECK_PARAMS)
+	isort $(JOBS_ARG) $(ISORT_PARAMS) $(ISORT_CHECK_PARAMS)
 
 black:
 	black $(BLACK_CHECK_PARAMS) $(LINT_PATHS)

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -125,8 +125,10 @@ class App:  # pylint: disable=too-few-public-methods
         """ Start the raiden app. """
         if self.raiden.stop_event.is_set():
             self.raiden.start()
+            log.info("Raiden started", node=self.raiden.address)
 
     def stop(self):
         """ Stop the raiden app. """
         if not self.raiden.stop_event.is_set():
             self.raiden.stop()
+            log.info("Raiden stopped", node=self.raiden.address)

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -12,6 +12,12 @@ from typing import Any, Callable, Dict, FrozenSet, List, Optional, Pattern, Tupl
 import gevent
 import structlog
 
+LOG_BLACKLIST = {
+    re.compile(r"\b(access_?token=)([a-z0-9_-]+)", re.I): r"\1<redacted>",
+    re.compile(
+        r"(@0x[0-9a-fA-F]{40}:(?:[\w\d._-]+(?::[0-9]+)?))/([0-9a-zA-Z-]+)"
+    ): r"\1/<redacted>",
+}
 DEFAULT_LOG_LEVEL = "INFO"
 MAX_LOG_FILE_SIZE = 20 * 1024 * 1024
 LOG_BACKUP_COUNT = 3
@@ -179,7 +185,7 @@ def configure_logging(
     else:
         formatter = "plain"
 
-    redact = redactor({re.compile(r"\b(access_?token=)([a-z0-9_-]+)", re.I): r"\1<redacted>"})
+    redact = redactor(LOG_BLACKLIST)
     _wrap_tracebackexception_format(redact)
 
     handlers: Dict[str, Any] = dict()

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -116,15 +116,14 @@ def get_onchain_locksroots(
 
 @contextmanager
 def log_transaction(log: BoundLoggerBase, description: str, details: Dict[Any, Any]) -> Generator:
+    bound_log = log.bind(description=description, **details)
     try:
-        log.debug("Entered", description=description, **details)
+        bound_log.debug("Entered")
         yield
     except:  # noqa
-        log.critical("Failed", description=description, **details)
-        log.exception("Failed because of")
+        bound_log.critical("Failed", exc_info=True)
         raise
-    else:
-        log.debug("Exited", description=description, **details)
+    bound_log.debug("Exited")
 
 
 def raise_on_call_returned_empty(given_block_identifier: BlockSpecification) -> NoReturn:

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -13,6 +13,7 @@ from matrix_client.client import CACHE, MatrixClient
 from matrix_client.errors import MatrixHttpLibError, MatrixRequestError
 from matrix_client.room import Room as MatrixRoom
 from matrix_client.user import User
+from requests import Response
 from requests.adapters import HTTPAdapter
 
 log = structlog.get_logger(__name__)
@@ -114,10 +115,13 @@ class GMatrixHttpApi(MatrixHttpApi):
     ) -> None:
         super().__init__(*args, **kwargs)
 
+        self.server_ident: Optional[str] = None
+
         http_adapter = HTTPAdapter(pool_maxsize=pool_maxsize)
         https_adapter = HTTPAdapter(pool_maxsize=pool_maxsize)
         self.session.mount("http://", http_adapter)
         self.session.mount("https://", https_adapter)
+        self.session.hooks["response"].append(self._record_server_ident)
 
         self._long_paths = long_paths
         if long_paths:
@@ -186,6 +190,11 @@ class GMatrixHttpApi(MatrixHttpApi):
             if last_ex:
                 raise last_ex
 
+    def _record_server_ident(
+        self, response: Response, *args, **kwargs  # pylint: disable=unused-argument
+    ):
+        self.server_ident = response.headers.get("Server")
+
 
 class GMatrixClient(MatrixClient):
     """ Gevent-compliant MatrixClient subclass """
@@ -222,6 +231,7 @@ class GMatrixClient(MatrixClient):
             retry_delay=http_retry_delay,
             long_paths=("/sync",),
         )
+        self.api.validate_certificate(valid_cert_check)
 
     def listen_forever(
         self,
@@ -285,17 +295,26 @@ class GMatrixClient(MatrixClient):
         self.should_listen = False
         if self.sync_thread:
             self.sync_thread.kill()
+            log.debug("Waiting on sync greenlet", current_user=self.user_id)
             exited = gevent.wait([self.sync_thread], timeout=SHUTDOWN_TIMEOUT)
             if not exited:
                 raise RuntimeError("Timeout waiting on sync greenlet during transport shutdown.")
             self.sync_thread.get()
         if self._handle_thread is not None:
+            log.debug("Waiting on handle greenlet", current_user=self.user_id)
             exited = gevent.wait([self._handle_thread], timeout=SHUTDOWN_TIMEOUT)
             if not exited:
                 raise RuntimeError("Timeout waiting on handle greenlet during transport shutdown.")
             self._handle_thread.get()
+        log.debug("Listener greenlet exited", current_user=self.user_id)
         self.sync_thread = None
         self._handle_thread = None
+
+    def stop(self):
+        self.stop_listener_thread()
+        self.sync_token = None
+        self.should_listen = False
+        self.rooms: Dict[str, Room] = {}
 
     def logout(self):
         super().logout()
@@ -395,6 +414,12 @@ class GMatrixClient(MatrixClient):
             f"GMatrixClient._sync user_id:{self.user_id} sync_token:{prev_sync_token}"
         )
         self._handle_thread.link_exception(lambda g: self.sync_thread.kill(g.exception))
+        log.debug(
+            "Starting handle greenlet",
+            first_sync=is_first_sync,
+            sync_token=prev_sync_token,
+            current_user=self.user_id,
+        )
         self._handle_thread.start()
 
         if self._post_hook_func is not None:
@@ -403,7 +428,9 @@ class GMatrixClient(MatrixClient):
     def _handle_response(self, response, first_sync=False):
         # We must ignore the stop flag during first_sync
         if not self.should_listen and not first_sync:
-            log.warning("Aborting handle response", reason="Transport stopped")
+            log.warning(
+                "Aborting handle response", reason="Transport stopped", current_user=self.user_id
+            )
             return
         # Handle presence after rooms
         for presence_update in response["presence"]["events"]:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1138,6 +1138,16 @@ class RaidenService(Runnable):
         if len(secret) != SECRET_LENGTH:
             raise InvalidSecret("secret of invalid length.")
 
+        log.debug(
+            "Mediated transfer",
+            node=self.address,
+            target=target,
+            amount=amount,
+            identifier=identifier,
+            fee=fee,
+            token_network_address=token_network_address,
+        )
+
         # We must check if the secret was registered against the latest block,
         # even if the block is forked away and the transaction that registers
         # the secret is removed from the blockchain. The rationale here is that

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -28,6 +28,7 @@ import time
 from pathlib import Path
 
 import gevent
+import structlog
 from _pytest.pathlib import LOCK_TIMEOUT, ensure_reset_dir, make_numbered_dir_with_cleanup
 from _pytest.tmpdir import get_user
 
@@ -45,6 +46,9 @@ from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
 from raiden.utils.ethereum_clients import is_supported_client
+
+
+log = structlog.get_logger()
 
 
 def pytest_addoption(parser):
@@ -239,6 +243,7 @@ def logging_level(request, logs_storage):
         cache_logger_on_first_use=False,
         debug_log_file_name=debug_path,
     )
+    log.info("Running test", nodeid=request.node.nodeid)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -207,7 +207,7 @@ def logging_level(request, logs_storage):
     For integration tests this also sets the geth verbosity.
     """
     # disable pytest's built in log capture, otherwise logs are printed twice
-    request.config.option.showcapture = "no"
+    request.config.option.showcapture = "stdout"
 
     if request.config.option.log_cli_level:
         level = request.config.option.log_cli_level

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -739,12 +739,6 @@ def test_matrix_invite_private_room_unhappy_case_1(
     assert join_rule1 == expected_join_rule1
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Issue raiden-network/raiden#4336. "
-        "The last loop times out because the invite isn't being seen after the restart."
-    )
-)
 @pytest.mark.parametrize(
     ("private_rooms", "expected_join_rule0", "expected_join_rule1"),
     [
@@ -819,12 +813,6 @@ def test_matrix_invite_private_room_unhappy_case_2(
     assert join_rule1 == expected_join_rule1
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Issue raiden-network/raiden#4336. "
-        "The last loop times out because the invite isn't being seen after the restart."
-    )
-)
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule",
     [
@@ -925,7 +913,6 @@ def test_matrix_user_roaming(matrix_transports):
     assert ping_pong_message_success(transport0, transport1)
 
 
-@pytest.mark.xfail(reason="XFail until raiden-network/raiden#4030 is fixed")
 @pytest.mark.parametrize("matrix_server_count", [3])
 @pytest.mark.parametrize("number_of_transports", [6])
 def test_matrix_multi_user_roaming(matrix_transports):
@@ -1036,9 +1023,10 @@ def test_matrix_multi_user_roaming(matrix_transports):
 
     # Node two switches to second server
     transport_rs1_0.stop()
-    wait_for_peer_unreachable(transport_rs1_0, raiden_service0.address)
+    wait_for_peer_unreachable(transport_rs0_2, raiden_service1.address)
 
     transport_rs1_1.start(raiden_service1, message_handler1, "")
+    transport_rs1_1.start_health_check(raiden_service0.address)
 
     wait_for_peer_reachable(transport_rs0_2, raiden_service1.address)
     wait_for_peer_reachable(transport_rs1_1, raiden_service0.address)
@@ -1061,7 +1049,6 @@ def test_matrix_multi_user_roaming(matrix_transports):
 @pytest.mark.parametrize("private_rooms", [[True, True]])
 @pytest.mark.parametrize("matrix_server_count", [2])
 @pytest.mark.parametrize("number_of_transports", [2])
-@pytest.mark.skip("Issue: #4379")
 def test_reproduce_handle_invite_send_race_issue_3588(matrix_transports):
     transport0, transport1 = matrix_transports
     received_messages0 = set()

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -43,7 +43,6 @@ def test_recovery_happy_case(
     # make a few transfers from app0 to app2
     amount = 1
     spent_amount = deposit - 2
-    identifier = 0
     for identifier in range(spent_amount):
         transfer_and_assert_path(
             path=raiden_network,
@@ -53,7 +52,6 @@ def test_recovery_happy_case(
             timeout=network_wait * number_of_nodes,
         )
 
-    app0.raiden.stop()
     app0.stop()
 
     waiting.wait_for_network_state(

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -138,6 +138,7 @@ def run_test_send_queued_messages(raiden_network, deposit, token_addresses, netw
         deposit + total_transferred_amount,
         [],
     )
+    new_transport.stop()
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -1,0 +1,169 @@
+import random
+from typing import List, Optional, Union
+
+import pytest
+
+from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
+from raiden.messages.transfers import SecretRequest
+from raiden.network.transport import MatrixTransport
+from raiden.network.transport.matrix.client import GMatrixClient, Room
+from raiden.storage.serialization import JSONSerializer
+from raiden.tests.utils import factories
+from raiden.tests.utils.mocks import MockRaidenService
+from raiden.utils import Address
+from raiden.utils.signer import LocalSigner
+
+USERID0 = "@0x1234567890123456789012345678901234567890:RestaurantAtTheEndOfTheUniverse"
+USERID1 = "@0x0987654321098765432109876543210987654321:Wonderland"
+
+
+@pytest.fixture()
+def skip_userid_validation(monkeypatch):
+    import raiden.network.transport.matrix
+    import raiden.network.transport.matrix.utils
+
+    def mock_validate_userid_signature(user):  # pylint: disable=unused-argument
+        return factories.HOP1
+
+    monkeypatch.setattr(
+        raiden.network.transport.matrix,
+        "validate_userid_signature",
+        mock_validate_userid_signature,
+    )
+    monkeypatch.setattr(
+        raiden.network.transport.matrix.transport,
+        "validate_userid_signature",
+        mock_validate_userid_signature,
+    )
+    monkeypatch.setattr(
+        raiden.network.transport.matrix.utils,
+        "validate_userid_signature",
+        mock_validate_userid_signature,
+    )
+
+
+@pytest.fixture
+def mock_matrix(monkeypatch, retry_interval, retries_before_backoff):
+
+    from raiden.network.transport.matrix.client import User
+    from raiden.network.transport.matrix import transport as transport_module
+
+    monkeypatch.setattr(User, "get_display_name", lambda _: "random_display_name")
+    monkeypatch.setattr(
+        transport_module, "make_client", lambda url, *a, **kw: GMatrixClient(url[0])
+    )
+
+    def mock_get_user(klass, user: Union[User, str]) -> User:  # pylint: disable=unused-argument
+        return User(None, USERID1)
+
+    def mock_get_room_ids_for_address(  # pylint: disable=unused-argument
+        klass, address: Address, filter_private: bool = None
+    ) -> List[str]:
+        return ["!roomID:server"]
+
+    def mock_set_room_id_for_address(  # pylint: disable=unused-argument
+        self, address: Address, room_id: Optional[str]
+    ):
+        pass
+
+    def mock_receive_message(klass, message):  # pylint: disable=unused-argument
+        # We are just unit testing the matrix transport receive so do nothing
+        assert message
+        assert message.sender
+
+    config = dict(
+        retry_interval=retry_interval,
+        retries_before_backoff=retries_before_backoff,
+        server="http://none",
+        server_name="none",
+        available_servers=[],
+        global_rooms=[],
+        private_rooms=False,
+    )
+
+    transport = MatrixTransport(config)
+    transport._raiden_service = MockRaidenService()
+    transport._stop_event.clear()
+    transport._address_mgr.add_userid_for_address(factories.HOP1, USERID1)
+    transport._client.user_id = USERID0
+
+    monkeypatch.setattr(MatrixTransport, "_get_user", mock_get_user)
+    monkeypatch.setattr(
+        MatrixTransport, "_get_room_ids_for_address", mock_get_room_ids_for_address
+    )
+    monkeypatch.setattr(MatrixTransport, "_set_room_id_for_address", mock_set_room_id_for_address)
+    monkeypatch.setattr(MatrixTransport, "_receive_message", mock_receive_message)
+
+    return transport
+
+
+def make_message(sign=True, overwrite_data=None):
+    room = Room(None, "!roomID:server")
+    if not overwrite_data:
+        message = SecretRequest(
+            message_identifier=random.randint(0, UINT64_MAX),
+            payment_identifier=1,
+            secrethash=factories.UNIT_SECRETHASH,
+            amount=1,
+            expiration=10,
+            signature=EMPTY_SIGNATURE,
+        )
+        if sign:
+            message.sign(LocalSigner(factories.HOP1_KEY))
+        data = JSONSerializer.serialize(message)
+    else:
+        data = overwrite_data
+
+    event = dict(
+        type="m.room.message", sender=USERID1, content={"msgtype": "m.text", "body": data}
+    )
+    return room, event
+
+
+def test_normal_processing_json(  # pylint: disable=unused-argument
+    mock_matrix, skip_userid_validation
+):
+    room, event = make_message()
+    assert mock_matrix._handle_message(room, event)
+
+
+def test_processing_invalid_json(  # pylint: disable=unused-argument
+    mock_matrix, skip_userid_validation
+):
+    invalid_json = '{"foo": 1,'
+    room, event = make_message(overwrite_data=invalid_json)
+    assert not mock_matrix._handle_message(room, event)
+
+
+def test_non_signed_message_is_rejected(mock_matrix, skip_userid_validation):
+    room, event = make_message(sign=False)
+    assert not mock_matrix._handle_message(room, event)
+
+
+def test_sending_nonstring_body(  # pylint: disable=unused-argument
+    mock_matrix, skip_userid_validation
+):
+    room, event = make_message(overwrite_data=b"somebinarydata")
+    assert not mock_matrix._handle_message(room, event)
+
+
+@pytest.mark.parametrize(
+    "message_input",
+    [
+        pytest.param('{"this": 1, "message": 5, "is": 3, "not_valid": 5}', id="json-1"),
+        pytest.param("[", id="json-2"),
+    ],
+)
+def test_processing_invalid_message_json(  # pylint: disable=unused-argument
+    mock_matrix, skip_userid_validation, message_input
+):
+    room, event = make_message(overwrite_data=message_input)
+    assert not mock_matrix._handle_message(room, event)
+
+
+def test_processing_invalid_message_type_json(  # pylint: disable=unused-argument
+    mock_matrix, skip_userid_validation
+):
+    invalid_message = '{"_type": "NonExistentMessage", "is": 3, "not_valid": 5}'
+    room, event = make_message(overwrite_data=invalid_message)
+    assert not mock_matrix._handle_message(room, event)

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -147,3 +147,27 @@ def test_redacted_traceback(capsys, tmpdir):
 
     assert token not in captured.err
     assert "accessToken=<redacted>" in captured.err
+
+
+def test_redacted_state_change(capsys, tmpdir):
+    configure_logging({"": "DEBUG"}, debug_log_file_name=str(tmpdir / "raiden-debug.log"))
+    auth_token = (
+        "MDAxZGxvY2F0aW9uIGxvY2FsaG9zdDo2NDAzMwowMDEzaWRlbnRpZmllciBrZXkKMDAxMGNpZCBnZW4gPSAxCjAwN"
+        "GVjaWQgdXNlcl9pZCA9IEAweDYyNjRkYThmMmViOGQ4MDM3NjM2OTEwYzFlYzAzODA0MzhmNGVmZWU6bG9jYWxob3"
+        "N0OjY0MDMzCjAwMTZjaWQgdHlwZSA9IGFjY2VzcwowMDIxY2lkIG5vbmNlID0gSlhjfjI4YVA9clZmbzZUSQowMDJ"
+        "mc2lnbmF0dXJlIKQ1WCUJ-1Mv6rN6yjnb2w5R2BqH7iew7RwFiKuMcYosCg"
+    )
+    auth_user = "@0x0123456789abcdef0123456789abcdef01234567:localhost:64033"
+    state_changes = [
+        {
+            "auth_data": f"{auth_user}/{auth_token}",
+            "_type": "raiden.transfer.state_change.ActionUpdateTransportAuthData",
+        }
+    ]
+    log = structlog.get_logger("raiden.raiden_service")
+    log.debug("State changes", state_changes=state_changes)
+
+    captured = capsys.readouterr()
+
+    assert auth_token not in captured.err
+    assert f"{auth_user}/<redacted>" in captured.err

--- a/raiden/tests/unit/test_matrix_transport.py
+++ b/raiden/tests/unit/test_matrix_transport.py
@@ -167,7 +167,7 @@ def test_sort_servers_closest(monkeypatch):
 
     server_count = 9
     sorted_servers = sort_servers_closest([f"https://server{i}.xyz" for i in range(server_count)])
-    rtts = [rtt for (_, rtt) in sorted_servers]
+    rtts = list(sorted_servers.values())
 
     assert len(sorted_servers) <= server_count
     assert all(rtts) and rtts == sorted(rtts)

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -220,6 +220,8 @@ class NodeRunner:
         finally:
             self._shutdown_hook()
 
+            app_.stop()
+
             def stop_task(task):
                 try:
                     if isinstance(task, Runnable):

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -127,14 +127,19 @@ class HTTPExecutor(MiHTTPExecutor):
     def kill(self):
         STDOUT = subprocess.STDOUT  # pylint: disable=no-member
 
-        ps_fax = subprocess.check_output(["ps", "fax"], stderr=STDOUT)
+        ps_param = "fax"
+        if platform.system() == "Darwin":
+            # BSD ``ps`` doesn't support the ``f`` flag
+            ps_param = "ax"
+
+        ps_fax = subprocess.check_output(["ps", ps_param], stderr=STDOUT)
 
         log.debug("Executor process: killing process", command=self.command)
         log.debug("EXecutor process: current processes", ps_fax=ps_fax)
 
         super().kill()
 
-        ps_fax = subprocess.check_output(["ps", "fax"], stderr=STDOUT)
+        ps_fax = subprocess.check_output(["ps", ps_param], stderr=STDOUT)
 
         log.debug("Executor process: process killed", command=self.command)
         log.debug("EXecutor process: current processes", ps_fax=ps_fax)


### PR DESCRIPTION
During transport shutdown some greenlets weren't properly being kept
track of which in combination with the long-polling used by Matrix could
lead to incorrect behaviour.

Additionally the `UserAddressManager` had no life-cycle control as well
which again could lead to reachability events appearing after transport
shutdown (esp. in tests).

This also splits the tests using a mocked matrix server out into a separate module and runs those parallel to the unit tests.

Fixes: #4336, fixes #4337, fixes: #4338, fixes #4379

(Technically) fixes #4030:
- The `ping_pong_message_success` helper now correctly emulates the raiden queues. This fulfils the requirements to properly test the transport but does need to be taken into account when testing the transports without this helper.