### PR TITLE
Remove module name from message `_type`

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -149,7 +149,7 @@ class _RetryQueue(Runnable):
                 _RetryQueue._MessageData(
                     queue_identifier=queue_identifier,
                     message=message,
-                    text=JSONSerializer.serialize(message),
+                    text=JSONSerializer.serialize(message, include_module=False),
                     expiration_generator=expiration_generator,
                 )
             )
@@ -619,7 +619,8 @@ class MatrixTransport(Runnable):
                 messages[room_name].append(message)
             for room_name, messages_for_room in messages.items():
                 message_text = "\n".join(
-                    JSONSerializer.serialize(message) for message in messages_for_room
+                    JSONSerializer.serialize(message, include_module=False)
+                    for message in messages_for_room
                 )
                 _send_global(room_name, message_text)
                 for _ in messages_for_room:
@@ -1290,7 +1291,10 @@ class MatrixTransport(Runnable):
         """ Sends send-to-device events to a all known devices of a peer without retries. """
         user_ids = self._address_mgr.get_userids_for_address(address)
 
-        data = {user_id: {"*": JSONSerializer.serialize(message)} for user_id in user_ids}
+        data = {
+            user_id: {"*": JSONSerializer.serialize(message, include_module=False)}
+            for user_id in user_ids
+        }
 
         return self._client.api.send_to_device("m.to_device_message", data)
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -39,7 +39,7 @@ from raiden.network.transport.matrix.utils import (
 )
 from raiden.network.transport.utils import timeout_exponential_backoff
 from raiden.raiden_service import RaidenService
-from raiden.storage.serialization import JSONSerializer
+from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, QueueIdentifier
 from raiden.transfer.state import (
@@ -149,7 +149,7 @@ class _RetryQueue(Runnable):
                 _RetryQueue._MessageData(
                     queue_identifier=queue_identifier,
                     message=message,
-                    text=JSONSerializer.serialize(message, include_module=False),
+                    text=MessageSerializer.serialize(message),
                     expiration_generator=expiration_generator,
                 )
             )
@@ -619,8 +619,7 @@ class MatrixTransport(Runnable):
                 messages[room_name].append(message)
             for room_name, messages_for_room in messages.items():
                 message_text = "\n".join(
-                    JSONSerializer.serialize(message, include_module=False)
-                    for message in messages_for_room
+                    MessageSerializer.serialize(message) for message in messages_for_room
                 )
                 _send_global(room_name, message_text)
                 for _ in messages_for_room:
@@ -1291,10 +1290,7 @@ class MatrixTransport(Runnable):
         """ Sends send-to-device events to a all known devices of a peer without retries. """
         user_ids = self._address_mgr.get_userids_for_address(address)
 
-        data = {
-            user_id: {"*": JSONSerializer.serialize(message, include_module=False)}
-            for user_id in user_ids
-        }
+        data = {user_id: {"*": MessageSerializer.serialize(message)} for user_id in user_ids}
 
         return self._client.api.send_to_device("m.to_device_message", data)
 

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -27,7 +27,7 @@ from raiden.exceptions import InvalidSignature, SerializationError, TransportErr
 from raiden.messages.abstract import Message, SignedMessage
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.utils import get_http_rtt
-from raiden.storage.serialization import JSONSerializer
+from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import Address, ChainID, Signature
 from raiden_contracts.constants import ID_TO_NETWORKNAME
@@ -615,7 +615,7 @@ def validate_and_parse_message(data, peer_address) -> List[Message]:
         if not line:
             continue
         try:
-            message = JSONSerializer.deserialize(line)
+            message = MessageSerializer.deserialize(line)
         except SerializationError as ex:
             log.warning(
                 "Not a valid Message",

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -129,8 +129,13 @@ class MessageSerializer(SerializationBase):
             raise SerializationError(f"Can't decode invalid JSON: {data}") from ex
 
         try:
-            decoded_json["type"] = MESSAGE_NAME_TO_QUALIFIED_NAME[decoded_json.pop("_type")]
+            msg_type = decoded_json.pop("type")
         except KeyError as ex:
-            raise SerializationError(f"Unknown message type: {decoded_json['_type']}") from ex
+            raise SerializationError(f"No 'type' attribute in message") from ex
+
+        try:
+            decoded_json["_type"] = MESSAGE_NAME_TO_QUALIFIED_NAME[msg_type]
+        except KeyError as ex:
+            raise SerializationError(f"Unknown message type: {msg_type}") from ex
 
         return DictSerializer.deserialize(decoded_json)

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -48,7 +48,7 @@ class DictSerializer(SerializationBase):
     # Dataclass]`, however, there is no base class available from the
     # dataclasses module that allows for such type annotation.
     @staticmethod
-    def serialize(obj: Any, include_module: bool = True) -> Dict:
+    def serialize(obj: Any) -> Dict:
         # Default, in case this is not a dataclass
         data = obj
         if is_dataclass(obj):
@@ -59,11 +59,6 @@ class DictSerializer(SerializationBase):
                 raise SerializationError(f"Can't serialize: {data}") from ex
         elif not isinstance(obj, Mapping):
             raise SerializationError(f"Can only serialize dataclasses or dict-like objects: {obj}")
-
-        if not include_module:
-            # Only use 'Message' instead of `raiden.messages.Message` as _type.
-            # Used for Raiden protocol messages.
-            data["_type"] = data["_type"].split(".")[-1]
 
         return data
 
@@ -77,14 +72,6 @@ class DictSerializer(SerializationBase):
         if not isinstance(data, Mapping):
             raise SerializationError(f"Can't deserialize non dict-like objects: {data}")
         if "_type" in data:
-            if "." not in data["_type"]:
-                # When serializing Messages for external communication, we
-                # strip the module part of the name to not leak implementation
-                # details. We need to reconstruct them when loading a message.
-                try:
-                    data["_type"] = MESSAGE_NAME_TO_QUALIFIED_NAME[data["_type"]]
-                except KeyError as ex:
-                    raise SerializationError(f"Unknown type: {data['_type']}") from ex
             try:
                 klass = _import_type(data["_type"])
                 schema = SchemaCache.get_or_create_schema(klass)
@@ -96,8 +83,8 @@ class DictSerializer(SerializationBase):
 
 class JSONSerializer(SerializationBase):
     @staticmethod
-    def serialize(obj: Any, include_module: bool = True) -> str:
-        data = DictSerializer.serialize(obj, include_module=include_module)
+    def serialize(obj: Any) -> str:
+        data = DictSerializer.serialize(obj)
         return json.dumps(data)
 
     @staticmethod
@@ -112,3 +99,38 @@ class JSONSerializer(SerializationBase):
             raise SerializationError(f"Can't decode invalid JSON: {data}") from ex
         data = DictSerializer.deserialize(decoded_json)
         return data
+
+
+class MessageSerializer(SerializationBase):
+    """ Serialize to JSON with adaptions for external messages
+
+    This serializer only includes the class name in the type. This is more
+    suitable for external Messages than including the complete module path as
+    JSONSerializer does.
+    The type is also saved in the `type` field (instead of `_type`), since we
+    can make sure that there are no name clashes for our Message objects.
+    """
+
+    @staticmethod
+    def serialize(obj: Any) -> str:
+        data = DictSerializer.serialize(obj)
+
+        # Only use 'Message' instead of `raiden.messages.Message` as type.
+        qualified_type = data.pop("_type")
+        data["type"] = qualified_type.split(".")[-1]
+
+        return json.dumps(data)
+
+    @staticmethod
+    def deserialize(data: str) -> Any:
+        try:
+            decoded_json = json.loads(data)
+        except (UnicodeDecodeError, JSONDecodeError) as ex:
+            raise SerializationError(f"Can't decode invalid JSON: {data}") from ex
+
+        try:
+            decoded_json["type"] = MESSAGE_NAME_TO_QUALIFIED_NAME[decoded_json.pop("_type")]
+        except KeyError as ex:
+            raise SerializationError(f"Unknown message type: {decoded_json['_type']}") from ex
+
+        return DictSerializer.deserialize(decoded_json)

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -14,33 +14,8 @@ from typing import Mapping
 from marshmallow import ValidationError
 
 from raiden.exceptions import SerializationError
-from raiden.storage.serialization.types import SchemaCache
+from raiden.storage.serialization.types import MESSAGE_NAME_TO_QUALIFIED_NAME, SchemaCache
 from raiden.utils.typing import Any, Dict
-
-MESSAGE_NAME_TO_QUALIFIED_NAME = {
-    "AuthenticatedMessage": "raiden.messages.abstract.AuthenticatedMessage",
-    "SignedMessage": "raiden.messages.abstract.SignedMessage",
-    "SignedRetrieableMessage": "raiden.messages.abstract.SignedRetrieableMessage",
-    "Ping": "raiden.messages.healthcheck.Ping",
-    "Pong": "raiden.messages.healthcheck.Pong",
-    "ToDevice": "raiden.messages.matrix.ToDevice",
-    "RequestMonitoring": "raiden.messages.monitoring_service.RequestMonitoring",
-    "PFSCapacityUpdate": "raiden.messages.path_finding_service.PFSCapacityUpdate",
-    "PFSFeeUpdate": "raiden.messages.path_finding_service.PFSFeeUpdate",
-    "Delivered": "raiden.messages.synchronization.Delivered",
-    "EnvelopeMessage": "raiden.messages.transfers.EnvelopeMessage",
-    "SecretRequest": "raiden.messages.transfers.SecretRequest",
-    "RevealSecret": "raiden.messages.transfers.RevealSecret",
-    "Processed": "raiden.messages.synchronization.Processed",
-    "WithdrawRequest": "raiden.messages.withdraw.WithdrawRequest",
-    "WithdrawConfirmation": "raiden.messages.withdraw.WithdrawConfirmation",
-    "WithdrawExpired": "raiden.messages.withdraw.WithdrawExpired",
-    "Unlock": "raiden.messages.transfers.Unlock",
-    "LockedTransferBase": "raiden.messages.transfers.LockedTransferBase",
-    "LockExpired": "raiden.messages.transfers.LockExpired",
-    "LockedTransfer": "raiden.messages.transfers.LockedTransfer",
-    "RefundTransfer": "raiden.messages.transfers.RefundTransfer",
-}
 
 
 def _import_type(type_name: str) -> type:

--- a/raiden/storage/serialization/types.py
+++ b/raiden/storage/serialization/types.py
@@ -60,6 +60,31 @@ from raiden.utils.typing import (
     WithdrawAmount,
 )
 
+MESSAGE_NAME_TO_QUALIFIED_NAME = {
+    "AuthenticatedMessage": "raiden.messages.abstract.AuthenticatedMessage",
+    "Delivered": "raiden.messages.synchronization.Delivered",
+    "EnvelopeMessage": "raiden.messages.transfers.EnvelopeMessage",
+    "LockedTransferBase": "raiden.messages.transfers.LockedTransferBase",
+    "LockedTransfer": "raiden.messages.transfers.LockedTransfer",
+    "LockExpired": "raiden.messages.transfers.LockExpired",
+    "PFSCapacityUpdate": "raiden.messages.path_finding_service.PFSCapacityUpdate",
+    "PFSFeeUpdate": "raiden.messages.path_finding_service.PFSFeeUpdate",
+    "Ping": "raiden.messages.healthcheck.Ping",
+    "Pong": "raiden.messages.healthcheck.Pong",
+    "Processed": "raiden.messages.synchronization.Processed",
+    "RefundTransfer": "raiden.messages.transfers.RefundTransfer",
+    "RequestMonitoring": "raiden.messages.monitoring_service.RequestMonitoring",
+    "RevealSecret": "raiden.messages.transfers.RevealSecret",
+    "SecretRequest": "raiden.messages.transfers.SecretRequest",
+    "SignedMessage": "raiden.messages.abstract.SignedMessage",
+    "SignedRetrieableMessage": "raiden.messages.abstract.SignedRetrieableMessage",
+    "ToDevice": "raiden.messages.matrix.ToDevice",
+    "Unlock": "raiden.messages.transfers.Unlock",
+    "WithdrawConfirmation": "raiden.messages.withdraw.WithdrawConfirmation",
+    "WithdrawExpired": "raiden.messages.withdraw.WithdrawExpired",
+    "WithdrawRequest": "raiden.messages.withdraw.WithdrawRequest",
+}
+
 
 def transfer_task_schema_serialization(task: TransferTask, parent: Any) -> Schema:
     # pylint: disable=unused-argument

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -617,7 +617,7 @@ def test_pfs_global_messages(
             gevent.idle()
     assert pfs_room.send_text.call_count == 2
     msg_data = json.loads(pfs_room.send_text.call_args[0][0])
-    assert msg_data["_type"] == "PFSFeeUpdate"
+    assert msg_data["type"] == "PFSFeeUpdate"
 
     transport.stop()
     transport.get()

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -617,7 +617,7 @@ def test_pfs_global_messages(
             gevent.idle()
     assert pfs_room.send_text.call_count == 2
     msg_data = json.loads(pfs_room.send_text.call_args[0][0])
-    assert msg_data["_type"] == "raiden.messages.path_finding_service.PFSFeeUpdate"
+    assert msg_data["_type"] == "PFSFeeUpdate"
 
     transport.stop()
     transport.get()

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -7,7 +7,7 @@ from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
 from raiden.messages.transfers import SecretRequest
 from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix.client import GMatrixClient, Room
-from raiden.storage.serialization import JSONSerializer
+from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.tests.utils import factories
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.utils import Address
@@ -110,7 +110,7 @@ def make_message(sign=True, overwrite_data=None):
         )
         if sign:
             message.sign(LocalSigner(factories.HOP1_KEY))
-        data = JSONSerializer.serialize(message)
+        data = MessageSerializer.serialize(message)
     else:
         data = overwrite_data
 
@@ -135,7 +135,9 @@ def test_processing_invalid_json(  # pylint: disable=unused-argument
     assert not mock_matrix._handle_message(room, event)
 
 
-def test_non_signed_message_is_rejected(mock_matrix, skip_userid_validation):
+def test_non_signed_message_is_rejected(
+    mock_matrix, skip_userid_validation
+):  # pylint: disable=unused-argument
     room, event = make_message(sign=False)
     assert not mock_matrix._handle_message(room, event)
 


### PR DESCRIPTION
## Description

These are considered an implementation details and should not be visible
in the wire protocol.

I don't like two things about the implementation in this change set:
* MESSAGE_NAME_TO_QUALIFIED_NAME needs to be maintained manually.
  We could do this automatically, but that would require importing all
  message classes in the serializer module, which is ugly in a different
  way.
* The check whether the type has to be expanded or not just looks at the
  presence of a dot in the `_type`. Maybe we should be more explicit
  about when to expand the type by passing a parameter to `deserialize`,
  like the one that has been added to `serialize` in this change?

Fixes https://github.com/raiden-network/raiden/issues/4427.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [x] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
