### PR TITLE
Locksroot from event

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -334,14 +334,15 @@ def actionchannelupdatefee_from_channelstate(
 
 
 def blockchainevent_to_statechange(
-    raiden: "RaidenService", event: DecodedEvent, latest_confirmed_block: BlockNumber
+    raiden: "RaidenService",
+    event: DecodedEvent,
+    latest_confirmed_block: BlockNumber,  # pylint: disable=unused-argument
 ) -> List[StateChange]:  # pragma: no unittest
     msg = "The state of the node has to be primed before blockchain events can be processed."
     assert raiden.wal, msg
 
     event_name = event.event_data["event"]
     chain_state = views.state_from_raiden(raiden)
-    chain_service = raiden.chain
 
     state_changes: List[StateChange] = []
 

--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -408,10 +408,7 @@ def blockchainevent_to_statechange(
 
     elif event_name == ChannelEvent.SETTLED:
         channel_settle_state = get_contractreceivechannelsettled_data_from_event(
-            chain_service=chain_service,
-            chain_state=chain_state,
-            event=event,
-            latest_confirmed_block=latest_confirmed_block,
+            storage=raiden.wal.storage, chain_state=chain_state, event=event
         )
 
         if channel_settle_state:

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from eth_utils import to_checksum_address, to_hex
 
 from raiden.blockchain.events import DecodedEvent
+from raiden.exceptions import RaidenUnrecoverableError
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.utils import get_onchain_locksroots
 from raiden.storage.restore import (
@@ -210,7 +211,8 @@ def get_contractreceivechannelbatchunlock_data_from_event(
         f"Can not resolve channel_id for unlock with locksroot {to_hex(locksroot)} and "
         f"partner {to_checksum_address(partner)}."
     )
-    assert canonical_identifier is not None, msg
+    if canonical_identifier is None:
+        raise RaidenUnrecoverableError(msg)
 
     return canonical_identifier
 

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -24,7 +24,6 @@ from eth_utils import to_checksum_address, to_hex
 
 from raiden.blockchain.events import DecodedEvent
 from raiden.exceptions import RaidenUnrecoverableError
-from raiden.network.blockchain_service import BlockChainService
 from raiden.storage.restore import (
     get_event_with_balance_proof_by_locksroot,
     get_state_change_with_balance_proof_by_locksroot,
@@ -36,7 +35,6 @@ from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import ChainState, NettingChannelState
 from raiden.utils.typing import (
     Address,
-    BlockNumber,
     ChainID,
     Locksroot,
     Optional,

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,5 +1,8 @@
+from dataclasses import dataclass
+
 from eth_utils import to_checksum_address, to_hex
 
+from raiden.constants import EMPTY_HASH, LOCKSROOT_OF_NO_LOCKS
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.storage.sqlite import (
     EventRecord,
@@ -23,6 +26,13 @@ from raiden.utils.typing import (
     Locksroot,
     Optional,
 )
+
+
+@dataclass(frozen=True)
+class LocksrootRecord:
+    partner_locksroot: Locksroot
+    our_locksroot: Locksroot
+
 
 if TYPE_CHECKING:
     from raiden.raiden_service import RaidenService
@@ -210,3 +220,87 @@ def balance_proof_query_from_keys(prefix: str, filters: Dict[str, Any]) -> Dict[
     for key, value in filters.items():
         transformed_filters[f"{prefix}balance_proof.{key}"] = value
     return transformed_filters
+
+
+def try_to_match_locksroots(
+    storage: SerializedSQLiteStorage,
+    latest_channel_state: NettingChannelState,
+    try_our_locksroot: Locksroot,
+    try_partner_locksroot: Locksroot,
+) -> Optional[LocksrootRecord]:
+    """Search in the database for `try_our_locksroot` and
+    `try_partner_locksroot`, if both are match the expected end of the channel
+    `latest_channel_state` then LocksrootRecord is returned.
+
+    Notes:
+        - The empty hash has to be handled. Because this value is the default,
+          it is always assumed to be valid.
+        - The locksroot does not have to match the latest state of the channel,
+          however it must have been part of some version of the channel. This
+          is necessary to handle cases were a malicious node closes the channel
+          with older balance proofs, otherwise settling would not be possible.
+    """
+    our_locksroot = None
+    partner_locksroot = None
+
+    if try_our_locksroot == EMPTY_HASH:
+        our_locksroot = LOCKSROOT_OF_NO_LOCKS
+    else:
+        event_record = get_event_with_balance_proof_by_locksroot(
+            storage=storage,
+            canonical_identifier=latest_channel_state.canonical_identifier,
+            locksroot=try_our_locksroot,
+            recipient=latest_channel_state.partner_state.address,
+        )
+
+        if event_record is not None:
+            our_locksroot = try_our_locksroot
+
+    if try_partner_locksroot == EMPTY_HASH:
+        partner_locksroot = LOCKSROOT_OF_NO_LOCKS
+    else:
+        state_change_record = get_state_change_with_balance_proof_by_locksroot(
+            storage=storage,
+            canonical_identifier=latest_channel_state.canonical_identifier,
+            locksroot=try_partner_locksroot,
+            sender=latest_channel_state.partner_state.address,
+        )
+
+        if state_change_record is not None:
+            partner_locksroot = try_partner_locksroot
+
+    if our_locksroot is not None and partner_locksroot is not None:
+        return LocksrootRecord(our_locksroot=our_locksroot, partner_locksroot=partner_locksroot)
+
+    return None
+
+
+def order_locksroot(
+    storage: SerializedSQLiteStorage,
+    latest_channel_state: NettingChannelState,
+    locksroot1: Locksroot,
+    locksroot2: Locksroot,
+) -> Optional[LocksrootRecord]:
+    """Finds order of locksroot1 and locksroot2.
+
+    Returns None if any of the two locksroots is unknown, otherwise return
+    LocksrootRecord with the end of the locksroot correctly set.
+    """
+
+    order = try_to_match_locksroots(
+        storage=storage,
+        latest_channel_state=latest_channel_state,
+        try_our_locksroot=locksroot1,
+        try_partner_locksroot=locksroot2,
+    )
+
+    # Try again in the reverse order
+    if order is None:
+        order = try_to_match_locksroots(
+            storage=storage,
+            latest_channel_state=latest_channel_state,
+            try_our_locksroot=locksroot2,
+            try_partner_locksroot=locksroot1,
+        )
+
+    return order

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -243,7 +243,7 @@ def try_to_match_locksroots(
     our_locksroot = None
     partner_locksroot = None
 
-    if try_our_locksroot == EMPTY_HASH:
+    if try_our_locksroot in (EMPTY_HASH, LOCKSROOT_OF_NO_LOCKS):
         our_locksroot = LOCKSROOT_OF_NO_LOCKS
     else:
         event_record = get_event_with_balance_proof_by_locksroot(
@@ -256,7 +256,7 @@ def try_to_match_locksroots(
         if event_record is not None:
             our_locksroot = try_our_locksroot
 
-    if try_partner_locksroot == EMPTY_HASH:
+    if try_partner_locksroot in (EMPTY_HASH, LOCKSROOT_OF_NO_LOCKS):
         partner_locksroot = LOCKSROOT_OF_NO_LOCKS
     else:
         state_change_record = get_state_change_with_balance_proof_by_locksroot(

--- a/raiden/tests/unit/transfer/test_state_diff.py
+++ b/raiden/tests/unit/transfer/test_state_diff.py
@@ -50,14 +50,16 @@ def test_detect_balance_proof_change():
     token_network_registry.tokennetworkaddresses_to_tokennetworks["a"] = token_network
     assert len(diff()) == 0
 
+    our_state = NettingChannelEndState(address=b"b", contract_balance=1)
+    partner_state = NettingChannelEndState(address=b"a", contract_balance=0)
     channel = NettingChannelState(
         canonical_identifier=factories.make_canonical_identifier(),
         token_address=b"a",
         token_network_registry_address=1,
         reveal_timeout=1,
         settle_timeout=2,
-        our_state=None,
-        partner_state=None,
+        our_state=our_state,
+        partner_state=partner_state,
         open_transaction=TransactionExecutionStatus(result="success"),
         settle_transaction=None,
         update_transaction=None,
@@ -66,9 +68,7 @@ def test_detect_balance_proof_change():
     )
     channel_copy = deepcopy(channel)
     token_network.channelidentifiers_to_channels["a"] = channel
-    our_state = NettingChannelEndState(address=b"b", contract_balance=1)
     our_state_copy = deepcopy(our_state)
-    partner_state = NettingChannelEndState(address=b"a", contract_balance=0)
     partner_state_copy = deepcopy(partner_state)
 
     channel.our_state = our_state


### PR DESCRIPTION
Follow up for #4466 

This uses the locksroot from the settle event instead of querying from the blockchain.