### PR TITLE
Test fee integration with different fee schedules

### DIFF
--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -333,12 +333,11 @@ def handle_secretrequest(
 
     already_received_secret_request = initiator_state.received_secret_request
 
-    # lock.amount includes the fees, transfer_description.amount is the actual
-    # payment amount, for the transfer to be valid and the unlock allowed the
-    # target must receive an amount between these values.
+    # transfer_description.amount is the actual payment amount without fees.
+    # For the transfer to be valid and the unlock allowed the target must
+    # receive at leat that amount.
     is_valid_secretrequest = (
-        state_change.amount <= lock.amount
-        and state_change.amount >= initiator_state.transfer_description.amount
+        state_change.amount >= initiator_state.transfer_description.amount
         and state_change.expiration == lock.expiration
         and initiator_state.transfer_description.secret != ABSENT_SECRET
     )

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -335,7 +335,7 @@ def handle_secretrequest(
 
     # transfer_description.amount is the actual payment amount without fees.
     # For the transfer to be valid and the unlock allowed the target must
-    # receive at leat that amount.
+    # receive at least that amount.
     is_valid_secretrequest = (
         state_change.amount >= initiator_state.transfer_description.amount
         and state_change.expiration == lock.expiration

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -116,7 +116,7 @@ def is_safe_to_wait(
 
 
 def is_send_transfer_almost_equal(
-    send_channel: NettingChannelState,
+    send_channel: NettingChannelState,  # pylint: disable=unused-argument
     send: LockedTransferUnsignedState,
     received: LockedTransferSignedState,
 ) -> bool:
@@ -127,8 +127,12 @@ def is_send_transfer_almost_equal(
         and isinstance(received, LockedTransferSignedState)
         and send.payment_identifier == received.payment_identifier
         and send.token == received.token
-        # FIXME: user proper fee calculation
-        and send.lock.amount == received.lock.amount - send_channel.fee_schedule.flat
+        # FIXME: Checking the transferred amount would make a lot of sense, but
+        #        this is hard to do precisely without larger changes to the
+        #        codebase. With the uncertainty about how we want to deal with
+        #        refunds and backtracking in the long term, this check is
+        #        skipped for now.
+        # and send.lock.amount == received.lock.amount - send_channel.fee_schedule.flat
         and send.lock.expiration == received.lock.expiration
         and send.lock.secrethash == received.lock.secrethash
         and send.initiator == received.initiator


### PR DESCRIPTION
Fixes: https://github.com/raiden-network/raiden/issues/4747

## Description

Test different fee schedules in an integration test. This showed the need to relax existing checks in the Raiden code base which are not true anymore after the introduction of the mediation fees. See commit messages for more details. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
