### PR TITLE
Fix crash in sphinx due to version number

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ Changelog
 * :bug:`4560` Formatting of timestamp fields on the API should follow ISO8601.
 * :bug:`4561` Limit and offset should now work properly in the payment API event queries.
 
-* :release:`0.100.5a0 <2019-08-12>`
+* :release:`0.100.5-a0 <2019-08-12>`
 * :feature:`-` Update WebUI to version 0.9.2 https://github.com/raiden-network/webui/releases/tag/v0.9.2
 * :bug:`4498` Raiden now waits for synchronization with the blockchain events before finishing its startup and opening the API.
 * :bug:`4348` Fix wrong calculation of ``balance`` field of channel information when tokens are locked in payments


### PR DESCRIPTION
Fixes: #4958
Fixes #4764

## Description

The changelog included a version number that crashed Sphinx. I added a dash in it, so that readthedocs can build again.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
