### PR TITLE
Further reduce test_stress deposit to improve reliability

### DIFF
--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -281,10 +281,9 @@ def assert_channels(raiden_network, token_network_address, deposit):
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [2])
-@pytest.mark.parametrize("deposit", [4])
+@pytest.mark.parametrize("deposit", [2])
 @pytest.mark.parametrize("reveal_timeout", [15])
 @pytest.mark.parametrize("settle_timeout", [120])
-@pytest.mark.skip("Issue: #4380")
 def test_stress(raiden_network, deposit, retry_timeout, token_addresses, port_generator):
     token_address = token_addresses[0]
     rest_apis = start_apiserver_for_network(raiden_network, port_generator)


### PR DESCRIPTION
The previous reduction didn't make the flakyness disappear. I've run this four times without having a failure in `test_stress`, so this is likely to close https://github.com/raiden-network/raiden/issues/4380.

Reducing the amount of work in the stress test this much might not be a good idea, but it *is* better than completely skipping the test.