### PR TITLE
Turn `raise_on_failure` into a decorator

### DIFF
--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -17,23 +17,10 @@ from raiden.transfer.state_change import ContractReceiveChannelSettled
 from raiden_contracts.constants import ChannelEvent
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("number_of_tokens", [1])
 def test_token_addresses(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_token_addresses,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-@pytest.mark.parametrize("number_of_nodes", [2])
-@pytest.mark.parametrize("number_of_tokens", [1])
-@pytest.mark.parametrize("channels_per_node", [0])
-def test_channel_open_token_network_not_registered_in_confirmed_block(
-    raiden_network, token_addresses
-):
     """
     Test that opening a channel via the API provides the confirmed block and not
     the latest block. The discrepancy there lead to potential timing issues where
@@ -87,21 +74,11 @@ def run_test_token_addresses(raiden_network, token_addresses):
     assert set(api.get_tokens_list(registry_address)) == set(token_addresses)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, retry_timeout):
     """Uses RaidenAPI to go through a complete channel lifecycle."""
-    raise_on_failure(
-        raiden_network,
-        run_test_raidenapi_channel_lifecycle,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, retry_timeout):
     node1, node2 = raiden_network
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(

--- a/raiden/tests/integration/api/test_pythonapi_regression.py
+++ b/raiden/tests/integration/api/test_pythonapi_regression.py
@@ -7,22 +7,13 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_close_regression(raiden_network, deposit, token_addresses):
     """ The python api was using the wrong balance proof to close the channel,
     thus the close was failing if a transfer was made.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_close_regression,
-        raiden_network=raiden_network,
-        deposit=deposit,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_close_regression(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -166,19 +166,10 @@ def wait_both_channel_deposit(
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_new(raiden_chain, retry_timeout, token_addresses):
-    raise_on_failure(
-        raiden_chain,
-        run_test_channel_new,
-        raiden_chain=raiden_chain,
-        retry_timeout=retry_timeout,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_channel_new(raiden_chain, retry_timeout, token_addresses):
     app0, app1 = raiden_chain  # pylint: disable=unbalanced-tuple-unpacking
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -198,21 +189,11 @@ def run_test_channel_new(raiden_chain, retry_timeout, token_addresses):
     assert channelcount0 + 1 == channelcount1
 
 
+@raise_on_failure
 @pytest.mark.parametrize("privatekey_seed", ["event_new_channel:{}"])
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
-    raise_on_failure(
-        raiden_chain,
-        run_test_channel_deposit,
-        raiden_chain=raiden_chain,
-        deposit=deposit,
-        retry_timeout=retry_timeout,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_channel_deposit(raiden_chain, deposit, retry_timeout, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
 
@@ -254,31 +235,10 @@ def run_test_channel_deposit(raiden_chain, deposit, retry_timeout, token_address
     assert_synced_channel_state(token_network_address, app0, deposit, [], app1, deposit, [])
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_query_events(
-    raiden_chain,
-    token_addresses,
-    deposit,
-    settle_timeout,
-    retry_timeout,
-    contract_manager,
-    blockchain_type,
-):
-    raise_on_failure(
-        raiden_chain,
-        run_test_query_events,
-        raiden_chain=raiden_chain,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        settle_timeout=settle_timeout,
-        retry_timeout=retry_timeout,
-        contract_manager=contract_manager,
-        blockchain_type=blockchain_type,
-    )
-
-
-def run_test_query_events(
     raiden_chain,
     token_addresses,
     deposit,
@@ -453,23 +413,10 @@ def run_test_query_events(
     assert must_have_event(all_netting_channel_events, settled_event)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_secret_revealed_on_chain(
-    raiden_chain, deposit, settle_timeout, token_addresses, retry_interval
-):
-    raise_on_failure(
-        raiden_chain,
-        run_test_secret_revealed_on_chain,
-        raiden_chain=raiden_chain,
-        deposit=deposit,
-        settle_timeout=settle_timeout,
-        token_addresses=token_addresses,
-        retry_interval=retry_interval,
-    )
-
-
-def run_test_secret_revealed_on_chain(
     raiden_chain, deposit, settle_timeout, token_addresses, retry_interval
 ):
     """ A node must reveal the secret on-chain if it's known and the channel is closed. """
@@ -541,19 +488,10 @@ def run_test_secret_revealed_on_chain(
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_clear_closed_queue(raiden_network, token_addresses, network_wait):
     """ Closing a channel clears the respective message queue. """
-    raise_on_failure(
-        raiden_network,
-        run_test_clear_closed_queue,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_clear_closed_queue(raiden_network, token_addresses, network_wait):
     app0, app1 = raiden_network
 
     hold_event_handler = app1.raiden.raiden_event_handler

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -74,17 +74,9 @@ def is_channel_registered(
     return is_in_channelid_map and is_in_partner_map
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_settle_is_automatically_called(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_settle_is_automatically_called,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_settle_is_automatically_called(raiden_network, token_addresses):
     """Settle is automatically called by one of the nodes."""
     app0, app1 = raiden_network
     registry_address = app0.raiden.default_registry.address
@@ -162,19 +154,10 @@ def run_test_settle_is_automatically_called(raiden_network, token_addresses):
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_lock_expiry(raiden_network, token_addresses, deposit):
     """Test lock expiry and removal."""
-    raise_on_failure(
-        raiden_network,
-        run_test_lock_expiry,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-    )
-
-
-def run_test_lock_expiry(raiden_network, token_addresses, deposit):
     alice_app, bob_app = raiden_network
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
@@ -284,6 +267,7 @@ def run_test_lock_expiry(raiden_network, token_addresses, deposit):
     assert transfer_2_secrethash in bob_channel_state.partner_state.secrethashes_to_lockedlocks
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_batch_unlock(raiden_network, token_addresses, secret_registry_address, deposit):
     """Tests that batch unlock is properly called.
@@ -292,17 +276,6 @@ def test_batch_unlock(raiden_network, token_addresses, secret_registry_address, 
     revealed *on-chain*. The node that receives the tokens has to call unlock,
     the node that doesn't gain anything does nothing.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_batch_unlock,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        secret_registry_address=secret_registry_address,
-        deposit=deposit,
-    )
-
-
-def run_test_batch_unlock(raiden_network, token_addresses, secret_registry_address, deposit):
     alice_app, bob_app = raiden_network
     alice_address = alice_app.raiden.address
     bob_address = bob_app.raiden.address
@@ -454,24 +427,10 @@ def run_test_batch_unlock(raiden_network, token_addresses, secret_registry_addre
     assert token_proxy.balance_of(bob_app.raiden.address) == bob_new_balance, msg
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_channel_withdraw(
     raiden_network, number_of_nodes, token_addresses, deposit, network_wait, retry_timeout
-):
-    raise_on_failure(
-        raiden_network,
-        run_test_channel_withdraw,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-        number_of_nodes=number_of_nodes,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_channel_withdraw(
-    raiden_network, token_addresses, deposit, network_wait, number_of_nodes, retry_timeout
 ):
     """ Withdraw funds after a mediated transfer."""
     alice_app, bob_app = raiden_network
@@ -531,24 +490,10 @@ def run_test_channel_withdraw(
     assert bob_initial_balance + total_withdraw == bob_balance_after_withdraw
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_channel_withdraw_expired(
     raiden_network, number_of_nodes, token_addresses, deposit, network_wait, retry_timeout
-):
-    raise_on_failure(
-        raiden_network,
-        run_test_channel_withdraw_expired,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-        number_of_nodes=number_of_nodes,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_channel_withdraw_expired(
-    raiden_network, token_addresses, deposit, network_wait, number_of_nodes, retry_timeout
 ):
     """ Tests withdraw expiration. """
     alice_app, bob_app = raiden_network
@@ -635,19 +580,10 @@ def run_test_channel_withdraw_expired(
         assert alice_bob_channel_state.partner_state.withdraws_pending.get(total_withdraw) is None
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_settled_lock(token_addresses, raiden_network, deposit):
-    raise_on_failure(
-        raiden_network,
-        run_test_settled_lock,
-        token_addresses=token_addresses,
-        raiden_network=raiden_network,
-        deposit=deposit,
-    )
-
-
-def run_test_settled_lock(token_addresses, raiden_network, deposit):
     """ Any transfer following a secret reveal must update the locksroot, so
     that an attacker cannot reuse a secret to double claim a lock.
     """
@@ -734,18 +670,10 @@ def run_test_settled_lock(token_addresses, raiden_network, deposit):
     assert token_proxy.balance_of(address1) == expected_balance1
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_automatic_secret_registration(raiden_chain, token_addresses):
-    raise_on_failure(
-        raiden_chain,
-        run_test_automatic_secret_registration,
-        raiden_chain=raiden_chain,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_automatic_secret_registration(raiden_chain, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
@@ -802,19 +730,10 @@ def run_test_automatic_secret_registration(raiden_chain, token_addresses):
     )
 
 
+@raise_on_failure
 @pytest.mark.xfail(reason="test incomplete")
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_start_end_attack(token_addresses, raiden_chain, deposit):
-    raise_on_failure(
-        raiden_chain,
-        run_test_start_end_attack,
-        token_addresses=token_addresses,
-        raiden_chain=raiden_chain,
-        deposit=deposit,
-    )
-
-
-def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
     """ An attacker can try to steal tokens from a hub or the last node in a
     path.
 
@@ -908,18 +827,9 @@ def run_test_start_end_attack(token_addresses, raiden_chain, deposit):
     assert hub_contract.participants[app1.raiden.address]["netted"] == deposit - amount
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_automatic_dispute(raiden_network, deposit, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_automatic_dispute,
-        raiden_network=raiden_network,
-        deposit=deposit,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_automatic_dispute(raiden_network, deposit, token_addresses):
     app0, app1 = raiden_network
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -992,18 +902,9 @@ def run_test_automatic_dispute(raiden_network, deposit, token_addresses):
     assert token_proxy.balance_of(app1.raiden.address) == expected_balance1
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_batch_unlock_after_restart(raiden_network, token_addresses, deposit):
-    raise_on_failure(
-        raiden_network,
-        run_test_batch_unlock_after_restart,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-    )
-
-
-def run_test_batch_unlock_after_restart(raiden_network, token_addresses, deposit):
     """Simulate the case where:
     - A sends B a transfer
     - B sends A a transfer

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -65,20 +65,12 @@ def saturated_count(connection_managers, registry_address, token_address):
 # TODO: add test scenarios for
 # - subsequent `connect()` calls with different `funds` arguments
 # - `connect()` calls with preexisting channels
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [6])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("settle_timeout", [10])
 @pytest.mark.parametrize("reveal_timeout", [3])
 def test_participant_selection(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_participant_selection,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_participant_selection(raiden_network, token_addresses):
     # pylint: disable=too-many-locals
     registry_address = raiden_network[0].raiden.default_registry.address
     one_to_n_address = raiden_network[0].raiden.default_one_to_n_address

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -16,6 +16,7 @@ from raiden.transfer.state_change import ContractReceiveChannelSettled
 from raiden_contracts.constants import MessageTypeId
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
@@ -32,19 +33,6 @@ def test_node_can_settle_if_close_didnt_use_any_balance_proof(
     - Assert that app0 can settle the closed channel, even though app1 didn't
     use the latest balance proof
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_node_can_settle_if_close_didnt_use_any_balance_proof,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
-    raiden_network, number_of_nodes, token_addresses, network_wait
-):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -115,6 +103,7 @@ def run_test_node_can_settle_if_close_didnt_use_any_balance_proof(
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
@@ -132,19 +121,6 @@ def test_node_can_settle_if_partner_does_not_call_update_transfer(
     - Assert that app0 can settle the closed channel, even though app1 didn't
     use the latest balance proof
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_node_can_settle_if_partner_does_not_call_update_transfer,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_node_can_settle_if_partner_does_not_call_update_transfer(
-    raiden_network, number_of_nodes, token_addresses, network_wait
-):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)

--- a/raiden/tests/integration/test_blockchainservice.py
+++ b/raiden/tests/integration/test_blockchainservice.py
@@ -5,19 +5,10 @@ from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.transfer import views
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_with_self(raiden_network, settle_timeout, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_channel_with_self,
-        raiden_network=raiden_network,
-        settle_timeout=settle_timeout,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_channel_with_self(raiden_network, settle_timeout, token_addresses):
     app0, = raiden_network  # pylint: disable=unbalanced-tuple-unpacking
 
     registry_address = app0.raiden.default_registry.address

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -19,22 +19,13 @@ from raiden.waiting import TransferWaitResult, wait_for_received_transfer_result
 log = structlog.get_logger(__name__)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("reveal_timeout", [15])
 @pytest.mark.parametrize("settle_timeout", [120])
 def test_echo_node_response(token_addresses, raiden_chain, retry_timeout):
-    raise_on_failure(
-        raiden_apps=raiden_chain,
-        test_function=run_test_echo_node_response,
-        token_addresses=token_addresses,
-        raiden_chain=raiden_chain,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_echo_node_response(token_addresses, raiden_chain, retry_timeout):
     app0, app1, echo_app = raiden_chain
     token_address = token_addresses[0]
     registry_address = echo_app.raiden.default_registry.address
@@ -112,22 +103,6 @@ def run_test_echo_node_response(token_addresses, raiden_chain, retry_timeout):
     echo_node.stop()
 
 
-@pytest.mark.parametrize("number_of_nodes", [8])
-@pytest.mark.parametrize("number_of_tokens", [1])
-@pytest.mark.parametrize("channels_per_node", [CHAIN])
-@pytest.mark.parametrize("reveal_timeout", [15])
-@pytest.mark.parametrize("settle_timeout", [120])
-@pytest.mark.skip("https://github.com/raiden-network/raiden/issues/3750")
-def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
-    raise_on_failure(
-        raiden_apps=raiden_chain,
-        test_function=run_test_echo_node_lottery,
-        token_addresses=token_addresses,
-        raiden_chain=raiden_chain,
-        network_wait=network_wait,
-    )
-
-
 def transfer_and_await(app, token_address, target, amount, identifier, timeout):
     payment_status = RaidenAPI(app.raiden).transfer_async(
         registry_address=app.raiden.default_registry.address,
@@ -147,7 +122,14 @@ def transfer_and_await(app, token_address, target, amount, identifier, timeout):
         payment_status.payment_done.wait()
 
 
-def run_test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
+@raise_on_failure
+@pytest.mark.parametrize("number_of_nodes", [8])
+@pytest.mark.parametrize("number_of_tokens", [1])
+@pytest.mark.parametrize("channels_per_node", [CHAIN])
+@pytest.mark.parametrize("reveal_timeout", [15])
+@pytest.mark.parametrize("settle_timeout", [120])
+@pytest.mark.skip("https://github.com/raiden-network/raiden/issues/3750")
+def test_echo_node_lottery(token_addresses, raiden_chain, network_wait):
     app0, app1, app2, app3, echo_app, app4, app5, app6 = raiden_chain
     address_to_app = {app.raiden.address: app for app in raiden_chain}
     token_address = token_addresses[0]

--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -11,6 +11,7 @@ from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.utils.typing import List, TokenAddress, TokenAmount, WithdrawAmount
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize(
@@ -18,18 +19,6 @@ from raiden.utils.typing import List, TokenAddress, TokenAmount, WithdrawAmount
 )
 @pytest.mark.parametrize("routing_mode", [RoutingMode.PFS])
 def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
-    raiden_network, token_addresses
-) -> None:
-
-    raise_on_failure(
-        raiden_apps=raiden_network,
-        test_function=run_test_pfs_send_capacity_update_on_deposit_and_withdraw,  # noqa
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_pfs_send_capacity_update_on_deposit_and_withdraw(
     raiden_network: List[App], token_addresses: List[TokenAddress]
 ) -> None:
     # we need to test if CapacityUpdates are sent after a deposit and a withdraw

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -44,23 +44,13 @@ TEST_TOKEN_SWAP_SETTLE_TIMEOUT = (
 )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("privatekey_seed", ["test_token_registration:{}"])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("environment_type", [Environment.DEVELOPMENT])
 def test_register_token(raiden_network, token_amount, contract_manager, retry_timeout):
-    raise_on_failure(
-        raiden_network,
-        run_test_register_token,
-        raiden_network=raiden_network,
-        token_amount=token_amount,
-        contract_manager=contract_manager,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_register_token(raiden_network, token_amount, contract_manager, retry_timeout):
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -101,21 +91,12 @@ def run_test_register_token(raiden_network, token_amount, contract_manager, retr
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("privatekey_seed", ["test_token_registration:{}"])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
 def test_register_token_insufficient_eth(raiden_network, token_amount, contract_manager):
-    raise_on_failure(
-        raiden_network,
-        run_test_register_token_insufficient_eth,
-        raiden_network=raiden_network,
-        token_amount=token_amount,
-        contract_manager=contract_manager,
-    )
-
-
-def run_test_register_token_insufficient_eth(raiden_network, token_amount, contract_manager):
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -143,6 +124,7 @@ def run_test_register_token_insufficient_eth(raiden_network, token_amount, contr
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -154,17 +136,6 @@ def test_token_registered_race(raiden_chain, token_amount, retry_timeout, contra
     node that receives an error for "already registered token" must see the
     token in the token list. Issue: #784
     """
-    raise_on_failure(
-        raiden_chain,
-        run_test_token_registered_race,
-        raiden_chain=raiden_chain,
-        token_amount=token_amount,
-        retry_timeout=retry_timeout,
-        contract_manager=contract_manager,
-    )
-
-
-def run_test_token_registered_race(raiden_chain, token_amount, retry_timeout, contract_manager):
     app0, app1 = raiden_chain
 
     api0 = RaidenAPI(app0.raiden)
@@ -211,6 +182,7 @@ def run_test_token_registered_race(raiden_chain, token_amount, retry_timeout, co
     assert token_address in api1.get_tokens_list(registry_address)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -220,15 +192,6 @@ def test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
     `ContractReceiveChannelDeposit` message since the API needs to return
     the channel with the deposit balance updated.
     """
-    raise_on_failure(
-        raiden_chain,
-        run_test_deposit_updates_balance_immediately,
-        raiden_chain=raiden_chain,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
     app0, app1 = raiden_chain
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -245,18 +208,10 @@ def run_test_deposit_updates_balance_immediately(raiden_chain, token_addresses):
     assert new_state.our_state.contract_balance == old_state.our_state.contract_balance + 10
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_transfer_to_unknownchannel(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_transfer_to_unknownchannel,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_transfer_to_unknownchannel(raiden_network, token_addresses):
     app0, _ = raiden_network
     token_address = token_addresses[0]
     str_address = "\xf0\xef3\x01\xcd\xcfe\x0f4\x9c\xf6d\xa2\x01?X4\x84\xa9\xf1"
@@ -322,18 +277,10 @@ def test_token_swap(raiden_network, deposit, token_addresses):
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_channel_events(raiden_chain, token_addresses):
-    raise_on_failure(
-        raiden_chain,
-        run_test_api_channel_events,
-        raiden_chain=raiden_chain,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_api_channel_events(raiden_chain, token_addresses):
     app0, app1 = raiden_chain
     token_address = token_addresses[0]
 
@@ -364,19 +311,10 @@ def run_test_api_channel_events(raiden_chain, token_addresses):
     assert must_have_event(app1_events, {"event": ChannelEvent.DEPOSIT})
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_insufficient_funds(raiden_network, token_addresses, deposit):
-    raise_on_failure(
-        raiden_network,
-        run_test_insufficient_funds,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-    )
-
-
-def run_test_insufficient_funds(raiden_network, token_addresses, deposit):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
@@ -389,19 +327,11 @@ def run_test_insufficient_funds(raiden_network, token_addresses, deposit):
     assert isinstance(result.payment_done.get(), EventPaymentSentFailed)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_funds_check_for_openchannel(raiden_network, token_addresses):
     """Reproduces issue 2923 -- two open channel racing through the gas reserve"""
-    raise_on_failure(
-        raiden_network,
-        run_test_funds_check_for_openchannel,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_funds_check_for_openchannel(raiden_network, token_addresses):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
 
@@ -426,6 +356,7 @@ def run_test_funds_check_for_openchannel(raiden_network, token_addresses):
         gevent.joinall(greenlets, raise_error=True)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("reveal_timeout", [8])
@@ -441,19 +372,6 @@ def test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=unus
 
     Issue: https://github.com/raiden-network/raiden/issues/3094"""
 
-    raise_on_failure(
-        raiden_network,
-        run_test_payment_timing_out_if_partner_does_not_respond,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        reveal_timeout=reveal_timeout,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=unused-argument
-    raiden_network, token_addresses, reveal_timeout, retry_timeout
-):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
@@ -475,6 +393,8 @@ def run_test_payment_timing_out_if_partner_does_not_respond(  # pylint: disable=
         assert not greenlet.value
 
 
+@raise_on_failure
+@pytest.mark.parametrize("privatekey_seed", ["test_set_deposit_limit_crash:{}"])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [0])
@@ -491,18 +411,6 @@ def test_participant_deposit_amount_must_be_smaller_than_the_limit(
     https://github.com/raiden-network/raiden-contracts/pull/276/ , the limit is
     available since version 0.4.0 of the smart contract.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_participant_deposit_amount_must_be_smaller_than_the_limit,
-        raiden_network=raiden_network,
-        contract_manager=contract_manager,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_participant_deposit_amount_must_be_smaller_than_the_limit(
-    raiden_network: List[App], contract_manager: ContractManager, retry_timeout: float
-) -> None:
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -562,6 +470,7 @@ def run_test_participant_deposit_amount_must_be_smaller_than_the_limit(
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [0])
@@ -583,18 +492,6 @@ def test_deposit_amount_must_be_smaller_than_the_token_network_limit(
 
     This test checks the limit is properly check from the REST API.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_deposit_amount_must_be_smaller_than_the_token_network_limit,
-        raiden_network=raiden_network,
-        contract_manager=contract_manager,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_deposit_amount_must_be_smaller_than_the_token_network_limit(
-    raiden_network: List[App], contract_manager: ContractManager, retry_timeout: float
-) -> None:
     app1 = raiden_network[0]
 
     registry_address = app1.raiden.default_registry.address
@@ -655,19 +552,11 @@ def run_test_deposit_amount_must_be_smaller_than_the_token_network_limit(
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_create_monitoring_request(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_create_monitoring_request,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_create_monitoring_request(raiden_network, token_addresses):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -33,6 +33,7 @@ from raiden.utils import BlockNumber
 from raiden.utils.typing import FeeAmount, PaymentAmount, PaymentID, ProportionalFeeAmount, Type
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -42,14 +43,6 @@ def test_regression_filters_must_be_installed_from_confirmed_block(raiden_networ
 
     Regression test for: https://github.com/raiden-network/raiden/issues/2894.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_regression_filters_must_be_installed_from_confirmed_block,
-        raiden_network=raiden_network,
-    )
-
-
-def run_test_regression_filters_must_be_installed_from_confirmed_block(raiden_network):
     app0 = raiden_network[0]
 
     app0.raiden.alarm.stop()
@@ -70,6 +63,7 @@ def run_test_regression_filters_must_be_installed_from_confirmed_block(raiden_ne
     assert not search_for_item(app0_state_changes, Block, {"block_number": target_block_num})
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize(
@@ -85,20 +79,6 @@ def test_regression_transport_global_queues_are_initialized_on_restart_for_servi
 
     Regression test for: https://github.com/raiden-network/raiden/issues/3656.
     """
-    raise_on_failure(
-        raiden_apps=raiden_network,
-        test_function=run_test_regression_transport_global_queues_are_initialized_on_restart_for_services,  # noqa
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-        user_deposit_address=user_deposit_address,
-    )
-
-
-def run_test_regression_transport_global_queues_are_initialized_on_restart_for_services(
-    raiden_network, number_of_nodes, token_addresses, network_wait, user_deposit_address
-):
     app0, app1 = raiden_network
     app0.config["services"]["monitoring_enabled"] = True
     # Send a transfer to make sure the state has a balance proof

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -50,6 +50,7 @@ def open_and_wait_for_channels(app_channels, registry_address, token, deposit, s
     wait_for_channels(app_channels, registry_address, [token], deposit)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [5])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("settle_timeout", [64])  # default settlement is too low for 3 hops
@@ -59,19 +60,6 @@ def test_regression_unfiltered_routes(raiden_network, token_addresses, settle_ti
     Transfers failed in networks where two or more paths to the destination are
     possible but they share same node as a first hop.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_regression_unfiltered_routes,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        settle_timeout=settle_timeout,
-        deposit=deposit,
-    )
-
-
-def run_test_regression_unfiltered_routes(
-    raiden_network, token_addresses, settle_timeout, deposit
-):
     app0, app1, app2, app3, app4 = raiden_network
     token = token_addresses[0]
     registry_address = app0.raiden.default_registry.address
@@ -87,24 +75,13 @@ def run_test_regression_unfiltered_routes(
     transfer(initiator_app=app0, target_app=app4, token_address=token, amount=1, identifier=1)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_regression_revealsecret_after_secret(raiden_network, token_addresses, transport_protocol):
     """ A RevealSecret message received after a Unlock message must be cleanly
     handled.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_regression_revealsecret_after_secret,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        transport_protocol=transport_protocol,
-    )
-
-
-def run_test_regression_revealsecret_after_secret(
-    raiden_network, token_addresses, transport_protocol
-):
     app0, app1, app2 = raiden_network
     token = token_addresses[0]
 
@@ -134,6 +111,7 @@ def run_test_regression_revealsecret_after_secret(
         raise TypeError("Unknown TransportProtocol")
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_regression_multiple_revealsecret(raiden_network, token_addresses, transport_protocol):
@@ -154,16 +132,6 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
     unregistered. And because the channel was already updated an exception was raised
     for an unknown secret.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_regression_multiple_revealsecret,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        transport_protocol=transport_protocol,
-    )
-
-
-def run_test_regression_multiple_revealsecret(raiden_network, token_addresses, transport_protocol):
     app0, app1 = raiden_network
     token = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
@@ -257,25 +225,13 @@ def test_regression_register_secret_once(secret_registry_address, deploy_service
     assert previous_nonce == deploy_service.client._available_nonce
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [5])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_regression_payment_complete_after_refund_to_the_initiator(
     raiden_network, token_addresses, settle_timeout, deposit
 ):
     """Regression test for issue #3915"""
-    raise_on_failure(
-        raiden_apps=raiden_network,
-        test_function=run_regression_payment_complete_after_refund_to_the_initiator,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        settle_timeout=settle_timeout,
-        deposit=deposit,
-    )
-
-
-def run_regression_payment_complete_after_refund_to_the_initiator(
-    raiden_network, token_addresses, settle_timeout, deposit
-):
     app0, app1, app2, app3, app4 = raiden_network
     token = token_addresses[0]
     registry_address = app0.raiden.default_registry.address

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -30,21 +30,10 @@ STATE_PRUNING = {
 }
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNING])
 def test_locksroot_loading_during_channel_settle_handling(
-    raiden_chain, deploy_client, token_addresses
-):
-    raise_on_failure(
-        raiden_chain,
-        run_test_locksroot_loading_during_channel_settle_handling,
-        raiden_chain=raiden_chain,
-        deploy_client=deploy_client,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_locksroot_loading_during_channel_settle_handling(
     raiden_chain, deploy_client, token_addresses
 ):
     app0, app1 = raiden_chain

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -21,6 +21,7 @@ from raiden.utils import BlockNumber, create_default_identifier
 from raiden.utils.typing import TokenAmount
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
@@ -29,17 +30,6 @@ def test_send_queued_messages(  # pylint: disable=unused-argument
     raiden_network, deposit, token_addresses, network_wait
 ):
     """Test re-sending of undelivered messages on node restart"""
-    raise_on_failure(
-        raiden_network,
-        run_test_send_queued_messages,
-        raiden_network=raiden_network,
-        deposit=deposit,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_send_queued_messages(raiden_network, deposit, token_addresses, network_wait):
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -142,6 +132,7 @@ def run_test_send_queued_messages(raiden_network, deposit, token_addresses, netw
     new_transport.stop()
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -159,16 +150,6 @@ def test_payment_statuses_are_restored(  # pylint: disable=unused-argument
     started the transfers.
     Related issue: https://github.com/raiden-network/raiden/issues/3432
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_payment_statuses_are_restored,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_payment_statuses_are_restored(raiden_network, token_addresses, network_wait):
     app0, app1 = raiden_network
 
     token_address = token_addresses[0]

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -35,23 +35,10 @@ from raiden.utils.typing import BlockNumber, FeeAmount, PaymentAmount, TokenAmou
 from raiden.waiting import wait_for_block
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer(
-    raiden_network, number_of_nodes, deposit, token_addresses, network_wait
-):
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        deposit=deposit,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_mediated_transfer(
     raiden_network, number_of_nodes, deposit, token_addresses, network_wait
 ):
     app0, app1, app2 = raiden_network
@@ -96,22 +83,10 @@ def run_test_mediated_transfer(
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [1])
 def test_locked_transfer_secret_registered_onchain(
-    raiden_network, token_addresses, secret_registry_address, retry_timeout
-):
-    raise_on_failure(
-        raiden_network,
-        run_test_locked_transfer_secret_registered_onchain,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        secret_registry_address=secret_registry_address,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_locked_transfer_secret_registered_onchain(
     raiden_network, token_addresses, secret_registry_address, retry_timeout
 ):
     app0 = raiden_network[0]
@@ -169,23 +144,10 @@ def run_test_locked_transfer_secret_registered_onchain(
     assert not transfer_statechange_dispatched
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer_with_entire_deposit(
-    raiden_network, number_of_nodes, token_addresses, deposit, network_wait
-):
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer_with_entire_deposit,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-    )
-
-
-def run_test_mediated_transfer_with_entire_deposit(
     raiden_network, number_of_nodes, token_addresses, deposit, network_wait
 ):
     app0, app1, app2 = raiden_network
@@ -240,22 +202,10 @@ def run_test_mediated_transfer_with_entire_deposit(
 
 
 @pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/4804")
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer_messages_out_of_order(  # pylint: disable=unused-argument
-    raiden_network, deposit, token_addresses, network_wait
-):
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer_messages_out_of_order,
-        raiden_network=raiden_network,
-        deposit=deposit,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_mediated_transfer_messages_out_of_order(
     raiden_network, deposit, token_addresses, network_wait
 ):
     """Raiden must properly handle repeated locked transfer messages."""
@@ -338,18 +288,10 @@ def run_test_mediated_transfer_messages_out_of_order(
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", (1,))
 @pytest.mark.parametrize("channels_per_node", (CHAIN,))
 def test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer_calls_pfs,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
     app0, = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -414,6 +356,7 @@ def run_test_mediated_transfer_calls_pfs(raiden_network, token_addresses):
 
 
 # pylint: disable=unused-argument
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
@@ -424,20 +367,6 @@ def test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
     Which means that the initiator will not reveal the secret
     to the target.
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer_with_node_consuming_more_than_allocated_fee,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        deposit=deposit,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
-    raiden_network, number_of_nodes, deposit, token_addresses, network_wait
-):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
@@ -509,6 +438,7 @@ def run_test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
     assert transfer_state != "transfer_secret_revealed", msg
 
 
+@raise_on_failure
 @pytest.mark.parametrize("case_no", range(7))
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [4])
@@ -518,22 +448,6 @@ def test_mediated_transfer_with_fees(
     """
     Test mediation with a variety of fee schedules
     """
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer_with_fees,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        deposit=deposit,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-        case_no=case_no,
-    )
-
-
-def run_test_mediated_transfer_with_fees(
-    raiden_network, number_of_nodes, deposit, token_addresses, network_wait, case_no
-):
-
     apps = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(apps[0])

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -13,22 +13,10 @@ from raiden.transfer.mediated_transfer.events import (
 from raiden.utils import wait_until
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_mediated_transfer_events(raiden_network, number_of_nodes, token_addresses, network_wait):
-    raise_on_failure(
-        raiden_network,
-        run_test_mediated_transfer_events,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        network_wait=network_wait,
-    )
-
-
-def run_test_mediated_transfer_events(
-    raiden_network, number_of_nodes, token_addresses, network_wait
-):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
 

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -27,24 +27,12 @@ from raiden.transfer.events import EventPaymentSentFailed
 from raiden.utils.signer import LocalSigner
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_failsfast_lockedtransfer_exceeding_distributable(
     raiden_network, token_addresses, deposit
 ):
-    raise_on_failure(
-        raiden_network,
-        run_test_failsfast_lockedtransfer_exceeding_distributable,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-    )
-
-
-def run_test_failsfast_lockedtransfer_exceeding_distributable(
-    raiden_network, token_addresses, deposit
-):
-
     app0, app1 = raiden_network
     token_address = token_addresses[0]
 
@@ -62,18 +50,10 @@ def run_test_failsfast_lockedtransfer_exceeding_distributable(
     assert_synced_channel_state(token_network_address, app0, deposit, [], app1, deposit, [])
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_failfast_lockedtransfer_nochannel,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
     """When the node has no channels it should fail without raising exceptions."""
     token_address = token_addresses[0]
     app0, app1 = raiden_network
@@ -89,27 +69,12 @@ def run_test_failfast_lockedtransfer_nochannel(raiden_network, token_addresses):
     assert isinstance(payment_status.payment_done.get(), EventPaymentSentFailed)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_receive_lockedtransfer_invalidnonce(
     raiden_network, number_of_nodes, deposit, token_addresses, reveal_timeout, network_wait
 ):
-    raise_on_failure(
-        raiden_network,
-        run_test_receive_lockedtransfer_invalidnonce,
-        raiden_network=raiden_network,
-        number_of_nodes=number_of_nodes,
-        deposit=deposit,
-        token_addresses=token_addresses,
-        reveal_timeout=reveal_timeout,
-        network_wait=network_wait,
-    )
-
-
-def run_test_receive_lockedtransfer_invalidnonce(
-    raiden_network, number_of_nodes, deposit, token_addresses, reveal_timeout, network_wait
-):
-
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
@@ -168,25 +133,12 @@ def run_test_receive_lockedtransfer_invalidnonce(
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 def test_receive_lockedtransfer_invalidsender(
     raiden_network, token_addresses, deposit, reveal_timeout
 ):
-    raise_on_failure(
-        raiden_network,
-        run_test_receive_lockedtransfer_invalidsender,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        reveal_timeout=reveal_timeout,
-    )
-
-
-def run_test_receive_lockedtransfer_invalidsender(
-    raiden_network, token_addresses, deposit, reveal_timeout
-):
-
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     other_key, other_address = make_privkey_address()
@@ -222,25 +174,12 @@ def run_test_receive_lockedtransfer_invalidsender(
     assert_synced_channel_state(token_network_address, app0, deposit, [], app1, deposit, [])
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_receive_lockedtransfer_invalidrecipient(
     raiden_network, token_addresses, reveal_timeout, deposit
 ):
-    raise_on_failure(
-        raiden_network,
-        run_test_receive_lockedtransfer_invalidrecipient,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-        reveal_timeout=reveal_timeout,
-        deposit=deposit,
-    )
-
-
-def run_test_receive_lockedtransfer_invalidrecipient(
-    raiden_network, token_addresses, reveal_timeout, deposit
-):
-
     app0, app1 = raiden_network
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
@@ -277,26 +216,13 @@ def run_test_receive_lockedtransfer_invalidrecipient(
     assert_synced_channel_state(token_network_address, app0, deposit, [], app1, deposit, [])
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("settle_timeout", [30])
 def test_received_lockedtransfer_closedchannel(
     raiden_network, reveal_timeout, token_addresses, deposit
 ):
-    raise_on_failure(
-        raiden_network,
-        run_test_received_lockedtransfer_closedchannel,
-        raiden_network=raiden_network,
-        reveal_timeout=reveal_timeout,
-        token_addresses=token_addresses,
-        deposit=deposit,
-    )
-
-
-def run_test_received_lockedtransfer_closedchannel(
-    raiden_network, reveal_timeout, token_addresses, deposit
-):
-
     app0, app1 = raiden_network
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -12,18 +12,10 @@ from raiden.transfer import views
 from raiden.utils.signer import LocalSigner
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
-    raise_on_failure(
-        raiden_network,
-        run_test_receive_secrethashtransfer_unknown,
-        raiden_network=raiden_network,
-        token_addresses=token_addresses,
-    )
-
-
-def run_test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     app0 = raiden_network[0]
     token_address = token_addresses[0]
 

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -35,21 +35,11 @@ from raiden.transfer.views import state_from_raiden
 from raiden.waiting import wait_for_block, wait_for_settle
 
 
+@raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("settle_timeout", [50])
 def test_refund_messages(raiden_chain, token_addresses, deposit, network_wait):
-    raise_on_failure(
-        raiden_chain,
-        run_test_refund_messages,
-        raiden_chain=raiden_chain,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-    )
-
-
-def run_test_refund_messages(raiden_chain, token_addresses, deposit, network_wait):
     # The network has the following topology:
     #
     #   App0 <---> App1 <---> App2
@@ -113,25 +103,11 @@ def run_test_refund_messages(raiden_chain, token_addresses, deposit, network_wai
         )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("privatekey_seed", ["test_refund_transfer:{}"])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_refund_transfer(
-    raiden_chain, number_of_nodes, token_addresses, deposit, network_wait, retry_timeout
-):
-    raise_on_failure(
-        raiden_chain,
-        run_test_refund_transfer,
-        raiden_chain=raiden_chain,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-        retry_timeout=retry_timeout,
-    )
-
-
-def run_test_refund_transfer(
     raiden_chain, number_of_nodes, token_addresses, deposit, network_wait, retry_timeout
 ):
     """A failed transfer must send a refund back.
@@ -315,32 +291,11 @@ def run_test_refund_transfer(
     assert secrethash not in state_from_raiden(app1.raiden).payment_mapping.secrethashes_to_task
 
 
+@raise_on_failure
 @pytest.mark.parametrize("privatekey_seed", ["test_different_view_of_last_bp_during_unlock:{}"])
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_different_view_of_last_bp_during_unlock(
-    raiden_chain,
-    number_of_nodes,
-    token_addresses,
-    deposit,
-    network_wait,
-    retry_timeout,
-    blockchain_type,
-):
-    raise_on_failure(
-        raiden_chain,
-        run_test_different_view_of_last_bp_during_unlock,
-        raiden_chain=raiden_chain,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-        retry_timeout=retry_timeout,
-        blockchain_type=blockchain_type,
-    )
-
-
-def run_test_different_view_of_last_bp_during_unlock(
     raiden_chain,
     number_of_nodes,
     token_addresses,
@@ -546,25 +501,12 @@ def run_test_different_view_of_last_bp_during_unlock(
     assert final_balance1 - deposit - initial_balance1 == 1
 
 
+@raise_on_failure
 @pytest.mark.parametrize("privatekey_seed", ["test_refund_transfer:{}"])
 @pytest.mark.parametrize("number_of_nodes", [4])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_refund_transfer_after_2nd_hop(
-    raiden_chain, number_of_nodes, token_addresses, deposit, network_wait
-):
-    raise_on_failure(
-        raiden_chain,
-        run_test_refund_transfer_after_2nd_hop,
-        raiden_chain=raiden_chain,
-        number_of_nodes=number_of_nodes,
-        token_addresses=token_addresses,
-        deposit=deposit,
-        network_wait=network_wait,
-    )
-
-
-def run_test_refund_transfer_after_2nd_hop(
     raiden_chain, number_of_nodes, token_addresses, deposit, network_wait
 ):
     """Test the refund transfer sent due to failure after 2nd hop"""

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -1,4 +1,5 @@
 import traceback
+from functools import wraps
 
 import gevent
 import structlog
@@ -7,36 +8,47 @@ from gevent.event import AsyncResult
 log = structlog.get_logger(__name__)
 
 
-def raise_on_failure(raiden_apps, test_function, **kwargs):
+def raise_on_failure(test_function):
     """Wait on the result for the test function and any of the apps.
 
-    This utility should be used for happy path testing with more than one app.
+    This decorator should be used for happy path testing with more than one app.
     This will raise if any of the apps is killed.
     """
-    result = AsyncResult()
 
-    # Do not use `link` or `link_value`, an app an be stopped to test restarts.
-    for app in raiden_apps:
-        assert app.raiden, "The RaidenService must be started"
-        app.raiden.link_exception(result)
+    @wraps(test_function)
+    def wrapper(**kwargs):
+        result = AsyncResult()
+        apps = kwargs.get("raiden_network", kwargs.get("raiden_chain"))
+        if not apps:
+            raise Exception(
+                f"Can't use `raise_on_failure` on test function {test_function.__name__} "
+                "which uses neither `raiden_network` nor `raiden_chain` fixtures."
+            )
 
-    test_greenlet = gevent.spawn(test_function, **kwargs)
-    test_greenlet.link(result)
+        # Do not use `link` or `link_value`, an app an be stopped to test restarts.
+        for app in apps:
+            assert app.raiden, "The RaidenService must be started"
+            app.raiden.link_exception(result)
 
-    # Returns if either happens:
-    # - The test finished (successfully or not)
-    # - One of the apps crashed during the test
-    try:
-        result.get()
-    except:  # noqa
-        # Print the stack trace of the running test to know in which line the
-        # test is waiting.
-        #
-        # This may print a duplicated stack trace, when the test fails.
-        log.exception(
-            "Test failed",
-            test_traceback="".join(traceback.format_stack(test_greenlet.gr_frame)),
-            all_tracebacks="\n".join(gevent.util.format_run_info()),
-        )
+        test_greenlet = gevent.spawn(test_function, **kwargs)
+        test_greenlet.link(result)
 
-        raise
+        # Returns if either happens:
+        # - The test finished (successfully or not)
+        # - One of the apps crashed during the test
+        try:
+            result.get()
+        except:  # noqa
+            # Print the stack trace of the running test to know in which line the
+            # test is waiting.
+            #
+            # This may print a duplicated stack trace, when the test fails.
+            log.exception(
+                "Test failed",
+                test_traceback="".join(traceback.format_stack(test_greenlet.gr_frame)),
+                all_tracebacks="\n".join(gevent.util.format_run_info()),
+            )
+
+            raise
+
+    return wrapper


### PR DESCRIPTION
## Description
This makes the code shorter and avoids the problem of mixing up the test
function with the function that actually implements the test body.
    
Tying it to the `raiden_network` and `raiden_chain` fixtures is a bit of
a hack, but it works nicely for our current use cases.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
