### PR TITLE
Split address exception

### DIFF
--- a/raiden/api/exceptions.py
+++ b/raiden/api/exceptions.py
@@ -7,8 +7,8 @@ class ChannelNotFound(RaidenValidationError):
     """
 
 
-class UnexistingChannel(RaidenValidationError):
-    """The request channel does not exist.
+class NonexistingChannel(RaidenValidationError):
+    """The requested channel does not exist.
 
     This exception can be raised for a few reasons:
 

--- a/raiden/api/exceptions.py
+++ b/raiden/api/exceptions.py
@@ -5,3 +5,14 @@ class ChannelNotFound(RaidenValidationError):
     """ Raised when a provided channel via the REST api is not found in the
     internal data structures.
     """
+
+
+class UnexistingChannel(RaidenValidationError):
+    """The request channel does not exist.
+
+    This exception can be raised for a few reasons:
+
+    - The user request raced and lost against a transaction to close/settle the
+      channel.
+    - The user provided invalid values, and the given channel does not exist.
+    """

--- a/raiden/api/exceptions.py
+++ b/raiden/api/exceptions.py
@@ -1,0 +1,7 @@
+from raiden.exceptions import RaidenValidationError
+
+
+class ChannelNotFound(RaidenValidationError):
+    """ Raised when a provided channel via the REST api is not found in the
+    internal data structures.
+    """

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -4,7 +4,7 @@ from eth_utils import is_binary_address, to_checksum_address
 
 import raiden.blockchain.events as blockchain_events
 from raiden import waiting
-from raiden.api.exceptions import ChannelNotFound, UnexistingChannel
+from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
@@ -507,7 +507,7 @@ class RaidenAPI:  # pragma: no unittest
             raise UnknownTokenAddress("Unknown token address")
 
         if channel_state is None:
-            raise UnexistingChannel("No channel with partner_address for the given token")
+            raise NonexistingChannel("No channel with partner_address for the given token")
 
         if total_withdraw <= channel_state.our_total_withdraw:
             raise WithdrawMismatch(f"Total withdraw {total_withdraw} did not increase")
@@ -583,7 +583,7 @@ class RaidenAPI:  # pragma: no unittest
             raise UnknownTokenAddress("Unknown token address")
 
         if channel_state is None:
-            raise UnexistingChannel("No channel with partner_address for the given token")
+            raise NonexistingChannel("No channel with partner_address for the given token")
 
         token = self.raiden.chain.token(token_address)
         token_network_registry = self.raiden.chain.token_network_registry(registry_address)

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -4,10 +4,10 @@ from eth_utils import is_binary_address, to_checksum_address
 
 import raiden.blockchain.events as blockchain_events
 from raiden import waiting
+from raiden.api.exceptions import ChannelNotFound
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
-    ChannelNotFound,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -182,11 +182,12 @@ class RaidenAPI:  # pragma: no unittest
         assert len(channel_list) <= 1
 
         if not channel_list:
-            raise ChannelNotFound(
-                "Channel with partner '{}' for token '{}' could not be found.".format(
-                    to_checksum_address(partner_address), to_checksum_address(token_address)
-                )
+            msg = (
+                f"Channel with partner '{to_checksum_address(partner_address)}' "
+                f"for token '{to_checksum_address(token_address)}' could not be "
+                f"found."
             )
+            raise ChannelNotFound(msg)
 
         return channel_list[0]
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -20,7 +20,7 @@ from raiden_webui import RAIDEN_WEBUI_PATH
 from webargs.flaskparser import parser
 from werkzeug.exceptions import NotFound
 
-from raiden.api.exceptions import ChannelNotFound, UnexistingChannel
+from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
 from raiden.api.objects import AddressList, PartnersPerTokenList
 from raiden.api.v1.encoding import (
     AddressListSchema,
@@ -642,7 +642,7 @@ class RestAPI:  # pragma: no unittest
                 )
             except InsufficientFunds as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
-            except (UnexistingChannel, UnknownTokenAddress) as e:
+            except (NonexistingChannel, UnknownTokenAddress) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
             except (DepositOverLimit, DepositMismatch) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
@@ -1118,7 +1118,7 @@ class RestAPI:  # pragma: no unittest
                 channel_state.partner_state.address,
                 total_withdraw,
             )
-        except (UnexistingChannel, UnknownTokenAddress) as e:
+        except (NonexistingChannel, UnknownTokenAddress) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
         except (InsufficientFunds, WithdrawMismatch) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -20,6 +20,7 @@ from raiden_webui import RAIDEN_WEBUI_PATH
 from webargs.flaskparser import parser
 from werkzeug.exceptions import NotFound
 
+from raiden.api.exceptions import ChannelNotFound
 from raiden.api.objects import AddressList, PartnersPerTokenList
 from raiden.api.v1.encoding import (
     AddressListSchema,
@@ -58,7 +59,6 @@ from raiden.exceptions import (
     AddressWithoutCode,
     AlreadyRegisteredTokenAddress,
     APIServerPortInUseError,
-    ChannelNotFound,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -91,8 +91,23 @@ class WithdrawMismatch(RaidenRecoverableError):
     """ Raised when the requested withdraw is larger than actual channel balance. """
 
 
-class InvalidAddress(RaidenError):
-    """ Raised when the user provided value is not a valid address. """
+class InvalidChecksummedAddress(RaidenError):
+    """Raised when the user provided address is not a str or the valus is not
+    properly checksummed.
+
+    Exception used to enforce the checksummed for external APIs. The address
+    provided by a user must be checksummed to avoid errors, the checksummed
+    address must be validated at the edges before calling internal functions.
+    """
+
+
+class InvalidBinaryAddress(RaidenValidationError):
+    """Raised when the address is not binary or it is not 20 bytes long.
+
+    Exception used to enforce the sandwhich encoding for python APIs. The
+    internal address representation used by Raiden is binary, the binary
+    address must be validated at the edges before calling internal functions.
+    """
 
 
 class InvalidSecret(RaidenError):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -44,9 +44,12 @@ class RaidenUnrecoverableError(RaidenError):
     """
 
 
-class ChannelNotFound(RaidenError):
-    """ Raised when a provided channel via the REST api is not found in the
-    internal data structures"""
+class RaidenValidationError(RaidenRecoverableError):
+    """Exception raised when an input value is invalid.
+
+    This exception must be raised on the edges of the system, to inform the
+    caller one of the provided values is invalid.
+    """
 
 
 class PaymentConflict(RaidenRecoverableError):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -92,7 +92,7 @@ class WithdrawMismatch(RaidenRecoverableError):
 
 
 class InvalidChecksummedAddress(RaidenError):
-    """Raised when the user provided address is not a str or the valus is not
+    """Raised when the user provided address is not a str or the value is not
     properly checksummed.
 
     Exception used to enforce the checksummed for external APIs. The address
@@ -104,7 +104,7 @@ class InvalidChecksummedAddress(RaidenError):
 class InvalidBinaryAddress(RaidenValidationError):
     """Raised when the address is not binary or it is not 20 bytes long.
 
-    Exception used to enforce the sandwhich encoding for python APIs. The
+    Exception used to enforce the sandwich encoding for python APIs. The
     internal address representation used by Raiden is binary, the binary
     address must be validated at the edges before calling internal functions.
     """

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -20,7 +20,6 @@ from raiden.constants import (
     RECEIPT_FAILURE_CODE,
 )
 from raiden.exceptions import (
-    InvalidAddress,
     NoStateForBlockIdentifier,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
@@ -47,7 +46,7 @@ log = structlog.get_logger(__name__)
 class SecretRegistry:
     def __init__(self, jsonrpc_client, secret_registry_address, contract_manager: ContractManager):
         if not is_binary_address(secret_registry_address):
-            raise InvalidAddress("Expected binary address format for secret registry")
+            raise ValueError("Expected binary address format for secret registry")
 
         self.contract_manager = contract_manager
         check_address_has_code(

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -5,7 +5,7 @@ import web3
 from eth_utils import is_binary_address, to_bytes, to_canonical_address, to_checksum_address
 from web3.exceptions import BadFunctionCallOutput
 
-from raiden.exceptions import BrokenPreconditionError, InvalidAddress, RaidenUnrecoverableError
+from raiden.exceptions import BrokenPreconditionError, RaidenUnrecoverableError
 from raiden.network.proxies.utils import log_transaction
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
@@ -24,7 +24,7 @@ class ServiceRegistry:
         contract_manager: ContractManager,
     ):
         if not is_binary_address(service_registry_address):
-            raise InvalidAddress("Expected binary address for service registry")
+            raise ValueError("Expected binary address for service registry")
 
         self.contract_manager = contract_manager
         check_address_has_code(

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -27,7 +27,6 @@ from raiden.exceptions import (
     ChannelOutdatedError,
     DepositOverLimit,
     DuplicatedChannelError,
-    InvalidAddress,
     InvalidChannelID,
     InvalidSettleTimeout,
     RaidenRecoverableError,
@@ -94,13 +93,13 @@ log = structlog.get_logger(__name__)
 
 def raise_if_invalid_address_pair(address1: Address, address2: Address) -> None:
     if NULL_ADDRESS_BYTES in (address1, address2):
-        raise InvalidAddress("The null address is not allowed as a channel participant.")
+        raise ValueError("The null address is not allowed as a channel participant.")
 
     if address1 == address2:
         raise SamePeerAddress("Using the same address for both participants is forbiden.")
 
     if not (is_binary_address(address1) and is_binary_address(address2)):
-        raise InvalidAddress("Addresses must be in binary")
+        raise ValueError("Addresses must be in binary")
 
 
 class ChannelData(NamedTuple):
@@ -141,7 +140,7 @@ class TokenNetwork:
         blockchain_service: "BlockChainService",
     ):
         if not is_binary_address(token_network_address):
-            raise InvalidAddress("Expected binary address format for token nework")
+            raise ValueError("Expected binary address format for token nework")
 
         check_address_has_code(
             jsonrpc_client,
@@ -391,7 +390,7 @@ class TokenNetwork:
             BadFunctionCallOutput: If the `block_identifier` points to a block
                 prior to the deployment of the TokenNetwork.
             SamePeerAddress: If an both addresses are equal.
-            InvalidAddress: If either of the address is an invalid type or the
+            ValueError: If either of the address is an invalid type or the
                 null address.
         """
         raise_if_invalid_address_pair(participant1, participant2)
@@ -552,7 +551,7 @@ class TokenNetwork:
             For now one of the participants has to be the node_address
         """
         if self.node_address not in (participant1, participant2):
-            raise InvalidAddress("One participant must be the node address")
+            raise ValueError("One participant must be the node address")
 
         if self.node_address == participant2:
             participant1, participant2 = participant2, participant1

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -13,12 +13,7 @@ from eth_utils import (
 )
 
 from raiden.constants import GENESIS_BLOCK_NUMBER, NULL_ADDRESS
-from raiden.exceptions import (
-    InvalidAddress,
-    InvalidToken,
-    RaidenRecoverableError,
-    RaidenUnrecoverableError,
-)
+from raiden.exceptions import InvalidToken, RaidenRecoverableError, RaidenUnrecoverableError
 from raiden.network.proxies.utils import log_transaction
 from raiden.network.rpc.client import StatelessFilter, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
@@ -55,7 +50,7 @@ class TokenNetworkRegistry:
         blockchain_service: "BlockChainService",
     ):
         if not is_binary_address(registry_address):
-            raise InvalidAddress("Expected binary address format for token network registry")
+            raise ValueError("Expected binary address format for token network registry")
 
         check_address_has_code(
             client=jsonrpc_client,
@@ -130,7 +125,7 @@ class TokenNetworkRegistry:
         self, token_address: TokenAddress, additional_arguments: Dict
     ) -> TokenNetworkAddress:
         if not is_binary_address(token_address):
-            raise InvalidAddress("Expected binary address format for token")
+            raise ValueError("Expected binary address format for token")
 
         token_proxy = self.blockchain_service.token(token_address)
 

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -10,7 +10,7 @@ from gevent.lock import RLock
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.constants import UINT256_MAX
-from raiden.exceptions import BrokenPreconditionError, InvalidAddress, RaidenRecoverableError
+from raiden.exceptions import BrokenPreconditionError, RaidenRecoverableError
 from raiden.network.proxies.token import Token
 from raiden.network.proxies.utils import log_transaction, raise_on_call_returned_empty
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
@@ -46,7 +46,7 @@ class UserDeposit:
         blockchain_service: "BlockChainService",
     ):
         if not is_binary_address(user_deposit_address):
-            raise InvalidAddress("Expected binary address format for token nework")
+            raise ValueError("Expected binary address format for token nework")
 
         check_address_has_code(
             jsonrpc_client,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -31,7 +31,7 @@ from raiden.constants import (
 )
 from raiden.exceptions import (
     BrokenPreconditionError,
-    InvalidAddress,
+    InvalidBinaryAddress,
     InvalidDBData,
     InvalidSecret,
     InvalidSecretHash,
@@ -1022,14 +1022,14 @@ class RaidenService(Runnable):
         self, token_network_address: TokenNetworkAddress
     ) -> ConnectionManager:
         if not is_binary_address(token_network_address):
-            raise InvalidAddress("token address is not valid.")
+            raise InvalidBinaryAddress("token address is not valid.")
 
         known_token_networks = views.get_token_network_addresses(
             views.state_from_raiden(self), self.default_registry.address
         )
 
         if token_network_address not in known_token_networks:
-            raise InvalidAddress("token is not registered.")
+            raise InvalidBinaryAddress("token is not registered.")
 
         manager = self.tokennetworkaddrs_to_connectionmanagers.get(token_network_address)
 

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -12,7 +12,6 @@ from raiden.constants import (
 )
 from raiden.exceptions import (
     BrokenPreconditionError,
-    InvalidAddress,
     InvalidChannelID,
     InvalidSettleTimeout,
     RaidenRecoverableError,
@@ -125,7 +124,7 @@ def test_token_network_proxy(
     )
 
     msg = "Hex encoded addresses are not supported, an exception must be raised"
-    with pytest.raises(InvalidAddress):
+    with pytest.raises(ValueError):
         c1_token_network_proxy.get_channel_identifier(
             participant1=to_checksum_address(c1_client.address),
             participant2=to_checksum_address(c2_client.address),

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -265,7 +265,7 @@ def run_test_transfer_to_unknownchannel(raiden_network, token_addresses):
     token_address = token_addresses[0]
     str_address = "\xf0\xef3\x01\xcd\xcfe\x0f4\x9c\xf6d\xa2\x01?X4\x84\xa9\xf1"
 
-    # Enforce sandwhich encoding. Calling `transfer` with a non binary address
+    # Enforce sandwich encoding. Calling `transfer` with a non binary address
     # raises an exception
     with pytest.raises(InvalidBinaryAddress):
         RaidenAPI(app0.raiden).transfer(

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -16,7 +16,7 @@ from raiden.exceptions import (
     DepositOverLimit,
     InsufficientFunds,
     InsufficientGasReserve,
-    InvalidAddress,
+    InvalidBinaryAddress,
 )
 from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils.client import burn_eth
@@ -263,15 +263,16 @@ def test_transfer_to_unknownchannel(raiden_network, token_addresses):
 def run_test_transfer_to_unknownchannel(raiden_network, token_addresses):
     app0, _ = raiden_network
     token_address = token_addresses[0]
-    non_existing_address = "\xf0\xef3\x01\xcd\xcfe\x0f4\x9c\xf6d\xa2\x01?X4\x84\xa9\xf1"
+    str_address = "\xf0\xef3\x01\xcd\xcfe\x0f4\x9c\xf6d\xa2\x01?X4\x84\xa9\xf1"
 
-    with pytest.raises(InvalidAddress):
-        # sending to an unknown/non-existant address
+    # Enforce sandwhich encoding. Calling `transfer` with a non binary address
+    # raises an exception
+    with pytest.raises(InvalidBinaryAddress):
         RaidenAPI(app0.raiden).transfer(
             app0.raiden.default_registry.address,
             token_address,
             10,
-            target=non_existing_address,
+            target=str_address,
             transfer_timeout=10,
         )
 

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -22,7 +22,7 @@ from web3 import Web3
 
 import raiden
 from raiden import constants
-from raiden.exceptions import InvalidAddress
+from raiden.exceptions import InvalidChecksummedAddress
 from raiden.utils.signing import sha3  # noqa
 from raiden.utils.typing import (
     Address,
@@ -64,10 +64,10 @@ def address_checksum_and_decode(addr: str) -> Address:
         checksummed according to EIP55 specification
     """
     if not is_0x_prefixed(addr):
-        raise InvalidAddress("Address must be 0x prefixed")
+        raise InvalidChecksummedAddress("Address must be 0x prefixed")
 
     if not is_checksum_address(addr):
-        raise InvalidAddress("Address must be EIP55 checksummed")
+        raise InvalidChecksummedAddress("Address must be EIP55 checksummed")
 
     addr_bytes = decode_hex(addr)
     assert len(addr_bytes) in (20, 0)

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -17,7 +17,7 @@ from click.formatting import iter_rows, measure_table, wrap_text
 from pytoml import TomlError, load
 from web3.gas_strategies.time_based import fast_gas_price_strategy, medium_gas_price_strategy
 
-from raiden.exceptions import InvalidAddress
+from raiden.exceptions import InvalidChecksummedAddress
 from raiden.utils import address_checksum_and_decode
 from raiden_contracts.constants import NETWORKNAME_TO_ID
 
@@ -229,7 +229,7 @@ class AddressType(click.ParamType):
     def convert(self, value, param, ctx):  # pylint: disable=unused-argument
         try:
             return address_checksum_and_decode(value)
-        except InvalidAddress as e:
+        except InvalidChecksummedAddress as e:
             self.fail(str(e))
 
 


### PR DESCRIPTION
~review/merge after #4389~

    Changes to Address exceptions

    - Split exceptions used for checksummed and binary addresses.
    - Added an exception for unexisting channel, instead of using the
      invalid address exception, which is misleading.
    - Extended the docstring of the exceptions explaining their usage.
    - Remove a try-block in the matrix transport. Andre mentioned it is not
      necessary anymore.