### PR TITLE
Add shell script + python command for integration test debugging

### DIFF
--- a/tools/debugging/split_debug_logs.sh
+++ b/tools/debugging/split_debug_logs.sh
@@ -3,8 +3,7 @@ set -e
 
 DEBUG_LOG_FILE=$1;
 OUTPUT_FOLDER=$2;
-FULL_PATH=`realpath $0`
-PWD=`dirname $FULL_PATH`
+PWD=`dirname $0`
 
 NODE_ADDRESS=`cat $DEBUG_LOG_FILE | jq .node | sort -u`
 

--- a/tools/debugging/split_debug_logs.sh
+++ b/tools/debugging/split_debug_logs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+DEBUG_LOG_FILE=$1;
+OUTPUT_FOLDER=$2;
+FULL_PATH=`realpath $0`
+PWD=`dirname $FULL_PATH`
+
+NODE_ADDRESS=`cat $DEBUG_LOG_FILE | jq .node | sort -u`
+
+if [[ $# != 2 ]]; then
+    echo "Usage: $0 <log_file> <output_folder>"
+    exit 1;
+fi;
+
+mkdir -p $OUTPUT_FOLDER
+
+for node in $NODE_ADDRESS; do
+    address=`echo $node | tr -d '"'`
+    node_folder=${OUTPUT_FOLDER}/${address}
+    full_log=${node_folder}/full.log
+    state_machine_log=${node_folder}/state_machine.log
+    state_change_timestamps=${node_folder}/state_change_timestamps.log
+
+    echo "Processing ${address}"
+    mkdir -p $node_folder
+    cat ${DEBUG_LOG_FILE} | jq -c ". | select(.node==${node})" > ${full_log}
+    cat ${full_log} | jq -c ". | select((.state_changes | length) > 0 or (.raiden_events | length) > 0)" > ${state_machine_log}
+
+    python $PWD/state_machine_report.py ${state_machine_log} > ${state_change_timestamps}
+done;

--- a/tools/debugging/state_machine_report.py
+++ b/tools/debugging/state_machine_report.py
@@ -1,0 +1,14 @@
+import json
+import sys
+
+for line in open(sys.argv[1]):
+    data = json.loads(line)
+
+    timestamp = data["timestamp"].split()[-1]
+    if "state_changes" in data:
+        state_changes = [sc["_type"].split(".")[-1] for sc in data["state_changes"]]
+        print(f"> {timestamp}: {', '.join(state_changes)}")
+
+    if "raiden_events" in data:
+        events = [ev["_type"].split(".")[-1] for ev in data["raiden_events"]]
+        print(f"< {timestamp}: {', '.join(events)}")


### PR DESCRIPTION
Scripts take the json data from the raiden log and extracts the state machine changes + events
from a raiden log file, split by raiden node.