### PR TITLE
adds integration test of sending capacity updates

### DIFF
--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -4,7 +4,7 @@ import gevent
 import pytest
 
 from raiden.app import App
-from raiden.constants import GENESIS_BLOCK_NUMBER, Environment
+from raiden.constants import GENESIS_BLOCK_NUMBER, Environment, RoutingMode
 from raiden.tests.utils.network import (
     CHAIN,
     BlockchainServices,
@@ -39,6 +39,11 @@ def timeout(blockchain_type: str) -> float:
 
 
 @pytest.fixture
+def routing_mode():
+    return RoutingMode.PRIVATE
+
+
+@pytest.fixture
 def raiden_chain(
     token_addresses: List[TokenAddress],
     token_network_registry_address: TokenNetworkRegistryAddress,
@@ -61,6 +66,7 @@ def raiden_chain(
     monitoring_service_contract_address: Address,
     global_rooms: List[str],
     logs_storage: str,
+    routing_mode: RoutingMode,
 ) -> Iterable[List[App]]:
 
     if len(token_addresses) != 1:
@@ -96,6 +102,7 @@ def raiden_chain(
         private_rooms=private_rooms,
         contracts_path=contracts_path,
         global_rooms=global_rooms,
+        routing_mode=routing_mode,
     )
 
     confirmed_block = raiden_apps[0].raiden.confirmation_blocks + 1
@@ -169,6 +176,7 @@ def raiden_network(
     global_rooms: List[str],
     logs_storage: str,
     start_raiden_apps: bool,
+    routing_mode: RoutingMode,
 ) -> Iterable[List[App]]:
     service_registry_address = None
     if blockchain_services.service_registry:
@@ -196,6 +204,7 @@ def raiden_network(
         local_matrix_url=local_matrix_servers[0],
         private_rooms=private_rooms,
         global_rooms=global_rooms,
+        routing_mode=routing_mode,
     )
 
     confirmed_block = raiden_apps[0].raiden.confirmation_blocks + 1

--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from raiden.api.python import RaidenAPI
+from raiden.app import App
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, RoutingMode
+from raiden.network.transport.matrix import make_room_alias
+from raiden.network.transport.matrix.client import Room
+from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.utils.typing import List, TokenAddress, TokenAmount, WithdrawAmount
+
+
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("channels_per_node", [0])
+@pytest.mark.parametrize(
+    "global_rooms", [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]]
+)
+@pytest.mark.parametrize("routing_mode", [RoutingMode.PFS])
+def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
+    raiden_network, token_addresses
+) -> None:
+
+    raise_on_failure(
+        raiden_apps=raiden_network,
+        test_function=run_test_pfs_send_capacity_update_on_deposit_and_withdraw,  # noqa
+        raiden_network=raiden_network,
+        token_addresses=token_addresses,
+    )
+
+
+def run_test_pfs_send_capacity_update_on_deposit_and_withdraw(
+    raiden_network: List[App], token_addresses: List[TokenAddress]
+) -> None:
+    # we need to test if CapacityUpdates are sent after a deposit and a withdraw
+    # therefore, we create two Raiden nodes app0 and app1
+    # the nodes open a channel but do not deposit
+    # a pfs matrix room is mocked to see what is sent to it
+
+    app0, app1 = raiden_network
+    transport0 = app0.raiden.transport
+
+    pfs_room_name = make_room_alias(transport0.network_id, PATH_FINDING_BROADCASTING_ROOM)
+    pfs_room = transport0._global_rooms.get(pfs_room_name)
+    # need to assert for mypy that pfs_room is not None
+    assert isinstance(pfs_room, Room)
+    pfs_room.send_text = MagicMock(spec=pfs_room.send_text)
+
+    api0 = RaidenAPI(app0.raiden)
+
+    api0.channel_open(
+        token_address=token_addresses[0],
+        registry_address=app0.raiden.default_registry.address,
+        partner_address=app1.raiden.address,
+    )
+
+    # the room should not have been called at channel opening
+    assert pfs_room.send_text.call_count == 0
+
+    api0.set_total_channel_deposit(
+        token_address=token_addresses[0],
+        registry_address=app0.raiden.default_registry.address,
+        partner_address=app1.raiden.address,
+        total_deposit=TokenAmount(10),
+    )
+
+    # now we expect the room to be called the 1st time with a PFSCapacityUpdate
+    # after the deposit
+    assert pfs_room.send_text.call_count == 1
+    assert "PFSCapacityUpdate" in str(pfs_room.send_text.call_args_list[0])
+
+    api0.set_total_channel_withdraw(
+        token_address=token_addresses[0],
+        registry_address=app0.raiden.default_registry.address,
+        partner_address=app1.raiden.address,
+        total_withdraw=WithdrawAmount(5),
+    )
+
+    # now we expect the room to be called the 2nd time with a PFSCapacityUpdate
+    # after the withdraw
+    assert pfs_room.send_text.call_count == 2
+    assert "PFSCapacityUpdate" in str(pfs_room.send_text.call_args_list[1])

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -351,6 +351,7 @@ def create_apps(
     local_matrix_url: Optional[ParsedURL],
     private_rooms: bool,
     global_rooms: List[str],
+    routing_mode: RoutingMode,
 ) -> List[App]:
     """ Create the apps."""
     # pylint: disable=too-many-locals
@@ -427,7 +428,7 @@ def create_apps(
             raiden_event_handler=hold_handler,
             message_handler=message_handler,
             user_deposit=user_deposit,
-            routing_mode=RoutingMode.PRIVATE,
+            routing_mode=routing_mode,
         )
         apps.append(app)
 


### PR DESCRIPTION
Fixes: #4743 

## Description

We need a test that the PFSCapacityUpdate is triggered by deposit and withdraw. The PFS does not listen to the blockchain anymore.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
