### PR TITLE
Fix console, add type annotations

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -608,7 +608,7 @@ class RaidenAPI:  # pragma: no unittest
         partner_address: Address,
         total_deposit: TokenAmount,
         retry_timeout: NetworkTimeout = DEFAULT_RETRY_TIMEOUT,
-    ):
+    ) -> None:
         """ Set the `total_deposit` in the channel with the peer at `partner_address` and the
         given `token_address` in order to be able to do transfers.
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -49,6 +49,7 @@ from raiden.utils.typing import (
     Address,
     AddressHex,
     Any,
+    BlockNumber,
     Callable,
     ChainID,
     Dict,
@@ -375,7 +376,7 @@ def run_smoketest(
         api_server = APIServer(rest_api, config={"host": api_host, "port": api_port})
         api_server.start()
 
-        block = app.raiden.get_block_number() + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+        block = BlockNumber(app.raiden.get_block_number() + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS)
         # Proxies now use the confirmed block hash to query the chain for
         # prerequisite checks. Wait a bit here to make sure that the confirmed
         # block hash contains the deployed token network or else things break

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -10,6 +10,7 @@ from eth_utils import to_canonical_address, to_checksum_address
 from web3 import HTTPProvider, Web3
 
 from raiden.accounts import AccountManager
+from raiden.app import App
 from raiden.constants import (
     GENESIS_BLOCK_NUMBER,
     MONITORING_BROADCASTING_ROOM,
@@ -76,7 +77,7 @@ from raiden_contracts.contract_manager import ContractManager
 log = structlog.get_logger(__name__)
 
 
-def _setup_matrix(config: Dict, routing_mode: RoutingMode):
+def _setup_matrix(config: Dict[str, Any], routing_mode: RoutingMode) -> MatrixTransport:
     if config["transport"]["matrix"].get("available_servers") is None:
         # fetch list of known servers from raiden-network/raiden-tranport repo
         available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[config["environment_type"]]
@@ -183,9 +184,8 @@ def run_app(
     blockchain_query_interval: float,
     cap_mediation_fees: bool,
     **kwargs: Any,  # FIXME: not used here, but still receives stuff in smoketest
-):
+) -> App:
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements,unused-argument
-    from raiden.app import App
 
     token_network_registry_deployed_at: Optional[BlockNumber]
     smart_contracts_start_at: BlockNumber

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -10,10 +10,11 @@ from copy import deepcopy
 from io import StringIO
 from subprocess import TimeoutExpired
 from tempfile import mkdtemp, mktemp
-from typing import Any, AnyStr, ContextManager, Dict, List, Optional, Tuple
+from typing import Any, AnyStr, Callable, ContextManager, Dict, List, Optional, Tuple
 
 import click
 import structlog
+from click import Context
 from requests.packages import urllib3
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
@@ -47,6 +48,7 @@ from raiden.utils.cli import (
     option_group,
     validate_option_dependencies,
 )
+from raiden.utils.typing import MYPY_ANNOTATION, TokenAddress
 
 from .runners import EchoNodeRunner, MatrixRunner
 
@@ -63,7 +65,7 @@ OPTION_DEPENDENCIES: Dict[str, List[Tuple[str, Any]]] = {
 }
 
 
-def options(func):
+def options(func: Callable) -> Callable:
     """Having the common app options as a decorator facilitates reuse."""
 
     # Until https://github.com/pallets/click/issues/926 is fixed the options need to be re-defined
@@ -481,7 +483,7 @@ def options(func):
 @group(invoke_without_command=True, context_settings={"max_content_width": 120})
 @options
 @click.pass_context
-def run(ctx, **kwargs):
+def run(ctx: Context, **kwargs: Any) -> None:
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
 
     flamegraph = kwargs.pop("flamegraph", None)
@@ -587,7 +589,7 @@ def run(ctx, **kwargs):
 
 @run.command()
 @option("--short", is_flag=True, help="Only display Raiden version")
-def version(short):
+def version(short: bool) -> None:
     """Print version information and exit. """
     if short:
         print(get_system_spec()["raiden"])
@@ -610,7 +612,9 @@ def version(short):
     help="Which Ethereum client to run for the smoketests",
 )
 @click.pass_context
-def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str]):
+def smoketest(
+    ctx: Context, debug: bool, eth_client: EthClient, report_path: Optional[str]
+) -> None:
     """ Test, that the raiden installation is sane. """
     from raiden.tests.utils.smoketest import (
         setup_raiden,
@@ -626,6 +630,7 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
     stdout = sys.stdout
     raiden_stdout = StringIO()
 
+    assert ctx.parent, MYPY_ANNOTATION
     environment_type = ctx.parent.params["environment_type"]
     transport = ctx.parent.params["transport"]
     disable_debug_logfile = ctx.parent.params["disable_debug_logfile"]
@@ -651,7 +656,7 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
         disable_debug_logfile=disable_debug_logfile,
     )
 
-    def append_report(subject: str, data: Optional[AnyStr] = None):
+    def append_report(subject: str, data: Optional[AnyStr] = None) -> None:
         with open(report_file, "a", encoding="UTF-8") as handler:
             handler.write(f'{f" {subject.upper()} ":=^80}{os.linesep}')
             if data is not None:
@@ -792,6 +797,6 @@ def smoketest(ctx, debug: bool, eth_client: EthClient, report_path: Optional[str
 )
 @click.option("--token-address", type=ADDRESS_TYPE, required=True)
 @click.pass_context
-def echonode(ctx, token_address):
+def echonode(ctx: Context, token_address: TokenAddress) -> None:
     """ Start a raiden Echo Node that will send received transfers back to the initiator. """
     EchoNodeRunner(ctx.obj, ctx, token_address).run()

--- a/raiden/ui/config.py
+++ b/raiden/ui/config.py
@@ -1,5 +1,6 @@
 import inspect
 from enum import Enum
+from typing import Any, Dict
 
 import pytoml
 from eth_utils import to_hex
@@ -7,7 +8,7 @@ from eth_utils import to_hex
 builtin_types = (int, str, bool, tuple)
 
 
-def _clean_non_serializables(data):
+def _clean_non_serializables(data: Dict) -> Dict:
     copy = {}
     for key, value in data.items():
         if callable(value):
@@ -41,17 +42,17 @@ def _clean_non_serializables(data):
     return copy
 
 
-def dump_config(config):
+def dump_config(config: Dict) -> None:
     print(pytoml.dumps({"configs": _clean_non_serializables(config)}))
     print()
 
 
-def dump_cmd_options(options):
+def dump_cmd_options(options: Dict) -> None:
     print(pytoml.dumps({"options": _clean_non_serializables(options)}))
     print()
 
 
-def dump_module(header, module):
+def dump_module(header: str, module: Any) -> None:
     attribs = dict()
     for name, value in inspect.getmembers(module):
         if name.isupper():

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -10,11 +10,22 @@ from IPython.lib.inputhook import inputhook_manager, stdin_ready
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
+from raiden.app import App
 from raiden.constants import UINT256_MAX
 from raiden.network.proxies.token_network import TokenNetwork
+from raiden.raiden_service import RaidenService
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
-from raiden.utils import TokenAddress, typing
 from raiden.utils.smart_contracts import deploy_contract_web3
+from raiden.utils.typing import (
+    AddressHex,
+    Any,
+    BlockTimeout,
+    Dict,
+    NetworkTimeout,
+    TokenAddress,
+    TokenAmount,
+    TokenNetworkRegistryAddress,
+)
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 
 GUI_GEVENT = "gevent"
@@ -29,7 +40,7 @@ ENDC = "\033[0m"
 IPython.core.shellapp.InteractiveShellApp.gui.values += ("gevent",)
 
 
-def print_usage():
+def print_usage() -> None:
     print(f"\t{OKBLUE}use `{HEADER}raiden{OKBLUE}` to interact with the raiden service.")
     print(f"\tuse `{HEADER}chain{OKBLUE}` to interact with the blockchain.")
     print(
@@ -45,7 +56,7 @@ def print_usage():
     print("\n" + ENDC)
 
 
-def inputhook_gevent():
+def inputhook_gevent() -> int:
     while not stdin_ready():
         gevent.sleep(0.05)
     return 0
@@ -53,11 +64,11 @@ def inputhook_gevent():
 
 @inputhook_manager.register("gevent")
 class GeventInputHook:
-    def __init__(self, manager):
+    def __init__(self, manager: Any) -> None:
         self.manager = manager
         self._current_gui = GUI_GEVENT
 
-    def enable(self, app=None):
+    def enable(self, app: Any = None) -> Any:
         """ Enable event loop integration with gevent.
 
         Args:
@@ -74,7 +85,7 @@ class GeventInputHook:
         self._current_gui = GUI_GEVENT
         return app
 
-    def disable(self):
+    def disable(self) -> None:
         """ Disable event loop integration with gevent.
 
         This merely sets PyOS_InputHook to NULL.
@@ -87,12 +98,12 @@ class Console(gevent.Greenlet):
     SIGSTP signal (e.g. via keyboard shortcut CTRL-Z).
     """
 
-    def __init__(self, app):
+    def __init__(self, app: App) -> None:
         super().__init__()
         self.app = app
-        self.console_locals = None
+        self.console_locals: Dict[str, Any] = {}
 
-    def _run(self):  # pylint: disable=method-hidden
+    def _run(self) -> None:  # pylint: disable=method-hidden
         # Remove handlers that log to stderr
         root = logging.getLogger()
         for handler in root.handlers[:]:
@@ -106,7 +117,7 @@ class Console(gevent.Greenlet):
         err = io.StringIO()
         sys.stderr = err
 
-        def lastlog(n=10, prefix=None, level=None):
+        def lastlog(n: int = 10, prefix: str = None, level: str = None) -> None:
             """ Print the last `n` log lines to stdout.
             Use `prefix='p2p'` to filter for a specific logger.
             Use `level=INFO` to filter for a specific level.
@@ -120,12 +131,12 @@ class Console(gevent.Greenlet):
             for line in lines[-n:]:
                 print(line)
 
-        def lasterr(n=1):
+        def lasterr(n: int = 1) -> None:
             """ Print the last `n` entries of stderr to stdout. """
             for line in (err.getvalue().strip().split("\n") or [])[-n:]:
                 print(line)
 
-        tools = ConsoleTools(self.app.raiden, self.app.config["settle_timeout"])
+        tools = ConsoleTools(self.app.raiden)
 
         self.console_locals = {
             "app": self.app,
@@ -147,33 +158,34 @@ class Console(gevent.Greenlet):
 
 
 class ConsoleTools:
-    def __init__(self, raiden_service, settle_timeout):
-        self._chain = raiden_service.chain
+    """ Some functions to make working in the console easier. """
+
+    def __init__(self, raiden_service: RaidenService) -> None:
         self._raiden = raiden_service
         self._api = RaidenAPI(raiden_service)
-        self.settle_timeout = settle_timeout
 
     def create_token(
         self,
-        registry_address,
-        initial_alloc=10 ** 6,
-        name="raidentester",
-        symbol="RDT",
-        decimals=2,
-        timeout=60,
-        auto_register=True,
-    ):
+        registry_address_hex: AddressHex,
+        initial_alloc: int = 10 ** 6,
+        name: str = "raidentester",
+        symbol: str = "RDT",
+        decimals: int = 2,
+        timeout: int = 60,
+        auto_register: bool = True,
+    ) -> AddressHex:
         """ Create a proxy for a new HumanStandardToken (ERC20), that is
         initialized with Args(below).
         Per default it will be registered with 'raiden'.
 
         Args:
-            initial_alloc (int): amount of initial tokens.
-            name (str): human readable token name.
-            symbol (str): token shorthand symbol.
-            decimals (int): decimal places.
-            timeout (int): timeout in seconds for creation.
-            auto_register (boolean): if True(default), automatically register
+            registry_address_hex: a hex encoded registry address.
+            initial_alloc: amount of initial tokens.
+            name: human readable token name.
+            symbol: token shorthand symbol.
+            decimals: decimal places.
+            timeout: timeout in seconds for creation.
+            auto_register: if True(default), automatically register
                 the token with raiden.
 
         Returns:
@@ -182,45 +194,48 @@ class ConsoleTools:
         with gevent.Timeout(timeout):
             token_address = deploy_contract_web3(
                 CONTRACT_HUMAN_STANDARD_TOKEN,
-                self._chain.client,
+                self._raiden.rpc_client,
                 contract_manager=self._raiden.contract_manager,
                 constructor_arguments=(initial_alloc, name, decimals, symbol),
             )
 
         token_address_hex = to_checksum_address(token_address)
         if auto_register:
-            self.register_token(registry_address, token_address_hex)
+            self.register_token(registry_address_hex, token_address_hex)
+
         print(
             "Successfully created {}the token '{}'.".format(
-                "and registered " if auto_register else " ", name
+                "and registered " if auto_register else "", name
             )
         )
         return token_address_hex
 
     def register_token(
         self,
-        registry_address_hex: typing.AddressHex,
-        token_address_hex: typing.AddressHex,
-        retry_timeout: typing.NetworkTimeout = DEFAULT_RETRY_TIMEOUT,
+        registry_address_hex: AddressHex,
+        token_address_hex: AddressHex,
+        retry_timeout: NetworkTimeout = DEFAULT_RETRY_TIMEOUT,
     ) -> TokenNetwork:
         """ Register a token with the raiden token manager.
 
         Args:
             registry_address_hex: a hex encoded registry address.
             token_address_hex: a hex encoded token address.
+            retry_timeout: the retry timeout
 
         Returns:
             The token network proxy.
         """
-        registry_address = to_canonical_address(registry_address_hex)
+        registry_address = TokenNetworkRegistryAddress(to_canonical_address(registry_address_hex))
         token_address = TokenAddress(to_canonical_address(token_address_hex))
 
         registry = self._raiden.proxy_manager.token_network_registry(registry_address)
 
         token_network_address = registry.add_token(
             token_address=token_address,
-            channel_participant_deposit_limit=UINT256_MAX,
-            token_network_deposit_limit=UINT256_MAX,
+            channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+            token_network_deposit_limit=TokenAmount(UINT256_MAX),
+            block_identifier="latest",
         )
         waiting.wait_for_token_network(
             self._raiden, registry.address, token_address, retry_timeout
@@ -230,43 +245,43 @@ class ConsoleTools:
 
     def open_channel_with_funding(
         self,
-        registry_address_hex,
-        token_address_hex,
-        peer_address_hex,
-        total_deposit,
-        settle_timeout=None,
-    ):
+        registry_address_hex: AddressHex,
+        token_address_hex: AddressHex,
+        peer_address_hex: AddressHex,
+        total_deposit: TokenAmount,
+        settle_timeout: BlockTimeout = None,
+    ) -> None:
         """ Convenience method to open a channel.
 
         Args:
-            registry_address_hex (str): hex encoded address of the registry for the channel.
-            token_address_hex (str): hex encoded address of the token for the channel.
-            peer_address_hex (str): hex encoded address of the channel peer.
-            total_deposit (int): amount of total funding for the channel.
-            settle_timeout (int): amount of blocks for the settle time (if None use app defaults).
+            registry_address_hex: hex encoded address of the registry for the channel.
+            token_address_hex: hex encoded address of the token for the channel.
+            peer_address_hex: hex encoded address of the channel peer.
+            total_deposit: amount of total funding for the channel.
+            settle_timeout: amount of blocks for the settle time (if None use app defaults).
 
         Return:
             netting_channel: the (newly opened) netting channel object.
         """
         # Check, if peer is discoverable
-        registry_address = decode_hex(registry_address_hex)
-        peer_address = decode_hex(peer_address_hex)
-        token_address = decode_hex(token_address_hex)
+        registry_address = TokenNetworkRegistryAddress(to_canonical_address(registry_address_hex))
+        peer_address = to_canonical_address(peer_address_hex)
+        token_address = TokenAddress(to_canonical_address(token_address_hex))
 
         self._api.channel_open(
             registry_address, token_address, peer_address, settle_timeout=settle_timeout
         )
 
-        return self._api.set_total_channel_deposit(
+        self._api.set_total_channel_deposit(
             registry_address, token_address, peer_address, total_deposit
         )
 
-    def wait_for_contract(self, contract_address_hex, timeout=None):
+    def wait_for_contract(self, contract_address_hex: AddressHex, timeout: int = None) -> bool:
         """ Wait until a contract is mined
 
         Args:
-            contract_address_hex (string): hex encoded address of the contract
-            timeout (int): time to wait for the contract to get mined
+            contract_address_hex: hex encoded address of the contract
+            timeout: time to wait for the contract to get mined
 
         Returns:
             True if the contract got mined, false otherwise

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -4,7 +4,7 @@ import traceback
 from copy import deepcopy
 from datetime import datetime
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import click
 import gevent
@@ -100,7 +100,9 @@ class NodeRunner:
             click.secho(str(e), fg="red")
             sys.exit(1)
 
-        tasks = [app_.raiden]  # RaidenService takes care of Transport and AlarmTask
+        tasks: List[Runnable] = [
+            app_.raiden
+        ]  # RaidenService takes care of Transport and AlarmTask
 
         domain_list = []
         if self._options["rpccorsdomain"]:

--- a/raiden/ui/sync.py
+++ b/raiden/ui/sync.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from itertools import count
+from typing import Any
 
 import gevent
 import pkg_resources
@@ -14,7 +15,7 @@ from raiden.network.rpc.client import JSONRPCClient
 
 
 def etherscan_query_with_retries(url: str, sleep: float, retries: int = 3) -> int:
-    def get_result():
+    def get_result() -> Any:
         response = requests.get(
             url,
             headers={

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,8 +61,10 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 [mypy-raiden.network.*]
 disallow_untyped_defs = False
-# ...but this part of raiden.network already is
+# ... but parts are
 [mypy-raiden.network.proxies.*]
+disallow_untyped_defs = True
+[mypy-raiden.ui.console]
 disallow_untyped_defs = True
 
 # No need to be as strict for our tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ warn_unused_ignores = True
 disallow_untyped_defs = False
 [mypy-raiden.api.*]
 disallow_untyped_defs = False
-[mypy-raiden.ui.*]
+[mypy-raiden.ui.runners]
 disallow_untyped_defs = False
 [mypy-raiden.messages.*]
 disallow_untyped_defs = False
@@ -63,8 +63,6 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 # ... but parts are
 [mypy-raiden.network.proxies.*]
-disallow_untyped_defs = True
-[mypy-raiden.ui.console]
 disallow_untyped_defs = True
 
 # No need to be as strict for our tools


### PR DESCRIPTION
Fixes: #5071

## Description

This was a leftover from the recent `ProxyManager` refactoring I did. 

This PR also adds type annotations, as mypy easily found that as soon as it started checking that file.


## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
