### PR TITLE
Remove pfs info settings

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -56,7 +56,6 @@ class PFSInfo:
     message: str
     operator: str
     version: str
-    settings: str
 
 
 @dataclass
@@ -153,7 +152,6 @@ def get_pfs_info(url: str) -> Optional[PFSInfo]:
             message=infos["message"],
             operator=infos["operator"],
             version=infos["version"],
-            settings=infos["settings"],
         )
     except (json.JSONDecodeError, requests.exceptions.RequestException, KeyError):
         return None

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -76,7 +76,6 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",
         "version": "0.0.1",
-        "settings": "",
         "payment_address": "0x2222222222222222222222222222222222222222",
     }
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -360,7 +360,6 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
                 message="",
                 operator="",
                 version="",
-                settings="",
                 price=TokenAmount(0),
             ),
             maximum_fee=TokenAmount(100),

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -112,7 +112,6 @@ PFS_CONFIG = PFSConfig(
         message="",
         operator="",
         version="",
-        settings="",
     ),
     maximum_fee=TokenAmount(100),
     iou_timeout=BlockNumber(100),
@@ -173,7 +172,6 @@ def test_get_pfs_info_success():
         assert pfs_info.message == "This is your favorite pathfinding service"
         assert pfs_info.operator == "John Doe"
         assert pfs_info.version == "0.0.1"
-        assert pfs_info.settings == ""
 
 
 def test_get_pfs_info_request_error():
@@ -924,7 +922,6 @@ def test_no_iou_when_pfs_price_0(query_paths_args):
             message="",
             operator="",
             version="",
-            settings="",
         ),
         maximum_fee=TokenAmount(100),
         iou_timeout=BlockNumber(100),

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -213,7 +213,6 @@ def patched_get_for_succesful_pfs_info():
         "operator": "John Doe",
         "version": "0.0.1",
         "payment_address": "0x2222222222222222222222222222222222222222",
-        "settings": "",
     }
 
     response = Mock()


### PR DESCRIPTION
We need to remove the "settings" info from the pfs info endpoint. It was removed from the pfs code today, see https://github.com/raiden-network/raiden-services/pull/484