### PR TITLE
Add check for highest/lowest parity/geth supported version.

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -119,3 +119,7 @@ PATH_FINDING_BROADCASTING_ROOM = "path_finding"
 # to signify that a channel_identifier of `0` passed to the messages adds them to the
 # global queue
 EMPTY_ADDRESS = b"\0" * 20
+
+
+# Keep in sync with .circleci/config.yaml
+HIGHEST_SUPPORTED_GETH_VERSION = "1.8.22"

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -122,4 +122,8 @@ EMPTY_ADDRESS = b"\0" * 20
 
 
 # Keep in sync with .circleci/config.yaml
-HIGHEST_SUPPORTED_GETH_VERSION = "1.8.22"
+HIGHEST_SUPPORTED_GETH_VERSION = "1.8.26"
+LOWEST_SUPPORTED_GETH_VERSION = "1.7.2"
+# this is the last stable version as of this comment
+HIGHEST_SUPPORTED_PARITY_VERSION = "2.5.5"
+LOWEST_SUPPORTED_PARITY_VERSION = "1.7.6"

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -406,7 +406,10 @@ class JSONRPCClient:
         except ConnectTimeout:
             raise EthNodeCommunicationError("couldnt reach the ethereum node")
 
-        _, eth_node = is_supported_client(version)
+        supported, eth_node, _ = is_supported_client(version)
+
+        if not supported:
+            raise EthNodeInterfaceError(f"Unsupported Ethereum client {version}")
 
         address = privatekey_to_address(privkey)
         address_checksumed = to_checksum_address(address)
@@ -432,9 +435,6 @@ class JSONRPCClient:
         elif eth_node is constants.EthClient.GETH:
             geth_assert_rpc_interfaces(web3)
             available_nonce = geth_discover_next_available_nonce(web3, address_checksumed)
-
-        else:
-            raise EthNodeInterfaceError(f"Unsupported Ethereum client {version}")
 
         self.eth_node = eth_node
         self.privkey = privkey

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -30,7 +30,6 @@ from pathlib import Path
 import gevent
 from _pytest.pathlib import LOCK_TIMEOUT, ensure_reset_dir, make_numbered_dir_with_cleanup
 from _pytest.tmpdir import get_user
-from pkg_resources import parse_version
 
 from raiden.constants import (
     HIGHEST_SUPPORTED_GETH_VERSION,

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -33,59 +33,81 @@ def test_cli_version(cli_runner):
 
 
 def test_check_json_rpc_geth():
-    g1, client = is_supported_client("Geth/v1.7.3-unstable-e9295163/linux-amd64/go1.9.1")
-    g2, _ = is_supported_client("Geth/v1.7.2-unstable-e9295163/linux-amd64/go1.9.1")
-    g3, _ = is_supported_client("Geth/v1.8.2-unstable-e9295163/linux-amd64/go1.9.1")
-    g4, _ = is_supported_client("Geth/v2.0.3-unstable-e9295163/linux-amd64/go1.9.1")
-    g5, _ = is_supported_client("Geth/v11.55.86-unstable-e9295163/linux-amd64/go1.9.1")
-    g6, _ = is_supported_client("Geth/v999.999.999-unstable-e9295163/linux-amd64/go1.9.1")
+    g1, client, v1 = is_supported_client("Geth/v1.7.3-unstable-e9295163/linux-amd64/go1.9.1")
+    g2, _, v2 = is_supported_client("Geth/v1.7.2-unstable-e9295163/linux-amd64/go1.9.1")
+    g3, _, v3 = is_supported_client("Geth/v1.8.2-unstable-e9295163/linux-amd64/go1.9.1")
+    g4, _, v4 = is_supported_client("Geth/v2.0.3-unstable-e9295163/linux-amd64/go1.9.1")
+    g5, _, v5 = is_supported_client("Geth/v11.55.86-unstable-e9295163/linux-amd64/go1.9.1")
+    g6, _, v6 = is_supported_client("Geth/v999.999.999-unstable-e9295163/linux-amd64/go1.9.1")
     assert client is EthClient.GETH
-    assert all([g1, g2, g3, g4, g5, g6])
+    assert all([g1, g2, g3])
+    assert not any([g4, g5, g6])
+    assert v1 == "1.7.3"
+    assert v2 == "1.7.2"
+    assert v3 == "1.8.2"
+    assert v4 == "2.0.3"
+    assert v5 == "11.55.86"
+    assert v6 == "999.999.999"
 
-    b1, client = is_supported_client("Geth/v1.7.1-unstable-e9295163/linux-amd64/go1.9.1")
-    b2, _ = is_supported_client("Geth/v0.7.1-unstable-e9295163/linux-amd64/go1.9.1")
-    b3, _ = is_supported_client("Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1")
-    b4, _ = is_supported_client("Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1")
-    assert not client
+    b1, client, v1 = is_supported_client("Geth/v1.7.1-unstable-e9295163/linux-amd64/go1.9.1")
+    b2, _, v2 = is_supported_client("Geth/v0.7.1-unstable-e9295163/linux-amd64/go1.9.1")
+    b3, _, v3 = is_supported_client("Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1")
+    b4, _, _ = is_supported_client("Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1")
+    assert client is EthClient.GETH
     assert not any([b1, b2, b3, b4])
+    assert v1 == "1.7.1"
+    assert v2 == "0.7.1"
+    assert v3 == "0.0.0"
 
 
 def test_check_json_rpc_parity():
-    g1, client = is_supported_client(
+    g1, client, v1 = is_supported_client(
         "Parity//v1.7.6-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    g2, _ = is_supported_client(
+    g2, _, v2 = is_supported_client(
         "Parity//v1.7.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    g3, _ = is_supported_client(
+    g3, _, v3 = is_supported_client(
         "Parity//v1.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    g4, _ = is_supported_client(
+    g4, _, v4 = is_supported_client(
         "Parity//v2.9.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    g5, _ = is_supported_client(
+    g5, _, v5 = is_supported_client(
         "Parity//v23.94.75-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    g6, _ = is_supported_client(
+    g6, _, v6 = is_supported_client(
         "Parity//v99.994.975-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     assert client is EthClient.PARITY
-    assert all([g1, g2, g3, g4, g5, g6])
+    assert all([g1, g2, g3])
+    assert not any([g4, g5, g6])
+    assert v1 == "1.7.6"
+    assert v2 == "1.7.7"
+    assert v3 == "1.8.7"
+    assert v4 == "2.9.7"
+    assert v5 == "23.94.75"
+    assert v6 == "99.994.975"
 
-    b1, client = is_supported_client(
+    b1, client, v1 = is_supported_client(
         "Parity//v1.7.5-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    b2, _ = is_supported_client(
+    b2, _, v2 = is_supported_client(
         "Parity//v1.5.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    b3, _ = is_supported_client(
+    b3, _, v3 = is_supported_client(
         "Parity//v0.7.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    b4, _ = is_supported_client(
+    b4, _, v4 = is_supported_client(
         "Parity//v0.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    b5, _ = is_supported_client(
+    b5, _, v5 = is_supported_client(
         "Parity//v0.0.0-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    assert not client
+    assert client is EthClient.PARITY
     assert not any([b1, b2, b3, b4, b5])
+    assert v1 == "1.7.5"
+    assert v2 == "1.5.1"
+    assert v3 == "0.7.1"
+    assert v4 == "0.8.7"
+    assert v5 == "0.0.0"

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -68,13 +68,13 @@ def test_check_json_rpc_parity():
         "Parity//v1.7.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     g3, _, v3 = is_supported_client(
-        "Parity//v1.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
+        "Parity/v1.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     g4, _, v4 = is_supported_client(
         "Parity//v2.9.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     g5, _, v5 = is_supported_client(
-        "Parity//v23.94.75-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
+        "Parity/v23.94.75-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     g6, _, v6 = is_supported_client(
         "Parity//v99.994.975-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
@@ -93,13 +93,13 @@ def test_check_json_rpc_parity():
         "Parity//v1.7.5-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     b2, _, v2 = is_supported_client(
-        "Parity//v1.5.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
+        "Parity/v1.5.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     b3, _, v3 = is_supported_client(
         "Parity//v0.7.1-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     b4, _, v4 = is_supported_client(
-        "Parity//v0.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
+        "Parity/v0.8.7-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     b5, _, v5 = is_supported_client(
         "Parity//v0.0.0-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -7,7 +7,15 @@ from requests.exceptions import ConnectTimeout
 from web3 import Web3
 
 from raiden.accounts import AccountManager
-from raiden.constants import SQLITE_MIN_REQUIRED_VERSION, Environment, RoutingMode
+from raiden.constants import (
+    HIGHEST_SUPPORTED_GETH_VERSION,
+    HIGHEST_SUPPORTED_PARITY_VERSION,
+    LOWEST_SUPPORTED_GETH_VERSION,
+    LOWEST_SUPPORTED_PARITY_VERSION,
+    SQLITE_MIN_REQUIRED_VERSION,
+    Environment,
+    RoutingMode,
+)
 from raiden.exceptions import EthNodeCommunicationError, EthNodeInterfaceError
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.service_registry import ServiceRegistry
@@ -43,10 +51,13 @@ def check_ethereum_client_is_supported(web3: Web3) -> None:
             "and --jsonrpc-apis=eth,net,web3,parity for parity."
         )
 
-    supported, _ = is_supported_client(node_version)
+    supported, our_client, our_version = is_supported_client(node_version)
     if not supported:
         click.secho(
-            "You need a Byzantium enabled ethereum node. Parity >= 1.7.6 or Geth >= 1.7.2",
+            f"You need a Byzantium enabled ethereum node. Parity >= "
+            f"{LOWEST_SUPPORTED_PARITY_VERSION} <= {HIGHEST_SUPPORTED_PARITY_VERSION}"
+            f" or Geth >= {LOWEST_SUPPORTED_GETH_VERSION} <= {HIGHEST_SUPPORTED_GETH_VERSION}",
+            f" but you have {our_version} {our_client}",
             fg="red",
         )
         sys.exit(1)

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -56,7 +56,7 @@ def check_ethereum_client_is_supported(web3: Web3) -> None:
         click.secho(
             f"You need a Byzantium enabled ethereum node. Parity >= "
             f"{LOWEST_SUPPORTED_PARITY_VERSION} <= {HIGHEST_SUPPORTED_PARITY_VERSION}"
-            f" or Geth >= {LOWEST_SUPPORTED_GETH_VERSION} <= {HIGHEST_SUPPORTED_GETH_VERSION}",
+            f" or Geth >= {LOWEST_SUPPORTED_GETH_VERSION} <= {HIGHEST_SUPPORTED_GETH_VERSION}"
             f" but you have {our_version} {our_client}",
             fg="red",
         )

--- a/raiden/utils/ethereum_clients.py
+++ b/raiden/utils/ethereum_clients.py
@@ -1,23 +1,47 @@
 import re
 
-from raiden.constants import EthClient
+from pkg_resources import parse_version
+
+from raiden.constants import (
+    HIGHEST_SUPPORTED_GETH_VERSION,
+    HIGHEST_SUPPORTED_PARITY_VERSION,
+    LOWEST_SUPPORTED_GETH_VERSION,
+    LOWEST_SUPPORTED_PARITY_VERSION,
+    EthClient,
+)
 from raiden.utils.typing import Optional, Tuple
 
 
-def is_supported_client(client_version: str,) -> Tuple[bool, Optional[EthClient]]:
-    if client_version.startswith("Parity"):
-        matches = re.search(r"//v(\d+)\.(\d+)\.(\d+)", client_version)
-        if matches is None:
-            return False, None
-        major, minor, patch = [int(x) for x in matches.groups()]
-        if (major, minor, patch) >= (1, 7, 6):
-            return True, EthClient.PARITY
-    elif client_version.startswith("Geth"):
-        matches = re.search(r"/v(\d+)\.(\d+)\.(\d+)", client_version)
-        if matches is None:
-            return False, None
-        major, minor, patch = [int(x) for x in matches.groups()]
-        if (major, minor, patch) >= (1, 7, 2):
-            return True, EthClient.GETH
+def is_supported_client(client_version: str) -> Tuple[bool, Optional[EthClient], Optional[str]]:
+    """Takes a client version string either from web3.version.node or from
+    `geth version` or `parity --version` and sees if it is supported.
 
-    return False, None
+    Returns a tuple with 3 elements:
+    (supported_or_not, none_or_EthClient, none_or_our_version_str)
+    """
+    if client_version.startswith("Parity"):
+        matches = re.search(r"//v(\d+\.\d+\.\d+)", client_version)
+        if matches is None:
+            return False, None, None
+        our_version = parse_version(matches.groups()[0])
+        supported = our_version >= parse_version(
+            LOWEST_SUPPORTED_PARITY_VERSION
+        ) and our_version <= parse_version(HIGHEST_SUPPORTED_PARITY_VERSION)
+        return supported, EthClient.PARITY, str(our_version)
+    elif client_version.startswith("Geth"):
+
+        if client_version.startswith("Geth/"):
+            # then this is a geth client version from web3.version.node
+            matches = re.search(r"/v(\d+\.\d+\.\d+)", client_version)
+        else:
+            # result of `geth version`
+            matches = re.search("Version: (.*)-", client_version)
+        if matches is None:
+            return False, None, None
+        our_version = parse_version(matches.groups()[0])
+        supported = our_version >= parse_version(
+            LOWEST_SUPPORTED_GETH_VERSION
+        ) and our_version <= parse_version(HIGHEST_SUPPORTED_GETH_VERSION)
+        return supported, EthClient.GETH, str(our_version)
+
+    return False, None, None

--- a/raiden/utils/ethereum_clients.py
+++ b/raiden/utils/ethereum_clients.py
@@ -20,7 +20,8 @@ def is_supported_client(client_version: str) -> Tuple[bool, Optional[EthClient],
     (supported_or_not, none_or_EthClient, none_or_our_version_str)
     """
     if client_version.startswith("Parity"):
-        matches = re.search(r"//v(\d+\.\d+\.\d+)", client_version)
+        # Parity has Parity// at web3.version.node and Parity/ prefix at parity --version
+        matches = re.search(r"/+v(\d+\.\d+\.\d+)", client_version)
         if matches is None:
             return False, None, None
         our_version = parse_version(matches.groups()[0])


### PR DESCRIPTION
I was just bittten by thinking the flaky tests were due to some problem
that ended up being due to geth v1.9.0. So I am adding this check on
tests to make sure that when we run the tests they are not with a
version that is not supported.

~~Not sure how to keep config.yaml with the raiden/constants.py~~

No need to. The build failing would show us that these two have fallen out of sync