### PR TITLE
Add typing_extensions to production requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,3 +28,4 @@ requests
 structlog
 web3
 webargs
+typing_extensions

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -70,6 +70,7 @@ six==1.12.0               # via attrdict, flask-cors, flask-restful, marshmallow
 structlog==19.1.0
 toolz==0.9.0              # via cytoolz
 traitlets==4.3.2          # via ipython
+typing-extensions==3.7.4  # via mypy
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
 web3==4.9.2


### PR DESCRIPTION
This is done only because of the Literal["foo", "boo"] construct. It
needs the typing extensions in order to exist.

Another way to go around adding this to requirements is to define all
literals in `raiden/utils/typing.py` and with an `if TYPE_CHECKING:`
change the type to `Any`.

Fix #4474 