### PR TITLE
Add TokenNetworkRegistry.get_max_token_networks()

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -236,3 +236,9 @@ class TokenNetworkRegistry:
         return self.proxy.contract.functions.token_network_created().call(
             block_identifier=to_block
         )
+
+    def get_max_token_networks(self, to_block: BlockSpecification = "latest") -> int:
+        """ Returns the maximal number of TokenNetwork contracts that the
+        token network registry.
+        """
+        return self.proxy.contract.functions.max_token_networks().call(block_identifier=to_block)

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -229,7 +229,7 @@ class TokenNetworkRegistry:
         """ Returns the maximal settlement timeout for the token network registry. """
         return self.proxy.contract.functions.settlement_timeout_max().call()
 
-    def get_token_network_created(self, to_block: BlockSpecification = "latest") -> int:
+    def get_token_network_created(self, to_block: BlockSpecification) -> int:
         """ Returns the number of TokenNetwork contracts created so far in the
         token network registry.
         """
@@ -237,7 +237,7 @@ class TokenNetworkRegistry:
             block_identifier=to_block
         )
 
-    def get_max_token_networks(self, to_block: BlockSpecification = "latest") -> int:
+    def get_max_token_networks(self, to_block: BlockSpecification) -> int:
         """ Returns the maximal number of TokenNetwork contracts that the
         token network registry.
         """

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -35,7 +35,7 @@ def test_token_network_registry(
 
     assert token_network_registry_proxy.settlement_timeout_min() == TEST_SETTLE_TIMEOUT_MIN
     assert token_network_registry_proxy.settlement_timeout_max() == TEST_SETTLE_TIMEOUT_MAX
-    assert token_network_registry_proxy.get_token_network_created() == 0
+    assert token_network_registry_proxy.get_token_network_created(to_block="latest") == 0
 
     bad_token_address = make_address()
     # try to register non-existing token network
@@ -73,7 +73,7 @@ def test_token_network_registry(
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
     )
-    assert token_network_registry_proxy.get_token_network_created() == 1
+    assert token_network_registry_proxy.get_token_network_created(to_block="latest") == 1
 
     with pytest.raises(RaidenRecoverableError) as exc:
         token_network_address = token_network_registry_proxy.add_token_with_limits(
@@ -117,4 +117,4 @@ def test_token_network_registry_max_token_networks(
         contract_manager=contract_manager,
         blockchain_service=blockchain_service,
     )
-    assert token_network_registry_proxy.get_max_token_networks() == UINT256_MAX
+    assert token_network_registry_proxy.get_max_token_networks(to_block="latest") == UINT256_MAX

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -6,6 +6,7 @@ from eth_utils import is_same_address, to_canonical_address
 from raiden.constants import (
     RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
     RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+    UINT256_MAX,
 )
 from raiden.exceptions import AddressWithoutCode, InvalidToken, RaidenRecoverableError
 from raiden.network.blockchain_service import BlockChainService
@@ -101,3 +102,19 @@ def test_token_network_registry(
     assert token_network_registry_proxy.get_token_network(bad_token_address, "latest") is None
     assert token_network_registry_proxy.get_token_network(token_network_address, "latest") is None
     assert token_network_registry_proxy.get_token_network(test_token_address, "latest") is not None
+
+
+def test_token_network_registry_max_token_networks(
+    deploy_client, token_network_registry_address, contract_manager
+):
+    """ get_max_token_networks() should return an integer """
+    blockchain_service = BlockChainService(
+        jsonrpc_client=deploy_client, contract_manager=contract_manager
+    )
+    token_network_registry_proxy = TokenNetworkRegistry(
+        jsonrpc_client=deploy_client,
+        registry_address=to_canonical_address(token_network_registry_address),
+        contract_manager=contract_manager,
+        blockchain_service=blockchain_service,
+    )
+    assert token_network_registry_proxy.get_max_token_networks() == UINT256_MAX


### PR DESCRIPTION
which is a getter for max_token_networks public variable in
TokenNetworkRegistry. The variable shows how many tokens can
be registered in the registry. Having this getter is useful
for checking preconditions for createERC20TokenNetwork()
in the proxy.

This is a part of #4795.

Fixes: #<issue>

## Description

Please, describe what this PR does in detail:
- If it's a new feature, describe the feature this PR is introducing and design decisions.

The PR adds a new getter function `get_max_token_networks()` in the TokenNetworkRegistry proxy.

There is not much design space.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
