### PR TITLE
Improve docstring, add typing

### DIFF
--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -29,7 +29,12 @@ from raiden_contracts.contract_manager import ContractManager
 
 
 class BlockChainService:
-    """ Exposes the blockchain's state through JSON-RPC. """
+    """ Encapsulates access and creation of contract proxies.
+
+    This class keeps track of mapping between contract addresses and their internal
+    contract proxy counterparts. It also synchronizes creation of proxies, so that
+    a 1-to-1 relationship is kept.
+    """
 
     # pylint: disable=too-many-instance-attributes
 

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -15,6 +15,7 @@ from raiden.utils.typing import (
     Address,
     BlockHash,
     BlockNumber,
+    BlockSpecification,
     ChainID,
     ChannelID,
     Dict,
@@ -75,7 +76,7 @@ class BlockChainService:
     def block_hash(self) -> BlockHash:
         return self.client.blockhash_from_blocknumber("latest")
 
-    def get_block(self, block_identifier):
+    def get_block(self, block_identifier: BlockSpecification):
         return self.client.web3.eth.getBlock(block_identifier=block_identifier)
 
     def is_synced(self) -> bool:
@@ -110,13 +111,10 @@ class BlockChainService:
         else:
             interval = last_block_number - oldest
         assert interval > 0
-        last_timestamp = self.get_block_header(last_block_number)["timestamp"]
-        first_timestamp = self.get_block_header(last_block_number - interval)["timestamp"]
+        last_timestamp = self.get_block(last_block_number)["timestamp"]
+        first_timestamp = self.get_block(last_block_number - interval)["timestamp"]
         delta = last_timestamp - first_timestamp
         return delta / interval
-
-    def get_block_header(self, block_number: int):
-        return self.client.web3.eth.getBlock(block_number, False)
 
     def next_block(self) -> int:
         target_block_number = self.block_number() + 1


### PR DESCRIPTION

## Description

This PR is a collection of various smaller changes:
- Expand docstring of BlockChainService after I discussed it with Augusto.
- Remove duplicated `get_block_header`, something I found while reading the code.
- Cleanup and type `AlarmTask`: Some cleanups also found during looking through the code. (Ref. https://github.com/raiden-network/raiden/issues/4033)


## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
