### PR TITLE
Handle insufficient eth during channel settlement

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -63,6 +63,7 @@ from raiden.exceptions import (
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
+    InsufficientEth,
     InsufficientFunds,
     InsufficientGasReserve,
     InvalidAmount,
@@ -570,7 +571,7 @@ class RestAPI:  # pragma: no unittest
             )
         except conflict_exceptions as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
-        except InsufficientFunds as e:
+        except InsufficientEth as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
         return api_response(
@@ -660,7 +661,7 @@ class RestAPI:  # pragma: no unittest
             TokenNotRegistered,
         ) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
-        except (InsufficientFunds, InsufficientGasReserve) as e:
+        except (InsufficientEth, InsufficientFunds, InsufficientGasReserve) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
         if total_deposit:
@@ -680,7 +681,7 @@ class RestAPI:  # pragma: no unittest
                     partner_address=partner_address,
                     total_deposit=total_deposit,
                 )
-            except InsufficientFunds as e:
+            except (InsufficientEth, InsufficientFunds) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
             except (NonexistingChannel, UnknownTokenAddress) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
@@ -723,7 +724,7 @@ class RestAPI:  # pragma: no unittest
                 initial_channel_target,
                 joinable_funds_target,
             )
-        except (InsufficientFunds, InsufficientGasReserve) as e:
+        except (InsufficientEth, InsufficientFunds, InsufficientGasReserve) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
         except (InvalidAmount, InvalidBinaryAddress) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
@@ -1125,7 +1126,7 @@ class RestAPI:  # pragma: no unittest
                 channel_state.partner_state.address,
                 total_deposit,
             )
-        except InsufficientFunds as e:
+        except (InsufficientEth, InsufficientFunds) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
         except DepositOverLimit as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
@@ -1173,6 +1174,7 @@ class RestAPI:  # pragma: no unittest
             return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
         except (InsufficientFunds, WithdrawMismatch) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
+        # TODO handle InsufficientEth here
 
         updated_channel_state = self.raiden_api.get_channel(
             registry_address, channel_state.token_address, channel_state.partner_state.address
@@ -1239,7 +1241,7 @@ class RestAPI:  # pragma: no unittest
             self.raiden_api.channel_close(
                 registry_address, channel_state.token_address, channel_state.partner_state.address
             )
-        except InsufficientFunds as e:
+        except InsufficientEth as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
         updated_channel_state = self.raiden_api.get_channel(

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -13,6 +13,7 @@ from raiden.exceptions import (
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
+    InsufficientEth,
     InsufficientFunds,
     InvalidAmount,
     InvalidDBData,
@@ -38,6 +39,7 @@ log = structlog.get_logger(__name__)
 RECOVERABLE_ERRORS = (
     DepositMismatch,
     DepositOverLimit,
+    InsufficientEth,
     InsufficientFunds,
     RaidenRecoverableError,
     UnexpectedChannelState,

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -286,6 +286,13 @@ class InsufficientGasReserve(RaidenError):
     """
 
 
+class InsufficientEth(RaidenError):
+    """ Raised when an on-chain action failed because we could not pay for
+    the gas. (The case we try to avoid with `InsufficientGasReserve`
+    exceptions.)
+    """
+
+
 class BrokenPreconditionError(RaidenError):
     """ Raised when the chain doesn't satisfy transaction preconditions
     that proxies check at the specified block.

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -24,7 +24,7 @@ from raiden.exceptions import (
     AddressWithoutCode,
     ContractCodeMismatch,
     EthNodeInterfaceError,
-    InsufficientFunds,
+    InsufficientEth,
 )
 from raiden.network.rpc.middleware import block_hash_cache_middleware
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
@@ -707,8 +707,8 @@ class JSONRPCClient:
     ) -> None:
         """ After estimate gas failure checks if our address has enough balance.
 
-        If the account did not have enough ETH balance to execute the,
-        transaction then it raises an `InsufficientFunds` error.
+        If the account did not have enough ETH balance to execute the
+        transaction, it raises an `InsufficientEth` error.
 
         Note:
             This check contains a race condition, it could be the case that a
@@ -724,7 +724,7 @@ class JSONRPCClient:
         if balance < required_balance:
             msg = f"Failed to execute {transaction_name} due to insufficient ETH"
             log.critical(msg, required_wei=required_balance, actual_wei=balance)
-            raise InsufficientFunds(msg)
+            raise InsufficientEth(msg)
 
     def get_checking_block(self) -> BlockSpecification:
         """Workaround for parity https://github.com/paritytech/parity-ethereum/issues/9707

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -11,6 +11,7 @@ from raiden.blockchain.filters import decode_event
 from raiden.constants import EthClient
 from raiden.exceptions import (
     InsufficientFunds,
+    RaidenUnrecoverableError,
     ReplacementTransactionUnderpriced,
     TransactionAlreadyPending,
 )
@@ -125,7 +126,9 @@ class ContractProxy:
                         "local transaction pool. Bailing ..."
                     )
 
-            raise e
+            raise RaidenUnrecoverableError(
+                f"Unexpected error in underlying Ethereum node: {str(e)}"
+            )
 
         return tx_hash
 

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -10,7 +10,7 @@ from raiden import constants
 from raiden.blockchain.filters import decode_event
 from raiden.constants import EthClient
 from raiden.exceptions import (
-    InsufficientFunds,
+    InsufficientEth,
     RaidenUnrecoverableError,
     ReplacementTransactionUnderpriced,
     TransactionAlreadyPending,
@@ -95,7 +95,10 @@ class ContractProxy:
         except ValueError as e:
             action = inspect_client_error(e, self.rpc_client.eth_node)
             if action == ClientErrorInspectResult.INSUFFICIENT_FUNDS:
-                raise InsufficientFunds("Insufficient ETH for transaction")
+                raise InsufficientEth(
+                    "Transaction failed due to insufficient ETH balance. "
+                    "Please top up your ETH account."
+                )
             elif action == ClientErrorInspectResult.TRANSACTION_UNDERPRICED:
                 raise ReplacementTransactionUnderpriced(
                     "Transaction was rejected. This is potentially "

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -11,7 +11,7 @@ from raiden.constants import (
     EMPTY_SIGNATURE,
     LOCKSROOT_OF_NO_LOCKS,
 )
-from raiden.exceptions import RaidenUnrecoverableError
+from raiden.exceptions import InsufficientEth, RaidenUnrecoverableError
 from raiden.messages.encode import message_from_sendevent
 from raiden.network.pathfinding import post_pfs_feedback
 from raiden.network.proxies.payment_channel import PaymentChannel
@@ -357,7 +357,12 @@ class RaidenEventHandler(EventHandler):
     def handle_contract_send_secretreveal(
         raiden: "RaidenService", channel_reveal_secret_event: ContractSendSecretReveal
     ) -> None:  # pragma: no unittest
-        raiden.default_secret_registry.register_secret(secret=channel_reveal_secret_event.secret)
+        try:
+            raiden.default_secret_registry.register_secret(
+                secret=channel_reveal_secret_event.secret
+            )
+        except InsufficientEth as e:
+            raise RaidenUnrecoverableError(str(e)) from e
 
     @staticmethod
     def handle_contract_send_channelwithdraw(
@@ -375,13 +380,16 @@ class RaidenEventHandler(EventHandler):
             canonical_identifier=channel_withdraw_event.canonical_identifier
         )
 
-        channel_proxy.set_total_withdraw(
-            total_withdraw=channel_withdraw_event.total_withdraw,
-            expiration_block=channel_withdraw_event.expiration,
-            participant_signature=our_signature,
-            partner_signature=channel_withdraw_event.partner_signature,
-            block_identifier=channel_withdraw_event.triggered_by_block_hash,
-        )
+        try:
+            channel_proxy.set_total_withdraw(
+                total_withdraw=channel_withdraw_event.total_withdraw,
+                expiration_block=channel_withdraw_event.expiration,
+                participant_signature=our_signature,
+                partner_signature=channel_withdraw_event.partner_signature,
+                block_identifier=channel_withdraw_event.triggered_by_block_hash,
+            )
+        except InsufficientEth as e:
+            raise RaidenUnrecoverableError(str(e)) from e
 
     @staticmethod
     def handle_contract_send_channelclose(
@@ -455,14 +463,22 @@ class RaidenEventHandler(EventHandler):
             )
             our_signature = raiden.signer.sign(data=non_closing_data)
 
-            channel.update_transfer(
-                nonce=balance_proof.nonce,
-                balance_hash=balance_proof.balance_hash,
-                additional_hash=balance_proof.message_hash,
-                partner_signature=balance_proof.signature,
-                signature=our_signature,
-                block_identifier=channel_update_event.triggered_by_block_hash,
-            )
+            try:
+                channel.update_transfer(
+                    nonce=balance_proof.nonce,
+                    balance_hash=balance_proof.balance_hash,
+                    additional_hash=balance_proof.message_hash,
+                    partner_signature=balance_proof.signature,
+                    signature=our_signature,
+                    block_identifier=channel_update_event.triggered_by_block_hash,
+                )
+            except InsufficientEth as e:
+                raise RaidenUnrecoverableError(
+                    f"{str(e)}\n"
+                    "CAUTION: This happened when updating our side of the channel "
+                    "during a channel settlement. You are in immediate danger of "
+                    "losing funds in this channel."
+                ) from e
 
     @staticmethod
     def handle_contract_send_channelunlock(
@@ -594,13 +610,16 @@ class RaidenEventHandler(EventHandler):
                 and gain.from_our_locks == 0
             )
             if not skip_unlock:
-                unlock(
-                    payment_channel=payment_channel,
-                    end_state=restored_channel_state.our_state,
-                    sender=our_address,
-                    receiver=partner_address,
-                    given_block_identifier=channel_unlock_event.triggered_by_block_hash,
-                )
+                try:
+                    unlock(
+                        payment_channel=payment_channel,
+                        end_state=restored_channel_state.our_state,
+                        sender=our_address,
+                        receiver=partner_address,
+                        given_block_identifier=channel_unlock_event.triggered_by_block_hash,
+                    )
+                except InsufficientEth as e:
+                    raise RaidenUnrecoverableError(str(e)) from e
 
     @staticmethod
     def handle_contract_send_channelsettle(
@@ -706,15 +725,18 @@ class RaidenEventHandler(EventHandler):
             partner_locked_amount = 0
             partner_locksroot = LOCKSROOT_OF_NO_LOCKS
 
-        payment_channel.settle(
-            transferred_amount=our_transferred_amount,
-            locked_amount=our_locked_amount,
-            locksroot=our_locksroot,
-            partner_transferred_amount=partner_transferred_amount,
-            partner_locked_amount=partner_locked_amount,
-            partner_locksroot=partner_locksroot,
-            block_identifier=triggered_by_block_hash,
-        )
+        try:
+            payment_channel.settle(
+                transferred_amount=our_transferred_amount,
+                locked_amount=our_locked_amount,
+                locksroot=our_locksroot,
+                partner_transferred_amount=partner_transferred_amount,
+                partner_locked_amount=partner_locked_amount,
+                partner_locksroot=partner_locksroot,
+                block_identifier=triggered_by_block_hash,
+            )
+        except InsufficientEth as e:
+            raise RaidenUnrecoverableError(str(e)) from e
 
 
 class PFSFeedbackEventHandler(RaidenEventHandler):

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -712,7 +712,7 @@ def test_api_close_insufficient_eth(api_server_test_instance, token_addresses, r
     response = request.send().response
     assert_proper_response(response, HTTPStatus.PAYMENT_REQUIRED)
     json_response = get_json_response(response)
-    assert "Insufficient ETH" in json_response["errors"]
+    assert "insufficient ETH" in json_response["errors"]
 
 
 @pytest.mark.parametrize("number_of_nodes", [1])

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -15,7 +15,7 @@ from raiden.constants import (
     PATH_FINDING_BROADCASTING_ROOM,
     RoutingMode,
 )
-from raiden.exceptions import InsufficientFunds
+from raiden.exceptions import InsufficientEth
 from raiden.messages.matrix import ToDevice
 from raiden.messages.path_finding_service import PFSFeeUpdate
 from raiden.messages.synchronization import Delivered, Processed
@@ -261,7 +261,7 @@ def test_matrix_tx_error_handling(  # pylint: disable=unused-argument
     app0.raiden.transport._client.add_presence_listener(make_tx)
 
     exception = ValueError("Exception was not raised from the transport")
-    with pytest.raises(InsufficientFunds), gevent.Timeout(10, exception=exception):
+    with pytest.raises(InsufficientEth), gevent.Timeout(10, exception=exception):
         # Change presence in peer app to trigger callback in app0
         app1.raiden.transport._client.set_presence_state(UserPresence.UNAVAILABLE.value)
         app0.raiden.get()

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -1,7 +1,7 @@
 import pytest
 from eth_utils import to_checksum_address
 
-from raiden.exceptions import InsufficientFunds
+from raiden.exceptions import InsufficientEth
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
@@ -62,7 +62,7 @@ def test_transact_opcode_oog(deploy_client):
     assert check_transaction_threw(receipt=receipt), "must not be empty"
 
 
-def test_transact_fail_if_the_account_does_not_have_enough_eth_to_pay_for_thegas(deploy_client):
+def test_transact_fails_if_the_account_does_not_have_enough_eth_to_pay_for_the_gas(deploy_client):
     """ The gas estimation does not fail if the transaction execution requires
     more gas then the account's eth balance. However sending the transaction
     will.
@@ -75,5 +75,5 @@ def test_transact_fail_if_the_account_does_not_have_enough_eth_to_pay_for_thegas
     assert startgas, "The gas estimation should not have failed."
 
     burn_eth(deploy_client, amount_to_leave=startgas // 2)
-    with pytest.raises(InsufficientFunds):
+    with pytest.raises(InsufficientEth):
         contract_proxy.transact("loop", startgas, 1000)

--- a/raiden/tests/integration/test_pythonapi.py
+++ b/raiden/tests/integration/test_pythonapi.py
@@ -11,7 +11,7 @@ from raiden.constants import UINT256_MAX, Environment
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
     DepositOverLimit,
-    InsufficientFunds,
+    InsufficientEth,
     InsufficientGasReserve,
     InvalidBinaryAddress,
 )
@@ -128,8 +128,7 @@ def test_register_token_insufficient_eth(raiden_network, retry_timeout, unregist
     # app1.raiden loses all its ETH because it has been naughty
     burn_eth(app1.raiden.rpc_client)
 
-    # At this point we should get an UnrecoverableError due to InsufficientFunds
-    with pytest.raises(InsufficientFunds):
+    with pytest.raises(InsufficientEth):
         api1.token_network_register(
             registry_address=registry_address,
             token_address=token_address,


### PR DESCRIPTION
This PR introduces an exception class for the case that onchain actions fail due to insufficient eth, and handles it by issuing a warning.

Related issue: #1861

Closes #5048 (issue from manual testing where this surfaced recently)

For the nonce mismatches in #5048, there will be a follow-up issue and pull request.

We also introcude an exception class for unexpected errors of the eth node. Raiden will still crash when that happens, but we want to avoid crashing with cryptic error messages like `ValueError: {'code': -32000}`
