### PR TITLE
Fix imbalance fee direction for incoming channel

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -535,7 +535,7 @@ def test_mediated_transfer_with_fees(
         # of the outgoing channel of mediator 1 should yield the same result.
         dict(
             incoming_fee_schedules=[
-                FeeScheduleState(imbalance_penalty=[(0, 0), (1000, 200)]),
+                FeeScheduleState(imbalance_penalty=[(0, 200), (1000, 0)]),
                 None,
                 None,
             ],

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -68,27 +68,31 @@ def test_imbalance_penalty():
             (TokenAmount(100), FeeAmount(10)),
         ]
     )
-    assert v_schedule.fee_payer(
+    assert v_schedule.fee_payee(
         balance=Balance(100 - 0), amount=PaymentWithFeeAmount(50)
     ) == FeeAmount(-10)
+    # The payer channel works in the opposite direction
     assert v_schedule.fee_payer(
+        balance=Balance(100 - 0), amount=PaymentWithFeeAmount(-50)
+    ) == FeeAmount(-10)
+    assert v_schedule.fee_payee(
         balance=Balance(100 - 50), amount=PaymentWithFeeAmount(50)
     ) == FeeAmount(10)
-    assert v_schedule.fee_payer(
+    assert v_schedule.fee_payee(
         balance=Balance(100 - 0), amount=PaymentWithFeeAmount(10)
     ) == FeeAmount(-2)
-    assert v_schedule.fee_payer(
+    assert v_schedule.fee_payee(
         balance=Balance(100 - 10), amount=PaymentWithFeeAmount(10)
     ) == FeeAmount(-2)
-    assert v_schedule.fee_payer(
+    assert v_schedule.fee_payee(
         balance=Balance(100 - 0), amount=PaymentWithFeeAmount(20)
     ) == FeeAmount(-4)
-    assert v_schedule.fee_payer(
+    assert v_schedule.fee_payee(
         balance=Balance(100 - 40), amount=PaymentWithFeeAmount(20)
     ) == FeeAmount(0)
 
     with pytest.raises(UndefinedMediationFee):
-        v_schedule.fee_payer(balance=Balance(0), amount=PaymentWithFeeAmount(1))
+        v_schedule.fee_payee(balance=Balance(0), amount=PaymentWithFeeAmount(1))
 
 
 def test_linspace():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1950,7 +1950,8 @@ def test_imbalance_penalty_at_insufficent_payer_balance():
     pair, _ = _foward_transfer_pair(
         10,
         NettingChannelStateProperties(
-            our_state=NettingChannelEndStateProperties(balance=9),
+            # the payer's capacity is 20 - 11 = 9
+            our_state=NettingChannelEndStateProperties(balance=11),
             fee_schedule=FeeScheduleState(flat=0, imbalance_penalty=imbalance_penalty),
         ),
         NettingChannelStateProperties(
@@ -1993,7 +1994,8 @@ def test_imbalance_penalty_with_barely_sufficient_balance():
     pair, _ = _foward_transfer_pair(
         10,
         NettingChannelStateProperties(
-            our_state=NettingChannelEndStateProperties(balance=11),
+            # the payer's capacity is 20 - 9 = 11
+            our_state=NettingChannelEndStateProperties(balance=9),
             fee_schedule=FeeScheduleState(flat=0, imbalance_penalty=imbalance_penalty),
         ),
         NettingChannelStateProperties(

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -72,7 +72,7 @@ class FeeScheduleState(State):
         return FeeAmount(0)
 
     def fee_payer(self, amount: PaymentWithFeeAmount, balance: Balance) -> FeeAmount:
-        imbalance_fee = self.imbalance_fee(amount=amount, balance=balance)
+        imbalance_fee = self.imbalance_fee(amount=PaymentWithFeeAmount(-amount), balance=balance)
 
         flat_fee = self.flat
         prop_fee = int(round(amount * self.proportional / 1e6))


### PR DESCRIPTION
The amount has to have the opposite sign for incoming and outgoing
channels. Otherwise, the fees would not properly represent the balance
moving back and forth.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
