### PR TITLE
Avoid crashes in test_participant_selection

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -22,7 +22,7 @@ from raiden.exceptions import (
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
 from raiden.transfer import views
 from raiden.utils import typing
-from raiden.utils.typing import Address, BlockNumber, TokenAmount, TokenNetworkAddress
+from raiden.utils.typing import Address, TokenAmount, TokenNetworkAddress
 
 log = structlog.get_logger(__name__)
 RECOVERABLE_ERRORS = (
@@ -326,17 +326,6 @@ class ConnectionManager:  # pragma: no unittest
             )
             if not channel_identifier:
                 raise
-
-        # Wait until a newer block is mined before moving to deposit.
-        # TODO: Remove this waiting block when
-        # https://github.com/raiden-network/raiden/issues/4220
-        # is resolved.
-        chain_state = views.state_from_raiden(self.raiden)
-        waiting.wait_for_block(
-            raiden=self.raiden,
-            block_number=BlockNumber(chain_state.block_number + 1),
-            retry_timeout=DEFAULT_RETRY_TIMEOUT,
-        )
 
         total_deposit = self._initial_funding_per_partner
         if total_deposit == 0:

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -19,7 +19,6 @@ from raiden.exceptions import (
     RaidenUnrecoverableError,
     TransactionThrew,
 )
-from raiden.settings import DEFAULT_RETRY_TIMEOUT
 from raiden.transfer import views
 from raiden.utils import typing
 from raiden.utils.typing import Address, TokenAmount, TokenNetworkAddress
@@ -310,36 +309,10 @@ class ConnectionManager:  # pragma: no unittest
             # If channel already exists (either because partner created it,
             # or it's nonfunded channel), continue to ensure it's funded
             pass
-        except RaidenRecoverableError:
-            # The channel may still have been created in the pending block.
-            # If that is the case, swallow the exception
-            token_network_address = views.get_token_network_address_by_token_address(
-                chain_state=views.state_from_raiden(self.raiden),
-                payment_network_address=self.registry_address,
-                token_address=self.token_address,
-            )
-            token_network = self.raiden.chain.address_to_token_network[token_network_address]
-            channel_identifier = token_network.get_channel_identifier_or_none(
-                participant1=self.raiden.address,
-                participant2=partner,
-                block_identifier=token_network.client.get_checking_block(),
-            )
-            if not channel_identifier:
-                raise
 
         total_deposit = self._initial_funding_per_partner
         if total_deposit == 0:
             return
-
-        # The channel may still be in the pending block only and our node may
-        # not be aware of it.
-        waiting.wait_for_newchannel(
-            raiden=self.raiden,
-            payment_network_address=self.registry_address,
-            token_address=self.token_address,
-            partner_address=partner,
-            retry_timeout=DEFAULT_RETRY_TIMEOUT,
-        )
 
         try:
             self.api.set_total_channel_deposit(

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -458,6 +458,11 @@ class ConnectionManager:  # pragma: no unittest
         return self.initial_channel_target < 1
 
     def __repr__(self) -> str:
+        if self.raiden.wal is None:
+            return (
+                f"{self.__class__.__name__}(target={self.initial_channel_target} "
+                "WAL not initialized)"
+            )
         open_channels = views.get_channelstate_open(
             chain_state=views.state_from_raiden(self.raiden),
             payment_network_address=self.registry_address,

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -66,7 +66,6 @@ def saturated_count(connection_managers, registry_address, token_address):
 # - Check if this test needs to be adapted for the matrix transport
 #   layer when activating it again. It might as it depends on the
 #   raiden_network fixture.
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("number_of_nodes", [6])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("settle_timeout", [10])

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -63,9 +63,6 @@ def saturated_count(connection_managers, registry_address, token_address):
 # TODO: add test scenarios for
 # - subsequent `connect()` calls with different `funds` arguments
 # - `connect()` calls with preexisting channels
-# - Check if this test needs to be adapted for the matrix transport
-#   layer when activating it again. It might as it depends on the
-#   raiden_network fixture.
 @pytest.mark.parametrize("number_of_nodes", [6])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("settle_timeout", [10])


### PR DESCRIPTION
`test_participant_selection` had become flaky due to two inconsistencies we introduced during the recent reworking of the contract proxies. (State pruning issues)

Fixes #4340

Also removes an obsolete todo comment from the early matrix days and resolves another todo related to issue #4220.