### PR TITLE
Test timeout fix

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -201,20 +201,19 @@ def pytest_runtest_setup(item):
         else:
             timeout = marker.kwargs["timeout"]
 
-    if timeout is None or timeout <= 0:
-        return
+    if isinstance(timeout, (int, float)) and timeout > 0:
 
-    def handler(signum, frame):  # pylint: disable=unused-argument
-        gevent.util.print_run_info()
-        pytest.fail(f"Timeout >{timeout}s")
+        def handler(signum, frame):  # pylint: disable=unused-argument
+            gevent.util.print_run_info()
+            pytest.fail(f"Timeout >{timeout}s")
 
-    def cancel():
-        signal.setitimer(signal.ITIMER_REAL, 0)
-        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+        def cancel():
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
-    item.cancel_timeout = cancel
-    signal.signal(signal.SIGALRM, handler)
-    signal.setitimer(signal.ITIMER_REAL, timeout)
+        item.cancel_timeout = cancel
+        signal.signal(signal.SIGALRM, handler)
+        signal.setitimer(signal.ITIMER_REAL, timeout)
 
     yield
 

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -135,7 +135,6 @@ pysha3==1.0.2
 pytest-forked==1.0.2
 pytest-random==0.2
 pytest-select==0.1.2
-pytest-timeout==1.3.3
 pytest-xdist==1.28.0
 pytest==4.6.3
 python-dateutil==2.8.0

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -23,7 +23,6 @@ black==19.3b0
 # Testing
 pytest
 pytest-random
-pytest-timeout
 pytest-select
 pytest-xdist
 grequests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -130,7 +130,6 @@ pysha3==1.0.2
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-random==0.2
 pytest-select==0.1.2
-pytest-timeout==1.3.3
 pytest-xdist==1.28.0
 pytest==4.6.3
 python-dateutil==2.8.0    # via pysaml2

--- a/tools/pip-compile-wrapper.py
+++ b/tools/pip-compile-wrapper.py
@@ -282,15 +282,14 @@ def main() -> None:
     parser.add_argument("-v", "--verbose", action="store_true", default=False)
     parser.add_argument("-n", "--dry-run", action="store_true", default=False)
 
-    commands = parser.add_subparsers(title="Sub-commands")
-    compile_parser = commands.add_parser(
+    commands = parser.add_subparsers(title="Sub-commands", required=True, dest="command")
+    commands.add_parser(
         "compile",
         help=(
             "Compile source files. "
             "Keep current versions unless changed requirements force newer versions."
         ),
     )
-    compile_parser.set_defaults(command="compile")
 
     upgrade_parser = commands.add_parser(
         "upgrade",
@@ -300,7 +299,6 @@ def main() -> None:
         ),
     )
     upgrade_parser.add_argument("packages", metavar="package", nargs="*")
-    upgrade_parser.set_defaults(command="upgrade")
 
     parsed = parser.parse_args()
     _ensure_pip_tools()


### PR DESCRIPTION
```
Removes a corner were a timeout kills the test suite.

`pytest-timeout` uses the `pytest_runtest_protocol` hook to install and
clear the timeout handlers. The problem is that this hook does not
handle exceptions, there are a few places were an exception can be
raised and result in a build failure because pytest itself is killed.

This change makes the period of time were a timeout can be raised
shorter. This is achieve by installing the signal inside
`pytest_runtest_setup`, and uinstalling it at `pytest_runtest_teardown`.

Ideally an exception should only be raised while execution is inside
`pytest_runtest_setup`, `pytest_runtest_call` or
`pytest_runtest_teardown`, but **not** in-between these calls. However there is no
hook available for that and this change would require additional complex
logic.

This means that even with this change, there is still the possibility of
a timeout raising an exception and resulting in an internal error.

This change also prints the stack traces of the greenlets, and not just
the python threads, this can be useful to find deadlocks.
```