### PR TITLE
Limit imbalance fee CLI arg to 5%

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -461,7 +461,7 @@ def options(func):
                     "Set the worst-case imbalance fee relative to the channels capacity "
                     "in parts-per-million (10^-6) for a certain token address."
                 ),
-                type=(ADDRESS_TYPE, click.IntRange(min=0, max=10 ** 6)),
+                type=(ADDRESS_TYPE, click.IntRange(min=0, max=50_000)),
                 multiple=True,
             ),
         ),


### PR DESCRIPTION
This is a requirement of the new imbalance fee function, so we should
enforce this here as well.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
