### PR TITLE
Remove --nodiscovery from the fixture setup

### DIFF
--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -133,10 +133,12 @@ def geth_to_cmd(node: Dict, datadir: str, chain_id: ChainID, verbosity: str) -> 
         # can override that.
         cmd.append("--allow-insecure-unlock")
 
-    # don't use the '--dev' flag
+    # Don't use the '--dev' flag
+    # Don't use `--nodiscover`. This flag completely disables the peer
+    # discovery, even if the peers are given through the `--bootnodes`
+    # configuration flag.
     cmd.extend(
         [
-            "--nodiscover",
             "--rpc",
             "--rpcapi",
             "eth,net,web3,personal,txpool",


### PR DESCRIPTION
## Description

`--nodiscovery` was given to make sure the test network didn't try to
join any mainnet nodes. This however has the negative side effect of
disabling discovery even if the `--bootnodes` flag is given, meaning
that only the miner node can be used for an integration test.

To allow more than one geth node on a test network that flag cannot be
used. Our private network should be independent of the main network
because we overwrite the `--bootnodes`.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
