### PR TITLE
Improved messages for failure on deposit

### DIFF
--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -409,7 +409,7 @@ def test_token_network_proxy(
         pytest.fail(msg)
 
     msg = "depositing to a closed channel must fail"
-    match = "Channel is already closed"
+    match = "closed"
     with pytest.raises(RaidenRecoverableError, match=match):
         c2_token_network_proxy.set_total_deposit(
             given_block_identifier=blocknumber_prior_to_close,


### PR DESCRIPTION
## Description

This reuses the failure messages from the gas estimation in the
transaction failure for a the channel deposit. This change is only
cosmetic, to improve the error message.

This commit also removes _get_channel_state, that was only adding an
extra indirection layer without any useful logic, it made bit harder to
review the code.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
