### PR TITLE
Catch up with variable rename in a comment

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -225,8 +225,9 @@ class RaidenAPI:  # pragma: no unittest
         if token_address == NULL_ADDRESS_BYTES:
             raise InvalidTokenAddress("token_address must be non-zero")
 
-        # The following check is on prestate because the chain state does not
-        # change here.
+        # The following check is on the same chain state as the
+        # `chainstate` variable defined below because the chain state does
+        # not change between this line and seven lines below.
         # views.state_from_raiden() returns the same state again and again
         # as far as this gevent context is running.
         if token_address in self.get_tokens_list(registry_address):


### PR DESCRIPTION
A variable prestate was renamed into chainstate but in a comment
the old variable name stayed. This commit changes the variable
name in the comment.

## Description

Please, describe what this PR does in detail:
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

Before this PR, a comment talked about a variable that no longer exists in the codebase.


## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
