### PR TITLE
Substitute calls for response.json() for one that calls python's built-in json.

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -22,6 +22,7 @@ from web3 import Web3
 from raiden.constants import DEFAULT_HTTP_REQUEST_TIMEOUT, ZERO_TOKENS, RoutingMode
 from raiden.exceptions import ServiceRequestFailed, ServiceRequestIOURejected
 from raiden.network.proxies.service_registry import ServiceRegistry
+from raiden.network.utils import get_response_json
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,
@@ -139,7 +140,7 @@ MAX_PATHS_QUERY_ATTEMPTS = 2
 def get_pfs_info(url: str) -> Optional[PFSInfo]:
     try:
         response = requests.get(f"{url}/api/v1/info", timeout=DEFAULT_HTTP_REQUEST_TIMEOUT)
-        infos = response.json()
+        infos = get_response_json(response)
 
         return PFSInfo(
             url=url,
@@ -419,7 +420,7 @@ def post_pfs_paths(
     if response.status_code != 200:
         info = {"http_error": response.status_code}
         try:
-            response_json = response.json()
+            response_json = get_response_json(response)
         except ValueError:
             raise ServiceRequestFailed(
                 "Pathfinding service returned error code (malformed json in response)", info
@@ -433,12 +434,12 @@ def post_pfs_paths(
         raise ServiceRequestFailed("Pathfinding service returned error code", info)
 
     try:
-        response_json = response.json()
+        response_json = get_response_json(response)
         return response_json["result"], UUID(response_json["feedback_token"])
     except KeyError:
         raise ServiceRequestFailed(
             "Answer from pathfinding service not understood ('result' field missing)",
-            dict(response=response.json()),
+            dict(response=get_response_json(response)),
         )
     except ValueError:
         raise ServiceRequestFailed(

--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -1,4 +1,5 @@
 import errno
+import json
 import socket
 import sys
 from contextlib import closing
@@ -12,6 +13,11 @@ import requests
 from raiden.utils.typing import Iterator, Optional, Port
 
 LOOPBACK = "127.0.0.1"
+
+
+def get_response_json(response):
+    return json.loads(response.content)
+
 
 # The solution based on psutils does not work on MacOS because it needs
 # root access

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -8,6 +8,7 @@ from raiden.constants import RoutingMode
 from raiden.exceptions import BrokenPreconditionError
 from raiden.network.pathfinding import configure_pfs_or_exit, get_random_pfs
 from raiden.tests.utils.factories import HOP1
+from raiden.tests.utils.mocks import mocked_failed_response, mocked_json_response
 from raiden.tests.utils.smartcontracts import deploy_service_registry_and_set_urls
 from raiden.utils import privatekey_to_address
 from raiden.utils.typing import ChainID
@@ -79,9 +80,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
         "payment_address": "0x2222222222222222222222222222222222222222",
     }
 
-    response = Mock()
-    response.configure_mock(status_code=200)
-    response.json = Mock(return_value=json_data)
+    response = mocked_json_response(response_data=json_data)
 
     # With local routing configure pfs should raise assertion
     with pytest.raises(AssertionError):
@@ -130,8 +129,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     assert config.price == json_data["price_info"]
 
     # Bad address, should exit the program
-    response = Mock()
-    response.configure_mock(status_code=400)
+    response = mocked_failed_response(error=requests.RequestException(), status_code=400)
     bad_address = "http://badaddress"
     with pytest.raises(SystemExit):
         with patch.object(requests, "get", side_effect=requests.RequestException()):
@@ -145,8 +143,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             )
 
     # Addresses of token network registries of pfs and client conflic, should exit the client
-    response.configure_mock(status_code=200)
-    response.json = Mock(return_value=json_data)
+    response = mocked_json_response(response_data=json_data)
 
     with pytest.raises(SystemExit):
         with patch.object(requests, "get", return_value=response):
@@ -159,8 +156,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
             )
 
     # ChainIDs of pfs and client conflic, should exit the client
-    response.configure_mock(status_code=200)
-    response.json = Mock(return_value=json_data)
+    response = mocked_json_response(response_data=json_data)
 
     with pytest.raises(SystemExit):
         with patch.object(requests, "get", return_value=response):

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -398,9 +398,7 @@ def test_routing_mocked_pfs_invalid_json(
         address3: NODE_NETWORK_REACHABLE,
     }
 
-    response = Mock()
-    response.configure_mock(status_code=200)
-    response.json = Mock(side_effect=ValueError())
+    response = mocked_failed_response(error=ValueError(), status_code=200)
 
     with patch.object(requests, "post", return_value=response):
         routes, feedback_token = get_best_routes_with_iou_request_mocked(
@@ -438,9 +436,7 @@ def test_routing_mocked_pfs_invalid_json_structure(
         address3: NODE_NETWORK_REACHABLE,
     }
 
-    response = Mock()
-    response.configure_mock(status_code=400)
-    response.json = Mock(return_value={})
+    response = mocked_json_response(response_data={}, status_code=400)
 
     with patch.object(requests, "post", return_value=response):
         routes, feedback_token = get_best_routes_with_iou_request_mocked(
@@ -493,9 +489,8 @@ def test_routing_mocked_pfs_unavailable_peer(
         address3: NODE_NETWORK_REACHABLE,
     }
 
-    response = Mock()
-    response.configure_mock(status_code=200)
-    response.json = Mock(return_value=json_data)
+    response = mocked_json_response(response_data=json_data, status_code=200)
+
     with patch.object(requests, "post", return_value=response):
         routes, feedback_token = get_best_routes_with_iou_request_mocked(
             chain_state=chain_state,


### PR DESCRIPTION
Resolves #4378 