### PR TITLE
TokenNetworkRegistry proxy checks against secret_registry_address zero

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -214,6 +214,12 @@ class TokenNetworkRegistry:
                 if self.get_token_network(token_address, block):
                     raise RaidenRecoverableError(f"{error_prefix}. Token already registered")
 
+                if self.get_secret_registry_address(to_block=block) == NULL_ADDRESS_BYTES:
+                    raise RaidenUnrecoverableError(
+                        f"{error_prefix}. The SecretRegistryAddress in "
+                        "TokenNetworkRegistry has changed to zero. Very weird."
+                    )
+
                 raise RaidenUnrecoverableError(error_prefix)
 
             token_network_address = self.get_token_network(token_address, "latest")


### PR DESCRIPTION
Fixes: #4882

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

Before this PR, TokenNetworkRegistry sent a transaction even when secret_registry_address is zero, so the constructor of TokenNetwork would fail.  After this PR, such transactions will not be sent.  Moreover, when a sent transaction fails and secret_registry_address is zero, the proxy raises a `RaidenUnrecoverableError` because the proxy is probably talking to a wrong contract.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
