### PR TITLE
Also auto-assign the PR itself and not only add review

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,7 +2,7 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: false
+addAssignees: true
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:


### PR DESCRIPTION

Hopefully this will allow github notifications to properly tell the
user they were requested to review the PR.

