### PR TITLE
Add assumption test for geth pruned block handling

### DIFF
--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -3,25 +3,13 @@ import pytest
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 from raiden.utils import safe_gas_limit
 
-pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
-
-# set very low values to force the client to prune old state
-STATE_PRUNING = {
-    "pruning": "fast",
-    "pruning-history": 1,
-    "pruning-memory": 1,
-    "cache-size-db": 1,
-    "cache-size-blocks": 1,
-    "cache-size-queue": 1,
-    "cache-size": 1,
-}
+pytestmark = pytest.mark.usefixtures("skip_if_not_geth")
 
 
-@pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNING])
-def test_parity_request_pruned_data_raises_an_exception(deploy_client):
+def test_geth_request_pruned_data_raises_an_exception(deploy_client, web3):
     """ Interacting with an old block identifier with a pruning client throws. """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
-    iterations = 1000
+    iterations = 1
 
     def send_transaction():
         check_block = deploy_client.get_checking_block()
@@ -34,7 +22,10 @@ def test_parity_request_pruned_data_raises_an_exception(deploy_client):
     first_receipt = send_transaction()
     pruned_block_number = first_receipt["blockNumber"]
 
-    for _ in range(10):
+    # geth keeps the latest 128 blocks before pruning. Unfortunately, this can
+    # not be configured to speed this test up.
+    non_pruned_blocks = 128
+    while web3.eth.blockNumber < pruned_block_number + non_pruned_blocks + 1:
         send_transaction()
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
The behaviour seems to be analogous to parity (tested with geth 1.9). So this is enough to close https://github.com/raiden-network/raiden/issues/4204.

Unfortunately, this test is really slow (~2min). I didn't find a faster way to exercise this behaviour. Maybe we should skip this test by default and only check it after major geth version changes and similar occasions? If someone finds a way to make geth prune quickly, that would be best, of course.