### PR TITLE
Checks against chain_id == 0 in TokenNetworkRegistry

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -26,6 +26,7 @@ from raiden.utils import safe_gas_limit
 from raiden.utils.typing import (
     TYPE_CHECKING,
     Address,
+    ChainID,
     BlockSpecification,
     Dict,
     T_TargetAddress,
@@ -267,3 +268,7 @@ class TokenNetworkRegistry:
         token network registry.
         """
         return self.proxy.contract.functions.max_token_networks().call(block_identifier=to_block)
+
+    def get_chain_id(self, to_block: BlockSpecification) -> ChainID:
+        """ Returns the value of chain_id stored in the TokenNetworkRegistry contract """
+        return ChainID(self.proxy.contract.functions.chain_id().call(block_identifier=to_block))

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -132,3 +132,19 @@ def test_token_network_registry_max_token_networks(
         blockchain_service=blockchain_service,
     )
     assert token_network_registry_proxy.get_max_token_networks(to_block="latest") == UINT256_MAX
+
+
+def test_token_network_registry_chain_id(
+    deploy_client, token_network_registry_address, contract_manager
+):
+    """ get_chain_id() should return the chain ID """
+    blockchain_service = BlockChainService(
+        jsonrpc_client=deploy_client, contract_manager=contract_manager
+    )
+    token_network_registry_proxy = TokenNetworkRegistry(
+        jsonrpc_client=deploy_client,
+        registry_address=to_canonical_address(token_network_registry_address),
+        contract_manager=contract_manager,
+        blockchain_service=blockchain_service,
+    )
+    assert token_network_registry_proxy.get_chain_id(to_block="latest") == int(deploy_client.web3.version.network)

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -147,4 +147,6 @@ def test_token_network_registry_chain_id(
         contract_manager=contract_manager,
         blockchain_service=blockchain_service,
     )
-    assert token_network_registry_proxy.get_chain_id(to_block="latest") == int(deploy_client.web3.version.network)
+    assert token_network_registry_proxy.get_chain_id(to_block="latest") == int(
+        deploy_client.web3.version.network
+    )


### PR DESCRIPTION
Fixes: #4886

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

A proxy should try to avoid sending a transaction that's going to fail.  Before this PR, TokenNetworkRegistry didn't check a condition: namely, `chain_id` state variable must hold a non-zero value.  Otherwise, `createERC20TokenNetwork()` calls will fail.

This PR adds a precondition check and a post-failure check against this case.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
