### PR TITLE
Make CI tag regex also recognize dev builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 templates:
   filter-tag-templates: &only-tagged-version-filter
     tags:
-      only: /^v\d+\.\d+\.\d+(\-rc\d+)?$/
+      only: /^v\d+\.\d+\.\d+((:?\-|\.)?(rc|dev)\d*)?$/
     branches:
       ignore: /.*/
 


### PR DESCRIPTION
Also support the canonical and alternate spellings of PEP440 versions.
e.g.:
- `1.2.3-rc1`
- `1.2.3.rc1`
- `1.2.3rc1`