### PR TITLE
Skip `test_stress` until is runs reliably

### DIFF
--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -284,6 +284,7 @@ def assert_channels(raiden_network, token_network_address, deposit):
 @pytest.mark.parametrize("deposit", [4])
 @pytest.mark.parametrize("reveal_timeout", [15])
 @pytest.mark.parametrize("settle_timeout", [120])
+@pytest.mark.skip("Issue: #4380")
 def test_stress(raiden_network, deposit, retry_timeout, token_addresses, port_generator):
     token_address = token_addresses[0]
     rest_apis = start_apiserver_for_network(raiden_network, port_generator)


### PR DESCRIPTION
This causes problems with PRs as well as with the build of nightlies


Until  #4380 is fixed