### PR TITLE
Better error handling for `SuccessOrError` type

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -3,7 +3,7 @@ import random
 from copy import deepcopy
 from dataclasses import replace
 
-import pytest
+import pytest  # type: ignore
 
 from raiden.constants import (
     EMPTY_HASH,
@@ -114,36 +114,36 @@ def test_is_safe_to_wait():
     # expiration is in 30 blocks, 19 blocks safe for waiting
     block_number = 10
     reveal_timeout = 10
-    is_safe, msg = mediator.is_safe_to_wait(expiration, reveal_timeout, block_number)
-    assert is_safe, msg
+    assert mediator.is_safe_to_wait(expiration, reveal_timeout, block_number).ok
 
     # expiration is in 20 blocks, 10 blocks safe for waiting
     block_number = 20
     reveal_timeout = 10
-    is_safe, msg = mediator.is_safe_to_wait(expiration, reveal_timeout, block_number)
-    assert is_safe, msg
+    assert mediator.is_safe_to_wait(expiration, reveal_timeout, block_number).ok
 
     # expiration is in 11 blocks, 1 block safe for waiting
     block_number = 29
     reveal_timeout = 10
-    is_safe, msg = mediator.is_safe_to_wait(expiration, reveal_timeout, block_number)
-    assert is_safe, msg
+    assert mediator.is_safe_to_wait(expiration, reveal_timeout, block_number).ok
 
     # at the block 30 it's not safe to wait anymore
     block_number = 30
     reveal_timeout = 10
-    is_safe, _ = mediator.is_safe_to_wait(expiration, reveal_timeout, block_number)
-    assert not is_safe, "this is expiration must not be safe"
+    assert mediator.is_safe_to_wait(
+        expiration, reveal_timeout, block_number
+    ).fail, "this is expiration must not be safe"
 
     block_number = 40
     reveal_timeout = 10
-    is_safe, _ = mediator.is_safe_to_wait(expiration, reveal_timeout, block_number)
-    assert not is_safe, "this is expiration must not be safe"
+    assert mediator.is_safe_to_wait(
+        expiration, reveal_timeout, block_number
+    ).fail, "this is expiration must not be safe"
 
     block_number = 50
     reveal_timeout = 10
-    is_safe, _ = mediator.is_safe_to_wait(expiration, reveal_timeout, block_number)
-    assert not is_safe, "this is expiration must not be safe"
+    assert mediator.is_safe_to_wait(
+        expiration, reveal_timeout, block_number
+    ).fail, "this is expiration must not be safe"
 
 
 def test_is_channel_usable_for_mediation():
@@ -1154,10 +1154,10 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
     )
 
     attack_block_number = from_transfer.lock.expiration - attacked_channel.reveal_timeout
-    is_safe, _ = mediator.is_safe_to_wait(
+    is_safe = mediator.is_safe_to_wait(
         from_transfer.lock.expiration, attacked_channel.reveal_timeout, attack_block_number
     )
-    assert not is_safe
+    assert is_safe.fail
 
     # Wait until it's not safe to wait for the off-chain unlock for B-C (and expire C-A2)
     new_iteration = iteration

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -465,13 +465,11 @@ def test_regression_mediator_not_update_payer_state_twice():
     assert current_state.transfers_pair[0].payee_state == "payee_expired"
     assert not channel.is_secret_known(payer_channel.partner_state, secrethash)
 
-    safe_to_wait, _ = mediator.is_safe_to_wait(
+    assert mediator.is_safe_to_wait(
         lock_expiration=lock.expiration,
         reveal_timeout=payer_channel.reveal_timeout,
         block_number=lock.expiration + 10,
-    )
-
-    assert not safe_to_wait
+    ).fail
 
     iteration = mediator.state_transition(
         mediator_state=current_state,

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -402,3 +402,30 @@ class BalanceProofSignedState(State):
     @property
     def channel_identifier(self) -> ChannelID:
         return self.canonical_identifier.channel_identifier
+
+
+class SuccessOrError:
+    """Helper class to be used when you want to test a boolean
+
+    and also collect feedback when the test fails. Initialize with any
+    number of "error message" strings. The object will be considered
+    truthy if there are no error messages.
+    """
+
+    def __init__(self, *error_messages: str) -> None:
+        self.error_messages: List[str] = [msg for msg in error_messages]
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+    @property
+    def ok(self) -> bool:
+        return not bool(self.error_messages)
+
+    @property
+    def fail(self) -> bool:
+        return not self.ok
+
+    @property
+    def as_error_message(self) -> str:
+        return " / ".join(self.error_messages)

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -107,7 +107,7 @@ def handle_block(
     lock_expiration_threshold = BlockExpiration(
         locked_lock.expiration + DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
     )
-    lock_has_expired, _ = channel.is_lock_expired(
+    lock_has_expired = channel.is_lock_expired(
         end_state=channel_state.our_state,
         lock=locked_lock,
         block_number=state_change.block_number,

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -173,7 +173,7 @@ def subdispatch_to_all_initiatortransfer(
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
     pseudo_random_generator: random.Random,
 ) -> TransitionResult[InitiatorPaymentState]:
-    events = list()
+    events: List[Event] = list()
     """ Copy and iterate over the list of keys because this loop
     will alter the `initiator_transfers` list and this is not
     allowed if iterating over the original list.

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -65,7 +65,7 @@ def events_for_onchain_secretreveal(
     transfer = target_state.transfer
     expiration = transfer.lock.expiration
 
-    safe_to_wait, _ = is_safe_to_wait(expiration, channel_state.reveal_timeout, block_number)
+    safe_to_wait = is_safe_to_wait(expiration, channel_state.reveal_timeout, block_number)
     secret_known_offchain = channel.is_secret_known_offchain(
         channel_state.partner_state, transfer.lock.secrethash
     )
@@ -111,7 +111,7 @@ def handle_inittarget(
         # the handler handle_receive_lockedtransfer.
         target_state = TargetTransferState(route, transfer)
 
-        safe_to_wait, _ = is_safe_to_wait(
+        safe_to_wait = is_safe_to_wait(
             transfer.lock.expiration, channel_state.reveal_timeout, block_number
         )
 
@@ -269,7 +269,7 @@ def handle_block(
     lock = transfer.lock
 
     secret_known = channel.is_secret_known(channel_state.partner_state, lock.secrethash)
-    lock_has_expired, _ = channel.is_lock_expired(
+    lock_has_expired = channel.is_lock_expired(
         end_state=channel_state.our_state,
         lock=lock,
         block_number=block_number,

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -1,5 +1,5 @@
 from typing import *  # NOQA pylint:disable=wildcard-import,unused-wildcard-import
-from typing import TYPE_CHECKING, Any, Dict, List, NewType, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, NewType, Tuple, Type, Union
 
 from raiden_contracts.contract_manager import CompiledContract  # NOQA pylint:disable=unused-import
 from raiden_contracts.utils.type_aliases import (  # NOQA pylint:disable=unused-import
@@ -156,9 +156,6 @@ EncodedData = NewType("EncodedData", T_EncodedData)
 
 T_WithdrawAmount = int
 WithdrawAmount = NewType("WithdrawAmount", T_WithdrawAmount)
-
-# This should be changed to `Optional[str]`
-SuccessOrError = Tuple[bool, Optional[str]]
 
 BlockSpecification = Union[str, T_BlockNumber, T_BlockHash]
 


### PR DESCRIPTION
Replace `SuccessOrError` type alias for a proper class.
    
We are using currently a custom-defined `SuccessOrError` type for the cases where we need to test if a condition is valid *and* we also would like to have a message indicating *why* the condition is not true.
    
This `SuccessOrError` is was basically an alias to a `Tuple[bool, str]`, which did not help much in terms of programmer ergonomics (we would still have to destructure the tuple to check on the condition) and did not help much with type-enforcing.

The alternative proposed was to replace `SuccessOrError` with a simple `ErrorMsg` type and having the functions returning `Optional[ErrorMsg]`.  This could make things a bit simpler but still did not help much in the ergonomics part (e.g, the return value would be `True` whenever a function had errors and the condition being tested was `False`.)
    
The solution proposed and implemented here transforms SuccessOrError into a proper class. Objects of `SuccessOrError` can be instantiated with multiple error messages. The object itself has its "truthyness" determined by the presence or absence or error messages, i.e, a object without any error messages is `True`. This allows us to write functions that return `SuccessOrError` objects and use the comparison right away if we want or check for the errors in case the condition fails.

Resolves #4296  