### PR TITLE
Raise AlreadyRegisteredTokenAddress whether or not the problem is found before calling the proxy

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -149,7 +149,7 @@ class TokenNotRegistered(RaidenError):
     """ Raised if there is no token network for token used when opening a channel  """
 
 
-class AlreadyRegisteredTokenAddress(RaidenError):
+class AlreadyRegisteredTokenAddress(RaidenValidationError):
     """ Raised when the token address in already registered with the given network. """
 
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -14,10 +14,10 @@ from web3.utils.contracts import find_matching_event_abi
 
 from raiden.constants import NULL_ADDRESS, NULL_ADDRESS_BYTES
 from raiden.exceptions import (
+    AlreadyRegisteredTokenAddress,
     BrokenPreconditionError,
     InvalidToken,
     InvalidTokenAddress,
-    RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
 from raiden.network.proxies.metadata import SmartContractMetadata
@@ -205,7 +205,9 @@ class TokenNetworkRegistry:
                 )
 
                 if self.get_token_network(token_address, block):
-                    raise RaidenRecoverableError(f"{error_prefix}. Token already registered")
+                    raise AlreadyRegisteredTokenAddress(
+                        f"{error_prefix}. Token already registered"
+                    )
 
                 raise RaidenUnrecoverableError(error_prefix)
 


### PR DESCRIPTION
Before this PR, the Python API's `add_token()` function raises `AlreadyRegisteredTokenAddress` when the problem is found before calling the proxy.  When the proxy finds the same problem, the API raised a different error (`RaidenRecoverableError`).

After this PR, in both cases, the caller gets `AlreadyRegisteredTokenAddress`.

------

**The description here is obsolete**

Before this commit, token_network_register() in the python API
caught RaidenRecoverableError and tried to figure out the cause
by looking at the error message.

After this commit, the proxy raises a more detailed exception
so that the proxy doesn't need to look at the error string.

Since AlreadyRegisteredTokenAddress exception never crashes the
node, it's classified into RaidenRecoverableError.

This is a part of https://github.com/raiden-network/raiden/issues/4878

## Description

- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

It's refactoring. We stop parsing strings that we generate. We raise an informative exception at the source of the problem. We don't let the wrapper to guess what happened in the proxy.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
