### PR TITLE
Remove checks that are not in the onchain contract

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -174,12 +174,6 @@ class TokenNetworkRegistry:
                     "The chain ID property for the TokenNetworkRegistry is invalid."
                 )
 
-            if chain_id != self.blockchain_service.network_id:
-                raise BrokenPreconditionError(
-                    "The provided chain ID {chain_id} does not match the "
-                    "network Raiden is running on: {self.blockchain_service.network_id}."
-                )
-
             if secret_registry_address == NULL_ADDRESS:
                 raise BrokenPreconditionError(
                     "The secret registry address for the token network is invalid."
@@ -301,12 +295,6 @@ class TokenNetworkRegistry:
                 if chain_id == 0:
                     raise RaidenUnrecoverableError(
                         "The chain ID property for the TokenNetworkRegistry is invalid."
-                    )
-
-                if chain_id != self.blockchain_service.network_id:
-                    raise RaidenUnrecoverableError(
-                        "The provided chain ID {chain_id} does not match the "
-                        "network Raiden is running on: {self.blockchain_service.network_id}."
                     )
 
                 if secret_registry_address == NULL_ADDRESS:


### PR DESCRIPTION
TokenNetworkRegistry.createERC20() succeeds even when the stored
chain_id value is different from the current chain_id of the blockchain.

Since the proxies should not check what's not checked onchain,
I'm removing the checks that do not exist in the onchain contracts.

This PR comes from this conversation https://github.com/raiden-network/raiden/pull/4936#discussion_r327028792

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

It's a bug fix.  Before this PR, the proxy failed even when the transaction would succeed.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
