### PR TITLE
Some more json-log-to-html improvements

### DIFF
--- a/tools/debugging/gather-test-addresses.py
+++ b/tools/debugging/gather-test-addresses.py
@@ -1,0 +1,71 @@
+import json
+import re
+import string
+from json import JSONDecodeError
+from typing import Any, Dict, List, Optional, Set, TextIO
+
+import click
+from eth_utils import to_checksum_address
+from eth_utils.typing import ChecksumAddress
+
+EVENT_FIELD_REGEXES = {
+    "node": re.compile(r"(0x[0-9a-fA-F]{40})"),
+    "current_user": re.compile("@(0x[0-9a-fA-F]{40}):.+"),
+    "greenlet_name": re.compile(".+node:(0x[0-9a-fA-F]{40}).*"),
+}
+
+
+def _to_base_26(value: int) -> str:
+    alphabet = string.ascii_uppercase
+    output: List[str] = []
+    if value == 0:
+        output = [alphabet[0]]
+    while value > 0:
+        output.append(alphabet[value % 26])
+        value //= 26
+    return "".join(reversed(output))
+
+
+def get_record_address(record: Dict[str, Any]) -> Optional[ChecksumAddress]:
+    for event_field, field_regex in EVENT_FIELD_REGEXES.items():
+        if event_field in record:
+            match = field_regex.match(record[event_field])
+            if match:
+                return to_checksum_address(match.group(1))
+
+
+def find_node_addresses(input_file: TextIO) -> Set[ChecksumAddress]:
+    addresses = set()
+    for line in input_file:
+        try:
+            record = json.loads(line)
+        except (JSONDecodeError, UnicodeDecodeError):
+            continue
+        address = get_record_address(record)
+        if address:
+            addresses.add(address)
+    return addresses
+
+
+@click.command(
+    help=(
+        "Collect node addresses used in a test run log file. "
+        "Writes a json-log-to-html compatible replacements file."
+    )
+)
+@click.argument("input-file", type=click.File("rt"))
+@click.argument("output-file", type=click.File("wt"), default="-")
+def main(input_file, output_file):
+    node_addresses = find_node_addresses(input_file)
+    click.secho(f"Found {len(node_addresses)} addresses", fg="green", err=True)
+    for node_address in sorted(node_addresses):
+        click.secho(f"  - {node_address}", fg="blue", err=True)
+    replacements = {
+        address: f"<<{_to_base_26(i)}>>" for i, address in enumerate(sorted(node_addresses))
+    }
+    output_file.write(json.dumps(replacements))
+    click.secho(f"Wrote replacements to {output_file.name}", fg="green", err=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/debugging/json-log-to-html.py
+++ b/tools/debugging/json-log-to-html.py
@@ -8,12 +8,16 @@ Allows to filter records by `event`.
 
 import hashlib
 import json
+import webbrowser
 from collections import Counter, namedtuple
 from copy import copy
+from dataclasses import dataclass
 from datetime import datetime
 from html import escape
+from itertools import chain
 from json import JSONDecodeError
 from math import log10
+from pathlib import Path
 from typing import (
     Any,
     Counter as CounterType,
@@ -36,8 +40,6 @@ from colour import Color
 from eth_utils import is_address, to_canonical_address
 
 from raiden.utils import pex
-
-Record = namedtuple("Line", ("event", "timestamp", "logger", "level", "fields"))
 
 TIME_PAST = datetime(1970, 1, 1)
 TIME_FUTURE = datetime(9999, 1, 1)
@@ -319,7 +321,6 @@ body {{
     color: white;
 }}
 table {{
-    white-space: nowrap;
     border: none;
 }}
 table tr.head {{
@@ -356,6 +357,13 @@ td.no, td.time * {{
 }}
 td.no {{
     text-align: right;
+}}
+td.event {{
+    min-width: 20em;
+    max-width: 35em;
+}}
+td.fields {{
+    white-space: nowrap;
 }}
 .lvl-debug {{
     color: #20d0d0;
@@ -396,13 +404,36 @@ PAGE_END = """\
 ROW_TEMPLATE = """
 <tr class="lvl-{record.level} {additional_row_class}">
     <td class="no">{index}</td>
-    <td><b style="color: {event_color}">{record.event}</b></td>
+    <td class="event"><b style="color: {event_color}">{record.event}</b></td>
     <td class="time"><span title="{time_absolute}" style="{time_color}">{time_display}</span></td>
-    <td>{record.logger}</td>
+    <td><span title="{record.logger}">{logger_name}</span></td>
     <td>{record.level}</td>
-    <td>{fields}</td>
+    <td class="fields">{fields}</td>
 </tr>
 """
+
+
+Record = namedtuple(
+    "Record", ("event", "timestamp", "logger", "truncated_logger", "level", "fields")
+)
+
+
+@cached(LRUCache(maxsize=1_000))
+def truncate_logger_name(logger: str) -> str:
+    """ Truncate dotted logger path names.
+
+    Keeps the last component unchanged.
+
+    >>> truncate_logger_name("some.logger.name")
+    s.l.name
+
+    >>> truncate_logger_name("name")
+    name
+    """
+    if "." not in logger:
+        return logger
+    logger_path, _, logger_module = logger.rpartition(".")
+    return ".".join(chain((part[0] for part in logger_path.split(".")), [logger_module]))
 
 
 def _colorize_cache_key(value: Any, min_luminance: float) -> Tuple[str, float]:
@@ -503,11 +534,13 @@ def parse_log(log_file: TextIO) -> Tuple[List[Record], CounterType[int]]:
         else:
             timestamp = last_ts
 
+        logger_name = line_dict.pop("logger", "MISSING")
         log_records.append(
             Record(
                 line_dict.pop("event"),
                 timestamp,
-                line_dict.pop("logger", "MISSING"),
+                logger_name,
+                truncate_logger_name(logger_name),
                 line_dict.pop("level", "MISSING"),
                 line_dict,
             )
@@ -556,7 +589,7 @@ def transform_records(
             return type(value)(replace(inner) for inner in value)
         elif isinstance(value, dict):
             return {replace(k): replace(v) for k, v in value.items()}
-        str_value = str(value).lower()
+        str_value = str(value).casefold()
         if isinstance(value, str):
             keys_in_value = [key for key in replacement_keys if key in str_value]
             for key in keys_in_value:
@@ -565,15 +598,19 @@ def transform_records(
                 except ValueError:
                     # Value no longer in string due to replacement
                     continue
+                # We use this awkward replacement code since matching is done on a lowercased
+                # version of the string but we want to keep the original case in the output
                 value = f"{value[:repl_start]}{replacements[key]}{value[repl_start + len(key):]}"
-                str_value = value.lower()
+                str_value = value.casefold()
         return replacements.get(str_value, value)
 
-    replacements = {str(k).lower(): v for k, v in replacements.items()}
+    replacements = {str(k).casefold(): v for k, v in replacements.items()}
     for k, v in copy(replacements).items():
-        # Special handling for `pex()`ed eth addresses
+        # Special handling for `pex()`ed and repr'd binary eth addresses
         if isinstance(k, str) and k.startswith("0x") and is_address(k):
-            replacements[pex(to_canonical_address(k))] = v
+            bytes_address = to_canonical_address(k)
+            replacements[pex(bytes_address)] = v
+            replacements[repr(bytes_address).casefold()] = v
     replacement_keys = replacements.keys()
     for record in log_records:
         yield replace(record)
@@ -586,8 +623,9 @@ def render(
     output: TextIO,
     wrap: bool = False,
     show_time_diff: bool = True,
+    truncate_logger: bool = False,
     highlight_records: Optional[Iterable[int]] = (),
-) -> None:
+):
     sorted_known_fields = [name for name, count in known_fields.most_common()]
     highlight_records_set = set(highlight_records) if highlight_records else set()
     prev_record = None
@@ -603,10 +641,12 @@ def render(
         time_absolute, time_color, time_display = get_time_display(prev_record, record)
         event_color = rgb_color_picker(record.event, min_luminance=0.6)
         rendered_fields = render_fields(record, sorted_known_fields)
+
         output.write(
             ROW_TEMPLATE.format(
                 index=i,
                 record=record,
+                logger_name=record.truncated_logger if truncate_logger else record.logger,
                 time_absolute=time_absolute,
                 time_display=time_display,
                 time_color=time_color,
@@ -661,7 +701,7 @@ def render(
         "Input must be a JSON object. "
         "Keys are transformed to lowercase strings before matching. "
         "Partial substring matches will also be replaced. "
-        "Eth-Addresses will also be replaced in pex()ed format."
+        "Eth-Addresses will also be replaced in pex()ed and binary format."
     ),
 )
 @click.option(
@@ -671,7 +711,6 @@ def render(
     help="Behaves as -r / --replacements but reads the JSON object from the given file.",
 )
 @click.option(
-    "-t",
     "--time-range",
     default="^",
     help=(
@@ -689,12 +728,26 @@ def render(
     "-w", "--wrap", is_flag=True, help="Wrap event details into multiple lines.", show_default=True
 )
 @click.option(
+    "-t",
+    "--truncate-logger",
+    is_flag=True,
+    show_default=True,
+    help="Shorten logger module paths ('some.module.logger' -> 's.m.logger').",
+)
+@click.option(
     "-h",
     "--highlight-record",
     "highlight_records",
     multiple=True,
     type=int,
     help="Highlight record with given number. Can be given multiple times.",
+)
+@click.option(
+    "-b",
+    "--open-browser",
+    is_flag=True,
+    help="Open output file in default browser after rendering",
+    show_default=True,
 )
 def main(
     log_file: TextIO,
@@ -706,7 +759,9 @@ def main(
     time_range: str,
     wrap: bool,
     time_diff: bool,
+    truncate_logger: bool,
     highlight_records: List[int],
+    open_browser: bool,
     output: TextIO,
 ) -> None:
     if replacements_from_file:
@@ -750,9 +805,14 @@ def main(
             output=output,
             wrap=wrap,
             show_time_diff=time_diff,
+            truncate_logger=truncate_logger,
             highlight_records=highlight_records,
         )
     click.secho(f"Output written to {click.style(output.name, fg='yellow')}", fg="green")
+    if open_browser:
+        if output.name == "<stdout>":
+            click.secho("Can't open output when writing to stdout.", fg="red")
+        webbrowser.open(f"file://{Path(output.name).resolve()}")
 
 
 if __name__ == "__main__":

--- a/tools/debugging/json-log-to-html.py
+++ b/tools/debugging/json-log-to-html.py
@@ -11,7 +11,6 @@ import json
 import webbrowser
 from collections import Counter, namedtuple
 from copy import copy
-from dataclasses import dataclass
 from datetime import datetime
 from html import escape
 from itertools import chain


### PR DESCRIPTION
Some more small improvements to the json-log-to-html tool.

Adds a `--truncate-logger` option to shorten logger names so they take up less space on screen.

Also adds another small utility that collects the active node addresses from log files and generates a replacement file mapping the addresses to nicer human readable strings usable with json-log-to-html.

Example usage:
```
~$ python3 raiden/tools/debugging/gather-test-addresses.py *.log replacements.json
~$ cat replacements.json
{"0xabcdef1234567890abcdef1234567890abcdef12": "<<A>>", "0x0987654321fedcba0x0987654321fedcba0x0987": "<<B>>"}
~$ python3 raiden/tools/debugging/json-log-to-html.py [... other options ...] -f replacements.json
```
