### PR TITLE
Enforce typing by default in `raiden`

### DIFF
--- a/raiden/__main__.py
+++ b/raiden/__main__.py
@@ -1,7 +1,7 @@
 # make it possible to run raiden with 'python -m raiden'
 
 
-def main():
+def main() -> None:
     import gevent.monkey
 
     gevent.monkey.patch_all()

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -9,7 +9,7 @@ from eth_utils import decode_hex, encode_hex, to_checksum_address
 
 from raiden.exceptions import RaidenError
 from raiden.utils import privatekey_to_address, privatekey_to_publickey
-from raiden.utils.typing import AddressHex, PrivateKey, PublicKey
+from raiden.utils.typing import Address, AddressHex, PrivateKey, PublicKey
 
 log = structlog.get_logger(__name__)
 
@@ -144,14 +144,14 @@ class Account:
         self._address = None
 
         try:
-            self._address = decode_hex(self.keystore["address"])
+            self._address = Address(decode_hex(self.keystore["address"]))
         except KeyError:
             pass
 
         if password is not None:
             self.unlock(password)
 
-    def unlock(self, password: str):
+    def unlock(self, password: str) -> None:
         """Unlock the account with a password.
 
         If the account is already unlocked, nothing happens, even if the password is wrong.
@@ -166,7 +166,7 @@ class Account:
             # get address such that it stays accessible after a subsequent lock
             self._fill_address()
 
-    def lock(self):
+    def lock(self) -> None:
         """Relock an unlocked account.
 
         This method sets `account.privkey` to `None` (unlike `account.address` which is preserved).
@@ -176,10 +176,11 @@ class Account:
         self._privkey = None
         self.locked = True
 
-    def _fill_address(self):
+    def _fill_address(self) -> None:
         if "address" in self.keystore:
-            self._address = decode_hex(self.keystore["address"])
+            self._address = Address(decode_hex(self.keystore["address"]))
         elif not self.locked:
+            assert self.privkey
             self._address = privatekey_to_address(self.privkey)
 
     @property
@@ -199,7 +200,7 @@ class Account:
         return None
 
     @property
-    def address(self):
+    def address(self) -> Optional[Address]:
         """The account's address or `None` if the address is not stored in the key file and cannot
         be reconstructed (because the account is locked)
         """
@@ -209,7 +210,7 @@ class Account:
         return self._address
 
     @property
-    def uuid(self):
+    def uuid(self) -> Optional[str]:
         """An optional unique identifier, formatted according to UUID version 4, or `None` if the
         account does not have an id
         """
@@ -219,14 +220,14 @@ class Account:
             return None
 
     @uuid.setter
-    def uuid(self, value):
+    def uuid(self, value: str) -> None:
         """Set the UUID. Set it to `None` in order to remove it."""
         if value is not None:
             self.keystore["id"] = value
         elif "id" in self.keystore:
             self.keystore.pop("id")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.address is not None:
             address = encode_hex(self.address)
         else:

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -3,11 +3,14 @@ from eth_utils import to_checksum_address
 
 from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, RoutingMode
 from raiden.exceptions import InvalidSettleTimeout
+from raiden.message_handler import MessageHandler
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
+from raiden.network.transport.matrix.transport import MatrixTransport
+from raiden.raiden_event_handler import EventHandler
 from raiden.raiden_service import RaidenService
 from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
@@ -71,9 +74,9 @@ class App:  # pylint: disable=too-few-public-methods
         default_service_registry: typing.Optional[ServiceRegistry],
         default_one_to_n_address: typing.Optional[Address],
         default_msc_address: Address,
-        transport,
-        raiden_event_handler,
-        message_handler,
+        transport: MatrixTransport,
+        raiden_event_handler: EventHandler,
+        message_handler: MessageHandler,
         routing_mode: RoutingMode,
         user_deposit: UserDeposit = None,
     ):
@@ -116,16 +119,16 @@ class App:  # pylint: disable=too-few-public-methods
         self.user_deposit = user_deposit
         self.raiden = raiden
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{} {}>".format(self.__class__.__name__, to_checksum_address(self.raiden.address))
 
-    def start(self):
+    def start(self) -> None:
         """ Start the raiden app. """
         if self.raiden.stop_event.is_set():
             self.raiden.start()
             log.info("Raiden started", node=self.raiden.address)
 
-    def stop(self):
+    def stop(self) -> None:
         """ Stop the raiden app. """
         if not self.raiden.stop_event.is_set():
             self.raiden.stop()

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -99,7 +99,7 @@ def after_new_deposit_join_network(
         raiden.add_pending_greenlet(join_channel)
 
 
-def after_blockchain_statechange(raiden: "RaidenService", state_change: StateChange):
+def after_blockchain_statechange(raiden: "RaidenService", state_change: StateChange) -> None:
     if type(state_change) == ContractReceiveNewTokenNetwork:
         assert isinstance(state_change, ContractReceiveNewTokenNetwork), MYPY_ANNOTATION
         after_new_token_network_create_filter(raiden, state_change)

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -24,7 +24,7 @@ LOG_BACKUP_COUNT = 3
 _FIRST_PARTY_PACKAGES = frozenset(["raiden", "raiden_contracts"])
 
 
-def _chain(first_func, *funcs) -> Callable:
+def _chain(first_func: Callable, *funcs: Callable) -> Callable:
     """Chains a give number of functions.
     First function receives all args/kwargs. Its result is passed on as an argument
     to the second one and so on and so forth until all function arguments are used.
@@ -32,7 +32,7 @@ def _chain(first_func, *funcs) -> Callable:
     """
 
     @wraps(first_func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         result = first_func(*args, **kwargs)
         for func in funcs:
             result = func(result)
@@ -99,11 +99,11 @@ class LogFilter:
 
 
 class RaidenFilter(logging.Filter):
-    def __init__(self, log_level_config, name=""):
+    def __init__(self, log_level_config: Dict[str, str], name: str = ""):
         super().__init__(name)
         self._log_filter = LogFilter(log_level_config, default_level=DEFAULT_LOG_LEVEL)
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> int:
         return self._log_filter.should_log(record.name, record.levelname)
 
 
@@ -141,7 +141,7 @@ def configure_logging(
     cache_logger_on_first_use: bool = True,
     _first_party_packages: FrozenSet[str] = _FIRST_PARTY_PACKAGES,
     _debug_log_file_additional_level_filters: Dict[str, str] = None,
-):
+) -> None:
     structlog.reset_defaults()
 
     logger_level_config = logger_level_config or dict()

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1,6 +1,7 @@
 import json
 import time
 from collections import defaultdict
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -38,7 +39,6 @@ from raiden.network.transport.matrix.utils import (
     validate_userid_signature,
 )
 from raiden.network.transport.utils import timeout_exponential_backoff
-from raiden.raiden_service import RaidenService
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, QueueIdentifier
@@ -71,6 +71,9 @@ from raiden.utils.typing import (
     Union,
     cast,
 )
+
+if TYPE_CHECKING:
+    from raiden.raiden_service import RaidenService
 
 log = structlog.get_logger(__name__)
 
@@ -283,7 +286,7 @@ class MatrixTransport(Runnable):
         super().__init__()
         self._uuid = uuid4()
         self._config = config
-        self._raiden_service: Optional[RaidenService] = None
+        self._raiden_service: Optional["RaidenService"] = None
 
         if config["server"] == "auto":
             available_servers = config["available_servers"]
@@ -354,7 +357,7 @@ class MatrixTransport(Runnable):
 
     def start(  # type: ignore
         self,
-        raiden_service: RaidenService,
+        raiden_service: "RaidenService",
         message_handler: MessageHandler,
         prev_auth_data: Optional[str],
     ):

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -111,14 +111,16 @@ def unlock(
 
 class EventHandler(ABC):
     @abstractmethod
-    def on_raiden_event(self, raiden: "RaidenService", chain_state: ChainState, event: Event):
+    def on_raiden_event(
+        self, raiden: "RaidenService", chain_state: ChainState, event: Event
+    ) -> None:
         pass
 
 
 class RaidenEventHandler(EventHandler):
     def on_raiden_event(
         self, raiden: "RaidenService", chain_state: ChainState, event: Event
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         # pylint: disable=too-many-branches
         if type(event) == SendLockExpired:
             assert isinstance(event, SendLockExpired), MYPY_ANNOTATION
@@ -189,7 +191,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_lockexpired(
         raiden: "RaidenService", send_lock_expired: SendLockExpired
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         lock_expired_message = message_from_sendevent(send_lock_expired)
         raiden.sign(lock_expired_message)
         raiden.transport.send_async(send_lock_expired.queue_identifier, lock_expired_message)
@@ -197,7 +199,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_lockedtransfer(
         raiden: "RaidenService", send_locked_transfer: SendLockedTransfer
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         mediated_transfer_message = message_from_sendevent(send_locked_transfer)
         raiden.sign(mediated_transfer_message)
         raiden.transport.send_async(
@@ -207,7 +209,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_secretreveal(
         raiden: "RaidenService", reveal_secret_event: SendSecretReveal
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         reveal_secret_message = message_from_sendevent(reveal_secret_event)
         raiden.sign(reveal_secret_message)
         raiden.transport.send_async(reveal_secret_event.queue_identifier, reveal_secret_message)
@@ -215,7 +217,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_balanceproof(
         raiden: "RaidenService", balance_proof_event: SendBalanceProof
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)
         raiden.transport.send_async(balance_proof_event.queue_identifier, unlock_message)
@@ -223,7 +225,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_secretrequest(
         raiden: "RaidenService", secret_request_event: SendSecretRequest
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         if reveal_secret_with_resolver(raiden, secret_request_event):
             return
 
@@ -234,7 +236,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_refundtransfer(
         raiden: "RaidenService", refund_transfer_event: SendRefundTransfer
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         refund_transfer_message = message_from_sendevent(refund_transfer_event)
         raiden.sign(refund_transfer_message)
         raiden.transport.send_async(
@@ -244,7 +246,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_withdrawrequest(
         raiden: "RaidenService", withdraw_request_event: SendWithdrawRequest
-    ):
+    ) -> None:
         withdraw_request_message = message_from_sendevent(withdraw_request_event)
         raiden.sign(withdraw_request_message)
         raiden.transport.send_async(
@@ -252,7 +254,9 @@ class RaidenEventHandler(EventHandler):
         )
 
     @staticmethod
-    def handle_send_withdraw(raiden: "RaidenService", withdraw_event: SendWithdrawConfirmation):
+    def handle_send_withdraw(
+        raiden: "RaidenService", withdraw_event: SendWithdrawConfirmation
+    ) -> None:
         withdraw_message = message_from_sendevent(withdraw_event)
         raiden.sign(withdraw_message)
         raiden.transport.send_async(withdraw_event.queue_identifier, withdraw_message)
@@ -260,7 +264,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_withdrawexpired(
         raiden: "RaidenService", withdraw_expired_event: SendWithdrawExpired
-    ):
+    ) -> None:
         withdraw_expired_message = message_from_sendevent(withdraw_expired_event)
         raiden.sign(withdraw_expired_message)
         raiden.transport.send_async(
@@ -270,7 +274,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_send_processed(
         raiden: "RaidenService", processed_event: SendProcessed
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         processed_message = message_from_sendevent(processed_event)
         raiden.sign(processed_message)
         raiden.transport.send_async(processed_event.queue_identifier, processed_message)
@@ -278,7 +282,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_paymentsentsuccess(
         raiden: "RaidenService", payment_sent_success_event: EventPaymentSentSuccess
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         target = payment_sent_success_event.target
         payment_identifier = payment_sent_success_event.identifier
         payment_status = raiden.targets_to_identifiers_to_statuses[target].pop(payment_identifier)
@@ -291,7 +295,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_paymentsentfailed(
         raiden: "RaidenService", payment_sent_failed_event: EventPaymentSentFailed
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         target = payment_sent_failed_event.target
         payment_identifier = payment_sent_failed_event.identifier
         payment_status = raiden.targets_to_identifiers_to_statuses[target].pop(
@@ -306,7 +310,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_unlockfailed(
         raiden: "RaidenService", unlock_failed_event: EventUnlockFailed
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         # pylint: disable=unused-argument
         log.error(
             "UnlockFailed!",
@@ -318,13 +322,13 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_contract_send_secretreveal(
         raiden: "RaidenService", channel_reveal_secret_event: ContractSendSecretReveal
-    ):  # pragma: no unittest
+    ) -> None:  # pragma: no unittest
         raiden.default_secret_registry.register_secret(secret=channel_reveal_secret_event.secret)
 
     @staticmethod
     def handle_contract_send_channelwithdraw(
         raiden: "RaidenService", channel_withdraw_event: ContractSendChannelWithdraw
-    ):
+    ) -> None:
         withdraw_confirmation_data = pack_withdraw(
             canonical_identifier=channel_withdraw_event.canonical_identifier,
             participant=raiden.address,
@@ -350,7 +354,7 @@ class RaidenEventHandler(EventHandler):
         raiden: "RaidenService",
         chain_state: ChainState,
         channel_close_event: ContractSendChannelClose,
-    ):
+    ) -> None:
         balance_proof = channel_close_event.balance_proof
 
         if balance_proof:
@@ -398,7 +402,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_contract_send_channelupdate(
         raiden: "RaidenService", channel_update_event: ContractSendChannelUpdateTransfer
-    ):
+    ) -> None:
         balance_proof = channel_update_event.balance_proof
 
         if balance_proof:
@@ -429,7 +433,7 @@ class RaidenEventHandler(EventHandler):
         raiden: "RaidenService",
         chain_state: ChainState,
         channel_unlock_event: ContractSendChannelBatchUnlock,
-    ):
+    ) -> None:
         assert raiden.wal, "The Raiden Service must be initialize to handle events"
 
         canonical_identifier = channel_unlock_event.canonical_identifier
@@ -565,7 +569,7 @@ class RaidenEventHandler(EventHandler):
     @staticmethod
     def handle_contract_send_channelsettle(
         raiden: "RaidenService", channel_settle_event: ContractSendChannelSettle
-    ):
+    ) -> None:
         assert raiden.wal, "The Raiden Service must be initialize to handle events"
 
         canonical_identifier = CanonicalIdentifier(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -38,6 +38,7 @@ from raiden.exceptions import (
     RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
+from raiden.message_handler import MessageHandler
 from raiden.messages.abstract import Message, SignedMessage
 from raiden.messages.decode import lockedtransfersigned_from_message
 from raiden.messages.encode import message_from_sendevent
@@ -47,6 +48,7 @@ from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
+from raiden.network.transport.matrix.transport import MatrixTransport
 from raiden.raiden_event_handler import EventHandler
 from raiden.services import (
     update_monitoring_service_from_balance_proof,
@@ -219,9 +221,9 @@ class RaidenService(Runnable):
         default_service_registry: Optional[ServiceRegistry],
         default_one_to_n_address: Optional[Address],
         default_msc_address: Address,
-        transport,
+        transport: MatrixTransport,
         raiden_event_handler: EventHandler,
-        message_handler,
+        message_handler: MessageHandler,
         routing_mode: RoutingMode,
         config: Dict[str, Any],
         user_deposit: UserDeposit = None,
@@ -1200,7 +1202,9 @@ class RaidenService(Runnable):
         init_target_statechange = target_init(transfer)
         self.handle_and_track_state_changes([init_target_statechange])
 
-    def withdraw(self, canonical_identifier: CanonicalIdentifier, total_withdraw: WithdrawAmount):
+    def withdraw(
+        self, canonical_identifier: CanonicalIdentifier, total_withdraw: WithdrawAmount
+    ) -> None:
         init_withdraw = ActionChannelWithdraw(
             canonical_identifier=canonical_identifier, total_withdraw=total_withdraw
         )

--- a/raiden/storage/serialization/cache.py
+++ b/raiden/storage/serialization/cache.py
@@ -1,16 +1,16 @@
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from marshmallow import Schema
 from marshmallow_dataclass import class_schema
 
 
-def bind(instance, func):
+def bind(instance: Any, func: Callable) -> Callable:
     """
     Bind the function *func* to *instance*.
     The provided *func* should accept the
     instance as the first argument, i.e. "self".
     """
-    bound_method = func.__get__(instance, instance.__class__)
+    bound_method = func.__get__(instance, instance.__class__)  # type: ignore
     setattr(instance, func.__name__, bound_method)
     return bound_method
 
@@ -19,25 +19,31 @@ def class_type(instance: Any) -> str:
     return f"{instance.__class__.__module__}.{instance.__class__.__name__}"
 
 
-def set_class_type(schema, data, instance, **kwargs):  # pylint: disable=unused-argument
+def set_class_type(  # pylint: disable=unused-argument
+    schema: Schema, data: dict, instance: Any, **kwargs: Any
+) -> dict:
     data["_type"] = class_type(instance)
     return data
 
 
-def remove_class_type(schema, data, **kwargs):  # pylint: disable=unused-argument
+def remove_class_type(  # pylint: disable=unused-argument
+    schema: Schema, data: dict, **kwargs: Any
+) -> dict:
     if "_type" in data:
         del data["_type"]
     return data
 
 
-def inject_type_resolver_hook(schema: Schema, clazz: type):  # pylint: disable=unused-argument
+def inject_type_resolver_hook(  # pylint: disable=unused-argument
+    schema: Schema, clazz: type
+) -> None:
     key = ("post_dump", False)
     schema._hooks[key].append("set_class_type")
     setattr(set_class_type, "__marshmallow_hook__", {key: {"pass_original": True}})  # noqa: B010
     bind(schema, set_class_type)
 
 
-def inject_remove_type_field_hook(schema: Schema):
+def inject_remove_type_field_hook(schema: Schema) -> None:
     key = ("pre_load", False)
     schema._hooks[key].append("remove_class_type")
     setattr(  # noqa: B010

--- a/raiden/storage/serialization/fields.py
+++ b/raiden/storage/serialization/fields.py
@@ -1,5 +1,6 @@
 import json
 from random import Random
+from typing import Callable
 
 import marshmallow
 import networkx
@@ -11,20 +12,20 @@ from raiden.utils.typing import Address, Any, ChainID, ChannelID, Optional, Tupl
 
 
 class IntegerToStringField(marshmallow.fields.Field):
-    def _serialize(self, value: int, attr: Any, obj: Any, **kwargs) -> str:
+    def _serialize(self, value: int, attr: Any, obj: Any, **kwargs: Any) -> str:
         return str(value)
 
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs) -> int:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> int:
         return int(value)
 
 
 class OptionalIntegerToStringField(marshmallow.fields.Field):
-    def _serialize(self, value: Optional[int], attr: Any, obj: Any, **kwargs) -> str:
+    def _serialize(self, value: Optional[int], attr: Any, obj: Any, **kwargs: Any) -> str:
         if value is None:
             return ""
         return str(value)
 
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs) -> Optional[int]:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> Optional[int]:
         if value == "":
             return None
         return int(value)
@@ -33,12 +34,12 @@ class OptionalIntegerToStringField(marshmallow.fields.Field):
 class BytesField(marshmallow.fields.Field):
     """ Used for `bytes` in the dataclass, serialize to hex encoding"""
 
-    def _serialize(self, value: bytes, attr: Any, obj: Any, **kwargs) -> str:
+    def _serialize(self, value: bytes, attr: Any, obj: Any, **kwargs: Any) -> str:
         if value is None:
             return value
         return to_hex(value)
 
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs) -> bytes:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> bytes:
         if value is None:
             return value
         return to_bytes(hexstr=value)
@@ -47,10 +48,10 @@ class BytesField(marshmallow.fields.Field):
 class AddressField(marshmallow.fields.Field):
     """ Converts addresses from bytes to hex and vice versa """
 
-    def _serialize(self, value: Address, attr: Any, obj: Any, **kwargs) -> str:
+    def _serialize(self, value: Address, attr: Any, obj: Any, **kwargs: Any) -> str:
         return to_checksum_address(value)
 
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs) -> Address:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> Address:
         return to_canonical_address(value)
 
 
@@ -77,14 +78,16 @@ class QueueIdentifierField(marshmallow.fields.Field):
             f"{canonical_id.channel_identifier}"
         )
 
-    def _serialize(self, queue_identifier: QueueIdentifier, attr: Any, obj: Any, **kwargs) -> str:
+    def _serialize(
+        self, queue_identifier: QueueIdentifier, attr: Any, obj: Any, **kwargs: Any
+    ) -> str:
         return (
             f"{to_checksum_address(queue_identifier.recipient)}"
             f"-{self._canonical_id_to_string(queue_identifier.canonical_identifier)}"
         )
 
     def _deserialize(
-        self, queue_identifier_str: str, attr: Any, data: Any, **kwargs
+        self, queue_identifier_str: str, attr: Any, data: Any, **kwargs: Any
     ) -> QueueIdentifier:
         str_recipient, str_canonical_id = queue_identifier_str.split("-")
         return QueueIdentifier(
@@ -105,20 +108,20 @@ class PRNGField(marshmallow.fields.Field):
 
         return pseudo_random_generator
 
-    def _serialize(self, value: Random, attr: Any, obj: Any, **kwargs) -> Tuple[Any, ...]:
+    def _serialize(self, value: Random, attr: Any, obj: Any, **kwargs: Any) -> Tuple[Any, ...]:
         return value.getstate()
 
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs) -> Random:
+    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> Random:
         return self.pseudo_random_generator_from_json(data)
 
 
 class CallablePolyField(PolyField):
     def __init__(
         self,
-        serialization_schema_selector=None,
-        deserialization_schema_selector=None,
-        many=False,
-        **metadata,
+        serialization_schema_selector: Callable = None,
+        deserialization_schema_selector: Callable = None,
+        many: bool = False,
+        **metadata: Any,
     ):
         super().__init__(
             serialization_schema_selector=serialization_schema_selector,
@@ -127,7 +130,7 @@ class CallablePolyField(PolyField):
             **metadata,
         )
 
-    def __call__(self, **metadata):
+    def __call__(self, **metadata: Any) -> "CallablePolyField":
         self.metadata = metadata
         return self
 
@@ -135,12 +138,12 @@ class CallablePolyField(PolyField):
 class NetworkXGraphField(marshmallow.fields.Field):
     """ Converts networkx.Graph objects to a string """
 
-    def _serialize(self, graph: networkx.Graph, attr: Any, obj: Any, **kwargs) -> str:
+    def _serialize(self, graph: networkx.Graph, attr: Any, obj: Any, **kwargs: Any) -> str:
         return json.dumps(
             [(to_checksum_address(edge[0]), to_checksum_address(edge[1])) for edge in graph.edges]
         )
 
-    def _deserialize(self, graph_data: str, attr: Any, data: Any, **kwargs) -> networkx.Graph:
+    def _deserialize(self, graph_data: str, attr: Any, data: Any, **kwargs: Any) -> networkx.Graph:
         raw_data = json.loads(graph_data)
         canonical_addresses = [
             (to_canonical_address(edge[0]), to_canonical_address(edge[1])) for edge in raw_data

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -34,11 +34,11 @@ def _import_type(type_name: str) -> type:
 
 class SerializationBase:
     @staticmethod
-    def serialize(obj):
+    def serialize(obj: Any) -> Any:
         raise NotImplementedError
 
     @staticmethod
-    def deserialize(data):
+    def deserialize(data: Any) -> Any:
         raise NotImplementedError
 
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from types import TracebackType
+from typing import Generator
 
 from typing_extensions import Literal
 
@@ -702,7 +704,7 @@ class SQLiteStorage:
             self.conn.commit()
 
     @contextmanager
-    def transaction(self):
+    def transaction(self) -> Generator[None, None, None]:
         cursor = self.conn.cursor()
         self.in_transaction = True
         try:
@@ -722,14 +724,19 @@ class SQLiteStorage:
         self.conn.close()
         del self.conn
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, "conn"):
             raise RuntimeError("The database connection was not closed.")
 
-    def __enter__(self):
+    def __enter__(self) -> "SQLiteStorage":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):  # pylint: disable=unused-arguments
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:  # pylint: disable=unused-arguments
         self.close()
 
 

--- a/raiden/storage/ulid.py
+++ b/raiden/storage/ulid.py
@@ -19,14 +19,14 @@ class ULID:
 
     identifier: bytes
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert len(self.identifier) == 16, "id_ must be 16 bytes long"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"ULID<{self.identifier.hex()}>"
 
     @property
-    def timestamp(self):
+    def timestamp(self) -> int:
         """Aproximated timestamp of the database entry.
 
         There is no lower bound for the skew in time.

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -41,9 +41,11 @@ of the easy of conversion.
 """
 from collections import namedtuple
 
+from raiden.transfer.architecture import Event
+
 
 class TimestampedEvent(namedtuple("TimestampedEvent", "wrapped_event log_time")):
-    def __getattr__(self, item):
+    def __getattr__(self, item: str) -> Event:
         return getattr(self.wrapped_event, item)
 
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -384,6 +384,7 @@ def transfer_and_assert_path(
 
         receiving.append((to_app, to_channel_state.identifier))
 
+    assert isinstance(app.raiden.message_handler, WaitForMessage)
     results = [
         app.raiden.message_handler.wait_for_message(
             Unlock,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -257,7 +257,7 @@ def run_app(
     )
 
     if transport == "matrix":
-        transport = _setup_matrix(config, routing_mode)
+        matrix_transport = _setup_matrix(config, routing_mode)
     else:
         raise RuntimeError(f'Unknown transport type "{transport}" given')
 
@@ -303,7 +303,7 @@ def run_app(
                 monitoring_service_contract_address
                 or contracts[CONTRACT_MONITORING_SERVICE]["address"]
             ),
-            transport=transport,
+            transport=matrix_transport,
             raiden_event_handler=event_handler,
             message_handler=message_handler,
             routing_mode=routing_mode,

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -11,7 +11,12 @@ from raiden.transfer.events import EventPaymentReceivedSuccess
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import EventUnlockClaimFailed
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
-from raiden.transfer.state import CHANNEL_AFTER_CLOSE_STATES, NODE_NETWORK_REACHABLE, ChannelState
+from raiden.transfer.state import (
+    CHANNEL_AFTER_CLOSE_STATES,
+    NODE_NETWORK_REACHABLE,
+    ChannelState,
+    NettingChannelEndState,
+)
 from raiden.transfer.state_change import (
     ContractReceiveChannelWithdraw,
     ContractReceiveSecretReveal,
@@ -163,11 +168,11 @@ def wait_for_payment_balance(
         This does not time out, use gevent.Timeout.
     """
 
-    def get_balance(end_state):
+    def get_balance(end_state: NettingChannelEndState) -> TokenAmount:
         if end_state.balance_proof:
             return end_state.balance_proof.transferred_amount
         else:
-            return 0
+            return TokenAmount(0)
 
     if target_address == raiden.address:
         balance = lambda channel_state: get_balance(channel_state.partner_state)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,21 +46,32 @@ markers =
 [mypy]
 ignore_missing_imports = True
 check_untyped_defs = True
-# disallow_untyped_defs = True
+disallow_untyped_defs = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
-[mypy-raiden.blockchain.*]
-disallow_untyped_defs = True
-
+# These parts of raiden are not fully typed, yet
+[mypy-raiden.utils.*]
+disallow_untyped_defs = False
+[mypy-raiden.api.*]
+disallow_untyped_defs = False
+[mypy-raiden.ui.*]
+disallow_untyped_defs = False
+[mypy-raiden.messages.*]
+disallow_untyped_defs = False
+[mypy-raiden.network.*]
+disallow_untyped_defs = False
+# ...but this part of raiden.network already is
 [mypy-raiden.network.proxies.*]
 disallow_untyped_defs = True
 
-[mypy-raiden.transfer.*]
-disallow_untyped_defs = True
+# No need to be as strict for our tools
+[mypy-tools.*]
+disallow_untyped_defs = False
 
 [mypy-raiden.tests.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
 
 [mypy-raiden.tests.utils.factories]
 ignore_errors = True

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -24,6 +24,7 @@ def main(keystore_file, password, rpc_url, eth_amount, targets_file) -> None:
         account = Account(json.load(keystore), password, keystore_file)
 
     assert account.privkey
+    assert account.address
     print("Using account:", to_checksum_address(account.address))
 
     client = JSONRPCClient(


### PR DESCRIPTION
## Description

To make sure that no new modules are added to raiden without typing, the
default is now to enforce typing via mypy. Some packages are excluded
for now to make this work without major effort. Before, typing has only
been enforce in selected packages. So we went from a white list to a
black list.

The main change is in `setup.cfg`. The other changes are mostly
straightforward type additions which should not introduce any problems.
These type additions have been made to keep the black list reasonable
short.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
