### PR TITLE
Sets deposit in bf1 scenario [skip tests]

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -11,7 +11,8 @@ settings:
       token:
         # Make sure that enough is deposited to pay for an MR
         # The cost of an MR is `5 * 10 ** 18`
-        balance_per_node: 7_000_000_000_000_000_000
+        deposit: true
+        balance_per_node: 100_000_000_000_000_000_000
         min_balance: 5_000_000_000_000_000_000
 
 token:


### PR DESCRIPTION
Fixes: #<no issue was created for that>

## Description

We need `deposit: true` in the scenario if UDC is enabled. If not the scenario crashes. 

