### PR TITLE
Check `settle_timeout` threshold for success, too

### DIFF
--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -22,6 +22,7 @@ from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.token_network import TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
+from raiden.tests.utils.factories import make_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import T_ChannelID
 from raiden_contracts.constants import (
@@ -165,6 +166,13 @@ def test_token_network_proxy(
         )
         pytest.fail(msg)
 
+    # Using exactly the minimal timeout must succeed
+    c1_token_network_proxy.new_netting_channel(
+        partner=make_address(),
+        settle_timeout=TEST_SETTLE_TIMEOUT_MIN,
+        given_block_identifier="latest",
+    )
+
     msg = (
         "Opening a channel with a settle_timeout larger then token "
         "network's maximum will fail. This must be validated and the "
@@ -177,6 +185,13 @@ def test_token_network_proxy(
             given_block_identifier="latest",
         )
         pytest.fail(msg)
+
+    # Using exactly the maximal timeout must succeed
+    c1_token_network_proxy.new_netting_channel(
+        partner=make_address(),
+        settle_timeout=TEST_SETTLE_TIMEOUT_MAX,
+        given_block_identifier="latest",
+    )
 
     msg = (
         "Opening a channel with itself is not allow. This must be validated and "
@@ -194,14 +209,14 @@ def test_token_network_proxy(
     with pytest.raises(BrokenPreconditionError):
         c1_token_network_proxy.set_total_deposit(
             given_block_identifier="latest",
-            channel_identifier=1,
+            channel_identifier=100,
             total_deposit=1,
             partner=c2_client.address,
         )
         pytest.fail(msg)
 
     empty_balance_proof = BalanceProof(
-        channel_identifier=1,
+        channel_identifier=100,
         token_network_address=c1_token_network_proxy.address,
         balance_hash=encode_hex(EMPTY_BALANCE_HASH),
         nonce=0,
@@ -216,7 +231,7 @@ def test_token_network_proxy(
     match = "The channel was not open at the provided block"
     with pytest.raises(RaidenUnrecoverableError, match=match):
         c1_token_network_proxy.close(
-            channel_identifier=1,
+            channel_identifier=100,
             partner=c2_client.address,
             balance_hash=EMPTY_HASH,
             nonce=0,


### PR DESCRIPTION
## Description

In https://github.com/raiden-network/raiden/pull/4766 the question comes
up whether the contracts check the settle timeout in exactly the same
way. We've already checked for failure of values outside the expected
bounds, but to make sure things match in all cases, we also have to test
for success.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
