### PR TITLE
Skipped tests for which flaky issues have been registered in Github

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1893,6 +1893,7 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [1000])
+@pytest.mark.skip("Issue: #4344")
 def test_api_withdraw(api_server_test_instance, raiden_network, token_addresses):
     _, app1 = raiden_network
     token_address = token_addresses[0]

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1890,7 +1890,6 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
     assert response.status_code == 404 and b"Channel" in response.content
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [1000])
 @pytest.mark.skip("Issue: #4344")

--- a/raiden/tests/integration/cli/test_cli_development.py
+++ b/raiden/tests/integration/cli/test_cli_development.py
@@ -17,6 +17,7 @@ pytestmark = [
 
 
 @pytest.mark.timeout(45)
+@pytest.mark.skip("Issue #4450")
 def test_cli_full_init_dev(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     expect_cli_normal_startup(child, Environment.DEVELOPMENT.value)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -467,6 +467,7 @@ def test_join_invalid_discovery(
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("matrix_server_count", [2])
 @pytest.mark.parametrize("number_of_transports", [3])
+@pytest.mark.skip("Issue: #4337")
 def test_matrix_cross_server_with_load_balance(matrix_transports):
     transport0, transport1, transport2 = matrix_transports
     received_messages0 = set()
@@ -719,6 +720,7 @@ def test_pfs_global_messages(
 )
 @pytest.mark.parametrize("number_of_transports", [2])
 @pytest.mark.parametrize("matrix_server_count", [2])
+@pytest.mark.skip("Issue: #4338")
 def test_matrix_invite_private_room_happy_case(matrix_transports, expected_join_rule):
     raiden_service0 = MockRaidenService(None)
     raiden_service1 = MockRaidenService(None)
@@ -836,6 +838,7 @@ def test_matrix_invite_private_room_unhappy_case1(
 )
 @pytest.mark.parametrize("matrix_server_count", [2])
 @pytest.mark.parametrize("number_of_transports", [2])
+@pytest.mark.skip("Issue: #4336")
 def test_matrix_invite_private_room_unhappy_case_2(
     matrix_transports, expected_join_rule0, expected_join_rule1
 ):
@@ -1101,6 +1104,7 @@ def test_matrix_multi_user_roaming(matrix_transports):
 @pytest.mark.parametrize("private_rooms", [[True, True]])
 @pytest.mark.parametrize("matrix_server_count", [2])
 @pytest.mark.parametrize("number_of_transports", [2])
+@pytest.mark.skip("Issue: #4379")
 def test_reproduce_handle_invite_send_race_issue_3588(matrix_transports):
     transport0, transport1 = matrix_transports
     received_messages0 = set()

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -464,7 +464,6 @@ def test_join_invalid_discovery(
     transport.get()
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("matrix_server_count", [2])
 @pytest.mark.parametrize("number_of_transports", [3])
 @pytest.mark.skip("Issue: #4337")
@@ -708,7 +707,6 @@ def test_pfs_global_messages(
     transport.get()
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule",
     [
@@ -826,7 +824,6 @@ def test_matrix_invite_private_room_unhappy_case1(
     assert join_rule1 == expected_join_rule1
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize(
     "private_rooms, expected_join_rule0, expected_join_rule1",
     [

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -25,6 +25,7 @@ from raiden.utils.typing import TokenAmount
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.skip("Issue: #4312")
 def test_send_queued_messages(  # pylint: disable=unused-argument
     raiden_network, deposit, token_addresses, network_wait
 ):

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -21,7 +21,6 @@ from raiden.utils import BlockNumber, create_default_identifier
 from raiden.utils.typing import TokenAmount
 
 
-@pytest.mark.flaky(max_runs=5)
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])


### PR DESCRIPTION
Specifically skipped:

- test_cli_development.py::test_cli_full_init_dev - issue #4450
- integration/network/test_matrix_transport.py::test_reproduce_handle_invite_send_race_issue_3588 - issue #4379
- integration/api/test_restapi.py::test_api_withdraw - issue #4344
- integration/network/test_matrix_transport.py::test_matrix_invite_private_room_unhappy_case_2 - issue #4336
- integration/network/test_matrix_transport.py::test_matrix_invite_private_room_happy_case - issue #4338
- integration/network/test_matrix_transport.py::test_matrix_cross_server_with_load_balance - issue #4337