### PR TITLE
Unskip `test_echo_node_lottery`

### DIFF
--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -13,6 +13,7 @@ from raiden.tests.utils.protocol import WaitForMessage
 from raiden.transfer.events import EventPaymentReceivedSuccess
 from raiden.utils import random_secret, wait_until
 from raiden.utils.echo_node import EchoNode
+from raiden.utils.typing import List, Optional
 from raiden.waiting import wait_for_transfer_success
 
 
@@ -112,7 +113,6 @@ def run_test_echo_node_response(token_addresses, raiden_chain, retry_timeout):
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("reveal_timeout", [15])
 @pytest.mark.parametrize("settle_timeout", [120])
-@pytest.mark.skip("Issue: 3750")
 def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
     raise_on_failure(
         raiden_apps=raiden_chain,
@@ -121,6 +121,25 @@ def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
         raiden_chain=raiden_chain,
         network_wait=network_wait,
     )
+
+
+def transfer_and_await(app, token_address, target, amount, identifier, timeout):
+    payment_status = RaidenAPI(app.raiden).transfer_async(
+        registry_address=app.raiden.default_registry.address,
+        token_address=token_address,
+        amount=amount,
+        target=target,
+        identifier=identifier,
+    )
+
+    msg = (
+        f"Transfer {identifier} from "
+        f"{to_checksum_address(app.raiden.address)} to "
+        f"{to_checksum_address(target)} timed out after "
+        f"{timeout}"
+    )
+    with gevent.Timeout(timeout, exception=RuntimeError(msg)):
+        payment_status.payment_done.wait()
 
 
 def run_test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
@@ -133,105 +152,94 @@ def run_test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
     echo_node.ready.wait(timeout=30)
     assert echo_node.ready.is_set()
 
-    expected = list()
+    transfer_timeout = 10
 
     # Let 6 participants enter the pool
     amount = 7
     for num, app in enumerate([app0, app1, app2, app3, app4, app5]):
-        payment_status = RaidenAPI(app.raiden).transfer_async(
-            app.raiden.default_registry.address,
-            token_address,
-            amount,
-            echo_app.raiden.address,
-            10 ** (num + 1),
+        identifier = 10 ** (num + 1)
+        transfer_and_await(
+            app=app,
+            token_address=token_address,
+            target=echo_app.raiden.address,
+            amount=amount,
+            identifier=identifier,
+            timeout=transfer_timeout,
         )
-        payment_status.payment_done.wait(timeout=20)
-        expected.append(amount)
 
     # test duplicated identifier + amount is ignored
-    payment_status = (
-        RaidenAPI(app5.raiden)
-        .transfer_async(
-            app.raiden.default_registry.address,
-            token_address,
-            amount,  # same amount as before
-            echo_app.raiden.address,
-            10 ** 6,  # app5 used this identifier before
-        )
-        .payment_done.wait(timeout=20)
+    transfer_and_await(
+        app=app5,
+        token_address=token_address,
+        target=echo_app.raiden.address,
+        amount=amount,
+        identifier=10 ** 6,  # app5 used this identifier before
+        timeout=transfer_timeout,
     )
 
     # test pool size querying
     pool_query_identifier = 77  # unused identifier different from previous one
-    payment_status = (
-        RaidenAPI(app5.raiden)
-        .transfer_async(
-            app.raiden.default_registry.address,
-            token_address,
-            amount,
-            echo_app.raiden.address,
-            pool_query_identifier,
-        )
-        .payment_done.wait(timeout=20)
+    transfer_and_await(
+        app=app5,
+        token_address=token_address,
+        target=echo_app.raiden.address,
+        amount=amount,
+        identifier=pool_query_identifier,
+        timeout=transfer_timeout,
     )
-    expected.append(amount)
 
     # fill the pool
-    payment_status = (
-        RaidenAPI(app6.raiden)
-        .transfer_async(
-            app.raiden.default_registry.address,
-            token_address,
-            amount,
-            echo_app.raiden.address,
-            10 ** 7,
-        )
-        .payment_done.wait(timeout=20)
+    transfer_and_await(
+        app=app6,
+        token_address=token_address,
+        target=echo_app.raiden.address,
+        amount=amount,
+        identifier=10 ** 7,
+        timeout=transfer_timeout,
     )
-    expected.append(amount)
 
-    while echo_node.num_handled_transfers < len(expected):
-        gevent.sleep(0.5)
-
-    def get_echoed_transfer(sent_transfer):
+    def get_echoed_transfer(sent_transfer) -> Optional[EventPaymentReceivedSuccess]:
         """For a given transfer sent to echo node, get the corresponding echoed transfer"""
         app = address_to_app[sent_transfer.initiator]
         events = RaidenAPI(app.raiden).get_raiden_events_payment_history(
             token_address=token_address
         )
 
-        def is_valid(event):
+        def is_valid(event) -> bool:
             return (
                 type(event) == EventPaymentReceivedSuccess
                 and event.initiator == echo_app.raiden.address
                 and event.identifier == sent_transfer.identifier + event.amount
             )
 
-        received = {event.identifier: event for event in events if is_valid(event)}
+        received_events = [event for event in events if is_valid(event)]
 
-        if len(received) != 1:
-            return None
-        return received.popitem()[1]
+        if len(received_events) == 1:
+            return received_events[0]
 
-    def received_is_of_size(size):
+        return None
+
+    def received_events_when_len(size: int) -> Optional[List[EventPaymentReceivedSuccess]]:
         """Return transfers received from echo_node when there's size transfers"""
-        received = {}
+        received_events = []
         # Check that payout was generated and pool_size_query answered
         for handled_transfer in echo_node.seen_transfers:
             event = get_echoed_transfer(handled_transfer)
             if not event:
                 continue
-            received[event.identifier] = event
-        if len(received) == size:
-            return received
+
+            received_events.append(event)
+
+        if len(received_events) == size:
+            return received_events
 
         return None
 
     # wait for the expected echoed transfers to be handled
-    received = wait_until(lambda: received_is_of_size(2), 2 * network_wait)
+    received = wait_until(lambda: received_events_when_len(2), network_wait)
     assert received
 
-    received = sorted(received.values(), key=lambda transfer: transfer.amount)
+    received.sort(key=lambda transfer: transfer.amount)
 
     pool_query = received[0]
     assert pool_query.amount == 6


### PR DESCRIPTION
This cleans up the tests and removes gevent.sleeps()


Fixes #3750 