### PR TITLE
Enable strict type checking for raiden.messages

### DIFF
--- a/raiden/messages/abstract.py
+++ b/raiden/messages/abstract.py
@@ -5,7 +5,7 @@ from eth_utils import to_hex
 from raiden.exceptions import InvalidSignature
 from raiden.messages.cmdid import CmdId
 from raiden.utils.signer import Signer, recover
-from raiden.utils.typing import Address, ClassVar, MessageID, Optional, Signature
+from raiden.utils.typing import Address, Any, ClassVar, MessageID, Optional, Signature
 
 
 @dataclass(repr=False, eq=False)
@@ -29,16 +29,16 @@ class SignedMessage(AuthenticatedMessage):
     # by changing the order to packing then signing
     signature: Signature
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self._data_to_sign(), self.signature))
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return isinstance(other, self.__class__) and hash(self) == hash(other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{klass} [msghash={msghash}]>".format(
             klass=self.__class__.__name__, msghash=to_hex(hash(self))
         )
@@ -50,7 +50,7 @@ class SignedMessage(AuthenticatedMessage):
         """
         raise NotImplementedError
 
-    def sign(self, signer: Signer):
+    def sign(self, signer: Signer) -> None:
         """ Sign message using signer. """
         message_data = self._data_to_sign()
         self.signature = signer.sign(data=message_data)

--- a/raiden/messages/decode.py
+++ b/raiden/messages/decode.py
@@ -2,6 +2,7 @@ from raiden.messages.transfers import EnvelopeMessage, LockedTransferBase
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.state import LockedTransferSignedState
 from raiden.transfer.state import BalanceProofSignedState, HashTimeLockState
+from raiden.utils.typing import AdditionalHash
 
 
 def balanceproof_from_envelope(envelope_message: EnvelopeMessage) -> BalanceProofSignedState:
@@ -11,7 +12,7 @@ def balanceproof_from_envelope(envelope_message: EnvelopeMessage) -> BalanceProo
         transferred_amount=envelope_message.transferred_amount,
         locked_amount=envelope_message.locked_amount,
         locksroot=envelope_message.locksroot,
-        message_hash=envelope_message.message_hash,
+        message_hash=AdditionalHash(envelope_message.message_hash),
         signature=envelope_message.signature,
         sender=envelope_message.sender,
         canonical_identifier=CanonicalIdentifier(

--- a/raiden/messages/encode.py
+++ b/raiden/messages/encode.py
@@ -47,10 +47,13 @@ def message_from_sendevent(send_event: SendMessageEvent) -> Message:
         assert isinstance(send_event, SendLockExpired), MYPY_ANNOTATION
         return LockExpired.from_event(send_event)
     elif type(send_event) == SendWithdrawRequest:
+        assert isinstance(send_event, SendWithdrawRequest), MYPY_ANNOTATION
         return WithdrawRequest.from_event(send_event)
     elif type(send_event) == SendWithdrawConfirmation:
+        assert isinstance(send_event, SendWithdrawConfirmation), MYPY_ANNOTATION
         return WithdrawConfirmation.from_event(send_event)
     elif type(send_event) == SendWithdrawExpired:
+        assert isinstance(send_event, SendWithdrawExpired), MYPY_ANNOTATION
         return WithdrawExpired.from_event(send_event)
     elif type(send_event) == SendProcessed:
         assert isinstance(send_event, SendProcessed), MYPY_ANNOTATION

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -12,10 +12,10 @@ class RouteMetadata:
     route: List[Address]
 
     @property
-    def hash(self):
+    def hash(self) -> bytes:
         return sha3(rlp.encode(self.route))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"RouteMetadata: {' -> '.join([to_checksum_address(a) for a in self.route])}"
 
 
@@ -24,8 +24,8 @@ class Metadata:
     routes: List[RouteMetadata]
 
     @property
-    def hash(self):
+    def hash(self) -> bytes:
         return sha3(rlp.encode([r.hash for r in self.routes]))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Metadata: routes: {[repr(route) for route in self.routes]}"

--- a/raiden/messages/monitoring_service.py
+++ b/raiden/messages/monitoring_service.py
@@ -37,7 +37,7 @@ class SignedBlindedBalanceProof:
     signature: Signature
     non_closing_signature: Optional[Signature] = field(default=EMPTY_SIGNATURE)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.signature == EMPTY_SIGNATURE:
             raise ValueError("balance proof is not signed")
 
@@ -100,10 +100,10 @@ class RequestMonitoring(SignedMessage):
     non_closing_participant: Address
     non_closing_signature: Optional[Signature] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         typecheck(self.balance_proof, SignedBlindedBalanceProof)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self._data_to_sign(), self.signature, self.non_closing_signature))
 
     @classmethod
@@ -127,7 +127,6 @@ class RequestMonitoring(SignedMessage):
             non_closing_participant=non_closing_participant,
             monitoring_service_contract_address=monitoring_service_contract_address,
         )
-        return cls(onchain_balance_proof=onchain_balance_proof, reward_amount=reward_amount)
 
     @property
     def reward_proof_signature(self) -> Optional[Signature]:
@@ -146,7 +145,7 @@ class RequestMonitoring(SignedMessage):
         )
         return packed
 
-    def sign(self, signer: Signer):
+    def sign(self, signer: Signer) -> None:
         """This method signs twice:
             - the `non_closing_signature` for the balance proof update
             - the `reward_proof_signature` for the monitoring request

--- a/raiden/messages/path_finding_service.py
+++ b/raiden/messages/path_finding_service.py
@@ -27,7 +27,7 @@ class PFSCapacityUpdate(SignedMessage):
     other_capacity: TokenAmount
     reveal_timeout: int
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.signature is None:
             self.signature = EMPTY_SIGNATURE
 
@@ -74,7 +74,7 @@ class PFSFeeUpdate(SignedMessage):
     fee_schedule: FeeScheduleState
     timestamp: datetime
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.signature is None:
             self.signature = EMPTY_SIGNATURE
 
@@ -95,7 +95,7 @@ class PFSFeeUpdate(SignedMessage):
         )
 
     @classmethod
-    def from_channel_state(cls, channel_state: NettingChannelState):
+    def from_channel_state(cls, channel_state: NettingChannelState) -> "PFSFeeUpdate":
         return cls(
             canonical_identifier=channel_state.canonical_identifier,
             updating_participant=channel_state.our_state.address,

--- a/raiden/messages/synchronization.py
+++ b/raiden/messages/synchronization.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.abstract import SignedMessage, SignedRetrieableMessage
 from raiden.messages.cmdid import CmdId
+from raiden.transfer.architecture import SendMessageEvent
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import ClassVar, MessageID
 
@@ -44,7 +45,7 @@ class Processed(SignedRetrieableMessage):
     message_identifier: MessageID
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendMessageEvent) -> "Processed":
         return cls(message_identifier=event.message_identifier, signature=EMPTY_SIGNATURE)
 
     def _data_to_sign(self) -> bytes:

--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -1,18 +1,26 @@
 from dataclasses import dataclass, field
 from hashlib import sha256
-from typing import overload
+from typing import Any, overload
 
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX, UINT256_MAX
 from raiden.messages.abstract import SignedRetrieableMessage
 from raiden.messages.cmdid import CmdId
 from raiden.messages.metadata import Metadata, RouteMetadata
 from raiden.transfer.identifiers import CanonicalIdentifier
-from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendRefundTransfer
+from raiden.transfer.mediated_transfer.events import (
+    SendBalanceProof,
+    SendLockedTransfer,
+    SendLockExpired,
+    SendRefundTransfer,
+    SendSecretRequest,
+    SendSecretReveal,
+)
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils import ishash, sha3
 from raiden.utils.packing import pack_balance_proof
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
+    AdditionalHash,
     Address,
     BlockExpiration,
     ChainID,
@@ -39,7 +47,7 @@ def assert_envelope_values(
     transferred_amount: TokenAmount,
     locked_amount: TokenAmount,
     locksroot: Locksroot,
-):
+) -> None:
     if nonce <= 0:
         raise ValueError("nonce cannot be zero or negative")
 
@@ -68,7 +76,9 @@ def assert_envelope_values(
         raise ValueError("locksroot must have length 32")
 
 
-def assert_transfer_values(payment_identifier, token, recipient):
+def assert_transfer_values(
+    payment_identifier: PaymentID, token: TokenAddress, recipient: Address
+) -> None:
     if payment_identifier < 0:
         raise ValueError("payment_identifier cannot be negative")
 
@@ -99,7 +109,7 @@ class Lock:
     expiration: BlockExpiration
     secrethash: SecretHash
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # guarantee that `amount` can be serialized using the available bytes
         # in the fixed length format
         if self.amount < 0:
@@ -118,21 +128,22 @@ class Lock:
             raise ValueError("secrethash {self.secrethash} is not a valid hash")
 
     @property
-    def as_bytes(self):
+    def as_bytes(self) -> bytes:
         return pack_data(
             (self.expiration, "uint256"), (self.amount, "uint256"), (self.secrethash, "bytes32")
         )
 
+    # FIXME: is this used?
     @property
-    def lockhash(self):
+    def lockhash(self) -> bytes:
         return sha3(self.as_bytes)
 
     @classmethod
-    def from_bytes(cls, serialized):
+    def from_bytes(cls, serialized: bytes) -> "Lock":
         return cls(
-            expiration=int.from_bytes(serialized[:32], byteorder="big"),
-            amount=int.from_bytes(serialized[32:64], byteorder="big"),
-            secrethash=serialized[64:],
+            expiration=BlockExpiration(int.from_bytes(serialized[:32], byteorder="big")),
+            amount=PaymentWithFeeAmount(int.from_bytes(serialized[32:64], byteorder="big")),
+            secrethash=SecretHash(serialized[64:]),
         )
 
 
@@ -153,7 +164,7 @@ class EnvelopeMessage(SignedRetrieableMessage):
     channel_identifier: ChannelID
     token_network_address: TokenNetworkAddress
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert_envelope_values(
             self.nonce,
             self.channel_identifier,
@@ -163,7 +174,7 @@ class EnvelopeMessage(SignedRetrieableMessage):
         )
 
     @property
-    def message_hash(self):
+    def message_hash(self) -> bytes:
         raise NotImplementedError
 
     def _data_to_sign(self) -> bytes:
@@ -173,7 +184,7 @@ class EnvelopeMessage(SignedRetrieableMessage):
         balance_proof_packed = pack_balance_proof(
             nonce=self.nonce,
             balance_hash=balance_hash,
-            additional_hash=self.message_hash,
+            additional_hash=AdditionalHash(self.message_hash),
             canonical_identifier=CanonicalIdentifier(
                 chain_identifier=self.chain_id,
                 token_network_address=self.token_network_address,
@@ -195,7 +206,7 @@ class SecretRequest(SignedRetrieableMessage):
     expiration: BlockExpiration
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendSecretRequest) -> "SecretRequest":
         # pylint: disable=unexpected-keyword-arg
         return cls(
             message_identifier=event.message_identifier,
@@ -253,7 +264,7 @@ class Unlock(EnvelopeMessage):
     payment_identifier: PaymentID
     secret: Secret = field(repr=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__post_init__()
         if self.payment_identifier < 0:
             raise ValueError("payment_identifier cannot be negative")
@@ -265,11 +276,11 @@ class Unlock(EnvelopeMessage):
             raise ValueError("secret must have 32 bytes")
 
     @property
-    def secrethash(self):
+    def secrethash(self) -> bytes:
         return sha256(self.secret).digest()
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendBalanceProof) -> "Unlock":
         balance_proof = event.balance_proof
         # pylint: disable=unexpected-keyword-arg
         return cls(
@@ -310,11 +321,11 @@ class RevealSecret(SignedRetrieableMessage):
     secret: Secret = field(repr=False)
 
     @property
-    def secrethash(self):
+    def secrethash(self) -> bytes:
         return sha256(self.secret).digest()
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendSecretReveal) -> "RevealSecret":
         # pylint: disable=unexpected-keyword-arg
         return cls(
             message_identifier=event.message_identifier,
@@ -345,7 +356,7 @@ class LockedTransferBase(EnvelopeMessage):
     initiator: InitiatorAddress
     metadata: Metadata
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__post_init__()
         assert_transfer_values(self.payment_identifier, self.token, self.recipient)
 
@@ -368,7 +379,7 @@ class LockedTransferBase(EnvelopeMessage):
         ...
 
     @classmethod  # noqa: F811
-    def from_event(cls, event):
+    def from_event(cls, event: Any) -> Any:
         transfer = event.transfer
         balance_proof = transfer.balance_proof
         lock = Lock(
@@ -399,7 +410,7 @@ class LockedTransferBase(EnvelopeMessage):
             ),
         )
 
-    def _packed_data(self):
+    def _packed_data(self) -> bytes:
         return pack_data(
             (self.cmdid.value, "uint8"),
             (self.message_identifier, "uint64"),
@@ -485,7 +496,7 @@ class LockExpired(EnvelopeMessage):
     secrethash: SecretHash
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendLockExpired) -> "LockExpired":
         balance_proof = event.balance_proof
 
         # pylint: disable=unexpected-keyword-arg

--- a/raiden/messages/withdraw.py
+++ b/raiden/messages/withdraw.py
@@ -3,6 +3,11 @@ from dataclasses import dataclass
 from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.abstract import SignedRetrieableMessage
 from raiden.messages.cmdid import CmdId
+from raiden.transfer.events import (
+    SendWithdrawConfirmation,
+    SendWithdrawExpired,
+    SendWithdrawRequest,
+)
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import (
     Address,
@@ -33,7 +38,7 @@ class WithdrawRequest(SignedRetrieableMessage):
     expiration: BlockExpiration
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendWithdrawRequest) -> "WithdrawRequest":
         return cls(
             message_identifier=event.message_identifier,
             chain_id=event.canonical_identifier.chain_identifier,
@@ -74,7 +79,7 @@ class WithdrawConfirmation(SignedRetrieableMessage):
     expiration: BlockExpiration
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendWithdrawConfirmation) -> "WithdrawConfirmation":
         return cls(
             message_identifier=event.message_identifier,
             chain_id=event.canonical_identifier.chain_identifier,
@@ -115,7 +120,7 @@ class WithdrawExpired(SignedRetrieableMessage):
     nonce: Nonce
 
     @classmethod
-    def from_event(cls, event):
+    def from_event(cls, event: SendWithdrawExpired) -> "WithdrawExpired":
         return cls(
             message_identifier=event.message_identifier,
             chain_id=event.canonical_identifier.chain_identifier,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -87,7 +87,7 @@ from raiden.utils import sha3
 from raiden.utils.packing import pack_withdraw
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.signer import LocalSigner
-from raiden.utils.typing import LockedAmount
+from raiden.utils.typing import EncodedData, LockedAmount
 
 PartnerStateModel = namedtuple(
     "PartnerStateModel",
@@ -1234,7 +1234,7 @@ def pending_locks_from_packed_data(packed: bytes) -> PendingLocksState:
     locks = make_empty_pending_locks_state()
     for i in range(0, number_of_bytes, 96):
         lock = Lock.from_bytes(packed[i : i + 96])
-        locks.locks.append(lock.as_bytes)  # pylint: disable=E1101
+        locks.locks.append(EncodedData(lock.as_bytes))  # pylint: disable=E1101
     return locks
 
 

--- a/raiden/tests/unit/test_messages.py
+++ b/raiden/tests/unit/test_messages.py
@@ -56,7 +56,7 @@ def test_request_monitoring() -> None:
     assert DictSerializer.deserialize(as_dict) == request_monitoring
     # RequestMonitoring can be created directly from BalanceProofSignedState
     direct_created = RequestMonitoring.from_balance_proof_signed_state(
-        balance_proof,
+        balance_proof=balance_proof,
         non_closing_participant=ADDRESS,
         reward_amount=TokenAmount(55),
         monitoring_service_contract_address=MSC_ADDRESS,
@@ -71,7 +71,7 @@ def test_request_monitoring() -> None:
     assert direct_created == request_monitoring
     other_balance_proof = factories.create(factories.replace(properties, message_hash=sha3(b"2")))
     other_instance = RequestMonitoring.from_balance_proof_signed_state(
-        other_balance_proof,
+        balance_proof=other_balance_proof,
         non_closing_participant=ADDRESS,
         reward_amount=TokenAmount(55),
         monitoring_service_contract_address=MSC_ADDRESS,

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -10,8 +10,8 @@ from raiden.utils.typing import (
     Address,
     BlockExpiration,
     List,
+    PaymentAmount,
     PaymentID,
-    PaymentWithFeeAmount,
     Secret,
     SecretHash,
     TokenAddress,
@@ -127,7 +127,7 @@ class SendSecretRequest(SendMessageEvent):
     """
 
     payment_identifier: PaymentID
-    amount: PaymentWithFeeAmount
+    amount: PaymentAmount
     expiration: BlockExpiration
     secrethash: SecretHash
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -27,6 +27,7 @@ from raiden.utils.typing import (
     BlockNumber,
     List,
     Optional,
+    PaymentAmount,
     TokenAmount,
 )
 
@@ -126,7 +127,7 @@ def handle_inittarget(
                 recipient=Address(recipient),
                 message_identifier=message_identifier,
                 payment_identifier=transfer.payment_identifier,
-                amount=transfer.lock.amount,
+                amount=PaymentAmount(transfer.lock.amount),
                 expiration=transfer.lock.expiration,
                 secrethash=transfer.lock.secrethash,
                 canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,8 +57,6 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 [mypy-raiden.ui.runners]
 disallow_untyped_defs = False
-[mypy-raiden.messages.*]
-disallow_untyped_defs = False
 [mypy-raiden.network.*]
 disallow_untyped_defs = False
 # ... but parts are


### PR DESCRIPTION
Part of #4033 

## Description

Add strict type checking for the `raiden.messages` module.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
