### PR TITLE
Resume waiting_transfer on `Block`

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -83,7 +83,11 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         )
 
         block_iteration = mediator.handle_block(
-            new_state, block_state_change, channels.channel_map, pseudo_random_generator
+            mediator_state=new_state,
+            state_change=block_state_change,
+            channelidentifiers_to_channels=channels.channel_map,
+            nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
+            pseudo_random_generator=pseudo_random_generator,
         )
         new_state = block_iteration.new_state
 
@@ -116,6 +120,7 @@ def test_payer_enter_danger_zone_with_transfer_payed():
         mediator_state=paid_state,
         state_change=expired_block_state_change,
         channelidentifiers_to_channels=channels.channel_map,
+        nodeaddresses_to_networkstates=channels.nodeaddresses_to_networkstates,
         pseudo_random_generator=pseudo_random_generator,
     )
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -207,6 +207,7 @@ def is_channel_usable_for_mediation(
     channel_usable = is_channel_usable_for_new_transfer(
         channel_state, transfer_amount, lock_timeout
     )
+    # FIXME: different definition of valid lock timeout than elsewhere
     lock_timeout_valid = lock_timeout > 0
 
     return channel_usable and lock_timeout_valid

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -207,10 +207,8 @@ def is_channel_usable_for_mediation(
     channel_usable = is_channel_usable_for_new_transfer(
         channel_state, transfer_amount, lock_timeout
     )
-    # FIXME: different definition of valid lock timeout than elsewhere
-    lock_timeout_valid = lock_timeout > 0
 
-    return channel_usable and lock_timeout_valid
+    return channel_usable
 
 
 def is_channel_usable_for_new_transfer(

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1144,6 +1144,7 @@ def handle_block(
     mediator_state: MediatorTransferState,
     state_change: Block,
     channelidentifiers_to_channels: Dict[ChannelID, NettingChannelState],
+    nodeaddresses_to_networkstates: NodeNetworkStateMap,
     pseudo_random_generator: random.Random,
 ) -> TransitionResult[MediatorTransferState]:
     """ After Raiden learns about a new block this function must be called to
@@ -1502,6 +1503,7 @@ def state_transition(
             mediator_state=mediator_state,
             state_change=state_change,
             channelidentifiers_to_channels=channelidentifiers_to_channels,
+            nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
             pseudo_random_generator=pseudo_random_generator,
         )
 


### PR DESCRIPTION
Fixes: #4998 

## Description

This implements resume for waiting transfers, if a newer `Block` changes the expiry validation. Previously, if a mediator received a transfer, which had a lock expiry higher than `current_block + settlement_timeout`, it would enter the `waiting_transfer` status (so far, so good) **and** be considered `expired` on the next incoming `Block`. The only way for a waiting transfer to be resumed was a change in partner availability.
As described in the addressed issue, this behavior could lead to unexpected results when users have very low margins between `reveal timeout` and `settlement timeout`.

This PR introduces "resume attempts" for waiting transfers on _every_ new `Block` that is seen by the client. I chose to attempt the resume every time, in order to not duplicate the code that validates the timeout properties.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
