### PR TITLE
Move room creation into healtcheck

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -2,7 +2,7 @@ import json
 import time
 from functools import wraps
 from itertools import repeat
-from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Set
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional
 from urllib.parse import quote
 
 import gevent
@@ -93,13 +93,8 @@ class Room(MatrixRoom):
 
     def is_member(self, user: User):
         """Check if given user is already member of the room or return exception"""
-        member_ids: Set[str] = set()
-        last_ex = None
-        try:
-            member_ids = {member.user_id for member in self.get_joined_members(force_resync=True)}
-        except MatrixRequestError as e:
-            last_ex = e
-        return user.user_id in member_ids, last_ex
+        member_ids = {member.user_id for member in self.get_joined_members()}
+        return user.user_id in member_ids
 
 
 class GMatrixHttpApi(MatrixHttpApi):

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -35,6 +35,7 @@ from raiden.network.transport.matrix.utils import (
     login_or_register,
     make_client,
     make_room_alias,
+    my_place_or_yours,
     validate_and_parse_message,
     validate_userid_signature,
 )
@@ -523,7 +524,10 @@ class MatrixTransport(Runnable):
                 if validate_userid_signature(user) == node_address
             }
             self._address_mgr.add_userids_for_address(node_address, user_ids)
-            self._get_room_for_address(node_address)
+
+            # Check if we should invite or if we should be invited to evade room creation races
+            if my_place_or_yours(self._raiden_service.address, node_address) is not node_address:
+                self._get_room_for_address(node_address)
 
             # Ensure network state is updated in case we already know about the user presences
             # representing the target node

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -197,7 +197,7 @@ class UserAddressManager:
             self.log.error(
                 "Detected multiple online users for a single address",
                 address=to_checksum_address(address),
-                user_ids=online_user_ids
+                user_ids=online_user_ids,
             )
         return online_user_ids
 

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -687,7 +687,5 @@ def my_place_or_yours(our_address: Address, partner_address: Address) -> Address
     """Convention to compare two addresses. Compares lexicographical
     order and returns the preceding address """
 
-    if our_address == partner_address:
-        raise ValueError("Addresses to compare must differ")
     sorted_addresses = sorted([our_address, partner_address])
     return our_address if sorted_addresses[0] == our_address else partner_address

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -191,7 +191,7 @@ class UserAddressManager:
         online_user_ids = {
             user_id
             for user_id in self.get_userids_for_address(address)
-            if self.get_userid_presence(user_id) == UserPresence.ONLINE or UserPresence.UNKNOWN
+            if self.get_userid_presence(user_id) in {UserPresence.ONLINE, UserPresence.UNKNOWN}
         }
         if len(online_user_ids) > 1:
             self.log.error(

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -187,6 +187,20 @@ class UserAddressManager:
                 ),
             )
 
+    def get_online_user_ids_for_address(self, address: Address) -> Set[str]:
+        online_user_ids = {
+            user_id
+            for user_id in self.get_userids_for_address(address)
+            if self.get_userid_presence(user_id) == UserPresence.ONLINE or UserPresence.UNKNOWN
+        }
+        if len(online_user_ids) > 1:
+            self.log.error(
+                "Detected multiple online users for a single address",
+                address=to_checksum_address(address),
+                user_ids=online_user_ids
+            )
+        return online_user_ids
+
     def refresh_address_presence(self, address: Address) -> None:
         """
         Update synthesized address presence state from cached user presence states.

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -687,5 +687,7 @@ def my_place_or_yours(our_address: Address, partner_address: Address) -> Address
     """Convention to compare two addresses. Compares lexicographical
     order and returns the preceding address """
 
+    if our_address == partner_address:
+        raise ValueError("Addresses to compare must differ")
     sorted_addresses = sorted([our_address, partner_address])
     return our_address if sorted_addresses[0] == our_address else partner_address

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -144,7 +144,9 @@ def wait_for_peer_unreachable(
     )
 
 
-def wait_for_peer_reachable(transport: MatrixTransport, target_address: Address, timeout: int = 5):
+def wait_for_peer_reachable(
+    transport: MatrixTransport, target_address: Address, timeout: int = 15
+):
     _wait_for_peer_reachability(
         transport=transport,
         target_address=target_address,

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -168,8 +168,6 @@ def test_matrix_message_sync(matrix_transports):
     raiden_service1 = MockRaidenService(message_handler)
 
     raiden_service1.handle_and_track_state_changes = MagicMock()
-    transport0.whitelist(raiden_service1.address)
-    transport1.whitelist(raiden_service0.address)
 
     transport0.start(raiden_service0, message_handler, None)
     transport1.start(raiden_service1, message_handler, None)

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -401,10 +401,10 @@ def test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=unus
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
-    def fake_receive(room, event):  # pylint: disable=unused-argument
-        return True
+    def fake_send(room, event):  # pylint: disable=unused-argument
+        return
 
-    with patch.object(app1.raiden.transport, "_handle_message", side_effect=fake_receive):
+    with patch.object(app1.raiden.transport, "_send_raw", side_effect=fake_send):
         greenlet = gevent.spawn(
             RaidenAPI(app0.raiden).transfer,
             app0.raiden.default_registry.address,


### PR DESCRIPTION
## Description

- Moves room creation into healthcheck
- iterates through available room_id in get_room and searches for one with an online peer. Only returns an empty one in case no other one is found. 
- Adds retries for user roaming to another server, where the  address is already known.
- Reuses invite_user_to_room_with_retries in get_rooom_for_address.

 Closes #4715, #4716, #4391