### PR TITLE
Make CI prepare-system symlinking more robust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,9 @@ commands:
           name: Link platform local binaries
           command: |
             export OS_NAME=$(uname -s | sed s/Darwin/macos/ | tr '[:lower:]' '[:upper:]')
-            [[ -d ~/.local-${OS_NAME} ]] && ln -s ~/.local-${OS_NAME} ~/.local || true
-            [[ -d ~/venv-<< parameters.py-version >>-${OS_NAME} ]] && ln -s ~/venv-<< parameters.py-version >>-${OS_NAME} ~/venv-<< parameters.py-version >> || true
+            rm -rf ~/.local
+            [[ -d ~/.local-${OS_NAME} ]] && ln -sfn ~/.local-${OS_NAME} ~/.local || true
+            [[ -d ~/venv-<< parameters.py-version >>-${OS_NAME} ]] && ln -sfn ~/venv-<< parameters.py-version >>-${OS_NAME} ~/venv-<< parameters.py-version >> || true
 
   prepare-system:
     steps:
@@ -138,7 +139,7 @@ commands:
             echo ${PARITY_VERSION} > /tmp/parity-version
             echo ${SOLC_VERSION} > /tmp/solc-version
       - restore_cache:
-          key: system-deps-v3-{{ arch }}-geth-{{ checksum "/tmp/geth-version" }}-parity-{{ checksum "/tmp/parity-version" }}-solc-{{ checksum "/tmp/solc-version" }}
+          key: system-deps-v4-{{ arch }}-geth-{{ checksum "/tmp/geth-version" }}-parity-{{ checksum "/tmp/parity-version" }}-solc-{{ checksum "/tmp/solc-version" }}
       - attach-and-link
       - run:
           name: Preparing environment
@@ -151,9 +152,9 @@ commands:
           command: |
             export LOCAL_BASE=~/.local-${OS_NAME}
             .circleci/fetch_geth_parity_solc.sh
-            ln -s ${LOCAL_BASE} ~/.local
+            ln -sfn ${LOCAL_BASE} ~/.local
       - save_cache:
-          key: system-deps-v3-{{ arch }}-geth-{{ checksum "/tmp/geth-version" }}-parity-{{ checksum "/tmp/parity-version" }}-solc-{{ checksum "/tmp/solc-version" }}
+          key: system-deps-v4-{{ arch }}-geth-{{ checksum "/tmp/geth-version" }}-parity-{{ checksum "/tmp/parity-version" }}-solc-{{ checksum "/tmp/solc-version" }}
           paths:
             - "~/.local-LINUX"
             - "~/.local-MACOS"

--- a/.circleci/fetch_geth_parity_solc.sh
+++ b/.circleci/fetch_geth_parity_solc.sh
@@ -27,7 +27,7 @@ if [[ ! -x ${GETH_PATH} ]]; then
       fi
   fi
 fi
-ln -sf ${GETH_PATH} ${LOCAL_BASE}/bin/geth
+ln -sfn ${GETH_PATH} ${LOCAL_BASE}/bin/geth
 
 PARITY_PATH="${LOCAL_BASE}/bin/parity-${OS_NAME}-${PARITY_VERSION}"
 if [[ ! -x ${PARITY_PATH} ]]; then
@@ -45,7 +45,7 @@ if [[ ! -x ${PARITY_PATH} ]]; then
       fi
   fi
 fi
-ln -sf ${PARITY_PATH} ${LOCAL_BASE}/bin/parity
+ln -sfn ${PARITY_PATH} ${LOCAL_BASE}/bin/parity
 
 # Only deal with solc for Linux since it's only used for testing
 if [[ ${OS_NAME} != "LINUX" ]]; then
@@ -59,4 +59,4 @@ if [[ ! -x ${SOLC_PATH} ]]; then
   curl -L ${!SOLC_URL_VAR} > ${SOLC_PATH}
   chmod 775 ${SOLC_PATH}
 fi
-ln -sf ${SOLC_PATH} ${LOCAL_BASE}/bin/solc
+ln -sfn ${SOLC_PATH} ${LOCAL_BASE}/bin/solc


### PR DESCRIPTION
## Description

We started to have weird build failures on CircleCI due to symlinks not being able to be created.
This makes the symlinking more robust.

/edit: Those changes definitely don't hurt but it seems the root cause was that the CI base image recently gained a pre-existing `~/.local` directory which interfered with out symlinking.