### PR TITLE
Fix set_total_deposit failure after channel is closed

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1402,9 +1402,16 @@ class TokenNetwork:
                 block_identifier=failed_at_blockhash,
             )
 
-            if detail.state != ChannelState.OPENED:
+            if detail.state > ChannelState.OPENED:
                 msg = (
                     f"cannot call setTotalWithdraw on a channel that is not open. "
+                    f"current_state={detail.state}"
+                )
+                raise RaidenRecoverableError(msg)
+
+            if detail.state < ChannelState.OPENED:
+                msg = (
+                    f"cannot call setTotalWithdraw on a channel that does not exist. "
                     f"current_state={detail.state}"
                 )
                 raise RaidenUnrecoverableError(msg)

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -249,14 +249,14 @@ def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
     Meanwhile, the partner node closes the channel so when the stopped node is back up, it tries to
     execute the pending withdraw transaction and fails because the channel was closed.
     Expected behaviour: Channel closed state change should cancel a withdraw transaction.
-    Actual behaviour: The channel closure isn't detected on recovery and
+    Buggy behaviour: The channel closure isn't detected on recovery and
     the on-chain transaction fails.
     """
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
     # Prevent the withdraw transaction from being sent on-chain. This
-    # Will keep the transaction in the pending list
+    # will keep the transaction in the pending list
     send_channel_withdraw_event = app0.raiden.raiden_event_handler.hold(
         ContractSendChannelWithdraw, {}
     )

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -74,6 +74,14 @@ class ContractSendChannelWithdraw(ContractSendEvent):
     expiration: BlockExpiration
     partner_signature: Signature
 
+    @property
+    def channel_identifier(self) -> ChannelID:
+        return self.canonical_identifier.channel_identifier
+
+    @property
+    def token_network_address(self) -> TokenNetworkAddress:
+        return self.canonical_identifier.token_network_address
+
 
 @dataclass(frozen=True)
 class ContractSendChannelClose(ContractSendEvent):

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -14,6 +14,7 @@ from raiden.transfer.events import (
     ContractSendChannelClose,
     ContractSendChannelSettle,
     ContractSendChannelUpdateTransfer,
+    ContractSendChannelWithdraw,
     ContractSendSecretReveal,
     SendWithdrawRequest,
 )
@@ -1102,6 +1103,15 @@ def is_transaction_invalidated(transaction: ContractSendEvent, state_change: Sta
         and state_change.channel_identifier == transaction.channel_identifier
     )
     if is_our_failed_update_transfer:
+        return True
+
+    is_our_failed_withdraw = (
+        isinstance(state_change, ContractReceiveChannelClosed)
+        and isinstance(transaction, ContractSendChannelWithdraw)
+        and state_change.token_network_address == transaction.token_network_address
+        and state_change.channel_identifier == transaction.channel_identifier
+    )
+    if is_our_failed_withdraw:
         return True
 
     return False

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -464,7 +464,7 @@ def wait_for_withdraw_complete(
     total_withdraw: WithdrawAmount,
     retry_timeout: float,
 ) -> None:
-    """Wait until a transfer with a specific identifier and amount
+    """Wait until a withdraw with a specific identifier and amount
     is seen in the WAL.
 
     Note:


### PR DESCRIPTION
Fixes: #4639 

## Description

Looking at the stacktrace posted in the issue, it was obvious that the node was being restarted and the withdraw transaction was being sent on-chain during the initialization phase.

What happened?

1. A withdraw was initialized
2. Withdraw was signed by both participants and the transaction was queued.
3. Node goes offline
4. Partner closes channel
5. Node goes back online and tries to execute the withdraw transaction on-chain.

The problems that caused this were:
1. A race condition of trying to withdraw after having lost the race with the partner node which closed the channel was not handled. Raiden was raising an Unrecoverable error when the transaction failed because the channel state on-chain was not open
2. When initializing the transaction queue, the withdraw transaction was not being "invalidated" by the channel closed state change.

Solution implemented:
1. If channel state > OPEN then we lost the race with the other node that closed the channel... it should be a recoverable error. If channel state < OPEN, the channel did not exist... crash.
2. Detect a channel closed state change and make sure this invalidates any withdraw transactions before they get sent on-chain. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [x] Exceptions are propagated to the correct parent greenlet
    - [x] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [x] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [x] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
