### PR TITLE
Remove `fee` from LockedTransfer

### DIFF
--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -343,7 +343,6 @@ class LockedTransferBase(EnvelopeMessage):
     lock: Lock
     target: TargetAddress
     initiator: InitiatorAddress
-    fee: int
     metadata: Metadata
 
     def __post_init__(self):
@@ -355,9 +354,6 @@ class LockedTransferBase(EnvelopeMessage):
 
         if len(self.initiator) != 20:
             raise ValueError("initiator is an invalid address")
-
-        if self.fee > UINT256_MAX:
-            raise ValueError("fee is too large")
 
     @overload
     @classmethod
@@ -380,7 +376,6 @@ class LockedTransferBase(EnvelopeMessage):
             expiration=transfer.lock.expiration,
             secrethash=transfer.lock.secrethash,
         )
-        fee = 0
 
         # pylint: disable=unexpected-keyword-arg
         return cls(
@@ -398,7 +393,6 @@ class LockedTransferBase(EnvelopeMessage):
             lock=lock,
             target=transfer.target,
             initiator=transfer.initiator,
-            fee=fee,
             signature=EMPTY_SIGNATURE,
             metadata=Metadata(
                 routes=[RouteMetadata(route=r.route) for r in transfer.route_states]
@@ -417,7 +411,6 @@ class LockedTransferBase(EnvelopeMessage):
             (self.initiator, "address"),
             (self.lock.secrethash, "bytes32"),
             (self.lock.amount, "uint256"),
-            (self.fee, "uint256"),
         )
 
 

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -766,7 +766,6 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit):
     app0.raiden.start_mediated_transfer_with_secret(
         token_network_address=token_network_address,
         amount=amount,
-        fee=0,
         target=target,
         identifier=identifier,
         secret=secret,

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -153,7 +153,6 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
         channel_identifier=channelstate_0_1.identifier,
         transferred_amount=transferred_amount,
         locked_amount=lock_amount,
-        fee=0,
         recipient=app1.raiden.address,
         locksroot=keccak(lock.as_bytes),
         lock=lock,

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -111,7 +111,6 @@ def test_receive_lockedtransfer_invalidnonce(
         lock=Lock(amount=amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
         target=app2.raiden.address,
         initiator=app0.raiden.address,
-        fee=0,
         signature=EMPTY_SIGNATURE,
         metadata=Metadata(
             routes=[RouteMetadata(route=[app1.raiden.address, app2.raiden.address])]
@@ -164,7 +163,6 @@ def test_receive_lockedtransfer_invalidsender(
         lock=Lock(amount=lock_amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
         target=app0.raiden.address,
         initiator=other_address,
-        fee=0,
         signature=EMPTY_SIGNATURE,
         metadata=Metadata(routes=[RouteMetadata(route=[app0.raiden.address])]),
     )
@@ -206,7 +204,6 @@ def test_receive_lockedtransfer_invalidrecipient(
         lock=Lock(amount=lock_amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
         target=app1.raiden.address,
         initiator=app0.raiden.address,
-        fee=0,
         signature=EMPTY_SIGNATURE,
         metadata=Metadata(routes=[RouteMetadata(route=[app1.raiden.address])]),
     )
@@ -256,7 +253,6 @@ def test_received_lockedtransfer_closedchannel(
         lock=Lock(amount=lock_amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
         target=app1.raiden.address,
         initiator=app0.raiden.address,
-        fee=0,
         signature=EMPTY_SIGNATURE,
         metadata=Metadata(routes=[RouteMetadata(route=[app1.raiden.address])]),
     )

--- a/raiden/tests/unit/test_binary_encoding.py
+++ b/raiden/tests/unit/test_binary_encoding.py
@@ -76,15 +76,13 @@ def test_processed():
 @pytest.mark.parametrize("payment_identifier", [0, constants.UINT64_MAX])
 @pytest.mark.parametrize("nonce", [1, constants.UINT64_MAX])
 @pytest.mark.parametrize("transferred_amount", [0, constants.UINT256_MAX])
-@pytest.mark.parametrize("fee", [0, constants.UINT256_MAX])
-def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, transferred_amount):
+def test_mediated_transfer_min_max(amount, payment_identifier, nonce, transferred_amount):
     mediated_transfer = factories.create(
         factories.LockedTransferProperties(
             amount=amount,
             payment_identifier=payment_identifier,
             nonce=nonce,
             transferred_amount=transferred_amount,
-            fee=fee,
         )
     )
     mediated_transfer._data_to_sign()  # Just test that packing works without exceptions.

--- a/raiden/tests/unit/test_dict_encoding.py
+++ b/raiden/tests/unit/test_dict_encoding.py
@@ -13,14 +13,12 @@ signer = LocalSigner(PRIVKEY)
 @pytest.mark.parametrize("payment_identifier", [0, UINT64_MAX])
 @pytest.mark.parametrize("nonce", [1, UINT64_MAX])
 @pytest.mark.parametrize("transferred_amount", [0, UINT256_MAX])
-@pytest.mark.parametrize("fee", [0, UINT256_MAX])
-def test_mediated_transfer_min_max(amount, payment_identifier, fee, nonce, transferred_amount):
+def test_mediated_transfer_min_max(amount, payment_identifier, nonce, transferred_amount):
     mediated_transfer = factories.create(
         factories.LockedTransferProperties(
             amount=amount,
             payment_identifier=payment_identifier,
             nonce=nonce,
-            fee=fee,
             transferred_amount=transferred_amount,
         )
     )

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -312,7 +312,6 @@ def invalid_values():
             "transferred_amount": [-1, UINT256_MAX + 1],
             "target": invalid_addresses,
             "initiator": invalid_addresses,
-            "fee": [UINT256_MAX + 1],
         }
     )
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -822,7 +822,6 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
     sender = params.pop("sender")
     if params["locksroot"] == LOCKSROOT_OF_NO_LOCKS:
         params["locksroot"] = keccak(lock.as_bytes)
-    params["fee"] = 0
 
     # Dancing with parameters for different LockedState and LockedTransfer classes
     routes = params.pop("routes")
@@ -864,7 +863,6 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
 
 @dataclass(frozen=True)
 class LockedTransferProperties(LockedTransferSignedStateProperties):
-    fee: FeeAmount = EMPTY
     metadata: Metadata = EMPTY
     TARGET_TYPE = LockedTransfer
 
@@ -872,7 +870,6 @@ class LockedTransferProperties(LockedTransferSignedStateProperties):
 LockedTransferProperties.DEFAULTS = LockedTransferProperties(
     **replace(LockedTransferSignedStateProperties.DEFAULTS, locksroot=GENERATE).__dict__,
     metadata=GENERATE,
-    fee=0,
 )
 
 

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -978,7 +978,6 @@ def make_receive_transfer_mediated(
         target=transfer_target,
         initiator=transfer_initiator,
         signature=EMPTY_SIGNATURE,
-        fee=0,
         metadata=transfer_metadata,
     )
     mediated_transfer_msg.sign(signer)


### PR DESCRIPTION
Fixes: #4991

## Description

As discussed in the call yesterday (see https://github.com/raiden-network/team/issues/628) we won't use `LockedTransfer.fee` in the short term.

This PR removes it to have a clean protocol for Alderaan. This is up for discussion, but I think it would be most clear to remove it instead of having it set to 0 all the time (even though there are mediation fees).

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
