### PR TITLE
Reverted pytest-timeout timeout_func_only

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -164,27 +164,6 @@ def insecure_tls():
     make_requests_insecure()
 
 
-@pytest.hookimpl
-def pytest_configure():
-    """ Workaround ``func_only`` bug in ``pytest-timeout``.
-    A bug in the code handling the ``func_only`` option in ``pytest-timeout`` caused the setting
-    to be ignored on any test that set a custom timeout via a pytest marker.
-    See: https://bitbucket.org/pytest-dev/pytest-timeout/issues/36
-    """
-
-    import pytest_timeout
-
-    def _validate_func_only(func_only, where):
-        if where == "config file":
-            if func_only is None:
-                return False
-            if not isinstance(func_only, bool):
-                raise ValueError(f"Invalid func_only value {func_only} from {where}")
-        return func_only
-
-    pytest_timeout._validate_func_only = _validate_func_only
-
-
 def pytest_generate_tests(metafunc):
     fixtures = metafunc.fixturenames
 

--- a/raiden/tests/integration/cli/test_cli_production.py
+++ b/raiden/tests/integration/cli/test_cli_production.py
@@ -20,15 +20,17 @@ pytestmark = [
     ),
 ]
 
+TIMEOUT = 120
 
-@pytest.mark.timeout(65)
+
+@pytest.mark.timeout(TIMEOUT)
 def test_cli_full_init(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     # expect the default mode
     expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("changed_args", [{"keystore_path": "."}])
 def test_cli_wrong_keystore_path(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -36,7 +38,7 @@ def test_cli_wrong_keystore_path(cli_args, raiden_spawner):
     child.expect("No Ethereum accounts found in the provided keystore directory")
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("removed_args", [["password_file"]])
 def test_cli_missing_password_file_enter_password(raiden_testchain, cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -49,14 +51,14 @@ def test_cli_missing_password_file_enter_password(raiden_testchain, cli_args, ra
     expect_cli_successful_connected(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("removed_args", [["data_dir"]])
 def test_cli_missing_data_dir(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT_VALUE)
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("changed_args", [{"eth_rpc_endpoint": "http://8.8.8.8:2020"}])
 def test_cli_wrong_rpc_endpoint(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -65,7 +67,7 @@ def test_cli_wrong_rpc_endpoint(cli_args, raiden_spawner):
     child.expect(".*Could not contact the Ethereum node through JSON-RPC.")
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("changed_args", [{"network_id": "42"}])
 def test_cli_wrong_network_id_try_kovan(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -73,7 +75,7 @@ def test_cli_wrong_network_id_try_kovan(cli_args, raiden_spawner):
     child.expect("The configured network.*differs from the Ethereum client's network")
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize(
     "changed_args",
     [

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ omit =
 
 [tool:pytest]
 timeout = 540
-timeout_func_only = true
 norecursedirs = node_modules
 ; Ignore warnings:
 ; - grequests monkeypatch


### PR DESCRIPTION
That configuration flag was enabled because the fixture teardown for the
parity private chain was hanging. The hanging caused timeouts for some
tests, which made the build flaky. Because of this the flag was added,
making the test fail only if running it took too long.

The problem with the above approach is that it does not remove the
flakyness of the fixture. The fixture teardown may still hang, and
without the timeout exception it will be killed by the continious
integrations timeout, which does not produce logs, making it hard to
debug the issue.