### PR TITLE
Bump to v0.100.5a0

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.100.5.dev1
+current_version = 0.100.5a0
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :release:`0.100.5-dev1 <2019-08-12>`
+* :release:`0.100.5a0 <2019-08-12>`
 * :feature:`-` Update WebUI to version 0.9.2 https://github.com/raiden-network/webui/releases/tag/v0.9.2
 * :bug:`4498` Raiden now waits for synchronization with the blockchain events before finishing its startup and opening the API.
 * :bug:`4348` Fix wrong calculation of ``balance`` field of channel information when tokens are locked in payments

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ master_doc = "index"
 project = "Raiden Network"
 author = "Raiden Project"
 
-version_string = "0.100.5-dev1"
+version_string = "0.100.5a0"
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ with open("requirements/requirements.txt") as req_file:
 test_requirements: List[str] = []
 
 # Do not edit: this is maintained by bumpversion (see .bumpversion_client.cfg)
-version = "0.100.5-dev1"
+version = "0.100.5a0"
 
 setup(
     name="raiden",


### PR DESCRIPTION
Apparently having a dev[N] version suffix can't work:

https://github.com/pypa/setuptools_scm/issues/213

We are switching to a new way of testnet releases using aN as a
suffix. Stands for Alpha0, Alpha1, e.t.c.