### PR TITLE
Update scenarios after `settle_timeout_min` change

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -231,18 +231,17 @@ scenario:
                 num_events: 1
                 event_args: {closing_participant: 3}
 
-            ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
-            - wait_blocks: 401
+            ## The MS reacts within the settle_timeout
+            - wait_blocks: 500
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "NonClosingBalanceProofUpdated"
                 num_events: 1
                 event_args: {closing_participant: 3}
 
-            ## Monitored channel must be settled before the monitoring service can claim its reward
-            ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
+            ## Monitored channel must be settled before the monitoring service can claim its reward.
             ## To make sure the transactions gets mined in time, 10 additional blocks are added
             ## Monitoring Service only reacts for the second closing because node4 settled to first
             ## channel itself
-            - wait_blocks: 110
+            - wait_blocks: 10
             - assert_ms_claim: {channel_info_key: "MS Test Channel 3-4"}

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -57,8 +57,8 @@ scenario:
           num_events: 1
           event_args: {closing_participant: 0}
 
-      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
-      - wait_blocks: 401
+      ## The MS reacts within the settle_timeout
+      - wait_blocks: 500
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -68,5 +68,5 @@ scenario:
       ## Monitored channel must be settled before the monitoring service can claim its reward
       ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
       ## To make sure the transactions gets mined in time, 10 additional blocks are added
-      - wait_blocks: 110
+      - wait_blocks: 10
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -57,8 +57,8 @@ scenario:
           num_events: 1
           event_args: {closing_participant: 0}
 
-      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
-      - wait_blocks: 401
+      ## The MS reacts within the settle_timeout
+      - wait_blocks: 500
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -70,7 +70,6 @@ scenario:
       - start_node: 1
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
       ## To make sure the transactions gets mined in time, 10 additional blocks are added
-      - wait_blocks: 110
+      - wait_blocks: 10
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -73,7 +73,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500 blocks -> 500 * 15s in Kovan = 7500s
+      ## Settlement timeout is 500 blocks, but we already waited 40 blocks.
       - wait_blocks: 461
       # will fail for now since channel was closed by node1. We should add functionality to assert a fail
       - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -80,8 +80,8 @@ scenario:
       - serial:
           name: "Wait for MS to not react"
           tasks:
-            # The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
-            - wait_blocks: 401
+            # The MS reacts within the settle_timeout
+            - wait_blocks: 500
             # Note that 0 events are expected
             - assert_events:
                 contract_name: "TokenNetwork"
@@ -93,9 +93,8 @@ scenario:
           name: "Wait for remaining timeout period to expire and check again that MS did not react"
           tasks:
             # Monitored channel must be settled before the monitoring service can claim its reward
-            # Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
             # To make sure the transactions gets mined in time, 10 additional blocks are added
-            - wait_blocks: 110
+            - wait_blocks: 10
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "NonClosingBalanceProofUpdated"


### PR DESCRIPTION
Otherwise the MS won't have acted before the assert in all cases.

Fixes https://github.com/raiden-network/raiden/issues/4988

[skip tests]
## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
