### PR TITLE
Blockchain exception

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 
 from eth_utils import to_canonical_address, to_checksum_address
 
+from raiden.blockchain.exceptions import UnknownRaidenEventType
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT64_MAX
-from raiden.exceptions import InvalidBlockNumberInput, UnknownEventType
+from raiden.exceptions import InvalidBlockNumberInput
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.utils.filters import (
@@ -161,7 +162,7 @@ def get_all_netting_channel_events(
     )
 
 
-def decode_event_to_internal(
+def decode_raiden_event_to_internal(
     abi: ABI, chain_id: ChainID, log_event: BlockchainEvent
 ) -> DecodedEvent:
     """ Enforce the binary for internal usage. """
@@ -170,7 +171,7 @@ def decode_event_to_internal(
     decoded_event = decode_event(abi, log_event)
 
     if not decoded_event:
-        raise UnknownEventType()
+        raise UnknownRaidenEventType()
 
     # copy the attribute dict because that data structure is immutable
     data = dict(decoded_event)
@@ -235,7 +236,7 @@ class BlockchainEvents:
             assert isinstance(event_listener.filter, StatelessFilter)
 
             for log_event in event_listener.filter.get_new_entries(block_number):
-                yield decode_event_to_internal(event_listener.abi, self.chain_id, log_event)
+                yield decode_raiden_event_to_internal(event_listener.abi, self.chain_id, log_event)
 
     def uninstall_all_event_listeners(self):
         for listener in self.event_listeners:

--- a/raiden/blockchain/exceptions.py
+++ b/raiden/blockchain/exceptions.py
@@ -1,0 +1,25 @@
+from raiden.exceptions import RaidenRecoverableError, RaidenUnrecoverableError
+
+
+class UnknownRaidenEventType(RaidenUnrecoverableError):
+    """Raised if decoding an event from a Raiden smart contract failed.
+
+    Deserializing an event from one of the Raiden smart contracts fails may
+    happen for a few reasons:
+
+    - The address is not a Raiden smart contract.
+    - The address is for a newer version of the Raiden's smart contracts with
+      an unknown event.
+
+    Either case, it means the node will not be properly synchronized with the
+    on-chain state, and this cannot be recovered from.
+    """
+
+
+class UnknownExternalEventType(RaidenRecoverableError):
+    """Raised if decoding an event from a third-party smart contract failed.
+
+    This cannot be an unrecoverable error, because third party contracts are
+    not controlled. If this was an unrecoverable it would open a surface for
+    attacks.
+    """

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -44,10 +44,6 @@ class RaidenUnrecoverableError(RaidenError):
     """
 
 
-class UnknownEventType(RaidenError):
-    """Raised if decoding of an event failed."""
-
-
 class ChannelNotFound(RaidenError):
     """ Raised when a provided channel via the REST api is not found in the
     internal data structures"""


### PR DESCRIPTION
~review/merge after #4389~

This splits the decoding failures into two, internal and external. The first is considered unrecoverable while the later is recoverable. The exception for external smart contracts is not used but it was added to make it clear for future usage that the two exceptions are not the same.