### PR TITLE
Introduce TokenNetworkRegistryFull exception

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -20,6 +20,7 @@ from raiden.exceptions import (
     InvalidSettleTimeout,
     RaidenRecoverableError,
     TokenNetworkDeprecated,
+    TokenNetworkRegistryFull,
     TokenNotRegistered,
     UnexpectedChannelState,
     UnknownTokenAddress,
@@ -210,6 +211,8 @@ class RaidenAPI:  # pragma: no unittest
         Raises:
             InvalidBinaryAddress: If the registry_address or token_address is not a valid address.
             AlreadyRegisteredTokenAddress: If the token is already registered.
+            TokenNetworkRegistryOverLimit: If the TokenNetworkRegistry has so many tokens
+                registered that no new token can be registered.
             TransactionThrew: If the register transaction failed, this may
                 happen because the account has not enough balance to pay for the
                 gas or this register call raced with another transaction and lost.
@@ -242,6 +245,9 @@ class RaidenAPI:  # pragma: no unittest
         except RaidenRecoverableError as e:
             if "Token already registered" in str(e):
                 raise AlreadyRegisteredTokenAddress("Token already registered")
+            # else
+            if "Too many tokens already registered" in str(e):
+                raise TokenNetworkRegistryFull("TokenNetworkRegistry is full")
             # else
             raise
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -211,7 +211,7 @@ class RaidenAPI:  # pragma: no unittest
         Raises:
             InvalidBinaryAddress: If the registry_address or token_address is not a valid address.
             AlreadyRegisteredTokenAddress: If the token is already registered.
-            TokenNetworkRegistryOverLimit: If the TokenNetworkRegistry has so many tokens
+            TokenNetworkRegistryFull the TokenNetworkRegistry has so many tokens
                 registered that no new token can be registered.
             TransactionThrew: If the register transaction failed, this may
                 happen because the account has not enough balance to pay for the
@@ -246,7 +246,7 @@ class RaidenAPI:  # pragma: no unittest
             if "Token already registered" in str(e):
                 raise AlreadyRegisteredTokenAddress("Token already registered")
             # else
-            if "Too many tokens already registered" in str(e):
+            if "TokenNetworkRegistry is full" in str(e):
                 raise TokenNetworkRegistryFull("TokenNetworkRegistry is full")
             # else
             raise

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -76,6 +76,7 @@ from raiden.exceptions import (
     PaymentConflict,
     SamePeerAddress,
     TokenNetworkDeprecated,
+    TokenNetworkRegistryFull,
     TokenNotRegistered,
     TransactionThrew,
     UnexpectedChannelState,
@@ -541,6 +542,7 @@ class RestAPI:  # pragma: no unittest
         conflict_exceptions = (
             InvalidBinaryAddress,
             AlreadyRegisteredTokenAddress,
+            TokenNetworkRegistryFull,
             TransactionThrew,
             InvalidToken,
             AddressWithoutCode,

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -156,6 +156,12 @@ class AlreadyRegisteredTokenAddress(RaidenError):
     """ Raised when the token address in already registered with the given network. """
 
 
+class TokenNetworkRegistryFull(RaidenError):
+    """ Raised when the TokenNetworkRegistry has so many tokens registered so no
+    new registration is possible.
+    """
+
+
 class InvalidToken(RaidenError):
     """ Raised if the token does not follow the ERC20 standard """
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -122,6 +122,9 @@ class TokenNetworkRegistry:
             already_registered = self.get_token_network(
                 token_address=token_address, block_identifier=block_identifier
             )
+            created = self.get_token_network_created(to_block=block_identifier)
+            limit = self.get_max_token_networks(to_block=block_identifier)
+            registry_is_full = created >= limit
         except ValueError:
             # If `block_identifier` has been pruned the checks cannot be performed
             pass
@@ -131,6 +134,11 @@ class TokenNetworkRegistry:
             if already_registered:
                 raise BrokenPreconditionError(
                     "The token is already registered in the TokenNetworkRegistry."
+                )
+            if registry_is_full:
+                raise BrokenPreconditionError(
+                    "The TokenNetworkRegistry has so many tokens registered "
+                    "that it cannot get any more tokens."
                 )
 
         return self._add_token(

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -211,6 +211,9 @@ class TokenNetworkRegistry:
                 if self.get_token_network(token_address, block):
                     raise RaidenRecoverableError(f"{error_prefix}. Token already registered")
 
+                if self.get_token_network_created(block) >= self.get_max_token_networks(block):
+                    raise RaidenRecoverableError(f"{error_prefix}. TokenNetworkRegistry is full.")
+
                 raise RaidenUnrecoverableError(error_prefix)
 
             token_network_address = self.get_token_network(token_address, "latest")

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -211,6 +211,32 @@ def deploy_token_network_registry_and_return_address(
     return address
 
 
+@pytest.fixture(name="limited_token_network_registry_address")
+def deploy_limited_token_network_registry_and_return_address(
+    deploy_client,
+    secret_registry_address,
+    chain_id,
+    settle_timeout_min,
+    settle_timeout_max,
+    contract_manager,
+) -> typing.Address:
+    constructor_arguments = [
+        to_checksum_address(secret_registry_address),
+        chain_id,
+        settle_timeout_min,
+        settle_timeout_max,
+        1,
+    ]
+
+    address = deploy_contract_web3(
+        contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
+        deploy_client=deploy_client,
+        contract_manager=contract_manager,
+        constructor_arguments=constructor_arguments,
+    )
+    return address
+
+
 @pytest.fixture(name="token_network_proxy")
 def register_token_and_return_the_network_proxy(
     contract_manager, deploy_client, token_proxy, token_network_registry_address


### PR DESCRIPTION
Sometimes TokenNetworkRegistry.createERC20TokenNetwork() fails
because the TokenNetworkRegistry has so many tokens registered
that no new tokens can be registered.

* This PR introduces a new exception for this case.
* Also the proxy has a new precondition check
* The proxy also has the corresponding after-failure check
* The API's make the corresponding check before calling the proxy

This is a part of https://github.com/raiden-network/raiden/issues/4795

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

It's a bug fix.  TokenNetworkRegistry contract fails when too many tokens are registered.  The TokenNetworkRegistry proxy didn't know about that.  This PR adds the corresponding checks in and out of the proxy.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
