### PR TITLE
Silence pytest warning about timeout marker

### DIFF
--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -2377,7 +2377,7 @@ def handle_channel_settled(
     return TransitionResult(channel_state, events)
 
 
-def handle_channel_depsoit(
+def handle_channel_deposit(
     channel_state: NettingChannelState,
     state_change: ContractReceiveChannelDeposit,
     block_number: BlockNumber,
@@ -2518,7 +2518,7 @@ def state_transition(
         iteration = handle_channel_settled(channel_state, state_change)
     elif type(state_change) == ContractReceiveChannelDeposit:
         assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
-        iteration = handle_channel_depsoit(channel_state, state_change, block_number)
+        iteration = handle_channel_deposit(channel_state, state_change, block_number)
     elif type(state_change) == ContractReceiveChannelBatchUnlock:
         assert isinstance(state_change, ContractReceiveChannelBatchUnlock), MYPY_ANNOTATION
         iteration = handle_channel_batch_unlock(channel_state, state_change)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ norecursedirs = node_modules
 filterwarnings =
     ignore::gevent.monkey.MonkeyPatchWarning
     ignore::urllib3.exceptions.InsecureRequestWarning
+markers =
+    timeout
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
Markers have to be explicitly declared, or they will raise warnings
during test execution.
See https://docs.pytest.org/en/latest/mark.html#registering-marks.