### PR TITLE
Using node address for storage path

### DIFF
--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -316,16 +316,16 @@ def eth_check_balance(web3: Web3, accounts_addresses: List[Address], retries: in
 
 
 def eth_node_config(
-    miner_pkey: PrivateKey, p2p_port: Port, rpc_port: Port, **extra_config: Any
+    node_pkey: PrivateKey, p2p_port: Port, rpc_port: Port, **extra_config: Any
 ) -> Dict[str, Any]:
-    address = privatekey_to_address(miner_pkey)
-    pub = privatekey_to_publickey(miner_pkey).hex()
+    address = privatekey_to_address(node_pkey)
+    pub = privatekey_to_publickey(node_pkey).hex()
 
     config = extra_config.copy()
     config.update(
         {
-            "nodekey": miner_pkey,
-            "nodekeyhex": remove_0x_prefix(encode_hex(miner_pkey)),
+            "nodekey": node_pkey,
+            "nodekeyhex": remove_0x_prefix(encode_hex(node_pkey)),
             "pub": pub,
             "address": address,
             "port": p2p_port,
@@ -344,12 +344,12 @@ def eth_node_config_set_bootnodes(nodes_configuration: List[Dict[str, Any]]) -> 
         config["bootnodes"] = bootnodes
 
 
-def eth_node_to_datadir(nodekeyhex: str, base_datadir: str) -> str:
+def eth_node_to_datadir(node_address: bytes, base_datadir: str) -> str:
     # HACK: Use only the first 8 characters to avoid golang's issue
     # https://github.com/golang/go/issues/6895 (IPC bind fails with path
     # longer than 108 characters).
     # BSD (and therefore macOS) socket path length limit is 104 chars
-    nodekey_part = nodekeyhex[:8]
+    nodekey_part = encode_hex(node_address)[:8]
     datadir = os.path.join(base_datadir, nodekey_part)
     return datadir
 
@@ -384,7 +384,7 @@ def eth_nodes_to_cmds(
 ) -> List[Command]:
     cmds = []
     for config, node_desc in zip(nodes_configuration, eth_node_descs):
-        datadir = eth_node_to_datadir(config["nodekeyhex"], base_datadir)
+        datadir = eth_node_to_datadir(config["address"], base_datadir)
 
         if node_desc.blockchain_type == "geth":
             geth_prepare_datadir(datadir, genesis_file)
@@ -532,7 +532,7 @@ def run_private_blockchain(
 
         for config in nodes_configuration:
             if config.get("mine"):
-                datadir = eth_node_to_datadir(config["nodekeyhex"], base_datadir)
+                datadir = eth_node_to_datadir(config["address"], base_datadir)
                 keyfile_path = geth_keyfile(datadir, config["address"])
                 eth_create_account_file(keyfile_path, config["nodekey"])
 
@@ -546,7 +546,7 @@ def run_private_blockchain(
 
         for config in nodes_configuration:
             if config.get("mine"):
-                datadir = eth_node_to_datadir(config["nodekeyhex"], base_datadir)
+                datadir = eth_node_to_datadir(config["address"], base_datadir)
                 keyfile_path = parity_keyfile(datadir)
                 eth_create_account_file(keyfile_path, config["nodekey"])
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 
 import click
 import requests
-from eth_utils import encode_hex, remove_0x_prefix, to_canonical_address, to_checksum_address
+from eth_utils import remove_0x_prefix, to_canonical_address, to_checksum_address
 from gevent import sleep
 from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
@@ -199,8 +199,7 @@ def setup_testchain(
         chain_id=NETWORKNAME_TO_ID["smoketest"],
     )
 
-    nodekeyhex = remove_0x_prefix(encode_hex(TEST_PRIVKEY))
-    datadir = eth_node_to_datadir(nodekeyhex, base_datadir)
+    datadir = eth_node_to_datadir(privatekey_to_address(TEST_PRIVKEY), base_datadir)
     if eth_client is EthClient.GETH:
         keystore = geth_keystore(datadir)
     elif eth_client is EthClient.PARITY:


### PR DESCRIPTION
## Description

This is just a cosmetic change. Because most of our log lines use the address instead of the private key, it's easier to match the logs to the files in the file system if the node's address is used instead.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
