### PR TITLE
Attempt to fix flakiness at geth_request_pruned_data test

### DIFF
--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -6,7 +6,6 @@ from raiden.utils import safe_gas_limit
 pytestmark = pytest.mark.usefixtures("skip_if_not_geth")
 
 
-@pytest.mark.skip(reason="Flaky, see https://github.com/raiden-network/raiden/issues/4545")
 def test_geth_request_pruned_data_raises_an_exception(deploy_client, web3):
     """ Interacting with an old block identifier with a pruning client throws. """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
@@ -26,7 +25,14 @@ def test_geth_request_pruned_data_raises_an_exception(deploy_client, web3):
     # geth keeps the latest 128 blocks before pruning. Unfortunately, this can
     # not be configured to speed this test up.
     non_pruned_blocks = 128
-    while web3.eth.blockNumber < pruned_block_number + non_pruned_blocks + 1:
+    # According to the geth devs if we run a PoA chain (clique, dev mode) and
+    # HEAD-127 doesn't contain any transactions, then the state of HEAD-127 will
+    # be the same as HEAD-128, so it will still be referenced and not deleted.
+    # To avoid this and make sure the pruned_block_number is pruned let's mine
+    # buffer period more blocks while at the same time sending transactions
+    buffer_period_blocks = 5
+    target_block = pruned_block_number + non_pruned_blocks + buffer_period_blocks + 1
+    while web3.eth.blockNumber <= target_block:
         send_transaction()
 
     with pytest.raises(ValueError):

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -1,4 +1,6 @@
+import gevent
 import pytest
+
 
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 from raiden.utils import safe_gas_limit
@@ -20,21 +22,20 @@ def test_geth_request_pruned_data_raises_an_exception(deploy_client, web3):
         return deploy_client.get_transaction_receipt(transaction)
 
     first_receipt = send_transaction()
-    pruned_block_number = first_receipt["blockNumber"]
+    mined_block_number = first_receipt["blockNumber"]
+
+    while mined_block_number + 127 > web3.eth.blockNumber:
+        gevent.sleep(0.5)
 
     # geth keeps the latest 128 blocks before pruning. Unfortunately, this can
     # not be configured to speed this test up.
-    non_pruned_blocks = 128
     # According to the geth devs if we run a PoA chain (clique, dev mode) and
     # HEAD-127 doesn't contain any transactions, then the state of HEAD-127 will
     # be the same as HEAD-128, so it will still be referenced and not deleted.
-    # To avoid this and make sure the pruned_block_number is pruned let's mine
-    # buffer period more blocks while at the same time sending transactions
-    buffer_period_blocks = 5
-    target_block = pruned_block_number + non_pruned_blocks + buffer_period_blocks + 1
-    while web3.eth.blockNumber <= target_block:
-        send_transaction()
+    # So for this test we mine a transaction, wait for mined + 127 block and then
+    # query the previous block which should be pruned
 
+    pruned_block_number = mined_block_number - 1
     with pytest.raises(ValueError):
         contract_proxy.contract.functions.const().call(block_identifier=pruned_block_number)
 


### PR DESCRIPTION
According to the geth devs if we run a PoA chain (clique, dev mode) and
HEAD-127 doesn't contain any transactions, then the state of HEAD-127 will
be the same as HEAD-128, so it will still be referenced and not deleted.
To avoid this and make sure the pruned_block_number is pruned let's mine
buffer period more blocks while at the same time sending transactions

Fix #4545

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
