### PR TITLE
Improve pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,19 @@
 # How to use this:
 # 1) Install https://pre-commit.com/ `pip install --user pre-commit`
-# 2) Execute `pre-commit install -c .pre-commit-config.yaml`
+# 2) Execute `pre-commit install` inside the checkout root
+# 2a) Optional: run `pre-commit run` to test if everything works.
 # 3) Every commit now goes through linting, mypy, etc.
 # 4) If you ever need to commit without passing checks, run `git commit --no-verify`
-exclude: '^$'
-fail_fast: false
-repos:
-  - repo: git://github.com/pre-commit/mirrors-isort
-    rev: v4.3.20
-    hooks:
-      - id: isort
-        args: ["--ignore-whitespace", "--settings-path", "./", "--recursive"]
-  - repo: https://github.com/python/black
-    rev: 19.3b0
-    hooks:
-      - id: black
-        language_version: python3.7
+#
+# Note: The first run will be very slow since pre-commit generates virtualenvs for the
+#       various hooks.
+#       Additionally the pylint and mypy hooks need to install all Raiden dependencies into their
+#       virtualenvs on first run. See tools/pre-commit/pre-commit-wrapper.py for details.
 
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: python -m pylint.__main__ --rcfile pylintrc raiden
-        language: system
-        types: [python]
+default_language_version:
+  python: python3.7
+
+repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.2
     hooks:
@@ -31,16 +21,55 @@ repos:
       - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
+      - id: check-docstring-first
       - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-vcs-permalinks
       - id: check-yaml
       - id: debug-statements
       - id: detect-private-key
-      # - id: double-quote-string-fixer
       - id: end-of-file-fixer
+        exclude: .bumpversion_client.cfg
+      - id: fix-encoding-pragma
+        args: ['--remove']
       - id: flake8
         args: ["--config=setup.cfg"]
         additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer",]
       - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args: ['--branch', 'master', '--branch', 'develop']
       - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.4.1
+    hooks:
+      - id: python-no-eval
+      - id: python-no-log-warn
+      - id: rst-backticks
+
+  - repo: git://github.com/pre-commit/mirrors-isort
+    rev: v4.3.20
+    hooks:
+      - id: isort
+        args: ["--ignore-whitespace", "--settings-path", "./", "--recursive"]
+
+  - repo: https://github.com/python/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.720
+    hooks:
+      - id: mypy
+        entry: tools/pre-commit/pre-commit-wrapper.py mypy
+        additional_dependencies: ["pip-tools==4.1.0"]
+
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v2.3.1
+    hooks:
+      - id: pylint
+        entry: tools/pre-commit/pre-commit-wrapper.py pylint
+        additional_dependencies: ["pip-tools==4.1.0"]

--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@ jobs=4
 persistent=yes
 suggestion-mode=yes
 unsafe-load-any-extension=no
-load-plugins=tools.pylint.gevent_checker
+load-plugins=tools.pylint.gevent_checker,tools.pylint.assert_checker
 
 # Blacklist files or directories (basenames, not paths)
 ignore=

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -232,7 +232,7 @@ class NodeRunner:
                     task.get()  # re-raise
 
             gevent.joinall(
-                [gevent.spawn(stop_task, task) for task in tasks],
+                set(gevent.spawn(stop_task, task) for task in tasks),
                 app_.config.get("shutdown_timeout", settings.DEFAULT_SHUTDOWN_TIMEOUT),
                 raise_error=True,
             )

--- a/tools/pre-commit/pre-commit-wrapper.py
+++ b/tools/pre-commit/pre-commit-wrapper.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+This is a small helper to run pylint and mypy with the Raiden dev requirements installed in the
+pre-commit generated hook virtualenv.
+This is necessary since both pylint and mypy need access to the third party library source files
+in order to function correctly.
+
+To speed up the hook runtime we generate and store a hash of the requirements-dev file and only
+(re-)run pip-sync if that hash has changed.
+
+The reason to have this at all instead of a repo-local pre-commit hook is that it's difficult to
+ensure the project virtualenv is always available during pre-commit execution.
+Git GUI clients, editor / IDE integrations, etc. all can cause the virtualenv to not be active
+when pre-commit is being executed.
+"""
+
+import hashlib
+import os
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+
+REQUIREMENTS_FILE = "requirements/requirements-dev.txt"
+REQUIREMENTS_HASH_FILE_NAME = "_RAIDEN_REQUIREMENTS_HASH.txt"
+
+
+def _get_file_hash(file: Path) -> str:
+    if not file.exists():
+        raise ValueError(f"File {file} doesn't exist")
+    return hashlib.sha256(file.read_bytes()).hexdigest()
+
+
+def _ensure_requirements() -> None:
+    requirements_file_path = Path(REQUIREMENTS_FILE)
+    # This path is inside the pre-commit generated virtualenv and therefore will automatically
+    # be invalidated if that virtualenv is re-created.
+    data_path_str = sysconfig.get_path("data")
+    if data_path_str is None:
+        raise RuntimeError("No sysconfig data path available.")
+    data_path = Path(data_path_str)
+    requirements_hash_file = data_path.joinpath(REQUIREMENTS_HASH_FILE_NAME)
+
+    stored_requirements_hash = ""
+    if requirements_hash_file.exists():
+        stored_requirements_hash = requirements_hash_file.read_text().strip()
+
+    requirements_hash = _get_file_hash(requirements_file_path)
+
+    if stored_requirements_hash != requirements_hash:
+        print(
+            "Requirements have changed. Updating virtualenv.",
+            requirements_hash_file,
+            requirements_hash,
+        )
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-c",
+                "from piptools.scripts.sync import cli; cli()",
+                REQUIREMENTS_FILE,
+            ],
+            stderr=subprocess.STDOUT,
+        )
+        requirements_hash_file.write_text(requirements_hash)
+
+
+def main() -> None:
+    _ensure_requirements()
+
+    # cwd is set to the project root by pre-commit.
+    # Add it to sys.path so pylint can find the project local plugins.
+    sys.path.insert(0, os.getcwd())
+
+    tool = sys.argv.pop(1)
+    if tool == "pylint":
+        from pylint import run_pylint
+
+        run_pylint()
+    elif tool == "mypy":
+        from mypy.__main__ import console_entry
+
+        console_entry()
+    else:
+        raise RuntimeError(f"Unsupported tool: {tool}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pylint/gevent_checker.py
+++ b/tools/pylint/gevent_checker.py
@@ -55,9 +55,13 @@ class GeventWaitall(BaseChecker):
         for inferred_func in node.func.infer():
             if is_joinall(inferred_func):
 
-                is_every_value_a_set = all(
-                    inferred_first_arg.pytype() == "builtins.set"
-                    for inferred_first_arg in node.args[0].infer()
-                )
+                try:
+                    is_every_value_a_set = all(
+                        inferred_first_arg.pytype() == "builtins.set"
+                        for inferred_first_arg in node.args[0].infer()
+                    )
+                except InferenceError:
+                    is_every_value_a_set = False
+
                 if not is_every_value_a_set:
                     self.add_message(JOINALL_ID, node=node)


### PR DESCRIPTION
This adds mypy to the pre-commit config and changes the way pylint is invoked via pre-commit.

Previously a repo-local pylint hook was used. That lead to pylint only being invokable if the project venv was activated in the context the pre-commit hook was called from. That usually isn't the case when using GUI git clients or IDE / editor integrations.

Instead it uses the default pylint mirror provided by pre-commit with a wrapper script that ensures the project requirements are available and adds the project root to the `PYTHONPATH`. That
allows the project local pylint plugins to be importable while still using the normal pre-commit hook venv isolation.

The same wrapper is used for mypy since it also needs access to third  party library code in order to successfully check type definitions.

Also adds some other useful sanity check hooks.

Small drive-by fix:
- Fix the pylint gevent_checker plugin to not choke on uninferrable values
  (This now found a so far missed instance of passing a list-comp to `joinall` in `raiden.ui.runners`.)