### PR TITLE
Display proper error if account does not have a keystore file

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -7,6 +7,7 @@ import structlog
 from eth_keyfile import decode_keyfile_json
 from eth_utils import decode_hex, encode_hex, to_checksum_address
 
+from raiden.exceptions import RaidenError
 from raiden.utils import privatekey_to_address, privatekey_to_publickey
 from raiden.utils.typing import AddressHex, PrivateKey, PublicKey
 
@@ -17,6 +18,10 @@ class InvalidAccountFile(Exception):
     """ Thrown when a file is not a valid keystore account file """
 
     pass
+
+
+class KeystoreFileNotFound(RaidenError):
+    """ A keystore file for a user provided account could not be found. """
 
 
 def _find_datadir() -> Optional[str]:  # pragma: no cover
@@ -109,7 +114,7 @@ class AccountManager:
             The private key associated with the address
         """
         if not self.address_in_keystore(address):
-            raise ValueError("Keystore file not found for %s" % address)
+            raise KeystoreFileNotFound("Keystore file not found for %s" % address)
 
         with open(self.accounts[address]) as data_file:
             data = json.load(data_file)

--- a/raiden/tests/unit/test_accounts.py
+++ b/raiden/tests/unit/test_accounts.py
@@ -8,7 +8,7 @@ import pytest
 from eth_keyfile.keyfile import decode_keyfile_json
 from eth_utils import decode_hex, encode_hex
 
-from raiden.accounts import Account, AccountManager
+from raiden.accounts import Account, AccountManager, KeystoreFileNotFound
 from raiden.ui.prompt import unlock_account_with_passwordfile
 from raiden.utils import get_project_root, privatekey_to_address, privatekey_to_publickey
 
@@ -68,7 +68,7 @@ def test_get_privkey(keystore_mock):
     with pytest.raises(ValueError) as exc:
         account_manager.get_privkey("0x3593403033d18b82f7b4a0F18e1ED24623D23b20", "456")
     assert "MAC mismatch" in str(exc.value)
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(KeystoreFileNotFound) as exc:
         account_manager.get_privkey("0xa05934d3033D18b82F7b4AdF18E1eD24E3D23b19", "123")
     assert "Keystore file not found for 0xa05934d3033D18b82F7b4AdF18E1eD24E3D23b19" in str(
         exc.value

--- a/raiden/ui/prompt.py
+++ b/raiden/ui/prompt.py
@@ -5,7 +5,7 @@ from typing import TextIO
 import click
 from eth_utils import to_checksum_address
 
-from raiden.accounts import AccountManager
+from raiden.accounts import AccountManager, KeystoreFileNotFound
 from raiden.utils.typing import AddressHex, PrivateKey
 
 
@@ -36,6 +36,9 @@ def unlock_account_with_passwordfile(
 
     try:
         return account_manager.get_privkey(address_hex, password.strip())
+    except KeystoreFileNotFound as e:
+        click.secho(str(e), fg="red")
+        sys.exit(1)
     except ValueError:
         click.secho(f"Incorrect password for {address_hex} in file. Aborting ...", fg="red")
         sys.exit(1)


### PR DESCRIPTION
Fix #4673 