### PR TITLE
Flaky tests in test_matrix_transport.py

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -45,7 +45,7 @@ from raiden_contracts.constants import ID_TO_NETWORKNAME
 
 log = structlog.get_logger(__name__)
 
-JOIN_RETRIES = 10
+JOIN_RETRIES = 5
 USERID_RE = re.compile(r"^@(0x[0-9a-f]{40})(?:\.[0-9a-f]{8})?(?::.+)?$")
 ROOM_NAME_SEPARATOR = "_"
 ROOM_NAME_PREFIX = "raiden"


### PR DESCRIPTION

For #4336, essentially `transport0` that was started first might do the health_check before the `transport1` reachability was propagated via `transport1.start`. Therefore `transport1.user_presence` by `transport0` was set to `UNREACHABLE`, causing the assertions to fail. 

This pattern was used to cause the flaky tests:
```
    transport0.start(raiden_service0, message_handler, None)
    transport1.start(raiden_service1, message_handler, None)
    transport0.start_health_check(transport1._raiden_service.address)
    transport1.start_health_check(transport0._raiden_service.address)
    assert is_reachable(transport0, raiden_service1.address)
    assert is_reachable(transport1, raiden_service0.address)
```

For #4338 a similar pattern was used, which might fail:
If _client.search_user_directory(address_hex) is called by `_get_room_for_address` before transport_start has updated the user_directory,  `_get_room_for_address` would return None causing the failing test.

This PR: 

- Adds timeouts to node reachability assertions
- Adds `refresh_address_presence` calls to reachability assertions (#4336)
- Adds timeouts and retries to tests involving `_get_room_for_address` (#4338)
- Adds reachability assertions before messages are sent ( #4337)
- Removes public room invite test cases, as public_rooms are currently not used
- lowers JOIN_RETRIES to the original value to speed up matrix tests with
offline nodes.

