### PR TITLE
Enable `check_untyped_defs` in `tests/integration/transfer`

### DIFF
--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -1,9 +1,7 @@
-import random
-
 import pytest
 
 from raiden.api.python import RaidenAPI
-from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX
+from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.metadata import Metadata, RouteMetadata
 from raiden.messages.transfers import Lock, LockedTransfer
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -11,6 +9,8 @@ from raiden.tests.utils.factories import (
     UNIT_CHAIN_ID,
     UNIT_SECRETHASH,
     make_address,
+    make_locksroot,
+    make_message_identifier,
     make_privkey_address,
 )
 from raiden.tests.utils.network import CHAIN
@@ -25,6 +25,14 @@ from raiden.tests.utils.transfer import (
 from raiden.transfer import views
 from raiden.transfer.events import EventPaymentSentFailed
 from raiden.utils.signer import LocalSigner
+from raiden.utils.typing import (
+    InitiatorAddress,
+    Nonce,
+    PaymentAmount,
+    PaymentID,
+    PaymentWithFeeAmount,
+    TokenAmount,
+)
 
 
 @raise_on_failure
@@ -40,6 +48,7 @@ def test_failsfast_lockedtransfer_exceeding_distributable(
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), token_network_registry_address, token_address
     )
+    assert token_network_address
     payment_status = app0.raiden.mediated_transfer_async(
         token_network_address, deposit * 2, app1.raiden.address, identifier=1
     )
@@ -80,35 +89,37 @@ def test_receive_lockedtransfer_invalidnonce(
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), app0.raiden.default_registry.address, token_address
     )
+    assert token_network_address
     channel0 = get_channelstate(app0, app1, token_network_address)
 
     amount = 10
+    payment_identifier = PaymentID(1)
     secrethash = transfer(
         initiator_app=app0,
         target_app=app2,
         token_address=token_address,
-        amount=amount,
-        identifier=1,
+        amount=PaymentAmount(10),
+        identifier=payment_identifier,
         timeout=network_wait * number_of_nodes,
     )
 
-    amount = 10
-    payment_identifier = 1
-    repeated_nonce = 1
+    repeated_nonce = Nonce(1)
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
-        message_identifier=random.randint(0, UINT64_MAX),
+        message_identifier=make_message_identifier(),
         payment_identifier=payment_identifier,
         nonce=repeated_nonce,
         token_network_address=token_network_address,
         token=token_address,
         channel_identifier=channel0.identifier,
-        transferred_amount=amount,
-        locked_amount=amount,
+        transferred_amount=TokenAmount(amount),
+        locked_amount=TokenAmount(amount),
         recipient=app1.raiden.address,
-        locksroot=UNIT_SECRETHASH,
-        lock=Lock(amount=amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
+        locksroot=make_locksroot(),
+        lock=Lock(
+            amount=PaymentWithFeeAmount(amount), expiration=expiration, secrethash=UNIT_SECRETHASH
+        ),
         target=app2.raiden.address,
         initiator=app0.raiden.address,
         signature=EMPTY_SIGNATURE,
@@ -145,24 +156,29 @@ def test_receive_lockedtransfer_invalidsender(
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), app0.raiden.default_registry.address, token_address
     )
+    assert token_network_address
     channel0 = get_channelstate(app0, app1, token_network_address)
-    lock_amount = 10
+    lock_amount = TokenAmount(10)
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
-        message_identifier=random.randint(0, UINT64_MAX),
-        payment_identifier=1,
-        nonce=1,
+        message_identifier=make_message_identifier(),
+        payment_identifier=PaymentID(1),
+        nonce=Nonce(1),
         token_network_address=token_network_address,
         token=token_address,
         channel_identifier=channel0.identifier,
-        transferred_amount=0,
+        transferred_amount=TokenAmount(0),
         locked_amount=lock_amount,
         recipient=app0.raiden.address,
-        locksroot=UNIT_SECRETHASH,
-        lock=Lock(amount=lock_amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
+        locksroot=make_locksroot(),
+        lock=Lock(
+            amount=PaymentWithFeeAmount(lock_amount),
+            expiration=expiration,
+            secrethash=UNIT_SECRETHASH,
+        ),
         target=app0.raiden.address,
-        initiator=other_address,
+        initiator=InitiatorAddress(other_address),
         signature=EMPTY_SIGNATURE,
         metadata=Metadata(routes=[RouteMetadata(route=[app0.raiden.address])]),
     )
@@ -183,25 +199,30 @@ def test_receive_lockedtransfer_invalidrecipient(
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), app0.raiden.default_registry.address, token_address
     )
+    assert token_network_address
     channel0 = get_channelstate(app0, app1, token_network_address)
 
-    payment_identifier = 1
+    payment_identifier = PaymentID(1)
     invalid_recipient = make_address()
-    lock_amount = 10
+    lock_amount = TokenAmount(10)
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
-        message_identifier=random.randint(0, UINT64_MAX),
+        message_identifier=make_message_identifier(),
         payment_identifier=payment_identifier,
-        nonce=1,
+        nonce=Nonce(1),
         token_network_address=token_network_address,
         token=token_address,
         channel_identifier=channel0.identifier,
-        transferred_amount=0,
+        transferred_amount=TokenAmount(0),
         locked_amount=lock_amount,
         recipient=invalid_recipient,
-        locksroot=UNIT_SECRETHASH,
-        lock=Lock(amount=lock_amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
+        locksroot=make_locksroot(),
+        lock=Lock(
+            amount=PaymentWithFeeAmount(lock_amount),
+            expiration=expiration,
+            secrethash=UNIT_SECRETHASH,
+        ),
         target=app1.raiden.address,
         initiator=app0.raiden.address,
         signature=EMPTY_SIGNATURE,
@@ -226,6 +247,7 @@ def test_received_lockedtransfer_closedchannel(
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), app0.raiden.default_registry.address, token_address
     )
+    assert token_network_address
     channel0 = get_channelstate(app0, app1, token_network_address)
 
     RaidenAPI(app1.raiden).channel_close(registry_address, token_address, app0.raiden.address)
@@ -235,22 +257,26 @@ def test_received_lockedtransfer_closedchannel(
     )
 
     # Now receive one mediated transfer for the closed channel
-    lock_amount = 10
-    payment_identifier = 1
+    lock_amount = TokenAmount(10)
+    payment_identifier = PaymentID(1)
     expiration = reveal_timeout * 2
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
-        message_identifier=random.randint(0, UINT64_MAX),
+        message_identifier=make_message_identifier(),
         payment_identifier=payment_identifier,
-        nonce=1,
+        nonce=Nonce(1),
         token_network_address=token_network_address,
         token=token_address,
         channel_identifier=channel0.identifier,
-        transferred_amount=0,
+        transferred_amount=TokenAmount(0),
         locked_amount=lock_amount,
         recipient=app1.raiden.address,
-        locksroot=UNIT_SECRETHASH,
-        lock=Lock(amount=lock_amount, expiration=expiration, secrethash=UNIT_SECRETHASH),
+        locksroot=make_locksroot(),
+        lock=Lock(
+            amount=PaymentWithFeeAmount(lock_amount),
+            expiration=expiration,
+            secrethash=UNIT_SECRETHASH,
+        ),
         target=app1.raiden.address,
         initiator=app0.raiden.address,
         signature=EMPTY_SIGNATURE,

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -85,11 +85,9 @@ def test_refund_messages(raiden_chain, token_addresses, deposit, network_wait):
         {"transfer": {"lock": {"amount": refund_amount_with_fees}}},
     )
     assert send_lockedtransfer
-    send_lockedtransfer = cast(SendLockedTransfer, send_lockedtransfer)
 
     send_refundtransfer = raiden_events_search_for_item(app1.raiden, SendRefundTransfer, {})
     assert send_refundtransfer
-    send_refundtransfer = cast(SendRefundTransfer, send_lockedtransfer)
 
     with gevent.Timeout(network_wait):
         wait_assert(
@@ -202,12 +200,10 @@ def test_refund_transfer(
         {"transfer": {"lock": {"amount": amount_refund_with_fees}}},
     )
     assert send_locked
-    send_locked = cast(SendLockedTransfer, send_locked)
     secrethash = send_locked.transfer.lock.secrethash
 
     send_refund = raiden_events_search_for_item(app1.raiden, SendRefundTransfer, {})
     assert send_refund
-    send_refund = cast(SendRefundTransfer, send_refund)
 
     lock = send_locked.transfer.lock
     refund_lock = send_refund.transfer.lock
@@ -400,11 +396,9 @@ def test_different_view_of_last_bp_during_unlock(
         {"transfer": {"lock": {"amount": amount_refund_with_fees}}},
     )
     assert send_locked
-    send_locked = cast(SendLockedTransfer, send_locked)
     secrethash = send_locked.transfer.lock.secrethash
 
     send_refund = raiden_events_search_for_item(app1.raiden, SendRefundTransfer, {})
-    send_refund = cast(SendRefundTransfer, send_refund)
     assert send_refund
 
     lock = send_locked.transfer.lock
@@ -622,11 +616,9 @@ def test_refund_transfer_after_2nd_hop(
         {"transfer": {"lock": {"amount": amount_refund_with_fees}}},
     )
     assert send_locked1
-    send_locked1 = cast(SendLockedTransfer, send_locked1)
 
     send_refund1 = raiden_events_search_for_item(app1.raiden, SendRefundTransfer, {})
     assert send_refund1
-    send_refund1 = cast(SendRefundTransfer, send_refund1)
 
     lock1 = send_locked1.transfer.lock
     refund_lock1 = send_refund1.transfer.lock
@@ -639,11 +631,9 @@ def test_refund_transfer_after_2nd_hop(
         {"transfer": {"lock": {"amount": amount_refund_with_fees}}},
     )
     assert send_locked2
-    send_locked2 = cast(SendLockedTransfer, send_locked2)
 
     send_refund2 = raiden_events_search_for_item(app2.raiden, SendRefundTransfer, {})
     assert send_refund2
-    send_refund2 = cast(SendRefundTransfer, send_refund2)
 
     lock2 = send_locked2.transfer.lock
     refund_lock2 = send_refund2.transfer.lock

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import gevent
 import pytest
 
@@ -266,7 +264,6 @@ def test_refund_transfer(
     receive_lock_expired = wait_for_state_change(
         app0.raiden, ReceiveLockExpired, {"secrethash": secrethash}, retry_timeout
     )
-    receive_lock_expired = cast(ReceiveLockExpired, receive_lock_expired)
     # And also till app1 received the processed
     wait_for_state_change(
         app1.raiden,
@@ -497,7 +494,6 @@ def test_different_view_of_last_bp_during_unlock(
             retry_timeout,
         )
     assert unlock_app0
-    unlock_app0 = cast(ContractReceiveChannelBatchUnlock, unlock_app0)
     assert unlock_app0.returned_tokens == amount_refund_with_fees
     with gevent.Timeout(timeout):
         unlock_app1 = wait_for_state_change(
@@ -507,7 +503,6 @@ def test_different_view_of_last_bp_during_unlock(
             retry_timeout,
         )
     assert unlock_app1
-    unlock_app1 = cast(ContractReceiveChannelBatchUnlock, unlock_app1)
     assert unlock_app1.returned_tokens == amount_refund_with_fees
     final_balance0 = token_proxy.balance_of(app0.raiden.address)
     final_balance1 = token_proxy.balance_of(app1.raiden.address)

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -10,8 +10,7 @@ from raiden.transfer.mediated_transfer.events import EventUnlockClaimFailed, Eve
 
 NOVALUE = object()
 T = TypeVar("T")
-T_Event = TypeVar("T_Event", bound="Event")
-T_StateChange = TypeVar("T_StateChange", bound="StateChange")
+TE = TypeVar("TE", bound=Event)
 SC = TypeVar("SC", bound=StateChange)
 TM = TypeVar("TM", bound=Mapping)
 
@@ -87,8 +86,8 @@ def search_for_item(
 
 
 def raiden_events_search_for_item(
-    raiden: RaidenService, item_type: Type[T_Event], attributes: Mapping
-) -> Optional[T_Event]:
+    raiden: RaidenService, item_type: Type[TE], attributes: Mapping
+) -> Optional[TE]:
     """ Search for the first event of type `item_type` with `attributes` in the
     `raiden` database.
 
@@ -96,7 +95,7 @@ def raiden_events_search_for_item(
     """
     assert raiden.wal, "RaidenService must be started"
     event = search_for_item(raiden.wal.storage.get_events(), item_type, attributes)
-    return cast(T_Event, event)
+    return cast(TE, event)
 
 
 def raiden_state_changes_search_for_item(
@@ -162,11 +161,8 @@ def wait_for_raiden_event(
 
 
 def wait_for_state_change(
-    raiden: RaidenService,
-    item_type: Type[T_StateChange],
-    attributes: Mapping,
-    retry_timeout: float,
-) -> T_StateChange:
+    raiden: RaidenService, item_type: Type[SC], attributes: Mapping, retry_timeout: float
+) -> SC:
     """Wait until a state change is seen in the WAL
 
     Note:

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -11,6 +11,7 @@ from raiden.transfer.mediated_transfer.events import EventUnlockClaimFailed, Eve
 NOVALUE = object()
 T = TypeVar("T")
 T_Event = TypeVar("T_Event", bound="Event")
+T_StateChange = TypeVar("T_StateChange", bound="StateChange")
 SC = TypeVar("SC", bound=StateChange)
 TM = TypeVar("TM", bound=Mapping)
 
@@ -161,8 +162,11 @@ def wait_for_raiden_event(
 
 
 def wait_for_state_change(
-    raiden: RaidenService, item_type: Type[StateChange], attributes: Mapping, retry_timeout: float
-) -> Optional[StateChange]:
+    raiden: RaidenService,
+    item_type: Type[T_StateChange],
+    attributes: Mapping,
+    retry_timeout: float,
+) -> T_StateChange:
     """Wait until a state change is seen in the WAL
 
     Note:

--- a/raiden/tests/utils/events.py
+++ b/raiden/tests/utils/events.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from typing import Any, Iterable, List, Optional, Tuple, Type, TypeVar, cast
 
 import gevent
 
@@ -6,10 +7,10 @@ from raiden.raiden_service import RaidenService
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.transfer.architecture import Event, StateChange
 from raiden.transfer.mediated_transfer.events import EventUnlockClaimFailed, EventUnlockFailed
-from raiden.utils.typing import Any, Iterable, List, Optional, Tuple, Type, TypeVar
 
 NOVALUE = object()
 T = TypeVar("T")
+T_Event = TypeVar("T_Event", bound="Event")
 SC = TypeVar("SC", bound=StateChange)
 TM = TypeVar("TM", bound=Mapping)
 
@@ -85,15 +86,16 @@ def search_for_item(
 
 
 def raiden_events_search_for_item(
-    raiden: RaidenService, item_type: Type[Event], attributes: Mapping
-) -> Optional[Event]:
+    raiden: RaidenService, item_type: Type[T_Event], attributes: Mapping
+) -> Optional[T_Event]:
     """ Search for the first event of type `item_type` with `attributes` in the
     `raiden` database.
 
     `attributes` are compared using the utility `check_nested_attrs`.
     """
     assert raiden.wal, "RaidenService must be started"
-    return search_for_item(raiden.wal.storage.get_events(), item_type, attributes)
+    event = search_for_item(raiden.wal.storage.get_events(), item_type, attributes)
+    return cast(T_Event, event)
 
 
 def raiden_state_changes_search_for_item(

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -1075,5 +1075,7 @@ def block_timeout_for_transfer_by_secrethash(
     )
 
 
-def calculate_fee_for_amount(amount: int) -> int:
-    return round((amount * INTERNAL_ROUTING_DEFAULT_FEE_PERC) * (1 + DEFAULT_MEDIATION_FEE_MARGIN))
+def calculate_fee_for_amount(amount: int) -> FeeAmount:
+    return FeeAmount(
+        round((amount * INTERNAL_ROUTING_DEFAULT_FEE_PERC) * (1 + DEFAULT_MEDIATION_FEE_MARGIN))
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,3 +97,5 @@ check_untyped_defs = True
 check_untyped_defs = True
 [mypy-raiden.tests.integration.transfer.test_mediatedtransfer]
 check_untyped_defs = True
+[mypy-raiden.tests.integration.transfer.test_refundtransfer]
+check_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,11 +91,5 @@ check_untyped_defs = True
 check_untyped_defs = True
 [mypy-raiden.tests.utils.*]
 check_untyped_defs = True
-[mypy-raiden.tests.integration.transfer.test_mediatedtransfer_events]
-check_untyped_defs = True
-[mypy-raiden.tests.integration.transfer.test_refund_invalid]
-check_untyped_defs = True
-[mypy-raiden.tests.integration.transfer.test_mediatedtransfer]
-check_untyped_defs = True
-[mypy-raiden.tests.integration.transfer.test_refundtransfer]
+[mypy-raiden.tests.integration.transfer.*]
 check_untyped_defs = True


### PR DESCRIPTION
The next step will be to enable it for all integration tests except those in `raiden/tests/integration/network`. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
