### PR TITLE
Added a test for #918

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -370,7 +370,18 @@ class RaidenAPI:  # pragma: no unittest
 
         if settle_timeout < self.raiden.config["reveal_timeout"] * 2:
             raise InvalidSettleTimeout(
-                "settle_timeout can not be smaller than double the reveal_timeout"
+                "`settle_timeout` can not be smaller than double the "
+                "`reveal_timeout`.\n "
+                "\n "
+                "The setting `reveal_timeout` determines the maximum number of "
+                "blocks it should take a transaction to be mined when the "
+                "blockchain is under congestion. This setting determines the "
+                "when a node must go on-chain to register a secret, and it is "
+                "therefore the lower bound of the lock expiration. The "
+                "`settle_timeout` determines when a channel can be settled "
+                "on-chain, for this operation to be safe all locks must have "
+                "been resolved, for this reason the `settle_timeout` has to be "
+                "larger than `reveal_timeout`."
             )
 
         if not is_binary_address(registry_address):

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -78,7 +78,9 @@ def run_test_token_addresses(raiden_network, token_addresses):
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, retry_timeout):
+def test_raidenapi_channel_lifecycle(
+    raiden_network, token_addresses, deposit, retry_timeout, settle_timeout_max
+):
     """Uses RaidenAPI to go through a complete channel lifecycle."""
     node1, node2 = raiden_network
     token_address = token_addresses[0]
@@ -105,6 +107,16 @@ def test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, r
     # Make sure a small settle timeout is not accepted when opening a channel
     with pytest.raises(InvalidSettleTimeout):
         invalid_settle_timeout = node1.raiden.config["reveal_timeout"] * 2 - 1
+        api1.channel_open(
+            registry_address=node1.raiden.default_registry.address,
+            token_address=token_address,
+            partner_address=api2.address,
+            settle_timeout=invalid_settle_timeout,
+        )
+
+    # Make sure a too large settle timeout is not accepted when opening a channel
+    with pytest.raises(InvalidSettleTimeout):
+        invalid_settle_timeout = settle_timeout_max + 1
         api1.channel_open(
             registry_address=node1.raiden.default_registry.address,
             token_address=token_address,

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -4,6 +4,7 @@ from eth_utils import to_checksum_address
 from raiden.api.python import RaidenAPI
 from raiden.exceptions import (
     DepositMismatch,
+    InvalidSettleTimeout,
     TokenNotRegistered,
     UnexpectedChannelState,
     UnknownTokenAddress,
@@ -99,6 +100,16 @@ def test_raidenapi_channel_lifecycle(raiden_network, token_addresses, deposit, r
     with pytest.raises(UnknownTokenAddress):
         api1.get_channel_list(
             registry_address=registry_address, token_address=None, partner_address=api2.address
+        )
+
+    # Make sure a small settle timeout is not accepted when opening a channel
+    with pytest.raises(InvalidSettleTimeout):
+        invalid_settle_timeout = node1.raiden.config["reveal_timeout"] * 2 - 1
+        api1.channel_open(
+            registry_address=node1.raiden.default_registry.address,
+            token_address=token_address,
+            partner_address=api2.address,
+            settle_timeout=invalid_settle_timeout,
         )
 
     # open is a synchronous api


### PR DESCRIPTION
## Description

Issue #918 needs that the reveal timeout and settle timeout are validated against each other.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
