### PR TITLE
Change formatting of timestamp to be closer to ISO8601

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`4560` Formatting of timestamp fields on the API should follow ISO8601
 * :bug:`4561` Limit and offset should now work properly in the payment API event queries. 
 
 * :release:`0.100.5a0 <2019-08-12>`

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -84,10 +84,14 @@ class TimeStampField(fields.DateTime):
     def _serialize(
         self, value: Optional[datetime.datetime], attr: Any, obj: Any, **kwargs
     ) -> Optional[str]:
-        return value and value.isoformat()
+        if value is not None:
+            return value.isoformat()
+        return None
 
     def _deserialize(self, value, attr, data, **kwargs) -> Optional[datetime.datetime]:
-        return value and datetime.datetime.fromisoformat(value)
+        if value is not None:
+            return datetime.datetime.fromisoformat(value)
+        return None
 
 
 class SecretField(fields.Field):

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -1,4 +1,6 @@
 import binascii
+import datetime
+from typing import Any, Optional
 
 from eth_utils import (
     is_0x_prefixed,
@@ -76,6 +78,16 @@ class AddressField(fields.Field):
             self.fail("invalid_size")
 
         return value
+
+
+class TimeStampField(fields.DateTime):
+    def _serialize(
+        self, value: Optional[datetime.datetime], attr: Any, obj: Any, **kwargs
+    ) -> Optional[str]:
+        return value and value.isoformat()
+
+    def _deserialize(self, value, attr, data, **kwargs) -> Optional[datetime.datetime]:
+        return value and datetime.datetime.fromisoformat(value)
 
 
 class SecretField(fields.Field):
@@ -350,7 +362,7 @@ class EventPaymentSentFailedSchema(BaseSchema):
     event = fields.Constant("EventPaymentSentFailed")
     reason = fields.Str()
     target = AddressField()
-    log_time = fields.String()
+    log_time = TimeStampField()
 
     class Meta:
         fields = ("block_number", "event", "reason", "target", "log_time")
@@ -364,7 +376,7 @@ class EventPaymentSentSuccessSchema(BaseSchema):
     event = fields.Constant("EventPaymentSentSuccess")
     amount = fields.Integer()
     target = AddressField()
-    log_time = fields.String()
+    log_time = TimeStampField()
 
     class Meta:
         fields = ("block_number", "event", "amount", "target", "identifier", "log_time")
@@ -378,7 +390,7 @@ class EventPaymentReceivedSuccessSchema(BaseSchema):
     event = fields.Constant("EventPaymentReceivedSuccess")
     amount = fields.Integer()
     initiator = AddressField()
-    log_time = fields.String()
+    log_time = TimeStampField()
 
     class Meta:
         fields = ("block_number", "event", "amount", "initiator", "identifier", "log_time")

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -58,7 +58,7 @@ DB_CREATE_STATE_CHANGES = """
 CREATE TABLE IF NOT EXISTS state_changes (
     identifier ULID PRIMARY KEY NOT NULL,
     data JSON,
-    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+    timestamp TIMESTAMP DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) NOT NULL
 );
 """
 
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS state_snapshot (
     identifier ULID PRIMARY KEY NOT NULL,
     statechange_id ULID NOT NULL,
     data JSON,
-    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    timestamp TIMESTAMP DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) NOT NULL,
     FOREIGN KEY(statechange_id) REFERENCES state_changes(identifier)
 );
 """
@@ -77,14 +77,14 @@ CREATE TABLE IF NOT EXISTS state_events (
     identifier ULID PRIMARY KEY NOT NULL,
     source_statechange_id ULID NOT NULL,
     data JSON,
-    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    timestamp TIMESTAMP DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) NOT NULL,
     FOREIGN KEY(source_statechange_id) REFERENCES state_changes(identifier)
 );
 """
 
 DB_CREATE_RUNS = """
 CREATE TABLE IF NOT EXISTS runs (
-    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP PRIMARY KEY NOT NULL,
+    started_at TIMESTAMP DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) PRIMARY KEY NOT NULL,
     raiden_version TEXT NOT NULL
 );
 """

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -897,11 +897,7 @@ def test_api_timestamp_format(api_server_test_instance, raiden_network, token_ad
 
     log_timestamp_iso = log_date.isoformat()
 
-    # However, sqlite expects a space to separate date and time, so this fails...
-    # assert log_timestamp_iso == log_timestamp, "log_time is not a valid ISO8601 string"
-
-    # and this passes:
-    assert log_timestamp_iso.replace("T", " ") == log_timestamp, "log_time is not a timestamp"
+    assert log_timestamp_iso == log_timestamp, "log_time is not a valid ISO8601 string"
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/unit/api/test_api_events.py
+++ b/raiden/tests/unit/api/test_api_events.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from raiden.api.python import event_filter_for_payments
@@ -36,13 +38,17 @@ def test_v1_event_payment_sent_failed_schema():
         target=factories.make_address(),
         reason="whatever",
     )
-    log_time = "2018-09-07T20:02:35.000"
+    log_time = datetime.datetime.now()
 
     timestamped = TimestampedEvent(event, log_time)
 
     dumped = EventPaymentSentFailedSchema().dump(timestamped)
 
-    expected = {"event": "EventPaymentSentFailed", "log_time": log_time, "reason": "whatever"}
+    expected = {
+        "event": "EventPaymentSentFailed",
+        "log_time": log_time.isoformat(),
+        "reason": "whatever",
+    }
 
     assert all(dumped.get(key) == value for key, value in expected.items())
 

--- a/raiden/tests/unit/api/test_encoding.py
+++ b/raiden/tests/unit/api/test_encoding.py
@@ -1,0 +1,22 @@
+import datetime
+
+from raiden.api.v1.encoding import BaseSchema, TimeStampField
+
+
+class TestSchema(BaseSchema):
+    timestamp = TimeStampField()
+
+    class Meta:
+        fields = ("timestamp",)
+        strict = True
+        decoding_class = dict
+
+
+def test_timestamp_field():
+    now = datetime.datetime.now()
+    assert (
+        TestSchema().dump({}) == {}
+    ), "timestamp fields should only be serialized when the date is provided"
+    assert TestSchema().dump({"timestamp": now}) == {
+        "timestamp": now.isoformat()
+    }, "timestamp fields should be formatted as ISO8601"


### PR DESCRIPTION
The API documentation states that records that provide a timestamp should follow the ISO8601 spec.
Meanwhile, our database tables were defined as storing the default `CURRENT_TIMESTAMP` format from sqlite, which do not hold milisecond information.

This commit changes all tables to start using TIMESTAMP fields with formatted with milisecond as well.

Fixes #4560

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
