### PR TITLE
Add get_token_networks_created()

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -228,3 +228,11 @@ class TokenNetworkRegistry:
     def settlement_timeout_max(self) -> int:
         """ Returns the maximal settlement timeout for the token network registry. """
         return self.proxy.contract.functions.settlement_timeout_max().call()
+
+    def get_token_network_created(self, to_block: BlockSpecification = "latest") -> int:
+        """ Returns the number of TokenNetwork contracts created so far in the
+        token network registry.
+        """
+        return self.proxy.contract.functions.token_network_created().call(
+            block_identifier=to_block
+        )

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -34,6 +34,7 @@ def test_token_network_registry(
 
     assert token_network_registry_proxy.settlement_timeout_min() == TEST_SETTLE_TIMEOUT_MIN
     assert token_network_registry_proxy.settlement_timeout_max() == TEST_SETTLE_TIMEOUT_MAX
+    assert token_network_registry_proxy.get_token_network_created() == 0
 
     bad_token_address = make_address()
     # try to register non-existing token network
@@ -71,6 +72,7 @@ def test_token_network_registry(
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
     )
+    assert token_network_registry_proxy.get_token_network_created() == 1
 
     with pytest.raises(RaidenRecoverableError) as exc:
         token_network_address = token_network_registry_proxy.add_token_with_limits(


### PR DESCRIPTION

Fixes: #<issue>

## Description

Please, describe what this PR does in detail:
- If it's a new feature, describe the feature this PR is introducing and design decisions.

I'm adding a new function get_token_networks_created(). This function
is a simple wrapper over `token_network_created` public variable in
TokenNetworkRegistry contract.

The reason for this change is to introduce a check for the `canCreateTokenNetworks()` modifier in the client.  This function will be useful for determining whether the TokenNetworkRegistry has too many tokens registered, in https://github.com/raiden-network/raiden/pull/4796/files



## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [x] Exceptions are propagated to the correct parent greenlet
    - [x] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [x] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
