### PR TITLE
Extended logging for the HTTPExecutor

### DIFF
--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -124,6 +124,23 @@ class HTTPExecutor(MiHTTPExecutor):
             raise
         return self
 
+    def kill(self):
+        log.debug("Executor process: killing process", command=self.command)
+        super().kill()
+        log.debug("Executor process: process killed", command=self.command)
+
+    def wait_for(self, wait_for):
+        log.debug(
+            "Executor process: waiting", command=self.command, until=self._endtime, now=time.time()
+        )
+        super().wait_for(wait_for)
+        log.debug(
+            "Executor process: waiting ended",
+            command=self.command,
+            until=self._endtime,
+            now=time.time(),
+        )
+
     def running(self) -> bool:
         """ Include pre_start_check in running, so stop will wait for the underlying listener """
         return super().running() or self.pre_start_check()

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -125,9 +125,19 @@ class HTTPExecutor(MiHTTPExecutor):
         return self
 
     def kill(self):
+        STDOUT = subprocess.STDOUT  # pylint: disable=no-member
+
+        ps_fax = subprocess.check_output(["ps", "fax"], stderr=STDOUT)
+
         log.debug("Executor process: killing process", command=self.command)
+        log.debug("EXecutor process: current processes", ps_fax=ps_fax)
+
         super().kill()
+
+        ps_fax = subprocess.check_output(["ps", "fax"], stderr=STDOUT)
+
         log.debug("Executor process: process killed", command=self.command)
+        log.debug("EXecutor process: current processes", ps_fax=ps_fax)
 
     def wait_for(self, wait_for):
         log.debug(

--- a/raiden/utils/http.py
+++ b/raiden/utils/http.py
@@ -13,7 +13,7 @@ from urllib.parse import urlunparse
 import structlog
 from gevent import subprocess
 from mirakuru.base import ENV_UUID
-from mirakuru.exceptions import AlreadyRunning, ProcessExitedWithError
+from mirakuru.exceptions import AlreadyRunning, ProcessExitedWithError, TimeoutExpired
 from mirakuru.http import HTTPConnection, HTTPException, HTTPExecutor as MiHTTPExecutor
 
 T_IO_OR_INT = Union[IO, int]
@@ -140,16 +140,25 @@ class HTTPExecutor(MiHTTPExecutor):
         log.debug("EXecutor process: current processes", ps_fax=ps_fax)
 
     def wait_for(self, wait_for):
-        log.debug(
-            "Executor process: waiting", command=self.command, until=self._endtime, now=time.time()
-        )
-        super().wait_for(wait_for)
-        log.debug(
-            "Executor process: waiting ended",
-            command=self.command,
-            until=self._endtime,
-            now=time.time(),
-        )
+        while self.check_timeout():
+            log.debug(
+                "Executor process: waiting",
+                command=self.command,
+                until=self._endtime,
+                now=time.time(),
+            )
+            if wait_for():
+                log.debug(
+                    "Executor process: waiting ended",
+                    command=self.command,
+                    until=self._endtime,
+                    now=time.time(),
+                )
+                return self
+            time.sleep(self._sleep)
+
+        self.kill()
+        raise TimeoutExpired(self, timeout=self._timeout)
 
     def running(self) -> bool:
         """ Include pre_start_check in running, so stop will wait for the underlying listener """


### PR DESCRIPTION
This adds logs around the wait_for operation and the kill methods. The
intention is to know if and when the managed processed is killed.