### PR TITLE
Fix for #4344

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -50,6 +50,7 @@ from raiden.transfer.state_change import (
     ContractReceiveUpdateTransfer,
 )
 from raiden.utils.typing import (
+    BlockNumber,
     BlockTimeout,
     FeeAmount,
     List,
@@ -336,7 +337,7 @@ def actionchannelupdatefee_from_channelstate(
 
 
 def blockchainevent_to_statechange(
-    raiden: "RaidenService", event: DecodedEvent
+    raiden: "RaidenService", event: DecodedEvent, latest_confirmed_block: BlockNumber
 ) -> List[StateChange]:  # pragma: no unittest
     msg = "The state of the node has to be primed before blockchain events can be processed."
     assert raiden.wal, msg
@@ -352,7 +353,10 @@ def blockchainevent_to_statechange(
 
     elif event_name == ChannelEvent.OPENED:
         new_channel_details = get_contractreceivechannelnew_data_from_event(
-            chain_state=chain_state, chain_service=chain_service, event=event
+            chain_state=chain_state,
+            chain_service=chain_service,
+            event=event,
+            latest_confirmed_block=latest_confirmed_block,
         )
 
         if new_channel_details is not None:
@@ -410,7 +414,10 @@ def blockchainevent_to_statechange(
 
     elif event_name == ChannelEvent.SETTLED:
         channel_settle_state = get_contractreceivechannelsettled_data_from_event(
-            chain_service=chain_service, chain_state=chain_state, event=event
+            chain_service=chain_service,
+            chain_state=chain_state,
+            event=event,
+            latest_confirmed_block=latest_confirmed_block,
         )
 
         if channel_settle_state:

--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -1,3 +1,10 @@
+"""Module to map a blockchain event to a state change.
+
+All fuctions that map an event to a state change must be side-effect free. If
+any additional data is necessary, either from the database or the blockchain
+itself. an utility should be added to raiden.blockchain.state, and then called
+by blockchainevent_to_statechange.
+"""
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
@@ -345,7 +352,7 @@ def blockchainevent_to_statechange(
 
     elif event_name == ChannelEvent.OPENED:
         new_channel_details = get_contractreceivechannelnew_data_from_event(
-            chain_state, chain_service, event
+            chain_state=chain_state, chain_service=chain_service, event=event
         )
 
         if new_channel_details is not None:
@@ -403,7 +410,7 @@ def blockchainevent_to_statechange(
 
     elif event_name == ChannelEvent.SETTLED:
         channel_settle_state = get_contractreceivechannelsettled_data_from_event(
-            chain_service, chain_state, event
+            chain_service=chain_service, chain_state=chain_state, event=event
         )
 
         if channel_settle_state:

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -51,6 +51,14 @@ class EventListener:
 
 @dataclass(frozen=True)
 class DecodedEvent:
+    """A confirmed event with the data decoded to conform with Raiden's internals.
+
+    Raiden prefers bytes for addresses and hashes, and it uses snake_case as a
+    naming convention. Instances of this class are created at the edges of the
+    code base to conform with the internal data types, i.e. this type describes
+    is used at the IO boundaries to conform with the sandwich encoding.
+    """
+
     chain_id: ChainID
     block_number: BlockNumber
     block_hash: BlockHash
@@ -165,7 +173,13 @@ def get_all_netting_channel_events(
 def decode_raiden_event_to_internal(
     abi: ABI, chain_id: ChainID, log_event: BlockchainEvent
 ) -> DecodedEvent:
-    """ Enforce the binary for internal usage. """
+    """Enforce the sandwhich encoding. Converts the JSON RPC/web3 data types
+    to the internal representation.
+
+    Note::
+
+        This function must only on confirmed data.
+    """
     # Note: All addresses inside the event_data must be decoded.
 
     decoded_event = decode_event(abi, log_event)

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -1,8 +1,7 @@
-"""This module is responsible to load additinal data necessary to instantiate
-the ContractReceive* state changes, i.e. state changes for the blockchain
-events.
+"""Module for functions that load additional data necessary to instantiate the
+ContractReceive* state changes, i.e. state changes for the blockchain events.
 
-It is *very* important that every function here only fetch **confirmed** data,
+It is *very* important that every function here only fetches **confirmed** data,
 otherwise the node will be susceptible to races due to reorgs. These races can
 crash the client in the best case, or be an attack vector in the worst case.
 Because of this, the event itself must already be confirmed.
@@ -16,7 +15,8 @@ Note that the latest confirmed block is *not necessarily* the same as the
 current block number in the state machine. The current block number in the
 ChainState is *a* confirmed block number, but not necessarily the latest. This
 distinction is important during restarts, where the node's latest known block
-is from the latest run, and is not up-to-date, this block may be pruned aswell.
+is from the latest run, and is not up-to-date, this block may be pruned as
+well.
 """
 from dataclasses import dataclass
 
@@ -121,7 +121,7 @@ def get_contractreceivechannelsettled_data_from_event(
         # with the wrong locksroot (i.e. not the locksroot used during the call
         # to settle). However this is fine, because at this point the channel
         # is settled, it is known that the locksroot can not be reverted
-        # without an unlock, and because the unlocks are fare it doesn't matter
+        # without an unlock, and because the unlocks are fair it doesn't matter
         # who called it, only if there are tokens locked in the settled
         # channel.
         our_locksroot, partner_locksroot = get_onchain_locksroots(

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -9,14 +9,14 @@ Because of this, the event itself must already be confirmed.
 
 If possible, the confirmed data should be retrievied from the same block at
 which the event was emitted. However, because of state pruning this is not
-always possible. If that block is pruned then the current confirmed block must
+always possible. If that block is pruned then the latest confirmed block must
 be used.
 
 Note that the latest confirmed block is *not necessarily* the same as the
 current block number in the state machine. The current block number in the
 ChainState is *a* confirmed block number, but not necessarily the latest. This
-distinction is important during restarts, where the Raiden node will have the
-latest known confirmed block in its state, which itself may be a pruned block.
+distinction is important during restarts, where the node's latest known block
+is from the latest run, and is not up-to-date, this block may be pruned aswell.
 """
 from dataclasses import dataclass
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -734,7 +734,7 @@ class RaidenService(Runnable):
             # Example: The user creates a new channel with an initial deposit
             # of X tokens. This is done with two operations, the first is to
             # open the new channel, the second is to deposit the requested
-            # tokens in it. Once the node fetchs the event for the new channel,
+            # tokens in it. Once the node fetches the event for the new channel,
             # it will imediately request the deposit, which leaves a window for
             # a race condition. If the Block state change was not yet
             # processed, the block hash used as the trigerring block for the

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -214,6 +214,7 @@ class AlarmTask(Runnable):
             latest_block_number=latest_block["number"],
             latest_gas_limit=latest_block["gasLimit"],
             latest_block_hash=to_hex(latest_block["hash"]),
+            node=to_checksum_address(self.chain.node_address),
         )
 
         self.known_block_number = known_block_number
@@ -240,6 +241,7 @@ class AlarmTask(Runnable):
                 old_block_number=latest_block["number"],
                 old_gas_limit=latest_block["gasLimit"],
                 old_block_hash=to_hex(latest_block["hash"]),
+                node=to_checksum_address(self.chain.node_address),
             )
         elif missed_blocks > 0:
             log_details = dict(
@@ -247,6 +249,7 @@ class AlarmTask(Runnable):
                 latest_block_number=latest_block_number,
                 latest_block_hash=to_hex(latest_block["hash"]),
                 latest_block_gas_limit=latest_block["gasLimit"],
+                node=to_checksum_address(self.chain.node_address),
             )
             if missed_blocks > 1:
                 log_details["num_missed_blocks"] = missed_blocks - 1

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1892,7 +1892,6 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [1000])
-@pytest.mark.skip("Issue: #4344")
 def test_api_withdraw(api_server_test_instance, raiden_network, token_addresses):
     _, app1 = raiden_network
     token_address = token_addresses[0]

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -129,7 +129,10 @@ def raiden_chain(
     exception = RuntimeError("`raiden_chain` fixture setup failed, nodes are unreachable")
     with gevent.Timeout(seconds=timeout(blockchain_type), exception=exception):
         wait_for_channels(
-            app_channels, blockchain_services.deploy_registry.address, token_addresses, deposit
+            app_channels=app_channels,
+            payment_network_address=blockchain_services.deploy_registry.address,
+            token_addresses=token_addresses,
+            deposit=deposit,
         )
 
     yield raiden_apps
@@ -219,7 +222,10 @@ def raiden_network(
     exception = RuntimeError("`raiden_network` fixture setup failed, nodes are unreachable")
     with gevent.Timeout(seconds=timeout(blockchain_type), exception=exception):
         wait_for_channels(
-            app_channels, blockchain_services.deploy_registry.address, token_addresses, deposit
+            app_channels=app_channels,
+            payment_network_address=blockchain_services.deploy_registry.address,
+            token_addresses=token_addresses,
+            deposit=deposit,
         )
 
     # Force blocknumber update

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -1,6 +1,7 @@
 import pytest
 
 from raiden import waiting
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import wait_for_state_change
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
@@ -12,10 +13,14 @@ from raiden.utils.packing import pack_signed_balance_proof
 
 pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
 
+# At least the confirmed block must be kept around, the additional blocks is to
+# given some room for the test to execute
+pruning_history = DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS + 5
+
 # set very low values to force the client to prune old state
 STATE_PRUNING = {
     "pruning": "fast",
-    "pruning-history": 1,
+    "pruning-history": pruning_history,
     "pruning-memory": 1,
     "cache-size-db": 1,
     "cache-size-blocks": 1,
@@ -118,8 +123,9 @@ def run_test_locksroot_loading_during_channel_settle_handling(
     for _ in range(10):
         send_transaction()
 
-    # The private chain used for tests has a very low pruning setting
-    pruned_after_blocks = 10
+    # Wait until the target block has be prunned, it has to be larger than
+    # pruning_history
+    pruned_after_blocks = pruning_history * 1.5
 
     waiting.wait_for_block(
         raiden=app1.raiden, block_number=close_block + pruned_after_blocks, retry_timeout=1

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -483,7 +483,7 @@ def wait_for_alarm_start(
 def wait_for_usable_channel(
     app0: App,
     app1: App,
-    registry_address: PaymentNetworkAddress,
+    payment_network_address: PaymentNetworkAddress,
     token_address: TokenAddress,
     our_deposit: TokenAmount,
     partner_deposit: TokenAmount,
@@ -495,30 +495,36 @@ def wait_for_usable_channel(
     is reachable.
     """
     waiting.wait_for_newchannel(
-        app0.raiden, registry_address, token_address, app1.raiden.address, retry_timeout
+        raiden=app0.raiden,
+        payment_network_address=payment_network_address,
+        token_address=token_address,
+        partner_address=app1.raiden.address,
+        retry_timeout=retry_timeout,
     )
 
     waiting.wait_for_participant_deposit(
-        app0.raiden,
-        registry_address,
-        token_address,
-        app1.raiden.address,
-        app0.raiden.address,
-        our_deposit,
-        retry_timeout,
+        raiden=app0.raiden,
+        payment_network_address=payment_network_address,
+        token_address=token_address,
+        partner_address=app1.raiden.address,
+        target_address=app0.raiden.address,
+        target_balance=our_deposit,
+        retry_timeout=retry_timeout,
     )
 
     waiting.wait_for_participant_deposit(
-        app0.raiden,
-        registry_address,
-        token_address,
-        app1.raiden.address,
-        app1.raiden.address,
-        partner_deposit,
-        retry_timeout,
+        raiden=app0.raiden,
+        payment_network_address=payment_network_address,
+        token_address=token_address,
+        partner_address=app1.raiden.address,
+        target_address=app1.raiden.address,
+        target_balance=partner_deposit,
+        retry_timeout=retry_timeout,
     )
 
-    waiting.wait_for_healthy(app0.raiden, app1.raiden.address, retry_timeout)
+    waiting.wait_for_healthy(
+        raiden=app0.raiden, node_address=app1.raiden.address, retry_timeout=retry_timeout
+    )
 
 
 def wait_for_token_networks(
@@ -536,7 +542,7 @@ def wait_for_token_networks(
 
 def wait_for_channels(
     app_channels: AppChannels,
-    registry_address: PaymentNetworkAddress,
+    payment_network_address: PaymentNetworkAddress,
     token_addresses: List[TokenAddress],
     deposit: TokenAmount,
     retry_timeout: float = DEFAULT_RETRY_TIMEOUT,
@@ -545,8 +551,20 @@ def wait_for_channels(
     for app0, app1 in app_channels:
         for token_address in token_addresses:
             wait_for_usable_channel(
-                app0, app1, registry_address, token_address, deposit, deposit, retry_timeout
+                app0=app0,
+                app1=app1,
+                payment_network_address=payment_network_address,
+                token_address=token_address,
+                our_deposit=deposit,
+                partner_deposit=deposit,
+                retry_timeout=retry_timeout,
             )
             wait_for_usable_channel(
-                app1, app0, registry_address, token_address, deposit, deposit, retry_timeout
+                app1=app1,
+                app0=app0,
+                payment_network_address=payment_network_address,
+                token_address=token_address,
+                our_deposit=deposit,
+                partner_deposit=deposit,
+                retry_timeout=retry_timeout,
             )

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -16,6 +16,7 @@ from eth_utils import (
     to_canonical_address,
     to_checksum_address,
 )
+from gevent import sleep
 from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
 
@@ -346,6 +347,15 @@ def setup_raiden(
 
         one_to_n_contract_address = to_checksum_address(contract_addresses[CONTRACT_ONE_TO_N])
         args["one_to_n_contract_address"] = one_to_n_contract_address
+
+    # Wait until the secret registry is confirmed, otherwise the App
+    # inialization will fail, needed for the check
+    # `check_ethereum_confirmed_block_is_not_pruned`.
+    current_block = client.block_number()
+    target_block_number = current_block + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+    while current_block < target_block_number:
+        current_block = client.block_number()
+        sleep(0.5)
 
     return {"args": args, "contract_addresses": contract_addresses, "token": token}
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -550,6 +550,16 @@ def assert_balance_proof(
     else:
         nonce1 = 0
 
+    if balanceproof0.nonce < nonce1:
+        msg = (
+            "This is a bug, it should never happen. The nonce updates **always**  "
+            "start with the owner of the channel's end. This means for a channel "
+            "A-B, only A can increase its nonce, same thing with B. At this "
+            "point, the assertion is failling because this rule was broken, and "
+            "the partner node has a larger nonce than the sending partner."
+        )
+        raise AssertionError(msg)
+
     if balanceproof0.nonce > nonce1:
         # TODO: Only consider the records up to saved state's state_change_id.
         # ATM this has a race condition where this utility could be called

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -566,13 +566,13 @@ def assert_balance_proof(
         # before the alarm task fetches the corresponding event but while it
         # runs it does fetch it.
         sent_balance_proof = get_event_with_balance_proof_by_balance_hash(
-            storage=app0.raiden.storage,
+            storage=app0.raiden.wal.storage,
             canonical_identifier=balanceproof0.canonical_identifier,
             balance_hash=balanceproof0.balance_hash,
             recipient=app1.raiden.address,
         )
         received_balance_proof = get_state_change_with_balance_proof_by_locksroot(
-            storage=app1.raiden.storage,
+            storage=app1.raiden.wal.storage,
             canonical_identifier=balanceproof0.canonical_identifier,
             locksroot=balanceproof0.locksroot,
             sender=app0.raiden.address,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -31,6 +31,7 @@ from raiden.settings import (
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.ui.checks import (
     check_ethereum_client_is_supported,
+    check_ethereum_confirmed_block_is_not_pruned,
     check_ethereum_has_accounts,
     check_ethereum_network_id,
     check_sql_version,
@@ -219,6 +220,12 @@ def run_app(
         contracts=contracts,
         routing_mode=routing_mode,
         pathfinding_service_address=pathfinding_service_address,
+    )
+
+    check_ethereum_confirmed_block_is_not_pruned(
+        jsonrpc_client=rpc_client,
+        secret_registry=proxies.secret_registry,
+        confirmation_blocks=config["blockchain"]["confirmation_blocks"],
     )
 
     database_path = os.path.join(

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -88,7 +88,7 @@ def check_account(account_manager: AccountManager, address_hex: Address) -> None
 def check_ethereum_confirmed_block_is_not_pruned(
     jsonrpc_client: JSONRPCClient, secret_registry: SecretRegistry, confirmation_blocks: int
 ) -> None:
-    """Checks the Ethereum client is not pruning data to aggressively, because
+    """Checks the Ethereum client is not pruning data too aggressively, because
     in some circunstances it is necessary for a node to fetch additional data
     from the smart contract.
     """
@@ -99,7 +99,7 @@ def check_ethereum_confirmed_block_is_not_pruned(
     # - AlarmTask sees a new block and calls RaidenService._callback_new_block
     # - The service gets the current latest block number and computes the
     #   confirmed block number.
-    # - The service fetchs every filter, this can take a while.
+    # - The service fetches every filter, this can take a while.
     # - While the above is happening, it is possible for a `few_blocks` to be
     #   mined.
     # - The decode function is called, and tries to access what it thinks is
@@ -124,7 +124,7 @@ def check_ethereum_confirmed_block_is_not_pruned(
         click.secho(
             f"The ethereum client does not have the necessary data available. "
             f"The client can not operate because the prunning strategy is too "
-            f"agressively. Please make sure that at very minimum "
+            f"agressive. Please make sure that at very minimum "
             f"{minimum_available_history} blocks of history are available.",
             fg="red",
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,9 @@ ignore_errors = False
 [mypy-raiden.tests.unit.test_raiden_event_handler]
 ignore_errors = False
 
+[mypy-raiden.tests.unit.transfer]
+ignore_errors = False
+
 [mypy-raiden.tests.unit.transfer.mediated_transfer.test_mediation_fee]
 ignore_errors = False
 


### PR DESCRIPTION
Note that the race documented in the issue itself is not possible anymore, it was fixed by 956afb28a7, that instead of arbitrarily using `latest` as the goto value https://github.com/raiden-network/raiden/commit/956afb28a72d186ef22efcef27d18d1c865568d7#diff-5fb0421ebe327aba371c460a48364cf8L88 it did a two step process, first trying the event's block number and only falling back to latest if needed https://github.com/raiden-network/raiden/commit/956afb28a72d186ef22efcef27d18d1c865568d7#diff-5fb0421ebe327aba371c460a48364cf8R217-R225 .

However, the case below was still possible:


   Fixes race condition from #4344

    This is a tricky race condition, it is unlikely to happen with the
    current version of the code, but it is fixed by this commit neverthless.
    The race condition manifests itself when the node is processing an event
    from a pruned block, and it needs to fetch additional data from the
    blockchain. The problem was that the existing code used `latest` by
    default, which effectively fetched unconfirmed data and used it as if it
    was confirmed.

    Consider the following:

    - Alice opens a channel with Bob
    - Bob crashes
    - Bob comes back online after at least `pruned_block`s.
    - At this point, Bob has to synchronize with the blockchain, it starts
      polling for the missing events, once it processes the ChannelOpen
      event, it can fetch additinal data. The existing code is fetching the
      channel deposit from the blockchain.
    - If Alice sends a transaction around this time, and Bob uses the block
      `latest` in the pruned block handler, the unconfirmed deposit of Alice
      will be used.

    To prevent the above two things should be done:

    - Fetching additional data from the blockchain on a event mapping should
      be kept to a minimum.
    - If fetching additional data is necessary, then it must use a confirmed
      block instead of latest.