### PR TITLE
 Tighten (de-)serialization error handling

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -212,10 +212,6 @@ class TransactionThrew(RaidenError):
         super().__init__(f"{txname} transaction threw. Receipt={receipt}")
 
 
-class InvalidProtocolMessage(RaidenError):
-    """Raised on an invalid or an unknown Raiden protocol message"""
-
-
 class APIServerPortInUseError(RaidenError):
     """Raised when API server port is already in use"""
 
@@ -306,3 +302,7 @@ class TokenNetworkDeprecated(RaidenError):
 
 class MintFailed(RaidenError):
     """ Raised when an attempt to mint a testnet token failed. """
+
+
+class SerializationError(RaidenError):
+    """ Invalid data are to be (de-)serialized. """

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -34,7 +34,7 @@ from gevent.event import Event
 from gevent.lock import Semaphore
 from matrix_client.errors import MatrixError, MatrixRequestError
 
-from raiden.exceptions import InvalidProtocolMessage, InvalidSignature, TransportError
+from raiden.exceptions import InvalidSignature, SerializationError, TransportError
 from raiden.messages import Message, SignedMessage
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.utils import get_http_rtt
@@ -560,17 +560,9 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
             continue
         try:
             message = JSONSerializer.deserialize(line)
-        except (UnicodeDecodeError, json.JSONDecodeError) as ex:
+        except SerializationError as ex:
             log.warning(
-                "Can't parse Message data JSON",
-                message_data=line,
-                peer_address=to_checksum_address(peer_address),
-                _exc=ex,
-            )
-            continue
-        except InvalidProtocolMessage as ex:
-            log.warning(
-                "Message data JSON is not a valid Message",
+                "Not a valid Message",
                 message_data=line,
                 peer_address=to_checksum_address(peer_address),
                 _exc=ex,

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -231,20 +231,22 @@ def test_sending_nonstring_body(  # pylint: disable=unused-argument
     assert not m._handle_message(room, event)
 
 
+@pytest.mark.parametrize(
+    "message_input", ['{"this": 1, "message": 5, "is": 3, "not_valid": 5}', "["]
+)
 def test_processing_invalid_message_json(  # pylint: disable=unused-argument
-    mock_matrix, skip_userid_validation
+    mock_matrix, skip_userid_validation, message_input
 ):
     m = mock_matrix
-    invalid_message = '{"this": 1, "message": 5, "is": 3, "not_valid": 5}'
-    room, event = make_message(overwrite_data=invalid_message)
+    room, event = make_message(overwrite_data=message_input)
     assert not m._handle_message(room, event)
 
 
-def test_processing_invalid_message_cmdid_json(  # pylint: disable=unused-argument
+def test_processing_invalid_message_type_json(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation
 ):
     m = mock_matrix
-    invalid_message = '{"type": "NonExistentMessage", "is": 3, "not_valid": 5}'
+    invalid_message = '{"_type": "NonExistentMessage", "is": 3, "not_valid": 5}'
     room, event = make_message(overwrite_data=invalid_message)
     assert not m._handle_message(room, event)
 

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -16,7 +16,7 @@ from raiden.storage.sqlite import (
 from raiden.storage.utils import TimestampedEvent
 from raiden.storage.wal import WriteAheadLog, restore_to_state_change
 from raiden.tests.utils import factories
-from raiden.transfer.architecture import State, StateManager, TransitionResult
+from raiden.transfer.architecture import State, StateChange, StateManager, TransitionResult
 from raiden.transfer.events import EventPaymentSentFailed
 from raiden.transfer.state_change import Block, ContractReceiveChannelBatchUnlock
 from raiden.utils import sha3
@@ -122,7 +122,7 @@ def test_write_read_log():
 
     # Make sure state snapshot can only go for corresponding state change ids
     with pytest.raises(sqlite3.IntegrityError):
-        wal.storage.write_state_snapshot(34, "AAAA")
+        wal.storage.write_state_snapshot(State(), "AAAA")
 
 
 def test_timestamped_event():
@@ -158,7 +158,7 @@ def test_write_read_events():
 
     previous_events = wal.storage.get_events_with_timestamps()
 
-    state_change_ids = wal.storage.write_state_changes(["statechangedata"])
+    state_change_ids = wal.storage.write_state_changes([StateChange()])
     wal.storage.write_events([(state_change_ids[0], event)])
 
     new_events = wal.storage.get_events_with_timestamps()


### PR DESCRIPTION
Reraise any exceptions during (de-)serialization as a unified `SerializationError`.

Fix the handling of this in the Transport since the previous implementation was broken (and therefore presented a DoS vector) with the move to dataclasses.