### PR TITLE
TokenNetworkRegistry checks deprecation executor

### DIFF
--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -132,3 +132,22 @@ def test_token_network_registry_max_token_networks(
         blockchain_service=blockchain_service,
     )
     assert token_network_registry_proxy.get_max_token_networks(to_block="latest") == UINT256_MAX
+
+
+def test_token_network_registry_get_deprecation_executor(
+    deploy_client, token_network_registry_address, contract_manager
+):
+    """ get_deprecation_executor() should return the deployer address """
+    blockchain_service = BlockChainService(
+        jsonrpc_client=deploy_client, contract_manager=contract_manager
+    )
+    token_network_registry_proxy = TokenNetworkRegistry(
+        jsonrpc_client=deploy_client,
+        registry_address=to_canonical_address(token_network_registry_address),
+        contract_manager=contract_manager,
+        blockchain_service=blockchain_service,
+    )
+    assert (
+        token_network_registry_proxy.get_deprecation_executor(to_block="latest")
+        == deploy_client.address
+    )


### PR DESCRIPTION
because if the address is zero, createERC20TokenNetowk() transactions
fail.

The same check is done before the transaction and after
failed gas estimation or a failed transaction in a block.

Fixes: https://github.com/raiden-network/raiden/issues/4884

## Description

- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

Before this PR, even when the node talks to a wrong TokenNetworkRegistry with deprecation executor being zero, the node sent a transaction to it.  After this PR, if deprecation_executor is zero, the node crashes.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
