### PR TITLE
Add fee capping

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`5053` Make mediation fees non-negative by default. This fixes some counter-intuitive behaviour.
 * :bug:`4835` Fix etherscan sync by passing user-agent in the HTTP request. The request was failing because etherscan is protected by Cloudflare.
 
 * :release:`0.200.0-rc1 <2019-08-12>`

--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -349,6 +349,7 @@ def blockchainevent_to_statechange(
             channel_config = ChannelConfig(
                 reveal_timeout=raiden.config["reveal_timeout"],
                 fee_schedule=FeeScheduleState(
+                    cap_fees=fee_config.cap_meditation_fees,
                     flat=fee_config.get_flat_fee(new_channel_details.token_address),
                     proportional=fee_config.get_proportional_fee(new_channel_details.token_address)
                     # no need to set the imbalance fee here, will be set during deposit

--- a/raiden/messages/path_finding_service.py
+++ b/raiden/messages/path_finding_service.py
@@ -84,6 +84,7 @@ class PFSFeeUpdate(SignedMessage):
             (self.canonical_identifier.token_network_address, "address"),
             (self.canonical_identifier.channel_identifier, "uint256"),
             (self.updating_participant, "address"),
+            (self.fee_schedule.cap_fees, "bool"),
             (self.fee_schedule.flat, "uint256"),
             (self.fee_schedule.proportional, "uint256"),
             (rlp.encode(self.fee_schedule.imbalance_penalty or 0), "bytes"),

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1008,6 +1008,7 @@ class RaidenService(Runnable):
                 log.info(
                     "Updating channel fees",
                     channel=channel.canonical_identifier,
+                    cap_mediation_fees=fee_config.cap_meditation_fees,
                     flat_fee=flat_fee,
                     proportional_fee=proportional_fee,
                     proportional_imbalance_fee=proportional_imbalance_fee,
@@ -1017,6 +1018,7 @@ class RaidenService(Runnable):
                     proportional_imbalance_fee=proportional_imbalance_fee,
                 )
                 channel.fee_schedule = FeeScheduleState(
+                    cap_fees=fee_config.cap_meditation_fees,
                     flat=flat_fee,
                     proportional=proportional_fee,
                     imbalance_penalty=imbalance_penalty,

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -87,6 +87,7 @@ class MediationFeeConfig:
     token_to_proportional_imbalance_fee: Dict[TokenAddress, ProportionalFeeAmount] = field(
         default_factory=dict
     )
+    cap_meditation_fees: bool = False
 
     def get_flat_fee(self, token_address: TokenAddress) -> FeeAmount:
         return self.token_to_flat_fee.get(  # pylint: disable=no-member

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -87,7 +87,7 @@ class MediationFeeConfig:
     token_to_proportional_imbalance_fee: Dict[TokenAddress, ProportionalFeeAmount] = field(
         default_factory=dict
     )
-    cap_meditation_fees: bool = False
+    cap_meditation_fees: bool = True
 
     def get_flat_fee(self, token_address: TokenAddress) -> FeeAmount:
         return self.token_to_flat_fee.get(  # pylint: disable=no-member

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -463,7 +463,7 @@ def test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
 
 
 @raise_on_failure
-@pytest.mark.parametrize("case_no", range(7))
+@pytest.mark.parametrize("case_no", range(8))
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [4])
 def test_mediated_transfer_with_fees(
@@ -585,15 +585,26 @@ def test_mediated_transfer_with_fees(
         # for every token transferred as a reward for moving the channel into a
         # better state. This causes the target to receive more than the `amount
         # + fees` which is sent by the initiator.
-        # transferred amount is 55, so 3 token get added from imbnalance fee
+        # transferred amount is 55, so 3 token get added from imbalance fee
+        # Here we also need to disable fee capping
         dict(
             fee_schedules=[
                 no_fees,
-                FeeScheduleState(imbalance_penalty=[(0, 50), (1000, 0)]),
+                FeeScheduleState(cap_fees=False, imbalance_penalty=[(0, 50), (1000, 0)]),
                 no_fees,
             ],
             incoming_fee_schedules=[no_fees, no_fees, no_fees],
             expected_transferred_amounts=[amount + fee, amount + fee + 3, amount + fee + 3],
+        ),
+        # Same case as above, but with fee capping enabled
+        dict(
+            fee_schedules=[
+                no_fees,
+                FeeScheduleState(cap_fees=True, imbalance_penalty=[(0, 50), (1000, 0)]),
+                no_fees,
+            ],
+            incoming_fee_schedules=[no_fees, no_fees, no_fees],
+            expected_transferred_amounts=[amount + fee, amount + fee, amount + fee],
         ),
     ]
 

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -92,19 +92,26 @@ def test_imbalance_penalty():
             (TokenAmount(0), FeeAmount(10)),
             (TokenAmount(50), FeeAmount(0)),
             (TokenAmount(100), FeeAmount(20)),
-        ],
-        # Here we also test negative imbalance fees
-        cap_fees=False,
+        ]
     )
 
-    for x1, amount, expected_fee_payee, expected_fee_payer in [
-        (0, 50, -6, 10),
-        (50, 50, 12, -20),
-        (0, 10, -2, 2),
-        (10, 10, -2, 2),
-        (0, 20, -5, 4),
-        (40, 15, 0, 0),
+    for cap_fees, x1, amount, expected_fee_payee, expected_fee_payer in [
+        # Uncapped fees
+        (False, 0, 50, -6, 10),
+        (False, 50, 50, 12, -20),
+        (False, 0, 10, -2, 2),
+        (False, 10, 10, -2, 2),
+        (False, 0, 20, -5, 4),
+        (False, 40, 15, 0, 0),
+        # Capped fees
+        (True, 0, 50, 0, 10),
+        (True, 50, 50, 12, 0),
+        (True, 0, 10, 0, 2),
+        (True, 10, 10, 0, 2),
+        (True, 0, 20, 0, 4),
+        (True, 40, 15, 0, 0),
     ]:
+        v_schedule.cap_fees = cap_fees
         x2 = x1 + amount
         assert v_schedule.fee_payee(
             balance=Balance(100 - x1), amount=PaymentWithFeeAmount(amount)

--- a/raiden/tests/unit/transfer/test_channel.py
+++ b/raiden/tests/unit/transfer/test_channel.py
@@ -435,8 +435,8 @@ def test_update_fee_schedule_after_balance_change():
     fee_config = prepare_mediation_fee_config(
         cli_token_to_flat_fee=(),
         cli_token_to_proportional_fee=(),
-        # 5%
-        cli_token_to_proportional_imbalance_fee=((channel_state.token_address, 50_000),),
+        cli_token_to_proportional_imbalance_fee=((channel_state.token_address, 50_000),),  # 5%
+        cli_cap_mediation_fees=True,
     )
     events = update_fee_schedule_after_balance_change(channel_state, fee_config)
     assert isinstance(events[0], SendPFSFeeUpdate)

--- a/raiden/tests/unit/utils/test_mediation_fees.py
+++ b/raiden/tests/unit/utils/test_mediation_fees.py
@@ -33,9 +33,11 @@ def test_prepare_mediation_fee_config_flat_fee(cli_flat_fee, expected_channel_fl
         cli_token_to_flat_fee=((token_address, cli_flat_fee),),
         cli_token_to_proportional_fee=((token_address, ProportionalFeeAmount(0)),),
         cli_token_to_proportional_imbalance_fee=((token_address, ProportionalFeeAmount(0)),),
+        cli_cap_mediation_fees=False,
     )
 
     assert fee_config.get_flat_fee(token_address) == expected_channel_flat_fee
+    assert fee_config.cap_meditation_fees is False
 
 
 @pytest.mark.parametrize(
@@ -55,6 +57,7 @@ def test_prepare_mediation_fee_config_prop_fee(cli_prop_fee):
         cli_token_to_flat_fee=(),
         cli_token_to_proportional_fee=((token_address, ProportionalFeeAmount(cli_prop_fee)),),
         cli_token_to_proportional_imbalance_fee=((token_address, ProportionalFeeAmount(0)),),
+        cli_cap_mediation_fees=False,
     )
 
     cli_prop_fee_ratio = cli_prop_fee / 1e6

--- a/raiden/tests/utils/mediation_fees.py
+++ b/raiden/tests/utils/mediation_fees.py
@@ -76,7 +76,7 @@ def fee_sender(
     imbalance_fee = imbalance_fee_sender(fee_schedule=fee_schedule, amount=amount, balance=balance)
     flat_fee = fee_schedule.flat
     prop_fee = int(round(amount * fee_schedule.proportional / 1e6))
-    return FeeAmount(flat_fee + prop_fee + imbalance_fee)
+    return fee_schedule.calculate_capped_fee(FeeAmount(flat_fee + prop_fee + imbalance_fee))
 
 
 def fee_receiver(
@@ -106,7 +106,7 @@ def fee_receiver(
             balance=balance,
         )
 
-    return fee_in(imbalance_fee=imbalance_fee)
+    return fee_schedule.calculate_capped_fee(fee_in(imbalance_fee=imbalance_fee))
 
 
 class FeesCalculation(NamedTuple):

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -2358,6 +2358,7 @@ def update_fee_schedule_after_balance_change(
     )
 
     channel_state.fee_schedule = FeeScheduleState(
+        cap_fees=channel_state.fee_schedule.cap_fees,
         flat=channel_state.fee_schedule.flat,
         proportional=channel_state.fee_schedule.proportional,
         imbalance_penalty=imbalance_penalty,

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -59,7 +59,7 @@ class FeeScheduleState(State):
             x_list, y_list = tuple(zip(*self.imbalance_penalty))
             self._penalty_func = Interpolate(x_list, y_list)
 
-    def _cap_fee(self, fee: FeeAmount) -> FeeAmount:
+    def calculate_capped_fee(self, fee: FeeAmount) -> FeeAmount:
         """ Caps `fee` to 0 if negative and `cap_fees` is `True`. """
         if self.cap_fees and fee < 0:
             return FeeAmount(0)
@@ -84,7 +84,7 @@ class FeeScheduleState(State):
 
         flat_fee = self.flat
         prop_fee = int(round(amount * self.proportional / 1e6))
-        return self._cap_fee(FeeAmount(flat_fee + prop_fee + imbalance_fee))
+        return self.calculate_capped_fee(FeeAmount(flat_fee + prop_fee + imbalance_fee))
 
     def fee_payee(
         self, amount: PaymentWithFeeAmount, balance: Balance, iterations: int = 2
@@ -102,7 +102,7 @@ class FeeScheduleState(State):
                 amount=PaymentWithFeeAmount(amount - fee_out(imbalance_fee)), balance=balance
             )
 
-        return self._cap_fee(fee_out(imbalance_fee))
+        return self.calculate_capped_fee(fee_out(imbalance_fee))
 
     def reversed(self: T) -> T:
         if not self.imbalance_penalty:

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -44,6 +44,7 @@ T = TypeVar("T", bound="FeeScheduleState")
 @dataclass
 class FeeScheduleState(State):
     # pylint: disable=not-an-iterable
+    cap_fees: bool = True
     flat: FeeAmount = FeeAmount(0)
     proportional: ProportionalFeeAmount = ProportionalFeeAmount(0)  # as micros, e.g. 1% = 0.01e6
     imbalance_penalty: Optional[List[Tuple[TokenAmount, FeeAmount]]] = None

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -181,6 +181,7 @@ def run_app(
     proportional_fee: Tuple[Tuple[TokenAddress, ProportionalFeeAmount], ...],
     proportional_imbalance_fee: Tuple[Tuple[TokenAddress, ProportionalFeeAmount], ...],
     blockchain_query_interval: float,
+    cap_mediation_fees: bool,
     **kwargs: Any,  # FIXME: not used here, but still receives stuff in smoketest
 ):
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,unused-argument
@@ -211,6 +212,7 @@ def run_app(
         cli_token_to_flat_fee=flat_fee,
         cli_token_to_proportional_fee=proportional_fee,
         cli_token_to_proportional_imbalance_fee=proportional_imbalance_fee,
+        cli_cap_mediation_fees=cap_mediation_fees,
     )
 
     config["console"] = console

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -464,6 +464,12 @@ def options(func):
                 type=(ADDRESS_TYPE, click.IntRange(min=0, max=50_000)),
                 multiple=True,
             ),
+            option(
+                "--cap-mediation-fees/--no-cap-mediation-fees",
+                help="Cap the mediation fees to never get negative.",
+                default=True,
+                show_default=True,
+            ),
         ),
     ]
 

--- a/raiden/utils/mediation_fees.py
+++ b/raiden/utils/mediation_fees.py
@@ -23,6 +23,7 @@ def prepare_mediation_fee_config(
     cli_token_to_proportional_imbalance_fee: Tuple[
         Tuple[TokenAddress, ProportionalFeeAmount], ...
     ],
+    cli_cap_mediation_fees: bool,
 ) -> MediationFeeConfig:
     """ Converts the mediation fee CLI args to proper per-channel
     mediation fees. """
@@ -50,4 +51,5 @@ def prepare_mediation_fee_config(
         token_to_flat_fee=tn_to_flat_fee,
         token_to_proportional_fee=tn_to_proportional_fee,
         token_to_proportional_imbalance_fee=tn_to_proportional_imbalance_fee,
+        cap_meditation_fees=cli_cap_mediation_fees,
     )

--- a/tools/dummy_resolver_server.py
+++ b/tools/dummy_resolver_server.py
@@ -2,6 +2,7 @@ import json
 import logging
 from hashlib import sha256
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
 from eth_utils import to_bytes, to_hex
 
 # The code below simulates XUD resolver functionality.


### PR DESCRIPTION
Fixes: #5053

## Description

This PR:
- Adds fee capping, so that the sum of all mediation fee components can not get smaller than 0
- Adds a CLI flag `--cap-mediation-fees/--no-cap-mediation-fees` to enable/disable this. The default is to enable fee capping
- Adds test for capped fees
- Fixes existing tests

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
