### PR TITLE
Fix check if PFS can be used

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -41,7 +41,7 @@ def get_best_routes(
     pfs_config = config.get("pfs_config", None)
 
     is_direct_partner = to_address in views.all_neighbour_nodes(chain_state)
-    can_use_pfs = pfs_config and one_to_n_address is not None
+    can_use_pfs = pfs_config is not None and one_to_n_address is not None
 
     log.debug(
         "Getting route for payment",


### PR DESCRIPTION
I saw this in some logs: `"can_use_pfs": null`

It worked before as well, but after this fix it's a proper boolean.


## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
