### PR TITLE
Add test helper to backwards calculate fees

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -45,27 +45,19 @@ def test_interpolation():
 
 def test_basic_fee():
     flat_schedule = FeeScheduleState(flat=FeeAmount(2))
-    assert flat_schedule.fee_payer(
-        PaymentWithFeeAmount(10), channel_balance=Balance(0)
-    ) == FeeAmount(2)
+    assert flat_schedule.fee_payer(PaymentWithFeeAmount(10), balance=Balance(0)) == FeeAmount(2)
 
     prop_schedule = FeeScheduleState(proportional=ProportionalFeeAmount(int(0.01e6)))
-    assert prop_schedule.fee_payer(
-        PaymentWithFeeAmount(40), channel_balance=Balance(0)
-    ) == FeeAmount(0)
-    assert prop_schedule.fee_payer(
-        PaymentWithFeeAmount(60), channel_balance=Balance(0)
-    ) == FeeAmount(1)
-    assert prop_schedule.fee_payer(
-        PaymentWithFeeAmount(1000), channel_balance=Balance(0)
-    ) == FeeAmount(10)
+    assert prop_schedule.fee_payer(PaymentWithFeeAmount(40), balance=Balance(0)) == FeeAmount(0)
+    assert prop_schedule.fee_payer(PaymentWithFeeAmount(60), balance=Balance(0)) == FeeAmount(1)
+    assert prop_schedule.fee_payer(PaymentWithFeeAmount(1000), balance=Balance(0)) == FeeAmount(10)
 
     combined_schedule = FeeScheduleState(
         flat=FeeAmount(2), proportional=ProportionalFeeAmount(int(0.01e6))
     )
-    assert combined_schedule.fee_payer(
-        PaymentWithFeeAmount(60), channel_balance=Balance(0)
-    ) == FeeAmount(3)
+    assert combined_schedule.fee_payer(PaymentWithFeeAmount(60), balance=Balance(0)) == FeeAmount(
+        3
+    )
 
 
 def test_imbalance_penalty():
@@ -77,26 +69,26 @@ def test_imbalance_penalty():
         ]
     )
     assert v_schedule.fee_payer(
-        channel_balance=Balance(100 - 0), amount=PaymentWithFeeAmount(50)
+        balance=Balance(100 - 0), amount=PaymentWithFeeAmount(50)
     ) == FeeAmount(-10)
     assert v_schedule.fee_payer(
-        channel_balance=Balance(100 - 50), amount=PaymentWithFeeAmount(50)
+        balance=Balance(100 - 50), amount=PaymentWithFeeAmount(50)
     ) == FeeAmount(10)
     assert v_schedule.fee_payer(
-        channel_balance=Balance(100 - 0), amount=PaymentWithFeeAmount(10)
+        balance=Balance(100 - 0), amount=PaymentWithFeeAmount(10)
     ) == FeeAmount(-2)
     assert v_schedule.fee_payer(
-        channel_balance=Balance(100 - 10), amount=PaymentWithFeeAmount(10)
+        balance=Balance(100 - 10), amount=PaymentWithFeeAmount(10)
     ) == FeeAmount(-2)
     assert v_schedule.fee_payer(
-        channel_balance=Balance(100 - 0), amount=PaymentWithFeeAmount(20)
+        balance=Balance(100 - 0), amount=PaymentWithFeeAmount(20)
     ) == FeeAmount(-4)
     assert v_schedule.fee_payer(
-        channel_balance=Balance(100 - 40), amount=PaymentWithFeeAmount(20)
+        balance=Balance(100 - 40), amount=PaymentWithFeeAmount(20)
     ) == FeeAmount(0)
 
     with pytest.raises(UndefinedMediationFee):
-        v_schedule.fee_payer(channel_balance=Balance(0), amount=PaymentWithFeeAmount(1))
+        v_schedule.fee_payer(balance=Balance(0), amount=PaymentWithFeeAmount(1))
 
 
 def test_linspace():

--- a/raiden/tests/utils/mediation_fees.py
+++ b/raiden/tests/utils/mediation_fees.py
@@ -1,0 +1,104 @@
+from itertools import islice
+
+from raiden.exceptions import UndefinedMediationFee
+from raiden.transfer.channel import get_balance
+from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
+from raiden.transfer.state import NettingChannelState
+from raiden.utils.typing import (
+    Balance,
+    FeeAmount,
+    Iterable,
+    List,
+    Optional,
+    PaymentAmount,
+    PaymentWithFeeAmount,
+    Sequence,
+)
+
+
+def window(seq: Sequence, n: int = 2) -> Iterable[tuple]:
+    """Returns a sliding window (of width n) over data from the iterable
+    s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...
+    See https://stackoverflow.com/a/6822773/114926
+    """
+    remaining_elements = iter(seq)
+    result = tuple(islice(remaining_elements, n))
+    if len(result) == n:
+        yield result
+    for elem in remaining_elements:
+        result = result[1:] + (elem,)
+        yield result
+
+
+def fee_sender(
+    fee_schedule: FeeScheduleState, balance: Balance, amount: PaymentWithFeeAmount
+) -> Optional[FeeAmount]:
+    """Returns the mediation fee for this channel when transferring the given amount"""
+    try:
+        return fee_schedule.fee_payer(amount, balance)
+    except UndefinedMediationFee:
+        return None
+
+
+def fee_receiver(
+    fee_schedule: FeeScheduleState, balance: Balance, amount: PaymentWithFeeAmount
+) -> Optional[FeeAmount]:
+    """Returns the mediation fee for this channel when receiving the given amount"""
+
+    def fee_in(imbalance_fee: FeeAmount) -> FeeAmount:
+        return FeeAmount(
+            round(
+                amount
+                - (
+                    (amount + fee_schedule.flat + imbalance_fee)
+                    / (1 - fee_schedule.proportional / 1e6)
+                )
+            )
+        )
+
+    imbalance_fee = fee_schedule.imbalance_fee(
+        amount=PaymentWithFeeAmount(amount - fee_in(imbalance_fee=FeeAmount(0))), balance=balance
+    )
+
+    return fee_in(imbalance_fee=imbalance_fee)
+
+
+def calculate_initial_amount_for_final_amount(
+    final_amount: PaymentAmount, channels: List[NettingChannelState]
+) -> Optional[PaymentWithFeeAmount]:
+    """ Calculates the payment amount including fees to be supplied to the given
+    channel configuration, so that `final_amount` arrived at the target. """
+
+    assert len(channels) >= 1, "Need at least one channel"
+
+    # No fees in direct transfer
+    if len(channels) == 1:
+        return PaymentWithFeeAmount(final_amount)
+
+    # Backpropagate fees in mediation scenario
+    total = PaymentWithFeeAmount(final_amount)
+    try:
+        for channel_in, channel_out in reversed(list(window(channels, 2))):
+            assert isinstance(channel_in, NettingChannelState)
+            fee_schedule_out = channel_out.fee_schedule
+            assert isinstance(channel_out, NettingChannelState)
+            fee_schedule_in = channel_in.fee_schedule
+
+            balance_out = get_balance(channel_out.our_state, channel_out.partner_state)
+            fee_out = fee_sender(fee_schedule=fee_schedule_out, balance=balance_out, amount=total)
+            if fee_out is None:
+                return None
+
+            total += fee_out  # type: ignore
+
+            # TODO: should order be switched?
+            balance_in = get_balance(channel_in.our_state, channel_in.partner_state)
+            fee_in = fee_receiver(fee_schedule=fee_schedule_in, balance=balance_in, amount=total)
+            if fee_in is None:
+                return None
+
+            total += fee_in  # type: ignore
+    except UndefinedMediationFee:
+        return None
+
+    return PaymentWithFeeAmount(total)

--- a/raiden/tests/utils/mediation_fees.py
+++ b/raiden/tests/utils/mediation_fees.py
@@ -49,11 +49,11 @@ def fee_receiver(
     def fee_in(imbalance_fee: FeeAmount) -> FeeAmount:
         return FeeAmount(
             round(
-                amount
-                - (
+                (
                     (amount + fee_schedule.flat + imbalance_fee)
                     / (1 - fee_schedule.proportional / 1e6)
                 )
+                - amount
             )
         )
 
@@ -93,7 +93,6 @@ def get_initial_payment_for_final_target_amount(
 
             total += fee_out  # type: ignore
 
-            # TODO: should order be switched?
             balance_in = get_balance(channel_in.our_state, channel_in.partner_state)
             fee_in = fee_receiver(fee_schedule=fee_schedule_in, balance=balance_in, amount=total)
             if fee_in is None:

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -250,7 +250,7 @@ def _fee_for_payee_channel(
     balance = get_balance(channel.our_state, channel.partner_state)
 
     try:
-        return channel.fee_schedule.fee_payee(amount=amount, channel_balance=balance)
+        return channel.fee_schedule.fee_payee(amount=amount, balance=balance)
     except UndefinedMediationFee:
         return None
 


### PR DESCRIPTION
Fixes: #4856 

## Description

This adds `raiden.tests.utils.mediation_fees.get_initial_payment_for_final_target_amount` which calculates the necessary initial amount, so that the target receives a certain payment amount after fees have been deducted.

We should add more tests, but this is a good enough for converting the tests to mediation fees.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
