### PR TITLE
Revert assignee for the github bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,7 +2,7 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:


### PR DESCRIPTION
Apparently, the requested reviewer is not the same as assignee