### PR TITLE
#4348: Return correct channel balance in API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`4348` Fix wrong calculation of ``balance`` field of channel information when tokens are locked in payments
 * :bug:`4502` Fix a Raiden crash related to routing feedback
 
 * :release:`0.100.5-dev0 <2019-07-30>`

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -271,7 +271,7 @@ class ChannelStateSchema(BaseSchema):
 
     @staticmethod
     def get_balance(channel_state: NettingChannelState) -> int:
-        return channel.get_distributable(channel_state.our_state, channel_state.partner_state)
+        return channel.get_balance(channel_state.our_state, channel_state.partner_state)
 
     @staticmethod
     def get_state(channel_state: NettingChannelState) -> str:


### PR DESCRIPTION
This is a fix for #4348 

The solution is to return the *balance* instead of the *distributable*.

I'll also create a follow up issue to discuss if *distributable* should be added to the channel infos in the API, as it might be interesting for user facing tools.

Closes #4348