### PR TITLE
Properly calculate per channel fees from CLI args

### DIFF
--- a/raiden/tests/utils/mediation_fees.py
+++ b/raiden/tests/utils/mediation_fees.py
@@ -1,0 +1,40 @@
+import pytest
+
+from raiden.tests.utils import factories
+from raiden.utils.mediation_fees import prepare_mediation_fee_config
+from raiden.utils.typing import ProportionalFeeAmount
+
+
+@pytest.mark.parametrize("flat_fees", [(42, 21), (43, 21)])
+def test_prepare_mediation_fee_config_flat_fee(flat_fees):
+    cli_flat_fee, expected_channel_flat_fee = flat_fees
+    token_network_address = factories.make_token_network_address()
+    fee_config = prepare_mediation_fee_config(
+        cli_token_network_to_flat_fee=((token_network_address, cli_flat_fee),),
+        proportional_fee=ProportionalFeeAmount(0),
+        proportional_imbalance_fee=ProportionalFeeAmount(0),
+    )
+
+    assert fee_config.get_flat_fee(token_network_address) == expected_channel_flat_fee
+
+
+@pytest.mark.parametrize(
+    "prop_fees",
+    [
+        (1_000_000, 1_000_000),  # 100%
+        (999_999, 999_000),  # 99.9999%
+        (990_000, 900_000),  # 99%
+        (100_000, 51317),  # 10%
+        (10_000, 5013),  # 1%
+        (0, 0),  # 0%
+    ],
+)
+def test_prepare_mediation_fee_config_prop_fee(prop_fees):
+    cli_prop_fee, expected_channel_prop_fee = prop_fees
+    fee_config = prepare_mediation_fee_config(
+        cli_token_network_to_flat_fee=(),
+        proportional_fee=ProportionalFeeAmount(cli_prop_fee),
+        proportional_imbalance_fee=ProportionalFeeAmount(0),
+    )
+
+    assert fee_config.proportional_fee == expected_channel_prop_fee

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -242,7 +242,7 @@ def get_lock_amount_after_fees(
     # fee_out should be calculated on the payment amount without any fees. But
     # we only have the amount including fee_out, so we use that as an
     # approximation.
-    fee_out = _fee_for_channel(payee_channel, PaymentAmount(lock.amount - fee_in))
+    fee_out = _fee_for_channel(payee_channel, PaymentAmount(lock.amount))
     return PaymentWithFeeAmount(lock.amount - fee_in - fee_out)
 
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -242,7 +242,7 @@ def get_lock_amount_after_fees(
     # fee_out should be calculated on the payment amount without any fees. But
     # we only have the amount including fee_out, so we use that as an
     # approximation.
-    fee_out = _fee_for_channel(payee_channel, PaymentAmount(lock.amount))
+    fee_out = _fee_for_channel(payee_channel, PaymentAmount(lock.amount - fee_in))
     return PaymentWithFeeAmount(lock.amount - fee_in - fee_out)
 
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -181,12 +181,16 @@ def run_app(
         api_port = Port(DEFAULT_HTTP_SERVER_PORT)
 
     # Store the flat fee settings for the given token networks
+    # The given flat fee is for the whole mediation, but that includes two channels.
+    # Therefore divide by 2 here.
     token_network_to_flat_fee: Dict[TokenNetworkAddress, FeeAmount] = {
-        address: fee for address, fee in flat_fee
+        address: FeeAmount(fee // 2) for address, fee in flat_fee
     }
+    # Given prop. fee also counts per mediation, therefore divide by 2 as well
+    # Division is fine here, as the prop. fees are applied independently, not subsequently
     fee_config = MediationFeeConfig(
         token_network_to_flat_fee=token_network_to_flat_fee,
-        proportional_fee=proportional_fee,
+        proportional_fee=ProportionalFeeAmount(proportional_fee // 2),
         proportional_imbalance_fee=proportional_imbalance_fee,
     )
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from math import sqrt
 from typing import Any, Callable, Dict, TextIO
 from urllib.parse import urlparse
 
@@ -125,6 +126,37 @@ def rpc_normalized_endpoint(eth_rpc_endpoint: str) -> str:
     return f"http://{eth_rpc_endpoint}"
 
 
+def prepare_mediation_fee_config(
+    flat_fees: Tuple[Tuple[TokenNetworkAddress, FeeAmount], ...],
+    proportional_fee: ProportionalFeeAmount,
+    proportional_imbalance_fee: ProportionalFeeAmount,
+) -> MediationFeeConfig:
+    """ Converts the mediation fee CLI args to proper per-channel
+    mediation fees. """
+    # Store the flat fee settings for the given token networks
+    # The given flat fee is for the whole mediation, but that includes two channels.
+    # Therefore divide by 2 here.
+    token_network_to_flat_fee: Dict[TokenNetworkAddress, FeeAmount] = {
+        address: FeeAmount(fee // 2) for address, fee in flat_fees
+    }
+    # Given prop. fee also counts per mediation, therefore it needs to be adjusted on
+    # a per-channel basis:
+    # x * (1 - p) * (1 - p) = x * (1 - q)
+    # where
+    #    x = payment amount
+    #    q = cli proportional fee
+    #    p = per channel proportional fee
+    # Leads to: p = 1 - sqrt(1 - q)
+    proportional_fee_ratio = proportional_fee / 1e6
+    channel_prop_fee_ratio = 1 - sqrt(1 - proportional_fee_ratio)
+    channel_prop_fee = round(channel_prop_fee_ratio * 1e6)
+    return MediationFeeConfig(
+        token_network_to_flat_fee=token_network_to_flat_fee,
+        proportional_fee=ProportionalFeeAmount(channel_prop_fee),
+        proportional_imbalance_fee=proportional_imbalance_fee,
+    )
+
+
 def run_app(
     address: Address,
     keystore_path: str,
@@ -180,17 +212,9 @@ def run_app(
     if not api_port:
         api_port = Port(DEFAULT_HTTP_SERVER_PORT)
 
-    # Store the flat fee settings for the given token networks
-    # The given flat fee is for the whole mediation, but that includes two channels.
-    # Therefore divide by 2 here.
-    token_network_to_flat_fee: Dict[TokenNetworkAddress, FeeAmount] = {
-        address: FeeAmount(fee // 2) for address, fee in flat_fee
-    }
-    # Given prop. fee also counts per mediation, therefore divide by 2 as well
-    # Division is fine here, as the prop. fees are applied independently, not subsequently
-    fee_config = MediationFeeConfig(
-        token_network_to_flat_fee=token_network_to_flat_fee,
-        proportional_fee=ProportionalFeeAmount(proportional_fee // 2),
+    fee_config = prepare_mediation_fee_config(
+        flat_fees=flat_fee,
+        proportional_fee=proportional_fee,
         proportional_imbalance_fee=proportional_imbalance_fee,
     )
 

--- a/raiden/utils/mediation_fees.py
+++ b/raiden/utils/mediation_fees.py
@@ -1,0 +1,35 @@
+from math import sqrt
+
+from raiden.settings import MediationFeeConfig
+from raiden.utils.typing import Dict, FeeAmount, ProportionalFeeAmount, TokenNetworkAddress, Tuple
+
+
+def prepare_mediation_fee_config(
+    cli_token_network_to_flat_fee: Tuple[Tuple[TokenNetworkAddress, FeeAmount], ...],
+    proportional_fee: ProportionalFeeAmount,
+    proportional_imbalance_fee: ProportionalFeeAmount,
+) -> MediationFeeConfig:
+    """ Converts the mediation fee CLI args to proper per-channel
+    mediation fees. """
+    # Store the flat fee settings for the given token networks
+    # The given flat fee is for the whole mediation, but that includes two channels.
+    # Therefore divide by 2 here.
+    token_network_to_flat_fee: Dict[TokenNetworkAddress, FeeAmount] = {
+        address: FeeAmount(fee // 2) for address, fee in cli_token_network_to_flat_fee
+    }
+    # Given prop. fee also counts per mediation, therefore it needs to be adjusted on
+    # a per-channel basis:
+    # x * (1 - p) * (1 - p) = x * (1 - q)
+    # where
+    #    x = payment amount
+    #    q = cli proportional fee
+    #    p = per channel proportional fee
+    # Leads to: p = 1 - sqrt(1 - q)
+    proportional_fee_ratio = proportional_fee / 1e6
+    channel_prop_fee_ratio = 1 - sqrt(1 - proportional_fee_ratio)
+    channel_prop_fee = round(channel_prop_fee_ratio * 1e6)
+    return MediationFeeConfig(
+        token_network_to_flat_fee=token_network_to_flat_fee,
+        proportional_fee=ProportionalFeeAmount(channel_prop_fee),
+        proportional_imbalance_fee=proportional_imbalance_fee,
+    )


### PR DESCRIPTION
Part of #4748

The CLI args are given as "per mediation", while the channel fees are
applied per channel that takes part in the mediation. This leads to
counter-intuitive behaviour, which is fixed by this PR.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
