### PR TITLE
[experiment] Make get_channel_identifier fail

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -397,6 +397,8 @@ class TokenNetwork:
             InvalidAddress: If either of the address is an invalid type or the
                 null address.
         """
+        raise RuntimeError("get_channel_identifier called")
+
         raise_if_invalid_address_pair(participant1, participant2)
 
         channel_identifier = self.proxy.contract.functions.getChannelIdentifier(


### PR DESCRIPTION
This is an experiment before removing getChannelIdentifier() function
from the TokenNetwork contract.

Sorry for abusing the CIs.

If CIs pass, this PR will remove get_channel_identifier() function.