### PR TITLE
Check build with timeout on patched web estimate_gas

### DIFF
--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -23,9 +23,7 @@ def test_estimate_gas_fail(deploy_client):
     assert contract_proxy.estimate_gas(check_block, "fail_require") is None, msg
 
 
-def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(
-    deploy_client, skip_if_not_geth  # pylint: disable=unused-argument
-):
+def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(deploy_client):
     """ Gas estimation fails if the transaction execution requires more gas
     then the block's gas limit.
     """


### PR DESCRIPTION
Fixes: #3835 

Running our function for `estimate_gas` would hang for 15+ minutes for parity when the contract required a long calculation. The main reason is that parity blocks for the request and web3 confuses that for a timeout, which leads to retries for the same request from two of middlewares that are installed:

 - Our own 'http_retry_with_backoff_middleware", which retries failed connections for 10 times, at increasing intervals
- web3's built-in "http_retry_request" middleware, which retries failed connections 5 times after a timeout of 10 seconds.

This leads to long-running calls to be tried and retried 50 times, 

 1. (50 + 0.2) seconds 10 s timeout for each of try from the http_retry_request) + initial sleep from backoff initial of 0.2s
 1. (50 + 0.4) seconds:  (our middleware mistakes the first one as a failure, 
 1. (50 + 0.4) seconds: 3rd retry from backoff middleware
 1. (50 + 0.8) seconds: 4th retry...
 1. (...)
 1. (...)
 1. (...)
 1. (...)
 1. (...)
 10. (50 + 102.4) seconds: last attempt.

The main issue is the interaction between the two middlewares, and the fact that the `http_retry_request` is not listed as part of the "middleware_stack" attribute of web3, so it can not be easily replaced.

The two immediate approaches would be:

 1. Remove our retry_with_backoff middleware
 2. Override web3 with a custom `HTTPProvider` class which does not include the built-in `http_retry_request` middleware, and leave only our own middleware.

Given that our middleware was only included as part of the solution for #3558, and that issue is theoretically fixed by the use of the block filters alone (i.e, the backoff middleware was added as being a "just-in-case" measure), it seems more reasonable to remove the backoff middleware and avoid the extra meddling of web3 internals.

Without this extra middleware, we can then solve the bug from `estimateGas` calls on parity by simply handling a `requests.ReadTimeout` exception, which should be the error thrown from web3 after 50 seconds.
