### PR TITLE
Change method of getting json data out of HTTP requests

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -279,20 +279,18 @@ def get_last_iou(
     signature = to_hex(LocalSigner(privkey).sign(signature_data))
 
     try:
-        data = (
-            requests.get(
-                f"{url}/api/v1/{to_checksum_address(token_network_address)}/payment/iou",
-                params=dict(
-                    sender=to_checksum_address(sender),
-                    receiver=to_checksum_address(receiver),
-                    timestamp=timestamp,
-                    signature=signature,
-                ),
-                timeout=DEFAULT_HTTP_REQUEST_TIMEOUT,
-            )
-            .json()
-            .get("last_iou")
+        response = requests.get(
+            f"{url}/api/v1/{to_checksum_address(token_network_address)}/payment/iou",
+            params=dict(
+                sender=to_checksum_address(sender),
+                receiver=to_checksum_address(receiver),
+                timestamp=timestamp,
+                signature=signature,
+            ),
+            timeout=DEFAULT_HTTP_REQUEST_TIMEOUT,
         )
+
+        data = json.loads(response.content).get("last_iou")
 
         if data is None:
             return None

--- a/raiden/network/resolver/client.py
+++ b/raiden/network/resolver/client.py
@@ -1,3 +1,4 @@
+import json
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
@@ -52,7 +53,7 @@ def reveal_secret_with_resolver(
 
     state_change = ReceiveSecretReveal(
         sender=secret_request_event.recipient,
-        secret=Secret(to_bytes(hexstr=response.json()["secret"])),
+        secret=Secret(to_bytes(hexstr=json.loads(response.content)["secret"])),
     )
     raiden.handle_and_track_state_changes([state_change])
     return True

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import shutil
@@ -407,7 +408,7 @@ def run_smoketest(
 
         assert response.status_code == HTTPStatus.OK
 
-        response_json = response.json()
+        response_json = json.loads(response.content)
         assert response_json[0]["partner_address"] == to_checksum_address(
             ConnectionManager.BOOTSTRAP_ADDR
         )

--- a/raiden/ui/sync.py
+++ b/raiden/ui/sync.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from itertools import count
 
@@ -10,15 +11,19 @@ from raiden.network.blockchain_service import BlockChainService
 
 
 def etherscan_query_with_retries(url: str, sleep: float, retries: int = 3) -> int:
+    def get_result():
+        response = requests.get(url)
+        return json.loads(response.content)["result"]
+
     for _ in range(retries - 1):
         try:
-            etherscan_block = to_int(hexstr=requests.get(url).json()["result"])
+            etherscan_block = to_int(hexstr=get_result())
         except (RequestException, ValueError, KeyError):
             gevent.sleep(sleep)
         else:
             return etherscan_block
 
-    etherscan_block = to_int(hexstr=requests.get(url).json()["result"])
+    etherscan_block = to_int(hexstr=get_result())
     return etherscan_block
 
 


### PR DESCRIPTION
The requests module has some undercover magic of using a different implementation
depending on whether the simplejson package is installed, which makes the built-in
requests.response.json() method unreliable

To avoid this issue, we are removing all calls to response.json() and parsing the
response using python's built-in json module.

Resolves #4174 