### PR TITLE
Adds wait_blocks to pfs scenarios before transfers to prevent PFSCapacityUpdate latency

### DIFF
--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -52,7 +52,9 @@ scenario:
           name: "Test providing routes"
           tasks:
             # Check that the payment goes through from 0 to 3
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
+            - wait_blocks: 1
 
             # Assert that correct amount was tranferred
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -52,9 +52,10 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 2
+            - wait_blocks: 1
             # Check that the payment goes through from 0 to 3
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
+            - wait_blocks: 1
 
             # Assert that correct amount was transferred
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -54,9 +54,11 @@ scenario:
           name: "Test shortest path route"
           tasks:
             # Check that a payment is made with shortest path [0, 4, 3] from 0 to 3
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
+            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_500_000_000_000_000, balance: 500_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
@@ -77,9 +79,11 @@ scenario:
 
             # There is not enough capacity through node4, so path [0, 1, 2, 3] 
             # should be used instead.
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
+            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_500_000_000_000_000, balance: 500_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -78,9 +78,11 @@ scenario:
           name: "Make payment from 0 to 3"
           tasks:
             # Check that a payment is made with shortest path [0, 4, 3] from 0 to 3
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
+            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
@@ -108,9 +110,11 @@ scenario:
           name: "Make payment from 0 to 3 after node4 is stopped"
           tasks:
             # Check that a payment is made with the only availabe path [0, 1, 2, 3] from 0 to 3
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
+            - wait_blocks: 1
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -79,9 +79,11 @@ scenario:
           name: "Make payment from 0 to 3"
           tasks:
             # Check that a payment is made with shortest path [0, 4, 3] from 0 to 3
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 300_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
+            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 700_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 700_000_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
@@ -117,9 +119,11 @@ scenario:
           name: "Make payment from 0 to 3 after node4 withdrew and does not have enough capacity"
           tasks:
             # Check that a payment is made with the only path [0, 1, 2, 3] with enough capacity from 0 to 3
+            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 300_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount is updated after payment 
+            - wait_blocks: 1
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 0, balance: 700_000_000_000_000_000, state: "opened"}
             - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 0, balance: 700_000_000_000_000_000, state: "opened"}
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 0, balance: 700_000_000_000_000_000, state: "opened"}


### PR DESCRIPTION
Fixes: #<issue>

## Description
Without a wait function, the PFSCapacityUpdate might not reach the pfs in time. This was the reason ot the failure of Oct 6 nightly runs in pfs5. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
