### PR TITLE
Reduce the number of transfers in `test_stress`

### DIFF
--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -278,14 +278,12 @@ def assert_channels(raiden_network, token_network_address, deposit):
         )
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [2])
-@pytest.mark.parametrize("deposit", [5])
+@pytest.mark.parametrize("deposit", [4])
 @pytest.mark.parametrize("reveal_timeout", [15])
 @pytest.mark.parametrize("settle_timeout", [120])
-@pytest.mark.flaky(max_runs=5)
 def test_stress(raiden_network, deposit, retry_timeout, token_addresses, port_generator):
     token_address = token_addresses[0]
     rest_apis = start_apiserver_for_network(raiden_network, port_generator)


### PR DESCRIPTION
The test runs into CircleCI's timeout, otherwise. This is a simple
measure to speed it up by ~20%.

Should close https://github.com/raiden-network/raiden/issues/4380.

This obsoletes and thus closes https://github.com/raiden-network/raiden/pull/4429.