### PR TITLE
Remove start_health_check_for call during _initialize_messages_queues.

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -860,8 +860,6 @@ class RaidenService(Runnable):
         )
 
         for queue_identifier, event_queue in events_queues.items():
-            self.start_health_check_for(queue_identifier.recipient)
-
             for event in event_queue:
                 message = message_from_sendevent(event)
                 self.sign(message)


### PR DESCRIPTION
_initialize_messages_queues is called before transport.start() s.t. the call has no effect. Start_health_check_for will be called after transport.start().