### PR TITLE
Use debian stretch based image to build linux bundle

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-stretch
 
 # these are defined in .travis.yml and passed here in the makefile
 ARG SOLC_URL_LINUX


### PR DESCRIPTION
The official docker python image switched to use the latest debian `buster` release as its base.
This leads to bundles build on there not being usable on older systems.

This switches back to use the older `stretch` based images.

Refs #4414 (this is only a partial fix since even stretch is relatively new)