### PR TITLE
Fixed race condition on test with entire deposit

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -15,7 +15,12 @@ from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
-from raiden.tests.utils.transfer import assert_synced_channel_state, transfer, wait_assert
+from raiden.tests.utils.transfer import (
+    assert_synced_channel_state,
+    transfer,
+    transfer_and_assert_path,
+    wait_assert,
+)
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
 from raiden.transfer.state_change import ActionChannelUpdateFee
@@ -185,18 +190,18 @@ def run_test_mediated_transfer_with_entire_deposit(
     token_network_address = views.get_token_network_address_by_token_address(
         chain_state, payment_network_address, token_address
     )
-    transfer(
-        initiator_app=app0,
-        target_app=app2,
+
+    transfer_and_assert_path(
+        path=raiden_network,
         token_address=token_address,
         amount=deposit,
         identifier=1,
         timeout=network_wait * number_of_nodes,
     )
 
-    transfer(
-        initiator_app=app2,
-        target_app=app0,
+    reverse_path = list(raiden_network[::-1])
+    transfer_and_assert_path(
+        path=reverse_path,
         token_address=token_address,
         amount=deposit * 2,
         identifier=2,


### PR DESCRIPTION
The test was not waiting for the mediator to synchronize with the first
transfer, so this was possible:

- App0 sends LockedTransfer to App1, which forwards it to App2
- App2 requests the secret and reveals it backwards
- App0 and App1 send the unlock (but none receive yet)
- App2 receives the unlock

At the point above, from App0's perspective the transfer is completed,
the unlock has been sent. Same thing for the App2, the Unlock has been
received, however that is not the same thing for App1.

If the second transfer is started fast enough, it is possible that App1
will reject the payment because the channel App1->App0 doesn't yet have
enough capacity (the 200 tokens are still locked from App1's
perspective).