### PR TITLE
Remove add_token_without_limits() b/c never used

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -112,14 +112,6 @@ class TokenNetworkRegistry:
             },
         )
 
-    def add_token_without_limits(self, token_address: TokenAddress) -> TokenNetworkAddress:
-        """
-        Register token of `token_address` with the token network.
-        This applies for versions prior to 0.13.0 of raiden-contracts,
-        since limits were hardcoded into the TokenNetwork contract.
-        """
-        return self._add_token(token_address=token_address, additional_arguments=dict())
-
     def _add_token(
         self, token_address: TokenAddress, additional_arguments: Dict
     ) -> TokenNetworkAddress:


### PR DESCRIPTION
This function is useful for interacting with TokenNetworkRegistry
of RedEyes and similar versions, but currently it is never used.

Moreover, when I try to change the interface of _add_token()
function, I need to make a spurious change in add_token_without_limits().
So it is about time that this function should be removed from the codebase.

Fixes: #<issue>

## Description

It is a refactoring.  The PR removes deadcode.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
