### PR TITLE
Added API endpoint to get Raiden version

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -106,6 +106,28 @@ Querying Information About Your Raiden Node
           "our_address": "0x2a65Aca4D5fC5B5C859090a6c34d164135398226"
       }
 
+.. http:get:: /api/(version)/version
+
+   Query the version of the Raiden instance
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      GET /api/v1/version HTTP/1.1
+      Host: localhost:5001
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "version": "0.100.5a1.dev157+geb2af878d"
+      }
+
 Deploying
 =========
 .. note::

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -52,6 +52,7 @@ from raiden.api.v1.resources import (
     RaidenInternalEventsResource,
     RegisterTokenResource,
     TokensResource,
+    VersionResource,
     create_blueprint,
 )
 from raiden.constants import GENESIS_BLOCK_NUMBER, UINT256_MAX, Environment
@@ -91,6 +92,7 @@ from raiden.transfer.state import ChannelState, NettingChannelState
 from raiden.utils import (
     Endpoint,
     create_default_identifier,
+    get_system_spec,
     optional_address_to_string,
     split_endpoint,
 )
@@ -130,6 +132,7 @@ ERROR_STATUS_CODES = [
 
 URLS_V1 = [
     ("/address", AddressResource),
+    ("/version", VersionResource),
     ("/channels", ChannelsResource),
     ("/channels/<hexaddress:token_address>", ChannelsResourceByTokenAddress),
     (
@@ -527,6 +530,10 @@ class RestAPI:  # pragma: no unittest
 
     def get_our_address(self) -> Response:
         return api_response(result=dict(our_address=to_checksum_address(self.raiden_api.address)))
+
+    @classmethod
+    def get_raiden_version(self):
+        return api_response(result=dict(version=get_system_spec()["raiden"]))
 
     def register_token(
         self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -34,6 +34,11 @@ class AddressResource(BaseResource):
         return self.rest_api.get_our_address()
 
 
+class VersionResource(BaseResource):
+    def get(self):
+        return self.rest_api.get_raiden_version()
+
+
 class ChannelsResource(BaseResource):
 
     put_schema = ChannelPutSchema

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -29,6 +29,7 @@ from raiden.tests.utils.smartcontracts import deploy_contract_web3
 from raiden.tests.utils.transfer import calculate_fee_for_amount
 from raiden.transfer import views
 from raiden.transfer.state import ChannelState
+from raiden.utils import get_system_spec
 from raiden.waiting import (
     TransferWaitResult,
     wait_for_received_transfer_result,
@@ -248,6 +249,16 @@ def test_api_query_our_address(api_server_test_instance):
 
     our_address = api_server_test_instance.rest_api.raiden_api.address
     assert get_json_response(response) == {"our_address": to_checksum_address(our_address)}
+
+
+def test_api_get_raiden_version(api_server_test_instance):
+    request = grequests.get(api_url_for(api_server_test_instance, "versionresource"))
+    response = request.send().response
+    assert_proper_response(response)
+
+    raiden_version = get_system_spec()["raiden"]
+
+    assert get_json_response(response) == {"version": raiden_version}
 
 
 @pytest.mark.parametrize("number_of_nodes", [1])


### PR DESCRIPTION
## Description

This PR adds an API endpoint (`/api/v1/version`) that shows the version of Raiden using the existing `get_system_spec` function.

This is useful for applications utilizing the API of Raiden so that they can ensure compatibility with the underlying service. Similar to what Raiden is doing with its version checks for GETH and Parity.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [x] Exceptions are propagated to the correct parent greenlet
    - [x] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [x] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
