### PR TITLE
Avoid adding a token at NULL_ADDRESS

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -210,8 +210,7 @@ class RaidenAPI:  # pragma: no unittest
             InvalidBinaryAddress: If the registry_address or token_address is not a valid address.
             AlreadyRegisteredTokenAddress: If the token is already registered.
             RaidenRecoverableError: If the register transaction failed, this may
-                happen because the account has not enough balance to pay for the
-                gas or this register call raced with another transaction and lost.
+            ValueError: If token_address is the null address (0x000000....00).
         """
 
         if not is_binary_address(registry_address):

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -232,13 +232,12 @@ class RaidenAPI:  # pragma: no unittest
         chainstate_before_addition = views.state_from_raiden(self.raiden)
 
         registry = self.raiden.chain.token_network_registry(registry_address)
-        chainstate = views.state_from_raiden(self.raiden)
 
         token_network_address = registry.add_token(
             token_address=token_address,
             channel_participant_deposit_limit=channel_participant_deposit_limit,
             token_network_deposit_limit=token_network_deposit_limit,
-            block_identifier=chainstate.block_hash,
+            block_identifier=chainstate_before_addition.block_hash,
         )
 
         waiting.wait_for_token_network(

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -549,6 +549,7 @@ class RestAPI:  # pragma: no unittest
             AlreadyRegisteredTokenAddress,
             InvalidToken,
             AddressWithoutCode,
+            ValueError,
         )
         log.debug(
             "Registering token",

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -73,6 +73,7 @@ from raiden.exceptions import (
     InvalidSecretHash,
     InvalidSettleTimeout,
     InvalidToken,
+    InvalidTokenAddress,
     MintFailed,
     PaymentConflict,
     SamePeerAddress,
@@ -545,11 +546,11 @@ class RestAPI:  # pragma: no unittest
             )
 
         conflict_exceptions = (
-            InvalidBinaryAddress,
-            AlreadyRegisteredTokenAddress,
-            InvalidToken,
             AddressWithoutCode,
-            ValueError,
+            AlreadyRegisteredTokenAddress,
+            InvalidBinaryAddress,
+            InvalidToken,
+            InvalidTokenAddress,
         )
         log.debug(
             "Registering token",

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -157,6 +157,10 @@ class InvalidToken(RaidenError):
     """ Raised if the token does not follow the ERC20 standard """
 
 
+class InvalidTokenAddress(RaidenError):
+    """ Raised if the token address is invalid """
+
+
 class STUNUnavailableException(RaidenError):
     pass
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -16,6 +16,7 @@ from raiden.constants import NULL_ADDRESS, NULL_ADDRESS_BYTES
 from raiden.exceptions import (
     BrokenPreconditionError,
     InvalidToken,
+    InvalidTokenAddress,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
@@ -110,7 +111,7 @@ class TokenNetworkRegistry:
             )
 
         if token_address == NULL_ADDRESS_BYTES:
-            raise ValueError("The call to register a token at 0x00..00 will fail.")
+            raise InvalidTokenAddress("The call to register a token at 0x00..00 will fail.")
 
         # check preconditions
         try:

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -109,6 +109,9 @@ class TokenNetworkRegistry:
                 "the result of the precondition check is not precisely predictable."
             )
 
+        if token_address == NULL_ADDRESS_BYTES:
+            raise ValueError("The call to register a token at 0x00..00 will fail.")
+
         # check preconditions
         try:
             already_registered = self.get_token_network(
@@ -120,10 +123,6 @@ class TokenNetworkRegistry:
         except BadFunctionCallOutput:
             raise_on_call_returned_empty(block_identifier)
         else:
-            if token_address == NULL_ADDRESS_BYTES:
-                raise BrokenPreconditionError(
-                    "The call to register a token at 0x00..00 will fail."
-                )
             if already_registered:
                 raise BrokenPreconditionError(
                     "The token is already registered in the TokenNetworkRegistry."

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -12,7 +12,7 @@ from eth_utils import (
 from web3.exceptions import BadFunctionCallOutput
 from web3.utils.contracts import find_matching_event_abi
 
-from raiden.constants import NULL_ADDRESS
+from raiden.constants import NULL_ADDRESS, NULL_ADDRESS_BYTES
 from raiden.exceptions import (
     BrokenPreconditionError,
     InvalidToken,
@@ -120,6 +120,10 @@ class TokenNetworkRegistry:
         except BadFunctionCallOutput:
             raise_on_call_returned_empty(block_identifier)
         else:
+            if token_address == NULL_ADDRESS_BYTES:
+                raise BrokenPreconditionError(
+                    "The call to register a token at 0x00..00 will fail."
+                )
             if already_registered:
                 raise BrokenPreconditionError(
                     "The token is already registered in the TokenNetworkRegistry."

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -142,15 +142,17 @@ def test_token_network_registry_with_zero_token_address(
 ):
     """ Try to register a token at 0x0000..00 """
     blockchain_service = BlockChainService(
-        jsonrpc_client=deploy_client, contract_manager=contract_manager
-    )
-    token_network_registry_proxy = TokenNetworkRegistry(
         jsonrpc_client=deploy_client,
-        registry_address=to_canonical_address(token_network_registry_address),
         contract_manager=contract_manager,
-        blockchain_service=blockchain_service,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
-    with pytest.raises(BrokenPreconditionError, match="0x00..00 will fail"):
+    token_network_registry_proxy = blockchain_service.token_network_registry(
+        token_network_registry_address
+    )
+    with pytest.raises(ValueError, match="0x00..00 will fail"):
         token_network_registry_proxy.add_token(
             token_address=NULL_ADDRESS_BYTES,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -4,7 +4,12 @@ import pytest
 from eth_utils import is_same_address, to_canonical_address, to_normalized_address
 
 from raiden.constants import GENESIS_BLOCK_NUMBER, NULL_ADDRESS_BYTES, UINT256_MAX
-from raiden.exceptions import AddressWithoutCode, InvalidToken, RaidenRecoverableError
+from raiden.exceptions import (
+    AddressWithoutCode,
+    InvalidToken,
+    InvalidTokenAddress,
+    RaidenRecoverableError,
+)
 from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.proxies.token import Token
 from raiden.network.rpc.client import JSONRPCClient
@@ -152,7 +157,7 @@ def test_token_network_registry_with_zero_token_address(
     token_network_registry_proxy = blockchain_service.token_network_registry(
         token_network_registry_address
     )
-    with pytest.raises(ValueError, match="0x00..00 will fail"):
+    with pytest.raises(InvalidTokenAddress, match="0x00..00 will fail"):
         token_network_registry_proxy.add_token(
             token_address=NULL_ADDRESS_BYTES,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),


### PR DESCRIPTION
because then the call to TokenNetworkRegistry will fail.

This fixes #4875.

~~Fixes: 4815~~

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

After this PR, TokenNetworkRegistry proxy refuses to register a token contract at address 0x00000000....00.  The constructor of TokenNetwork contract checks against this case, so the contract proxy needs to check this condition.

I didn't add post-failure checks because the precondition checks will completely remove the possibility that the token address is 0x00000000..00.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
