### PR TITLE
 Treat trying to deposit on a closed channel as recoverable error

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -8,6 +8,7 @@ from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
+    ChannelNotOpenError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -571,6 +572,7 @@ class RaidenAPI:  # pragma: no unittest
             AddressWithoutCode: The channel was settled during the deposit
                 execution.
             DepositOverLimit: The total deposit amount is higher than the limit.
+            ChannelNotOpenError: The channel is no longer in an open state.
         """
         chain_state = views.state_from_raiden(self.raiden)
 
@@ -642,8 +644,7 @@ class RaidenAPI:  # pragma: no unittest
         is_channel_open = channel.get_status(channel_state) == ChannelState.STATE_OPENED
 
         if not is_channel_open:
-            msg = "Channel is not in an open state."
-            raise ValueError(msg)
+            raise ChannelNotOpenError("Channel is not in an open state.")
 
         if safety_deprecation_switch:
             msg = (

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -8,7 +8,6 @@ from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
-    ChannelNotOpenError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -22,6 +21,7 @@ from raiden.exceptions import (
     RaidenRecoverableError,
     TokenNetworkDeprecated,
     TokenNotRegistered,
+    UnexpectedChannelState,
     UnknownTokenAddress,
     WithdrawMismatch,
 )
@@ -572,7 +572,7 @@ class RaidenAPI:  # pragma: no unittest
             AddressWithoutCode: The channel was settled during the deposit
                 execution.
             DepositOverLimit: The total deposit amount is higher than the limit.
-            ChannelNotOpenError: The channel is no longer in an open state.
+            UnexpectedChannelState: The channel is no longer in an open state.
         """
         chain_state = views.state_from_raiden(self.raiden)
 
@@ -644,7 +644,7 @@ class RaidenAPI:  # pragma: no unittest
         is_channel_open = channel.get_status(channel_state) == ChannelState.STATE_OPENED
 
         if not is_channel_open:
-            raise ChannelNotOpenError("Channel is not in an open state.")
+            raise UnexpectedChannelState("Channel is not in an open state.")
 
         if safety_deprecation_switch:
             msg = (

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -59,6 +59,7 @@ from raiden.exceptions import (
     AddressWithoutCode,
     AlreadyRegisteredTokenAddress,
     APIServerPortInUseError,
+    ChannelNotOpenError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -646,7 +647,7 @@ class RestAPI:  # pragma: no unittest
                 return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
             except (NonexistingChannel, UnknownTokenAddress) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
-            except (DepositOverLimit, DepositMismatch) as e:
+            except (DepositOverLimit, DepositMismatch, ChannelNotOpenError) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
         channel_state = views.get_channelstate_for(
@@ -1091,6 +1092,8 @@ class RestAPI:  # pragma: no unittest
         except DepositMismatch as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
         except TokenNetworkDeprecated as e:
+            return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
+        except ChannelNotOpenError as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
         updated_channel_state = self.raiden_api.get_channel(

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -59,7 +59,6 @@ from raiden.exceptions import (
     AddressWithoutCode,
     AlreadyRegisteredTokenAddress,
     APIServerPortInUseError,
-    ChannelNotOpenError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -79,6 +78,7 @@ from raiden.exceptions import (
     TokenNetworkDeprecated,
     TokenNotRegistered,
     TransactionThrew,
+    UnexpectedChannelState,
     UnknownTokenAddress,
     WithdrawMismatch,
 )
@@ -647,7 +647,7 @@ class RestAPI:  # pragma: no unittest
                 return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
             except (NonexistingChannel, UnknownTokenAddress) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
-            except (DepositOverLimit, DepositMismatch, ChannelNotOpenError) as e:
+            except (DepositOverLimit, DepositMismatch, UnexpectedChannelState) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
         channel_state = views.get_channelstate_for(
@@ -1093,7 +1093,7 @@ class RestAPI:  # pragma: no unittest
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
         except TokenNetworkDeprecated as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
-        except ChannelNotOpenError as e:
+        except UnexpectedChannelState as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
         updated_channel_state = self.raiden_api.get_channel(

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -9,6 +9,7 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.constants import Environment
 from raiden.exceptions import (
+    ChannelNotOpenError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -30,6 +31,7 @@ RECOVERABLE_ERRORS = (
     InsufficientFunds,
     RaidenRecoverableError,
     TransactionThrew,
+    ChannelNotOpenError,
 )
 
 

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -9,7 +9,6 @@ from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.constants import Environment
 from raiden.exceptions import (
-    ChannelNotOpenError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -19,6 +18,7 @@ from raiden.exceptions import (
     RaidenRecoverableError,
     RaidenUnrecoverableError,
     TransactionThrew,
+    UnexpectedChannelState,
 )
 from raiden.transfer import views
 from raiden.utils import typing
@@ -31,7 +31,7 @@ RECOVERABLE_ERRORS = (
     InsufficientFunds,
     RaidenRecoverableError,
     TransactionThrew,
-    ChannelNotOpenError,
+    UnexpectedChannelState,
 )
 
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -189,8 +189,8 @@ class DuplicatedChannelError(RaidenRecoverableError):
     """Raised if someone tries to create a channel that already exists."""
 
 
-class ChannelNotOpenError(RaidenRecoverableError):
-    """Raised if someone tries to work on a channel that is no longer in an open state."""
+class UnexpectedChannelState(RaidenRecoverableError):
+    """Raised if an operation is attempted on a channel while it is in an unexpected state."""
 
 
 class ContractCodeMismatch(RaidenError):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -189,6 +189,10 @@ class DuplicatedChannelError(RaidenRecoverableError):
     """Raised if someone tries to create a channel that already exists."""
 
 
+class ChannelNotOpenError(RaidenRecoverableError):
+    """Raised if someone tries to work on a channel that is no longer in an open state."""
+
+
 class ContractCodeMismatch(RaidenError):
     """Raised if the onchain code of the contract differs."""
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -2,7 +2,12 @@ import pytest
 from eth_utils import to_checksum_address
 
 from raiden.api.python import RaidenAPI
-from raiden.exceptions import DepositMismatch, TokenNotRegistered, UnknownTokenAddress
+from raiden.exceptions import (
+    ChannelNotOpenError,
+    DepositMismatch,
+    TokenNotRegistered,
+    UnknownTokenAddress,
+)
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import must_have_event, wait_for_state_change
 from raiden.tests.utils.transfer import get_channelstate
@@ -204,6 +209,11 @@ def run_test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposi
         },
     )
     assert channel.get_status(channel12) == ChannelState.STATE_CLOSED
+
+    with pytest.raises(ChannelNotOpenError):
+        api1.set_total_channel_deposit(
+            registry_address, token_address, api2.address, deposit + 100
+        )
 
     assert wait_for_state_change(
         node1.raiden,

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -3,9 +3,9 @@ from eth_utils import to_checksum_address
 
 from raiden.api.python import RaidenAPI
 from raiden.exceptions import (
-    ChannelNotOpenError,
     DepositMismatch,
     TokenNotRegistered,
+    UnexpectedChannelState,
     UnknownTokenAddress,
 )
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -210,7 +210,7 @@ def run_test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposi
     )
     assert channel.get_status(channel12) == ChannelState.STATE_CLOSED
 
-    with pytest.raises(ChannelNotOpenError):
+    with pytest.raises(UnexpectedChannelState):
         api1.set_total_channel_deposit(
             registry_address, token_address, api2.address, deposit + 100
         )


### PR DESCRIPTION
Maybe fix #4451 

## Description

If a channel is not open, or is in a closing state (still open but
waiting on the closing transaction result) the `set_total_deposit`
function was throwing a `ValueError`.

That is a valid and recoverable race condition so this commit
introduces an appropriate error and handles it in all places where it
can be thrown.

From the stack trace shown in #4451 this seems to have been the problem but without logs it's hard to say with 100% certainty.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
