### PR TITLE
Use `DEFAULT_MEDIATION_FEE_MARGIN` in test

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -11,7 +11,7 @@ from raiden.message_handler import MessageHandler
 from raiden.messages.transfers import LockedTransfer, RevealSecret, SecretRequest
 from raiden.network.pathfinding import PFSConfig, PFSInfo
 from raiden.routing import get_best_routes_internal
-from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.settings import DEFAULT_MEDIATION_FEE_MARGIN, DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -553,7 +553,7 @@ def run_test_mediated_transfer_with_fees(
     def get_best_routes_with_fees(*args, **kwargs):
         routes = get_best_routes_internal(*args, **kwargs)
         for r in routes:
-            r.estimated_fee = fee
+            r.estimated_fee = fee_without_margin
         return routes
 
     def assert_balances(expected_transferred_amounts=List[int]):
@@ -568,7 +568,8 @@ def run_test_mediated_transfer_with_fees(
                 pending_locks1=[],
             )
 
-    fee = FeeAmount(5)
+    fee_without_margin = FeeAmount(20)
+    fee = round(fee_without_margin * (1 + DEFAULT_MEDIATION_FEE_MARGIN))
     amount = PaymentAmount(10)
     cases = [
         # The fee is added by the initiator, but no mediator deducts fees. As a


### PR DESCRIPTION
## Description

in `test_mediated_transfer_with_fees`. In its current form, the test
works without this change. But changing the fee amount in the test or
the DEFAULT_MEDIATION_FEE_MARGIN will break the test without clearly
showing the cause. So it's better to handle this case explicitly.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
