### PR TITLE
Fee updates should be triggered after onchain events processing

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -13,10 +13,7 @@ from gevent import Greenlet
 from gevent.event import AsyncResult, Event
 
 from raiden import constants, routing
-from raiden.blockchain.decode import (
-    actionchannelupdatefee_from_channelstate,
-    blockchainevent_to_statechange,
-)
+from raiden.blockchain.decode import blockchainevent_to_statechange
 from raiden.blockchain.events import BlockchainEvents
 from raiden.blockchain_events_handler import after_blockchain_statechange
 from raiden.connection_manager import ConnectionManager
@@ -80,6 +77,7 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils import lpex, random_secret
 from raiden.utils.logging import redact_secret
+from raiden.utils.mediation_fees import actionchannelupdatefee_from_channelstate
 from raiden.utils.runnable import Runnable
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.signer import LocalSigner, Signer

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -50,6 +50,7 @@ from raiden.transfer.events import (
     SendWithdrawConfirmation,
     SendWithdrawExpired,
     SendWithdrawRequest,
+    TriggerFeeUpdate,
 )
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.mediated_transfer.state_change import ReceiveLockExpired
@@ -237,7 +238,7 @@ def test_endstate_update_contract_balance():
 
 def test_channelstate_update_contract_balance():
     """A blockchain event for a new balance must increase the respective
-    participants balance.
+    participants balance and trigger a fee update
     """
     deposit_block_number = 10
     block_number = deposit_block_number + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS + 1
@@ -277,6 +278,9 @@ def test_channelstate_update_contract_balance():
 
     assert_partner_state(new_state.our_state, new_state.partner_state, our_model2)
     assert_partner_state(new_state.partner_state, new_state.our_state, partner_model2)
+    # Also make sure that a fee update triggering event is created
+    assert len(iteration.events) == 1
+    assert isinstance(iteration.events[0], TriggerFeeUpdate)
 
 
 def test_channelstate_decreasing_contract_balance():
@@ -2263,6 +2267,9 @@ def test_receive_contract_withdraw():
     assert iteration.new_state.our_state.total_withdraw == total_withdraw
     assert iteration.new_state.our_total_withdraw == total_withdraw
     assert total_withdraw not in iteration.new_state.our_state.withdraws_pending
+    # Also make sure that a fee update triggering event is created
+    assert len(iteration.events) == 1
+    assert isinstance(iteration.events[0], TriggerFeeUpdate)
 
     contract_receive_withdraw = ContractReceiveChannelWithdraw(
         canonical_identifier=channel_state.canonical_identifier,
@@ -2284,3 +2291,6 @@ def test_receive_contract_withdraw():
     assert iteration.new_state.partner_state.total_withdraw == total_withdraw
     assert iteration.new_state.partner_total_withdraw == total_withdraw
     assert total_withdraw not in iteration.new_state.partner_state.withdraws_pending
+    # Also make sure that a fee update triggering event is created
+    assert len(iteration.events) == 1
+    assert isinstance(iteration.events[0], TriggerFeeUpdate)

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -311,3 +311,13 @@ class EventInvalidSecretRequest(Event):
     payment_identifier: PaymentID
     intended_amount: PaymentAmount
     actual_amount: PaymentAmount
+
+
+@dataclass(frozen=True)
+class TriggerFeeUpdate(Event):
+    """Event emitted when a fee update needs to be made for a channel.
+
+    For example when a deposit or a withdrawal is made into a channel
+    """
+
+    canonical_identifier: CanonicalIdentifier

--- a/raiden/utils/mediation_fees.py
+++ b/raiden/utils/mediation_fees.py
@@ -1,7 +1,30 @@
 from math import sqrt
 
 from raiden.settings import MediationFeeConfig
+from raiden.transfer.channel import get_capacity
+from raiden.transfer.mediated_transfer.mediation_fee import calculate_imbalance_fees
+from raiden.transfer.state import FeeScheduleState, NettingChannelState
+from raiden.transfer.state_change import ActionChannelUpdateFee
 from raiden.utils.typing import Dict, FeeAmount, ProportionalFeeAmount, TokenNetworkAddress, Tuple
+
+
+def actionchannelupdatefee_from_channelstate(
+    channel_state: NettingChannelState,
+    flat_fee: FeeAmount,
+    proportional_fee: ProportionalFeeAmount,
+    proportional_imbalance_fee: ProportionalFeeAmount,
+) -> ActionChannelUpdateFee:
+    imbalance_penalty = calculate_imbalance_fees(
+        channel_capacity=get_capacity(channel_state),
+        proportional_imbalance_fee=proportional_imbalance_fee,
+    )
+
+    return ActionChannelUpdateFee(
+        canonical_identifier=channel_state.canonical_identifier,
+        fee_schedule=FeeScheduleState(
+            flat=flat_fee, proportional=proportional_fee, imbalance_penalty=imbalance_penalty
+        ),
+    )
 
 
 def prepare_mediation_fee_config(


### PR DESCRIPTION
## Description

Fixes a bug described here:
https://github.com/raiden-network/raiden/pull/4802#issuecomment-530153318

While fixing the tests, and specifically [this](https://github.com/raiden-network/raiden/blob/3b12c5564b99e8bdda7d7f143c4608754fca3f76/raiden/tests/integration/test_raidenservice.py#L222) one I discovered a bug at how fees are set.

At the moment when an on-chain deposit is seen

https://github.com/raiden-network/raiden/blob/3b12c5564b99e8bdda7d7f143c4608754fca3f76/raiden/blockchain/decode.py#L382-L390

 we generate both the state change to [process the deposit](https://github.com/raiden-network/raiden/blob/3b12c5564b99e8bdda7d7f143c4608754fca3f76/raiden/blockchain/decode.py#L386) and the state change to [change the fees](https://github.com/raiden-network/raiden/blob/3b12c5564b99e8bdda7d7f143c4608754fca3f76/raiden/blockchain/decode.py#L399) at the same place.

This results in the state change to update fees using the old channel state before the deposit happened. So for each deposit seen on-chain the fees are updated according to the values of the previous deposit.

Same applies to the withdraw logic.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
