### PR TITLE
Stop tests before ci kill it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,21 +369,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            mkdir -p test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>
-            coverage run \
-              --include="~/raiden/**/*" \
-              --parallel-mode \
-              --module pytest \
-              raiden/tests \
-              -vvvvvv \
-              --log-config='raiden:DEBUG' \
-              --random \
-              --junit-xml=test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>/results.xml \
-              --blockchain-type=<< parameters.blockchain-type >> \
-              --select-fail-on-missing \
-              --select-from-file selected-tests.txt \
-              << parameters.additional-args >>
-
+            .circleci/run_tests.sh "test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>" "<< parameters.blockchain-type >>" << parameters.additional-args >>
       - run:
           name: Store coverage
           command: |

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -35,6 +35,7 @@ dormant_signal=SIGUSR1
     --module pytest \
     raiden/tests \
     -vvvvvv \
+    --color=yes \
     --log-config='raiden:DEBUG' \
     --random \
     --junit-xml=${test_report_dir}/results.xml \

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -14,13 +14,16 @@ mkdir -p ${test_report_dir}
 # Using 9min as the dormant timeout, CircleCI will kill the container after
 # 10min
 # https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit
-dormant_timeout=540
+#
+# This value should be larger than our tests timeout configuration, the default
+# is defined at setup.cfg under the section `[tool:pytest]`.
+dormant_timeout=570
 
 # This signal is installed in
 # raiden/tests/conftest.py::auto_enable_gevent_monitoring_signal
 dormant_signal=SIGUSR1
 
-./tools/kill_if_no_output.py
+./tools/kill_if_no_output.py \
     --dormant-timeout=${dormant_timeout} \
     --dormant-signal=${dormant_signal} \
     --kill-timeout=15 \
@@ -38,4 +41,4 @@ dormant_signal=SIGUSR1
     --blockchain-type=${blockchain_type} \
     --select-fail-on-missing \
     --select-from-file selected-tests.txt \
-    ${@}
+    "${@}"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+test_report_dir=$1
+blockchain_type=$2
+
+# Remove the above arguments, every thing extra will be passed down to coverage
+shift 2
+
+mkdir -p ${test_report_dir}
+
+# Using 9min as the dormant timeout, CircleCI will kill the container after
+# 10min
+# https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit
+dormant_timeout=540
+
+# This signal is installed in
+# raiden/tests/conftest.py::auto_enable_gevent_monitoring_signal
+dormant_signal=SIGUSR1
+
+./tools/kill_if_no_output.py
+    --dormant-timeout=${dormant_timeout} \
+    --dormant-signal=${dormant_signal} \
+    --kill-timeout=15 \
+    --kill-signal=SIGKILL \
+    coverage \
+    run \
+    --include="~/raiden/**/*" \
+    --parallel-mode \
+    --module pytest \
+    raiden/tests \
+    -vvvvvv \
+    --log-config='raiden:DEBUG' \
+    --random \
+    --junit-xml=${test_report_dir}/results.xml \
+    --blockchain-type=${blockchain_type} \
+    --select-fail-on-missing \
+    --select-from-file selected-tests.txt \
+    ${@}

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -34,7 +34,6 @@ from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
-from raiden.utils.debugging import enable_gevent_monitoring_signal
 
 
 def pytest_addoption(parser):
@@ -66,9 +65,15 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def auto_enable_gevent_monitoring_signal():
-    enable_gevent_monitoring_signal()
+@pytest.fixture(autouse=True)
+def auto_enable_gevent_monitoring_signal(capsys):
+    import gevent.util
+
+    def on_signal(signalnum, stack_frame):  # pylint: disable=unused-argument
+        with capsys.disabled():
+            gevent.util.print_run_info()
+
+    signal.signal(signal.SIGUSR1, on_signal)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -38,6 +38,6 @@ def raise_on_failure(raiden_apps, test_function, **kwargs):
             "Test stacktrace",
             test_traceback="".join(traceback.format_stack(test_greenlet.gr_frame)),
         )
-        log.exception("Pending greenlets", tracebacks="\n".join(gevent.util.format_run_info()))
+        log.debug("Pending greenlets", tracebacks="\n".join(gevent.util.format_run_info()))
 
         raise

--- a/raiden/utils/debugging.py
+++ b/raiden/utils/debugging.py
@@ -11,4 +11,7 @@ def enable_gevent_monitoring_signal():
     import gevent.util
     import signal
 
-    signal.signal(signal.SIGUSR1, gevent.util.print_run_info)
+    def on_signal(signalnum, stack_frame):  # pylint: disable=unused-argument
+        gevent.util.print_run_info()
+
+    signal.signal(signal.SIGUSR1, on_signal)

--- a/tools/kill_if_no_output.py
+++ b/tools/kill_if_no_output.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+import fcntl
+import os
+import select
+import signal
+import subprocess
+import sys
+from typing import Any, List
+
+
+def make_async(fd: int) -> None:
+    fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+
+
+def kill_child(process, dormant_signal: int, kill_after: float, kill_signal: int) -> None:
+    os.kill(process.pid, dormant_signal)
+
+    try:
+        # process.wait handles timeouts and captures the exit status
+        process.wait(timeout=kill_after)
+    except subprocess.TimeoutExpired:
+        os.kill(process.pid, kill_signal)
+
+
+def read_until_exhaustion(fd: int) -> None:
+    try:
+        data = os.read(fd, 1024)
+    except BlockingIOError:
+        data = b""
+
+    while data:
+        sys.stdout.buffer.write(data)
+        sys.stdout.flush()
+        try:
+            data = os.read(fd, 1024)
+        except BlockingIOError:
+            data = b""
+
+
+def monitor(
+    subcommand, dormant_after: float, dormant_signal: int, kill_after: float, kill_signal: int
+) -> int:
+    # Using a single pipe for both stderr and stdout because it allows the
+    # parent process to read the child output in the correct order.
+    parent_read, child_stdout_write = os.pipe()
+    child_stderr_write = os.dup(child_stdout_write)
+
+    process = subprocess.Popen(
+        subcommand, stdin=subprocess.DEVNULL, stdout=child_stdout_write, stderr=child_stderr_write
+    )
+
+    # These are used by the child process only
+    os.close(child_stderr_write)
+    os.close(child_stdout_write)
+
+    make_async(parent_read)
+
+    read_targets = [parent_read]
+    empty_targets: List[Any] = []
+
+    while process.poll() is None:
+        # using select because it works both on Linux and MacOS, otherwise
+        # epoll and kqueue would have to be handled separtly.
+        (read_list, _, _) = select.select(
+            read_targets, empty_targets, empty_targets, dormant_after
+        )
+
+        # The process timedout, kill it. After the proess is killed the loop
+        # will exit and the left over in the stdout will be consumed
+        if not read_list:
+            kill_child(process, dormant_signal, kill_after, kill_signal)
+
+        for fd in read_list:
+            read_until_exhaustion(fd)
+
+    # Read the last bit of data after the process exited.
+    for fd in read_targets:
+        read_until_exhaustion(fd)
+
+    os.close(parent_read)
+
+    return process.poll()
+
+
+def main() -> None:
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+
+    Signals = signal.Signals  # pylint: disable=no-member
+    signal_names = [sig.name for sig in Signals]
+
+    parser.add_argument("--dormant-timeout", required=True, type=float)
+    parser.add_argument("--dormant-signal", required=True, choices=signal_names)
+    parser.add_argument("--kill-timeout", required=True, type=float)
+    parser.add_argument("--kill-signal", required=True, choices=signal_names)
+
+    args, subcommand = parser.parse_known_args()
+
+    dormant_signal_number = getattr(Signals, args.dormant_signal)
+    kill_signal_number = getattr(Signals, args.kill_signal)
+
+    exit_status = monitor(
+        subcommand=subcommand,
+        dormant_after=args.dormant_timeout,
+        dormant_signal=dormant_signal_number,
+        kill_after=args.kill_timeout,
+        kill_signal=kill_signal_number,
+    )
+    sys.exit(exit_status)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```
This tool is being added to help misbehaving builds. The continuous
integration services, e.g. Travis and CircleCI, will kill the build if
the process doesn't output any data. Because the whole environment is
kill, e.g. the container or the VM is killed, there is no logs available
to debug the problem.

This tool should be used to send a user signal before the CI timeout is
reached, the test suite should run a signal handler to print debugging
data and exit. If the test suite doesn't exit in a timely manner then it
will be forcefully killed.
```