### PR TITLE
Make sure that SendWithdrawRequest is deserializable

### DIFF
--- a/raiden/tests/unit/storage/test_serialization.py
+++ b/raiden/tests/unit/storage/test_serialization.py
@@ -1,12 +1,18 @@
+import random
+
 import pytest
 
+from raiden.storage.serialization import JSONSerializer
 from raiden.storage.serialization.fields import (
     BytesField,
     OptionalIntegerToStringField,
     QueueIdentifierField,
 )
+from raiden.storage.sqlite import RAIDEN_DB_VERSION, SerializedSQLiteStorage
 from raiden.tests.utils import factories
+from raiden.transfer.events import SendWithdrawRequest
 from raiden.transfer.identifiers import QueueIdentifier
+from raiden.transfer.state_change import ActionInitChain
 
 
 def assert_roundtrip(field, value):
@@ -48,3 +54,38 @@ def test_bytes_field_roundtrip():
     assert_roundtrip(field, b"foo")
     assert_roundtrip(field, b"")
     assert_roundtrip(field, None)
+
+
+def test_events_loaded_from_storage_should_deserialize(tmp_path):
+    filename = f"{tmp_path}/v{RAIDEN_DB_VERSION}_log.db"
+    storage = SerializedSQLiteStorage(filename, serializer=JSONSerializer())
+
+    # Satisfy the foreign-key constraint for state change ID
+    ids = storage.write_state_changes(
+        [
+            ActionInitChain(
+                pseudo_random_generator=random.Random(),
+                block_number=1,
+                block_hash=b"",
+                our_address=factories.make_address(),
+                chain_id=1,
+            )
+        ]
+    )
+
+    canonical_identifier = factories.make_canonical_identifier()
+    recipient = factories.make_address()
+    participant = factories.make_address()
+    event = SendWithdrawRequest(
+        recipient=recipient,
+        canonical_identifier=canonical_identifier,
+        message_identifier=factories.make_message_identifier(),
+        total_withdraw=1,
+        participant=participant,
+        expiration=10,
+        nonce=15,
+    )
+    storage.write_events([(ids[0], event)])
+
+    stored_events = storage.get_events()
+    assert stored_events[0] == event


### PR DESCRIPTION
Fixes: #4738

## Description

Provide a test which checks that the SendWithdrawRequest is serializable/deserializable.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
