### PR TITLE
Remove unecessary RPC calls

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -161,14 +161,6 @@ class STUNUnavailableException(RaidenError):
     pass
 
 
-class EthNodeCommunicationError(RaidenError):
-    """ Raised when something unexpected has happened during
-    communication with the underlying ethereum node"""
-
-    def __init__(self, error_msg: str) -> None:
-        super().__init__(error_msg)
-
-
 class EthNodeInterfaceError(RaidenError):
     """ Raised when the underlying ETH node does not support an rpc interface"""
 

--- a/raiden/network/rpc/middleware.py
+++ b/raiden/network/rpc/middleware.py
@@ -1,35 +1,7 @@
 import functools
-from json.decoder import JSONDecodeError
 
 from cachetools import LRUCache
 from web3.middleware.cache import construct_simple_cache_middleware
-
-from raiden.exceptions import EthNodeCommunicationError
-
-
-def make_connection_test_middleware():
-    def connection_test_middleware(make_request, web3):
-        """ Creates middleware that checks if the provider is connected. """
-
-        def middleware(method, params):
-            try:
-                if web3.isConnected():
-                    return make_request(method, params)
-                else:
-                    raise EthNodeCommunicationError("Web3 provider not connected")
-
-            # the isConnected check doesn't currently catch JSON errors
-            # see https://github.com/ethereum/web3.py/issues/866
-            except JSONDecodeError:
-                raise EthNodeCommunicationError("Web3 provider not connected")
-
-        return middleware
-
-    return connection_test_middleware
-
-
-connection_test_middleware = make_connection_test_middleware()
-
 
 BLOCK_HASH_CACHE_RPC_WHITELIST = {"eth_getBlockByHash"}
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -1,5 +1,4 @@
 import re
-from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Dict
 
 import click
@@ -20,7 +19,6 @@ from raiden.constants import (
     RELEASE_PAGE,
     SECURITY_EXPRESSION,
 )
-from raiden.exceptions import EthNodeCommunicationError
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.settings import MIN_REI_THRESHOLD
@@ -202,10 +200,7 @@ class AlarmTask(Runnable):
 
         sleep_time = self.sleep_time
         while self._stop_event and self._stop_event.wait(sleep_time) is not True:
-            try:
-                latest_block = self.chain.get_block(block_identifier="latest")
-            except JSONDecodeError as e:
-                raise EthNodeCommunicationError(str(e))
+            latest_block = self.chain.get_block(block_identifier="latest")
 
             self._maybe_run_callbacks(latest_block)
 

--- a/raiden/tests/unit/network/rpc/test_client.py
+++ b/raiden/tests/unit/network/rpc/test_client.py
@@ -1,0 +1,21 @@
+import pytest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from web3 import HTTPProvider, Web3
+
+from raiden.network.rpc.client import JSONRPCClient
+from raiden.tests.utils.factories import make_privatekey_bin
+
+
+def test_connection_issues() -> None:
+    # 641 is a port registered with IANA for this service:
+    #
+    # repcmd            641/tcp
+    # repcmd            641/udp
+    #
+    # This is a comcast utility agent that is unlikely to be running. The numbe
+    # was chosen with. `sum(ord(c) for c in 'random')`
+
+    web3 = Web3(HTTPProvider("http://localhost:641"))
+
+    with pytest.raises(RequestsConnectionError):
+        JSONRPCClient(web3=web3, privkey=make_privatekey_bin())

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -3,7 +3,6 @@ import sys
 import click
 import structlog
 from eth_utils import to_checksum_address
-from requests.exceptions import ConnectTimeout
 from web3 import Web3
 
 from raiden.accounts import AccountManager
@@ -16,7 +15,7 @@ from raiden.constants import (
     SQLITE_MIN_REQUIRED_VERSION,
     Environment,
 )
-from raiden.exceptions import EthNodeCommunicationError, EthNodeInterfaceError
+from raiden.exceptions import EthNodeInterfaceError
 from raiden.network.blockchain_service import BlockChainService
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
@@ -44,8 +43,6 @@ def check_sql_version() -> None:
 def check_ethereum_client_is_supported(web3: Web3) -> None:
     try:
         node_version = web3.version.node  # pylint: disable=no-member
-    except ConnectTimeout:
-        raise EthNodeCommunicationError("Couldn't connect to the ethereum node")
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying ethereum node does not have the web3 rpc interface "

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -11,17 +11,12 @@ import gevent
 import gevent.monkey
 import structlog
 from gevent.event import AsyncResult
-from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ConnectionError as RequestsConnectionError, ConnectTimeout
 
 from raiden import constants, settings
 from raiden.api.rest import APIServer, RestAPI
 from raiden.app import App
-from raiden.exceptions import (
-    APIServerPortInUseError,
-    EthNodeCommunicationError,
-    EthNodeInterfaceError,
-    RaidenError,
-)
+from raiden.exceptions import APIServerPortInUseError, EthNodeInterfaceError, RaidenError
 from raiden.log_config import configure_logging
 from raiden.tasks import check_gas_reserve, check_network_id, check_rdn_deposits, check_version
 from raiden.utils import get_system_spec, merge_dict, split_endpoint, typing
@@ -93,7 +88,7 @@ class NodeRunner:
         # this catches exceptions raised when waiting for the stalecheck to complete
         try:
             app_ = run_app(**self._options)
-        except (EthNodeCommunicationError, RequestsConnectionError):
+        except (ConnectionError, ConnectTimeout, RequestsConnectionError):
             print(ETHEREUM_NODE_COMMUNICATION_ERROR)
             sys.exit(1)
         except RuntimeError as e:
@@ -197,7 +192,7 @@ class NodeRunner:
         try:
             event.get()
             print("Signal received. Shutting down ...")
-        except (EthNodeCommunicationError, RequestsConnectionError):
+        except (ConnectionError, ConnectTimeout, RequestsConnectionError):
             print(ETHEREUM_NODE_COMMUNICATION_ERROR)
             sys.exit(1)
         except RaidenError as ex:


### PR DESCRIPTION
fix #2226

## Description

The existing middleware doubled the number of RPC calls, because prior
to every RPC call a check for connectivity was done.

Additionally this EthNodeCommunicationError removes Instead of wrapping
the underlying exceptions (ConnectTimeout, JSONDecodeError), this just
let them to propagate.

I'm surprised this didn't appear on #4872 , perhaps the result was being cached?

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
