### PR TITLE
Update contracts and reward_proof

### DIFF
--- a/raiden/messages.py
+++ b/raiden/messages.py
@@ -1107,15 +1107,12 @@ class RequestMonitoring(SignedMessage):
 
     def _data_to_sign(self) -> bytes:
         """ Return the binary data to be/which was signed """
+        assert self.non_closing_signature
         packed = pack_reward_proof(
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=self.balance_proof.chain_id,
-                token_network_address=self.balance_proof.token_network_address,
-                channel_identifier=self.balance_proof.channel_identifier,
-            ),
+            chain_id=self.balance_proof.chain_id,
             reward_amount=self.reward_amount,
-            nonce=self.balance_proof.nonce,
             monitoring_service_contract_address=self.monitoring_service_contract_address,
+            non_closing_signature=self.non_closing_signature,
         )
         return packed
 
@@ -1158,14 +1155,10 @@ class RequestMonitoring(SignedMessage):
             partner_signature=self.balance_proof.signature,
         )
         reward_proof_data = pack_reward_proof(
-            canonical_identifier=CanonicalIdentifier(
-                chain_identifier=self.balance_proof.chain_id,
-                token_network_address=self.balance_proof.token_network_address,
-                channel_identifier=self.balance_proof.channel_identifier,
-            ),
+            chain_id=self.balance_proof.chain_id,
             reward_amount=self.reward_amount,
-            nonce=self.balance_proof.nonce,
             monitoring_service_contract_address=self.monitoring_service_contract_address,
+            non_closing_signature=self.non_closing_signature,
         )
         reward_proof_signature = self.reward_proof_signature or EMPTY_SIGNATURE
         return (

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -78,14 +78,10 @@ def test_request_monitoring() -> None:
 
     # test signature verification
     reward_proof_data = pack_reward_proof(
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=request_monitoring.balance_proof.chain_id,
-            token_network_address=request_monitoring.balance_proof.token_network_address,
-            channel_identifier=request_monitoring.balance_proof.channel_identifier,
-        ),
+        chain_id=request_monitoring.balance_proof.chain_id,
         reward_amount=request_monitoring.reward_amount,
-        nonce=request_monitoring.balance_proof.nonce,
         monitoring_service_contract_address=MSC_ADDRESS,
+        non_closing_signature=request_monitoring.non_closing_signature,
     )
 
     assert recover(reward_proof_data, request_monitoring.reward_proof_signature) == ADDRESS
@@ -170,14 +166,10 @@ def test_tamper_request_monitoring():
     exploited_signature = request_monitoring.reward_proof_signature
 
     reward_proof_data = pack_reward_proof(
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=request_monitoring.balance_proof.chain_id,
-            token_network_address=request_monitoring.balance_proof.token_network_address,
-            channel_identifier=request_monitoring.balance_proof.channel_identifier,
-        ),
+        chain_id=request_monitoring.balance_proof.chain_id,
         reward_amount=request_monitoring.reward_amount,
-        nonce=request_monitoring.balance_proof.nonce,
         monitoring_service_contract_address=msc_address,
+        non_closing_signature=request_monitoring.non_closing_signature,
     )
 
     # An attacker might change the balance hash
@@ -192,14 +184,10 @@ def test_tamper_request_monitoring():
 
     tampered_bp = tampered_balance_hash_request_monitoring.balance_proof
     tampered_balance_hash_reward_proof_data = pack_reward_proof(
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=tampered_bp.chain_id,
-            token_network_address=tampered_bp.token_network_address,
-            channel_identifier=tampered_bp.channel_identifier,
-        ),
+        chain_id=tampered_bp.chain_id,
         reward_amount=tampered_balance_hash_request_monitoring.reward_amount,
-        nonce=tampered_balance_hash_request_monitoring.balance_proof.nonce,
         monitoring_service_contract_address=msc_address,
+        non_closing_signature=request_monitoring.non_closing_signature,
     )
     # The signature works/is unaffected by that change...
     recovered_address_tampered = recover(
@@ -226,14 +214,10 @@ def test_tamper_request_monitoring():
 
     tampered_bp = tampered_additional_hash_request_monitoring.balance_proof
     tampered_additional_hash_reward_proof_data = pack_reward_proof(
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=tampered_bp.chain_id,
-            token_network_address=tampered_bp.token_network_address,
-            channel_identifier=tampered_bp.channel_identifier,
-        ),
+        chain_id=tampered_bp.chain_id,
         reward_amount=tampered_additional_hash_request_monitoring.reward_amount,
-        nonce=tampered_additional_hash_request_monitoring.balance_proof.nonce,
         monitoring_service_contract_address=msc_address,
+        non_closing_signature=request_monitoring.non_closing_signature,
     )
 
     # The signature works/is unaffected by that change...
@@ -261,14 +245,10 @@ def test_tamper_request_monitoring():
 
     tampered_bp = tampered_non_closing_signature_request_monitoring.balance_proof
     tampered_non_closing_signature_reward_proof_data = pack_reward_proof(
-        canonical_identifier=factories.make_canonical_identifier(
-            chain_identifier=tampered_bp.chain_id,
-            token_network_address=tampered_bp.token_network_address,
-            channel_identifier=tampered_bp.channel_identifier,
-        ),
+        chain_id=tampered_bp.chain_id,
         reward_amount=tampered_non_closing_signature_request_monitoring.reward_amount,
-        nonce=tampered_non_closing_signature_request_monitoring.balance_proof.nonce,
         monitoring_service_contract_address=msc_address,
+        non_closing_signature=request_monitoring.non_closing_signature,
     )
 
     # The signature works/is unaffected by that change...

--- a/raiden/utils/packing.py
+++ b/raiden/utils/packing.py
@@ -1,3 +1,5 @@
+from eth_utils import to_checksum_address
+
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
@@ -5,12 +7,14 @@ from raiden.utils.typing import (
     Address,
     BalanceHash,
     BlockExpiration,
+    ChainID,
     Nonce,
     Signature,
     TokenAmount,
     WithdrawAmount,
 )
 from raiden_contracts.constants import MessageTypeId
+from raiden_contracts.utils import proofs
 
 
 def pack_balance_proof(
@@ -61,22 +65,16 @@ def pack_balance_proof_update(
 
 
 def pack_reward_proof(
-    canonical_identifier: CanonicalIdentifier,
+    chain_id: ChainID,
     reward_amount: TokenAmount,
-    nonce: Nonce,
     monitoring_service_contract_address: Address,
+    non_closing_signature: Signature,
 ) -> bytes:
-    channel_identifier = canonical_identifier.channel_identifier
-    token_network_address = canonical_identifier.token_network_address
-    chain_id = canonical_identifier.chain_identifier
-    return pack_data(
-        (monitoring_service_contract_address, "address"),
-        (chain_id, "uint256"),
-        (MessageTypeId.MSReward, "uint256"),
-        (channel_identifier, "uint256"),
-        (reward_amount, "uint256"),
-        (token_network_address, "address"),
-        (nonce, "uint256"),
+    return proofs.pack_reward_proof(
+        to_checksum_address(monitoring_service_contract_address),
+        chain_id,
+        non_closing_signature,
+        reward_amount,
     )
 
 

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -143,7 +143,7 @@ python-magic==0.4.15      # via s3cmd
 pytoml==0.1.20
 pytz==2019.1
 pyyaml==5.1.1
-raiden-contracts==0.25.1
+raiden-contracts==0.26.0
 raiden-webui==0.8.0
 readme-renderer==24.0
 releases==1.6.1

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -137,7 +137,7 @@ python-dateutil==2.8.0    # via pysaml2
 pytoml==0.1.20
 pytz==2019.1
 pyyaml==5.1.1             # via matrix-synapse
-raiden-contracts==0.25.1
+raiden-contracts==0.26.0
 raiden-webui==0.8.0
 readme-renderer==24.0
 releases==1.6.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -22,7 +22,7 @@ py-geth
 py-solc
 pysha3
 pytoml
-raiden-contracts==0.25.1
+raiden-contracts
 raiden-webui
 requests
 structlog

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -59,7 +59,7 @@ pycryptodome==3.8.2       # via eth-hash, eth-keyfile
 pysha3==1.0.2
 pytoml==0.1.20
 pytz==2019.1              # via flask-restful
-raiden-contracts==0.25.1
+raiden-contracts==0.26.0
 raiden-webui==0.8.0
 requests==2.22.0
 rlp==1.1.0                # via eth-rlp, raiden-contracts


### PR DESCRIPTION
The reward proof definition has changed in the smart contracts
(https://github.com/raiden-network/raiden-contracts/pull/1119).

Using the `pack_reward_proof` function from raiden-contracts will make
it easier to fix signature mismatches in the future since we will get a
mypy error instead of a signature error when the signature changes the
next time.