### PR TITLE
The settle_timeout range is inclusive

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -227,7 +227,7 @@ class TokenNetwork:
 
         timeout_min = self.settlement_timeout_min()
         timeout_max = self.settlement_timeout_max()
-        invalid_timeout = settle_timeout < timeout_min or settle_timeout > timeout_max
+        invalid_timeout = settle_timeout <= timeout_min or settle_timeout >= timeout_max
         if invalid_timeout:
             msg = (
                 f"settle_timeout must be in range [{timeout_min}, "


### PR DESCRIPTION
## Description

This fixes a mismatch among the proxies and the smart contract. The smart contract allowed inclusive values, while the proxies used exclusive checks.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
