### PR TITLE
Handle Imbalance penalty fees edge cases in the state machine

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -228,7 +228,8 @@ def get_pending_transfer_pairs(
 def _fee_for_channel(channel: NettingChannelState, amount: PaymentAmount) -> Optional[FeeAmount]:
     """Returns the fee for the channel calculated from the channel state
 
-    Can also return None if the imbalance fee is calculated with an outdated/incosistent schedule.
+    Can also return None if the imbalance fee is calculated with an outdated/incosistent
+    schedule or if there is not enough balance to cover the transfer.
     """
     balance = get_balance(channel.our_state, channel.partner_state)
     try:


### PR DESCRIPTION


## Description

Fixes:  #4835 

1. Having an imbalance penalty fee during a transfer with insufficient
    balance does not throw an `UndefinedMediationFee` exception from the state machine

2. Having an outdated (for older capacity) imbalance penalty fee
    during a transfer where we have sufficient balance does not throw an
    `UndefinedMediationFee` exception from the state machine.

For (2) there is an open question.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
