### PR TITLE
adds retries to pfs info query

### DIFF
--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -790,7 +790,7 @@ def test_insufficient_payment(query_paths_args, valid_response_json):
 
     # PFS fails to return info
     assert_failed_pfs_request(
-        query_paths_args, [insufficient_response], expected_requests=1, expected_get_iou_requests=2
+        query_paths_args, [insufficient_response], expected_requests=1, expected_get_iou_requests=1
     )
 
     # PFS has increased fees

--- a/raiden/tests/unit/test_pfs_integration_refactored.py
+++ b/raiden/tests/unit/test_pfs_integration_refactored.py
@@ -31,7 +31,7 @@ def test_get_pfs_info_success():
     response = Mock()
     response.configure_mock(status_code=200, content=json.dumps(info_data))
 
-    with patch.object(requests, "get", return_value=response):
+    with patch.object(requests.Session, "get", return_value=response):
         pfs_info = get_pfs_info("url")
 
         req_registry_address = to_canonical_address(pfs_test_default_registry_address)
@@ -63,14 +63,14 @@ def test_get_pfs_info_error():
     response = Mock()
     response.configure_mock(status_code=200, content=str(incorrect_json_info_data))
 
-    with patch.object(requests, "get", return_value=response):
+    with patch.object(requests.Session, "get", return_value=response):
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 
         assert "Expecting property name enclosed in double quotes:" in str(error.value)
 
     # test RequestException
-    with patch.object(requests, "get", side_effect=requests.RequestException()):
+    with patch.object(requests.Session, "get", side_effect=requests.RequestException()):
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 
@@ -85,7 +85,7 @@ def test_get_pfs_info_error():
     }
 
     response.configure_mock(status_code=200, content=json.dumps(incorrect_info_data))
-    with patch.object(requests, "get", return_value=response):
+    with patch.object(requests.Session, "get", return_value=response):
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 


### PR DESCRIPTION
Fixes: #4454 

## Description

Please, describe what this PR does in detail:
It fixes the bug, that the node requested the pfs info only once. If there were errors due to a bad connection, Raiden would crash. Now it retries 3 times.  

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
