### PR TITLE
Refresh presence

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -408,7 +408,6 @@ class MatrixTransport(Runnable):
         self._client.sync_thread.link_exception(self.on_error)
         self._client.sync_thread.link_value(on_success)
         self.greenlets = [self._client.sync_thread]
-        self._schedule_new_greenlet(self._address_mgr.log_status_message)
 
         self._client.set_presence_state(UserPresence.ONLINE.value)
 
@@ -423,6 +422,9 @@ class MatrixTransport(Runnable):
         self._started = True
 
         self.log.debug("Matrix started", config=self._config)
+
+        # Spawn a greenlet to periodically refresh UserPresences
+        self._schedule_new_greenlet(self._address_mgr.refresh_presence, in_seconds_from_now=1)
 
         # Handle any delayed invites in the future
         self._schedule_new_greenlet(self._process_queued_invites, in_seconds_from_now=1)

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -294,12 +294,11 @@ class UserAddressManager:
         return user_id
 
     def _fetch_user_presence(self, user_id: str) -> UserPresence:
-        if user_id not in self._userid_to_presence:
-            try:
-                presence = UserPresence(self._client.get_user_presence(user_id))
-            except MatrixRequestError:
-                presence = UserPresence.UNKNOWN
-            self._userid_to_presence[user_id] = presence
+        try:
+            presence = UserPresence(self._client.get_user_presence(user_id))
+        except MatrixRequestError:
+            presence = UserPresence.UNKNOWN
+        self._userid_to_presence[user_id] = presence
         return self._userid_to_presence[user_id]
 
     @staticmethod

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -265,8 +265,14 @@ class UserAddressManager:
         if self._user_presence_changed_callback:
             self._user_presence_changed_callback(user, new_state)
 
-    def log_status_message(self) -> None:
+    def refresh_presence(self) -> None:
         while not self._stop_event.ready():
+            # Refresh our own presence to Online
+            self._client.set_presence_state(UserPresence.ONLINE.value)
+            # Refresh our view of the presence of our peers
+            for address in self.known_addresses:
+                self.refresh_address_presence(address)
+
             addresses_uids_presence = {
                 to_checksum_address(address): {
                     user_id: self.get_userid_presence(user_id).value
@@ -276,7 +282,7 @@ class UserAddressManager:
             }
 
             log.debug(
-                "Matrix address manager status",
+                "Presences refreshed - current Matrix address manager status:",
                 addresses_uids_and_presence=addresses_uids_presence,
                 current_user=self._user_id,
             )


### PR DESCRIPTION
Description

This PR
- removes caching from UserAddressManager._fetch_user_presence to give us the most recent Reachability
- adds a Greenlet, that set our Presence periodically and fetches PresenceUpdates from our peers. 

Rationale: 
We might miss PresenceUpdates from the Server or the Server might fail to notify us. With this PR, we renew our own Presence with the Server and poll for PR Reachability.

## PR review check list

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [x] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
