### PR TITLE
Link to GitBook docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Raiden Network |capitalized_version| Documentation
 This is the documentation for the |version| version of the `Raiden Network <http://raiden.network/>`_. You can find the source code in `our Github Repository <https://github.com/raiden-network/raiden>`_.
 
 .. NOTE::
-      We are currently reworking our documentation for Raiden. While this is still an ongoing process you can already view the updated parts in this `new but incomplete version of the documentation <http://doc.raiden.network/>`_.
+      We are currently reworking our documentation for Raiden. While this is still an ongoing process you can already view the updated parts in this `new but incomplete version of the documentation <https://docs.raiden.network/>`_.
 What is the Raiden Network?
 ---------------------------
 The Raiden Network is an off-chain scaling solution, enabling near-instant, low-fee and scalable payments. It’s complementary to the Ethereum blockchain and works with any ERC20 compatible token. The Raiden project is work in progress. Its goal is to research state channel technology, define protocols and develop reference implementations.
@@ -19,7 +19,7 @@ New to Raiden?
 ~~~~~~~~~~~~~~
 If you're new to Raiden and just want to install and try it out, you can either:
 
-    * Use the `Raiden Wizard <http://doc.raiden.network/>`_ for quickly installing and running a Raiden node.
+    * Use the `Raiden Wizard <https://docs.raiden.network/quick-start/>`_ for quickly installing and running a Raiden node.
     * :doc:`Read about different options for installing and firing up <overview_and_guide>` a Raiden client.
     * Check out the :doc:`WebUI tutorial <webui_tutorial>` to quickly get started doing payments.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,9 +17,10 @@ Whether you've just heard of Raiden for the first time or you're here looking fo
 
 New to Raiden?
 ~~~~~~~~~~~~~~
-If you're new to Raiden and just want to install and try it out:
+If you're new to Raiden and just want to install and try it out, you can either:
 
-    * :doc:`Install and fire up <overview_and_guide>` a Raiden client.
+    * Use the `Raiden Wizard <http://doc.raiden.network/>`_ for quickly installing and running a Raiden node.
+    * :doc:`Read about different options for installing and firing up <overview_and_guide>` a Raiden client.
     * Check out the :doc:`WebUI tutorial <webui_tutorial>` to quickly get started doing payments.
 
 Developing on Raiden?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,8 @@ Raiden Network |capitalized_version| Documentation
 
 This is the documentation for the |version| version of the `Raiden Network <http://raiden.network/>`_. You can find the source code in `our Github Repository <https://github.com/raiden-network/raiden>`_.
 
+.. NOTE::
+      We are currently reworking our documentation for Raiden. While this is still an ongoing process you can already view the updated parts in this `new but incomplete version of the documentation <http://doc.raiden.network/>`_.
 What is the Raiden Network?
 ---------------------------
 The Raiden Network is an off-chain scaling solution, enabling near-instant, low-fee and scalable payments. It’s complementary to the Ethereum blockchain and works with any ERC20 compatible token. The Raiden project is work in progress. Its goal is to research state channel technology, define protocols and develop reference implementations.

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -12,8 +12,12 @@ Raiden is a payment channel implementation which provides scalable, low latency,
 Installation
 ============
 
-The preferred way to install Raiden is downloading a self contained application bundle from the
-`GitHub release page <https://github.com/raiden-network/raiden/releases>`_.
+To install Raiden you can either:
+
+    * Use the `Raiden Wizard <http://doc.raiden.network/>`_
+    * Download a self contained application bundle from the `GitHub release page <https://github.com/raiden-network/raiden/releases>`_
+
+**If you're installing Raiden from the self contained application bundle the following sections will detail how to set up Raiden on various platforms.**
 
 Linux
 *****

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -14,7 +14,7 @@ Installation
 
 To install Raiden you can either:
 
-    * Use the `Raiden Wizard <http://doc.raiden.network/>`_
+    * Use the `Raiden Wizard <https://docs.raiden.network/quick-start/>`_
     * Download a self contained application bundle from the `GitHub release page <https://github.com/raiden-network/raiden/releases>`_
 
 **If you're installing Raiden from the self contained application bundle the following sections will detail how to set up Raiden on various platforms.**

--- a/docs/webui_tutorial.rst
+++ b/docs/webui_tutorial.rst
@@ -4,8 +4,8 @@ Web Application Tutorial
 .. toctree::
   :maxdepth: 2
 
-..NOTE::
-     We are currently reworking our documentation for Raiden and just finished updating this tutorial for the web application. You can view the updated web application tutorial in this `new but incomplete version of the documentation <http://doc.raiden.network/>`_.
+.. NOTE::
+      We are currently reworking our documentation for Raiden and just finished updating this tutorial for the web application. You can view the updated web application tutorial in this `new but incomplete version of the documentation <http://doc.raiden.network/>`_.
 
 In order to quickly give an overview and idea of what Raiden is capable of, a web application has been created. This application utilizes the :doc:`Raiden REST API endpoints <rest_api>` to allow the user to interact with token networks, make token payments, see the current status of open channels along with closing and settling channels to name some of the functionalities. For a more specific guide of the API itself see the :doc:`API Walkthrough <api_walkthrough>`.
 

--- a/docs/webui_tutorial.rst
+++ b/docs/webui_tutorial.rst
@@ -4,6 +4,9 @@ Web Application Tutorial
 .. toctree::
   :maxdepth: 2
 
+..NOTE::
+     We are currently reworking our documentation for Raiden and just finished updating this tutorial for the web application. You can view the updated web application tutorial in this `new but incomplete version of the documentation <http://doc.raiden.network/>`_.
+
 In order to quickly give an overview and idea of what Raiden is capable of, a web application has been created. This application utilizes the :doc:`Raiden REST API endpoints <rest_api>` to allow the user to interact with token networks, make token payments, see the current status of open channels along with closing and settling channels to name some of the functionalities. For a more specific guide of the API itself see the :doc:`API Walkthrough <api_walkthrough>`.
 
 The main focus of the web application is to display functionality. If you want to contribute, don't hesitate to create a `pull request <https://github.com/raiden-network/webui/pulls>`_.

--- a/docs/webui_tutorial.rst
+++ b/docs/webui_tutorial.rst
@@ -5,7 +5,7 @@ Web Application Tutorial
   :maxdepth: 2
 
 .. NOTE::
-      We are currently reworking our documentation for Raiden and just finished updating this tutorial for the web application. You can view the updated web application tutorial in this `new but incomplete version of the documentation <http://doc.raiden.network/>`_.
+      We are currently reworking our documentation for Raiden and just finished updating this tutorial for the web application. You can view the updated web application tutorial in this `new but incomplete version of the documentation <https://docs.raiden.network/the-raiden-web-interface/>`_.
 
 In order to quickly give an overview and idea of what Raiden is capable of, a web application has been created. This application utilizes the :doc:`Raiden REST API endpoints <rest_api>` to allow the user to interact with token networks, make token payments, see the current status of open channels along with closing and settling channels to name some of the functionalities. For a more specific guide of the API itself see the :doc:`API Walkthrough <api_walkthrough>`.
 


### PR DESCRIPTION
This PR is part of the "Documentation for the pragmatic developer" issue.

An infobox has been added on the index page and on the "Web Application Tutorial" page which notifies visitors about the current process of updating the docs and provides a link to the new (incomplete) GitBook version.