### PR TITLE
Set flat_fee per token network

### DIFF
--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -60,6 +60,7 @@ class NewChannelDetails:
     chain_id: ChainID
     token_network_registry_address: TokenNetworkRegistryAddress
     token_address: TokenAddress
+    token_network_address: TokenNetworkAddress
     our_address: Address
     partner_address: Address
 
@@ -250,6 +251,7 @@ def get_contractreceivechannelnew_data_from_event(
         chain_id=event.chain_id,
         token_network_registry_address=token_network_registry.address,
         token_address=token_network.token_address,
+        token_network_address=token_network_address,
         our_address=our_address,
         partner_address=partner_address,
     )

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -370,6 +370,7 @@ def create_apps(
             "rpc": True,
             "console": False,
             "default_fee_schedule": FeeScheduleState(),
+            "flat_fees": {},
         }
 
         if local_matrix_url is not None:

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -23,7 +23,6 @@ from raiden.log_config import configure_logging
 from raiden.network.utils import get_free_port
 from raiden.settings import (
     DEFAULT_HTTP_SERVER_PORT,
-    DEFAULT_MEDIATION_FLAT_FEE,
     DEFAULT_MEDIATION_MAX_IMBALANCE_FEE,
     DEFAULT_MEDIATION_PROPORTIONAL_FEE,
     DEFAULT_PATHFINDING_IOU_TIMEOUT,
@@ -327,7 +326,7 @@ def options(func):
             option("--log-json", help="Output log lines in JSON format", is_flag=True),
             option(
                 "--debug-logfile-name",
-                help=("The debug logfile name."),
+                help="The debug logfile name.",
                 type=click.Path(dir_okay=False, writable=True, resolve_path=True),
             ),
             option(
@@ -402,14 +401,16 @@ def options(func):
             "Mediation Fee Options",
             option(
                 "--flat-fee",
-                help=("Flat fee required for every mediation in wei of the mediated token."),
-                default=DEFAULT_MEDIATION_FLAT_FEE,
-                type=FeeAmount,
-                show_default=True,
+                help=(
+                    "Sets the flat fee required for every mediation in wei of the "
+                    "mediated token for a certain token network."
+                ),
+                type=(ADDRESS_TYPE, click.IntRange(min=0)),
+                multiple=True,
             ),
             option(
                 "--proportional-fee",
-                help=("Mediation fee as ratio of mediated amount in parts-per-million (10^-6)."),
+                help="Mediation fee as ratio of mediated amount in parts-per-million (10^-6).",
                 default=DEFAULT_MEDIATION_PROPORTIONAL_FEE,
                 type=int,
                 show_default=True,
@@ -655,13 +656,13 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
 
             port = next(free_port_generator)
 
-            # TODO: Use a routing_mode PRIVATE here, as no updates should be broadcasted
             args["api_address"] = f"localhost:{port}"
             args["config"] = deepcopy(App.DEFAULT_CONFIG)
             args["environment_type"] = environment_type
             args["extra_config"] = {"transport": {"matrix": {"available_servers": server_urls}}}
             args["one_to_n_contract_address"] = "0x" + "1" * 40
             args["routing_mode"] = RoutingMode.PRIVATE
+            args["flat_fee"] = ()
 
             for option_ in run.params:
                 if option_.name in args.keys():

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -10,11 +10,11 @@ from typing import Any, Callable
 import gevent
 from eth_keys import keys
 from eth_utils import (
-    decode_hex,
     encode_hex,
     is_0x_prefixed,
     is_checksum_address,
     remove_0x_prefix,
+    to_canonical_address,
     to_checksum_address,
 )
 from web3 import Web3
@@ -68,9 +68,7 @@ def address_checksum_and_decode(addr: str) -> Address:
     if not is_checksum_address(addr):
         raise InvalidChecksummedAddress("Address must be EIP55 checksummed")
 
-    addr_bytes = decode_hex(addr)
-    assert len(addr_bytes) in (20, 0)
-    return Address(addr_bytes)
+    return to_canonical_address(addr)
 
 
 def pex(data: bytes) -> str:

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -22,7 +22,7 @@ from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES, SerializedSQLiteStora
 from raiden.storage.wal import WriteAheadLog
 from raiden.transfer import node, views
 from raiden.transfer.architecture import Event, StateChange, StateManager
-from raiden.utils import address_checksum_and_decode, pex, to_checksum_address
+from raiden.utils import pex, to_checksum_address
 from raiden.utils.typing import (
     Address,
     Any,
@@ -55,8 +55,8 @@ class Translator(dict):
         """
         try:
             addr = str(to_checksum_address(addr))
-            rxp = "(?:0x)?" + pex(address_checksum_and_decode(addr)) + f"(?:{addr.lower()[10:]})?"
-            self._extra_keys[pex(address_checksum_and_decode(addr))] = addr.lower()
+            rxp = "(?:0x)?" + pex(to_canonical_address(addr)) + f"(?:{addr.lower()[10:]})?"
+            self._extra_keys[pex(to_canonical_address(addr))] = addr.lower()
             self._extra_keys[addr[2:].lower()] = addr.lower()
         except ValueError:
             rxp = addr


### PR DESCRIPTION
Fixes: #4653 

## Description

This PR adds the possibility to set the flat mediation fee on a per token network basis. This is required as tokens in different networks have different values and therefore different settings are required.

This is accomplished by changing the `--flat-fee XXX` CLI flag to take two arguments: The checksummed address of the token network and the flat fee for that network (`--flat-fee 0xdeadbeef 123`). This flag can be set multiple times for different networks.

In the future we should introduce a `MediationFeeConfig` class to collect all related settings.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
