### PR TITLE
Cast imbalance fees to `int` and then `FeeAmount`

### DIFF
--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -103,7 +103,7 @@ def calculate_imbalance_fees(channel_capacity: TokenAmount) -> List[Tuple[TokenA
         constant = 4 * MAX_IMBALANCE_FEE / channel_capacity ** 2
         inner = balance - (channel_capacity // 2)
 
-        return FeeAmount(constant * inner ** 2)
+        return FeeAmount(int(constant * inner ** 2))
 
     # Do not duplicate base points when not enough token are available
     num_base_points = min(NUM_DISCRETISATION_POINTS, channel_capacity)


### PR DESCRIPTION
Counter-intuitively, mypy's `NewType`s don't get replaced by their base
class during runtime but by a dummy function just returning their
argument. So a call like `x = FeeAmount(1.1)` will return a float
despite `FeeAmount` having `int` as a base type.

Fixes https://github.com/raiden-network/raiden/issues/4373.

This would not have happened if `FeeAmount` was an actual subclass of
`int`. If the performance implications are acceptable, that sounds like
a better solution.