### PR TITLE
Remove remaining usages of sha256(secret).digest()

### DIFF
--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -89,7 +89,7 @@ class Lock:
     Args:
         amount: Amount of the token being transferred.
         expiration: Highest block_number until which the transfer can be settled
-        secrethash: Hashed secret `sha256(secret).digest()` used to register the transfer,
+        secrethash: Hashed secret used to register the transfer,
         the real `secret` is necessary to release the locked amount.
     """
 

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -31,6 +31,7 @@ from raiden.tests.utils.smartcontracts import deploy_contract_web3
 from raiden.transfer import views
 from raiden.transfer.state import ChannelState
 from raiden.utils import get_system_spec
+from raiden.utils.secrethash import sha256_secrethash
 from raiden.waiting import (
     TransferWaitResult,
     wait_for_block,
@@ -1360,7 +1361,7 @@ def assert_payment_secret_and_hash(response, payment):
     secret = to_bytes(hexstr=response["secret"])
     assert len(secret) == SECRET_LENGTH
 
-    assert to_bytes(hexstr=response["secret_hash"]) == sha256(secret).digest()
+    assert to_bytes(hexstr=response["secret_hash"]) == sha256_secrethash(secret)
 
 
 def assert_payment_conflict(responses):
@@ -2235,7 +2236,7 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
     mediator.raiden.message_handler = mediator_wait = WaitForMessage()
 
     secret = factories.make_secret()
-    secrethash = sha256(secret).digest()
+    secrethash = sha256_secrethash(secret)
 
     request = grequests.get(
         api_url_for(

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -1,4 +1,3 @@
-from hashlib import sha256
 from typing import Dict, List
 
 import gevent
@@ -29,11 +28,13 @@ from raiden.transfer.mediated_transfer.events import SendLockedTransfer
 from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
 from raiden.transfer.state_change import ContractReceiveSecretReveal
 from raiden.utils import sha3, wait_until
+from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     Address,
     Balance,
     BlockSpecification,
     ChannelID,
+    Secret,
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import (
@@ -502,8 +503,8 @@ def test_clear_closed_queue(raiden_network, token_addresses, network_wait):
     )
 
     target = app1.raiden.address
-    secret = sha3(target)
-    secrethash = sha256(secret).digest()
+    secret = Secret(sha3(target))
+    secrethash = sha256_secrethash(secret)
     hold_event_handler.hold_secretrequest_for(secrethash=secrethash)
 
     # make an unconfirmed transfer to ensure the nodes have communicated

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -1,5 +1,4 @@
 import random
-from hashlib import sha256
 
 import gevent
 import pytest
@@ -378,7 +377,7 @@ def test_batch_unlock(raiden_network, token_addresses, secret_registry_address, 
         "expected balances."
     )
     assert lock.expiration > alice_app.raiden.get_block_number(), msg
-    assert lock.secrethash == sha256(secret).digest()
+    assert lock.secrethash == sha256_secrethash(secret)
 
     waiting.wait_for_settle(
         alice_app.raiden,
@@ -608,8 +607,8 @@ def test_settled_lock(token_addresses, raiden_network, deposit):
     initial_balance1 = token_proxy.balance_of(address1)
     identifier = 1
     target = app1.raiden.address
-    secret = sha3(target)
-    secrethash = sha256(secret).digest()
+    secret = Secret(sha3(target))
+    secrethash = sha256_secrethash(secret)
 
     secret_available = hold_event_handler.hold_secretrequest_for(secrethash=secrethash)
 
@@ -758,8 +757,8 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit):
     # the attacker owns app0 and app2 and creates a transfer through app1
     identifier = 1
     target = app2.raiden.address
-    secret = sha3(target)
-    secrethash = sha256(secret).digest()
+    secret = Secret(sha3(target))
+    secrethash = sha256_secrethash(secret)
 
     hold_event_handler.hold_secretrequest_for(secrethash=secrethash)
 

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -1,5 +1,4 @@
 import random
-from hashlib import sha256
 
 import gevent
 import pytest
@@ -25,6 +24,7 @@ from raiden.transfer.mediated_transfer.state_change import ReceiveTransferCancel
 from raiden.utils import PaymentID, sha3
 
 # pylint: disable=too-many-locals
+from raiden.utils.secrethash import sha256_secrethash
 
 
 def open_and_wait_for_channels(app_channels, registry_address, token, deposit, settle_timeout):
@@ -136,7 +136,7 @@ def test_regression_multiple_revealsecret(raiden_network, token_addresses, trans
 
     payment_identifier = 1
     secret = sha3(b"test_regression_multiple_revealsecret")
-    secrethash = sha256(secret).digest()
+    secrethash = sha256_secrethash(secret)
     expiration = app0.raiden.get_block_number() + 100
     lock_amount = 10
     lock = Lock(amount=lock_amount, expiration=expiration, secrethash=secrethash)

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -1,5 +1,3 @@
-from hashlib import sha256
-
 import gevent
 import pytest
 
@@ -18,6 +16,7 @@ from raiden.transfer import views
 from raiden.transfer.events import EventPaymentSentSuccess
 from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendSecretReveal
 from raiden.utils import create_default_identifier
+from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import BlockNumber, TokenAmount
 
 
@@ -46,7 +45,7 @@ def test_send_queued_messages(  # pylint: disable=unused-argument
     transfers = []
     for secret_seed in range(number_of_transfers):
         secret = make_secret(secret_seed)
-        secrethash = sha256(secret).digest()
+        secrethash = sha256_secrethash(secret)
         transfers.append((create_default_identifier(), amount_per_transfer, secret, secrethash))
 
         app0.raiden.raiden_event_handler.hold(

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -1,5 +1,3 @@
-from hashlib import sha256
-
 from raiden.api.python import transfer_tasks_view
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.state import (
@@ -14,6 +12,7 @@ from raiden.transfer.mediated_transfer.state import (
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask, MediatorTask, TargetTask
 from raiden.transfer.state import RouteState
 from raiden.transfer.views import list_channelstate_for_tokennetwork
+from raiden.utils.secrethash import sha256_secrethash
 
 
 def test_list_channelstate_for_tokennetwork(chain_state, token_network_registry_address, token_id):
@@ -43,7 +42,7 @@ def test_initiator_task_view():
         initiator=transfer.initiator,
         target=transfer.target,
         secret=secret,
-        secrethash=sha256(secret).digest(),
+        secrethash=sha256_secrethash(secret),
     )
     transfer_state = InitiatorTransferState(
         route=RouteState(

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -85,6 +85,7 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils import sha3
 from raiden.utils.packing import pack_withdraw
+from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import LockedAmount
 
@@ -1504,7 +1505,7 @@ def test_get_amount_locked():
     assert channel.get_amount_locked(state) == 23
 
     secret = make_secret(1)
-    secrethash = sha256(secret).digest()
+    secrethash = sha256_secrethash(secret)
     lock = HashTimeLockState(amount=21, expiration=100, secrethash=secrethash)
     state.secrethashes_to_unlockedlocks[secrethash] = UnlockPartialProofState(
         lock=lock, secret=secret
@@ -1512,7 +1513,7 @@ def test_get_amount_locked():
     assert channel.get_amount_locked(state) == 44
 
     secret = make_secret(2)
-    secrethash = sha256(secret).digest()
+    secrethash = sha256_secrethash(secret)
     lock = HashTimeLockState(amount=19, expiration=100, secrethash=secrethash)
     state.secrethashes_to_onchain_unlockedlocks[secrethash] = UnlockPartialProofState(
         lock=lock, secret=secret


### PR DESCRIPTION

## Description

Rmoves remaining usages of `sha256(secret).digest()` that can be replaced with `sha256_secrethash`.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
