### PR TITLE
Removed old RedEyes constants from the main module.

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -32,9 +32,6 @@ UINT64_MAX = 2 ** 64 - 1
 
 SECONDS_PER_DAY = 24 * 60 * 60
 
-RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT = int(0.075 * 10 ** 18)
-RED_EYES_PER_TOKEN_NETWORK_LIMIT = int(250 * 10 ** 18)
-
 GENESIS_BLOCK_NUMBER = BlockNumber(0)
 # Set at 64 since parity's default is 64 and Geth's default is 128
 # TODO: Make this configurable. Since in parity this is also a configurable value

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -5,7 +5,7 @@ from enum import Enum
 import pytest
 from eth_utils import remove_0x_prefix
 
-from raiden.constants import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT, Environment
+from raiden.constants import Environment
 from raiden.network.utils import get_free_port
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, DEFAULT_RETRY_TIMEOUT
 from raiden.tests.fixtures.constants import DEFAULT_BALANCE
@@ -183,8 +183,8 @@ def account_genesis_eth_balance():
 
 
 @pytest.fixture
-def token_amount(number_of_nodes):
-    total_per_node = RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT * 4
+def token_amount(number_of_nodes, deposit):
+    total_per_node = 3 * (deposit + 1)
     total_token = total_per_node * number_of_nodes
     return total_token
 

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -1,14 +1,7 @@
 import pytest
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.constants import (
-    EMPTY_ADDRESS,
-    RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-    RED_EYES_PER_TOKEN_NETWORK_LIMIT,
-    SECONDS_PER_DAY,
-    UINT256_MAX,
-    Environment,
-)
+from raiden.constants import EMPTY_ADDRESS, SECONDS_PER_DAY, UINT256_MAX, Environment
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.token import Token
@@ -30,6 +23,9 @@ from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
 )
+
+RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT = int(0.075 * 10 ** 18)
+RED_EYES_PER_TOKEN_NETWORK_LIMIT = int(250 * 10 ** 18)
 
 
 @pytest.fixture

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -1,34 +1,34 @@
 from unittest.mock import patch
 
 import pytest
-from eth_utils import is_same_address, to_canonical_address
+from eth_utils import is_same_address, to_canonical_address, to_normalized_address
 
-from raiden.constants import (
-    RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-    RED_EYES_PER_TOKEN_NETWORK_LIMIT,
-    UINT256_MAX,
-)
+from raiden.constants import UINT256_MAX
 from raiden.exceptions import AddressWithoutCode, InvalidToken, RaidenRecoverableError
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.token import Token
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
-from raiden.tests.utils.factories import make_address
+from raiden.network.rpc.client import JSONRPCClient
+from raiden.tests.utils.factories import make_token_address
 from raiden.tests.utils.smartcontracts import deploy_token
+from raiden.utils.typing import TokenAddress, TokenAmount, TokenNetworkRegistryAddress
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIMEOUT_MIN
+from raiden_contracts.contract_manager import ContractManager
 
 
 def test_token_network_registry(
-    deploy_client, contract_manager, token_network_registry_address, token_contract_name
-):
-    registry_address = to_canonical_address(token_network_registry_address)
-
+    deploy_client: JSONRPCClient,
+    contract_manager: ContractManager,
+    token_network_registry_address: TokenNetworkRegistryAddress,
+    token_contract_name: str,
+) -> None:
     blockchain_service = BlockChainService(
         jsonrpc_client=deploy_client, contract_manager=contract_manager
     )
 
     token_network_registry_proxy = TokenNetworkRegistry(
         jsonrpc_client=deploy_client,
-        registry_address=registry_address,
+        registry_address=token_network_registry_address,
         contract_manager=contract_manager,
         blockchain_service=blockchain_service,
     )
@@ -37,71 +37,80 @@ def test_token_network_registry(
     assert token_network_registry_proxy.settlement_timeout_max() == TEST_SETTLE_TIMEOUT_MAX
     assert token_network_registry_proxy.get_token_network_created(to_block="latest") == 0
 
-    bad_token_address = make_address()
-    # try to register non-existing token network
+    bad_token_address = make_token_address()
+
+    # Registering a non-existing token network should fail
     with pytest.raises(AddressWithoutCode):
         token_network_registry_proxy.add_token_with_limits(
             token_address=bad_token_address,
-            channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-            token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+            channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+            token_network_deposit_limit=TokenAmount(UINT256_MAX),
         )
-    # create token network & register it
+
     test_token = deploy_token(
         deploy_client=deploy_client,
         contract_manager=contract_manager,
-        initial_amount=1000,
+        initial_amount=TokenAmount(1000),
         decimals=0,
         token_name="TKN",
         token_symbol="TKN",
         token_contract_name=token_contract_name,
     )
+    test_token_address = TokenAddress(to_canonical_address(test_token.contract.address))
 
-    test_token_address = to_canonical_address(test_token.contract.address)
-    # try to register a token network not following ERC20 protocol
-
+    # Check the proper exception is raised if the token does not comply to the
+    # ERC20 interface. In this case the token does not have the totalSupply()
+    # function implemented #3697 which is validated in the smart contract.
     with patch.object(Token, "total_supply", return_value=""):
         with pytest.raises(InvalidToken):
             token_network_registry_proxy.add_token_with_limits(
                 token_address=test_token_address,
-                channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-                token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+                channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+                token_network_deposit_limit=TokenAmount(UINT256_MAX),
             )
 
+    # Register a valid token
     event_filter = token_network_registry_proxy.tokenadded_filter()
     token_network_address = token_network_registry_proxy.add_token_with_limits(
         token_address=test_token_address,
-        channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-        token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+        channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+        token_network_deposit_limit=TokenAmount(UINT256_MAX),
     )
+    assert token_network_address
     assert token_network_registry_proxy.get_token_network_created(to_block="latest") == 1
 
-    with pytest.raises(RaidenRecoverableError) as exc:
-        token_network_address = token_network_registry_proxy.add_token_with_limits(
+    # Re-registering the same token should fail with a recoverable error
+    # because it is a race condition.
+    match = "Token already registered"
+    with pytest.raises(RaidenRecoverableError, match=match):
+        token_network_registry_proxy.add_token_with_limits(
             token_address=test_token_address,
-            channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-            token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+            channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+            token_network_deposit_limit=TokenAmount(UINT256_MAX),
         )
-
-        assert "Token already registered" in str(exc)
 
     logs = event_filter.get_all_entries()
     assert len(logs) == 1
     decoded_event = token_network_registry_proxy.proxy.decode_event(logs[0])
     assert is_same_address(decoded_event["args"]["token_address"], test_token.contract.address)
     assert is_same_address(decoded_event["args"]["token_network_address"], token_network_address)
-    # test other getters
     assert token_network_registry_proxy.get_token_network(bad_token_address, "latest") is None
-    assert is_same_address(
-        token_network_registry_proxy.get_token_network(test_token_address, "latest"),
-        token_network_address,
-    )
+
+    result_address = token_network_registry_proxy.get_token_network(test_token_address, "latest")
+
+    assert result_address
+    assert to_normalized_address(result_address) == to_normalized_address(token_network_address)
 
     with pytest.raises(ValueError):
-        assert token_network_registry_proxy.get_token_network(None, "latest") is None
+        assert token_network_registry_proxy.get_token_network(None, "latest")  # type: ignore
 
+    # These are not registered token addresses
     assert token_network_registry_proxy.get_token_network(bad_token_address, "latest") is None
-    assert token_network_registry_proxy.get_token_network(token_network_address, "latest") is None
     assert token_network_registry_proxy.get_token_network(test_token_address, "latest") is not None
+    address = token_network_registry_proxy.get_token_network(  # type: ignore
+        token_network_address, "latest"
+    )
+    assert address is None
 
 
 def test_token_network_registry_max_token_networks(

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -5,12 +5,7 @@ import pytest
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
-from raiden.constants import (
-    RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-    RED_EYES_PER_TOKEN_NETWORK_LIMIT,
-    UINT256_MAX,
-    Environment,
-)
+from raiden.constants import UINT256_MAX, Environment
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     DepositOverLimit,
@@ -517,8 +512,8 @@ def run_test_set_deposit_limit_crash(
     api1.token_network_register(
         registry_address=registry_address,
         token_address=token_address,
-        channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-        token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+        channel_participant_deposit_limit=UINT256_MAX,
+        token_network_deposit_limit=UINT256_MAX,
     )
     exception = RuntimeError("Did not see the token registration within 30 seconds")
     with gevent.Timeout(seconds=30, exception=exception):

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -17,14 +17,7 @@ from raiden.accounts import AccountManager
 from raiden.api.python import RaidenAPI
 from raiden.api.rest import APIServer, RestAPI
 from raiden.connection_manager import ConnectionManager
-from raiden.constants import (
-    EMPTY_ADDRESS,
-    RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-    RED_EYES_PER_TOKEN_NETWORK_LIMIT,
-    SECONDS_PER_DAY,
-    UINT256_MAX,
-    EthClient,
-)
+from raiden.constants import EMPTY_ADDRESS, SECONDS_PER_DAY, UINT256_MAX, EthClient
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.rpc.client import JSONRPCClient
@@ -304,8 +297,8 @@ def setup_raiden(
 
     registry.add_token_with_limits(
         token_address=to_canonical_address(token.contract.address),
-        channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
-        token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+        channel_participant_deposit_limit=UINT256_MAX,
+        token_network_deposit_limit=UINT256_MAX,
     )
 
     print_step("Setting up Raiden")


### PR DESCRIPTION

## Description


These constants used to be hardcoded in the smart contracts. Now they
are configurable through the smart contract constructors, and therefore
their value can vary. Because of this Raiden must query the limits from
the smart contracts and cannot rely on the constants anymore.

The only usages left of the constants in the codebase were for the
tests. This reduces the constant footprint and leave them as the default
for the default fixture setup, just because this value works fine for
now.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
