### PR TITLE
Add dockerhub build hook

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build --build-arg RAIDENVERSION=${SOURCE_BRANCH} -t $IMAGE_NAME .


### PR DESCRIPTION
In order to build the proper raiden version from `Dockerfile`, we need
to pass the intended `RAIDENVERSION` build argument. According to
https://github.com/docker/hub-feedback/issues/508 the current way of
doing this is via build hook.
dockerhub has the `SOURCE_BRANCH` environment variable available, that
should translate just fine to the values we want in `RAIDENVERSION`.

Fixes: the root cause of #5049 -- merging this PR will not magically fix the incorrectly tagged/build docker image.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
