### PR TITLE
Use block timeout in events integration test

### DIFF
--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -210,9 +210,12 @@ def get_event_with_balance_proof_by_locksroot(
 def get_state_change_with_transfer_by_secrethash(
     storage: SerializedSQLiteStorage, secrethash: SecretHash
 ) -> Optional[StateChangeRecord]:
-    filters = [{"transfer.lock.secrethash": to_hex(secrethash)}]
+    filters = [
+        {"from_transfer.lock.secrethash": to_hex(secrethash)},
+        {"transfer.lock.secrethash": to_hex(secrethash)},
+    ]
     query = FilteredDBQuery(
-        filters=filters, main_operator=Operator.NONE, inner_operator=Operator.NONE
+        filters=filters, main_operator=Operator.OR, inner_operator=Operator.NONE
     )
     return storage.get_latest_state_change_by_data_field(query)
 

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -18,6 +18,7 @@ from raiden.blockchain.events import (
 from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.network.blockchain_service import BlockChainService
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import must_have_event, search_for_item, wait_for_state_change
 from raiden.tests.utils.network import CHAIN
@@ -28,13 +29,11 @@ from raiden.transfer.mediated_transfer.events import SendLockedTransfer
 from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
 from raiden.transfer.state_change import ContractReceiveSecretReveal
 from raiden.utils import sha3, wait_until
-from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     Address,
     Balance,
     BlockSpecification,
     ChannelID,
-    Secret,
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import (
@@ -484,8 +483,7 @@ def run_test_secret_revealed_on_chain(
     amount = 10
     identifier = 1
     target = app2.raiden.address
-    secret = Secret(sha3(target))
-    secrethash = sha256_secrethash(secret)
+    secret, secrethash = factories.make_secret_with_hash()
 
     # Reveal the secret, but do not unlock it off-chain
     app1_hold_event_handler = app1.raiden.raiden_event_handler

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -2,7 +2,6 @@ from hashlib import sha256
 from typing import List
 from unittest.mock import patch
 
-import gevent
 import pytest
 
 from raiden.app import App
@@ -21,6 +20,7 @@ from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import (
     assert_succeeding_transfer_invariants,
     assert_synced_channel_state,
+    block_timeout_for_transfer_by_secrethash,
     transfer,
     transfer_and_assert_path,
     wait_assert,
@@ -62,7 +62,7 @@ def run_test_mediated_transfer(
     )
 
     amount = 10
-    transfer(
+    secrethash = transfer(
         initiator_app=app0,
         target_app=app2,
         token_address=token_address,
@@ -71,7 +71,7 @@ def run_test_mediated_transfer(
         timeout=network_wait * number_of_nodes,
     )
 
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app1.raiden, secrethash):
         wait_assert(
             assert_succeeding_transfer_invariants,
             token_network_address,
@@ -82,7 +82,7 @@ def run_test_mediated_transfer(
             deposit + amount,
             [],
         )
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app1.raiden, secrethash):
         wait_assert(
             assert_succeeding_transfer_invariants,
             token_network_address,
@@ -195,7 +195,7 @@ def run_test_mediated_transfer_with_entire_deposit(
         chain_state, token_network_registry_address, token_address
     )
 
-    transfer_and_assert_path(
+    secrethash = transfer_and_assert_path(
         path=raiden_network,
         token_address=token_address,
         amount=deposit,
@@ -212,7 +212,7 @@ def run_test_mediated_transfer_with_entire_deposit(
         timeout=network_wait * number_of_nodes,
     )
 
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app1.raiden, secrethash):
         wait_assert(
             assert_succeeding_transfer_invariants,
             token_network_address,
@@ -223,7 +223,7 @@ def run_test_mediated_transfer_with_entire_deposit(
             0,
             [],
         )
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app2.raiden, secrethash):
         wait_assert(
             assert_succeeding_transfer_invariants,
             token_network_address,
@@ -309,7 +309,7 @@ def run_test_mediated_transfer_messages_out_of_order(
     )
 
     transfer_received.payment_done.wait()
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app1.raiden, secrethash):
         wait_assert(
             assert_succeeding_transfer_invariants,
             token_network_address,
@@ -321,7 +321,7 @@ def run_test_mediated_transfer_messages_out_of_order(
             [],
         )
 
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app2.raiden, secrethash):
         wait_assert(
             assert_succeeding_transfer_invariants,
             token_network_address,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -1,6 +1,5 @@
 import random
 
-import gevent
 import pytest
 
 from raiden.api.python import RaidenAPI
@@ -17,6 +16,7 @@ from raiden.tests.utils.factories import (
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
+    block_timeout_for_transfer_by_secrethash,
     get_channelstate,
     sign_and_inject,
     transfer,
@@ -118,7 +118,7 @@ def run_test_receive_lockedtransfer_invalidnonce(
     channel0 = get_channelstate(app0, app1, token_network_address)
 
     amount = 10
-    transfer(
+    secrethash = transfer(
         initiator_app=app0,
         target_app=app2,
         token_address=token_address,
@@ -155,7 +155,7 @@ def run_test_receive_lockedtransfer_invalidnonce(
 
     sign_and_inject(mediated_transfer_message, app0.raiden.signer, app1)
 
-    with gevent.Timeout(network_wait):
+    with block_timeout_for_transfer_by_secrethash(app1.raiden, secrethash):
         wait_assert(
             assert_synced_channel_state,
             token_network_address,


### PR DESCRIPTION
Replace `gevent.Timeout` by `BlockTimeout` in integration tests where it makes sense, to make sure we wait long enough in every test run.

Related issue: #4524

Edit: The issue has been postponed to the next milestone, so this pr is only for the part of the tests that have been adapted so far. There will be a follow-up pr for the remaining tests.
