### PR TITLE
Fixed restore logging

### DIFF
--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -40,6 +40,7 @@ def channel_state_until_state_change(
         transition_function=node.state_transition,
         storage=raiden.wal.storage,
         state_change_identifier=state_change_identifier,
+        node_address=raiden.address,
     )
 
     msg = "There is a state change, therefore the state must not be None"

--- a/raiden/utils/logging.py
+++ b/raiden/utils/logging.py
@@ -1,0 +1,19 @@
+from raiden.utils.typing import Dict
+
+
+def redact_secret(data: Dict) -> Dict:
+    """ Modify `data` in-place and replace keys named `secret`. """
+    if not isinstance(data, dict):
+        raise ValueError("data must be a dict.")
+
+    stack = [data]
+
+    while stack:
+        current = stack.pop()
+
+        if "secret" in current:
+            current["secret"] = "<redacted>"
+        else:
+            stack.extend(value for value in current.values() if isinstance(value, dict))
+
+    return data

--- a/tools/debugging/state_machine_report.py
+++ b/tools/debugging/state_machine_report.py
@@ -1,3 +1,4 @@
+#!/bin/env python
 import json
 import sys
 


### PR DESCRIPTION
The restore logging was:

- Producing bad output, because the objects were serialized with
  `__repr__`. Now the state changes are encoded as dictories and produce
  parseable json.
- Not properly redacting secrets. Now the same utility used for the
  normal execution of the node is also used by the recovery.
- Not logging the node address.

Fixes: #<issue>

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
