### PR TITLE
Upgrade raiden-contracts to 0.30.0

### DIFF
--- a/raiden/messages/monitoring_service.py
+++ b/raiden/messages/monitoring_service.py
@@ -20,6 +20,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
     typecheck,
 )
+from raiden_contracts.constants import MessageTypeId
 
 
 @dataclass(repr=False, eq=False)
@@ -63,6 +64,7 @@ class SignedBlindedBalanceProof:
 
     def _data_to_sign(self) -> bytes:
         packed = pack_signed_balance_proof(
+            msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
             nonce=self.nonce,
             balance_hash=self.balance_hash,
             additional_hash=self.additional_hash,
@@ -167,6 +169,7 @@ class RequestMonitoring(SignedMessage):
             ),
         )
         blinded_data = pack_signed_balance_proof(
+            msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
             nonce=self.balance_proof.nonce,
             balance_hash=self.balance_proof.balance_hash,
             additional_hash=self.balance_proof.additional_hash,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -77,6 +77,7 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
     ChannelInfoIndex,
     ChannelState,
+    MessageTypeId,
     ParticipantInfoIndex,
 )
 from raiden_contracts.contract_manager import ContractManager, gas_measurements
@@ -1448,6 +1449,7 @@ class TokenNetwork:
         )
 
         our_signed_data = pack_signed_balance_proof(
+            msg_type=MessageTypeId.BALANCE_PROOF,
             nonce=nonce,
             balance_hash=balance_hash,
             additional_hash=additional_hash,
@@ -1697,6 +1699,7 @@ class TokenNetwork:
         )
 
         our_signed_data = pack_signed_balance_proof(
+            msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
             nonce=nonce,
             balance_hash=balance_hash,
             additional_hash=additional_hash,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -67,6 +67,7 @@ from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import get_channelstate_by_token_network_and_partner
 from raiden.utils.packing import pack_signed_balance_proof, pack_withdraw
 from raiden.utils.typing import MYPY_ANNOTATION, Address, BlockSpecification, Nonce
+from raiden_contracts.constants import MessageTypeId
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -367,6 +368,7 @@ class RaidenEventHandler(EventHandler):
             canonical_identifier = channel_close_event.canonical_identifier
 
         closing_data = pack_signed_balance_proof(
+            msg_type=MessageTypeId.BALANCE_PROOF,
             nonce=nonce,
             balance_hash=balance_hash,
             additional_hash=message_hash,
@@ -404,6 +406,7 @@ class RaidenEventHandler(EventHandler):
             channel = raiden.chain.payment_channel(canonical_identifier=canonical_identifier)
 
             non_closing_data = pack_signed_balance_proof(
+                msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
                 nonce=balance_proof.nonce,
                 balance_hash=balance_proof.balance_hash,
                 additional_hash=balance_proof.message_hash,

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -47,7 +47,6 @@ from raiden.utils.cli import LogLevelConfigType
 from raiden.utils.debugging import enable_gevent_monitoring_signal
 from raiden.utils.ethereum_clients import is_supported_client
 
-
 log = structlog.get_logger()
 
 

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -152,13 +152,18 @@ def deploy_user_deposit_and_return_address(
 
 @pytest.fixture(name="one_to_n_address")
 def deploy_one_to_n_and_return_address(
-    user_deposit_address, deploy_client, contract_manager, environment_type, chain_id
+    user_deposit_address,
+    deploy_client,
+    contract_manager,
+    environment_type,
+    chain_id,
+    service_registry_address,
 ) -> typing.Optional[typing.Address]:
     """ Deploy OneToN contract and return the address """
     if environment_type != Environment.DEVELOPMENT:
         return None
 
-    constructor_arguments = [user_deposit_address, chain_id]
+    constructor_arguments = [user_deposit_address, chain_id, service_registry_address]
     one_to_n_address = deploy_contract_web3(
         contract_name=CONTRACT_ONE_TO_N,
         deploy_client=deploy_client,

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -64,8 +64,7 @@ def test_payment_channel_proxy_basics(
         transferred_amount=0,
     )
     closing_data = (
-        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
-        + EMPTY_SIGNATURE
+        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF) + EMPTY_SIGNATURE
     )
     channel_proxy_1.close(
         nonce=0,

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -208,8 +208,7 @@ def test_token_network_proxy(
         transferred_amount=0,
     )
     closing_data = (
-        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
-        + EMPTY_SIGNATURE
+        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF) + EMPTY_SIGNATURE
     )
 
     msg = "Trying to close an inexisting channel must fail."
@@ -322,8 +321,7 @@ def test_token_network_proxy(
     msg = "close must fail if the closing_signature is invalid"
     for invalid_signature in invalid_signatures:
         closing_data = (
-            balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
-            + invalid_signature
+            balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF) + invalid_signature
         )
         with pytest.raises(RaidenUnrecoverableError):
             c2_token_network_proxy.close(
@@ -340,9 +338,9 @@ def test_token_network_proxy(
 
     blocknumber_prior_to_close = c2_client.block_number()
 
-    closing_data = balance_proof.serialize_bin(
-        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE
-    ) + decode_hex(balance_proof.signature)
+    closing_data = balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF) + decode_hex(
+        balance_proof.signature
+    )
     c2_token_network_proxy.close(
         channel_identifier=channel_identifier,
         partner=c1_client.address,
@@ -565,7 +563,7 @@ def test_token_network_proxy_update_transfer(
 
     # close by c1
     closing_data = balance_proof_c2.serialize_bin(
-        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE
+        msg_type=MessageTypeId.BALANCE_PROOF
     ) + decode_hex(balance_proof_c2.signature)
     c1_token_network_proxy.close(
         channel_identifier=channel_identifier,
@@ -797,8 +795,7 @@ def test_token_network_actions_at_pruned_blocks(
         transferred_amount=0,
     )
     closing_data = (
-        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
-        + EMPTY_SIGNATURE
+        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF) + EMPTY_SIGNATURE
     )
     c1_token_network_proxy.close(
         channel_identifier=channel_identifier,

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -84,8 +84,7 @@ def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
         transferred_amount=0,
     )
     closing_data = (
-        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF_UPDATE)
-        + EMPTY_SIGNATURE
+        empty_balance_proof.serialize_bin(msg_type=MessageTypeId.BALANCE_PROOF) + EMPTY_SIGNATURE
     )
     closing_signature = app1.raiden.signer.sign(data=closing_data)
 

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -10,6 +10,7 @@ from raiden.transfer import views
 from raiden.transfer.state_change import ContractReceiveChannelSettled
 from raiden.utils import safe_gas_limit
 from raiden.utils.packing import pack_signed_balance_proof
+from raiden_contracts.constants import MessageTypeId
 
 pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
 
@@ -81,6 +82,7 @@ def run_test_locksroot_loading_during_channel_settle_handling(
     block_number = app0.raiden.chain.block_number()
 
     closing_data = pack_signed_balance_proof(
+        msg_type=MessageTypeId.BALANCE_PROOF,
         nonce=balance_proof.nonce,
         balance_hash=balance_proof.balance_hash,
         additional_hash=balance_proof.message_hash,

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -23,6 +23,7 @@ from raiden.utils import sha3
 from raiden.utils.packing import pack_balance_proof, pack_reward_proof, pack_signed_balance_proof
 from raiden.utils.signer import LocalSigner, recover
 from raiden.utils.typing import Address, TokenAmount
+from raiden_contracts.constants import MessageTypeId
 
 MSC_ADDRESS = Address(bytes([1] * 20))
 PARTNER_PRIVKEY, PARTNER_ADDRESS = factories.make_privkey_address()
@@ -89,6 +90,7 @@ def test_request_monitoring() -> None:
     assert recover(reward_proof_data, request_monitoring.reward_proof_signature) == ADDRESS
 
     blinded_data = pack_signed_balance_proof(
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
         nonce=request_monitoring.balance_proof.nonce,
         balance_hash=request_monitoring.balance_proof.balance_hash,
         additional_hash=request_monitoring.balance_proof.additional_hash,

--- a/raiden/utils/packing.py
+++ b/raiden/utils/packing.py
@@ -39,6 +39,7 @@ def pack_balance_proof(
 
 
 def pack_signed_balance_proof(
+    msg_type: MessageTypeId,
     nonce: Nonce,
     balance_hash: BalanceHash,
     additional_hash: AdditionalHash,
@@ -54,7 +55,7 @@ def pack_signed_balance_proof(
         token_network_address=to_checksum_address(canonical_identifier.token_network_address),
         chain_identifier=canonical_identifier.chain_identifier,
         channel_identifier=canonical_identifier.channel_identifier,
-        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
+        msg_type=msg_type,
         nonce=nonce,
         balance_hash=balance_hash,
         additional_hash=additional_hash,

--- a/raiden/utils/packing.py
+++ b/raiden/utils/packing.py
@@ -12,6 +12,7 @@ from raiden.utils.typing import (
     TokenAmount,
     WithdrawAmount,
 )
+from raiden_contracts.constants import MessageTypeId
 from raiden_contracts.utils import proofs
 
 
@@ -30,6 +31,7 @@ def pack_balance_proof(
         token_network_address=to_checksum_address(canonical_identifier.token_network_address),
         chain_identifier=canonical_identifier.chain_identifier,
         channel_identifier=canonical_identifier.channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF,
         nonce=nonce,
         balance_hash=balance_hash,
         additional_hash=additional_hash,
@@ -48,10 +50,11 @@ def pack_signed_balance_proof(
     Packs the given arguments in a byte array in the same configuration the
     contracts expect the signed data for updateNonClosingBalanceProof to have.
     """
-    return proofs.pack_balance_proof_update_message(
+    return proofs.pack_balance_proof_message(
         token_network_address=to_checksum_address(canonical_identifier.token_network_address),
         chain_identifier=canonical_identifier.chain_identifier,
         channel_identifier=canonical_identifier.channel_identifier,
+        msg_type=MessageTypeId.BALANCE_PROOF_UPDATE,
         nonce=nonce,
         balance_hash=balance_hash,
         additional_hash=additional_hash,

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -141,7 +141,7 @@ python-magic==0.4.15      # via s3cmd
 pytoml==0.1.20
 pytz==2019.1
 pyyaml==5.1.1
-raiden-contracts==0.29.0
+raiden-contracts==0.30.0
 raiden-webui==0.9.2
 readme-renderer==24.0
 releases==1.6.1

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -135,7 +135,7 @@ python-dateutil==2.8.0    # via pysaml2
 pytoml==0.1.20
 pytz==2019.1
 pyyaml==5.1.1             # via matrix-synapse
-raiden-contracts==0.29.0
+raiden-contracts==0.30.0
 raiden-webui==0.9.2
 readme-renderer==24.0
 releases==1.6.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -59,7 +59,7 @@ pycryptodome==3.8.2       # via eth-hash, eth-keyfile
 pysha3==1.0.2
 pytoml==0.1.20
 pytz==2019.1              # via flask-restful
-raiden-contracts==0.29.0
+raiden-contracts==0.30.0
 raiden-webui==0.9.2
 requests==2.22.0
 rlp==1.1.0                # via eth-rlp, raiden-contracts


### PR DESCRIPTION
## Description

This PR upgrades a dependency `raiden-contracts` to `0.30.0`. It contains a bug fix so monitoring services can no longer close channels.

This PR
* changes some MessageTypeId.BALANCE_PROOF into MessageTypeId.BALANCE_PROOF_UPDATE.
* adds one argument to the constructor argument of OneToN contract.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
