### PR TITLE
1.8.21 is now the  lowest geth supported

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` The lowest supported geth version is now 1.8.21.
 * :feature:`4976` Geth users no longer need to activate the special txpool RPC api when starting their geth node.
 * :feature:`4917` Added documentation on using Raiden for atomic swaps.
 * :feature:`-` Added a new api endpoint ``/api/v1/version`` to query the raiden version via the Rest API.

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -163,7 +163,7 @@ EMPTY_ADDRESS = b"\0" * 20
 
 # Keep in sync with .circleci/config.yaml
 HIGHEST_SUPPORTED_GETH_VERSION = "1.9.2"
-LOWEST_SUPPORTED_GETH_VERSION = "1.7.2"
+LOWEST_SUPPORTED_GETH_VERSION = "1.8.21"
 # this is the last stable version as of this comment
 HIGHEST_SUPPORTED_PARITY_VERSION = "2.5.5"
 LOWEST_SUPPORTED_PARITY_VERSION = "1.7.6"

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -68,7 +68,9 @@ def run_test_check_json_rpc_geth():
 
 def test_check_json_rpc_geth():
     # Pin the highest supported version for the test purposes
-    with patch("raiden.utils.ethereum_clients.HIGHEST_SUPPORTED_GETH_VERSION", new="1.9.2"):
+    with patch("raiden.utils.ethereum_clients.HIGHEST_SUPPORTED_GETH_VERSION", new="1.9.2"), patch(
+        "raiden.utils.ethereum_clients.LOWEST_SUPPORTED_GETH_VERSION", new="1.7.2"
+    ):
         run_test_check_json_rpc_geth()
 
 


### PR DESCRIPTION

## Description

 Set 1.8.21 to lowest supported geth version

This is to have the eth_getTransactionCount fix:  ethereum/go-ethereum#2880

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
