### PR TITLE
Remove `gevent.sleep` from tests

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -31,7 +31,7 @@ from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.smartcontracts import deploy_contract_web3
 from raiden.transfer import views
 from raiden.transfer.state import ChannelState
-from raiden.waiting import wait_for_transfer_success
+from raiden.waiting import wait_for_token_network, wait_for_transfer_success
 from raiden_contracts.constants import (
     CONTRACT_CUSTOM_TOKEN,
     CONTRACT_HUMAN_STANDARD_TOKEN,
@@ -1234,7 +1234,9 @@ def test_get_token_network_for_token(
     assert_proper_response(register_response, status_code=HTTPStatus.CREATED)
     token_network_address = get_json_response(register_response)["token_network_address"]
 
-    gevent.sleep(app0.raiden.alarm.sleep_time * 10)
+    wait_for_token_network(
+        app0.raiden, app0.raiden.default_registry.address, new_token_address, 0.1
+    )
 
     # now it should return the token address
     token_request = grequests.get(

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1472,8 +1472,6 @@ def test_api_deposit_limit(api_server_test_instance, token_addresses, reveal_tim
         "total_deposit": balance_working,
     }
 
-    gevent.sleep(2)
-
     request = grequests.put(
         api_url_for(api_server_test_instance, "channelsresource"), json=channel_data_obj
     )

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -801,8 +801,6 @@ def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
         secret=secret,
     )
 
-    gevent.sleep(1)  # wait for the messages to be exchanged
-
     attack_channel = get_channelstate(app2, app1, token_network_address)
     attack_transfer = None  # TODO
     attack_contract = attack_channel.external_state.netting_channel.address

--- a/raiden/tests/integration/rpc/test_client.py
+++ b/raiden/tests/integration/rpc/test_client.py
@@ -13,17 +13,14 @@ def test_geth_discover_next_available_nonce(
     https://github.com/raiden-network/raiden/pull/3683#issue-264551799
     """
 
-    greenlets = set()
-    for _ in range(100):
-        greenlets.add(
-            gevent.spawn(deploy_client.send_transaction, make_address(), 50000)  # to  # startgas
-        )
-    gevent.sleep(0.5)
+    greenlets = {
+        gevent.spawn(deploy_client.send_transaction, make_address(), 50000)  # to  # startgas
+        for _ in range(100)
+    }
+    gevent.joinall(set(greenlets), raise_error=True)
 
     nonce = geth_discover_next_available_nonce(
         web3=deploy_client.web3, address=deploy_client.address
     )
     assert nonce > 0
-    assert nonce < 100
-
-    gevent.joinall(greenlets, raise_error=True)
+    assert nonce <= 100

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -184,8 +184,6 @@ def run_test_token_registered_race(raiden_chain, token_amount, retry_timeout, co
         constructor_arguments=(token_amount, 2, "raiden", "Rd"),
     )
 
-    gevent.sleep(1)
-
     registry_address = app0.raiden.default_registry.address
     assert token_address not in api0.get_tokens_list(registry_address)
     assert token_address not in api1.get_tokens_list(registry_address)

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -1,4 +1,3 @@
-import gevent
 import pytest
 
 from raiden import waiting
@@ -208,8 +207,6 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
     )
 
     app0.stop()
-
-    gevent.sleep(1)
 
     raiden_event_handler = RaidenEventHandler()
     message_handler = MessageHandler()

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -169,9 +169,6 @@ def run_test_refund_transfer(
         timeout=network_wait,
     )
 
-    # wait for the nodes to sync
-    gevent.sleep(1)
-
     with gevent.Timeout(network_wait):
         wait_assert(
             assert_synced_channel_state,
@@ -204,8 +201,6 @@ def run_test_refund_transfer(
     )
     msg = "there is no path with capacity, the transfer must fail"
     assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
-
-    gevent.sleep(0.2)
 
     # A lock structure with the correct amount
 
@@ -416,8 +411,6 @@ def run_test_different_view_of_last_bp_during_unlock(
     )
     msg = "there is no path with capacity, the transfer must fail"
     assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
-
-    gevent.sleep(0.2)
 
     # A lock structure with the correct amount
 
@@ -642,8 +635,6 @@ def run_test_refund_transfer_after_2nd_hop(
     )
     msg = "there is no path with capacity, the transfer must fail"
     assert isinstance(payment_status.payment_done.wait(), EventPaymentSentFailed), msg
-
-    gevent.sleep(0.2)
 
     # Lock structures with the correct amount
 


### PR DESCRIPTION
Sleep has been kept in:
* wait loops, there using `gevent.sleep` makes sense and is safe
* `test_token_swap`, which is skipped right no without a documented reason (https://github.com/raiden-network/raiden/blob/develop/raiden/tests/integration/test_pythonapi.py#L280-L326)

I added timeouts in many places where I removed sleeps, so that waiting for an event won't be done for unreasonably long times when the test is broken. These timeouts should be chosen generously, so that slow tests won't cause flakyness.

Closes https://github.com/raiden-network/raiden/issues/4368.
