### PR TITLE
Correctly format addresses in duplicate channel open API error

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -456,8 +456,9 @@ class RaidenAPI:  # pragma: no unittest
         )
         if duplicated_channel:
             raise DuplicatedChannelError(
-                f"A channel with {partner_address} for token {token_address} already exists. "
-                f"(At block: {confirmed_block_identifier})"
+                f"A channel with {to_checksum_address(partner_address)} for token "
+                f"{to_checksum_address(token_address)} already exists. "
+                f"(At blockhash: {confirmed_block_identifier.hex()})"
             )
 
         with self.raiden.gas_reserve_lock:


### PR DESCRIPTION
Fixes: #5099 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
