### PR TITLE
Add message_identifier to WithdrawExp. signature

### DIFF
--- a/raiden/messages/withdraw.py
+++ b/raiden/messages/withdraw.py
@@ -133,6 +133,7 @@ class WithdrawExpired(SignedRetrieableMessage):
             (self.cmdid.value, "uint8"),
             (b"\x00" * 3, "bytes"),  # padding
             (self.nonce, "uint256"),
+            (self.message_identifier, "uint64"),
             (self.token_network_address, "address"),
             (self.chain_id, "uint256"),
             (self.message_type, "uint256"),


### PR DESCRIPTION
This should have been in https://github.com/raiden-network/raiden/pull/4935 already, but I missed it because the field was defined in a superclass.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
