### PR TITLE
Validate the channel id on deposit

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -799,7 +799,7 @@ class TokenNetwork:
             else:
                 if queried_channel_identifier != channel_identifier:
                     msg = (
-                        f"There is a channel open among "
+                        f"There is a channel open between "
                         f"{to_checksum_address(self.node_address)} and "
                         f"{to_checksum_address(partner)}. However the channel id "
                         f"on-chain {queried_channel_identifier} and the provided "
@@ -1137,10 +1137,9 @@ class TokenNetwork:
                 Address(self.address), failed_at_blocknumber
             )
 
-            # This check can only be done against the block
-            # `failed_at_blockhash` if the channel id is in the mapping
-            # `participants_hash_to_channel_identifier`. The id is added on
-            # channel open and removed on settle.
+            # This check can only be done if the channel is in the open/closed
+            # states because from the settled state and after the id is removed
+            # from the smart contract.
             is_invalid_channel_id = (
                 channel_data.state in (ChannelState.OPENED, ChannelState.CLOSED)
                 and queried_channel_identifier != channel_identifier
@@ -1150,7 +1149,7 @@ class TokenNetwork:
                     f"There is an open channel with the id {channel_identifier}. "
                     f"However addresses {to_checksum_address(self.node_address)} "
                     f"and {to_checksum_address(partner)} are not participants of "
-                    f"that channel, the correct id is {queried_channel_identifier}."
+                    f"that channel. The correct id is {queried_channel_identifier}."
                 )
                 raise RaidenUnrecoverableError(msg)  # This error is considered a bug
 

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -477,8 +477,7 @@ def test_token_network_proxy(
     assert token_proxy.balance_of(c2_client.address) == (initial_balance_c2 + transferred_amount)
 
     msg = "depositing to a settled channel must fail"
-    match = "The channel was not opened"
-    with pytest.raises(BrokenPreconditionError, match=match):
+    with pytest.raises(BrokenPreconditionError):
         c1_token_network_proxy.set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,


### PR DESCRIPTION
Part of #4763

## Description

    Added check for the channel identifier.

    The function `set_total_deposit` is provided with a channel identifier
    and a partner address. This is necessary because the smart contract does
    not store the participants addresses to save storage and reduces costs.

    These values must validated, otherwise it is possible to call the
    proxy's `set_total_deposit` with a correct channel id which the current
    node is not a participant, where correct is just a channel that was
    created at some point in the past.

    The check is not complete: Because of state prunning the preconditions
    cannot always be checked, and because once theis removed the id is
    removed from the smart contract storage, the check can only be performed
    if the state of the channel is at OPENED or CLOSED.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
