### PR TITLE
Add fee round trip test

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -232,7 +232,7 @@ def test_get_lock_amount_after_fees(flat_fee, prop_fee, initial_amount, expected
 @pytest.mark.parametrize(
     "flat_fee, prop_fee, imbalance_fee, initial_amount, expected_amount",
     [
-        # The higher the imbalance fee, the stronger the impact of the fee interation
+        # The higher the imbalance fee, the stronger the impact of the fee iteration
         (0, 0, 10_000, 50_000, 50_000 + 2_000),
         (0, 0, 20_000, 50_000, 50_000 + 3_995),
         (0, 0, 30_000, 50_000, 50_000 + 5_908),

--- a/raiden/tests/utils/mediation_fees.py
+++ b/raiden/tests/utils/mediation_fees.py
@@ -80,7 +80,10 @@ def fee_sender(
 
 
 def fee_receiver(
-    fee_schedule: FeeScheduleState, balance: Balance, amount: PaymentWithFeeAmount
+    fee_schedule: FeeScheduleState,
+    balance: Balance,
+    amount: PaymentWithFeeAmount,
+    iterations: int = 2,
 ) -> FeeAmount:
     """Returns the mediation fee for this channel when receiving the given amount"""
 
@@ -95,11 +98,13 @@ def fee_receiver(
             )
         )
 
-    imbalance_fee = imbalance_fee_receiver(
-        fee_schedule=fee_schedule,
-        amount=PaymentWithFeeAmount(amount - fee_in(imbalance_fee=FeeAmount(0))),
-        balance=balance,
-    )
+    imbalance_fee = FeeAmount(0)
+    for _ in range(iterations):
+        imbalance_fee = imbalance_fee_receiver(
+            fee_schedule=fee_schedule,
+            amount=PaymentWithFeeAmount(amount + fee_in(imbalance_fee=imbalance_fee)),
+            balance=balance,
+        )
 
     return fee_in(imbalance_fee=imbalance_fee)
 

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -151,7 +151,7 @@ def calculate_imbalance_fees(
     c = max_imbalance_fee
     o = channel_capacity / 2
     b = s * o / c
-    b = min(b, 100)  # limit exponent to keep numerical stability
+    b = min(b, 10)  # limit exponent to keep numerical stability
     a = c / o ** b
 
     def f(x: TokenAmount) -> FeeAmount:


### PR DESCRIPTION
We add iteration to the test helper for backwards fee calculation as is intended in the PFS. This allows us to write a test that checks a complete fee calculation round trip of
* PFS calculates fees from target amount
* Initiator sends target_amount + fees
* Mediator takes fees based on amount sent by initiator
* Amount sent by mediator is approx. target amount 

The fee margin is currently not included.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
