### PR TITLE
Disable confirmation_prompt for `transfer_eth` tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint: mypy mypy-all isort black
 
 mypy:
 	mypy raiden
-	mypy tools/debugging
+	mypy tools
 
 mypy-all:
 	# Be aware, that we currently ignore all mypy errors in `raiden.tests.*` through `setup.cfg`.

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -14,7 +14,7 @@ WEI_TO_ETH = 10 ** 18
 
 @click.command()
 @click.option("--keystore-file", required=True, type=click.Path(exists=True, dir_okay=False))
-@click.password_option("--password", envvar="ACCOUNT_PASSWORD", required=True)  # type: ignore
+@click.password_option("--password", envvar="ACCOUNT_PASSWORD", confirmation_prompt=False)
 @click.option("--rpc-url", default="http://localhost:8545")
 @click.argument("eth-amount", type=int)
 @click.argument("targets_file", type=click.File())


### PR DESCRIPTION
Just makes `transfer_eth` a bit more convinient to use.