### PR TITLE
Change `--max-imbalance-fee` to `--proportional-imbalance-fee`

### DIFF
--- a/raiden/app.py
+++ b/raiden/app.py
@@ -10,7 +10,7 @@ from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.raiden_service import RaidenService
 from raiden.settings import (
-    DEFAULT_MEDIATION_MAX_IMBALANCE_FEE,
+    DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE,
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     DEFAULT_PATHFINDING_IOU_TIMEOUT,
     DEFAULT_PATHFINDING_MAX_FEE,
@@ -60,7 +60,7 @@ class App:  # pylint: disable=too-few-public-methods
             "pathfinding_iou_timeout": DEFAULT_PATHFINDING_IOU_TIMEOUT,
             "monitoring_enabled": False,
         },
-        "max_imbalance_fee": DEFAULT_MEDIATION_MAX_IMBALANCE_FEE,
+        "proportional_imbalance_fee": DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE,
     }
 
     def __init__(

--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -56,7 +56,7 @@ from raiden.utils.typing import (
     FeeAmount,
     List,
     Optional,
-    RelativeFeeAmount,
+    ProportionalFeeAmount,
     SecretRegistryAddress,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
@@ -327,8 +327,8 @@ def contractreceivechannelbatchunlock_from_event(
 def actionchannelupdatefee_from_channelstate(
     channel_state: NettingChannelState,
     flat_fee: FeeAmount,
-    proportional_fee: RelativeFeeAmount,
-    proportional_imbalance_fee: RelativeFeeAmount,
+    proportional_fee: ProportionalFeeAmount,
+    proportional_imbalance_fee: ProportionalFeeAmount,
 ) -> ActionChannelUpdateFee:
     imbalance_penalty = calculate_imbalance_fees(
         channel_capacity=get_capacity(channel_state),

--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -56,6 +56,7 @@ from raiden.utils.typing import (
     FeeAmount,
     List,
     Optional,
+    RelativeFeeAmount,
     SecretRegistryAddress,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
@@ -326,11 +327,12 @@ def contractreceivechannelbatchunlock_from_event(
 def actionchannelupdatefee_from_channelstate(
     channel_state: NettingChannelState,
     flat_fee: FeeAmount,
-    proportional_fee: int,
-    max_imbalance_fee: FeeAmount,
+    proportional_fee: RelativeFeeAmount,
+    proportional_imbalance_fee: RelativeFeeAmount,
 ) -> ActionChannelUpdateFee:
     imbalance_penalty = calculate_imbalance_fees(
-        channel_capacity=get_capacity(channel_state), max_imbalance_fee=max_imbalance_fee
+        channel_capacity=get_capacity(channel_state),
+        proportional_imbalance_fee=proportional_imbalance_fee,
     )
 
     return ActionChannelUpdateFee(
@@ -394,7 +396,7 @@ def blockchainevent_to_statechange(
                 channel_state=channel_state,
                 flat_fee=channel_state.fee_schedule.flat,
                 proportional_fee=channel_state.fee_schedule.proportional,
-                max_imbalance_fee=raiden.config["max_imbalance_fee"],
+                proportional_imbalance_fee=raiden.config["proportional_imbalance_fee"],
             )
             state_changes.append(update_fee)
 
@@ -410,7 +412,7 @@ def blockchainevent_to_statechange(
                 channel_state=channel_state,
                 flat_fee=channel_state.fee_schedule.flat,
                 proportional_fee=channel_state.fee_schedule.proportional,
-                max_imbalance_fee=raiden.config["max_imbalance_fee"],
+                proportional_imbalance_fee=raiden.config["proportional_imbalance_fee"],
             )
             state_changes.append(update_fee)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1005,14 +1005,14 @@ class RaidenService(Runnable):
                     channel=channel.canonical_identifier,
                     flat_fee=flat_fee,
                     proportional_fee=proportional_fee,
-                    max_imbalance_fee=self.config["max_imbalance_fee"],
+                    proportional_imbalance_fee=self.config["proportional_imbalance_fee"],
                 )
 
                 state_change = actionchannelupdatefee_from_channelstate(
                     channel_state=channel,
                     flat_fee=flat_fee,
                     proportional_fee=proportional_fee,
-                    max_imbalance_fee=self.config["max_imbalance_fee"],
+                    proportional_imbalance_fee=self.config["proportional_imbalance_fee"],
                 )
                 self.handle_and_track_state_changes([state_change])
 

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -2,7 +2,7 @@ from eth_utils import denoms, to_hex
 
 import raiden_contracts.constants
 from raiden.constants import Environment
-from raiden.utils.typing import FeeAmount, NetworkTimeout, RelativeFeeAmount, TokenAmount
+from raiden.utils.typing import FeeAmount, NetworkTimeout, ProportionalFeeAmount, TokenAmount
 
 CACHE_TTL = 60
 GAS_LIMIT = 10 * 10 ** 6
@@ -44,8 +44,8 @@ DEFAULT_PATHFINDING_MAX_FEE = 1000
 DEFAULT_PATHFINDING_IOU_TIMEOUT = 50000  # now the pfs has 200h to cash in
 
 DEFAULT_MEDIATION_FLAT_FEE = FeeAmount(0)
-DEFAULT_MEDIATION_PROPORTIONAL_FEE = RelativeFeeAmount(0)
-DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE = RelativeFeeAmount(0)
+DEFAULT_MEDIATION_PROPORTIONAL_FEE = ProportionalFeeAmount(0)
+DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE = ProportionalFeeAmount(0)
 
 ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE = 3
 ETHERSCAN_API = "https://{network}.etherscan.io/api?module=proxy&action={action}"

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -2,7 +2,7 @@ from eth_utils import denoms, to_hex
 
 import raiden_contracts.constants
 from raiden.constants import Environment
-from raiden.utils.typing import FeeAmount, NetworkTimeout, TokenAmount
+from raiden.utils.typing import FeeAmount, NetworkTimeout, RelativeFeeAmount, TokenAmount
 
 CACHE_TTL = 60
 GAS_LIMIT = 10 * 10 ** 6
@@ -44,8 +44,8 @@ DEFAULT_PATHFINDING_MAX_FEE = 1000
 DEFAULT_PATHFINDING_IOU_TIMEOUT = 50000  # now the pfs has 200h to cash in
 
 DEFAULT_MEDIATION_FLAT_FEE = FeeAmount(0)
-DEFAULT_MEDIATION_PROPORTIONAL_FEE = 0
-DEFAULT_MEDIATION_MAX_IMBALANCE_FEE = FeeAmount(0)
+DEFAULT_MEDIATION_PROPORTIONAL_FEE = RelativeFeeAmount(0)
+DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE = RelativeFeeAmount(0)
 
 ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE = 3
 ETHERSCAN_API = "https://{network}.etherscan.io/api?module=proxy&action={action}"

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -1,7 +1,6 @@
 import gevent
 import pytest
 
-
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 from raiden.utils import safe_gas_limit
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -7,7 +7,13 @@ from raiden.transfer.mediated_transfer.mediation_fee import (
     calculate_imbalance_fees,
     linspace,
 )
-from raiden.utils.typing import Balance, FeeAmount, PaymentAmount, RelativeFeeAmount, TokenAmount
+from raiden.utils.typing import (
+    Balance,
+    FeeAmount,
+    PaymentAmount,
+    ProportionalFeeAmount,
+    TokenAmount,
+)
 
 
 def test_interpolation():
@@ -35,13 +41,13 @@ def test_basic_fee():
     flat_schedule = FeeScheduleState(flat=FeeAmount(2))
     assert flat_schedule.fee(PaymentAmount(10), channel_balance=Balance(0)) == FeeAmount(2)
 
-    prop_schedule = FeeScheduleState(proportional=RelativeFeeAmount(int(0.01e6)))
+    prop_schedule = FeeScheduleState(proportional=ProportionalFeeAmount(int(0.01e6)))
     assert prop_schedule.fee(PaymentAmount(40), channel_balance=Balance(0)) == FeeAmount(0)
     assert prop_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FeeAmount(1)
     assert prop_schedule.fee(PaymentAmount(1000), channel_balance=Balance(0)) == FeeAmount(10)
 
     combined_schedule = FeeScheduleState(
-        flat=FeeAmount(2), proportional=RelativeFeeAmount(int(0.01e6))
+        flat=FeeAmount(2), proportional=ProportionalFeeAmount(int(0.01e6))
     )
     assert combined_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FeeAmount(3)
 
@@ -89,7 +95,7 @@ def test_linspace():
 
 
 def test_rebalancing_fee_calculation():
-    sample = calculate_imbalance_fees(TokenAmount(200), RelativeFeeAmount(500_000))  # 50%
+    sample = calculate_imbalance_fees(TokenAmount(200), ProportionalFeeAmount(500_000))  # 50%
     assert sample is not None
     assert len(sample) == NUM_DISCRETISATION_POINTS
     assert all(0 <= x <= 200 for x, _ in sample)
@@ -97,7 +103,7 @@ def test_rebalancing_fee_calculation():
     assert all(0 <= y <= 100 for _, y in sample)
     assert max(y for _, y in sample) == 100  # 50% of the 200 TokenAmount capacity
 
-    sample = calculate_imbalance_fees(TokenAmount(10), RelativeFeeAmount(200_000))  # 20%
+    sample = calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(200_000))  # 20%
     assert sample is not None
     assert len(sample) == 11
     assert all(0 <= x <= 10 for x, _ in sample)
@@ -105,7 +111,7 @@ def test_rebalancing_fee_calculation():
     assert all(0 <= y <= 2 for _, y in sample)
     assert max(y for _, y in sample) == 2  # 20% of the 10 TokenAmount capacity
 
-    sample = calculate_imbalance_fees(TokenAmount(1), RelativeFeeAmount(1_000_000))  # 100%
+    sample = calculate_imbalance_fees(TokenAmount(1), ProportionalFeeAmount(1_000_000))  # 100%
     assert sample is not None
     assert len(sample) == 2
     assert all(0 <= x <= 1 for x, _ in sample)
@@ -113,5 +119,5 @@ def test_rebalancing_fee_calculation():
     assert all(0 <= y <= 1 for _, y in sample)
     assert max(y for _, y in sample) == 1  # 100% of the 1 TokenAmount capacity
 
-    assert calculate_imbalance_fees(TokenAmount(0), RelativeFeeAmount(1)) is None
-    assert calculate_imbalance_fees(TokenAmount(10), RelativeFeeAmount(0)) is None
+    assert calculate_imbalance_fees(TokenAmount(0), ProportionalFeeAmount(1)) is None
+    assert calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(0)) is None

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -7,13 +7,7 @@ from raiden.transfer.mediated_transfer.mediation_fee import (
     calculate_imbalance_fees,
     linspace,
 )
-from raiden.utils.typing import (
-    Balance,
-    FeeAmount as FA,
-    PaymentAmount,
-    RelativeFeeAmount as RFA,
-    TokenAmount as TA,
-)
+from raiden.utils.typing import Balance, FeeAmount, PaymentAmount, RelativeFeeAmount, TokenAmount
 
 
 def test_interpolation():
@@ -38,68 +32,86 @@ def test_interpolation():
 
 
 def test_basic_fee():
-    flat_schedule = FeeScheduleState(flat=FA(2))
-    assert flat_schedule.fee(PaymentAmount(10), channel_balance=Balance(0)) == FA(2)
+    flat_schedule = FeeScheduleState(flat=FeeAmount(2))
+    assert flat_schedule.fee(PaymentAmount(10), channel_balance=Balance(0)) == FeeAmount(2)
 
-    prop_schedule = FeeScheduleState(proportional=RFA(int(0.01e6)))
-    assert prop_schedule.fee(PaymentAmount(40), channel_balance=Balance(0)) == FA(0)
-    assert prop_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FA(1)
-    assert prop_schedule.fee(PaymentAmount(1000), channel_balance=Balance(0)) == FA(10)
+    prop_schedule = FeeScheduleState(proportional=RelativeFeeAmount(int(0.01e6)))
+    assert prop_schedule.fee(PaymentAmount(40), channel_balance=Balance(0)) == FeeAmount(0)
+    assert prop_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FeeAmount(1)
+    assert prop_schedule.fee(PaymentAmount(1000), channel_balance=Balance(0)) == FeeAmount(10)
 
-    combined_schedule = FeeScheduleState(flat=FA(2), proportional=RFA(int(0.01e6)))
-    assert combined_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FA(3)
+    combined_schedule = FeeScheduleState(
+        flat=FeeAmount(2), proportional=RelativeFeeAmount(int(0.01e6))
+    )
+    assert combined_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FeeAmount(3)
 
 
 def test_imbalance_penalty():
     v_schedule = FeeScheduleState(
-        imbalance_penalty=[(TA(0), FA(10)), (TA(50), FA(0)), (TA(100), FA(10))]
+        imbalance_penalty=[
+            (TokenAmount(0), FeeAmount(10)),
+            (TokenAmount(50), FeeAmount(0)),
+            (TokenAmount(100), FeeAmount(10)),
+        ]
     )
-    assert v_schedule.fee(channel_balance=Balance(100 - 0), amount=PaymentAmount(50)) == FA(-10)
-    assert v_schedule.fee(channel_balance=Balance(100 - 50), amount=PaymentAmount(50)) == FA(10)
-    assert v_schedule.fee(channel_balance=Balance(100 - 0), amount=PaymentAmount(10)) == FA(-2)
-    assert v_schedule.fee(channel_balance=Balance(100 - 10), amount=PaymentAmount(10)) == FA(-2)
-    assert v_schedule.fee(channel_balance=Balance(100 - 0), amount=PaymentAmount(20)) == FA(-4)
-    assert v_schedule.fee(channel_balance=Balance(100 - 40), amount=PaymentAmount(20)) == FA(0)
+    assert v_schedule.fee(channel_balance=Balance(100 - 0), amount=PaymentAmount(50)) == FeeAmount(
+        -10
+    )
+    assert v_schedule.fee(
+        channel_balance=Balance(100 - 50), amount=PaymentAmount(50)
+    ) == FeeAmount(10)
+    assert v_schedule.fee(channel_balance=Balance(100 - 0), amount=PaymentAmount(10)) == FeeAmount(
+        -2
+    )
+    assert v_schedule.fee(
+        channel_balance=Balance(100 - 10), amount=PaymentAmount(10)
+    ) == FeeAmount(-2)
+    assert v_schedule.fee(channel_balance=Balance(100 - 0), amount=PaymentAmount(20)) == FeeAmount(
+        -4
+    )
+    assert v_schedule.fee(
+        channel_balance=Balance(100 - 40), amount=PaymentAmount(20)
+    ) == FeeAmount(0)
 
 
 def test_linspace():
-    assert linspace(TA(0), TA(4), 5) == [0, 1, 2, 3, 4]
-    assert linspace(TA(0), TA(4), 4) == [0, 1, 3, 4]
-    assert linspace(TA(0), TA(4), 3) == [0, 2, 4]
-    assert linspace(TA(0), TA(4), 2) == [0, 4]
-    assert linspace(TA(0), TA(0), 3) == [0, 0, 0]
+    assert linspace(TokenAmount(0), TokenAmount(4), 5) == [0, 1, 2, 3, 4]
+    assert linspace(TokenAmount(0), TokenAmount(4), 4) == [0, 1, 3, 4]
+    assert linspace(TokenAmount(0), TokenAmount(4), 3) == [0, 2, 4]
+    assert linspace(TokenAmount(0), TokenAmount(4), 2) == [0, 4]
+    assert linspace(TokenAmount(0), TokenAmount(0), 3) == [0, 0, 0]
 
     with pytest.raises(AssertionError):
-        assert linspace(TA(0), TA(4), 1)
+        assert linspace(TokenAmount(0), TokenAmount(4), 1)
 
     with pytest.raises(AssertionError):
-        assert linspace(TA(4), TA(0), 2)
+        assert linspace(TokenAmount(4), TokenAmount(0), 2)
 
 
 def test_rebalancing_fee_calculation():
-    sample = calculate_imbalance_fees(TA(200), RFA(500_000))  # 50%
+    sample = calculate_imbalance_fees(TokenAmount(200), RelativeFeeAmount(500_000))  # 50%
     assert sample is not None
     assert len(sample) == NUM_DISCRETISATION_POINTS
     assert all(0 <= x <= 200 for x, _ in sample)
     assert max(x for x, _ in sample) == 200
     assert all(0 <= y <= 100 for _, y in sample)
-    assert max(y for _, y in sample) == 100  # 50% of the 200 TA capacity
+    assert max(y for _, y in sample) == 100  # 50% of the 200 TokenAmount capacity
 
-    sample = calculate_imbalance_fees(TA(10), RFA(200_000))  # 20%
+    sample = calculate_imbalance_fees(TokenAmount(10), RelativeFeeAmount(200_000))  # 20%
     assert sample is not None
     assert len(sample) == 11
     assert all(0 <= x <= 10 for x, _ in sample)
     assert max(x for x, _ in sample) == 10
     assert all(0 <= y <= 2 for _, y in sample)
-    assert max(y for _, y in sample) == 2  # 20% of the 10 TA capacity
+    assert max(y for _, y in sample) == 2  # 20% of the 10 TokenAmount capacity
 
-    sample = calculate_imbalance_fees(TA(1), RFA(1_000_000))  # 100%
+    sample = calculate_imbalance_fees(TokenAmount(1), RelativeFeeAmount(1_000_000))  # 100%
     assert sample is not None
     assert len(sample) == 2
     assert all(0 <= x <= 1 for x, _ in sample)
     assert max(x for x, _ in sample) == 1
     assert all(0 <= y <= 1 for _, y in sample)
-    assert max(y for _, y in sample) == 1  # 100% of the 1 TA capacity
+    assert max(y for _, y in sample) == 1  # 100% of the 1 TokenAmount capacity
 
-    assert calculate_imbalance_fees(TA(0), RFA(1)) is None
-    assert calculate_imbalance_fees(TA(10), RFA(0)) is None
+    assert calculate_imbalance_fees(TokenAmount(0), RelativeFeeAmount(1)) is None
+    assert calculate_imbalance_fees(TokenAmount(10), RelativeFeeAmount(0)) is None

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -7,7 +7,13 @@ from raiden.transfer.mediated_transfer.mediation_fee import (
     calculate_imbalance_fees,
     linspace,
 )
-from raiden.utils.typing import Balance, FeeAmount as FA, PaymentAmount, TokenAmount as TA
+from raiden.utils.typing import (
+    Balance,
+    FeeAmount as FA,
+    PaymentAmount,
+    RelativeFeeAmount as RFA,
+    TokenAmount as TA,
+)
 
 
 def test_interpolation():
@@ -35,12 +41,12 @@ def test_basic_fee():
     flat_schedule = FeeScheduleState(flat=FA(2))
     assert flat_schedule.fee(PaymentAmount(10), channel_balance=Balance(0)) == FA(2)
 
-    prop_schedule = FeeScheduleState(proportional=int(0.01e6))
+    prop_schedule = FeeScheduleState(proportional=RFA(int(0.01e6)))
     assert prop_schedule.fee(PaymentAmount(40), channel_balance=Balance(0)) == FA(0)
     assert prop_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FA(1)
     assert prop_schedule.fee(PaymentAmount(1000), channel_balance=Balance(0)) == FA(10)
 
-    combined_schedule = FeeScheduleState(flat=FA(2), proportional=int(0.01e6))
+    combined_schedule = FeeScheduleState(flat=FA(2), proportional=RFA(int(0.01e6)))
     assert combined_schedule.fee(PaymentAmount(60), channel_balance=Balance(0)) == FA(3)
 
 
@@ -71,24 +77,28 @@ def test_linspace():
 
 
 def test_rebalancing_fee_calculation():
-    max_imbalance_fee = FA(10 ** 18)
-    sample = calculate_imbalance_fees(TA(200), max_imbalance_fee)
+    sample = calculate_imbalance_fees(TA(200), RFA(500_000))  # 50%
     assert sample is not None
     assert len(sample) == NUM_DISCRETISATION_POINTS
+    assert all(0 <= x <= 200 for x, _ in sample)
     assert max(x for x, _ in sample) == 200
-    assert max(y for _, y in sample) == 10 ** 18
+    assert all(0 <= y <= 50 for _, y in sample)
+    assert max(y for _, y in sample) == 50  # 50% of the 100 TA per channel side
 
-    sample = calculate_imbalance_fees(TA(10), max_imbalance_fee)
+    sample = calculate_imbalance_fees(TA(10), RFA(200_000))  # 20%
     assert sample is not None
     assert len(sample) == 11
+    assert all(0 <= x <= 10 for x, _ in sample)
     assert max(x for x, _ in sample) == 10
-    assert max(y for _, y in sample) == 10 ** 18
+    assert all(0 <= y <= 1 for _, y in sample)
+    assert max(y for _, y in sample) == 1  # 20% of the 5 TA per channel side
 
-    sample = calculate_imbalance_fees(TA(1), max_imbalance_fee)
+    sample = calculate_imbalance_fees(TA(1), RFA(1_000_000))  # 100%
     assert sample is not None
     assert len(sample) == 2
+    assert all(0 <= x <= 1 for x, _ in sample)
     assert max(x for x, _ in sample) == 1
-    assert max(y for _, y in sample) == 10 ** 18
+    assert all(y == 0 for _, y in sample)
 
-    assert calculate_imbalance_fees(TA(0), max_imbalance_fee) is None
-    assert calculate_imbalance_fees(TA(10), max_imbalance_fee=FA(0)) is None
+    assert calculate_imbalance_fees(TA(0), RFA(1_000_000)) is None
+    assert calculate_imbalance_fees(TA(10), RFA(0)) is None

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -119,5 +119,23 @@ def test_rebalancing_fee_calculation():
     assert all(0 <= y <= 1 for _, y in sample)
     assert max(y for _, y in sample) == 1  # 100% of the 1 TokenAmount capacity
 
+    # test rounding of the max_balance_fee calculation
+    sample = calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(549_000))  # 54.9%
+    assert sample is not None
+    assert len(sample) == 11
+    assert all(0 <= x <= 10 for x, _ in sample)
+    assert max(x for x, _ in sample) == 10
+    assert all(0 <= y <= 5 for _, y in sample)
+    assert max(y for _, y in sample) == 5  # 5.49 is rounded to 5
+
+    sample = calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(550_000))  # 55%
+    assert sample is not None
+    assert len(sample) == 11
+    assert all(0 <= x <= 10 for x, _ in sample)
+    assert max(x for x, _ in sample) == 10
+    assert all(0 <= y <= 6 for _, y in sample)
+    assert max(y for _, y in sample) == 6  # 5.5 is rounded to 6
+
+    # test cases where no imbalance fee is created
     assert calculate_imbalance_fees(TokenAmount(0), ProportionalFeeAmount(1)) is None
     assert calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(0)) is None

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -82,23 +82,24 @@ def test_rebalancing_fee_calculation():
     assert len(sample) == NUM_DISCRETISATION_POINTS
     assert all(0 <= x <= 200 for x, _ in sample)
     assert max(x for x, _ in sample) == 200
-    assert all(0 <= y <= 50 for _, y in sample)
-    assert max(y for _, y in sample) == 50  # 50% of the 100 TA per channel side
+    assert all(0 <= y <= 100 for _, y in sample)
+    assert max(y for _, y in sample) == 100  # 50% of the 200 TA capacity
 
     sample = calculate_imbalance_fees(TA(10), RFA(200_000))  # 20%
     assert sample is not None
     assert len(sample) == 11
     assert all(0 <= x <= 10 for x, _ in sample)
     assert max(x for x, _ in sample) == 10
-    assert all(0 <= y <= 1 for _, y in sample)
-    assert max(y for _, y in sample) == 1  # 20% of the 5 TA per channel side
+    assert all(0 <= y <= 2 for _, y in sample)
+    assert max(y for _, y in sample) == 2  # 20% of the 10 TA capacity
 
     sample = calculate_imbalance_fees(TA(1), RFA(1_000_000))  # 100%
     assert sample is not None
     assert len(sample) == 2
     assert all(0 <= x <= 1 for x, _ in sample)
     assert max(x for x, _ in sample) == 1
-    assert all(y == 0 for _, y in sample)
+    assert all(0 <= y <= 1 for _, y in sample)
+    assert max(y for _, y in sample) == 1  # 100% of the 1 TA capacity
 
-    assert calculate_imbalance_fees(TA(0), RFA(1_000_000)) is None
+    assert calculate_imbalance_fees(TA(0), RFA(1)) is None
     assert calculate_imbalance_fees(TA(10), RFA(0)) is None

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -1,6 +1,5 @@
 from bisect import bisect_right
 from dataclasses import dataclass, field, replace
-from math import floor
 from typing import List, Optional, Sequence, Tuple, TypeVar
 
 from raiden.exceptions import UndefinedMediationFee
@@ -117,7 +116,7 @@ def calculate_imbalance_fees(
         return None
 
     # calculate the maximum imbalance fee for the channel
-    max_imbalance_fee = floor(channel_capacity * proportional_imbalance_fee / int(1e6))
+    max_imbalance_fee = round(channel_capacity * proportional_imbalance_fee / int(1e6))
 
     def f(balance: TokenAmount) -> FeeAmount:
         constant = max_imbalance_fee / (channel_capacity / 2) ** 2

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -5,7 +5,13 @@ from typing import List, Optional, Sequence, Tuple, TypeVar
 
 from raiden.exceptions import UndefinedMediationFee
 from raiden.transfer.architecture import State
-from raiden.utils.typing import Balance, FeeAmount, PaymentAmount, RelativeFeeAmount, TokenAmount
+from raiden.utils.typing import (
+    Balance,
+    FeeAmount,
+    PaymentAmount,
+    ProportionalFeeAmount,
+    TokenAmount,
+)
 
 NUM_DISCRETISATION_POINTS = 21
 
@@ -40,7 +46,7 @@ T = TypeVar("T", bound="FeeScheduleState")
 class FeeScheduleState(State):
     # pylint: disable=not-an-iterable
     flat: FeeAmount = FeeAmount(0)
-    proportional: RelativeFeeAmount = RelativeFeeAmount(0)  # as micros, e.g. 1% = 0.01e6
+    proportional: ProportionalFeeAmount = ProportionalFeeAmount(0)  # as micros, e.g. 1% = 0.01e6
     imbalance_penalty: Optional[List[Tuple[TokenAmount, FeeAmount]]] = None
     _penalty_func: Optional[Interpolate] = field(init=False, repr=False, default=None)
 
@@ -94,7 +100,7 @@ def linspace(start: TokenAmount, stop: TokenAmount, num: int) -> List[TokenAmoun
 
 
 def calculate_imbalance_fees(
-    channel_capacity: TokenAmount, proportional_imbalance_fee: RelativeFeeAmount
+    channel_capacity: TokenAmount, proportional_imbalance_fee: ProportionalFeeAmount
 ) -> Optional[List[Tuple[TokenAmount, FeeAmount]]]:
     """ Calculates a quadratic rebalancing curve.
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -27,8 +27,8 @@ from raiden.settings import (
     DEFAULT_HTTP_SERVER_PORT,
     DEFAULT_MATRIX_KNOWN_SERVERS,
     DEFAULT_MEDIATION_FLAT_FEE,
-    DEFAULT_MEDIATION_MAX_IMBALANCE_FEE,
     DEFAULT_MEDIATION_PROPORTIONAL_FEE,
+    DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE,
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
 )
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
@@ -272,7 +272,7 @@ def run_app(
         == FeeScheduleState(
             flat=DEFAULT_MEDIATION_FLAT_FEE, proportional=DEFAULT_MEDIATION_PROPORTIONAL_FEE
         )
-        and config["max_imbalance_fee"] == DEFAULT_MEDIATION_MAX_IMBALANCE_FEE
+        and config["proportional_imbalance_fee"] == DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE
     )
     if has_default_fees:
         click.secho(

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -56,6 +56,7 @@ from raiden.utils.typing import (
     Optional,
     Port,
     PrivateKey,
+    RelativeFeeAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
     Tuple,
@@ -155,8 +156,8 @@ def run_app(
     routing_mode: RoutingMode,
     config: Dict[str, Any],
     flat_fee: Tuple[Tuple[TokenNetworkAddress, FeeAmount], ...],
-    proportional_fee: int,
-    max_imbalance_fee: FeeAmount,
+    proportional_fee: RelativeFeeAmount,
+    proportional_imbalance_fee: RelativeFeeAmount,
     **kwargs: Any,  # FIXME: not used here, but still receives stuff in smoketest
 ):
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,unused-argument
@@ -201,7 +202,7 @@ def run_app(
     config["default_fee_schedule"] = FeeScheduleState(
         flat=DEFAULT_MEDIATION_FLAT_FEE, proportional=proportional_fee
     )
-    config["max_imbalance_fee"] = max_imbalance_fee
+    config["proportional_imbalance_fee"] = proportional_imbalance_fee
 
     setup_environment(config, environment_type)
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -56,7 +56,7 @@ from raiden.utils.typing import (
     Optional,
     Port,
     PrivateKey,
-    RelativeFeeAmount,
+    ProportionalFeeAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
     Tuple,
@@ -156,8 +156,8 @@ def run_app(
     routing_mode: RoutingMode,
     config: Dict[str, Any],
     flat_fee: Tuple[Tuple[TokenNetworkAddress, FeeAmount], ...],
-    proportional_fee: RelativeFeeAmount,
-    proportional_imbalance_fee: RelativeFeeAmount,
+    proportional_fee: ProportionalFeeAmount,
+    proportional_imbalance_fee: ProportionalFeeAmount,
     **kwargs: Any,  # FIXME: not used here, but still receives stuff in smoketest
 ):
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,unused-argument

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -23,8 +23,8 @@ from raiden.log_config import configure_logging
 from raiden.network.utils import get_free_port
 from raiden.settings import (
     DEFAULT_HTTP_SERVER_PORT,
-    DEFAULT_MEDIATION_MAX_IMBALANCE_FEE,
     DEFAULT_MEDIATION_PROPORTIONAL_FEE,
+    DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE,
     DEFAULT_PATHFINDING_IOU_TIMEOUT,
     DEFAULT_PATHFINDING_MAX_FEE,
     DEFAULT_PATHFINDING_MAX_PATHS,
@@ -45,7 +45,6 @@ from raiden.utils.cli import (
     option_group,
     validate_option_dependencies,
 )
-from raiden.utils.typing import FeeAmount
 
 from .runners import EchoNodeRunner, MatrixRunner
 
@@ -412,14 +411,17 @@ def options(func):
                 "--proportional-fee",
                 help="Mediation fee as ratio of mediated amount in parts-per-million (10^-6).",
                 default=DEFAULT_MEDIATION_PROPORTIONAL_FEE,
-                type=int,
+                type=click.IntRange(min=0),
                 show_default=True,
             ),
             option(
-                "--max-imbalance-fee",
-                help="Set the worst-case imbalance fee in wei of the mediated token. (Preview)",
-                default=DEFAULT_MEDIATION_MAX_IMBALANCE_FEE,
-                type=FeeAmount,
+                "--proportional-imbalance-fee",
+                help=(
+                    "Set the worst-case imbalance fee relative to the channels capacity "
+                    "in parts-per-million (10^-6)."
+                ),
+                default=DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE,
+                type=click.IntRange(min=0),
                 show_default=True,
             ),
         ),

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -411,7 +411,7 @@ def options(func):
                 "--proportional-fee",
                 help="Mediation fee as ratio of mediated amount in parts-per-million (10^-6).",
                 default=DEFAULT_MEDIATION_PROPORTIONAL_FEE,
-                type=click.IntRange(min=0),
+                type=click.IntRange(min=0, max=10 ** 6),
                 show_default=True,
             ),
             option(
@@ -421,7 +421,7 @@ def options(func):
                     "in parts-per-million (10^-6)."
                 ),
                 default=DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE,
-                type=click.IntRange(min=0),
+                type=click.IntRange(min=0, max=10 ** 6),
                 show_default=True,
             ),
         ),

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -104,9 +104,9 @@ T_FeeAmount = int
 FeeAmount = NewType("FeeAmount", T_FeeAmount)
 
 # A proportional fee, unit is parts-per-million
-# So 1_000_000 means 100%
-T_RelativeFeeAmount = int
-RelativeFeeAmount = NewType("RelativeFeeAmount", T_RelativeFeeAmount)
+# 1_000_000 means 100%, 25_000 is 2.5%
+T_ProportionalFeeAmount = int
+ProportionalFeeAmount = NewType("ProportionalFeeAmount", T_ProportionalFeeAmount)
 
 T_LockedAmount = int
 LockedAmount = NewType("LockedAmount", T_LockedAmount)

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -103,6 +103,8 @@ PublicKey = NewType("PublicKey", T_PublicKey)
 T_FeeAmount = int
 FeeAmount = NewType("FeeAmount", T_FeeAmount)
 
+# A proportional fee, unit is parts-per-million
+# So 1_000_000 means 100%
 T_RelativeFeeAmount = int
 RelativeFeeAmount = NewType("RelativeFeeAmount", T_RelativeFeeAmount)
 

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -103,6 +103,9 @@ PublicKey = NewType("PublicKey", T_PublicKey)
 T_FeeAmount = int
 FeeAmount = NewType("FeeAmount", T_FeeAmount)
 
+T_RelativeFeeAmount = int
+RelativeFeeAmount = NewType("RelativeFeeAmount", T_RelativeFeeAmount)
+
 T_LockedAmount = int
 LockedAmount = NewType("LockedAmount", T_LockedAmount)
 


### PR DESCRIPTION
Fixes: https://github.com/raiden-network/raiden/issues/4654

## Description

This makes the definition of the imbalance penalty fee relative to the
capacity to the channel. The goal is to make the setting more useful
until we implement a endpoint to configure it in the API.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
