### PR TITLE
Encoding locks for logging

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2094,7 +2094,7 @@ class TokenNetwork:
             channel_identifier=channel_identifier,
             receiver=receiver,
             sender=sender,
-            locks=leaves_packed,
+            locks=encode_hex(leaves_packed),
         )
 
         if gas_limit:


### PR DESCRIPTION
Without this the locks are printed as binary, which is harder to read