### PR TITLE
Add assertions to transfer integration tests

### DIFF
--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -22,6 +22,7 @@ from raiden.utils.typing import (
     List,
     Locksroot,
     Optional,
+    SecretHash,
 )
 
 if TYPE_CHECKING:
@@ -204,6 +205,16 @@ def get_event_with_balance_proof_by_locksroot(
     )
     event = storage.get_latest_event_by_data_field(query)
     return event
+
+
+def get_state_change_with_transfer_by_secrethash(
+    storage: SerializedSQLiteStorage, secrethash: SecretHash
+) -> Optional[StateChangeRecord]:
+    filters = [{"transfer.lock.secrethash": to_hex(secrethash)}]
+    query = FilteredDBQuery(
+        filters=filters, main_operator=Operator.NONE, inner_operator=Operator.NONE
+    )
+    return storage.get_latest_state_change_by_data_field(query)
 
 
 def balance_proof_query_from_keys(prefix: str, filters: Dict[str, Any]) -> Dict[str, Any]:

--- a/raiden/tests/integration/api/test_pythonapi_regression.py
+++ b/raiden/tests/integration/api/test_pythonapi_regression.py
@@ -23,7 +23,6 @@ def test_close_regression(raiden_network, deposit, token_addresses):
 
 def run_test_close_regression(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network
-    registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
 
     api1 = RaidenAPI(app0.raiden)

--- a/raiden/tests/integration/api/test_pythonapi_regression.py
+++ b/raiden/tests/integration/api/test_pythonapi_regression.py
@@ -41,8 +41,14 @@ def run_test_close_regression(raiden_network, deposit, token_addresses):
     amount = 10
     identifier = 42
     secret, secrethash = factories.make_secret_with_hash()
-    assert api1.transfer(
-        registry_address, token_address, amount, api2.address, identifier=identifier, secret=secret
+    assert api1.transfer_and_wait(
+        registry_address=registry_address,
+        token_address=token_address,
+        amount=amount,
+        target=api2.address,
+        identifier=identifier,
+        secret=secret,
+        transfer_timeout=10,
     )
     exception = ValueError("Waiting for transfer received success in the WAL timed out")
     with gevent.Timeout(seconds=5, exception=exception):

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -291,11 +291,9 @@ def run_test_query_events(
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
-    token_network_address = views.get_token_network_address_by_token_address(
-        views.state_from_app(app0), registry_address, token_address
-    )
 
     token_network_address = app0.raiden.default_registry.get_token_network(token_address, "latest")
+
     assert token_network_address
     manager0 = app0.raiden.chain.token_network(token_network_address)
 

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -5,7 +5,7 @@ from raiden import routing, waiting
 from raiden.api.python import RaidenAPI
 from raiden.exceptions import InvalidAmount
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.transfer import has_unlock_failure
+from raiden.tests.utils.transfer import watch_for_unlock_failures
 from raiden.transfer import channel, views
 from raiden.transfer.state import ChannelState
 from raiden.utils.typing import PaymentAmount, TokenAmount
@@ -200,7 +200,7 @@ def run_test_participant_selection(raiden_network, token_addresses):
     with gevent.Timeout(30, exception=ValueError("partner not reachable")):
         waiting.wait_for_healthy(sender, receiver.address, PaymentAmount(1))
 
-    try:
+    with watch_for_unlock_failures(*raiden_network):
         amount = PaymentAmount(1)
         RaidenAPI(sender).transfer_and_wait(
             registry_address, token_address, amount, receiver.address, transfer_timeout=10
@@ -210,9 +210,6 @@ def run_test_participant_selection(raiden_network, token_addresses):
             30, exception=ValueError("timeout while waiting for incoming transaction")
         ):
             wait_for_transaction(receiver, registry_address, token_address, sender.address)
-    finally:
-        for app in raiden_network:
-            assert not has_unlock_failure(app.raiden)
 
     # test `leave()` method
     connection_manager = connection_managers[0]

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -18,7 +18,7 @@ from raiden.tests.utils.events import (
 )
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.tests.utils.network import payment_channel_open_and_deposit
-from raiden.tests.utils.transfer import get_channelstate, has_unlock_failure, transfer
+from raiden.tests.utils.transfer import get_channelstate, transfer, watch_for_unlock_failures
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.events import EventRouteFailed, SendSecretReveal
 from raiden.transfer.mediated_transfer.state_change import ReceiveTransferCancelRoute
@@ -111,11 +111,8 @@ def run_test_regression_revealsecret_after_secret(
     payment_status = app0.raiden.mediated_transfer_async(
         token_network_address, amount=1, target=app2.raiden.address, identifier=identifier
     )
-    try:
+    with watch_for_unlock_failures(*raiden_network):
         assert payment_status.payment_done.wait()
-    finally:
-        for app in raiden_network:
-            assert not has_unlock_failure(app.raiden)
 
     event = search_for_item(app1.raiden.wal.storage.get_events(), SendSecretReveal, {})
     assert event

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -13,7 +13,7 @@ from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import raiden_events_search_for_item
 from raiden.tests.utils.factories import make_secret
 from raiden.tests.utils.network import CHAIN
-from raiden.tests.utils.transfer import assert_synced_channel_state
+from raiden.tests.utils.transfer import assert_synced_channel_state, has_unlock_failure
 from raiden.transfer import views
 from raiden.transfer.events import EventPaymentSentSuccess
 from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendSecretReveal
@@ -106,28 +106,32 @@ def run_test_send_queued_messages(raiden_network, deposit, token_addresses, netw
     #     msg = "The secrethashes of the pending transfers must be in the queue after a restart."
     #     assert secrethash in chain_state.payment_mapping.secrethashes_to_task, msg
 
-    exception = RuntimeError("Timeout while waiting for balance update for app0")
-    with gevent.Timeout(20, exception=exception):
-        waiting.wait_for_payment_balance(
-            raiden=app0_restart.raiden,
-            token_network_registry_address=token_network_registry_address,
-            token_address=token_address,
-            partner_address=app1.raiden.address,
-            target_address=app1.raiden.address,
-            target_balance=total_transferred_amount,
-            retry_timeout=network_wait,
-        )
-    exception = RuntimeError("Timeout while waiting for balance update for app1")
-    with gevent.Timeout(20, exception=exception):
-        waiting.wait_for_payment_balance(
-            raiden=app1.raiden,
-            token_network_registry_address=token_network_registry_address,
-            token_address=token_address,
-            partner_address=app0_restart.raiden.address,
-            target_address=app1.raiden.address,
-            target_balance=total_transferred_amount,
-            retry_timeout=network_wait,
-        )
+    try:
+        exception = RuntimeError("Timeout while waiting for balance update for app0")
+        with gevent.Timeout(20, exception=exception):
+            waiting.wait_for_payment_balance(
+                raiden=app0_restart.raiden,
+                token_network_registry_address=token_network_registry_address,
+                token_address=token_address,
+                partner_address=app1.raiden.address,
+                target_address=app1.raiden.address,
+                target_balance=total_transferred_amount,
+                retry_timeout=network_wait,
+            )
+        exception = RuntimeError("Timeout while waiting for balance update for app1")
+        with gevent.Timeout(20, exception=exception):
+            waiting.wait_for_payment_balance(
+                raiden=app1.raiden,
+                token_network_registry_address=token_network_registry_address,
+                token_address=token_address,
+                partner_address=app0_restart.raiden.address,
+                target_address=app1.raiden.address,
+                target_balance=total_transferred_amount,
+                retry_timeout=network_wait,
+            )
+    finally:
+        for app in raiden_network:
+            assert not has_unlock_failure(app.raiden)
 
     assert_synced_channel_state(
         token_network_address,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -16,8 +16,8 @@ from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import (
+    assert_succeeding_transfer_invariants,
     assert_synced_channel_state,
-    assert_transfer_happy_path_invariants,
     transfer,
     transfer_and_assert_path,
     wait_assert,
@@ -70,7 +70,7 @@ def run_test_mediated_transfer(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_transfer_happy_path_invariants,
+            assert_succeeding_transfer_invariants,
             token_network_address,
             app0,
             deposit - amount,
@@ -81,7 +81,7 @@ def run_test_mediated_transfer(
         )
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_transfer_happy_path_invariants,
+            assert_succeeding_transfer_invariants,
             token_network_address,
             app1,
             deposit - amount,
@@ -212,7 +212,7 @@ def run_test_mediated_transfer_with_entire_deposit(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_transfer_happy_path_invariants,
+            assert_succeeding_transfer_invariants,
             token_network_address,
             app0,
             deposit * 2,
@@ -223,7 +223,7 @@ def run_test_mediated_transfer_with_entire_deposit(
         )
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_transfer_happy_path_invariants,
+            assert_succeeding_transfer_invariants,
             token_network_address,
             app1,
             deposit * 2,
@@ -310,7 +310,7 @@ def run_test_mediated_transfer_messages_out_of_order(
     transfer_received.payment_done.wait()
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_transfer_happy_path_invariants,
+            assert_succeeding_transfer_invariants,
             token_network_address,
             app0,
             deposit - amount,
@@ -322,7 +322,7 @@ def run_test_mediated_transfer_messages_out_of_order(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_transfer_happy_path_invariants,
+            assert_succeeding_transfer_invariants,
             token_network_address,
             app1,
             deposit - amount,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -16,7 +16,6 @@ from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import (
-    assert_synced_channel_state,
     assert_transfer_happy_path_invariants,
     transfer,
     transfer_and_assert_path,
@@ -212,11 +211,25 @@ def run_test_mediated_transfer_with_entire_deposit(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state, token_network_address, app0, deposit * 2, [], app1, 0, []
+            assert_transfer_happy_path_invariants,
+            token_network_address,
+            app0,
+            deposit * 2,
+            [],
+            app1,
+            0,
+            [],
         )
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state, token_network_address, app1, deposit * 2, [], app2, 0, []
+            assert_transfer_happy_path_invariants,
+            token_network_address,
+            app1,
+            deposit * 2,
+            [],
+            app2,
+            0,
+            [],
         )
 
 
@@ -296,7 +309,7 @@ def run_test_mediated_transfer_messages_out_of_order(
     transfer_received.payment_done.wait()
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app0,
             deposit - amount,
@@ -308,7 +321,7 @@ def run_test_mediated_transfer_messages_out_of_order(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app1,
             deposit - amount,
@@ -448,7 +461,7 @@ def run_test_mediated_transfer_with_allocated_fee(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app0,
             deposit - amount - fee,
@@ -459,7 +472,7 @@ def run_test_mediated_transfer_with_allocated_fee(
         )
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app1,
             deposit - amount - fee,
@@ -496,7 +509,7 @@ def run_test_mediated_transfer_with_allocated_fee(
     # The fees have been consumed exclusively by app1
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app0,
             deposit - 2 * (amount + fee),
@@ -518,7 +531,7 @@ def run_test_mediated_transfer_with_allocated_fee(
     # app1 (provided we've set the fee of the channel)
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app1,
             deposit - (amount * 2) - fee,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -17,6 +17,7 @@ from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
+    assert_transfer_happy_path_invariants,
     transfer,
     transfer_and_assert_path,
     wait_assert,
@@ -69,7 +70,7 @@ def run_test_mediated_transfer(
 
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app0,
             deposit - amount,
@@ -80,7 +81,7 @@ def run_test_mediated_transfer(
         )
     with gevent.Timeout(network_wait):
         wait_assert(
-            assert_synced_channel_state,
+            assert_transfer_happy_path_invariants,
             token_network_address,
             app1,
             deposit - amount,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -3,7 +3,7 @@ import pytest
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
-from raiden.tests.utils.transfer import transfer
+from raiden.tests.utils.transfer import has_unlock_failure, transfer
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockClaimSuccess,
     EventUnlockSuccess,
@@ -43,6 +43,7 @@ def run_test_mediated_transfer_events(
     )
 
     def test_initiator_events():
+        assert not has_unlock_failure(app0.raiden)
         initiator_events = app0.raiden.wal.storage.get_events()
         return search_for_item(initiator_events, SendSecretReveal, {}) and search_for_item(
             initiator_events, EventUnlockSuccess, {}
@@ -51,6 +52,7 @@ def run_test_mediated_transfer_events(
     assert wait_until(test_initiator_events, network_wait)
 
     def test_mediator_events():
+        assert not has_unlock_failure(app1.raiden)
         mediator_events = app1.raiden.wal.storage.get_events()
         return search_for_item(mediator_events, EventUnlockSuccess, {}) and search_for_item(
             mediator_events, EventUnlockClaimSuccess, {}
@@ -59,6 +61,7 @@ def run_test_mediated_transfer_events(
     assert wait_until(test_mediator_events, network_wait)
 
     def test_target_events():
+        assert not has_unlock_failure(app2.raiden)
         target_events = app2.raiden.wal.storage.get_events()
         return (
             search_for_item(target_events, SendSecretRequest, {})

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -45,18 +45,18 @@ def run_test_mediated_transfer_events(
     def test_initiator_events():
         assert not has_unlock_failure(app0.raiden)
         initiator_events = app0.raiden.wal.storage.get_events()
-        return search_for_item(initiator_events, SendSecretReveal, {}) and search_for_item(
-            initiator_events, EventUnlockSuccess, {}
-        )
+        secret_reveal = search_for_item(initiator_events, SendSecretReveal, {})
+        unlock_success = search_for_item(initiator_events, EventUnlockSuccess, {})
+        return secret_reveal and unlock_success
 
     assert wait_until(test_initiator_events, network_wait)
 
     def test_mediator_events():
         assert not has_unlock_failure(app1.raiden)
         mediator_events = app1.raiden.wal.storage.get_events()
-        return search_for_item(mediator_events, EventUnlockSuccess, {}) and search_for_item(
-            mediator_events, EventUnlockClaimSuccess, {}
-        )
+        unlock_success = search_for_item(mediator_events, EventUnlockSuccess, {})
+        unlock_claim_success = search_for_item(mediator_events, EventUnlockClaimSuccess, {})
+        return unlock_success and unlock_claim_success
 
     assert wait_until(test_mediator_events, network_wait)
 

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -1,12 +1,12 @@
 from collections.abc import Mapping
-from typing import Type
 
 import gevent
 
 from raiden.raiden_service import RaidenService
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.transfer.architecture import Event, StateChange
-from raiden.utils.typing import Any, Iterable, List, Optional, TypeVar
+from raiden.transfer.mediated_transfer.events import EventUnlockClaimFailed, EventUnlockFailed
+from raiden.utils.typing import Any, Iterable, List, Optional, Tuple, Type, TypeVar
 
 NOVALUE = object()
 T = TypeVar("T")
@@ -127,6 +127,20 @@ def must_have_events(event_list: List[TM], *args) -> bool:
             return False
 
     return True
+
+
+def has_event_of_types(events: List[Event], event_types: Tuple[Type, ...]) -> bool:
+    for event in events:
+        for event_type in event_types:
+            if isinstance(event, event_type):
+                return True
+    else:
+        return False
+
+
+def has_unlock_failure(raiden: RaidenService) -> bool:
+    events = raiden.wal.storage.get_events()
+    return has_event_of_types(events, [EventUnlockFailed, EventUnlockClaimFailed])
 
 
 def wait_for_raiden_event(

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -139,8 +139,8 @@ def has_event_of_types(events: List[Event], event_types: Tuple[Type, ...]) -> bo
 
 
 def has_unlock_failure(raiden: RaidenService) -> bool:
-    events = raiden.wal.storage.get_events()
-    return has_event_of_types(events, [EventUnlockFailed, EventUnlockClaimFailed])
+    events = raiden.wal.storage.get_events()  # type: ignore
+    return has_event_of_types(events, (EventUnlockFailed, EventUnlockClaimFailed))
 
 
 def wait_for_raiden_event(

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -236,6 +236,12 @@ def make_secret_hash(i: int = EMPTY) -> SecretHash:
         return make_32bytes()
 
 
+def make_secret_with_hash(i: int = EMPTY) -> Tuple[Secret, SecretHash]:
+    secret = make_secret(i)
+    secrethash = sha256_secrethash(secret)
+    return secret, secrethash
+
+
 def make_lock() -> HashTimeLockState:
     return HashTimeLockState(
         amount=random.randint(0, UINT256_MAX),

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -803,7 +803,7 @@ def assert_synced_channel_state(
     )
 
 
-def assert_transfer_happy_path_invariants(
+def assert_succeeding_transfer_invariants(
     token_network_address: TokenNetworkAddress,
     app0: App,
     balance0: Balance,

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -17,7 +17,7 @@ from raiden.storage.restore import (
     get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.storage.wal import SavedState
-from raiden.tests.utils.events import raiden_state_changes_search_for_item
+from raiden.tests.utils.events import has_unlock_failure, raiden_state_changes_search_for_item
 from raiden.tests.utils.factories import (
     make_initiator_address,
     make_message_identifier,
@@ -777,6 +777,24 @@ def assert_synced_channel_state(
         channel1=channel1,
         balance1=balance1,
         pending_locks1=pending_locks1,
+    )
+
+
+def assert_transfer_happy_path_invariants(
+    token_network_address: TokenNetworkAddress,
+    app0: App,
+    balance0: Balance,
+    pending_locks0: List[HashTimeLockState],
+    app1: App,
+    balance1: Balance,
+    pending_locks1: List[HashTimeLockState],
+) -> None:
+    """ Channels are in synced states and no unlock failures have occurred. """
+    assert not has_unlock_failure(app0.raiden)
+    assert not has_unlock_failure(app1.raiden)
+
+    assert_synced_channel_state(
+        token_network_address, app0, balance0, pending_locks0, app1, balance1, pending_locks1
     )
 
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -183,13 +183,17 @@ def _transfer_unlocked(
         fee=fee,
     )
 
-    with Timeout(seconds=timeout):
-        wait_for_unlock.get()
-        msg = (
-            f"transfer from {to_checksum_address(initiator_app.raiden.address)} "
-            f"to {to_checksum_address(target_app.raiden.address)} failed."
-        )
-        assert payment_status.payment_done.get(), msg
+    try:
+        with Timeout(seconds=timeout):
+            wait_for_unlock.get()
+            msg = (
+                f"transfer from {to_checksum_address(initiator_app.raiden.address)} "
+                f"to {to_checksum_address(target_app.raiden.address)} failed."
+            )
+            assert payment_status.payment_done.get(), msg
+    finally:
+        assert not has_unlock_failure(initiator_app.raiden)
+        assert not has_unlock_failure(target_app.raiden)
 
 
 def _transfer_expired(
@@ -385,13 +389,17 @@ def transfer_and_assert_path(
         secret=secret,
     )
 
-    with Timeout(seconds=timeout):
-        gevent.wait(results)
-        msg = (
-            f"transfer from {to_checksum_address(first_app.raiden.address)} "
-            f"to {to_checksum_address(last_app.raiden.address)} failed."
-        )
-        assert payment_status.payment_done.get(), msg
+    try:
+        with Timeout(seconds=timeout):
+            gevent.wait(results)
+            msg = (
+                f"transfer from {to_checksum_address(first_app.raiden.address)} "
+                f"to {to_checksum_address(last_app.raiden.address)} failed."
+            )
+            assert payment_status.payment_done.get(), msg
+    finally:
+        for app in path:
+            assert not has_unlock_failure(app.raiden)
 
 
 def assert_deposit(


### PR DESCRIPTION
Assert that no failed unlocks occur in happy path transfer tests.

Closes #4369