### PR TITLE
Rename `wait_for_payment_network`

### DIFF
--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -40,7 +40,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
     Tuple,
 )
-from raiden.waiting import wait_for_payment_network
+from raiden.waiting import wait_for_token_network
 from raiden_contracts.contract_manager import ContractManager
 
 AppChannels = Iterable[Tuple[App, App]]
@@ -529,7 +529,7 @@ def wait_for_token_networks(
 ) -> None:
     for token_address in token_addresses:
         for app in raiden_apps:
-            wait_for_payment_network(
+            wait_for_token_network(
                 app.raiden, token_network_registry_address, token_address, retry_timeout
             )
 

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -228,8 +228,7 @@ class ConsoleTools:
         else:
             token_network_address = registry.add_token_without_limits(token_address=token_address)
 
-        # Register the channel manager with the raiden registry
-        waiting.wait_for_payment_network(
+        waiting.wait_for_token_network(
             self._raiden, registry.address, token_address, retry_timeout
         )
 

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -287,6 +287,11 @@ def wait_for_token_network(
     token_address: TokenAddress,
     retry_timeout: float,
 ) -> None:  # pragma: no unittest
+    """Wait until the token network is visible to the RaidenService.
+
+    Note:
+        This does not time out, use gevent.Timeout.
+    """
     token_network = views.get_token_network_by_token_address(
         views.state_from_raiden(raiden), payment_network_address, token_address
     )

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -281,7 +281,7 @@ def wait_for_close(
     )
 
 
-def wait_for_payment_network(
+def wait_for_token_network(
     raiden: "RaidenService",
     payment_network_address: PaymentNetworkAddress,
     token_address: TokenAddress,
@@ -298,7 +298,7 @@ def wait_for_payment_network(
         assert raiden, ALARM_TASK_ERROR_MSG
         assert raiden.alarm, ALARM_TASK_ERROR_MSG
 
-        log.debug("wait_for_payment_network", **log_details)
+        log.debug("wait_for_token_network", **log_details)
         gevent.sleep(retry_timeout)
         token_network = views.get_token_network_by_token_address(
             views.state_from_raiden(raiden), payment_network_address, token_address


### PR DESCRIPTION
It actually waits for token networks, so the name should reflect that.

I also remove one comment that looks more misleading than helpful to me.