### PR TITLE
external resolver related changes

### DIFF
--- a/raiden/network/resolver/client.py
+++ b/raiden/network/resolver/client.py
@@ -8,6 +8,7 @@ from eth_utils import to_bytes, to_hex
 from raiden.storage.wal import WriteAheadLog
 from raiden.transfer.mediated_transfer.events import SendSecretRequest
 from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
+from raiden.transfer.state import ChainState
 from raiden.utils import Secret
 
 if TYPE_CHECKING:
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
 
 def reveal_secret_with_resolver(
-    raiden: "RaidenService", secret_request_event: SendSecretRequest
+    raiden: "RaidenService", chain_state: ChainState, secret_request_event: SendSecretRequest
 ) -> bool:
 
     if "resolver_endpoint" not in raiden.config:
@@ -39,8 +40,8 @@ def reveal_secret_with_resolver(
         "payment_sender": to_hex(secret_request_event.recipient),
         "expiration": secret_request_event.expiration,
         "payment_recipient": to_hex(raiden.address),
-        "reveal_timeout": raiden.config["reveal_timeout"],
-        "settle_timeout": raiden.config["settle_timeout"],
+        "chain_id": chain_state.chain_id,
+        "chain_height": chain_state.block_number,
     }
 
     try:

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -244,7 +244,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_secretrequest(
         raiden: "RaidenService", chain_state: ChainState, secret_request_event: SendSecretRequest
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         if reveal_secret_with_resolver(raiden, chain_state, secret_request_event):
             return
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -139,7 +139,7 @@ class RaidenEventHandler(EventHandler):
             self.handle_send_balanceproof(raiden, event)
         elif type(event) == SendSecretRequest:
             assert isinstance(event, SendSecretRequest), MYPY_ANNOTATION
-            self.handle_send_secretrequest(raiden, event)
+            self.handle_send_secretrequest(raiden, chain_state, event)
         elif type(event) == SendRefundTransfer:
             assert isinstance(event, SendRefundTransfer), MYPY_ANNOTATION
             self.handle_send_refundtransfer(raiden, event)
@@ -243,9 +243,9 @@ class RaidenEventHandler(EventHandler):
 
     @staticmethod
     def handle_send_secretrequest(
-        raiden: "RaidenService", secret_request_event: SendSecretRequest
-    ) -> None:  # pragma: no unittest
-        if reveal_secret_with_resolver(raiden, secret_request_event):
+        raiden: "RaidenService", chain_state: ChainState, secret_request_event: SendSecretRequest
+    ):  # pragma: no unittest
+        if reveal_secret_with_resolver(raiden, chain_state, secret_request_event):
             return
 
         secret_request_message = message_from_sendevent(secret_request_event)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1122,11 +1122,11 @@ class RaidenService(Runnable):
 
         if secrethash is None:
             secrethash = sha256_secrethash(secret)
-        elif secrethash != sha256_secrethash(secret):
-            raise InvalidSecretHash("provided secret and secret_hash do not match.")
-
-        if len(secret) != SECRET_LENGTH:
-            raise InvalidSecret("secret of invalid length.")
+        elif secret != ABSENT_SECRET:
+            if secrethash != sha256_secrethash(secret):
+                raise InvalidSecretHash("provided secret and secret_hash do not match.")
+            if len(secret) != SECRET_LENGTH:
+                raise InvalidSecret("secret of invalid length.")
 
         log.debug(
             "Mediated transfer",

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -20,8 +20,8 @@ from raiden.constants import GENESIS_BLOCK_NUMBER, SECRET_LENGTH, Environment
 from raiden.messages.transfers import LockedTransfer, Unlock
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.integration.api.utils import create_api_server
-from raiden.tests.integration.fixtures.smartcontracts import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
 from raiden.tests.integration.fixtures.raiden_network import stop_resolvers
+from raiden.tests.integration.fixtures.smartcontracts import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.events import check_dict_nested_attrs, must_have_event, must_have_events

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -20,7 +20,6 @@ from raiden.constants import GENESIS_BLOCK_NUMBER, SECRET_LENGTH, Environment
 from raiden.messages.transfers import LockedTransfer, Unlock
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.integration.api.utils import create_api_server
-from raiden.tests.integration.fixtures.raiden_network import stop_resolvers
 from raiden.tests.integration.fixtures.smartcontracts import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
@@ -1133,7 +1132,7 @@ def test_api_payments_with_resolver(
     assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
     assert payment == payment
 
-    # payment with secret where the resolver don't have the secret. Should work.
+    # payment with secret where the resolver doesn't have the secret. Should work.
 
     request = grequests.post(
         api_url_for(
@@ -1165,9 +1164,6 @@ def test_api_payments_with_resolver(
     response = request.send().response
     assert_proper_response(response, status_code=HTTPStatus.OK)
     assert payment == payment
-
-    # cleanup - stop resolvers.
-    stop_resolvers(resolvers)
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -21,6 +21,7 @@ from raiden.messages.transfers import LockedTransfer, Unlock
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.integration.api.utils import create_api_server
 from raiden.tests.integration.fixtures.smartcontracts import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
+from raiden.tests.integration.fixtures.raiden_network import stop_resolvers
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.events import check_dict_nested_attrs, must_have_event, must_have_events
@@ -1091,6 +1092,82 @@ def test_api_payments_with_hash_no_secret(
     response = request.send().response
     assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
     assert payment == payment
+
+
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("resolver_ports", [[None, 8000]])
+def test_api_payments_with_resolver(
+    api_server_test_instance, raiden_network, token_addresses, resolvers
+):
+
+    _, app1 = raiden_network
+    amount = 100
+    identifier = 42
+    token_address = token_addresses[0]
+    target_address = app1.raiden.address
+    secret = to_hex(factories.make_secret())
+    secret_hash = to_hex(sha256(to_bytes(hexstr=secret)).digest())
+
+    our_address = api_server_test_instance.rest_api.raiden_api.address
+
+    payment = {
+        "initiator_address": to_checksum_address(our_address),
+        "target_address": to_checksum_address(target_address),
+        "token_address": to_checksum_address(token_address),
+        "amount": amount,
+        "identifier": identifier,
+    }
+
+    # payment with secret_hash when both resolver and initiator don't have the secret
+
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "secret_hash": secret_hash},
+    )
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
+    assert payment == payment
+
+    # payment with secret where the resolver don't have the secret. Should work.
+
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "secret": secret},
+    )
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.OK)
+    assert payment == payment
+
+    # payment with secret_hash where the resolver has the secret. Should work.
+
+    secret = "0x2ff886d47b156de00d4cad5d8c332706692b5b572adfe35e6d2f65e92906806e"
+    secret_hash = to_hex(sha256(to_bytes(hexstr=secret)).digest())
+
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "secret_hash": secret_hash},
+    )
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.OK)
+    assert payment == payment
+
+    # cleanup - stop resolvers.
+    stop_resolvers(resolvers)
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -158,7 +158,11 @@ def monitoring_service_contract_address() -> Address:
 
 
 @pytest.fixture
-def resolvers(resolver_ports) -> List[Optional[subprocess.Popen]]:
+def resolvers(resolver_ports):
+    """Invoke resolver process for each node having a resolver port
+
+    By default, Raiden nodes start without hash resolvers (all ports are None)
+    """
     resolvers = []
     for port in resolver_ports:
         resolver = None
@@ -168,10 +172,8 @@ def resolvers(resolver_ports) -> List[Optional[subprocess.Popen]]:
             assert resolver.poll() is None
         resolvers.append(resolver)
 
-    return resolvers
+    yield resolvers
 
-
-def stop_resolvers(resolvers: List[subprocess.Popen]):
     for resolver in resolvers:
         if resolver is not None:
             resolver.terminate()

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -6,6 +6,7 @@ from raiden.constants import DISCOVERY_DEFAULT_ROOM
 from raiden.network.transport import MatrixTransport
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.utils.transport import generate_synapse_config, matrix_server_starter
+from raiden.utils.typing import Optional
 
 
 @pytest.fixture
@@ -85,3 +86,8 @@ def matrix_transports(
         # Calling `get()` on a never started Greenlet will block forever
         if transport._started:
             transport.get()
+
+
+@pytest.fixture
+def resolver_ports(number_of_nodes) -> List[Optional[int]]:
+    return [None] * number_of_nodes

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -90,4 +90,10 @@ def matrix_transports(
 
 @pytest.fixture
 def resolver_ports(number_of_nodes) -> List[Optional[int]]:
+    """Default resolver ports for all nodes.
+
+    By default, Raiden nodes start without hash resolvers.
+    This is achieved by setting the ports to None. This cause the command line not to
+    include --resolver-endpoint  and resolver processes will not start.
+    """
     return [None] * number_of_nodes

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -353,6 +353,7 @@ def create_apps(
     global_rooms: List[str],
     routing_mode: RoutingMode,
     blockchain_query_interval: float,
+    resolver_ports: List[Optional[int]],
 ) -> List[App]:
     """ Create the apps."""
     # pylint: disable=too-many-locals
@@ -361,6 +362,8 @@ def create_apps(
     apps = []
     for idx, blockchain in enumerate(services):
         database_path = database_from_privatekey(base_dir=database_basedir, app_number=idx)
+        assert len(resolver_ports) > idx
+        resolver_port = resolver_ports[idx]
 
         config = {
             "chain_id": chain_id,
@@ -398,6 +401,9 @@ def create_apps(
                     },
                 },
             )
+
+        if resolver_port is not None:
+            merge_dict(config, {"resolver_endpoint": "http://localhost:" + str(resolver_port)})
 
         config_copy = deepcopy(App.DEFAULT_CONFIG)
         config_copy.update(config)

--- a/tools/dummy_resolver_server.py
+++ b/tools/dummy_resolver_server.py
@@ -13,7 +13,7 @@ def resolve(request):
 
     preimage = None
 
-    if not "secrethash" in request:
+    if "secrethash" not in request:
         return preimage
 
     x_secret = "0x2ff886d47b156de00d4cad5d8c332706692b5b572adfe35e6d2f65e92906806e"

--- a/tools/dummy_resolver_server.py
+++ b/tools/dummy_resolver_server.py
@@ -1,10 +1,8 @@
 import json
 import logging
+from hashlib import sha256
 from http.server import BaseHTTPRequestHandler, HTTPServer
-
 from eth_utils import to_bytes, to_hex
-
-from raiden.utils import sha3
 
 # The code below simulates XUD resolver functionality.
 # It should only be used for testing and should not be used in
@@ -15,10 +13,13 @@ def resolve(request):
 
     preimage = None
 
-    x_secret = "0x2ff886d47b156de00d4cad5d8c332706692b5b572adfe35e6d2f65e92906806e"
-    x_secret_hash = to_hex(sha3(to_bytes(hexstr=x_secret)))
+    if not "secrethash" in request:
+        return preimage
 
-    if request["secret_hash"] == x_secret_hash:
+    x_secret = "0x2ff886d47b156de00d4cad5d8c332706692b5b572adfe35e6d2f65e92906806e"
+    x_secret_hash = to_hex(sha256(to_bytes(hexstr=x_secret)).digest())
+
+    if request["secrethash"] == x_secret_hash:
         preimage = {"secret": x_secret}
 
     return preimage

--- a/tools/dummy_resolver_server.py
+++ b/tools/dummy_resolver_server.py
@@ -45,6 +45,9 @@ def serve():
                 self.send_response(400)
                 self.end_headers()
 
+    # TODO: accept port as runtime parameters to allow parallel execution
+    # of multiple resolvers.
+
     httpd = HTTPServer(("localhost", 8000), SimpleHTTPRequestHandler)
     httpd.serve_forever()
 


### PR DESCRIPTION
This PR merge changes related to external resolver (XUD) done in private fork of raiden. 

feature: add chain_height and chain_id to the resolver request
---------------------------------------------------------------
chain_height is needed for the extraction of the lock_duration from the expiration.
chain_id can be used to ensure that the request is coming from the right chain.
remove unneeded members

replace sha3 with sha256
----------------------------
the dummy resolver can be used to simulate a payment where the payee has the secret. Since raiden changed the hash function of the secret to sha256 we also need to do this for the dummy resolver.

Allow payment with secret_hash and no secret
-------------------------------------------------
restore functionality added in the past. It is valid to provide secret_hash without providing a secret
