### PR TITLE
Upgrade flake8-tuple to 0.4.0

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -52,7 +52,7 @@ execnet==1.6.0
 fancycompleter==0.8
 filelock==3.0.12
 flake8-bugbear==19.3.0
-flake8-tuple==0.3.1
+flake8-tuple==0.4.0
 flake8==3.7.7
 flask-cors==3.0.8
 flask-restful==0.3.7

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -51,7 +51,7 @@ execnet==1.6.0            # via pytest-xdist
 fancycompleter==0.8       # via pdbpp
 filelock==3.0.12
 flake8-bugbear==19.3.0
-flake8-tuple==0.3.1
+flake8-tuple==0.4.0
 flake8==3.7.7
 flask-cors==3.0.8
 flask-restful==0.3.7


### PR DESCRIPTION
It seems that 0.3.1 got deleted from pypi, so all builds will fail if
they are pinned to that version. *sigh*

https://pypi.org/project/flake8-tuple/#history