### PR TITLE
Improvements to timeout option handling

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -190,9 +190,17 @@ def pytest_runtest_call(item):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_setup(item):
-    timeout = item.config.getvalue("timeout")
-    marker = item.get_closest_marker("timeout")
+    """ Limit the tests runtime
 
+    The timeout is read from the following places (last one takes precedence):
+    * setup.cfg (ini)
+    * commandline option (option)
+    * pytest timeout marker at the specific test (market)
+    """
+    timeout = int(item.config.getini("timeout"))
+    timeout = item.config.getoption("timeout", default=timeout)
+
+    marker = item.get_closest_marker("timeout")
     if marker is not None:
         # This marker supports only one argument, it may be positional or
         # keyword


### PR DESCRIPTION
I was getting
```python
    @pytest.hookimpl(hookwrapper=True)
    def pytest_runtest_setup(item):
>       timeout = item.config.getvalue("timeout")
E       ValueError: no option named 'timeout'
```
when running tests locally after https://github.com/raiden-network/raiden/pull/4420. I don't see why it worked in CI, but the following changes made it work fine for me and should also be an improvement by themselves:

* `getvalue` replaced (deprecated, see
https://docs.pytest.org/en/latest/reference.html?highlight=addini#_pytest.config.Config.getvalue)
* use both values from cli and `setup.cfg`
* cast values from `setup.cfg` to int, which is necessary for them to be
  actually used
* add docstring describing settings precedence