### PR TITLE
Set total withdraw expired message

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`4762` Properly check the withdraw expiration on the TokenNetworkProxy. This gives a better error message to the users and prevents a corner case error.
 * :feature:`4102` Display progress during syncing the blockchain.
 * :feature:`4654` Define imbalance fees relative to channel balance.
 * :feature:`4653` Allow setting per token network flat mediation fee from CLI.

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1447,11 +1447,19 @@ class TokenNetwork:
                 )
                 raise RaidenUnrecoverableError(msg)
 
+            if expiration_block < failed_at_blocknumber:
+                msg = (
+                    f"setTotalWithdraw would have failed because current block is "
+                    f"higher than the withdraw expiration expiration_block={expiration_block} "
+                    f"transation_checked_at={failed_at_blocknumber}"
+                )
+                raise RaidenRecoverableError(msg)
+
             total_withdraw_done = our_details.withdrawn >= total_withdraw
             if total_withdraw_done:
                 raise RaidenRecoverableError("Requested total withdraw was already performed")
 
-            raise RaidenUnrecoverableError("unlock failed for an unknown reason")
+            raise RaidenUnrecoverableError("setTotalWithdraw failed for an unknown reason")
 
     def close(
         self,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -1416,7 +1416,7 @@ class TokenNetwork:
                     )
                     raise RaidenUnrecoverableError(msg)
 
-                if expiration_block < failed_at_blocknumber:
+                if expiration_block <= failed_at_blocknumber:
                     msg = (
                         f"setTotalWithdraw failed because the transaction was "
                         f"mined after the withdraw expired "
@@ -1478,10 +1478,11 @@ class TokenNetwork:
                 )
                 raise RaidenUnrecoverableError(msg)
 
-            if expiration_block < failed_at_blocknumber:
+            if expiration_block <= failed_at_blocknumber:
                 msg = (
-                    f"setTotalWithdraw would have failed because current block is "
-                    f"higher than the withdraw expiration expiration_block={expiration_block} "
+                    f"setTotalWithdraw would have failed because current block "
+                    f"has already reached the withdraw expiration "
+                    f"expiration_block={expiration_block} "
                     f"transation_checked_at={failed_at_blocknumber}"
                 )
                 raise RaidenRecoverableError(msg)


### PR DESCRIPTION
## Description

This PR improves the error checking for withdraws noticed on https://github.com/raiden-network/raiden/issues/4749#issuecomment-528455275 , instead of:

> raiden.exceptions.RaidenUnrecoverableError: unlock failed for an unknown reason

This will use:

> raiden.exceptions.RaidenRecoverableError: setTotalWithdraw would have failed because current block is higher than the withdraw expiration expiration_block=13274504 transation_checked_at=13299685

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [x] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [x] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [x] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [x] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
