### PR TITLE
Add missing check for the deprecation switch on channel open

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -391,6 +391,18 @@ class RaidenAPI:  # pragma: no unittest
 
         token_network = self.raiden.chain.token_network(token_network_address)
 
+        safety_deprecation_switch = token_network.safety_deprecation_switch(
+            block_identifier=confirmed_block_identifier
+        )
+
+        if safety_deprecation_switch:
+            msg = (
+                "This token_network has been deprecated. New channels cannot be "
+                "open for this network, usage of the newly deployed token "
+                "network contract is highly encouraged."
+            )
+            raise TokenNetworkDeprecated(msg)
+
         duplicated_channel = self.is_already_existing_channel(
             token_network_address=token_network_address,
             partner_address=partner_address,


### PR DESCRIPTION
## Description

New channels cannot be open if the deprecation switch is on. This adds the missing check to the open operation.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
