### PR TITLE
enforcing `pending` as the block_identifier for estimate_gas

### DIFF
--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -156,9 +156,7 @@ class SecretRegistry:
         log_details: Dict[Any, Any],
     ) -> None:
         checking_block = self.client.get_checking_block()
-        gas_limit = self.proxy.estimate_gas(
-            checking_block, "registerSecretBatch", secrets_to_register
-        )
+        gas_limit = self.proxy.estimate_gas("pending", "registerSecretBatch", secrets_to_register)
         receipt = None
         transaction_hash = None
         msg = None

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -93,7 +93,7 @@ class ServiceRegistry:
             raise BrokenPreconditionError(msg)
 
         with log_transaction(log, "set_url", log_details):
-            gas_limit = self.proxy.estimate_gas("latest", "setURL", url)
+            gas_limit = self.proxy.estimate_gas("pending", "setURL", url)
             if not gas_limit:
                 msg = f"URL {url} is invalid"
                 raise RaidenUnrecoverableError(msg)

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -72,10 +72,9 @@ class Token:
             }
 
             with log_transaction(log, "approve", log_details):
-                checking_block = self.client.get_checking_block()
                 error_prefix = "Call to approve will fail"
                 gas_limit = self.proxy.estimate_gas(
-                    checking_block, "approve", to_checksum_address(allowed_address), allowance
+                    "pending", "approve", to_checksum_address(allowed_address), allowance
                 )
 
                 if gas_limit:
@@ -186,7 +185,7 @@ class Token:
             with log_transaction(log, "transfer", log_details):
                 checking_block = self.client.get_checking_block()
                 gas_limit = self.proxy.estimate_gas(
-                    checking_block, "transfer", to_checksum_address(to_address), amount
+                    "pending", "transfer", to_checksum_address(to_address), amount
                 )
                 failed_receipt = None
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -289,9 +289,8 @@ class TokenNetwork:
     def _new_netting_channel(
         self, partner: Address, settle_timeout: int, log_details: Dict[Any, Any]
     ) -> ChannelID:
-        checking_block = self.client.get_checking_block()
         gas_limit = self.proxy.estimate_gas(
-            checking_block,
+            "pending",
             "openChannel",
             participant1=self.node_address,
             participant2=partner,
@@ -849,7 +848,6 @@ class TokenNetwork:
         previous_total_deposit: TokenAmount,
         log_details: Dict[Any, Any],
     ) -> None:
-        checking_block = self.client.get_checking_block()
         amount_to_deposit = TokenAmount(total_deposit - previous_total_deposit)
 
         # If there are channels being set up concurrently either the
@@ -873,7 +871,7 @@ class TokenNetwork:
         self.token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
 
         gas_limit = self.proxy.estimate_gas(
-            checking_block,
+            "pending",
             "setTotalDeposit",
             channel_identifier=channel_identifier,
             participant=self.node_address,
@@ -1300,10 +1298,8 @@ class TokenNetwork:
         participant_signature: Signature,
         log_details: Dict[Any, Any],
     ) -> None:
-        checking_block = self.client.get_checking_block()
-
         gas_limit = self.proxy.estimate_gas(
-            checking_block,
+            "pending",
             "setTotalWithdraw",
             channel_identifier=channel_identifier,
             participant=participant,
@@ -1540,9 +1536,8 @@ class TokenNetwork:
         log_details: Dict[Any, Any],
     ) -> None:
         with self.channel_operations_lock[partner]:
-            checking_block = self.client.get_checking_block()
             gas_limit = self.proxy.estimate_gas(
-                checking_block,
+                "pending",
                 "closeChannel",
                 channel_identifier=channel_identifier,
                 partner=partner,
@@ -1794,9 +1789,8 @@ class TokenNetwork:
         non_closing_signature: Signature,
         log_details: Dict[Any, Any],
     ) -> None:
-        checking_block = self.client.get_checking_block()
         gas_limit = self.proxy.estimate_gas(
-            checking_block,
+            "pending",
             "updateNonClosingBalanceProof",
             channel_identifier=channel_identifier,
             closing_participant=partner,
@@ -2067,10 +2061,9 @@ class TokenNetwork:
         given_block_identifier: BlockSpecification,
         log_details: Dict[Any, Any],
     ) -> None:
-        checking_block = self.client.get_checking_block()
         leaves_packed = b"".join(pending_locks.locks)
         gas_limit = self.proxy.estimate_gas(
-            checking_block,
+            "pending",
             "unlock",
             channel_identifier=channel_identifier,
             receiver=receiver,
@@ -2285,8 +2278,6 @@ class TokenNetwork:
         partner_locksroot: Locksroot,
         log_details: Dict[Any, Any],
     ):
-        checking_block = self.client.get_checking_block()
-
         # The second participant transferred + locked amount must be higher
         our_maximum = transferred_amount + locked_amount
         partner_maximum = partner_transferred_amount + partner_locked_amount
@@ -2315,7 +2306,7 @@ class TokenNetwork:
             }
 
         gas_limit = self.proxy.estimate_gas(
-            checking_block, "settleChannel", channel_identifier=channel_identifier, **kwargs
+            "pending", "settleChannel", channel_identifier=channel_identifier, **kwargs
         )
 
         if gas_limit:

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -146,13 +146,12 @@ class TokenNetworkRegistry:
         }
 
         with log_transaction(log, "add_token", log_details):
-            checking_block = self.client.get_checking_block()
             error_prefix = "Call to createERC20TokenNetwork will fail"
 
             kwarguments = {"_token_address": token_address}
             kwarguments.update(additional_arguments)
             gas_limit = self.proxy.estimate_gas(
-                checking_block, "createERC20TokenNetwork", **kwarguments
+                "pending", "createERC20TokenNetwork", **kwarguments
             )
 
             if gas_limit:
@@ -174,7 +173,7 @@ class TokenNetworkRegistry:
                 if transaction_executed:
                     block = receipt_or_none["blockNumber"]
                 else:
-                    block = checking_block
+                    block = self.client.get_checking_block()
 
                 required_gas = (
                     gas_limit

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -207,9 +207,8 @@ class UserDeposit:
     ):
         token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
 
-        checking_block = self.client.get_checking_block()
         gas_limit = self.proxy.estimate_gas(
-            checking_block, "deposit", to_checksum_address(beneficiary), total_deposit
+            "pending", "deposit", to_checksum_address(beneficiary), total_deposit
         )
 
         if not gas_limit:

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_filters_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_filters_assumptions.py
@@ -6,9 +6,8 @@ def test_filter_start_block_inclusive(deploy_client):
     """ A filter includes events from the block given in from_block """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
-    check_block = deploy_client.get_checking_block()
     # call the create event function twice and wait for confirmation each time
-    startgas = safe_gas_limit(contract_proxy.estimate_gas(check_block, "createEvent", 1))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas("pending", "createEvent", 1))
     transaction_1 = contract_proxy.transact("createEvent", startgas, 1)
     deploy_client.poll(transaction_1)
     transaction_2 = contract_proxy.transact("createEvent", startgas, 2)
@@ -37,9 +36,8 @@ def test_filter_end_block_inclusive(deploy_client):
     until and including end_block. """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
-    check_block = deploy_client.get_checking_block()
     # call the create event function twice and wait for confirmation each time
-    startgas = safe_gas_limit(contract_proxy.estimate_gas(check_block, "createEvent", 1))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas("pending", "createEvent", 1))
     transaction_1 = contract_proxy.transact("createEvent", startgas, 1)
     deploy_client.poll(transaction_1)
     transaction_2 = contract_proxy.transact("createEvent", startgas, 2)

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -12,8 +12,7 @@ def test_estimate_gas_fail(deploy_client):
     address = contract_proxy.contract_address
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
-    check_block = deploy_client.get_checking_block()
-    assert not contract_proxy.estimate_gas(check_block, "fail")
+    assert not contract_proxy.estimate_gas("pending", "fail")
 
 
 def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(
@@ -36,7 +35,5 @@ def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(
     # block_identifier for eth_estimateGas. The test should not be flaky
     # because number_iterations is order of magnitudes larger then it needs to
     # be
-    block_identifier = None
-
-    startgas = contract_proxy.estimate_gas(block_identifier, "waste_storage", number_iterations)
+    startgas = contract_proxy.estimate_gas("pending", "waste_storage", number_iterations)
     assert startgas is None, "estimate_gas must return empty if sending the transaction would fail"

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
@@ -40,8 +40,7 @@ def test_duplicated_transaction_same_gas_price_raises(deploy_client):
         contract_proxy.contract.abi, contract_proxy.contract_address
     )
 
-    check_block = deploy_client.get_checking_block()
-    gas_estimate = contract_proxy.estimate_gas(check_block, "ret")
+    gas_estimate = contract_proxy.estimate_gas("pending", "ret")
     assert gas_estimate, "Gas estimation should not fail here"
     startgas = safe_gas_limit(gas_estimate)
 
@@ -65,8 +64,7 @@ def test_duplicated_transaction_different_gas_price_raises(deploy_client):
         contract_proxy.contract.abi, contract_proxy.contract_address
     )
 
-    check_block = deploy_client.get_checking_block()
-    startgas = safe_gas_limit(contract_proxy.estimate_gas(check_block, "ret"))
+    startgas = safe_gas_limit(contract_proxy.estimate_gas("pending", "ret"))
 
     with pytest.raises(ReplacementTransactionUnderpriced):
         second_proxy.transact("ret", startgas)

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -15,8 +15,7 @@ def test_transact_opcode(deploy_client):
     address = contract_proxy.contract_address
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
-    check_block = deploy_client.get_checking_block()
-    startgas = contract_proxy.estimate_gas(check_block, "ret") * 2
+    startgas = contract_proxy.estimate_gas("pending", "ret") * 2
 
     transaction = contract_proxy.transact("ret", startgas)
     deploy_client.poll(transaction)
@@ -48,8 +47,7 @@ def test_transact_opcode_oog(deploy_client):
     assert len(deploy_client.web3.eth.getCode(to_checksum_address(address))) > 0
 
     # divide the estimate by 2 to run into out-of-gas
-    check_block = deploy_client.get_checking_block()
-    startgas = safe_gas_limit(contract_proxy.estimate_gas(check_block, "loop", 1000)) // 2
+    startgas = safe_gas_limit(contract_proxy.estimate_gas("pending", "loop", 1000)) // 2
 
     transaction = contract_proxy.transact("loop", startgas, 1000)
     deploy_client.poll(transaction)
@@ -64,9 +62,7 @@ def test_transact_fail_if_the_account_does_not_have_enough_eth_to_pay_for_thegas
     """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
-    check_block = deploy_client.get_checking_block()
-
-    startgas = contract_proxy.estimate_gas(check_block, "loop", 1000)
+    startgas = contract_proxy.estimate_gas("pending", "loop", 1000)
     assert startgas, "The gas estimation should not have failed."
 
     burn_eth(deploy_client, amount_to_leave=startgas // 2)

--- a/raiden/tests/integration/rpc/test_assumptions_geth.py
+++ b/raiden/tests/integration/rpc/test_assumptions_geth.py
@@ -3,25 +3,17 @@ import pytest
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 from raiden.utils import safe_gas_limit
 
-pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
+pytestmark = pytest.mark.usefixtures("skip_if_not_geth")
 
 # set very low values to force the client to prune old state
-STATE_PRUNING = {
-    "pruning": "fast",
-    "pruning-history": 1,
-    "pruning-memory": 1,
-    "cache-size-db": 1,
-    "cache-size-blocks": 1,
-    "cache-size-queue": 1,
-    "cache-size": 1,
-}
+STATE_PRUNNING = {"cache": 1, "trie-cache-gens": 1}
 
 
-@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNING])
-def test_parity_request_prunned_data_raises_an_exception(deploy_client):
+@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNNING])
+def test_geth_request_prunned_data_raises_an_exception(deploy_client):
     """ Interacting with an old block identifier with a pruning client throws. """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
-    iterations = 1000
+    iterations = 500
 
     def send_transaction():
         startgas = contract_proxy.estimate_gas("pending", "waste_storage", iterations)
@@ -33,7 +25,7 @@ def test_parity_request_prunned_data_raises_an_exception(deploy_client):
     first_receipt = send_transaction()
     pruned_block_number = first_receipt["blockNumber"]
 
-    for _ in range(10):
+    for _ in range(500):
         send_transaction()
 
     with pytest.raises(ValueError):

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -98,8 +98,7 @@ def run_test_locksroot_loading_during_channel_settle_handling(
     iterations = 1000
 
     def send_transaction():
-        check_block = deploy_client.get_checking_block()
-        startgas = contract_proxy.estimate_gas(check_block, "waste_storage", iterations)
+        startgas = contract_proxy.estimate_gas("pending", "waste_storage", iterations)
         startgas = safe_gas_limit(startgas)
         transaction = contract_proxy.transact("waste_storage", startgas, iterations)
         deploy_client.poll(transaction)

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -137,7 +137,9 @@ def compile_files_cwd(*args: Any, **kwargs: Any) -> str:
     return compiled_contracts
 
 
-def deploy_rpc_test_contract(deploy_client, name: str):
+def deploy_rpc_test_contract(
+    deploy_client: JSONRPCClient, name: str
+) -> Tuple[ContractProxy, typing.Dict]:
     contract_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "smart_contracts", f"{name}.sol")
     )

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -224,7 +224,12 @@ def safe_gas_limit(*estimates: int) -> int:
     """ Calculates a safe gas limit for a number of gas estimates
     including a security margin
     """
-    assert None not in estimates, "if estimateGas returned None it should not reach here"
+    msg = (
+        "estimateGas returns None when the transaction execution would fail. "
+        "This may happen either because a revert/assert is hit, or the required "
+        "startgas is larger then the current block gas limit."
+    )
+    assert None not in estimates, msg
     calculated_limit = max(estimates)
     return int(calculated_limit * constants.GAS_FACTOR)
 

--- a/raiden/utils/testnet.py
+++ b/raiden/utils/testnet.py
@@ -62,7 +62,7 @@ def call_minting_method(
     """
     method = contract_method.value
 
-    gas_limit = proxy.estimate_gas("latest", method, *args)
+    gas_limit = proxy.estimate_gas("pending", method, *args)
     if gas_limit is None:
         raise MintFailed(
             f"Gas estimation failed. Make sure the token has a "


### PR DESCRIPTION
This forces the gas estimation to be done against the pending block,
because this is the only mode supported by the Geth client. Using any
other block identifier may lead to different behavior on different
clients.