### PR TITLE
Fix wrong parameter in connection manager

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -233,11 +233,11 @@ class ConnectionManager:  # pragma: no unittest
         # Wait for any pending operation in the channel to complete, before
         # deciding on the deposit
         with self.lock, token_network_proxy.channel_operations_lock[partner_address]:
-            channel_state = views.get_channelstate_for(  # type: ignore # FIXME: arg 2 looks wrong!
-                views.state_from_raiden(self.raiden),
-                self.token_network_address,
-                self.token_address,
-                partner_address,
+            channel_state = views.get_channelstate_for(
+                chain_state=views.state_from_raiden(self.raiden),
+                token_network_registry_address=self.registry_address,
+                token_address=self.token_address,
+                partner_address=partner_address,
             )
 
             if not channel_state:


### PR DESCRIPTION
Fixes: #4725 

## Description

The second paramter of the function call was wrong.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
