### PR TITLE
Added __str__ to QueueIdentifier

### DIFF
--- a/raiden/transfer/identifiers.py
+++ b/raiden/transfer/identifiers.py
@@ -44,6 +44,14 @@ class QueueIdentifier:
     recipient: Address
     canonical_identifier: CanonicalIdentifier
 
+    def __str__(self) -> str:
+        return (
+            "QueueIdentifier("
+            f"recipient={to_checksum_address(self.recipient)}, "
+            f"canonical_identifier={self.canonical_identifier}"
+            ")"
+        )
+
 
 CANONICAL_IDENTIFIER_GLOBAL_QUEUE = CanonicalIdentifier(
     ChainID(0), TokenNetworkAddress(EMPTY_ADDRESS), ChannelID(0)


### PR DESCRIPTION
## Description
This just adds a __str__ that encoded the recipient address as a checksum address. I introduce this because the current format while logging this value looks like this `QueueIdentifier(recipient=b'\\xe0\\x90\"\\x84\\xc8Z\\x9a\\x03\\xda\\xa3\\xb5\\xab\\x03.#\\x8c\\xc0\\\\\\xff\\x9a', canonical_identifier=CanonicalIdentifier(chain_identifier=42, token_network_address=b'#\\xe1\\xf3\\xb0\\x0e\\t\\xb6\\x00D\\xb2#\\xba\\xce\\xe8\\x1e\\xad\\xf8\\xf50\\xff', channel_identifier=1))`

(Note: The token network address is fixed by: https://github.com/raiden-network/raiden/pull/4753)

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
