### PR TITLE
feature: lock_timeout can be provided when making a payment

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`4917` Added documentation on using Raiden for atomic swaps.
 * :feature:`-` Added a new api endpoint ``/api/v1/version`` to query the raiden version via the Rest API.
+* :feature:`4697` lock_timeout can be provided when making a payment.
 * :bug:`4762` Properly check the withdraw expiration on the TokenNetworkProxy. This gives a better error message to the users and prevents a corner case error.
 * :feature:`4102` Display progress during syncing the blockchain.
 * :feature:`4654` Define imbalance fees relative to channel balance.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -707,6 +707,8 @@ Payments
 
    :reqjson int amount: Amount to be sent to the target
    :reqjson int identifier: Identifier of the payment (optional)
+   :reqjson int lock_timeout: lock timeout, in blocks, to be used with the payment. Default is 2 * channel's reveal_timeout, Value must be greater than channel's reveal_timeout (optional)
+
 
    **Example Response**:
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -884,6 +884,7 @@ class RaidenAPI:  # pragma: no unittest
         transfer_timeout: int = None,
         secret: Secret = None,
         secrethash: SecretHash = None,
+        lock_timeout: BlockTimeout = None,
     ):
         """ Do a transfer with `target` with the given `amount` of `token_address`. """
         # pylint: disable=too-many-arguments
@@ -896,6 +897,7 @@ class RaidenAPI:  # pragma: no unittest
             identifier=identifier,
             secret=secret,
             secrethash=secrethash,
+            lock_timeout=lock_timeout,
         )
         payment_status.payment_done.wait(timeout=transfer_timeout)
         return payment_status
@@ -909,6 +911,7 @@ class RaidenAPI:  # pragma: no unittest
         identifier: PaymentID = None,
         secret: Secret = None,
         secrethash: SecretHash = None,
+        lock_timeout: BlockTimeout = None,
     ):
         current_state = views.state_from_raiden(self.raiden)
         token_network_registry_address = self.raiden.default_registry.address
@@ -974,6 +977,7 @@ class RaidenAPI:  # pragma: no unittest
             identifier=identifier,
             secret=secret,
             secrethash=secrethash,
+            lock_timeout=lock_timeout,
         )
         return payment_status
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1024,6 +1024,7 @@ class RestAPI:  # pragma: no unittest
         identifier: PaymentID,
         secret: Secret,
         secret_hash: SecretHash,
+        lock_timeout: BlockTimeout,
     ) -> Response:
         log.debug(
             "Initiating payment",
@@ -1035,6 +1036,7 @@ class RestAPI:  # pragma: no unittest
             payment_identifier=identifier,
             secret=secret,
             secret_hash=secret_hash,
+            lock_timeout=lock_timeout,
         )
 
         if identifier is None:
@@ -1049,6 +1051,7 @@ class RestAPI:  # pragma: no unittest
                 identifier=identifier,
                 secret=secret,
                 secrethash=secret_hash,
+                lock_timeout=lock_timeout,
             )
         except (
             InvalidAmount,

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -338,6 +338,7 @@ class PaymentSchema(BaseSchema):
     identifier = fields.Integer(missing=None)
     secret = SecretField(missing=None)
     secret_hash = SecretHashField(missing=None)
+    lock_timeout = fields.Integer(missing=None)
 
     class Meta:
         strict = True

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -214,7 +214,9 @@ class ConnectionsInfoResource(BaseResource):
 
 class PaymentResource(BaseResource):
 
-    post_schema = PaymentSchema(only=("amount", "identifier", "secret", "secret_hash"))
+    post_schema = PaymentSchema(
+        only=("amount", "identifier", "secret", "secret_hash", "lock_timeout")
+    )
     get_schema = RaidenEventsRequestSchema()
 
     @use_kwargs(get_schema, locations=("query",))
@@ -238,6 +240,7 @@ class PaymentResource(BaseResource):
         identifier: typing.PaymentID,
         secret: typing.Secret,
         secret_hash: typing.SecretHash,
+        lock_timeout: typing.BlockTimeout,
     ):
         return self.rest_api.initiate_payment(
             registry_address=self.rest_api.raiden_api.raiden.default_registry.address,
@@ -247,6 +250,7 @@ class PaymentResource(BaseResource):
             identifier=identifier,
             secret=secret,
             secret_hash=secret_hash,
+            lock_timeout=lock_timeout,
         )
 
 

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -18,6 +18,7 @@ from flask import url_for
 from raiden.api.v1.encoding import AddressField, HexAddressConverter
 from raiden.constants import GENESIS_BLOCK_NUMBER, SECRET_LENGTH, Environment
 from raiden.messages.transfers import LockedTransfer, Unlock
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.integration.api.utils import create_api_server
 from raiden.tests.integration.fixtures.smartcontracts import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
 from raiden.tests.utils import factories
@@ -2158,3 +2159,67 @@ def test_api_testnet_token_mint(api_server_test_instance, token_addresses):
     request = grequests.post(url, json=dict(to=user_address[:-2], value=10))
     response = request.send().response
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
+
+
+@pytest.mark.parametrize("number_of_nodes", [2])
+def test_api_payments_with_lock_timeout(api_server_test_instance, raiden_network, token_addresses):
+    _, app1 = raiden_network
+    amount = 100
+    identifier = 42
+    token_address = token_addresses[0]
+    target_address = app1.raiden.address
+    number_of_nodes = 2
+    reveal_timeout = number_of_nodes * 4 + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+    settle_timeout = 39
+
+    # try lock_timeout = reveal_timeout - should not work
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "lock_timeout": reveal_timeout},
+    )
+    response = request.send().response
+    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
+
+    # try lock_timeout = reveal_timeout * 2  - should  work.
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "lock_timeout": 2 * reveal_timeout},
+    )
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.OK)
+
+    # try lock_timeout = settle_timeout - should work.
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "lock_timeout": settle_timeout},
+    )
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.OK)
+
+    # try lock_timeout = settle_timeout+1 - should not work.
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        ),
+        json={"amount": amount, "identifier": identifier, "lock_timeout": settle_timeout + 1},
+    )
+    response = request.send().response
+    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -240,7 +240,9 @@ def try_new_route(
             continue
 
         is_channel_usable = channel.is_channel_usable_for_new_transfer(
-            channel_state=candidate_channel_state, transfer_amount=amount_with_fee
+            channel_state=candidate_channel_state,
+            transfer_amount=amount_with_fee,
+            lock_timeout=transfer_description.lock_timeout,
         )
         if is_channel_usable:
             channel_state = candidate_channel_state
@@ -304,7 +306,7 @@ def send_lockedtransfer(
     assert channel_state.token_network_address == transfer_description.token_network_address
 
     lock_expiration = channel.get_safe_initial_expiration(
-        block_number, channel_state.reveal_timeout
+        block_number, channel_state.reveal_timeout, transfer_description.lock_timeout
     )
 
     # The payment amount and the fee amount must be included in the locked

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -14,6 +14,7 @@ from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     TYPE_CHECKING,
     Address,
+    BlockTimeout,
     ChannelID,
     Dict,
     InitiatorAddress,
@@ -112,6 +113,7 @@ class TransferDescriptionWithSecretState(State):
     target: TargetAddress
     secret: Secret = field(repr=False)
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
+    lock_timeout: Optional[BlockTimeout] = field(default=None)
 
     def __post_init__(self) -> None:
         if self.secrethash == EMPTY_SECRETHASH and self.secret:


### PR DESCRIPTION
Example:
```
curl -X POST http://localhost:5001/api/v1/payments/0xF6f11bb624aabb2782FD53CcbF10db73f303F367/0x22b001098c212eA447EF291dE687Bf5C2Ef40914 -H 'Content-Type: application/json' --data-raw '{"amount": 500, "identifier": 987654326, "secret": "0x78c8d676e2f2399aa2a015f3433a2083c55003591a0f3f3349b6e50fc9ca44f1", "lock_timeout": 50}'
```
for a channel to be used, the lock_timeout should be bigger than reveal_timeout and not bigger than settle_timeout.


Fixes #4669 