### PR TITLE
Precondition check in add_token

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -221,6 +221,12 @@ class RaidenAPI:  # pragma: no unittest
         if not is_binary_address(token_address):
             raise InvalidBinaryAddress("token_address must be a valid address in binary")
 
+        chainstate_before_addition = views.state_from_raiden(self.raiden)
+
+        # The following check is on prestate because the chain state does not
+        # change here.
+        # views.state_from_raiden() returns the same state again and again
+        # as far as this gevent context is running.
         if token_address in self.get_tokens_list(registry_address):
             raise AlreadyRegisteredTokenAddress("Token already registered")
 
@@ -231,6 +237,7 @@ class RaidenAPI:  # pragma: no unittest
                 token_address=token_address,
                 channel_participant_deposit_limit=channel_participant_deposit_limit,
                 token_network_deposit_limit=token_network_deposit_limit,
+                block_identifier=chainstate_before_addition.block_hash,
             )
         except RaidenRecoverableError as e:
             if "Token already registered" in str(e):

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -98,7 +98,9 @@ class TokenNetworkRegistry:
         token_address: TokenAddress,
         channel_participant_deposit_limit: TokenAmount,
         token_network_deposit_limit: TokenAmount,
+        block_identifier: BlockSpecification,
     ) -> TokenNetworkAddress:
+        # pylint: disable=unused-argument
         """
         Register token of `token_address` with the token network.
         The limits apply for version 0.13.0 and above of raiden-contracts,

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -111,6 +111,12 @@ class TokenNetworkRegistry:
         The limits apply for version 0.13.0 and above of raiden-contracts,
         since instantiation also takes the limits as constructor arguments.
         """
+        if block_identifier == "latest":
+            raise ValueError(
+                'Calling a proxy with "latest" is usually wrong because '
+                "the result of the precondition check is not precisely predictable."
+            )
+
         # check preconditions
         try:
             already_registered = self.get_token_network(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -456,10 +456,6 @@ class JSONRPCClient:
         """ Return the most recent block. """
         return self.web3.eth.blockNumber
 
-    def blockhash(self):
-        """ Return the most recent block hash """
-        return self.blockhash_from_blocknumber(self.block_number())
-
     def get_block(self, block_identifier: BlockSpecification) -> Dict:
         """Given a block number, query the chain to get its corresponding block hash"""
         return self.web3.eth.getBlock(block_identifier)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -456,6 +456,10 @@ class JSONRPCClient:
         """ Return the most recent block. """
         return self.web3.eth.blockNumber
 
+    def blockhash(self):
+        """ Return the most recent block hash """
+        return self.blockhash_from_blocknumber(self.block_number())
+
     def get_block(self, block_identifier: BlockSpecification) -> Dict:
         """Given a block number, query the chain to get its corresponding block hash"""
         return self.web3.eth.getBlock(block_identifier)

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -231,7 +231,7 @@ def register_token_and_return_the_network_proxy(
         token_address=token_proxy.address,
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
-        block_identifier=deploy_client.blockhash(),
+        block_identifier=deploy_client.get_confirmed_blockhash(),
     )
 
     blockchain_service = BlockChainService(

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -72,6 +72,7 @@ def deploy_all_tokens_register_and_return_their_addresses(
                 token_address=token,
                 channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
                 token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+                block_identifier=deploy_service.block_hash(),
             )
 
     return token_addresses
@@ -230,6 +231,7 @@ def register_token_and_return_the_network_proxy(
         token_address=token_proxy.address,
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
+        block_identifier=deploy_client.blockhash(),
     )
 
     blockchain_service = BlockChainService(

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -73,11 +73,12 @@ def test_token_network_registry(
 
     # Register a valid token
     event_filter = token_network_registry_proxy.tokenadded_filter()
+    preblockhash = deploy_client.blockhash()
     token_network_address = token_network_registry_proxy.add_token(
         token_address=test_token_address,
         channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
         token_network_deposit_limit=TokenAmount(UINT256_MAX),
-        block_identifier=deploy_client.blockhash(),
+        block_identifier=preblockhash,
     )
     assert token_network_address
     assert token_network_registry_proxy.get_token_network_created(to_block="latest") == 1
@@ -90,7 +91,7 @@ def test_token_network_registry(
             token_address=test_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),
-            block_identifier=deploy_client.blockhash(),
+            block_identifier=preblockhash,
         )
 
     logs = event_filter.get_all_entries()

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -45,7 +45,7 @@ def test_token_network_registry(
             token_address=bad_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),
-            block_identifier=deploy_client.blockhash(),
+            block_identifier=deploy_client.get_confirmed_blockhash(),
         )
 
     test_token = deploy_token(
@@ -68,12 +68,12 @@ def test_token_network_registry(
                 token_address=test_token_address,
                 channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
                 token_network_deposit_limit=TokenAmount(UINT256_MAX),
-                block_identifier=deploy_client.blockhash(),
+                block_identifier=deploy_client.get_confirmed_blockhash(),
             )
 
     # Register a valid token
     event_filter = token_network_registry_proxy.tokenadded_filter()
-    preblockhash = deploy_client.blockhash()
+    preblockhash = deploy_client.get_confirmed_blockhash()
     token_network_address = token_network_registry_proxy.add_token(
         token_address=test_token_address,
         channel_participant_deposit_limit=TokenAmount(UINT256_MAX),

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -45,6 +45,7 @@ def test_token_network_registry(
             token_address=bad_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),
+            block_identifier=deploy_client.blockhash(),
         )
 
     test_token = deploy_token(
@@ -67,6 +68,7 @@ def test_token_network_registry(
                 token_address=test_token_address,
                 channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
                 token_network_deposit_limit=TokenAmount(UINT256_MAX),
+                block_identifier=deploy_client.blockhash(),
             )
 
     # Register a valid token
@@ -75,6 +77,7 @@ def test_token_network_registry(
         token_address=test_token_address,
         channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
         token_network_deposit_limit=TokenAmount(UINT256_MAX),
+        block_identifier=deploy_client.blockhash(),
     )
     assert token_network_address
     assert token_network_registry_proxy.get_token_network_created(to_block="latest") == 1
@@ -87,6 +90,7 @@ def test_token_network_registry(
             token_address=test_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),
+            block_identifier=deploy_client.blockhash(),
         )
 
     logs = event_filter.get_all_entries()

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -299,7 +299,7 @@ def setup_raiden(
         token_address=to_canonical_address(token.contract.address),
         channel_participant_deposit_limit=UINT256_MAX,
         token_network_deposit_limit=UINT256_MAX,
-        block_identifier=client.blockhash(),
+        block_identifier=client.get_confirmed_blockhash(),
     )
 
     print_step("Setting up Raiden")

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -299,6 +299,7 @@ def setup_raiden(
         token_address=to_canonical_address(token.contract.address),
         channel_participant_deposit_limit=UINT256_MAX,
         token_network_deposit_limit=UINT256_MAX,
+        block_identifier=client.blockhash(),
     )
 
     print_step("Setting up Raiden")


### PR DESCRIPTION
Fixes: #4830

## Description
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

TokenNetworkRegistry.add_token() never raised `BrokenPreconditionError` because the precondition checks were missing.  This PR implements the precondition check in `TokenNetworkRegistry.add_token()` against "token already registered".

I had to add an argument `block_identifier` so I changed all callers.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
