### PR TITLE
Fix problems in `calculate_imbalance_fees`

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -80,8 +80,15 @@ def test_rebalancing_fee_calculation():
 
     sample = calculate_imbalance_fees(TA(10), max_imbalance_fee)
     assert sample is not None
-    assert len(sample) == 10
+    assert len(sample) == 11
     assert max(x for x, _ in sample) == 10
     assert max(y for _, y in sample) == 10 ** 18
 
+    sample = calculate_imbalance_fees(TA(1), max_imbalance_fee)
+    assert sample is not None
+    assert len(sample) == 2
+    assert max(x for x, _ in sample) == 1
+    assert max(y for _, y in sample) == 10 ** 18
+
+    assert calculate_imbalance_fees(TA(0), max_imbalance_fee) is None
     assert calculate_imbalance_fees(TA(10), max_imbalance_fee=FA(0)) is None


### PR DESCRIPTION
There were multiple problems with `calculate_imbalance_fees`:
- With a `channel_capacity` of 0 it raised an AssertionError
- With a `channel_capacity` of 1, only one grid point was calculated and
the extrema were wrong

Fixes #4446