### PR TITLE
Rename occurrences of newbalance to deposit

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -623,7 +623,7 @@ class RaidenAPI:  # pragma: no unittest
         channel_proxy.set_total_deposit(total_deposit=total_deposit, block_identifier=blockhash)
 
         target_address = self.raiden.address
-        waiting.wait_for_participant_newbalance(
+        waiting.wait_for_participant_deposit(
             raiden=self.raiden,
             payment_network_address=registry_address,
             token_address=token_address,

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -9,8 +9,8 @@ from raiden.services import send_pfs_update
 from raiden.transfer.architecture import StateChange
 from raiden.transfer.state_change import (
     ActionChannelUpdateFee,
+    ContractReceiveChannelDeposit,
     ContractReceiveChannelNew,
-    ContractReceiveChannelNewBalance,
     ContractReceiveNewTokenNetwork,
     ContractReceiveRouteNew,
 )
@@ -85,7 +85,7 @@ def after_new_channel_start_healthcheck(
 
 
 def after_new_deposit_join_network(
-    raiden: "RaidenService", state_change: ContractReceiveChannelNewBalance
+    raiden: "RaidenService", state_change: ContractReceiveChannelDeposit
 ) -> None:
     our_address = raiden.address
 
@@ -125,8 +125,8 @@ def after_blockchain_statechange(raiden: "RaidenService", state_change: StateCha
         assert isinstance(state_change, ContractReceiveRouteNew), MYPY_ANNOTATION
         after_new_route_join_network(raiden, state_change)
 
-    elif type(state_change) == ContractReceiveChannelNewBalance:
-        assert isinstance(state_change, ContractReceiveChannelNewBalance), MYPY_ANNOTATION
+    elif type(state_change) == ContractReceiveChannelDeposit:
+        assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
         after_new_deposit_join_network(raiden, state_change)
 
     elif type(state_change) == ActionChannelUpdateFee:

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -138,7 +138,7 @@ def wait_both_channel_open(app0, app1, registry_address, token_address, retry_ti
 def wait_both_channel_deposit(
     app_deposit, app_partner, registry_address, token_address, total_deposit, retry_timeout
 ):
-    waiting.wait_for_participant_newbalance(
+    waiting.wait_for_participant_deposit(
         app_deposit.raiden,
         registry_address,
         token_address,
@@ -148,7 +148,7 @@ def wait_both_channel_deposit(
         retry_timeout,
     )
 
-    waiting.wait_for_participant_newbalance(
+    waiting.wait_for_participant_deposit(
         app_partner.raiden,
         registry_address,
         token_address,

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -221,7 +221,7 @@ def run_test_token_registered_race(raiden_chain, token_amount, retry_timeout, co
 def test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
     """ Test that the balance of a channel gets updated by the deposit() call
     immediately and without having to wait for the
-    `ContractReceiveChannelNewBalance` message since the API needs to return
+    `ContractReceiveChannelDeposit` message since the API needs to return
     the channel with the deposit balance updated.
     """
     raise_on_failure(

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -62,7 +62,7 @@ from raiden.transfer.state import (
     PendingLocksState,
     PendingWithdrawState,
     RouteState,
-    TransactionChannelNewBalance,
+    TransactionChannelDeposit,
     TransactionExecutionStatus,
     UnlockPartialProofState,
     balanceproof_from_envelope,
@@ -74,7 +74,7 @@ from raiden.transfer.state_change import (
     ActionChannelWithdraw,
     Block,
     ContractReceiveChannelClosed,
-    ContractReceiveChannelNewBalance,
+    ContractReceiveChannelDeposit,
     ContractReceiveChannelSettled,
     ContractReceiveChannelWithdraw,
     ContractReceiveUpdateTransfer,
@@ -250,10 +250,10 @@ def test_channelstate_update_contract_balance():
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
 
-    deposit_transaction = TransactionChannelNewBalance(
+    deposit_transaction = TransactionChannelDeposit(
         our_model1.participant_address, balance1_new, deposit_block_number
     )
-    state_change = ContractReceiveChannelNewBalance(
+    state_change = ContractReceiveChannelDeposit(
         transaction_hash=make_transaction_hash(),
         canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
@@ -294,10 +294,10 @@ def test_channelstate_decreasing_contract_balance():
     amount = 10
     balance1_new = our_model1.balance - amount
 
-    deposit_transaction = TransactionChannelNewBalance(
+    deposit_transaction = TransactionChannelDeposit(
         our_model1.participant_address, balance1_new, deposit_block_number
     )
-    state_change = ContractReceiveChannelNewBalance(
+    state_change = ContractReceiveChannelDeposit(
         transaction_hash=make_transaction_hash(),
         canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
@@ -333,10 +333,10 @@ def test_channelstate_repeated_contract_balance():
     deposit_amount = 10
     balance1_new = our_model1.balance + deposit_amount
 
-    deposit_transaction = TransactionChannelNewBalance(
+    deposit_transaction = TransactionChannelDeposit(
         our_model1.participant_address, balance1_new, deposit_block_number
     )
-    state_change = ContractReceiveChannelNewBalance(
+    state_change = ContractReceiveChannelDeposit(
         transaction_hash=make_transaction_hash(),
         canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,
@@ -386,10 +386,10 @@ def test_deposit_must_wait_for_confirmation():
     # pylint: disable=E1101
     assert channel_state.partner_state.contract_balance == 0
 
-    deposit_transaction = TransactionChannelNewBalance(
+    deposit_transaction = TransactionChannelDeposit(
         channel_state.our_state.address, deposit_amount, block_number
     )
-    new_balance = ContractReceiveChannelNewBalance(
+    new_balance = ContractReceiveChannelDeposit(
         transaction_hash=make_transaction_hash(),
         canonical_identifier=channel_state.canonical_identifier,
         deposit_transaction=deposit_transaction,

--- a/raiden/tests/unit/test_data/db_statechanges.json
+++ b/raiden/tests/unit/test_data/db_statechanges.json
@@ -893,11 +893,11 @@
                 "participant_address": "0x3503221a95028173969fc1f36b2E4F0705a3cc8b",
                 "contract_balance": "200",
                 "deposit_block_number": "28",
-                "_type": "raiden.transfer.state.TransactionChannelNewBalance",
+                "_type": "raiden.transfer.state.TransactionChannelDeposit",
                 "_version": 0
             },
             "block_number": "28",
-            "_type": "raiden.transfer.state_change.ContractReceiveChannelNewBalance",
+            "_type": "raiden.transfer.state_change.ContractReceiveChannelDeposit",
             "_version": 0
         }
     ],
@@ -951,11 +951,11 @@
                 "participant_address": "0xE9DD7660D8f328Cc45B8F01e5C4fA45A1ADe4747",
                 "contract_balance": "200",
                 "deposit_block_number": "32",
-                "_type": "raiden.transfer.state.TransactionChannelNewBalance",
+                "_type": "raiden.transfer.state.TransactionChannelDeposit",
                 "_version": 0
             },
             "block_number": "32",
-            "_type": "raiden.transfer.state_change.ContractReceiveChannelNewBalance",
+            "_type": "raiden.transfer.state_change.ContractReceiveChannelDeposit",
             "_version": 0
         }
     ],

--- a/raiden/tests/unit/test_state.py
+++ b/raiden/tests/unit/test_state.py
@@ -1,47 +1,47 @@
-from raiden.transfer.state import TransactionChannelNewBalance, TransactionOrder
+from raiden.transfer.state import TransactionChannelDeposit, TransactionOrder
 
 
 def test_transaction_channel_new_balance_ordering():
-    a = TransactionChannelNewBalance(bytes(1), 1, 1)
-    b = TransactionChannelNewBalance(bytes(2), 2, 2)
+    a = TransactionChannelDeposit(bytes(1), 1, 1)
+    b = TransactionChannelDeposit(bytes(2), 2, 2)
     assert a != b
     assert a < b
     assert b > a
 
-    a = TransactionChannelNewBalance(bytes(1), 1, 1)
-    b = TransactionChannelNewBalance(bytes(2), 2, 1)
+    a = TransactionChannelDeposit(bytes(1), 1, 1)
+    b = TransactionChannelDeposit(bytes(2), 2, 1)
     assert a != b
     assert a < b
     assert b > a
 
-    a = TransactionChannelNewBalance(bytes(3), 3, 3)
-    b = TransactionChannelNewBalance(bytes(3), 3, 3)
+    a = TransactionChannelDeposit(bytes(3), 3, 3)
+    b = TransactionChannelDeposit(bytes(3), 3, 3)
     assert a == b
     assert not a > b
     assert not b > a
 
 
 def test_transaction_order_ordering():
-    a = TransactionOrder(1, TransactionChannelNewBalance(bytes(1), 1, 1))
-    b = TransactionOrder(2, TransactionChannelNewBalance(bytes(2), 2, 2))
+    a = TransactionOrder(1, TransactionChannelDeposit(bytes(1), 1, 1))
+    b = TransactionOrder(2, TransactionChannelDeposit(bytes(2), 2, 2))
     assert a != b
     assert a < b
     assert b > a
 
-    a = TransactionOrder(1, TransactionChannelNewBalance(bytes(1), 1, 1))
-    b = TransactionOrder(2, TransactionChannelNewBalance(bytes(2), 2, 1))
+    a = TransactionOrder(1, TransactionChannelDeposit(bytes(1), 1, 1))
+    b = TransactionOrder(2, TransactionChannelDeposit(bytes(2), 2, 1))
     assert a != b
     assert a < b
     assert b > a
 
-    a = TransactionOrder(3, TransactionChannelNewBalance(bytes(3), 3, 3))
-    b = TransactionOrder(3, TransactionChannelNewBalance(bytes(3), 3, 3))
+    a = TransactionOrder(3, TransactionChannelDeposit(bytes(3), 3, 3))
+    b = TransactionOrder(3, TransactionChannelDeposit(bytes(3), 3, 3))
     assert a == b
     assert not a > b
     assert not b > a
 
-    a = TransactionOrder(1, TransactionChannelNewBalance(bytes(1), 1, 1))
-    b = TransactionOrder(2, TransactionChannelNewBalance(bytes(1), 1, 1))
+    a = TransactionOrder(1, TransactionChannelDeposit(bytes(1), 1, 1))
+    b = TransactionOrder(2, TransactionChannelDeposit(bytes(1), 1, 1))
     assert a != b
     assert a < b
     assert b > a

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -493,7 +493,7 @@ def wait_for_usable_channel(
         app0.raiden, registry_address, token_address, app1.raiden.address, retry_timeout
     )
 
-    waiting.wait_for_participant_newbalance(
+    waiting.wait_for_participant_deposit(
         app0.raiden,
         registry_address,
         token_address,
@@ -503,7 +503,7 @@ def wait_for_usable_channel(
         retry_timeout,
     )
 
-    waiting.wait_for_participant_newbalance(
+    waiting.wait_for_participant_deposit(
         app0.raiden,
         registry_address,
         token_address,

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -49,8 +49,8 @@ from raiden.transfer.state_change import (
     Block,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
+    ContractReceiveChannelDeposit,
     ContractReceiveChannelNew,
-    ContractReceiveChannelNewBalance,
     ContractReceiveChannelSettled,
     ContractReceiveChannelWithdraw,
     ContractReceiveNewPaymentNetwork,
@@ -84,7 +84,7 @@ TokenNetworkStateChange = Union[
     ActionChannelClose,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelNew,
-    ContractReceiveChannelNewBalance,
+    ContractReceiveChannelDeposit,
     ContractReceiveChannelSettled,
     ContractReceiveRouteNew,
     ContractReceiveRouteClosed,
@@ -833,8 +833,8 @@ def handle_state_change(
     elif type(state_change) == ContractReceiveChannelClosed:
         assert isinstance(state_change, ContractReceiveChannelClosed), MYPY_ANNOTATION
         iteration = handle_contract_receive_channel_closed(chain_state, state_change)
-    elif type(state_change) == ContractReceiveChannelNewBalance:
-        assert isinstance(state_change, ContractReceiveChannelNewBalance), MYPY_ANNOTATION
+    elif type(state_change) == ContractReceiveChannelDeposit:
+        assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
         iteration = handle_token_network_action(chain_state, state_change)
     elif type(state_change) == ContractReceiveChannelSettled:
         assert isinstance(state_change, ContractReceiveChannelSettled), MYPY_ANNOTATION
@@ -926,7 +926,7 @@ def is_transaction_effect_satisfied(
     # exclusively through the external APIs.
     #
     #  - ContractReceiveChannelNew
-    #  - ContractReceiveChannelNewBalance
+    #  - ContractReceiveChannelDeposit
     #  - ContractReceiveNewPaymentNetwork
     #  - ContractReceiveNewTokenNetwork
     #  - ContractReceiveRouteNew

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -273,7 +273,7 @@ def make_empty_pending_locks_state() -> PendingLocksState:
 
 
 @dataclass(order=True)
-class TransactionChannelNewBalance(State):
+class TransactionChannelDeposit(State):
     participant_address: Address
     contract_balance: TokenAmount
     deposit_block_number: BlockNumber
@@ -287,7 +287,7 @@ class TransactionChannelNewBalance(State):
 @dataclass(order=True)
 class TransactionOrder(State):
     block_number: BlockNumber
-    transaction: TransactionChannelNewBalance
+    transaction: TransactionChannelDeposit
 
 
 @dataclass

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -15,7 +15,7 @@ from raiden.transfer.state import (
     NettingChannelState,
     PaymentNetworkState,
     TokenNetworkState,
-    TransactionChannelNewBalance,
+    TransactionChannelDeposit,
 )
 from raiden.utils.typing import (
     Address,
@@ -196,11 +196,11 @@ class ActionNewTokenNetwork(StateChange):
 
 
 @dataclass
-class ContractReceiveChannelNewBalance(ContractReceiveStateChange):
+class ContractReceiveChannelDeposit(ContractReceiveStateChange):
     """ A channel to which this node IS a participant had a deposit. """
 
     canonical_identifier: CanonicalIdentifier
-    deposit_transaction: TransactionChannelNewBalance
+    deposit_transaction: TransactionChannelDeposit
 
     @property
     def channel_identifier(self) -> ChannelID:

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -9,8 +9,8 @@ from raiden.transfer.state_change import (
     ActionChannelWithdraw,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
+    ContractReceiveChannelDeposit,
     ContractReceiveChannelNew,
-    ContractReceiveChannelNewBalance,
     ContractReceiveChannelSettled,
     ContractReceiveChannelWithdraw,
     ContractReceiveRouteClosed,
@@ -29,7 +29,7 @@ StateChangeWithChannelID = Union[
     ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ContractReceiveChannelClosed,
-    ContractReceiveChannelNewBalance,
+    ContractReceiveChannelDeposit,
     ContractReceiveChannelSettled,
     ContractReceiveUpdateTransfer,
     ContractReceiveChannelWithdraw,
@@ -138,7 +138,7 @@ def handle_channelnew(
 
 def handle_balance(
     token_network_state: TokenNetworkState,
-    state_change: ContractReceiveChannelNewBalance,
+    state_change: ContractReceiveChannelDeposit,
     block_number: BlockNumber,
     block_hash: BlockHash,
     pseudo_random_generator: random.Random,
@@ -387,8 +387,8 @@ def state_transition(
         iteration = handle_channelnew(
             token_network_state=token_network_state, state_change=state_change
         )
-    elif type(state_change) == ContractReceiveChannelNewBalance:
-        assert isinstance(state_change, ContractReceiveChannelNewBalance), MYPY_ANNOTATION
+    elif type(state_change) == ContractReceiveChannelDeposit:
+        assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
         iteration = handle_balance(
             token_network_state=token_network_state,
             state_change=state_change,

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -85,7 +85,7 @@ def wait_for_newchannel(
         )
 
 
-def wait_for_participant_newbalance(
+def wait_for_participant_deposit(
     raiden: "RaidenService",
     payment_network_address: PaymentNetworkAddress,
     token_address: TokenAddress,
@@ -123,9 +123,7 @@ def wait_for_participant_newbalance(
         assert raiden, ALARM_TASK_ERROR_MSG
         assert raiden.alarm, ALARM_TASK_ERROR_MSG
 
-        log.debug(
-            "wait_for_participant_newbalance", current_balance=current_balance, **log_details
-        )
+        log.debug("wait_for_participant_deposit", current_balance=current_balance, **log_details)
         gevent.sleep(retry_timeout)
         channel_state = views.get_channelstate_for(
             views.state_from_raiden(raiden),


### PR DESCRIPTION
This was inconsistent in the codebase and should be closer to how stuff
is called in the contracts afterwards.