### PR TITLE
More mypy type checking in tests

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -1,7 +1,7 @@
 import json
 import warnings
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import gevent
 import structlog
@@ -558,7 +558,7 @@ class JSONRPCClient:
         self,
         contract_name: str,
         contract: CompiledContract,
-        constructor_parameters: Tuple[Any, ...] = None,
+        constructor_parameters: Sequence = None,
     ) -> Tuple[ContractProxy, Dict]:
         """
         Deploy a single solidity contract without dependencies.

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -47,7 +47,7 @@ def deploy_all_tokens_register_and_return_their_addresses(
     register_tokens,
     contract_manager,
     token_contract_name,
-) -> typing.List[typing.Address]:
+) -> typing.List[typing.TokenAddress]:
     """ Fixture that yields `number_of_tokens` ERC20 token addresses, where the
     `token_amount` (per token) is distributed among the addresses behind `deploy_client` and
     potentially pre-registered with the raiden Registry.

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -11,7 +11,7 @@ from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.events import must_have_event
 from raiden.tests.utils.factories import make_secret
-from raiden.utils.typing import SecretHash
+from raiden.utils.secrethash import sha256_secrethash
 
 
 def secret_registry_batch_happy_path(secret_registry_proxy):
@@ -47,9 +47,9 @@ def test_register_secret_happy_path(secret_registry_proxy: SecretRegistry, contr
     the SecretRegistered event.
     """
     secret = make_secret()
-    secrethash = SecretHash(sha256(secret).digest())
+    secrethash = sha256_secrethash(secret)
     secret_unregistered = make_secret()
-    secrethash_unregistered = SecretHash(sha256(secret_unregistered).digest())
+    secrethash_unregistered = sha256_secrethash(secret_unregistered)
 
     secret_registered_filter = secret_registry_proxy.secret_registered_filter()
 

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -11,6 +11,7 @@ from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.events import must_have_event
 from raiden.tests.utils.factories import make_secret
+from raiden.utils.typing import SecretHash
 
 
 def secret_registry_batch_happy_path(secret_registry_proxy):
@@ -46,9 +47,9 @@ def test_register_secret_happy_path(secret_registry_proxy: SecretRegistry, contr
     the SecretRegistered event.
     """
     secret = make_secret()
-    secrethash = sha256(secret).digest()
+    secrethash = SecretHash(sha256(secret).digest())
     secret_unregistered = make_secret()
-    secrethash_unregistered = sha256(secret_unregistered).digest()
+    secrethash_unregistered = SecretHash(sha256(secret_unregistered).digest())
 
     secret_registered_filter = secret_registry_proxy.secret_registered_filter()
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 from copy import deepcopy
 from hashlib import sha256
 from itertools import cycle
-from typing import List
 
 import pytest
 
@@ -1221,7 +1220,7 @@ def test_channelstate_unlock_without_locks():
     assert not iteration.events
 
 
-def pending_locks_from_packed_data(packed: bytes) -> List[HashTimeLockState]:
+def pending_locks_from_packed_data(packed: bytes) -> PendingLocksState:
     number_of_bytes = len(packed)
     locks = make_empty_pending_locks_state()
     for i in range(0, number_of_bytes, 96):

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, Iterator, List, Optional, Union
 
 import pytest
 from eth_utils import to_canonical_address
@@ -28,17 +28,17 @@ class DummyUser:
 class DummyMatrixClient:
     def __init__(self, user_id: str, user_directory_content: Optional[List[DummyUser]] = None):
         self.user_id = user_id
-        self._presence_callback = None
+        self._presence_callback: Optional[Callable] = None
         self._user_directory_content = user_directory_content if user_directory_content else []
         # This is only used in `get_user_presence()`
-        self._user_presence = {}
+        self._user_presence: Dict[str, str] = {}
 
     def add_presence_listener(self, callback: Callable):
         if self._presence_callback is not None:
             raise RuntimeError("Callback has already been registered")
         self._presence_callback = callback
 
-    def search_user_directory(self, term: str) -> List[DummyUser]:
+    def search_user_directory(self, term: str) -> Iterator[DummyUser]:
         for user in self._user_directory_content:
             if term in user.user_id:
                 yield user

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -83,12 +83,23 @@ def create_square_network_topology(
     # (2)  ----- 100 --->  (3) <-------100---
 
     routes = [
-        factories.RouteProperties(address1=our_address, address2=address1, capacity1to2=50),
-        factories.RouteProperties(address1=our_address, address2=address2, capacity1to2=100),
-        factories.RouteProperties(address1=address4, address2=address1, capacity1to2=50),
-        factories.RouteProperties(address1=address2, address2=address3, capacity1to2=100),
         factories.RouteProperties(
-            address1=address3, address2=address4, capacity1to2=100, capacity2to1=100
+            address1=our_address, address2=address1, capacity1to2=TokenAmount(50)
+        ),
+        factories.RouteProperties(
+            address1=our_address, address2=address2, capacity1to2=TokenAmount(100)
+        ),
+        factories.RouteProperties(
+            address1=address4, address2=address1, capacity1to2=TokenAmount(50)
+        ),
+        factories.RouteProperties(
+            address1=address2, address2=address3, capacity1to2=TokenAmount(100)
+        ),
+        factories.RouteProperties(
+            address1=address3,
+            address2=address4,
+            capacity1to2=TokenAmount(100),
+            capacity2to1=TokenAmount(100),
         ),
     ]
 
@@ -654,7 +665,7 @@ def test_update_iou():
 def assert_failed_pfs_request(
     paths_args: typing.Dict[str, typing.Any],
     responses: typing.List[typing.Dict],
-    status_codes: typing.List[int] = (400, 400),
+    status_codes: typing.Sequence[int] = (400, 400),
     expected_requests: int = MAX_PATHS_QUERY_ATTEMPTS,
     expected_get_iou_requests: int = None,
     expected_success: bool = False,

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -169,7 +169,7 @@ def test_pfs_handler_handle_routefailed_with_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(  # type: ignore
+        pfs_handler.on_raiden_event(
             raiden=raiden,
             chain_state=raiden.wal.state_manager.current_state,
             event=route_failed_event,
@@ -195,7 +195,7 @@ def test_pfs_handler_handle_routefailed_without_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(  # type: ignore
+        pfs_handler.on_raiden_event(
             raiden=raiden,
             chain_state=raiden.wal.state_manager.current_state,
             event=route_failed_event,
@@ -229,7 +229,7 @@ def test_pfs_handler_handle_paymentsentsuccess_with_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(  # type: ignore
+        pfs_handler.on_raiden_event(
             raiden=raiden,
             chain_state=raiden.wal.state_manager.current_state,
             event=route_failed_event,
@@ -271,7 +271,7 @@ def test_pfs_handler_handle_paymentsentsuccess_without_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(  # type: ignore
+        pfs_handler.on_raiden_event(
             raiden=raiden,
             chain_state=raiden.wal.state_manager.current_state,
             event=route_failed_event,

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -349,7 +349,7 @@ def test_get_event_with_balance_proof():
 
         # Checking that balance proof attribute can be accessed for all events.
         # Issue https://github.com/raiden-network/raiden/issues/3179
-        assert event_record.data.balance_proof == event.balance_proof  # type: ignore
+        assert event_record.data.balance_proof == event.balance_proof
 
     storage.close()
 

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -43,7 +43,7 @@ def state_transtion_acc(state, state_change):
 
 
 def new_wal(state_transition: Callable, state: State = None) -> WriteAheadLog:
-    serializer = JSONSerializer
+    serializer = JSONSerializer()
 
     state_manager = StateManager(state_transition, state)
     storage = SerializedSQLiteStorage(":memory:", serializer)

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -3,7 +3,7 @@ import random
 from copy import deepcopy
 from dataclasses import replace
 
-import pytest  # type: ignore
+import pytest
 
 from raiden.constants import (
     EMPTY_HASH,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -38,9 +38,10 @@ from raiden.transfer.mediated_transfer.state_change import (
 from raiden.transfer.state import NODE_NETWORK_UNREACHABLE, message_identifier_from_prng
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal
 from raiden.utils.signer import LocalSigner
+from raiden.utils.typing import BlockExpiration
 
 LONG_EXPIRATION = factories.create_properties(
-    factories.LockedTransferSignedStateProperties(expiration=30)
+    factories.LockedTransferSignedStateProperties(expiration=BlockExpiration(30))
 )
 
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_targetstate.py
@@ -37,6 +37,7 @@ from raiden.transfer.mediated_transfer.state_change import (
 )
 from raiden.transfer.state_change import Block, ContractReceiveSecretReveal, ReceiveUnlock
 from raiden.utils import typing
+from raiden.utils.typing import TokenAmount
 
 
 def make_target_transfer(channel, amount=None, expiration=None, initiator=None, block_number=1):
@@ -114,12 +115,18 @@ def make_target_state(
 
 channel_properties = NettingChannelStateProperties(
     our_state=NettingChannelEndStateProperties(address=UNIT_TRANSFER_TARGET),
-    partner_state=NettingChannelEndStateProperties(address=UNIT_TRANSFER_SENDER, balance=3),
+    partner_state=NettingChannelEndStateProperties(
+        address=UNIT_TRANSFER_SENDER, balance=TokenAmount(3)
+    ),
 )
 
 channel_properties2 = NettingChannelStateProperties(
-    our_state=NettingChannelEndStateProperties(address=factories.make_address(), balance=100),
-    partner_state=NettingChannelEndStateProperties(address=UNIT_TRANSFER_SENDER, balance=130),
+    our_state=NettingChannelEndStateProperties(
+        address=factories.make_address(), balance=TokenAmount(100)
+    ),
+    partner_state=NettingChannelEndStateProperties(
+        address=UNIT_TRANSFER_SENDER, balance=TokenAmount(130)
+    ),
 )
 
 

--- a/raiden/tests/unit/transfer/test_channel.py
+++ b/raiden/tests/unit/transfer/test_channel.py
@@ -39,7 +39,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelSettled,
 )
 from raiden.utils import sha3
-from raiden.utils.typing import TokenAmount
+from raiden.utils.typing import BlockExpiration, TokenAmount
 
 
 def _channel_and_transfer(num_pending_locks):
@@ -345,7 +345,9 @@ def test_handle_action_set_fee():
 
 
 def make_hash_time_lock_state(amount) -> HashTimeLockState:
-    return HashTimeLockState(amount=amount, expiration=5, secrethash=factories.UNIT_SECRETHASH)
+    return HashTimeLockState(
+        amount=amount, expiration=BlockExpiration(5), secrethash=factories.UNIT_SECRETHASH
+    )
 
 
 def make_unlock_partial_proof_state(amount):

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -232,7 +232,7 @@ def parity_generate_chain_spec(
     validators = {"list": [to_checksum_address(seal_account)]}
     extra_data = parity_extradata(genesis_description.random_marker)
 
-    chain_spec = PARITY_CHAIN_SPEC_STUB.copy()
+    chain_spec: dict = PARITY_CHAIN_SPEC_STUB.copy()
     chain_spec["params"]["networkID"] = genesis_description.chain_id
     chain_spec["accounts"].update(alloc)
     chain_spec["engine"]["authorityRound"]["params"]["validators"] = validators
@@ -306,7 +306,7 @@ def eth_check_balance(web3: Web3, accounts_addresses: List[Address], retries: in
 
 
 def eth_node_config(
-    miner_pkey: PrivateKey, p2p_port: Port, rpc_port: Port, **extra_config: Dict[str, Any]
+    miner_pkey: PrivateKey, p2p_port: Port, rpc_port: Port, **extra_config: Any
 ) -> Dict[str, Any]:
     address = privatekey_to_address(miner_pkey)
     pub = privatekey_to_publickey(miner_pkey).hex()
@@ -383,7 +383,7 @@ def eth_nodes_to_cmds(
             commandline = parity_to_cmd(config, datadir, chain_id, genesis_file, verbosity)
 
         else:
-            assert False, f"Invalid blockchain type {config.blockchain_type}"
+            assert False, f"Invalid blockchain type {config['blockchain_type']}"
 
         cmds.append(commandline)
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -273,7 +273,7 @@ UNIT_SETTLE_TIMEOUT = 50
 UNIT_REVEAL_TIMEOUT = 5
 UNIT_TRANSFER_AMOUNT = 10
 UNIT_TRANSFER_FEE = 5
-UNIT_SECRET = b"secretsecretsecretsecretsecretse"
+UNIT_SECRET = Secret(b"secretsecretsecretsecretsecretse")
 UNIT_SECRETHASH = sha256_secrethash(UNIT_SECRET)
 UNIT_TOKEN_ADDRESS = b"tokentokentokentoken"
 UNIT_TOKEN_NETWORK_ADDRESS = b"networknetworknetwor"
@@ -289,11 +289,11 @@ UNIT_OUR_ADDRESS = privatekey_to_address(UNIT_OUR_KEY)
 
 UNIT_PAYMENT_NETWORK_IDENTIFIER = b"paymentnetworkidentifier"
 UNIT_TRANSFER_IDENTIFIER = 37
-UNIT_TRANSFER_INITIATOR = b"initiatorinitiatorin"
-UNIT_TRANSFER_TARGET = b"targettargettargetta"
+UNIT_TRANSFER_INITIATOR = Address(b"initiatorinitiatorin")
+UNIT_TRANSFER_TARGET = Address(b"targettargettargetta")
 UNIT_TRANSFER_PKEY_BIN = sha3(b"transfer pkey")
 UNIT_TRANSFER_PKEY = UNIT_TRANSFER_PKEY_BIN
-UNIT_TRANSFER_SENDER = privatekey_to_address(sha3(b"transfer pkey"))
+UNIT_TRANSFER_SENDER = Address(privatekey_to_address(sha3(b"transfer pkey")))
 
 HOP1_KEY = b"11111111111111111111111111111111"
 HOP2_KEY = b"22222222222222222222222222222222"

--- a/raiden/utils/smart_contracts.py
+++ b/raiden/utils/smart_contracts.py
@@ -1,7 +1,7 @@
 from eth_utils import to_canonical_address
 
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.utils.typing import Address, Any, Tuple
+from raiden.utils.typing import Address, Sequence
 from raiden_contracts.contract_manager import ContractManager
 
 
@@ -9,7 +9,7 @@ def deploy_contract_web3(
     contract_name: str,
     deploy_client: JSONRPCClient,
     contract_manager: ContractManager,
-    constructor_arguments: Tuple[Any, ...] = None,
+    constructor_arguments: Sequence = None,
 ) -> Address:
     contract_proxy, _ = deploy_client.deploy_single_contract(
         contract_name=contract_name,

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -28,7 +28,7 @@ MYPY_ANNOTATION = "This assert is used to tell mypy what is the type of the vari
 
 def typecheck(value: Any, expected: Type):
     if not isinstance(value, expected):
-        raise ValueError(f"Expected a value of type {expected}")
+        raise ValueError(f"Expected a value of type {expected}, got value of type {type(value)}")
 
 
 ABI = List[Dict[str, Any]]

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,31 +51,7 @@ warn_unused_configs = True
 warn_unused_ignores = True
 
 [mypy-raiden.tests.*]
+check_untyped_defs = False
+
+[mypy-raiden.tests.utils.*]
 ignore_errors = True
-
-[mypy-raiden.tests.utils.events]
-ignore_errors = False
-
-[mypy-raiden.tests.utils.client]
-ignore_errors = False
-
-[mypy-raiden.tests.utils.network]
-ignore_errors = False
-
-[mypy-raiden.tests.unit.test_sqlite]
-ignore_errors = False
-
-[mypy-raiden.tests.unit.test_raiden_event_handler]
-ignore_errors = False
-
-[mypy-raiden.tests.unit.transfer]
-ignore_errors = False
-
-[mypy-raiden.tests.unit.transfer.mediated_transfer.test_mediation_fee]
-ignore_errors = False
-
-[mypy-raiden.tests.integration.long_running.test_stress]
-ignore_errors = False
-
-[mypy-raiden.tests.integration.fixtures.raiden_network]
-ignore_errors = False


### PR DESCRIPTION
Use `check_untyped_defs = False` instead of turning everything off with
`ignore_errors = True`. Now `raiden.tests.utils` is the only package
where mypy checking is completely turned off.