### PR TITLE
Tightened error types

### DIFF
--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -20,6 +20,7 @@ from raiden.utils.typing import (
     List,
     Locksroot,
     MessageID,
+    NamedTuple,
     Nonce,
     Optional,
     Signature,
@@ -117,6 +118,11 @@ class Event:
     """
 
     pass
+
+
+class EventsError(NamedTuple):
+    events: List[Event]
+    error: str
 
 
 @dataclass

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -107,7 +107,7 @@ def handle_block(
     lock_expiration_threshold = BlockExpiration(
         locked_lock.expiration + DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
     )
-    lock_has_expired, _ = channel.is_lock_expired(
+    msg_if_lock_has_not_expired = channel.is_lock_expired(
         end_state=channel_state.our_state,
         lock=locked_lock,
         block_number=state_change.block_number,
@@ -116,7 +116,10 @@ def handle_block(
 
     events: List[Event] = list()
 
-    if lock_has_expired and initiator_state.transfer_state != "transfer_expired":
+    if (
+        msg_if_lock_has_not_expired is None
+        and initiator_state.transfer_state != "transfer_expired"
+    ):
         is_channel_open = channel.get_status(channel_state) == CHANNEL_STATE_OPENED
         if is_channel_open:
             expired_lock_events = channel.send_lock_expired(

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -1,5 +1,5 @@
 from typing import *  # NOQA pylint:disable=wildcard-import,unused-wildcard-import
-from typing import TYPE_CHECKING, Any, Dict, List, NewType, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, NewType, NoReturn, Optional, Tuple, Type, Union
 
 from raiden_contracts.contract_manager import CompiledContract  # NOQA pylint:disable=unused-import
 from raiden_contracts.utils.type_aliases import (  # NOQA pylint:disable=unused-import
@@ -158,8 +158,7 @@ EncodedData = NewType("EncodedData", T_EncodedData)
 T_WithdrawAmount = int
 WithdrawAmount = NewType("WithdrawAmount", T_WithdrawAmount)
 
-# This should be changed to `Optional[str]`
-SuccessOrError = Tuple[bool, Optional[str]]
+SuccessOrErrorMsg = Optional[str]
 
 BlockSpecification = Union[str, T_BlockNumber, T_BlockHash]
 
@@ -173,3 +172,12 @@ Endpoint = NewType("Endpoint", str)
 LockType = Union["HashTimeLockState", "UnlockPartialProofState"]
 ErrorType = Union[Type["RaidenRecoverableError"], Type["RaidenUnrecoverableError"]]
 LockedTransferType = Union["LockedTransferUnsignedState", "LockedTransferSignedState"]
+
+
+class Uninhabited:
+    def __init__(self):
+        raise RuntimeError("Uninhabited class cannot be instantiated")
+
+
+def never(x: Uninhabited) -> NoReturn:
+    raise RuntimeError(f"Unhandled type: {type(x).__name__}")


### PR DESCRIPTION
This tries to make the error handling a bit more streamlined by used
`Optional[str]` instead of `Tuple[bool, Optional[str]]`.

It also adds the utility `never` and the type `Uninhabited` to do
exhaustive checks, however mypy does not support analysis over a generic
and this pattern can only be used with plain types.