### PR TITLE
Fix flaky 3714

### DIFF
--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -122,7 +122,7 @@ class SecretHashField(fields.Field):
         "missing_prefix": "Not a valid hex encoded value, must be 0x prefixed.",
         "invalid_data": "Not a valid hex formated string, contains invalid characters.",
         "invalid_size": (
-            f"Not a valid secrethash, decoded value is not {SECRETHASH_LENGTH} " f"bytes long."
+            f"Not a valid secrethash, decoded value is not {SECRETHASH_LENGTH} bytes long."
         ),
     }
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1125,9 +1125,7 @@ class TokenNetwork:
                 raise RaidenRecoverableError(msg)
 
             if network_balance + amount_to_deposit > token_network_deposit_limit:
-                msg = (
-                    f"Deposit of {amount_to_deposit} exceeded " f"the token network deposit limit."
-                )
+                msg = f"Deposit of {amount_to_deposit} exceeded the token network deposit limit."
                 raise RaidenRecoverableError(msg)
 
             raise RaidenRecoverableError("Deposit gas estimatation failed for unknown reasons")
@@ -1914,7 +1912,7 @@ class TokenNetwork:
                     #
                     # This is a race condition that cannot be prevented,
                     # therefore it is a recoverable error.
-                    msg = "update transfer was mined after the settlement " "window."
+                    msg = "update transfer was mined after the settlement window."
                     raise RaidenRecoverableError(msg)
 
                 partner_details = self._detail_participant(

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -94,7 +94,7 @@ class _RetryQueue(Runnable):
         self._notify_event = gevent.event.Event()
         self._lock = gevent.lock.Semaphore()
         super().__init__()
-        self.greenlet.name = f"RetryQueue " f"recipient:{to_checksum_address(self.receiver)}"
+        self.greenlet.name = f"RetryQueue recipient:{to_checksum_address(self.receiver)}"
 
     @property
     def log(self):

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -13,7 +13,7 @@ from raiden.transfer.architecture import BalanceProofSignedState, BalanceProofUn
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import ChainState
 from raiden.utils import to_rdn
-from raiden.utils.typing import TYPE_CHECKING, Address
+from raiden.utils.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from raiden.raiden_service import RaidenService
@@ -30,10 +30,7 @@ def update_services_from_balance_proof(
     send_pfs_update(raiden=raiden, canonical_identifier=balance_proof.canonical_identifier)
     if isinstance(balance_proof, BalanceProofSignedState):
         update_monitoring_service_from_balance_proof(
-            raiden=raiden,
-            chain_state=chain_state,
-            new_balance_proof=balance_proof,
-            monitoring_service_contract_address=raiden.default_msc_address,
+            raiden=raiden, chain_state=chain_state, new_balance_proof=balance_proof
         )
 
 
@@ -66,10 +63,7 @@ def send_pfs_update(
 
 
 def update_monitoring_service_from_balance_proof(
-    raiden: "RaidenService",
-    chain_state: ChainState,
-    new_balance_proof: BalanceProofSignedState,
-    monitoring_service_contract_address: Address,
+    raiden: "RaidenService", chain_state: ChainState, new_balance_proof: BalanceProofSignedState
 ) -> None:
     if raiden.config["services"]["monitoring_enabled"] is False:
         return
@@ -115,7 +109,9 @@ def update_monitoring_service_from_balance_proof(
     )
 
     monitoring_message = RequestMonitoring.from_balance_proof_signed_state(
-        new_balance_proof, MONITORING_REWARD, monitoring_service_contract_address
+        balance_proof=new_balance_proof,
+        reward_amount=MONITORING_REWARD,
+        monitoring_service_contract_address=raiden.default_msc_address,
     )
     monitoring_message.sign(raiden.signer)
     raiden.transport.send_global(constants.MONITORING_BROADCASTING_ROOM, monitoring_message)

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -344,9 +344,7 @@ class SQLiteStorage:
     def write_state_snapshot(self, snapshot: str, statechange_id: StateChangeID) -> SnapshotID:
         snapshot_id = self._ulid_factory(SnapshotID).new()
 
-        query = (
-            "INSERT INTO state_snapshot (" " identifier, statechange_id, data" ") VALUES(?, ?, ?)"
-        )
+        query = "INSERT INTO state_snapshot (identifier, statechange_id, data) VALUES(?, ?, ?)"
         self.conn.execute(query, (snapshot_id, statechange_id, snapshot))
         self.maybe_commit()
 

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -152,7 +152,7 @@ def test_payload_with_invalid_addresses(api_server_test_instance, rest_api_port_
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
 
     url_without_prefix = (
-        "http://localhost:{port}/api/v1/" "channels/ea674fdde714fd979de3edf0f56aa9716b898ec8"
+        "http://localhost:{port}/api/v1/channels/ea674fdde714fd979de3edf0f56aa9716b898ec8"
     ).format(port=rest_api_port_number)
 
     request = grequests.patch(

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -137,9 +137,7 @@ def test_concurrent_secret_registration(secret_registry_proxy, monkeypatch):
         def count_transactions(function_name, startgas, secrets):
             for secret in secrets:
                 count[secret] += 1
-                msg = (
-                    "All secrets must be registered, " "and they all must be registered only once"
-                )
+                msg = "All secrets must be registered, and they all must be registered only once"
                 assert count[secret] == 1, msg
 
             return transact(function_name, startgas, secrets)
@@ -178,5 +176,5 @@ def test_concurrent_secret_registration(secret_registry_proxy, monkeypatch):
 
         gevent.joinall(greenlets, raise_error=True)
 
-        msg = "All secrets must be registered, " "and they all must be registered only once"
+        msg = "All secrets must be registered, and they all must be registered only once"
         assert all(count[secret] == 1 for secret in secrets), msg

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -619,10 +619,7 @@ def test_monitoring_global_messages(
     raiden_service.user_deposit.effective_balance.return_value = 100
 
     update_monitoring_service_from_balance_proof(
-        raiden=raiden_service,
-        chain_state=None,
-        new_balance_proof=balance_proof,
-        monitoring_service_contract_address=bytes([1] * 20),
+        raiden=raiden_service, chain_state=None, new_balance_proof=balance_proof
     )
     gevent.idle()
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -514,7 +514,7 @@ def test_channelstate_receive_lockedtransfer():
         sender=invalid_balance_proof.sender,
     )
     is_valid, _, _ = channel.handle_unlock(channel_state, invalid_unlock_state_change)
-    assert not is_valid, "Unlock message with chain_id different than the " "channel's should fail"
+    assert not is_valid, "Unlock message with chain_id different than the channel's should fail"
 
     is_valid, _, msg = channel.handle_unlock(channel_state, unlock_state_change)
     assert is_valid, msg

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -597,7 +597,5 @@ def test_regression_unavailable_nodes_must_be_properly_filtered():
     )
 
     send_transfer = search_for_item(initial_iteration.events, SendLockedTransfer, {})
-    msg = (
-        "All available routes are with unavailable nodes, therefore no send " "should be produced"
-    )
+    msg = "All available routes are with unavailable nodes, therefore no send should be produced"
     assert send_transfer is None, msg

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -131,6 +131,7 @@ class MockRaidenService:
         self.default_registry = Mock()
         self.default_registry.address = factories.make_address()
         self.default_one_to_n_address = factories.make_address()
+        self.default_msc_address = factories.make_address()
 
         self.targets_to_identifiers_to_statuses = defaultdict(dict)
         self.route_to_feedback_token = {}

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -846,7 +846,7 @@ def is_valid_unlock(
         # Unlock messages must increase the transferred_amount by lock amount,
         # otherwise the sender is trying to play the protocol and steal token.
         msg = (
-            "Invalid Unlock message. " "Balance proof's wrong locked_amount, expected: {} got: {}."
+            "Invalid Unlock message. Balance proof's wrong locked_amount, expected: {} got: {}."
         ).format(expected_locked_amount, received_balance_proof.locked_amount)
 
         result = (False, msg, None)

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -513,7 +513,7 @@ class ChainState(State):
 
     def __repr__(self):
         return (
-            "ChainState(block_number={} block_hash={} networks={} " "qty_transfers={} chain_id={})"
+            "ChainState(block_number={} block_hash={} networks={} qty_transfers={} chain_id={})"
         ).format(
             self.block_number,
             to_hex(self.block_hash),

--- a/tools/check_circleci_config.py
+++ b/tools/check_circleci_config.py
@@ -43,7 +43,7 @@ def _check_workflows_align(config):
     )
     message = [
         _yellow(
-            "Mismatch in common items of workflow definitions 'raiden-default' and " "'nightly':\n"
+            "Mismatch in common items of workflow definitions 'raiden-default' and 'nightly':\n"
         )
     ]
     for line in job_diff:

--- a/tools/debugging/json-log-to-html.py
+++ b/tools/debugging/json-log-to-html.py
@@ -480,7 +480,7 @@ def render_fields(record: Record, sorted_known_fields: List[str]) -> List[str]:
             continue
         field_value = record.fields[field_name]
         colorized_value = str(colorize_value(field_value, min_luminance=0.6))
-        rendered_fields.append(f'<span class="fn">{field_name}</span>' f"=" f"{colorized_value}")
+        rendered_fields.append(f'<span class="fn">{field_name}</span> = {colorized_value}')
     return rendered_fields
 
 


### PR DESCRIPTION
Tests seems fine in general, however it was never adapted to the
addition of the PFSFeeUpdate message. This was added and a more fine
grained checking for which messages should be queued added.

One problem than was found after this is that two identical
PFSCapacityUpdate were queued. This was fixed by calling
update_monitoring_service_from_balance_proof directly.

Closes #3714 