### PR TITLE
Defines one TokenAddress per Scenario and fixes bf1

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -15,6 +15,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed
@@ -74,7 +75,7 @@ scenario:
       - parallel:
           name: "Enable MSs between node 4 and 3 (will be used later in the scenario)"
           tasks:
-            - store_channel_info: {from: 4, to: 3, key: "MS Test Channel"}
+            - store_channel_info: {from: 4, to: 3, key: "MS Test Channel 3-4"}
       - serial:
           name: "Make 10 transfers from 3 to 0"
           repeat: 10
@@ -218,10 +219,12 @@ scenario:
             ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
             - wait_blocks: 401
             # Below line should potentially have num_events: 2
-            - assert_events: {contract_name: "TokenNetwork", event_name: "NonClosingBalanceProofUpdated", num_events: 1}
+            - assert_events: {contract_name: "TokenNetwork", event_name: "NonClosingBalanceProofUpdated", num_events: 2}
 
             ## Monitored channel must be settled before the monitoring service can claim its reward
             ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
             ## To make sure the transactions gets mined in time, 10 additional blocks are added
+            ## Monitoring Service only reacts for the second closing because node4 settled to first
+            ## channel itself
             - wait_blocks: 110
-            - assert_ms_claim: {channel_info_key: "MS Test Channel"}
+            - assert_ms_claim: {channel_info_key: "MS Test Channel 3-4"}

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -15,7 +15,9 @@ settings:
         # The cost of an MR is `5 * 10 ** 18`
         balance_per_node: 7_000_000_000_000_000_000
         min_balance: 5_000_000_000_000_000_000
+
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -15,7 +15,9 @@ settings:
         # The cost of an MR is `5 * 10 ** 18`
         balance_per_node: 7_000_000_000_000_000_000
         min_balance: 5_000_000_000_000_000_000
+
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -15,7 +15,9 @@ settings:
         # The cost of an MR is `5 * 10 ** 18`
         balance_per_node: 7_000_000_000_000_000_000
         min_balance: 5_000_000_000_000_000_000
+
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -13,7 +13,9 @@ settings:
         deposit: true
         # MS reward is 5 * 10 ** 18 tokens, so less than that must be deposited
         max_funding: 10000
+
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -12,6 +12,7 @@ settings:
         deposit: true
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -12,6 +12,7 @@ settings:
         deposit: true
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -12,6 +12,7 @@ settings:
         deposit: true
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -12,6 +12,7 @@ settings:
         deposit: true
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -12,6 +12,7 @@ settings:
         deposit: true
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -12,6 +12,7 @@ settings:
         deposit: true
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -14,6 +14,7 @@ settings:
         min_balance: 20000
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -13,6 +13,7 @@ settings:
         balance_per_node: 5000
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -13,6 +13,7 @@ settings:
         balance_per_node: 5000
 
 token:
+  address: "0x62083c80353Df771426D209eF578619EE68D5C7A"
 
 nodes:
   mode: managed


### PR DESCRIPTION
Reasoning: When we add default fee values, it is easier to
set fees for that one token address to 0 than doing so for
every newly created TokenNetwork for every scenario

Fixes BF1 the last assert was wrong

