### PR TITLE
Added __str__ to CanonicalIdentifier

### DIFF
--- a/raiden/transfer/identifiers.py
+++ b/raiden/transfer/identifiers.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from eth_utils import to_checksum_address
+
 from raiden.constants import EMPTY_ADDRESS, UINT256_MAX
 from raiden.utils.typing import (
     Address,
@@ -26,6 +28,15 @@ class CanonicalIdentifier:
 
         if self.channel_identifier < 0 or self.channel_identifier > UINT256_MAX:
             raise ValueError("channel id is invalid")
+
+    def __str__(self) -> str:
+        return (
+            "CanonicalIdentifier("
+            f"chain_identifier={self.chain_identifier}, "
+            f"token_network_address={to_checksum_address(self.token_network_address)}, "
+            f"channel_identifier={self.channel_identifier}"
+            ")"
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Description

This just adds a `__str__` that encoded the token address as a checksum address. I introduce this because the current format while [logging](https://github.com/raiden-network/raiden/blob/8ff88a3fb1f6852156ab0505a92778d5a3b8f7b8/raiden/waiting.py#L478-L481) this value looks like this `canonical_identifier=CanonicalIdentifier(chain_identifier=42, token_network_address=b'#\xe1\xf3\xb0\x0e\t\xb6\x00D\xb2#\xba\xce\xe8\x1e\xad\xf8\xf50\xff', channel_identifier=1)`

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
