### PR TITLE
Smart contract metadata

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -33,6 +33,21 @@ UINT64_MAX = 2 ** 64 - 1
 SECONDS_PER_DAY = 24 * 60 * 60
 
 GENESIS_BLOCK_NUMBER = BlockNumber(0)
+
+
+class EthereumForks(Enum):
+    # https://eips.ethereum.org/EIPS/eip-606
+    HOMESTEAD = BlockNumber(1_150_000)
+    # https://eips.ethereum.org/EIPS/eip-608
+    TANGERINE_WHISTLE = BlockNumber(2_463_000)
+    # https://eips.ethereum.org/EIPS/eip-607
+    SPURIOUS_DRAGON = BlockNumber(2_675_000)
+    # https://eips.ethereum.org/EIPS/eip-609
+    BYZANTIUM = BlockNumber(4_370_000)
+    # https://eips.ethereum.org/EIPS/eip-1013
+    CONSTANTINOPLE = BlockNumber(7_280_000)
+
+
 # Set at 64 since parity's default is 64 and Geth's default is 128
 # TODO: Make this configurable. Since in parity this is also a configurable value
 STATE_PRUNING_AFTER_BLOCKS = 64

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -34,18 +34,34 @@ SECONDS_PER_DAY = 24 * 60 * 60
 
 GENESIS_BLOCK_NUMBER = BlockNumber(0)
 
+# Relevant forks:
+# BYZANTIUM https://eips.ethereum.org/EIPS/eip-609
+# CONSTANTINOPLE https://eips.ethereum.org/EIPS/eip-1013
+
 
 class EthereumForks(Enum):
-    # https://eips.ethereum.org/EIPS/eip-606
-    HOMESTEAD = BlockNumber(1_150_000)
-    # https://eips.ethereum.org/EIPS/eip-608
-    TANGERINE_WHISTLE = BlockNumber(2_463_000)
-    # https://eips.ethereum.org/EIPS/eip-607
-    SPURIOUS_DRAGON = BlockNumber(2_675_000)
-    # https://eips.ethereum.org/EIPS/eip-609
     BYZANTIUM = BlockNumber(4_370_000)
-    # https://eips.ethereum.org/EIPS/eip-1013
     CONSTANTINOPLE = BlockNumber(7_280_000)
+
+
+class RopstenForks(Enum):
+    BYZANTIUM = BlockNumber(1_700_000)
+    CONSTANTINOPLE = BlockNumber(4_230_000)
+
+
+class KovanForks(Enum):
+    BYZANTIUM = BlockNumber(0)
+    CONSTANTINOPLE = BlockNumber(4_230_000)
+
+
+class RinkebyForks(Enum):
+    BYZANTIUM = BlockNumber(0)
+    CONSTANTINOPLE = BlockNumber(3_660_663)
+
+
+class GoerliForks(Enum):
+    BYZANTIUM = BlockNumber(0)
+    CONSTANTINOPLE = BlockNumber(0)
 
 
 class Networks(Enum):

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -48,6 +48,15 @@ class EthereumForks(Enum):
     CONSTANTINOPLE = BlockNumber(7_280_000)
 
 
+class Networks(Enum):
+    MAINNET = 1
+    ROPSTEN = 3
+    RINKEBY = 4
+    GOERLI = 5
+    KOVAN = 42
+    SMOKETEST = 627
+
+
 # Set at 64 since parity's default is 64 and Geth's default is 128
 # TODO: Make this configurable. Since in parity this is also a configurable value
 STATE_PRUNING_AFTER_BLOCKS = 64

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -47,10 +47,10 @@ class BlockChainServiceMetadata:
         # deployed doesn't make sense. A smaller value will have a negative
         # impact on performance (see #3958), a larger value will miss logs.
         is_filter_start_valid = (
-            self.token_network_registry_deployed_at is not None
-            and self.token_network_registry_deployed_at != self.filters_start_at
+            self.token_network_registry_deployed_at is None
+            or self.token_network_registry_deployed_at == self.filters_start_at
         )
-        if is_filter_start_valid:
+        if not is_filter_start_valid:
             raise ValueError(
                 "The deployed_at is known, the filters should start at that exact block"
             )

--- a/raiden/network/blockchain_service.py
+++ b/raiden/network/blockchain_service.py
@@ -2,11 +2,12 @@ import gevent
 from eth_utils import is_binary_address
 from gevent.lock import Semaphore
 
+from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.network.proxies.payment_channel import PaymentChannel
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.token import Token
-from raiden.network.proxies.token_network import TokenNetwork
+from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.network.rpc.client import JSONRPCClient
@@ -166,11 +167,18 @@ class BlockChainService:
 
         with self._token_network_creation_lock:
             if address not in self.address_to_token_network:
+                metadata = TokenNetworkMetadata(
+                    deployed_at=None,
+                    token_network_registry_address=None,
+                    filter_start_at=GENESIS_BLOCK_NUMBER,  # FIXME: Issue #3958
+                )
+
                 self.address_to_token_network[address] = TokenNetwork(
                     jsonrpc_client=self.client,
                     token_network_address=address,
                     contract_manager=self.contract_manager,
                     blockchain_service=self,
+                    metadata=metadata,
                 )
 
         return self.address_to_token_network[address]

--- a/raiden/network/proxies/metadata.py
+++ b/raiden/network/proxies/metadata.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from raiden.utils.typing import (
+    ABI,
+    Address,
+    BlockNumber,
+    EVMBytecode,
+    GasMeasurements,
+    Optional,
+    TypeVar,
+)
+
+T = TypeVar("T")
+
+
+@dataclass
+class SmartContractMetadata:
+    """Basic metadata of a smart contract."""
+
+    # If the user deployed the smart contract, the mined block is unknown.
+    deployed_at: Optional[BlockNumber]
+
+    # Value to use as `fromBlock` for filters. If the deployed block number is
+    # know it must be used, otherwise a hard fork block number can be used as a
+    # lower bound.
+    #
+    # The deployed_at must be used because querying for logs before the smart
+    # contract is deployed has bad performance (see #3958), and values larger
+    # than the deployed_at will potentially miss logs.
+    filters_start_at: BlockNumber
+
+    # Make this a generic once https://github.com/python/mypy/issues/7520 is fixed
+    address: Address
+
+    abi: ABI
+    runtime_bytecode: EVMBytecode
+    gas_measurements: GasMeasurements
+
+    def __post_init__(self) -> None:
+        is_filter_start_valid = (
+            self.deployed_at is not None and self.deployed_at != self.filters_start_at
+        )
+        if is_filter_start_valid:
+            raise ValueError(
+                "The deployed_at is known, the filters should start at that exact block"
+            )

--- a/raiden/network/proxies/metadata.py
+++ b/raiden/network/proxies/metadata.py
@@ -38,9 +38,9 @@ class SmartContractMetadata:
 
     def __post_init__(self) -> None:
         is_filter_start_valid = (
-            self.deployed_at is not None and self.deployed_at != self.filters_start_at
+            self.deployed_at is None or self.deployed_at == self.filters_start_at
         )
-        if is_filter_start_valid:
+        if not is_filter_start_valid:
             raise ValueError(
                 "The deployed_at is known, the filters should start at that exact block"
             )

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -3,7 +3,7 @@ from typing import Optional
 from web3.utils.filters import Filter
 
 from raiden.blockchain.filters import decode_event, get_filter_args_for_specific_event_from_channel
-from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
+from raiden.constants import UINT256_MAX
 from raiden.network.proxies.token_network import ChannelDetails, TokenNetwork
 from raiden.network.proxies.utils import get_channel_participants_from_open_event
 from raiden.transfer.state import PendingLocksState
@@ -42,7 +42,7 @@ class PaymentChannel:
             token_network=token_network,
             channel_identifier=channel_identifier,
             contract_manager=contract_manager,
-            from_block=GENESIS_BLOCK_NUMBER,  # FIXME: Issue #3958
+            from_block=token_network.metadata.filter_start_at,
         )
 
         if not participants:

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -3,7 +3,7 @@ from typing import Optional
 from web3.utils.filters import Filter
 
 from raiden.blockchain.filters import decode_event, get_filter_args_for_specific_event_from_channel
-from raiden.constants import UINT256_MAX
+from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX
 from raiden.network.proxies.token_network import ChannelDetails, TokenNetwork
 from raiden.network.proxies.utils import get_channel_participants_from_open_event
 from raiden.transfer.state import PendingLocksState
@@ -42,6 +42,7 @@ class PaymentChannel:
             token_network=token_network,
             channel_identifier=channel_identifier,
             contract_manager=contract_manager,
+            from_block=GENESIS_BLOCK_NUMBER,  # FIXME: Issue #3958
         )
 
         if not participants:

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -42,7 +42,7 @@ class PaymentChannel:
             token_network=token_network,
             channel_identifier=channel_identifier,
             contract_manager=contract_manager,
-            from_block=token_network.metadata.filter_start_at,
+            from_block=token_network.metadata.filters_start_at,
         )
 
         if not participants:

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2519,6 +2519,7 @@ class TokenNetwork:
                     token_network=self,
                     channel_identifier=channel_identifier,
                     contract_manager=self.contract_manager,
+                    from_block=GENESIS_BLOCK_NUMBER,  # FIXME: Issue #3958
                 )
                 if not participants:
                     msg = (
@@ -2602,6 +2603,7 @@ class TokenNetwork:
                 token_network=self,
                 channel_identifier=channel_identifier,
                 contract_manager=self.contract_manager,
+                from_block=GENESIS_BLOCK_NUMBER,  # FIXME: Issue #3958
             )
             if not participants:
                 msg = (

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -5,12 +5,12 @@ from eth_utils import decode_hex, to_hex
 from structlog import BoundLoggerBase
 
 from raiden.blockchain.filters import decode_event, get_filter_args_for_specific_event_from_channel
-from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.typing import (
     Address,
     Any,
+    BlockNumber,
     BlockSpecification,
     ChannelID,
     Dict,
@@ -31,11 +31,11 @@ if TYPE_CHECKING:
 
 
 def get_channel_participants_from_open_event(
-    token_network: "TokenNetwork", channel_identifier: ChannelID, contract_manager: ContractManager
+    token_network: "TokenNetwork",
+    channel_identifier: ChannelID,
+    contract_manager: ContractManager,
+    from_block: BlockNumber,
 ) -> Optional[Tuple[Address, Address]]:
-    # FIXME: Issue #3958
-    from_block = GENESIS_BLOCK_NUMBER
-
     # For this check it is perfectly fine to use a `latest` block number.
     # Because the filter is looking just for the OPENED event.
     to_block = "latest"

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -3,8 +3,8 @@ import os
 import pytest
 from web3 import HTTPProvider, Web3
 
-from raiden.constants import EthClient
-from raiden.network.blockchain_service import BlockChainService
+from raiden.constants import GENESIS_BLOCK_NUMBER, EthClient
+from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.eth_node import (
     AccountDescription,
@@ -103,7 +103,13 @@ def deploy_client(blockchain_rpc_ports, deploy_key, web3, blockchain_type):
 
 @pytest.fixture
 def deploy_service(deploy_key, deploy_client, contract_manager):
-    return BlockChainService(jsonrpc_client=deploy_client, contract_manager=contract_manager)
+    return BlockChainService(
+        jsonrpc_client=deploy_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
 
 
 @pytest.fixture

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -107,7 +107,8 @@ def deploy_service(deploy_key, deploy_client, contract_manager):
         jsonrpc_client=deploy_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -1,11 +1,17 @@
 import pytest
 from eth_utils import to_canonical_address, to_checksum_address
 
-from raiden.constants import EMPTY_ADDRESS, SECONDS_PER_DAY, UINT256_MAX, Environment
+from raiden.constants import (
+    EMPTY_ADDRESS,
+    GENESIS_BLOCK_NUMBER,
+    SECONDS_PER_DAY,
+    UINT256_MAX,
+    Environment,
+)
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.token import Token
-from raiden.network.proxies.token_network import TokenNetwork
+from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.settings import MONITORING_REWARD
 from raiden.tests.utils.smartcontracts import (
@@ -242,6 +248,11 @@ def register_token_and_return_the_network_proxy(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=blockchain_service,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
 
 

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -8,11 +8,10 @@ from raiden.constants import (
     UINT256_MAX,
     Environment,
 )
-from raiden.network.blockchain_service import BlockChainService
+from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.token import Token
 from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
-from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.settings import MONITORING_REWARD
 from raiden.tests.utils.smartcontracts import (
     deploy_contract_web3,
@@ -224,15 +223,14 @@ def register_token_and_return_the_network_proxy(
     registry_address = to_canonical_address(token_network_registry_address)
 
     blockchain_service = BlockChainService(
-        jsonrpc_client=deploy_client, contract_manager=contract_manager
+        jsonrpc_client=deploy_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
     )
 
-    token_network_registry_proxy = TokenNetworkRegistry(
-        jsonrpc_client=deploy_client,
-        registry_address=registry_address,
-        contract_manager=contract_manager,
-        blockchain_service=blockchain_service,
-    )
+    token_network_registry_proxy = blockchain_service.token_network(registry_address)
     token_network_address = token_network_registry_proxy.add_token(
         token_address=token_proxy.address,
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
@@ -241,7 +239,11 @@ def register_token_and_return_the_network_proxy(
     )
 
     blockchain_service = BlockChainService(
-        jsonrpc_client=deploy_client, contract_manager=contract_manager
+        jsonrpc_client=deploy_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
     )
     return TokenNetwork(
         jsonrpc_client=deploy_client,

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -225,7 +225,8 @@ def register_token_and_return_the_network_proxy(
         jsonrpc_client=deploy_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 
@@ -241,7 +242,8 @@ def register_token_and_return_the_network_proxy(
         jsonrpc_client=deploy_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     return blockchain_service.token_network(token_network_address)

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -11,7 +11,6 @@ from raiden.constants import (
 from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.token import Token
-from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.settings import MONITORING_REWARD
 from raiden.tests.utils.smartcontracts import (
     deploy_contract_web3,
@@ -230,7 +229,7 @@ def register_token_and_return_the_network_proxy(
         ),
     )
 
-    token_network_registry_proxy = blockchain_service.token_network(registry_address)
+    token_network_registry_proxy = blockchain_service.token_network_registry(registry_address)
     token_network_address = token_network_registry_proxy.add_token(
         token_address=token_proxy.address,
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
@@ -245,17 +244,7 @@ def register_token_and_return_the_network_proxy(
             token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
         ),
     )
-    return TokenNetwork(
-        jsonrpc_client=deploy_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=blockchain_service,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    return blockchain_service.token_network(token_network_address)
 
 
 @pytest.fixture(name="token_proxy")

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -33,7 +33,8 @@ def test_payment_channel_proxy_basics(
         jsonrpc_client=client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     token_network_proxy = chain.token_network(address=token_network_address)

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -1,13 +1,19 @@
 import pytest
 from eth_utils import encode_hex
 
-from raiden.constants import EMPTY_BALANCE_HASH, EMPTY_HASH, EMPTY_SIGNATURE, LOCKSROOT_OF_NO_LOCKS
+from raiden.constants import (
+    EMPTY_BALANCE_HASH,
+    EMPTY_HASH,
+    EMPTY_SIGNATURE,
+    GENESIS_BLOCK_NUMBER,
+    LOCKSROOT_OF_NO_LOCKS,
+)
 from raiden.exceptions import (
     BrokenPreconditionError,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
-from raiden.network.blockchain_service import BlockChainService
+from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -23,7 +29,13 @@ def test_payment_channel_proxy_basics(
     partner = privatekey_to_address(private_keys[0])
 
     client = JSONRPCClient(web3, private_keys[1])
-    chain = BlockChainService(jsonrpc_client=client, contract_manager=contract_manager)
+    chain = BlockChainService(
+        jsonrpc_client=client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     token_network_proxy = chain.token_network(address=token_network_address)
     start_block = web3.eth.blockNumber
 

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -64,7 +64,8 @@ def test_register_secret_happy_path(secret_registry_proxy: SecretRegistry, contr
         jsonrpc_client=secret_registry_proxy.client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     chain.wait_until_block(STATE_PRUNING_AFTER_BLOCKS + 1)
@@ -116,7 +117,8 @@ def test_register_secret_batch_with_pruned_block(
         jsonrpc_client=c1_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     # Now wait until this block becomes pruned

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -65,7 +65,7 @@ def test_register_secret_happy_path(secret_registry_proxy: SecretRegistry, contr
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
             token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
-            smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     chain.wait_until_block(STATE_PRUNING_AFTER_BLOCKS + 1)

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -118,7 +118,7 @@ def test_register_secret_batch_with_pruned_block(
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
             token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
-            smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     # Now wait until this block becomes pruned

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -4,9 +4,9 @@ from hashlib import sha256
 import gevent
 import pytest
 
-from raiden.constants import STATE_PRUNING_AFTER_BLOCKS
+from raiden.constants import GENESIS_BLOCK_NUMBER, STATE_PRUNING_AFTER_BLOCKS
 from raiden.exceptions import NoStateForBlockIdentifier
-from raiden.network.blockchain_service import BlockChainService
+from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.events import must_have_event
@@ -61,7 +61,11 @@ def test_register_secret_happy_path(secret_registry_proxy: SecretRegistry, contr
     ), "Test setup is invalid, secret must be unknown"
 
     chain = BlockChainService(
-        jsonrpc_client=secret_registry_proxy.client, contract_manager=contract_manager
+        jsonrpc_client=secret_registry_proxy.client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
     )
     chain.wait_until_block(STATE_PRUNING_AFTER_BLOCKS + 1)
 
@@ -108,7 +112,13 @@ def test_register_secret_batch_with_pruned_block(
 ):
     """Test secret registration with a pruned given block."""
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(jsonrpc_client=c1_client, contract_manager=contract_manager)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     # Now wait until this block becomes pruned
     pruned_number = c1_chain.block_number()
     c1_chain.wait_until_block(target_block_number=pruned_number + STATE_PRUNING_AFTER_BLOCKS)

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -19,7 +19,7 @@ from raiden.exceptions import (
     RaidenUnrecoverableError,
     SamePeerAddress,
 )
-from raiden.network.blockchain_service import BlockChainService
+from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
@@ -47,7 +47,11 @@ def test_token_network_deposit_race(
     c2_client = JSONRPCClient(web3, private_keys[2])
 
     blockchain_service = BlockChainService(
-        jsonrpc_client=c1_client, contract_manager=contract_manager
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
     )
 
     c1_token_network_proxy = TokenNetwork(
@@ -94,9 +98,21 @@ def test_token_network_proxy(
 
     c1_signer = LocalSigner(private_keys[1])
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(jsonrpc_client=c1_client, contract_manager=contract_manager)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     c2_client = JSONRPCClient(web3, private_keys[2])
-    c2_chain = BlockChainService(jsonrpc_client=c2_client, contract_manager=contract_manager)
+    c2_chain = BlockChainService(
+        jsonrpc_client=c2_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     c2_signer = LocalSigner(private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
@@ -510,10 +526,22 @@ def test_token_network_proxy_update_transfer(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
 
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(jsonrpc_client=c1_client, contract_manager=contract_manager)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     c1_signer = LocalSigner(private_keys[1])
     c2_client = JSONRPCClient(web3, private_keys[2])
-    c2_chain = BlockChainService(jsonrpc_client=c2_client, contract_manager=contract_manager)
+    c2_chain = BlockChainService(
+        jsonrpc_client=c2_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
         token_network_address=token_network_address,
@@ -734,7 +762,13 @@ def test_query_pruned_state(token_network_proxy, private_keys, web3, contract_ma
 
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
     c1_client = JSONRPCClient(web3, private_keys[1])
-    c1_chain = BlockChainService(jsonrpc_client=c1_client, contract_manager=contract_manager)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     c2_client = JSONRPCClient(web3, private_keys[2])
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
@@ -774,7 +808,13 @@ def test_token_network_actions_at_pruned_blocks(
     token_network_address = to_canonical_address(token_network_proxy.proxy.contract.address)
     c1_client = JSONRPCClient(web3, private_keys[1])
 
-    c1_chain = BlockChainService(jsonrpc_client=c1_client, contract_manager=contract_manager)
+    c1_chain = BlockChainService(
+        jsonrpc_client=c1_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
     c1_token_network_proxy = TokenNetwork(
         jsonrpc_client=c1_client,
         token_network_address=token_network_address,
@@ -788,7 +828,13 @@ def test_token_network_actions_at_pruned_blocks(
     )
 
     c2_client = JSONRPCClient(web3, private_keys[2])
-    c2_chain = BlockChainService(jsonrpc_client=c2_client, contract_manager=contract_manager)
+    c2_chain = BlockChainService(
+        jsonrpc_client=c2_client,
+        contract_manager=contract_manager,
+        metadata=BlockChainServiceMetadata(
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+        ),
+    )
 
     c2_token_network_proxy = TokenNetwork(
         jsonrpc_client=c2_client,

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -20,7 +20,6 @@ from raiden.exceptions import (
     SamePeerAddress,
 )
 from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
-from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.tests.utils.factories import make_address
@@ -54,17 +53,7 @@ def test_token_network_deposit_race(
         ),
     )
 
-    c1_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c1_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=blockchain_service,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    c1_token_network_proxy = blockchain_service.token_network(token_network_address)
     token_proxy.transfer(c1_client.address, 10)
     channel_identifier = c1_token_network_proxy.new_netting_channel(
         partner=c2_client.address,
@@ -114,28 +103,8 @@ def test_token_network_proxy(
         ),
     )
     c2_signer = LocalSigner(private_keys[2])
-    c1_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c1_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c1_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
-    c2_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c2_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c2_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    c1_token_network_proxy = c1_chain.token_network(token_network_address)
+    c2_token_network_proxy = c2_chain.token_network(token_network_address)
 
     initial_token_balance = 100
     token_proxy.transfer(c1_client.address, initial_token_balance)
@@ -542,28 +511,8 @@ def test_token_network_proxy_update_transfer(
             token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
         ),
     )
-    c1_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c1_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c1_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
-    c2_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c2_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c2_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    c1_token_network_proxy = c1_chain.token_network(token_network_address)
+    c2_token_network_proxy = c2_chain.token_network(token_network_address)
     # create a channel
     channel_identifier = c1_token_network_proxy.new_netting_channel(
         partner=c2_client.address, settle_timeout=10, given_block_identifier="latest"
@@ -770,17 +719,7 @@ def test_query_pruned_state(token_network_proxy, private_keys, web3, contract_ma
         ),
     )
     c2_client = JSONRPCClient(web3, private_keys[2])
-    c1_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c1_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c1_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    c1_token_network_proxy = c1_chain.token_network(token_network_address)
     # create a channel and query the state at the current block hash
     channel_identifier = c1_token_network_proxy.new_netting_channel(
         partner=c2_client.address, settle_timeout=10, given_block_identifier="latest"
@@ -815,17 +754,7 @@ def test_token_network_actions_at_pruned_blocks(
             token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
         ),
     )
-    c1_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c1_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c1_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    c1_token_network_proxy = c1_chain.token_network(token_network_address)
 
     c2_client = JSONRPCClient(web3, private_keys[2])
     c2_chain = BlockChainService(
@@ -836,17 +765,7 @@ def test_token_network_actions_at_pruned_blocks(
         ),
     )
 
-    c2_token_network_proxy = TokenNetwork(
-        jsonrpc_client=c2_client,
-        token_network_address=token_network_address,
-        contract_manager=contract_manager,
-        blockchain_service=c2_chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None,
-            token_network_registry_address=None,
-            filter_start_at=GENESIS_BLOCK_NUMBER,
-        ),
-    )
+    c2_token_network_proxy = c2_chain.token_network(token_network_address)
     initial_token_balance = 100
     token_proxy.transfer(c1_client.address, initial_token_balance)
     token_proxy.transfer(c2_client.address, initial_token_balance)

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -49,7 +49,8 @@ def test_token_network_deposit_race(
         jsonrpc_client=c1_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 
@@ -91,7 +92,8 @@ def test_token_network_proxy(
         jsonrpc_client=c1_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     c2_client = JSONRPCClient(web3, private_keys[2])
@@ -99,7 +101,8 @@ def test_token_network_proxy(
         jsonrpc_client=c2_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     c2_signer = LocalSigner(private_keys[2])
@@ -499,7 +502,8 @@ def test_token_network_proxy_update_transfer(
         jsonrpc_client=c1_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     c1_signer = LocalSigner(private_keys[1])
@@ -508,7 +512,8 @@ def test_token_network_proxy_update_transfer(
         jsonrpc_client=c2_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     c1_token_network_proxy = c1_chain.token_network(token_network_address)
@@ -715,7 +720,8 @@ def test_query_pruned_state(token_network_proxy, private_keys, web3, contract_ma
         jsonrpc_client=c1_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     c2_client = JSONRPCClient(web3, private_keys[2])
@@ -751,7 +757,8 @@ def test_token_network_actions_at_pruned_blocks(
         jsonrpc_client=c1_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     c1_token_network_proxy = c1_chain.token_network(token_network_address)
@@ -761,7 +768,8 @@ def test_token_network_actions_at_pruned_blocks(
         jsonrpc_client=c2_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -7,6 +7,7 @@ from raiden.constants import (
     EMPTY_BALANCE_HASH,
     EMPTY_HASH,
     EMPTY_SIGNATURE,
+    GENESIS_BLOCK_NUMBER,
     LOCKSROOT_OF_NO_LOCKS,
     STATE_PRUNING_AFTER_BLOCKS,
 )
@@ -19,7 +20,7 @@ from raiden.exceptions import (
     SamePeerAddress,
 )
 from raiden.network.blockchain_service import BlockChainService
-from raiden.network.proxies.token_network import TokenNetwork
+from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.tests.utils.factories import make_address
@@ -54,6 +55,11 @@ def test_token_network_deposit_race(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=blockchain_service,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
     token_proxy.transfer(c1_client.address, 10)
     channel_identifier = c1_token_network_proxy.new_netting_channel(
@@ -97,12 +103,22 @@ def test_token_network_proxy(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c1_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
     c2_token_network_proxy = TokenNetwork(
         jsonrpc_client=c2_client,
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c2_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
 
     initial_token_balance = 100
@@ -503,12 +519,22 @@ def test_token_network_proxy_update_transfer(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c1_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
     c2_token_network_proxy = TokenNetwork(
         jsonrpc_client=c2_client,
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c2_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
     # create a channel
     channel_identifier = c1_token_network_proxy.new_netting_channel(
@@ -715,6 +741,11 @@ def test_query_pruned_state(token_network_proxy, private_keys, web3, contract_ma
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c1_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
     # create a channel and query the state at the current block hash
     channel_identifier = c1_token_network_proxy.new_netting_channel(
@@ -749,6 +780,11 @@ def test_token_network_actions_at_pruned_blocks(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c1_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
 
     c2_client = JSONRPCClient(web3, private_keys[2])
@@ -759,6 +795,11 @@ def test_token_network_actions_at_pruned_blocks(
         token_network_address=token_network_address,
         contract_manager=contract_manager,
         blockchain_service=c2_chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None,
+            token_network_registry_address=None,
+            filter_start_at=GENESIS_BLOCK_NUMBER,
+        ),
     )
     initial_token_balance = 100
     token_proxy.transfer(c1_client.address, initial_token_balance)

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -26,7 +26,7 @@ def test_token_network_registry(
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
             token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
-            smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -25,7 +25,8 @@ def test_token_network_registry(
         jsonrpc_client=deploy_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -127,7 +127,8 @@ def test_token_network_registry_max_token_networks(
         jsonrpc_client=deploy_client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
     token_network_registry_proxy = blockchain_service.token_network_registry(

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -3,8 +3,7 @@ from eth_utils import encode_hex, to_checksum_address
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
-from raiden.constants import EMPTY_BALANCE_HASH, EMPTY_HASH, EMPTY_SIGNATURE, GENESIS_BLOCK_NUMBER
-from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
+from raiden.constants import EMPTY_BALANCE_HASH, EMPTY_HASH, EMPTY_SIGNATURE
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -57,15 +56,7 @@ def test_node_can_settle_if_close_didnt_use_any_balance_proof(
     )
     # stop app1 - the test uses token_network_contract now
     app1.stop()
-    token_network_contract = TokenNetwork(
-        jsonrpc_client=app1.raiden.chain.client,
-        token_network_address=token_network_address,
-        contract_manager=app1.raiden.contract_manager,
-        blockchain_service=app1.raiden.chain,
-        metadata=TokenNetworkMetadata(
-            deployed_at=None, token_network_address=None, filter_start_at=GENESIS_BLOCK_NUMBER
-        ),
-    )
+    token_network_contract = app1.raiden.chain.token_network(token_network_address)
     empty_balance_proof = BalanceProof(
         channel_identifier=channel_identifier,
         token_network_address=to_checksum_address(token_network_contract.address),

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -3,8 +3,8 @@ from eth_utils import encode_hex, to_checksum_address
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
-from raiden.constants import EMPTY_BALANCE_HASH, EMPTY_HASH, EMPTY_SIGNATURE
-from raiden.network.proxies.token_network import TokenNetwork
+from raiden.constants import EMPTY_BALANCE_HASH, EMPTY_HASH, EMPTY_SIGNATURE, GENESIS_BLOCK_NUMBER
+from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetadata
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -62,6 +62,9 @@ def test_node_can_settle_if_close_didnt_use_any_balance_proof(
         token_network_address=token_network_address,
         contract_manager=app1.raiden.contract_manager,
         blockchain_service=app1.raiden.chain,
+        metadata=TokenNetworkMetadata(
+            deployed_at=None, token_network_address=None, filter_start_at=GENESIS_BLOCK_NUMBER
+        ),
     )
     empty_balance_proof = BalanceProof(
         channel_identifier=channel_identifier,

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -10,8 +10,8 @@ from web3 import Web3
 
 from raiden import waiting
 from raiden.app import App
-from raiden.constants import Environment, RoutingMode
-from raiden.network.blockchain_service import BlockChainService
+from raiden.constants import GENESIS_BLOCK_NUMBER, Environment, RoutingMode
+from raiden.network.blockchain_service import BlockChainService, BlockChainServiceMetadata
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
@@ -471,7 +471,11 @@ def jsonrpc_services(
     for privkey in private_keys:
         rpc_client = JSONRPCClient(web3, privkey)
         blockchain = BlockChainService(
-            jsonrpc_client=rpc_client, contract_manager=contract_manager
+            jsonrpc_client=rpc_client,
+            contract_manager=contract_manager,
+            metadata=BlockChainServiceMetadata(
+                token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            ),
         )
         blockchain_services.append(blockchain)
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -474,7 +474,8 @@ def jsonrpc_services(
             jsonrpc_client=rpc_client,
             contract_manager=contract_manager,
             metadata=BlockChainServiceMetadata(
-                token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+                token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+                smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
             ),
         )
         blockchain_services.append(blockchain)

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -475,7 +475,7 @@ def jsonrpc_services(
             contract_manager=contract_manager,
             metadata=BlockChainServiceMetadata(
                 token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
-                smart_contracts_start_at=GENESIS_BLOCK_NUMBER,
+                filters_start_at=GENESIS_BLOCK_NUMBER,
             ),
         )
         blockchain_services.append(blockchain)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -278,7 +278,8 @@ def setup_raiden(
         jsonrpc_client=client,
         contract_manager=contract_manager,
         metadata=BlockChainServiceMetadata(
-            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER
+            token_network_registry_deployed_at=GENESIS_BLOCK_NUMBER,
+            filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -236,7 +236,7 @@ def run_app(
         contract_manager=ContractManager(config["contracts_path"]),
         metadata=BlockChainServiceMetadata(
             token_network_registry_deployed_at=token_network_registry_deployed_at,
-            smart_contracts_start_at=smart_contracts_start_at,
+            filters_start_at=smart_contracts_start_at,
         ),
     )
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -17,7 +17,11 @@ from raiden.constants import (
     RAIDEN_DB_VERSION,
     Environment,
     EthereumForks,
+    GoerliForks,
+    KovanForks,
     Networks,
+    RinkebyForks,
+    RopstenForks,
     RoutingMode,
 )
 from raiden.exceptions import RaidenError
@@ -117,6 +121,23 @@ def get_account_and_private_key(
         )
 
     return to_canonical_address(address_hex), privatekey_bin
+
+
+def get_smart_contracts_start_at(network_id: ChainID) -> BlockNumber:
+    if network_id == Networks.MAINNET:
+        smart_contracts_start_at = EthereumForks.CONSTANTINOPLE.value
+    elif network_id == Networks.ROPSTEN:
+        smart_contracts_start_at = RopstenForks.CONSTANTINOPLE.value
+    elif network_id == Networks.KOVAN:
+        smart_contracts_start_at = KovanForks.CONSTANTINOPLE.value
+    elif network_id == Networks.RINKEBY:
+        smart_contracts_start_at = RinkebyForks.CONSTANTINOPLE.value
+    elif network_id == Networks.GOERLI:
+        smart_contracts_start_at = GoerliForks.CONSTANTINOPLE.value
+    else:
+        smart_contracts_start_at = GENESIS_BLOCK_NUMBER
+
+    return smart_contracts_start_at
 
 
 def rpc_normalized_endpoint(eth_rpc_endpoint: str) -> str:
@@ -224,12 +245,10 @@ def run_app(
             contracts["TokenNetworkRegistry"]["block_number"]
         )
 
-    if token_network_registry_deployed_at is not None:
-        smart_contracts_start_at = token_network_registry_deployed_at
-    elif network_id == Networks.MAINNET:
-        smart_contracts_start_at = EthereumForks.CONSTANTINOPLE.value
+    if token_network_registry_deployed_at is None:
+        smart_contracts_start_at = get_smart_contracts_start_at(network_id)
     else:
-        smart_contracts_start_at = GENESIS_BLOCK_NUMBER
+        smart_contracts_start_at = token_network_registry_deployed_at
 
     blockchain_service = BlockChainService(
         jsonrpc_client=rpc_client,

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -36,6 +36,11 @@ def typecheck(value: Any, expected: Type):
 ABI = List[Dict[str, Any]]
 BlockchainEvent = Dict[str, Any]
 
+T_EVMBytecode = bytes
+EVMBytecode = NewType("EVMBytecode", T_EVMBytecode)
+
+GasMeasurements = Dict[str, int]
+
 T_Address = bytes
 
 AddressHex = ChecksumAddress


### PR DESCRIPTION
Partially solves: #3958

## Description

The main objective of this PR is to define the *lower bound* to used for a query logs `fromBlock` which is not the genesis block.

With this PR the deployment of the contract `TokenNetworkRegistry` is used. If that metadata is not available, then either the Constantinople fork or the genesis block is used. Note that because Constantinople is used, instead of Byzantium, this is yet another incompatible change with Red Eyes.

There are a few problems left to be fixed in the future with this PR:

- It assumes only one `TokenNetworkRegistry`.
- It doesn't query the `TokenNetworkCreated` event, it just uses the same `filters_start_at` as the registry. This will also degrade have a negative impact in performance over time.
- It introduces the `BlockChainService.token_network_from_registry` method but does not update the code to use it. Meaning the `TokenNetwork` metadata will never have the field `token_network_registry_address` set.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
