### PR TITLE
When fees >= amount, drop transfer

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -287,15 +287,6 @@ class UndefinedMediationFee(RaidenError):
     FeeSchedule is outdated/inconsistent."""
 
 
-class TransferAmountSmallerThanFees(RaidenRecoverableError):
-    """The node can't cover its mediations fees from the tranferred amount.
-
-    The transferred amount can't go negative, so the node has no way to earn
-    its mediation fees when the transferred amount is too low. The mediator has
-    no incentive to mediate and will drop the transfer.
-    """
-
-
 class TokenNetworkDeprecated(RaidenError):
     """ Raised when the token network proxy safety switch
     is turned on (i.e deprecated).

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -287,6 +287,15 @@ class UndefinedMediationFee(RaidenError):
     FeeSchedule is outdated/inconsistent."""
 
 
+class TransferAmountSmallerThanFees(RaidenRecoverableError):
+    """The node can't cover its mediations fees from the tranferred amount.
+
+    The transferred amount can't go negative, so the node has no way to earn
+    its mediation fees when the transferred amount is too low. The mediator has
+    no incentive to mediate and will drop the transfer.
+    """
+
+
 class TokenNetworkDeprecated(RaidenError):
     """ Raised when the token network proxy safety switch
     is turned on (i.e deprecated).

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -1,5 +1,6 @@
 import pytest
 
+from raiden.exceptions import UndefinedMediationFee
 from raiden.transfer.mediated_transfer.mediation_fee import (
     NUM_DISCRETISATION_POINTS,
     FeeScheduleState,
@@ -78,6 +79,9 @@ def test_imbalance_penalty():
     assert v_schedule.fee(
         channel_balance=Balance(100 - 40), amount=PaymentAmount(20)
     ) == FeeAmount(0)
+
+    with pytest.raises(UndefinedMediationFee):
+        v_schedule.fee(channel_balance=Balance(0), amount=PaymentAmount(1))
 
 
 def test_linspace():


### PR DESCRIPTION
## Description

Otherwise the next transfer will be be zero or less, which does not make
any sense. Better handle this case with an explicit exception. We could
try a refund for that case, but it's worth the complexity for such a
rare case.

Fixes: https://github.com/raiden-network/raiden/issues/4750

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
