### PR TITLE
Add EventInvalidSecretRequest

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -41,6 +41,7 @@ from raiden.transfer.events import (
     EventInvalidReceivedWithdraw,
     EventInvalidReceivedWithdrawExpired,
     EventInvalidReceivedWithdrawRequest,
+    EventInvalidSecretRequest,
     EventPaymentReceivedSuccess,
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
@@ -161,6 +162,9 @@ class RaidenEventHandler(EventHandler):
         elif type(event) == EventUnlockFailed:
             assert isinstance(event, EventUnlockFailed), MYPY_ANNOTATION
             self.handle_unlockfailed(raiden, event)
+        elif type(event) == EventInvalidSecretRequest:
+            assert isinstance(event, EventInvalidSecretRequest), MYPY_ANNOTATION
+            self.handle_invalidsecretrequest(raiden, event)
         elif type(event) == ContractSendSecretReveal:
             assert isinstance(event, ContractSendSecretReveal), MYPY_ANNOTATION
             self.handle_contract_send_secretreveal(raiden, event)
@@ -316,6 +320,19 @@ class RaidenEventHandler(EventHandler):
             "UnlockFailed!",
             secrethash=to_hex(unlock_failed_event.secrethash),
             reason=unlock_failed_event.reason,
+            node=to_checksum_address(raiden.address),
+        )
+
+    @staticmethod
+    def handle_invalidsecretrequest(
+        raiden: "RaidenService", invalid_secret_request_event: EventInvalidSecretRequest
+    ) -> None:  # pragma: no unittest
+        # pylint: disable=unused-argument
+        log.warning(
+            "Received invalid SecretRequest!",
+            payment_id=invalid_secret_request_event.payment_identifier,
+            intended_amount=invalid_secret_request_event.intended_amount,
+            actual_amount=invalid_secret_request_event.actual_amount,
             node=to_checksum_address(raiden.address),
         )
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -29,6 +29,7 @@ from raiden.transfer import channel
 from raiden.transfer.architecture import State
 from raiden.transfer.events import (
     EventInvalidReceivedLockExpired,
+    EventInvalidSecretRequest,
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
     SendProcessed,
@@ -1685,7 +1686,7 @@ def test_state_wait_secretrequest_valid_amount_and_fee():
 
     state_change = ReceiveSecretRequest(
         payment_identifier=UNIT_TRANSFER_IDENTIFIER,
-        amount=setup.lock.amount - 1,  # Assuming 1 is the fee amount that was deducted
+        amount=setup.lock.amount - fee_amount,
         expiration=setup.lock.expiration,
         secrethash=setup.lock.secrethash,
         sender=UNIT_TRANSFER_TARGET,
@@ -1709,7 +1710,7 @@ def test_state_wait_secretrequest_valid_amount_and_fee():
 
     state_change_2 = ReceiveSecretRequest(
         payment_identifier=UNIT_TRANSFER_IDENTIFIER,
-        amount=setup.lock.amount - fee_amount - 1,
+        amount=setup.lock.amount - fee_amount - 1,  # Now the amount becomes too small
         expiration=setup.lock.expiration,
         secrethash=setup.lock.secrethash,
         sender=UNIT_TRANSFER_TARGET,
@@ -1724,7 +1725,8 @@ def test_state_wait_secretrequest_valid_amount_and_fee():
         block_number=setup.block_number,
     )
 
-    assert len(iteration2.events) == 0
+    assert len(iteration2.events) == 1
+    assert search_for_item(iteration2.events, EventInvalidSecretRequest, {}) is not None
 
 
 def test_initiator_manager_drops_invalid_state_changes():

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -308,5 +308,6 @@ class SendProcessed(SendMessageEvent):
 class EventInvalidSecretRequest(Event):
     """ Event emitted when an invalid SecretRequest is received. """
 
+    payment_identifier: PaymentID
     intended_amount: PaymentAmount
     actual_amount: PaymentAmount

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -302,3 +302,11 @@ class EventInvalidActionWithdraw(Event):
 @dataclass(frozen=True)
 class SendProcessed(SendMessageEvent):
     pass
+
+
+@dataclass(frozen=True)
+class EventInvalidSecretRequest(Event):
+    """ Event emitted when an invalid SecretRequest is received. """
+
+    intended_amount: PaymentAmount
+    actual_amount: PaymentAmount

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -375,6 +375,7 @@ def handle_secretrequest(
     elif not is_valid_secretrequest and is_message_from_target:
         initiator_state.received_secret_request = True
         invalid_request = EventInvalidSecretRequest(
+            payment_identifier=state_change.payment_identifier,
             intended_amount=initiator_state.transfer_description.amount,
             actual_amount=state_change.amount,
         )

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -4,7 +4,11 @@ from raiden.constants import ABSENT_SECRET
 from raiden.settings import DEFAULT_MEDIATION_FEE_MARGIN, DEFAULT_WAIT_BEFORE_LOCK_REMOVAL
 from raiden.transfer import channel, routes
 from raiden.transfer.architecture import Event, TransitionResult
-from raiden.transfer.events import EventPaymentSentFailed, EventPaymentSentSuccess
+from raiden.transfer.events import (
+    EventInvalidSecretRequest,
+    EventPaymentSentFailed,
+    EventPaymentSentSuccess,
+)
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE
 from raiden.transfer.mediated_transfer.events import (
     EventRouteFailed,
@@ -370,7 +374,11 @@ def handle_secretrequest(
 
     elif not is_valid_secretrequest and is_message_from_target:
         initiator_state.received_secret_request = True
-        iteration = TransitionResult(initiator_state, list())
+        invalid_request = EventInvalidSecretRequest(
+            intended_amount=initiator_state.transfer_description.amount,
+            actual_amount=state_change.amount,
+        )
+        iteration = TransitionResult(initiator_state, [invalid_request])
 
     else:
         iteration = TransitionResult(initiator_state, list())


### PR DESCRIPTION
## Description

During my work on I found out that there is currently no event emitted when a `SecretReveal` is received, which has an amount that is smaller than the intended transfer amount.

This PR adds `EventInvalidSecretRequest` for that case.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [x] Exceptions are propagated to the correct parent greenlet
    - [x] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [x] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [x] Properly covers the bug
        - [x] If an integration test is used, it could not be written as a unit test
- Documentation
    - [x] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [x] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
