### PR TITLE
Remove an exception that is never thrown

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -210,7 +210,7 @@ class RaidenAPI:  # pragma: no unittest
         Raises:
             InvalidBinaryAddress: If the registry_address or token_address is not a valid address.
             AlreadyRegisteredTokenAddress: If the token is already registered.
-            TransactionThrew: If the register transaction failed, this may
+            RaidenRecoverableError: If the register transaction failed, this may
                 happen because the account has not enough balance to pay for the
                 gas or this register call raced with another transaction and lost.
         """
@@ -576,7 +576,7 @@ class RaidenAPI:  # pragma: no unittest
         Raises:
             InvalidBinaryAddress: If either token_address or partner_address is not
                 20 bytes long.
-            TransactionThrew: May happen for multiple reasons:
+            RaidenRecoverableError: May happen for multiple reasons:
                 - If the token approval fails, e.g. the token may validate if
                 account has enough balance for the allowance.
                 - The deposit failed, e.g. the allowance did not set the token

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -77,7 +77,6 @@ from raiden.exceptions import (
     SamePeerAddress,
     TokenNetworkDeprecated,
     TokenNotRegistered,
-    TransactionThrew,
     UnexpectedChannelState,
     UnknownTokenAddress,
     WithdrawMismatch,
@@ -541,7 +540,6 @@ class RestAPI:  # pragma: no unittest
         conflict_exceptions = (
             InvalidBinaryAddress,
             AlreadyRegisteredTokenAddress,
-            TransactionThrew,
             InvalidToken,
             AddressWithoutCode,
         )

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -18,7 +18,6 @@ from raiden.exceptions import (
     InvalidDBData,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
-    TransactionThrew,
     UnexpectedChannelState,
 )
 from raiden.transfer import views
@@ -41,7 +40,6 @@ RECOVERABLE_ERRORS = (
     DepositOverLimit,
     InsufficientFunds,
     RaidenRecoverableError,
-    TransactionThrew,
     UnexpectedChannelState,
 )
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -1,6 +1,3 @@
-from typing import Any, Dict, Optional
-
-
 class RaidenError(Exception):
     """Raiden base exception.
 
@@ -195,14 +192,6 @@ class UnexpectedChannelState(RaidenRecoverableError):
 
 class ContractCodeMismatch(RaidenError):
     """Raised if the onchain code of the contract differs."""
-
-
-class TransactionThrew(RaidenError):
-    """Raised when, after waiting for a transaction to be mined,
-    the receipt has a 0x0 status field"""
-
-    def __init__(self, txname: str, receipt: Optional[Dict[str, Any]]) -> None:
-        super().__init__(f"{txname} transaction threw. Receipt={receipt}")
 
 
 class APIServerPortInUseError(RaidenError):


### PR DESCRIPTION
TransactionThrewn exception was defined but never raised.
So this commit removes this exception from the codebase.

## Description

It's refactoring.  The PR removed an exception that was never used. It also updates docstrings that mention this exception `TransactionThrew`.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
