### PR TITLE
Match withdraw messages for schema generation during deserialization

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`5055` Fix withdraw messages deserialization when the messages are queued in `queueids_to_queues`.
 * :feature:`5053` Make mediation fees non-negative by default. This fixes some counter-intuitive behaviour.
 * :bug:`4835` Fix etherscan sync by passing user-agent in the HTTP request. The request was failing because etherscan is protected by Cloudflare.
 

--- a/raiden/storage/serialization/types.py
+++ b/raiden/storage/serialization/types.py
@@ -177,6 +177,21 @@ def message_event_schema_deserialization(
 
         return SchemaCache.get_or_create_schema(SendRefundTransfer)
 
+    elif message_type.endswith("SendWithdrawRequest"):
+        from raiden.transfer.events import SendWithdrawRequest
+
+        return SchemaCache.get_or_create_schema(SendWithdrawRequest)
+
+    elif message_type.endswith("SendWithdrawConfirmation"):
+        from raiden.transfer.events import SendWithdrawConfirmation
+
+        return SchemaCache.get_or_create_schema(SendWithdrawConfirmation)
+
+    elif message_type.endswith("SendWithdrawExpired"):
+        from raiden.transfer.events import SendWithdrawExpired
+
+        return SchemaCache.get_or_create_schema(SendWithdrawExpired)
+
     elif message_type.endswith("SendProcessed"):
         from raiden.transfer.events import SendProcessed
 


### PR DESCRIPTION
Fixes: #5055

## Description

During deserialization, marshmallow should know how to deserialize messages inside `queueids_to_queues`.
```
SendMessageEvent: CallablePolyField(
            serialization_schema_selector=message_event_schema_serialization,
            deserialization_schema_selector=message_event_schema_deserialization,
            allow_none=True,
        ),
```
This is how it is done. However, the matches we have did not include withdraw-related messages. This PR adds missing classes to the match list.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
