### PR TITLE
Increase `no_output_timeout` to run `test_stress`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,7 @@ jobs:
               --select-fail-on-missing \
               --select-from-file selected-tests.txt \
               << parameters.additional-args >>
+          no_output_timeout: 15m
 
       - run:
           name: Store coverage

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -278,14 +278,12 @@ def assert_channels(raiden_network, token_network_address, deposit):
         )
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [2])
 @pytest.mark.parametrize("deposit", [5])
 @pytest.mark.parametrize("reveal_timeout", [15])
 @pytest.mark.parametrize("settle_timeout", [120])
-@pytest.mark.flaky(max_runs=5)
 def test_stress(raiden_network, deposit, retry_timeout, token_addresses, port_generator):
     token_address = token_addresses[0]
     rest_apis = start_apiserver_for_network(raiden_network, port_generator)


### PR DESCRIPTION
I could not reproduce the `test_stress` flakyness locally. I also could
not see find any indication that there is a specific problem on
CircleCI. Looking at the runtimes of the successful runs on CircleCI,
the test might just be so slow that it occasionally runs into CircleCI's
10-minutes-without-output-limit.
This PR increases the limit to 15 minutes, which will hopefully give the
test enough time to finish normally.

Hopefully fixes https://github.com/raiden-network/raiden/issues/4380.

I've only checked this with two CircleCI runs, so this is far from a verified fix. But if it doesn't help, it's easy enough to revert.