### PR TITLE
Changes MS3 scenario s.t. final claim fails

### DIFF
--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -56,4 +56,4 @@ scenario:
       ## Settlement timeout is 500 blocks -> 500 * 15s in Kovan = 7500s
       - wait_blocks: 461
       # will fail for now since channel was closed by node1. We should add functionality to assert a fail
-      - assert_ms_claim: {channel_info_key: "MS Test Channel"}
+      - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}


### PR DESCRIPTION
Changes MS3 scenario such that the scenario succeeds even if the final assertion fails (as intended by the author). In this scenario, the monitoring service cannot claim a reward, since the node came back online and updated the channel information itself, there was no work for the monitoring service 