### PR TITLE
RaidenRecoverableError indicates conflicts.

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -76,6 +76,7 @@ from raiden.exceptions import (
     InvalidTokenAddress,
     MintFailed,
     PaymentConflict,
+    RaidenRecoverableError,
     SamePeerAddress,
     TokenNetworkDeprecated,
     TokenNotRegistered,
@@ -551,6 +552,7 @@ class RestAPI:  # pragma: no unittest
             InvalidBinaryAddress,
             InvalidToken,
             InvalidTokenAddress,
+            RaidenRecoverableError,
         )
         log.debug(
             "Registering token",


### PR DESCRIPTION
Proxies raise RaidenRecoverableErrorr when the failure was not
the caller's fault but because of somebody else interacting
with the blockchain.  This fits perfectly with the "conflict"
situation.  So the HTTP status should indicate "conflict".

Fixes: #<issue>

## Description

- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.

It's a bug fix.  When a proxy raises `RaidenRecoverableError`, that should indicate the fact that there was a race.  So the HTTP status should indicate a conflict.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
