### PR TITLE
Update handling of proportional fees given on cli

### DIFF
--- a/raiden/tests/unit/utils/test_mediation_fees.py
+++ b/raiden/tests/unit/utils/test_mediation_fees.py
@@ -43,4 +43,8 @@ def test_prepare_mediation_fee_config_prop_fee(cli_prop_fee):
     cli_prop_fee_ratio = cli_prop_fee / 1e6
     channel_prop_fee_ratio = fee_config.proportional_fee / 1e6
 
-    assert isclose((1 - channel_prop_fee_ratio) ** 2, 1 - cli_prop_fee_ratio, rel_tol=1e-6)
+    assert isclose(
+        1 + cli_prop_fee_ratio,
+        1 + channel_prop_fee_ratio + channel_prop_fee_ratio * (1 + cli_prop_fee_ratio),
+        rel_tol=1e-6,
+    )


### PR DESCRIPTION
## Description

After https://github.com/raiden-network/raiden/issues/4844, we need to
handle do the fee-per-mediation to fee-per-channel conversion slightly
differently.
This is also a good occasion to use the same function in the test, where
we have the same need.

Fixes https://github.com/raiden-network/raiden/issues/4860.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
