### PR TITLE
Coverage flags take 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,6 @@ jobs:
       RAIDEN_TESTS_SYNAPSE_BASE_DIR: /home/circleci/.cache/synapse
       RAIDEN_TESTS_SYNAPSE_LOGS_DIR: /tmp/synapse-logs
       RAIDEN_TESTS_LOGSDIR: /tmp/tests/logs
-      COVERAGE_DIR: /home/circleci/raiden/coverage
 
     parallelism: << parameters.parallelism >>
 
@@ -358,12 +357,6 @@ jobs:
           keys:
             - synapse-keys-v1
             - synapse-keys-
-      # Remove any existing .coverage files so we don't persist them again, causing a conflict.
-      - run:
-          name: Prepare coverage
-          command: |
-            mkdir -p ${COVERAGE_DIR}
-            rm ${COVERAGE_DIR}/.coverage.* || true
       - run:
           name: Select tests
           command: .circleci/select_tests.sh "raiden/tests/<< parameters.test-type >>" "<< parameters.blockchain-type >>" << parameters.additional-args >>
@@ -373,14 +366,9 @@ jobs:
           command: |
             .circleci/run_tests.sh "test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>" "<< parameters.blockchain-type >>" << parameters.additional-args >>
       - run:
-          name: Store coverage
+          name: Report coverage
           command: |
-            mv .coverage.* ${COVERAGE_DIR}
-
-      - persist_to_workspace:
-          root: "~"
-          paths:
-            - "./raiden/coverage"
+            bash <(curl -s https://codecov.io/bash) -c -F << parameters.test-type >>
 
       - save_cache:
           key: ethash-{{ checksum "~/.local/bin/geth" }}
@@ -420,12 +408,7 @@ jobs:
       - conditional-skip
       - config-path
       - run:
-          name: Report to Codecov
-          command: |
-            pip install codecov
-            cd ~/raiden
-            coverage combine coverage
-            codecov
+          command: "true"
 
   build-binary-linux:
     parameters:


### PR DESCRIPTION
The return of https://github.com/raiden-network/raiden/pull/4022


The problem with this approach is that we're not using the `.unittest-coveragerc` file for the unit tests, which changes the coverage percentage.