### PR TITLE
Enforce confirmed block usage in api/python.py get_token_network() calls

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -383,7 +383,7 @@ class TokenNetwork:
         Raises:
             RaidenRecoverableError: If there is not open channel among
                 `(participant1, participant2)`. Note this is the case even if
-                there is a channel is a settle state.
+                there is a channel in a settled state.
             BadFunctionCallOutput: If the `block_identifier` points to a block
                 prior to the deployment of the TokenNetwork.
             SamePeerAddress: If an both addresses are equal.

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -76,7 +76,7 @@ class TokenNetworkRegistry:
         self.node_address = self.client.address
 
     def get_token_network(
-        self, token_address: TokenAddress, block_identifier: BlockSpecification = "latest"
+        self, token_address: TokenAddress, block_identifier: BlockSpecification
     ) -> Optional[TokenNetworkAddress]:
         """ Return the token network address for the given token or None if
         there is no correspoding address.

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -295,7 +295,7 @@ def run_test_query_events(
         views.state_from_app(app0), registry_address, token_address
     )
 
-    token_network_address = app0.raiden.default_registry.get_token_network(token_address)
+    token_network_address = app0.raiden.default_registry.get_token_network(token_address, "latest")
     assert token_network_address
     manager0 = app0.raiden.chain.token_network(token_network_address)
 

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -130,6 +130,7 @@ def test_token_network_proxy(
             participant2=to_checksum_address(c2_client.address),
             block_identifier="latest",
         )
+        pytest.fail(msg)
 
     msg = "Zero is not a valid channel_identifier identifier, an exception must be raised."
     with pytest.raises(InvalidChannelID):
@@ -281,6 +282,7 @@ def test_token_network_proxy(
             total_deposit=-1,
             partner=c2_client.address,
         )
+        pytest.fail(msg)
 
     msg = "set_total_deposit must fail with a zero amount"
     with pytest.raises(BrokenPreconditionError):
@@ -290,6 +292,7 @@ def test_token_network_proxy(
             total_deposit=0,
             partner=c2_client.address,
         )
+        pytest.fail(msg)
 
     c1_token_network_proxy.set_total_deposit(
         given_block_identifier="latest",

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -87,14 +87,15 @@ def test_token_network_registry(
     assert is_same_address(decoded_event["args"]["token_address"], test_token.contract.address)
     assert is_same_address(decoded_event["args"]["token_network_address"], token_network_address)
     # test other getters
-    assert token_network_registry_proxy.get_token_network(bad_token_address) is None
+    assert token_network_registry_proxy.get_token_network(bad_token_address, "latest") is None
     assert is_same_address(
-        token_network_registry_proxy.get_token_network(test_token_address), token_network_address
+        token_network_registry_proxy.get_token_network(test_token_address, "latest"),
+        token_network_address,
     )
 
     with pytest.raises(ValueError):
-        assert token_network_registry_proxy.get_token_network(None) is None
+        assert token_network_registry_proxy.get_token_network(None, "latest") is None
 
-    assert token_network_registry_proxy.get_token_network(bad_token_address) is None
-    assert token_network_registry_proxy.get_token_network(token_network_address) is None
-    assert token_network_registry_proxy.get_token_network(test_token_address) is not None
+    assert token_network_registry_proxy.get_token_network(bad_token_address, "latest") is None
+    assert token_network_registry_proxy.get_token_network(token_network_address, "latest") is None
+    assert token_network_registry_proxy.get_token_network(test_token_address, "latest") is not None

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -28,7 +28,7 @@ def run_test_channel_with_self(raiden_network, settle_timeout, token_addresses):
     )
     assert not current_chanels
 
-    token_network_address = app0.raiden.default_registry.get_token_network(token_address)
+    token_network_address = app0.raiden.default_registry.get_token_network(token_address, "latest")
     token_network0 = app0.raiden.chain.token_network(token_network_address)
 
     with pytest.raises(SamePeerAddress):

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -21,6 +21,7 @@ from raiden.tests.utils.app import database_from_privatekey
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.tests.utils.protocol import HoldRaidenEventHandler, WaitForMessage
 from raiden.tests.utils.transport import ParsedURL
+from raiden.transfer import views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.views import state_from_raiden
@@ -125,12 +126,17 @@ def payment_channel_open_and_deposit(
     """ Open a new channel with app0 and app1 as participants """
     assert token_address
 
-    token_network_address = app0.raiden.default_registry.get_token_network(token_address)
+    confirmed_block_identifier = views.state_from_raiden(app0.raiden).block_hash
+    token_network_address = app0.raiden.default_registry.get_token_network(
+        token_address=token_address, block_identifier=confirmed_block_identifier
+    )
     assert token_network_address, "request a channel for an unregistered token"
     token_network_proxy = app0.raiden.chain.token_network(token_network_address)
 
     channel_identifier = token_network_proxy.new_netting_channel(
-        partner=app1.raiden.address, settle_timeout=settle_timeout, given_block_identifier="latest"
+        partner=app1.raiden.address,
+        settle_timeout=settle_timeout,
+        given_block_identifier=confirmed_block_identifier,
     )
     assert channel_identifier
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -28,6 +28,7 @@ from raiden.transfer.views import state_from_raiden
 from raiden.utils import BlockNumber, merge_dict
 from raiden.utils.typing import (
     Address,
+    BlockSpecification,
     BlockTimeout,
     ChainID,
     ChannelID,
@@ -126,9 +127,13 @@ def payment_channel_open_and_deposit(
     """ Open a new channel with app0 and app1 as participants """
     assert token_address
 
-    confirmed_block_identifier = views.state_from_raiden(app0.raiden).block_hash
+    block_identifier: BlockSpecification
+    if app0.raiden.wal:
+        block_identifier = views.state_from_raiden(app0.raiden).block_hash
+    else:
+        block_identifier = "latest"
     token_network_address = app0.raiden.default_registry.get_token_network(
-        token_address=token_address, block_identifier=confirmed_block_identifier
+        token_address=token_address, block_identifier=block_identifier
     )
     assert token_network_address, "request a channel for an unregistered token"
     token_network_proxy = app0.raiden.chain.token_network(token_network_address)
@@ -136,7 +141,7 @@ def payment_channel_open_and_deposit(
     channel_identifier = token_network_proxy.new_netting_channel(
         partner=app1.raiden.address,
         settle_timeout=settle_timeout,
-        given_block_identifier=confirmed_block_identifier,
+        given_block_identifier=block_identifier,
     )
     assert channel_identifier
 


### PR DESCRIPTION
Fixes: #4470 

## Description

### Implemented

- Enforce confirmed block in api/python.py get_token_network() calls. This addresses the problem described in this [comment](https://github.com/raiden-network/raiden/issues/4470#issuecomment-521233420) of #4470 
- Also disallow default argument for block_identifier for get_token_network. This will only lead to bad surprises. Let's just be explicit

### Regression Test

Test that opening a channel via the API provides the confirmed block and not
the latest block as given_block. The discrepancy there lead to potential timing issues where the token network was deployed for the state in the "latest" block but not yet in the confirmed state and a BadFunctionCallOutput exception was thrown from web3.



## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
