### PR TITLE
typing for rest.py

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -4,7 +4,6 @@ import logging
 import socket
 from hashlib import sha256
 from http import HTTPStatus
-from typing import Dict
 
 import gevent
 import gevent.pool
@@ -22,6 +21,7 @@ from werkzeug.exceptions import NotFound
 
 from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
 from raiden.api.objects import AddressList, PartnersPerTokenList
+from raiden.api.python import RaidenAPI
 from raiden.api.v1.encoding import (
     AddressListSchema,
     ChannelStateSchema,
@@ -93,9 +93,25 @@ from raiden.utils import (
     create_default_identifier,
     optional_address_to_string,
     split_endpoint,
-    typing,
 )
 from raiden.utils.runnable import Runnable
+from raiden.utils.testnet import MintingMethod
+from raiden.utils.typing import (
+    Address,
+    Any,
+    BlockSpecification,
+    BlockTimeout,
+    Dict,
+    PaymentAmount,
+    PaymentID,
+    Secret,
+    SecretHash,
+    TargetAddress,
+    TokenAddress,
+    TokenAmount,
+    TokenNetworkRegistryAddress,
+    WithdrawAmount,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -303,8 +319,13 @@ class APIServer(Runnable):  # pragma: no unittest
     _api_prefix = "/api/1"
 
     def __init__(
-        self, rest_api, config, cors_domain_list=None, web_ui=False, eth_rpc_endpoint=None
-    ):
+        self,
+        rest_api: "RestAPI",
+        config: Dict[str, Any],
+        cors_domain_list=None,
+        web_ui=False,
+        eth_rpc_endpoint=None,
+    ) -> None:
         super().__init__()
         if rest_api.version != 1:
             raise ValueError(f"Invalid api version: {rest_api.version}")
@@ -412,7 +433,7 @@ class APIServer(Runnable):  # pragma: no unittest
             self.stop()  # ensure cleanup and wait on subtasks
             raise
 
-    def start(self):
+    def start(self) -> None:
         log.debug(
             "REST API starting",
             host=self.config["host"],
@@ -453,7 +474,7 @@ class APIServer(Runnable):  # pragma: no unittest
 
         super().start()
 
-    def stop(self):
+    def stop(self) -> None:
         log.debug(
             "REST API stopping",
             host=self.config["host"],
@@ -492,7 +513,7 @@ class RestAPI:  # pragma: no unittest
 
     version = 1
 
-    def __init__(self, raiden_api):
+    def __init__(self, raiden_api: RaidenAPI) -> None:
         self.raiden_api = raiden_api
         self.channel_schema = ChannelStateSchema()
         self.address_list_schema = AddressListSchema()
@@ -506,9 +527,7 @@ class RestAPI:  # pragma: no unittest
         return api_response(result=dict(our_address=to_checksum_address(self.raiden_api.address)))
 
     def register_token(
-        self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
+        self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress
     ):
         if self.raiden_api.raiden.config["environment_type"] == Environment.PRODUCTION:
             return api_error(
@@ -533,8 +552,8 @@ class RestAPI:  # pragma: no unittest
             token_network_address = self.raiden_api.token_network_register(
                 registry_address=registry_address,
                 token_address=token_address,
-                channel_participant_deposit_limit=UINT256_MAX,
-                token_network_deposit_limit=UINT256_MAX,
+                channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+                token_network_deposit_limit=TokenAmount(UINT256_MAX),
             )
         except conflict_exceptions as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
@@ -548,10 +567,10 @@ class RestAPI:  # pragma: no unittest
 
     def mint_token(
         self,
-        token_address: typing.TokenAddress,
-        to: typing.Address,
-        value: typing.TokenAmount,
-        contract_method: str,
+        token_address: TokenAddress,
+        to: Address,
+        value: TokenAmount,
+        contract_method: MintingMethod,
     ):
         if self.raiden_api.raiden.config["environment_type"] == Environment.PRODUCTION:
             return api_error(
@@ -581,11 +600,11 @@ class RestAPI:  # pragma: no unittest
 
     def open(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        partner_address: typing.Address,
-        token_address: typing.TokenAddress,
-        settle_timeout: typing.BlockTimeout = None,
-        total_deposit: typing.TokenAmount = None,
+        registry_address: TokenNetworkRegistryAddress,
+        partner_address: Address,
+        token_address: TokenAddress,
+        settle_timeout: BlockTimeout = None,
+        total_deposit: TokenAmount = None,
     ):
         log.debug(
             "Opening channel",
@@ -662,11 +681,11 @@ class RestAPI:  # pragma: no unittest
 
     def connect(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
-        funds: typing.TokenAmount,
-        initial_channel_target: int = None,
-        joinable_funds_target: float = None,
+        registry_address: TokenNetworkRegistryAddress,
+        token_address: TokenAddress,
+        funds: TokenAmount,
+        initial_channel_target: int = 3,
+        joinable_funds_target: float = 0.4,
     ):
         log.debug(
             "Connecting to token network",
@@ -692,11 +711,7 @@ class RestAPI:  # pragma: no unittest
 
         return api_response(result=dict(), status_code=HTTPStatus.NO_CONTENT)
 
-    def leave(
-        self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
-    ):
+    def leave(self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress):
         log.debug(
             "Leaving token network",
             node=to_checksum_address(self.raiden_api.address),
@@ -709,7 +724,7 @@ class RestAPI:  # pragma: no unittest
         ]
         return api_response(result=closed_channels)
 
-    def get_connection_managers_info(self, registry_address: typing.TokenNetworkRegistryAddress):
+    def get_connection_managers_info(self, registry_address: TokenNetworkRegistryAddress):
         """Get a dict whose keys are token addresses and whose values are
         open channels, funds of last request, sum of deposits and number of channels"""
         log.debug(
@@ -718,6 +733,7 @@ class RestAPI:  # pragma: no unittest
             registry_address=to_checksum_address(registry_address),
         )
         connection_managers = dict()
+        raiden_service = self.raiden_api.raiden
 
         for token in self.raiden_api.get_tokens_list(registry_address):
             token_network_address = views.get_token_network_address_by_token_address(
@@ -725,13 +741,15 @@ class RestAPI:  # pragma: no unittest
                 token_network_registry_address=registry_address,
                 token_address=token,
             )
+            connection_manager = None
 
-            try:
-                connection_manager = self.raiden_api.raiden.connection_manager_for_token_network(
-                    token_network_address
-                )
-            except InvalidBinaryAddress:
-                connection_manager = None
+            if token_network_address is not None:
+                try:
+                    connection_manager = raiden_service.connection_manager_for_token_network(
+                        token_network_address
+                    )
+                except InvalidBinaryAddress:
+                    pass
 
             open_channels = views.get_channelstate_open(
                 chain_state=views.state_from_raiden(self.raiden_api.raiden),
@@ -751,9 +769,9 @@ class RestAPI:  # pragma: no unittest
 
     def get_channel_list(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress = None,
-        partner_address: typing.Address = None,
+        registry_address: TokenNetworkRegistryAddress,
+        token_address: TokenAddress = None,
+        partner_address: Address = None,
     ):
         log.debug(
             "Getting channel list",
@@ -771,7 +789,7 @@ class RestAPI:  # pragma: no unittest
         ]
         return api_response(result=result)
 
-    def get_tokens_list(self, registry_address: typing.TokenNetworkRegistryAddress):
+    def get_tokens_list(self, registry_address: TokenNetworkRegistryAddress):
         log.debug(
             "Getting token list",
             node=to_checksum_address(self.raiden_api.address),
@@ -784,9 +802,7 @@ class RestAPI:  # pragma: no unittest
         return api_response(result=result)
 
     def get_token_network_for_token(
-        self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
+        self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress
     ):
         log.debug(
             "Getting token network for token",
@@ -806,9 +822,9 @@ class RestAPI:  # pragma: no unittest
 
     def get_blockchain_events_network(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        from_block: typing.BlockSpecification = GENESIS_BLOCK_NUMBER,
-        to_block: typing.BlockSpecification = "latest",
+        registry_address: TokenNetworkRegistryAddress,
+        from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
+        to_block: BlockSpecification = "latest",
     ):
         log.debug(
             "Getting network events",
@@ -828,9 +844,9 @@ class RestAPI:  # pragma: no unittest
 
     def get_blockchain_events_token_network(
         self,
-        token_address: typing.TokenAddress,
-        from_block: typing.BlockSpecification = GENESIS_BLOCK_NUMBER,
-        to_block: typing.BlockSpecification = "latest",
+        token_address: TokenAddress,
+        from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
+        to_block: BlockSpecification = "latest",
     ):
         log.debug(
             "Getting token network blockchain events",
@@ -851,8 +867,8 @@ class RestAPI:  # pragma: no unittest
 
     def get_raiden_events_payment_history_with_timestamps(
         self,
-        token_address: typing.TokenAddress = None,
-        target_address: typing.Address = None,
+        token_address: TokenAddress = None,
+        target_address: Address = None,
         limit: int = None,
         offset: int = None,
     ):
@@ -902,10 +918,10 @@ class RestAPI:  # pragma: no unittest
 
     def get_blockchain_events_channel(
         self,
-        token_address: typing.TokenAddress,
-        partner_address: typing.Address = None,
-        from_block: typing.BlockSpecification = GENESIS_BLOCK_NUMBER,
-        to_block: typing.BlockSpecification = "latest",
+        token_address: TokenAddress,
+        partner_address: Address = None,
+        from_block: BlockSpecification = GENESIS_BLOCK_NUMBER,
+        to_block: BlockSpecification = "latest",
     ):
         log.debug(
             "Getting channel blockchain events",
@@ -930,9 +946,9 @@ class RestAPI:  # pragma: no unittest
 
     def get_channel(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
-        partner_address: typing.Address,
+        registry_address: TokenNetworkRegistryAddress,
+        token_address: TokenAddress,
+        partner_address: Address,
     ):
         log.debug(
             "Getting channel",
@@ -953,9 +969,7 @@ class RestAPI:  # pragma: no unittest
             return api_error(errors=str(e), status_code=HTTPStatus.NOT_FOUND)
 
     def get_partners_by_token(
-        self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
+        self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress
     ):
         log.debug(
             "Getting partners by token",
@@ -990,13 +1004,13 @@ class RestAPI:  # pragma: no unittest
 
     def initiate_payment(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
-        target_address: typing.Address,
-        amount: typing.TokenAmount,
-        identifier: typing.PaymentID,
-        secret: typing.Secret,
-        secret_hash: typing.SecretHash,
+        registry_address: TokenNetworkRegistryAddress,
+        token_address: TokenAddress,
+        target_address: TargetAddress,
+        amount: PaymentAmount,
+        identifier: PaymentID,
+        secret: Secret,
+        secret_hash: SecretHash,
     ):
         log.debug(
             "Initiating payment",
@@ -1059,9 +1073,9 @@ class RestAPI:  # pragma: no unittest
 
     def _deposit(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
+        registry_address: TokenNetworkRegistryAddress,
         channel_state: NettingChannelState,
-        total_deposit: typing.TokenAmount,
+        total_deposit: TokenAmount,
     ):
         log.debug(
             "Depositing to channel",
@@ -1102,9 +1116,9 @@ class RestAPI:  # pragma: no unittest
 
     def _withdraw(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
+        registry_address: TokenNetworkRegistryAddress,
         channel_state: NettingChannelState,
-        total_withdraw: typing.TokenAmount,
+        total_withdraw: WithdrawAmount,
     ):
         log.debug(
             "Withdrawing from channel",
@@ -1139,9 +1153,7 @@ class RestAPI:  # pragma: no unittest
         return api_response(result=result)
 
     def _close(
-        self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        channel_state: NettingChannelState,
+        self, registry_address: TokenNetworkRegistryAddress, channel_state: NettingChannelState
     ):
         log.debug(
             "Closing channel",
@@ -1172,11 +1184,11 @@ class RestAPI:  # pragma: no unittest
 
     def patch_channel(
         self,
-        registry_address: typing.TokenNetworkRegistryAddress,
-        token_address: typing.TokenAddress,
-        partner_address: typing.Address,
-        total_deposit: typing.TokenAmount = None,
-        total_withdraw: typing.TokenAmount = None,
+        registry_address: TokenNetworkRegistryAddress,
+        token_address: TokenAddress,
+        partner_address: Address,
+        total_deposit: TokenAmount = None,
+        total_withdraw: WithdrawAmount = None,
         state: str = None,
     ):
         log.debug(


### PR DESCRIPTION
I added the type for the RaidenService so that jedi can jump around the definitions. That caught two bugs in the connection manager endpoint.