### PR TITLE
Increase mypy coverage in tests

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -33,6 +33,9 @@ UINT64_MAX = 2 ** 64 - 1
 
 SECONDS_PER_DAY = 24 * 60 * 60
 
+RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT = TokenAmount(int(0.075 * 10 ** 18))
+RED_EYES_PER_TOKEN_NETWORK_LIMIT = TokenAmount(int(250 * 10 ** 18))
+
 GENESIS_BLOCK_NUMBER = BlockNumber(0)
 
 # Relevant forks:

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -37,9 +37,7 @@ def web3(
 ):
     """ Starts a private chain with accounts funded. """
     # include the deploy key in the list of funded accounts
-    keys_to_fund = set(private_keys)
-    keys_to_fund.add(deploy_key)
-    keys_to_fund = sorted(keys_to_fund)
+    keys_to_fund = sorted(set(private_keys + [deploy_key]))
 
     if blockchain_type not in {client.value for client in EthClient}:
         raise ValueError(f"unknown blockchain_type {blockchain_type}")

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -1,4 +1,3 @@
-from hashlib import sha256
 from typing import List, cast
 from unittest.mock import patch
 
@@ -18,6 +17,7 @@ from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
+from raiden.tests.utils.factories import make_secret
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import (
@@ -33,7 +33,7 @@ from raiden.transfer.mediated_transfer.initiator import calculate_fee_margin
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask
-from raiden.utils import sha3
+from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     BlockExpiration,
     BlockNumber,
@@ -41,8 +41,6 @@ from raiden.utils.typing import (
     PaymentAmount,
     PaymentID,
     ProportionalFeeAmount,
-    Secret,
-    SecretHash,
     TargetAddress,
     TokenAmount,
 )
@@ -114,7 +112,7 @@ def test_locked_transfer_secret_registered_onchain(
     amount = TokenAmount(1)
     target = factories.UNIT_TRANSFER_INITIATOR
     identifier = PaymentID(1)
-    transfer_secret = Secret(sha3(target + b"1"))
+    transfer_secret = make_secret()
 
     secret_registry_proxy = app0.raiden.proxy_manager.secret_registry(secret_registry_address)
     secret_registry_proxy.register_secret(secret=transfer_secret)
@@ -258,7 +256,7 @@ def test_mediated_transfer_messages_out_of_order(  # pylint: disable=unused-argu
     app2.raiden.message_handler = app2_wait_for_message
 
     secret = factories.make_secret(0)
-    secrethash = SecretHash(sha256(secret).digest())
+    secrethash = sha256_secrethash(secret)
 
     # Save the messages, these will be processed again
     app1_mediatedtransfer = app1_wait_for_message.wait_for_message(
@@ -430,7 +428,7 @@ def test_mediated_transfer_with_node_consuming_more_than_allocated_fee(
     app1_app2_channel_state.fee_schedule = FeeScheduleState(flat=FeeAmount(fee * 2))
 
     secret = factories.make_secret(0)
-    secrethash = SecretHash(sha256(secret).digest())
+    secrethash = sha256_secrethash(secret)
 
     wait_message_handler = WaitForMessage()
     app0.raiden.message_handler = wait_message_handler

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_events.py
@@ -11,6 +11,7 @@ from raiden.transfer.mediated_transfer.events import (
     SendSecretReveal,
 )
 from raiden.utils import wait_until
+from raiden.utils.typing import PaymentAmount, PaymentID
 
 
 @raise_on_failure
@@ -25,8 +26,8 @@ def test_mediated_transfer_events(raiden_network, number_of_nodes, token_address
         initiator_app=app0,
         target_app=app2,
         token_address=token_address,
-        amount=amount,
-        identifier=1,
+        amount=PaymentAmount(amount),
+        identifier=PaymentID(1),
         timeout=network_wait * number_of_nodes,
     )
 

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -1,16 +1,21 @@
-import random
-
 import pytest
 
-from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
+from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.transfers import RevealSecret, SecretRequest, Unlock
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.factories import HOP1_KEY, UNIT_CHAIN_ID, UNIT_SECRET, UNIT_SECRETHASH
+from raiden.tests.utils.factories import (
+    HOP1_KEY,
+    UNIT_CHAIN_ID,
+    UNIT_SECRET,
+    UNIT_SECRETHASH,
+    make_32bytes,
+    make_message_identifier,
+)
 from raiden.tests.utils.transfer import sign_and_inject
 from raiden.transfer import views
 from raiden.utils.signer import LocalSigner
-from raiden.utils.typing import Locksroot, MessageID, Nonce, PaymentAmount, PaymentID, TokenAmount
+from raiden.utils.typing import Locksroot, Nonce, PaymentAmount, PaymentID, TokenAmount
 
 
 @raise_on_failure
@@ -32,7 +37,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     )
 
     amount = TokenAmount(10)
-    locksroot = Locksroot(UNIT_SECRETHASH)
+    locksroot = Locksroot(make_32bytes())
     refund_transfer_message = factories.create(
         factories.RefundTransferProperties(
             payment_identifier=PaymentID(1),
@@ -50,7 +55,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
 
     unlock = Unlock(
         chain_id=UNIT_CHAIN_ID,
-        message_identifier=MessageID(random.randint(0, UINT64_MAX)),
+        message_identifier=make_message_identifier(),
         payment_identifier=PaymentID(1),
         nonce=Nonce(1),
         channel_identifier=canonical_identifier.channel_identifier,
@@ -64,7 +69,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     sign_and_inject(unlock, other_signer, app0)
 
     secret_request_message = SecretRequest(
-        message_identifier=MessageID(random.randint(0, UINT64_MAX)),
+        message_identifier=make_message_identifier(),
         payment_identifier=PaymentID(1),
         secrethash=UNIT_SECRETHASH,
         amount=PaymentAmount(1),
@@ -74,8 +79,6 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     sign_and_inject(secret_request_message, other_signer, app0)
 
     reveal_secret_message = RevealSecret(
-        message_identifier=MessageID(random.randint(0, UINT64_MAX)),
-        secret=UNIT_SECRET,
-        signature=EMPTY_SIGNATURE,
+        message_identifier=make_message_identifier(), secret=UNIT_SECRET, signature=EMPTY_SIGNATURE
     )
     sign_and_inject(reveal_secret_message, other_signer, app0)

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -10,6 +10,7 @@ from raiden.tests.utils.factories import HOP1_KEY, UNIT_CHAIN_ID, UNIT_SECRET, U
 from raiden.tests.utils.transfer import sign_and_inject
 from raiden.transfer import views
 from raiden.utils.signer import LocalSigner
+from raiden.utils.typing import Locksroot, MessageID, Nonce, PaymentAmount, PaymentID, TokenAmount
 
 
 @raise_on_failure
@@ -22,6 +23,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), app0.raiden.default_registry.address, token_address
     )
+    assert token_network_address
 
     other_key = HOP1_KEY
     other_signer = LocalSigner(other_key)
@@ -29,16 +31,17 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
         token_network_address=token_network_address
     )
 
-    amount = 10
+    amount = TokenAmount(10)
+    locksroot = Locksroot(UNIT_SECRETHASH)
     refund_transfer_message = factories.create(
         factories.RefundTransferProperties(
-            payment_identifier=1,
-            nonce=1,
+            payment_identifier=PaymentID(1),
+            nonce=Nonce(1),
             token=token_address,
             canonical_identifier=canonical_identifier,
             transferred_amount=amount,
             recipient=app0.raiden.address,
-            locksroot=UNIT_SECRETHASH,
+            locksroot=locksroot,
             amount=amount,
             secret=UNIT_SECRET,
         )
@@ -47,31 +50,31 @@ def test_receive_secrethashtransfer_unknown(raiden_network, token_addresses):
 
     unlock = Unlock(
         chain_id=UNIT_CHAIN_ID,
-        message_identifier=random.randint(0, UINT64_MAX),
-        payment_identifier=1,
-        nonce=1,
+        message_identifier=MessageID(random.randint(0, UINT64_MAX)),
+        payment_identifier=PaymentID(1),
+        nonce=Nonce(1),
         channel_identifier=canonical_identifier.channel_identifier,
         token_network_address=token_network_address,
         transferred_amount=amount,
-        locked_amount=0,
-        locksroot=UNIT_SECRETHASH,
+        locked_amount=TokenAmount(0),
+        locksroot=locksroot,
         secret=UNIT_SECRET,
         signature=EMPTY_SIGNATURE,
     )
     sign_and_inject(unlock, other_signer, app0)
 
     secret_request_message = SecretRequest(
-        message_identifier=random.randint(0, UINT64_MAX),
-        payment_identifier=1,
+        message_identifier=MessageID(random.randint(0, UINT64_MAX)),
+        payment_identifier=PaymentID(1),
         secrethash=UNIT_SECRETHASH,
-        amount=1,
+        amount=PaymentAmount(1),
         expiration=refund_transfer_message.lock.expiration,
         signature=EMPTY_SIGNATURE,
     )
     sign_and_inject(secret_request_message, other_signer, app0)
 
     reveal_secret_message = RevealSecret(
-        message_identifier=random.randint(0, UINT64_MAX),
+        message_identifier=MessageID(random.randint(0, UINT64_MAX)),
         secret=UNIT_SECRET,
         signature=EMPTY_SIGNATURE,
     )

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -781,8 +781,8 @@ class LockedTransferSignedStateProperties(BalanceProofProperties):
     payment_identifier: PaymentID = EMPTY
     token: TokenAddress = EMPTY
     secret: Secret = EMPTY
-    sender: Address = EMPTY
-    recipient: Address = EMPTY
+    sender: InitiatorAddress = EMPTY
+    recipient: TargetAddress = EMPTY
     pkey: bytes = EMPTY
     message_identifier: MessageID = EMPTY
     routes: List[List[Address]] = EMPTY

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -16,10 +16,12 @@ from raiden.utils import privatekey_to_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,
+    BlockNumber,
     BlockSpecification,
     ChannelID,
     Dict,
     Optional,
+    TokenAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
 )
@@ -29,7 +31,7 @@ from raiden_contracts.utils.type_aliases import ChainID
 class MockJSONRPCClient:
     def __init__(self, address: Address):
         # To be manually set by each test
-        self.balances_mapping: Dict[Address, int] = {}
+        self.balances_mapping: Dict[Address, TokenAmount] = {}
         self.chain_id = ChainID(17)
         self.address = address
 
@@ -97,18 +99,18 @@ class MockChannelState:
 
 class MockTokenNetwork:
     def __init__(self):
-        self.channelidentifiers_to_channels = {}
-        self.partneraddresses_to_channelidentifiers = {}
+        self.channelidentifiers_to_channels: dict = {}
+        self.partneraddresses_to_channelidentifiers: dict = {}
 
 
 class MockTokenNetworkRegistry:
     def __init__(self):
-        self.tokennetworkaddresses_to_tokennetworks = {}
+        self.tokennetworkaddresses_to_tokennetworks: dict = {}
 
 
 class MockChainState:
     def __init__(self):
-        self.identifiers_to_tokennetworkregistries = {}
+        self.identifiers_to_tokennetworkregistries: dict = {}
 
 
 class MockRaidenService:
@@ -133,20 +135,20 @@ class MockRaidenService:
         self.default_one_to_n_address = factories.make_address()
         self.default_msc_address = factories.make_address()
 
-        self.targets_to_identifiers_to_statuses = defaultdict(dict)
-        self.route_to_feedback_token = {}
+        self.targets_to_identifiers_to_statuses: Dict[Address, dict] = defaultdict(dict)
+        self.route_to_feedback_token: dict = {}
 
         if state_transition is None:
             state_transition = node.state_transition
 
-        serializer = JSONSerializer
+        serializer = JSONSerializer()
         state_manager = StateManager(state_transition, None)
         storage = SerializedSQLiteStorage(":memory:", serializer)
         self.wal = WriteAheadLog(state_manager, storage)
 
         state_change = ActionInitChain(
             pseudo_random_generator=random.Random(),
-            block_number=0,
+            block_number=BlockNumber(0),
             block_hash=factories.make_block_hash(),
             our_address=self.rpc_client.address,
             chain_id=self.rpc_client.chain_id,

--- a/raiden/tests/utils/protocol.py
+++ b/raiden/tests/utils/protocol.py
@@ -40,7 +40,7 @@ class Holding(NamedTuple):
 
 class WaitForMessage(MessageHandler):
     def __init__(self):
-        self.waiting = defaultdict(list)
+        self.waiting: Dict[type, list] = defaultdict(list)
 
     def wait_for_message(self, message_type: type, attributes: dict) -> AsyncResult:
         assert not any(attributes == waiting.attributes for waiting in self.waiting[message_type])

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -286,7 +286,7 @@ def setup_raiden(
     token = deploy_token(
         deploy_client=client,
         contract_manager=contract_manager,
-        initial_amount=1000,
+        initial_amount=TokenAmount(1000),
         decimals=0,
         token_name="TKN",
         token_symbol="TKN",
@@ -296,16 +296,16 @@ def setup_raiden(
         client=client,
         chain_id=NETWORKNAME_TO_ID["smoketest"],
         contract_manager=contract_manager,
-        token_address=to_canonical_address(token.contract.address),
+        token_address=to_checksum_address(token.contract.address),
     )
     registry = proxy_manager.token_network_registry(
-        contract_addresses[CONTRACT_TOKEN_NETWORK_REGISTRY]
+        TokenNetworkRegistryAddress(contract_addresses[CONTRACT_TOKEN_NETWORK_REGISTRY])
     )
 
     registry.add_token(
-        token_address=to_canonical_address(token.contract.address),
-        channel_participant_deposit_limit=UINT256_MAX,
-        token_network_deposit_limit=UINT256_MAX,
+        token_address=TokenAddress(to_canonical_address(token.contract.address)),
+        channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
+        token_network_deposit_limit=TokenAmount(UINT256_MAX),
         block_identifier=client.get_confirmed_blockhash(),
     )
 

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -17,7 +17,7 @@ from twisted.internet import defer
 
 from raiden.utils.http import EXECUTOR_IO, HTTPExecutor
 from raiden.utils.signer import recover
-from raiden.utils.typing import Iterable, Port
+from raiden.utils.typing import Iterable, Port, Signature
 
 _SYNAPSE_BASE_DIR_VAR_NAME = "RAIDEN_TESTS_SYNAPSE_BASE_DIR"
 _SYNAPSE_LOGS_PATH = os.environ.get("RAIDEN_TESTS_SYNAPSE_LOGS_DIR")
@@ -31,7 +31,7 @@ class ParsedURL(str):
     """ A string subclass that allows direct access to the split components of a URL """
 
     def __new__(cls, *args, **kwargs):
-        new = str.__new__(cls, *args, **kwargs)
+        new = str.__new__(cls, *args, **kwargs)  # type: ignore
         new._parsed = urlsplit(new)
         return new
 
@@ -74,7 +74,7 @@ class EthAuthProvider:
             )
             defer.returnValue(False)
 
-        signature = unhexlify(password[2:])
+        signature = Signature(unhexlify(password[2:]))
 
         user_match = self._user_re.match(user_id)
         if not user_match or user_match.group(2) != self.hs_hostname:
@@ -150,7 +150,7 @@ def make_requests_insecure():
     """
     # Disable verification in requests by replacing the 'verify'
     # attribute with non-writable property that always returns `False`
-    requests.Session.verify = property(lambda self: False, lambda self, val: None)
+    requests.Session.verify = property(lambda self: False, lambda self, val: None)  # type: ignore
 
 
 @contextmanager

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,13 @@ check_untyped_defs = True
 check_untyped_defs = True
 [mypy-raiden.tests.integration.long_running.*]
 check_untyped_defs = True
-[mypy-raiden.tests.integration.fixtures.raiden_network.*]
+[mypy-raiden.tests.integration.fixtures.*]
 check_untyped_defs = True
 [mypy-raiden.tests.utils.*]
+check_untyped_defs = True
+[mypy-raiden.tests.integration.transfer.test_mediatedtransfer_events]
+check_untyped_defs = True
+[mypy-raiden.tests.integration.transfer.test_refund_invalid]
+check_untyped_defs = True
+[mypy-raiden.tests.integration.transfer.test_mediatedtransfer]
 check_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,13 +77,11 @@ disallow_untyped_defs = False
 ignore_errors = True
 
 # These packages already check untyped defs
-[mypy-raiden.tests.unit.test_raiden_event_handler]
+[mypy-raiden.tests.unit.test_raiden_event_handler.*]
 check_untyped_defs = True
-[mypy-raiden.tests.unit.transfer]
-check_untyped_defs = True
-[mypy-raiden.tests.unit.transfer.mediated_transfer.test_mediation_fee]
+[mypy-raiden.tests.unit.transfer.mediated_transfer.test_mediation_fee.*]
 check_untyped_defs = True
 [mypy-raiden.tests.integration.long_running.*]
 check_untyped_defs = True
-[mypy-raiden.tests.integration.fixtures.raiden_network]
+[mypy-raiden.tests.integration.fixtures.raiden_network.*]
 check_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,3 +85,5 @@ check_untyped_defs = True
 check_untyped_defs = True
 [mypy-raiden.tests.integration.fixtures.raiden_network.*]
 check_untyped_defs = True
+[mypy-raiden.tests.utils.*]
+check_untyped_defs = True


### PR DESCRIPTION
This brings us roughly half the way towards enabling `check_untyped_defs = True` for all integration tests.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
