### PR TITLE
Reduce the number of state changes for fee updates

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -165,7 +165,9 @@ def contractreceivechannelnew_from_event(
     )
 
 
-def contractreceivechanneldeposit_from_event(event: DecodedEvent) -> ContractReceiveChannelDeposit:
+def contractreceivechanneldeposit_from_event(
+    event: DecodedEvent, fee_config: MediationFeeConfig
+) -> ContractReceiveChannelDeposit:
     data = event.event_data
     args = data["args"]
     block_number = event.block_number
@@ -182,11 +184,12 @@ def contractreceivechanneldeposit_from_event(event: DecodedEvent) -> ContractRec
         transaction_hash=event.transaction_hash,
         block_number=block_number,
         block_hash=event.block_hash,
+        fee_config=fee_config,
     )
 
 
 def contractreceivechannelwithdraw_from_event(
-    event: DecodedEvent
+    event: DecodedEvent, fee_config: MediationFeeConfig
 ) -> ContractReceiveChannelWithdraw:
     data = event.event_data
     args = data["args"]
@@ -205,6 +208,7 @@ def contractreceivechannelwithdraw_from_event(
         transaction_hash=event.transaction_hash,
         block_number=event.block_number,
         block_hash=event.block_hash,
+        fee_config=fee_config,
     )
 
 
@@ -358,11 +362,13 @@ def blockchainevent_to_statechange(
             state_changes.append(contractreceiveroutenew_from_event(event))
 
     elif event_name == ChannelEvent.DEPOSIT:
-        deposit = contractreceivechanneldeposit_from_event(event)
+        deposit = contractreceivechanneldeposit_from_event(event, raiden.config["mediation_fees"])
         state_changes.append(deposit)
 
     elif event_name == ChannelEvent.WITHDRAW:
-        withdraw = contractreceivechannelwithdraw_from_event(event)
+        withdraw = contractreceivechannelwithdraw_from_event(
+            event, raiden.config["mediation_fees"]
+        )
         state_changes.append(withdraw)
 
     elif event_name == ChannelEvent.BALANCE_PROOF_UPDATED:

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -3,10 +3,8 @@ from typing import TYPE_CHECKING
 import gevent
 
 from raiden.connection_manager import ConnectionManager
-from raiden.services import send_pfs_update
 from raiden.transfer.architecture import StateChange
 from raiden.transfer.state_change import (
-    ActionChannelUpdateFee,
     ContractReceiveChannelDeposit,
     ContractReceiveChannelNew,
     ContractReceiveNewTokenNetwork,
@@ -49,17 +47,6 @@ def after_new_route_join_network(
     )
     retry_connect = gevent.spawn(connection_manager.retry_connect)
     raiden.add_pending_greenlet(retry_connect)
-
-
-def after_local_fee_update_inform_the_pfs(
-    raiden: "RaidenService", update_fee: ActionChannelUpdateFee
-) -> None:
-    """Update the PFS with the new fee schedule."""
-    send_pfs_update(
-        raiden=raiden,
-        canonical_identifier=update_fee.canonical_identifier,
-        update_fee_schedule=True,
-    )
 
 
 def after_new_channel_start_healthcheck(
@@ -115,7 +102,3 @@ def after_blockchain_statechange(raiden: "RaidenService", state_change: StateCha
     elif type(state_change) == ContractReceiveChannelDeposit:
         assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
         after_new_deposit_join_network(raiden, state_change)
-
-    elif type(state_change) == ActionChannelUpdateFee:
-        assert isinstance(state_change, ActionChannelUpdateFee), MYPY_ANNOTATION
-        after_local_fee_update_inform_the_pfs(raiden, state_change)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -17,6 +17,7 @@ from raiden.network.pathfinding import post_pfs_feedback
 from raiden.network.proxies.payment_channel import PaymentChannel
 from raiden.network.proxies.token_network import TokenNetwork
 from raiden.network.resolver.client import reveal_secret_with_resolver
+from raiden.services import send_pfs_update
 from raiden.storage.restore import (
     channel_state_until_state_change,
     get_event_with_balance_proof_by_balance_hash,
@@ -24,7 +25,6 @@ from raiden.storage.restore import (
     get_state_change_with_balance_proof_by_balance_hash,
     get_state_change_with_balance_proof_by_locksroot,
 )
-from raiden.transfer import views
 from raiden.transfer.architecture import Event
 from raiden.transfer.channel import get_batch_unlock, get_batch_unlock_gain
 from raiden.transfer.events import (
@@ -46,11 +46,11 @@ from raiden.transfer.events import (
     EventPaymentReceivedSuccess,
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
+    SendPFSFeeUpdate,
     SendProcessed,
     SendWithdrawConfirmation,
     SendWithdrawExpired,
     SendWithdrawRequest,
-    TriggerFeeUpdate,
 )
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import (
@@ -68,7 +68,6 @@ from raiden.transfer.mediated_transfer.events import (
 )
 from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import get_channelstate_by_token_network_and_partner
-from raiden.utils.mediation_fees import actionchannelupdatefee_from_channelstate
 from raiden.utils.packing import pack_signed_balance_proof, pack_withdraw
 from raiden.utils.typing import MYPY_ANNOTATION, Address, BlockSpecification, Nonce
 from raiden_contracts.constants import MessageTypeId
@@ -186,9 +185,9 @@ class RaidenEventHandler(EventHandler):
         elif type(event) == ContractSendChannelWithdraw:
             assert isinstance(event, ContractSendChannelWithdraw), MYPY_ANNOTATION
             self.handle_contract_send_channelwithdraw(raiden, event)
-        elif type(event) == TriggerFeeUpdate:
-            assert isinstance(event, TriggerFeeUpdate), MYPY_ANNOTATION
-            self.handle_trigger_fee_update(raiden, event)
+        elif type(event) == SendPFSFeeUpdate:
+            assert isinstance(event, SendPFSFeeUpdate), MYPY_ANNOTATION
+            self.handle_send_pfs_fee_update(raiden, event)
         elif type(event) in UNEVENTFUL_EVENTS:
             pass
         else:
@@ -199,28 +198,14 @@ class RaidenEventHandler(EventHandler):
             )
 
     @staticmethod
-    def handle_trigger_fee_update(
-        raiden: "RaidenService", event: TriggerFeeUpdate
+    def handle_send_pfs_fee_update(
+        raiden: "RaidenService", event: SendPFSFeeUpdate
     ) -> None:  # pragma: no unittest
-        chain_state = views.state_from_raiden(raiden)
-        channel_state = views.get_channelstate_by_canonical_identifier(
-            chain_state, event.canonical_identifier
+        send_pfs_update(
+            raiden=raiden,
+            canonical_identifier=event.canonical_identifier,
+            update_fee_schedule=True,
         )
-        if not channel_state:
-            # This should not happen. Channel should not dissapear between the
-            # triggering of the fee update event and its processing
-            raise RaidenUnrecoverableError(
-                f"Failed to find channel state for {event.canonical_identifier}"
-            )
-
-        fee_config = raiden.config["mediation_fees"]
-        state_change = actionchannelupdatefee_from_channelstate(
-            channel_state=channel_state,
-            flat_fee=channel_state.fee_schedule.flat,
-            proportional_fee=channel_state.fee_schedule.proportional,
-            proportional_imbalance_fee=fee_config.proportional_imbalance_fee,
-        )
-        raiden.handle_and_track_state_changes([state_change])
 
     @staticmethod
     def handle_send_lockexpired(

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -29,7 +29,6 @@ from raiden.tests.utils.transfer import (
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
-from raiden.transfer.state_change import ActionChannelUpdateFee
 from raiden.utils import sha3
 from raiden.utils.typing import BlockNumber, FeeAmount, PaymentAmount, TokenAmount
 from raiden.waiting import wait_for_block
@@ -384,12 +383,7 @@ def test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
     )
 
     # Let app1 consume all of the allocated mediation fee
-    action_update_fee = ActionChannelUpdateFee(
-        canonical_identifier=app1_app2_channel_state.canonical_identifier,
-        fee_schedule=FeeScheduleState(flat=FeeAmount(fee * 2)),
-    )
-
-    app1.raiden.handle_state_changes(state_changes=[action_update_fee])
+    app1_app2_channel_state.fee_schedule = FeeScheduleState(flat=FeeAmount(fee * 2))
 
     secret = factories.make_secret(0)
     secrethash = sha256(secret).digest()
@@ -463,10 +457,7 @@ def test_mediated_transfer_with_fees(
             partner_address=other_app.raiden.address,
         )
         assert channel_state
-        action_update_fee = ActionChannelUpdateFee(
-            canonical_identifier=channel_state.canonical_identifier, fee_schedule=fee_schedule
-        )
-        app.raiden.handle_state_changes(state_changes=[action_update_fee])
+        channel_state.fee_schedule = fee_schedule
 
     def get_best_routes_with_fees(*args, **kwargs):
         routes = get_best_routes_internal(*args, **kwargs)

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from eth_utils import encode_hex, keccak, to_checksum_address, to_hex
 
 from raiden.constants import LOCKSROOT_OF_NO_LOCKS, MAXIMUM_PENDING_TRANSFERS, UINT256_MAX
-from raiden.exceptions import RaidenUnrecoverableError
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, MediationFeeConfig
 from raiden.transfer.architecture import Event, StateChange, SuccessOrError, TransitionResult
 from raiden.transfer.events import (
@@ -2303,13 +2302,6 @@ def handle_channel_settled(
 def update_fee_schedule_after_balance_change(
     channel_state: NettingChannelState, fee_config: MediationFeeConfig
 ) -> List[Event]:
-    if not channel_state:
-        # This should not happen. Channel should not dissapear between the
-        # triggering of the fee update event and its processing
-        raise RaidenUnrecoverableError(
-            f"Failed to find channel state for {channel_state.canonical_identifier}"
-        )
-
     imbalance_penalty = calculate_imbalance_fees(
         channel_capacity=get_capacity(channel_state),
         proportional_imbalance_fee=fee_config.proportional_imbalance_fee,

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -314,8 +314,8 @@ class EventInvalidSecretRequest(Event):
 
 
 @dataclass(frozen=True)
-class TriggerFeeUpdate(Event):
-    """Event emitted when a fee update needs to be made for a channel.
+class SendPFSFeeUpdate(Event):
+    """ Tell the PFSs about changed fee schedules
 
     For example when a deposit or a withdrawal is made into a channel
     """

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -45,7 +45,6 @@ from raiden.transfer.state import ChainState, TokenNetworkRegistryState, TokenNe
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
     ActionChannelClose,
-    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ActionInitChain,
     ActionNewTokenNetwork,
@@ -812,13 +811,6 @@ def handle_state_change(
         elif type(state_change) == ActionChannelClose:
             assert isinstance(state_change, ActionChannelClose), MYPY_ANNOTATION
             iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ActionChannelUpdateFee:
-            assert isinstance(state_change, ActionChannelUpdateFee), MYPY_ANNOTATION
-            iteration = subdispatch_by_canonical_id(
-                chain_state=chain_state,
-                canonical_identifier=state_change.canonical_identifier,
-                state_change=state_change,
-            )
         elif type(state_change) == ActionChannelWithdraw:
             assert isinstance(state_change, ActionChannelWithdraw), MYPY_ANNOTATION
             iteration = subdispatch_by_canonical_id(

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -3,13 +3,13 @@ from dataclasses import dataclass, field
 from random import Random
 
 from raiden.constants import EMPTY_SECRETHASH
+from raiden.settings import MediationFeeConfig
 from raiden.transfer.architecture import (
     AuthenticatedSenderStateChange,
     ContractReceiveStateChange,
     StateChange,
 )
 from raiden.transfer.identifiers import CanonicalIdentifier
-from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.state import (
     BalanceProofSignedState,
     NettingChannelState,
@@ -126,16 +126,6 @@ class ActionChannelWithdraw(StateChange):
 
 
 @dataclass(frozen=True)
-class ActionChannelUpdateFee(StateChange):
-    canonical_identifier: CanonicalIdentifier
-    fee_schedule: FeeScheduleState
-
-    @property
-    def channel_identifier(self) -> ChannelID:
-        return self.canonical_identifier.channel_identifier
-
-
-@dataclass(frozen=True)
 class ContractReceiveChannelNew(ContractReceiveStateChange):
     """ A new channel was created and this node IS a participant. """
 
@@ -199,6 +189,7 @@ class ContractReceiveChannelDeposit(ContractReceiveStateChange):
 
     canonical_identifier: CanonicalIdentifier
     deposit_transaction: TransactionChannelDeposit
+    fee_config: MediationFeeConfig
 
     @property
     def channel_identifier(self) -> ChannelID:
@@ -216,6 +207,7 @@ class ContractReceiveChannelWithdraw(ContractReceiveStateChange):
     canonical_identifier: CanonicalIdentifier
     participant: Address
     total_withdraw: WithdrawAmount
+    fee_config: MediationFeeConfig
 
     @property
     def channel_identifier(self) -> ChannelID:

--- a/raiden/transfer/token_network.py
+++ b/raiden/transfer/token_network.py
@@ -5,7 +5,6 @@ from raiden.transfer.architecture import Event, StateChange, TransitionResult
 from raiden.transfer.state import TokenNetworkState
 from raiden.transfer.state_change import (
     ActionChannelClose,
-    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -26,7 +25,6 @@ from raiden.utils.typing import MYPY_ANNOTATION, BlockHash, BlockNumber, List, U
 # that contains channel IDs and other specific channel attributes
 StateChangeWithChannelID = Union[
     ActionChannelClose,
-    ActionChannelUpdateFee,
     ActionChannelWithdraw,
     ContractReceiveChannelClosed,
     ContractReceiveChannelDeposit,
@@ -358,15 +356,6 @@ def state_transition(
     if type(state_change) == ActionChannelClose:
         assert isinstance(state_change, ActionChannelClose), MYPY_ANNOTATION
         iteration = handle_channel_close(
-            token_network_state=token_network_state,
-            state_change=state_change,
-            block_number=block_number,
-            block_hash=block_hash,
-            pseudo_random_generator=pseudo_random_generator,
-        )
-    elif type(state_change) == ActionChannelUpdateFee:
-        assert isinstance(state_change, ActionChannelUpdateFee), MYPY_ANNOTATION
-        iteration = subdispatch_to_channel_by_id(
             token_network_state=token_network_state,
             state_change=state_change,
             block_number=block_number,

--- a/raiden/utils/mediation_fees.py
+++ b/raiden/utils/mediation_fees.py
@@ -1,28 +1,5 @@
 from raiden.settings import MediationFeeConfig
-from raiden.transfer.channel import get_capacity
-from raiden.transfer.mediated_transfer.mediation_fee import calculate_imbalance_fees
-from raiden.transfer.state import FeeScheduleState, NettingChannelState
-from raiden.transfer.state_change import ActionChannelUpdateFee
 from raiden.utils.typing import Dict, FeeAmount, ProportionalFeeAmount, TokenNetworkAddress, Tuple
-
-
-def actionchannelupdatefee_from_channelstate(
-    channel_state: NettingChannelState,
-    flat_fee: FeeAmount,
-    proportional_fee: ProportionalFeeAmount,
-    proportional_imbalance_fee: ProportionalFeeAmount,
-) -> ActionChannelUpdateFee:
-    imbalance_penalty = calculate_imbalance_fees(
-        channel_capacity=get_capacity(channel_state),
-        proportional_imbalance_fee=proportional_imbalance_fee,
-    )
-
-    return ActionChannelUpdateFee(
-        canonical_identifier=channel_state.canonical_identifier,
-        fee_schedule=FeeScheduleState(
-            flat=flat_fee, proportional=proportional_fee, imbalance_penalty=imbalance_penalty
-        ),
-    )
 
 
 def ppm_fee_per_channel(per_hop_fee: ProportionalFeeAmount) -> ProportionalFeeAmount:


### PR DESCRIPTION
## Description

In https://github.com/raiden-network/raiden/pull/4827, we've added
`TriggerFeeUpdate` in addition to having `ActionChannelUpdateFee`. This
commit remove these in favor of one simple `SendPFSFeeUpdate` event. The
main purpose of this is to make sure that balances and fees are always
consistent by changing them during the same state change.

Pro:
- Easier to enforce consistency
- No `ActionChannelUpdateFee` in `blockchain_events_handler.py` (I don't
  think it belonged there)
- Less state changes
- Shorter code

Cons:
- Needed to add `fee_config` to deposit and withdraw state changes
- Will probably need to reintroduce a state change once users can change
  fees during runtime.
- Quite a lot of changed lines for not that much gain.

Closes https://github.com/raiden-network/raiden/issues/4852.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
