### PR TITLE
Update contracts versions in `raiden/settings.py`

### DIFF
--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -1,5 +1,6 @@
 from eth_utils import denoms, to_hex
 
+import raiden_contracts.constants
 from raiden.constants import Environment
 from raiden.utils.typing import FeeAmount, NetworkTimeout, TokenAmount
 
@@ -45,8 +46,8 @@ DEFAULT_PATHFINDING_IOU_TIMEOUT = 50000  # now the pfs has 200h to cash in
 ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE = 3
 ETHERSCAN_API = "https://{network}.etherscan.io/api?module=proxy&action={action}"
 
-PRODUCTION_CONTRACT_VERSION = "0.18.0"
-DEVELOPMENT_CONTRACT_VERSION = "0.18.0"
+PRODUCTION_CONTRACT_VERSION = raiden_contracts.constants.CONTRACTS_VERSION
+DEVELOPMENT_CONTRACT_VERSION = raiden_contracts.constants.CONTRACTS_VERSION
 
 MIN_REI_THRESHOLD = 100
 


### PR DESCRIPTION
I forgot to change these in 12d4d7977e04feef4de79ba7cce6bcb266833d05.

The DEVELOPMENT_CONTRACT_VERSION is now set to always reflect the
installed contracts version.