### PR TITLE
Blockchain query have to be inside the try block.

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -777,6 +777,9 @@ class TokenNetwork:
                 channel_participant_deposit_limit = self.channel_participant_deposit_limit(
                     block_identifier=given_block_identifier
                 )
+                network_total_deposit = self.token.balance_of(
+                    address=Address(self.address), block_identifier=given_block_identifier
+                )
             except ValueError:
                 # If `given_block_identifier` has been pruned the checks cannot be
                 # performed.
@@ -820,10 +823,6 @@ class TokenNetwork:
                         f"channel participant deposit limit"
                     )
                     raise BrokenPreconditionError(msg)
-
-                network_total_deposit = self.token.balance_of(
-                    Address(self.address), given_block_identifier
-                )
 
                 if network_total_deposit + amount_to_deposit > token_network_deposit_limit:
                     msg = (


### PR DESCRIPTION
Part of #4763

## Description

The call to `balance_of` does an rpc call to query the state of the
blockchain at the block `given_block_identifier`, which may have been
pruned. For thir reason the call must be inside the try block.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
