### PR TITLE
Reduce Sphinx warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,42 +52,36 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: dirhtml
 dirhtml:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: singlehtml
 singlehtml:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: pickle
 pickle:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
 .PHONY: json
 json:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
 .PHONY: htmlhelp
 htmlhelp:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
@@ -95,7 +89,6 @@ htmlhelp:
 
 .PHONY: qthelp
 qthelp:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -106,7 +99,6 @@ qthelp:
 
 .PHONY: applehelp
 applehelp:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
 	@echo
 	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
@@ -116,7 +108,6 @@ applehelp:
 
 .PHONY: devhelp
 devhelp:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -127,21 +118,18 @@ devhelp:
 
 .PHONY: epub
 epub:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
 .PHONY: epub3
 epub3:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b epub3 $(ALLSPHINXOPTS) $(BUILDDIR)/epub3
 	@echo
 	@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
 .PHONY: latex
 latex:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
@@ -150,7 +138,6 @@ latex:
 
 .PHONY: latexpdf
 latexpdf:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
@@ -158,7 +145,6 @@ latexpdf:
 
 .PHONY: latexpdfja
 latexpdfja:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
@@ -166,21 +152,18 @@ latexpdfja:
 
 .PHONY: text
 text:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
 .PHONY: man
 man:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
 .PHONY: texinfo
 texinfo:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
@@ -189,7 +172,6 @@ texinfo:
 
 .PHONY: info
 info:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
@@ -197,21 +179,18 @@ info:
 
 .PHONY: gettext
 gettext:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
 .PHONY: changes
 changes:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 .PHONY: linkcheck
 linkcheck:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
@@ -219,35 +198,30 @@ linkcheck:
 
 .PHONY: doctest
 doctest:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 .PHONY: coverage
 coverage:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
 	@echo "Testing of coverage in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/coverage/python.txt."
 
 .PHONY: xml
 xml:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
 .PHONY: pseudoxml
 pseudoxml:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 .PHONY: dummy
 dummy:
-	$(SPHINXAPIDOC) -o $(BUILDDIR)/generated $(RAIDENMODULEPATH)
 	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
 	@echo
 	@echo "Build finished. Dummy builder generates no files."

--- a/docs/adr/0002-testing-strategy.rst
+++ b/docs/adr/0002-testing-strategy.rst
@@ -1,5 +1,5 @@
 Better testing framework for the entire Raiden suite (client, MS and PFS)
-*********************************************************************
+*************************************************************************
 
 * **Status**: proposed
 * **Deciders**: @czepluch, @stefante
@@ -12,9 +12,9 @@ Context and Problem Statement
 @rakanalh @karlb @LefterisJP and @czepluch had a meeting to discuss testing moving forward. More precisely how we can test the client together with the MS and PFS. Most of the discussion was focused on whether it makes sense to continue to support the scenario player and update it to support the third party services. Currently the SP is good for testing happy cases, but it is not easy to debug when errors occur and it doesn't allow for introspection in the same way as pytest does. On the other hand, the current way that the integration tests work by spinning up a new blockchain per test is very inefficient. It's also quite intimidating for people new to the project or less experienced to grasp how the integration tests work.
 Based on these short comings of the current two solutions, we discussed what could be done to create a setup that solves both problems.
 
-.. Decision drivers is optional
+
 Decision Drivers
--------------------
+----------------
 
 * Lack debug options for scenario player
 * Slow to spin up a fresh blockchain for every integration test
@@ -23,17 +23,17 @@ Decision Drivers
 * Have a way of testing all Raiden components
 
 Considered Options
----------------------
+------------------
 
 * **Option1:** New repo that integrate the client with the MS/PFS with rewritten fixtures that only spins up one blockchain per test suit session. `Link to meeting discussing this <https://github.com/raiden-network/team/issues/357>`_
 * **Option2:** Stick with things as they are and focus on adding functionality to the scenario player
 
 Decision Outcome
--------------------
+-----------------
 
 **TBD**
 
-.. Pros and cons are optional
+
 Pros and Cons of the Options
 ----------------------------
 

--- a/docs/adr/0005-withdraw-expiry.rst
+++ b/docs/adr/0005-withdraw-expiry.rst
@@ -67,20 +67,20 @@ Complex:
   `total_withdraw=10`.
 - Alice requests a withdraw of another 10 tokens. `total_withdraw=20`.
 - Alice requests a withdraw of another 20 tokens. `total_withdraw=40`.
-- Alice withdraw states look as follows
-```
-[
-  {
-    "total_withdraw": 10,
-  },
-  {
-    "total_withdraw": 20,
-  }
-  {
-    "total_withdraw": 30,
-  }
-]
-```
+- Alice withdraw states look as follows::
+
+    [
+      {
+        "total_withdraw": 10,
+      },
+      {
+        "total_withdraw": 20,
+      }
+      {
+        "total_withdraw": 30,
+      }
+    ]
+
 - Bob does not confirm any withdraw.
 - Alice sends Bob a `WithdrawExpired` message for the first withdraw request which had a `total_withdraw=10`.
   Before sending `WithdrawExpired`, Alice clears the expired withdraw state `total_withdraw=10`. However, that doesn't affect Alice's `total_withdraw`

--- a/docs/adr/template.rst
+++ b/docs/adr/template.rst
@@ -13,6 +13,7 @@ Context and Problem Statement
 [Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
 
 .. Optional
+
 Decision Drivers
 ----------------
 
@@ -34,19 +35,19 @@ Decision Outcome
 Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
 Positive Consequences <!-- optional -->
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
 * …
 
 Negative Consequences <!-- optional -->
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * [e.g., compromising quality attribute, follow-up decisions required, …]
 * …
 
 Pros and Cons of the Options <!-- optional -->
--------------------------------
+-------------------------------~~~~~~~~~~~~~~~
 
 [option 1]
 ~~~~~~~~~~
@@ -79,7 +80,7 @@ Pros and Cons of the Options <!-- optional -->
 * … <!-- numbers of pros and cons can vary -->
 
 Links <!-- optional -->
-----------------------
+-----------------------
 
 * [Link type] [Link to ADR] <!-- example: Refined by `ADR-0005 <0005-example.md>`_ -->
 * … <!-- numbers of links can vary -->

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,6 @@ Contents
 
   config_file
   trademarks
-  Raiden Codebase Documentation <./_build/generated/modules>
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
## Description

Reduces the number of warning in the raiden docs.

- Remove autodoc for now
- Fix headings and some markup

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
