### PR TITLE
Calculate imbalance penalty with slope <= 1

### DIFF
--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -237,8 +237,8 @@ def test_fees_are_updated_during_startup(
     # once both channels have deposited the default (200) deposit
     default_imbalance_penalty = [
         (0, 1),
-        (20, 1),
-        (40, 1),
+        (20, 0),
+        (40, 0),
         (60, 0),
         (80, 0),
         (100, 0),
@@ -254,8 +254,8 @@ def test_fees_are_updated_during_startup(
         (300, 0),
         (320, 0),
         (340, 0),
-        (360, 1),
-        (380, 1),
+        (360, 0),
+        (380, 0),
         (400, 1),
     ]
 
@@ -294,35 +294,38 @@ def test_fees_are_updated_during_startup(
     # Now restart app0, and set new proportional imbalance fee
     app0.stop()
     app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_proportional_imbalance_fee = {token_address: 1e6}
+    app0.raiden.config["mediation_fees"].token_to_proportional_imbalance_fee = {
+        token_address: 0.05e6
+    }
     app0.start()
 
     channel_state = get_channel_state(app0)
     assert channel_state.fee_schedule.flat == DEFAULT_MEDIATION_FLAT_FEE
     assert channel_state.fee_schedule.proportional == DEFAULT_MEDIATION_PROPORTIONAL_FEE
-    # with 100% imbalance fee
+    # with 5% 400imbalance fee
+    print(channel_state.fee_schedule.imbalance_penalty)
     full_imbalance_penalty = [
-        (0, 400),
-        (20, 324),
-        (40, 256),
-        (60, 196),
-        (80, 144),
-        (100, 100),
-        (120, 64),
-        (140, 36),
-        (160, 16),
-        (180, 4),
+        (0, 20),
+        (20, 18),
+        (40, 16),
+        (60, 14),
+        (80, 12),
+        (100, 10),
+        (120, 8),
+        (140, 6),
+        (160, 4),
+        (180, 2),
         (200, 0),
-        (220, 4),
-        (240, 16),
-        (260, 36),
-        (280, 64),
-        (300, 100),
-        (320, 144),
-        (340, 196),
-        (360, 256),
-        (380, 324),
-        (400, 400),
+        (220, 2),
+        (240, 4),
+        (260, 6),
+        (280, 8),
+        (300, 10),
+        (320, 12),
+        (340, 14),
+        (360, 16),
+        (380, 18),
+        (400, 20),
     ]
 
     assert channel_state.fee_schedule.imbalance_penalty == full_imbalance_penalty

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -209,12 +209,12 @@ def test_mediated_transfer_with_entire_deposit(
         token_network_address=token_network_address,
         partner_address=app0.raiden.address,
     )
-    app1_app2_channel_state = views.get_channelstate_by_token_network_and_partner(
-        chain_state=views.state_from_raiden(app1.raiden),
+    app2_app1_channel_state = views.get_channelstate_by_token_network_and_partner(
+        chain_state=views.state_from_raiden(app2.raiden),
         token_network_address=token_network_address,
-        partner_address=app2.raiden.address,
+        partner_address=app1.raiden.address,
     )
-    mediator_channels = [app1_app2_channel_state, app1_app0_channel_state]
+    mediator_channels = [app2_app1_channel_state, app1_app0_channel_state]
     reverse_calculation = get_amount_for_sending_before_and_after_fees(
         amount_to_leave_initiator=deposit + calculation.amount_to_send, channels=mediator_channels
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -127,44 +127,44 @@ def test_linspace():
 
 
 def test_rebalancing_fee_calculation():
-    sample = calculate_imbalance_fees(TokenAmount(200), ProportionalFeeAmount(500_000))  # 50%
+    sample = calculate_imbalance_fees(TokenAmount(200), ProportionalFeeAmount(50_000))  # 5%
     assert sample is not None
     assert len(sample) == NUM_DISCRETISATION_POINTS
     assert all(0 <= x <= 200 for x, _ in sample)
     assert max(x for x, _ in sample) == 200
-    assert all(0 <= y <= 100 for _, y in sample)
-    assert max(y for _, y in sample) == 100  # 50% of the 200 TokenAmount capacity
+    assert all(0 <= y <= 10 for _, y in sample)
+    assert max(y for _, y in sample) == 10  # 5% of the 200 TokenAmount capacity
 
-    sample = calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(200_000))  # 20%
+    sample = calculate_imbalance_fees(TokenAmount(100), ProportionalFeeAmount(20_000))  # 2%
     assert sample is not None
-    assert len(sample) == 11
-    assert all(0 <= x <= 10 for x, _ in sample)
-    assert max(x for x, _ in sample) == 10
+    assert len(sample) == NUM_DISCRETISATION_POINTS
+    assert all(0 <= x <= 100 for x, _ in sample)
+    assert max(x for x, _ in sample) == 100
     assert all(0 <= y <= 2 for _, y in sample)
-    assert max(y for _, y in sample) == 2  # 20% of the 10 TokenAmount capacity
+    assert max(y for _, y in sample) == 2  # 2% of the 100 TokenAmount capacity
 
-    sample = calculate_imbalance_fees(TokenAmount(1), ProportionalFeeAmount(1_000_000))  # 100%
+    sample = calculate_imbalance_fees(TokenAmount(15), ProportionalFeeAmount(50_000))  # 5%
     assert sample is not None
-    assert len(sample) == 2
-    assert all(0 <= x <= 1 for x, _ in sample)
-    assert max(x for x, _ in sample) == 1
+    assert len(sample) == 16
+    assert all(0 <= x <= 16 for x, _ in sample)
+    assert max(x for x, _ in sample) == 15
     assert all(0 <= y <= 1 for _, y in sample)
-    assert max(y for _, y in sample) == 1  # 100% of the 1 TokenAmount capacity
+    assert max(y for _, y in sample) == 1  # 5% of the 5 rounded up
 
     # test rounding of the max_balance_fee calculation
-    sample = calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(549_000))  # 54.9%
+    sample = calculate_imbalance_fees(TokenAmount(1000), ProportionalFeeAmount(5_490))  # 0.549%
     assert sample is not None
-    assert len(sample) == 11
-    assert all(0 <= x <= 10 for x, _ in sample)
-    assert max(x for x, _ in sample) == 10
+    assert len(sample) == NUM_DISCRETISATION_POINTS
+    assert all(0 <= x <= 1000 for x, _ in sample)
+    assert max(x for x, _ in sample) == 1000
     assert all(0 <= y <= 5 for _, y in sample)
     assert max(y for _, y in sample) == 5  # 5.49 is rounded to 5
 
-    sample = calculate_imbalance_fees(TokenAmount(10), ProportionalFeeAmount(550_000))  # 55%
+    sample = calculate_imbalance_fees(TokenAmount(1000), ProportionalFeeAmount(5_500))  # 0.55%
     assert sample is not None
-    assert len(sample) == 11
-    assert all(0 <= x <= 10 for x, _ in sample)
-    assert max(x for x, _ in sample) == 10
+    assert len(sample) == NUM_DISCRETISATION_POINTS
+    assert all(0 <= x <= 1000 for x, _ in sample)
+    assert max(x for x, _ in sample) == 1000
     assert all(0 <= y <= 6 for _, y in sample)
     assert max(y for _, y in sample) == 6  # 5.5 is rounded to 6
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -227,7 +227,7 @@ def test_get_lock_amount_after_fees(flat_fee, prop_fee, initial_amount, expected
 
 @pytest.mark.parametrize(
     "flat_fee, prop_fee, imbalance_fee, initial_amount, expected_amount",
-    [(0, 0, 10_000, 50_000, 50_000 + 1996)],
+    [(0, 0, 10_000, 50_000, 50_000 + 2_000)],
 )
 def test_get_lock_amount_after_fees_imbalanced_channel(
     flat_fee, prop_fee, imbalance_fee, initial_amount, expected_amount

--- a/raiden/tests/unit/transfer/test_channel.py
+++ b/raiden/tests/unit/transfer/test_channel.py
@@ -434,9 +434,9 @@ def test_update_fee_schedule_after_balance_change():
     fee_config = prepare_mediation_fee_config(
         cli_token_to_flat_fee=(),
         cli_token_to_proportional_fee=(),
-        # 10%
-        cli_token_to_proportional_imbalance_fee=((channel_state.token_address, 100_000),),
+        # 5%
+        cli_token_to_proportional_imbalance_fee=((channel_state.token_address, 50_000),),
     )
     events = update_fee_schedule_after_balance_change(channel_state, fee_config)
     assert isinstance(events[0], SendPFSFeeUpdate)
-    assert channel_state.fee_schedule.imbalance_penalty[0] == (0, 10)
+    assert channel_state.fee_schedule.imbalance_penalty[0] == (0, 5)

--- a/raiden/tests/utils/mediation_fees.py
+++ b/raiden/tests/utils/mediation_fees.py
@@ -71,7 +71,7 @@ def imbalance_fee_sender(
 
 def fee_sender(
     fee_schedule: FeeScheduleState, balance: Balance, amount: PaymentWithFeeAmount
-) -> Optional[FeeAmount]:
+) -> FeeAmount:
     """Returns the mediation fee for this channel when transferring the given amount"""
     imbalance_fee = imbalance_fee_sender(fee_schedule=fee_schedule, amount=amount, balance=balance)
     flat_fee = fee_schedule.flat
@@ -81,7 +81,7 @@ def fee_sender(
 
 def fee_receiver(
     fee_schedule: FeeScheduleState, balance: Balance, amount: PaymentWithFeeAmount
-) -> Optional[FeeAmount]:
+) -> FeeAmount:
     """Returns the mediation fee for this channel when receiving the given amount"""
 
     def fee_in(imbalance_fee: FeeAmount) -> FeeAmount:
@@ -136,15 +136,11 @@ def get_initial_payment_for_final_target_amount(
 
             balance_out = get_balance(channel_out.our_state, channel_out.partner_state)
             fee_out = fee_sender(fee_schedule=fee_schedule_out, balance=balance_out, amount=total)
-            if fee_out is None:
-                return None
 
             total += fee_out  # type: ignore
 
             balance_in = get_balance(channel_in.our_state, channel_in.partner_state)
             fee_in = fee_receiver(fee_schedule=fee_schedule_in, balance=balance_in, amount=total)
-            if fee_in is None:
-                return None
 
             total += fee_in  # type: ignore
 

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -78,7 +78,9 @@ class FeeScheduleState(State):
         prop_fee = int(round(amount * self.proportional / 1e6))
         return FeeAmount(flat_fee + prop_fee + imbalance_fee)
 
-    def fee_payee(self, amount: PaymentWithFeeAmount, balance: Balance) -> FeeAmount:
+    def fee_payee(
+        self, amount: PaymentWithFeeAmount, balance: Balance, iterations: int = 2
+    ) -> FeeAmount:
         def fee_out(imbalance_fee: FeeAmount) -> FeeAmount:
             return FeeAmount(
                 round(
@@ -86,9 +88,11 @@ class FeeScheduleState(State):
                 )
             )
 
-        imbalance_fee = self.imbalance_fee(
-            amount=PaymentWithFeeAmount(amount - fee_out(FeeAmount(0))), balance=balance
-        )
+        imbalance_fee = FeeAmount(0)
+        for _ in range(iterations):
+            imbalance_fee = self.imbalance_fee(
+                amount=PaymentWithFeeAmount(amount - fee_out(imbalance_fee)), balance=balance
+            )
 
         return fee_out(imbalance_fee)
 


### PR DESCRIPTION
When the slope exceeds 1, I could balance the channels more cheaply
myself. It also makes fee calculations ambiguous.

Hopefully fixes https://github.com/raiden-network/team/issues/623

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
