### PR TITLE
Include all fields in `WithdrawExpired` signature

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -149,7 +149,6 @@ class MessageHandler:
             participant=message.participant,
             nonce=message.nonce,
             expiration=message.expiration,
-            signature=message.signature,
         )
         raiden.handle_and_track_state_changes([withdraw_expired])
 

--- a/raiden/messages/withdraw.py
+++ b/raiden/messages/withdraw.py
@@ -130,6 +130,9 @@ class WithdrawExpired(SignedRetrieableMessage):
 
     def _data_to_sign(self) -> bytes:
         return pack_data(
+            (self.cmdid.value, "uint8"),
+            (b"\x00" * 3, "bytes"),  # padding
+            (self.nonce, "uint256"),
             (self.token_network_address, "address"),
             (self.chain_id, "uint256"),
             (self.message_type, "uint256"),

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -354,9 +354,7 @@ def is_valid_channel_total_withdraw(channel_total_withdraw: TokenAmount) -> bool
 
 
 def is_valid_withdraw(
-    withdraw_request: Union[
-        ReceiveWithdrawRequest, ReceiveWithdrawConfirmation, ReceiveWithdrawExpired
-    ]
+    withdraw_request: Union[ReceiveWithdrawRequest, ReceiveWithdrawConfirmation]
 ) -> SuccessOrError:
     """True if the signature of the message corresponds is valid.
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1027,8 +1027,6 @@ def is_valid_withdraw_expired(
 ) -> SuccessOrError:
     expected_nonce = get_next_nonce(channel_state.partner_state)
 
-    is_valid = is_valid_withdraw(state_change)
-
     withdraw_expired = is_withdraw_expired(
         block_number=block_number,
         expiration_threshold=get_receiver_expiration_threshold(
@@ -1056,7 +1054,7 @@ def is_valid_withdraw_expired(
             f"got: {state_change.nonce}."
         )
     else:
-        return is_valid
+        return SuccessOrError()
 
 
 def get_amount_unclaimed_onchain(end_state: NettingChannelEndState) -> TokenAmount:

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -440,7 +440,6 @@ class ReceiveWithdrawExpired(AuthenticatedSenderStateChange):
     total_withdraw: WithdrawAmount
     expiration: BlockExpiration
     nonce: Nonce
-    signature: Signature
     participant: Address
 
     @property


### PR DESCRIPTION
Fixes: #4934

## Description

This reduces the options of tampering with the message for attackers. It
also makes the signature different from the `WithdrawRequest` one.
Ideally all messages and proofs are guaranteed to have different
signatures.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
