### PR TITLE
Add more logs to the connection manager

### DIFF
--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -319,6 +319,11 @@ class ConnectionManager:  # pragma: no unittest
 
     def _join_partner(self, partner: Address) -> None:
         """ Ensure a channel exists with partner and is funded in our side """
+        log.info(
+            "Trying to join or fund channel with partner further",
+            node=to_checksum_address(self.raiden.address),
+            partner=to_checksum_address(partner),
+        )
         try:
             self.api.channel_open(self.registry_address, self.token_address, partner)
         except DuplicatedChannelError:
@@ -474,5 +479,5 @@ class ConnectionManager:  # pragma: no unittest
         )
         return (
             f"{self.__class__.__name__}(target={self.initial_channel_target} "
-            + f"channels={len(open_channels)}:{open_channels!r})"
+            + f"open_channels={len(open_channels)}:{open_channels!r})"
         )


### PR DESCRIPTION
If I had these logs when debugging this:
https://github.com/raiden-network/raiden/issues/4451#issuecomment-527405820
things would have gone much faster.

