### PR TITLE
Simplify add_token_with_limits()

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -227,7 +227,7 @@ class RaidenAPI:  # pragma: no unittest
         registry = self.raiden.chain.token_network_registry(registry_address)
 
         try:
-            return registry.add_token_with_limits(
+            return registry.add_token(
                 token_address=token_address,
                 channel_participant_deposit_limit=channel_participant_deposit_limit,
                 token_network_deposit_limit=token_network_deposit_limit,

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -93,7 +93,7 @@ class TokenNetworkRegistry:
 
         return address
 
-    def add_token_with_limits(
+    def add_token(
         self,
         token_address: TokenAddress,
         channel_participant_deposit_limit: TokenAmount,
@@ -106,14 +106,15 @@ class TokenNetworkRegistry:
         """
         return self._add_token(
             token_address=token_address,
-            additional_arguments={
-                "_channel_participant_deposit_limit": channel_participant_deposit_limit,
-                "_token_network_deposit_limit": token_network_deposit_limit,
-            },
+            channel_participant_deposit_limit=channel_participant_deposit_limit,
+            token_network_deposit_limit=token_network_deposit_limit,
         )
 
     def _add_token(
-        self, token_address: TokenAddress, additional_arguments: Dict
+        self,
+        token_address: TokenAddress,
+        channel_participant_deposit_limit: TokenAmount,
+        token_network_deposit_limit: TokenAmount,
     ) -> TokenNetworkAddress:
         if not is_binary_address(token_address):
             raise ValueError("Expected binary address format for token")
@@ -136,8 +137,11 @@ class TokenNetworkRegistry:
             checking_block = self.client.get_checking_block()
             error_prefix = "Call to createERC20TokenNetwork will fail"
 
-            kwarguments = {"_token_address": token_address}
-            kwarguments.update(additional_arguments)
+            kwarguments = {
+                "_token_address": token_address,
+                "_channel_participant_deposit_limit": channel_participant_deposit_limit,
+                "_token_network_deposit_limit": token_network_deposit_limit,
+            }
             gas_limit = self.proxy.estimate_gas(
                 checking_block, "createERC20TokenNetwork", **kwarguments
             )

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -68,7 +68,7 @@ def deploy_all_tokens_register_and_return_their_addresses(
     if register_tokens:
         for token in token_addresses:
             registry = deploy_service.token_network_registry(token_network_registry_address)
-            registry.add_token_with_limits(
+            registry.add_token(
                 token_address=token,
                 channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
                 token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
@@ -226,7 +226,7 @@ def register_token_and_return_the_network_proxy(
         contract_manager=contract_manager,
         blockchain_service=blockchain_service,
     )
-    token_network_address = token_network_registry_proxy.add_token_with_limits(
+    token_network_address = token_network_registry_proxy.add_token(
         token_address=token_proxy.address,
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -41,7 +41,7 @@ def test_token_network_registry(
 
     # Registering a non-existing token network should fail
     with pytest.raises(AddressWithoutCode):
-        token_network_registry_proxy.add_token_with_limits(
+        token_network_registry_proxy.add_token(
             token_address=bad_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),
@@ -63,7 +63,7 @@ def test_token_network_registry(
     # function implemented #3697 which is validated in the smart contract.
     with patch.object(Token, "total_supply", return_value=""):
         with pytest.raises(InvalidToken):
-            token_network_registry_proxy.add_token_with_limits(
+            token_network_registry_proxy.add_token(
                 token_address=test_token_address,
                 channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
                 token_network_deposit_limit=TokenAmount(UINT256_MAX),
@@ -71,7 +71,7 @@ def test_token_network_registry(
 
     # Register a valid token
     event_filter = token_network_registry_proxy.tokenadded_filter()
-    token_network_address = token_network_registry_proxy.add_token_with_limits(
+    token_network_address = token_network_registry_proxy.add_token(
         token_address=test_token_address,
         channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
         token_network_deposit_limit=TokenAmount(UINT256_MAX),
@@ -83,7 +83,7 @@ def test_token_network_registry(
     # because it is a race condition.
     match = "Token already registered"
     with pytest.raises(RaidenRecoverableError, match=match):
-        token_network_registry_proxy.add_token_with_limits(
+        token_network_registry_proxy.add_token(
             token_address=test_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -295,7 +295,7 @@ def setup_raiden(
         blockchain_service=blockchain_service,
     )
 
-    registry.add_token_with_limits(
+    registry.add_token(
         token_address=to_canonical_address(token.contract.address),
         channel_participant_deposit_limit=UINT256_MAX,
         token_network_deposit_limit=UINT256_MAX,

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -217,7 +217,7 @@ class ConsoleTools:
 
         registry = self._raiden.chain.token_network_registry(registry_address)
 
-        token_network_address = registry.add_token_with_limits(
+        token_network_address = registry.add_token(
             token_address=token_address,
             channel_participant_deposit_limit=UINT256_MAX,
             token_network_deposit_limit=UINT256_MAX,


### PR DESCRIPTION
First, since there is no longer add_token_without_limits() function,
the function can be simply named add_token().

Second, since we no longer have similar functions with different sets of keyword
arguments, we don't have to pass the keyword arguments in a dictionary.
As a result, the typechecking becomes more effective.

Fixes: #<issue>

## Description

Please, describe what this PR does in detail:
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

It's a refactoring.  Arguably the change is not necessary now.  Even without making the change I can probably add the `block_identifier` argument (#4830 ).  So this PR is a detour.  But I think other people don't have to ask "what does with_limits mean?"

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
