### PR TITLE
Enable strrict mypy checks for raiden.network.rpc

### DIFF
--- a/raiden/network/proxies/proxy_manager.py
+++ b/raiden/network/proxies/proxy_manager.py
@@ -116,8 +116,8 @@ class ProxyManager:
         delta = last_timestamp - first_timestamp
         return delta / interval
 
-    def next_block(self) -> int:
-        target_block_number = self.client.block_number() + 1
+    def next_block(self) -> BlockNumber:
+        target_block_number = BlockNumber(self.client.block_number() + 1)
         self.wait_until_block(target_block_number=target_block_number)
         return target_block_number
 

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -265,7 +265,8 @@ class SecretRegistry:
             #
             # Either of these is a bug. The contract does not use
             # assert/revert, and the account should always be funded
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            assert gas_limit
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="registerSecretBatch",
                 transaction_executed=True,
                 required_gas=gas_limit,

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -125,11 +125,11 @@ class Token:
                         )
 
                 else:
-                    failed_at = self.proxy.jsonrpc_client.get_block("latest")
+                    failed_at = self.proxy.rpc_client.get_block("latest")
                     failed_at_blockhash = encode_hex(failed_at["hash"])
                     failed_at_blocknumber = failed_at["number"]
 
-                    self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                    self.proxy.rpc_client.check_for_insufficient_eth(
                         transaction_name="approve",
                         transaction_executed=False,
                         required_gas=GAS_REQUIRED_FOR_APPROVE,
@@ -216,7 +216,7 @@ class Token:
                         self.client.blockhash_from_blocknumber(failed_at_number)
                     )
 
-                    self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                    self.proxy.rpc_client.check_for_insufficient_eth(
                         transaction_name="transfer",
                         transaction_executed=False,
                         required_gas=GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -306,11 +306,11 @@ class TokenNetwork:
             settle_timeout=settle_timeout,
         )
         if not gas_limit:
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blockhash = encode_hex(failed_at["hash"])
             failed_at_blocknumber = failed_at["number"]
 
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="openChannel",
                 transaction_executed=False,
                 required_gas=self.metadata.gas_measurements["TokenNetwork.openChannel"],
@@ -1072,11 +1072,11 @@ class TokenNetwork:
         else:
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blockhash = encode_hex(failed_at["hash"])
             failed_at_blocknumber = failed_at["number"]
 
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="setTotalDeposit",
                 transaction_executed=False,
                 required_gas=self.metadata.gas_measurements["TokenNetwork.setTotalDeposit"],
@@ -1483,11 +1483,11 @@ class TokenNetwork:
 
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blockhash = encode_hex(failed_at["hash"])
             failed_at_blocknumber = failed_at["number"]
 
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="total_withdraw",
                 transaction_executed=False,
                 required_gas=self.metadata.gas_measurements["TokenNetwork.setTotalWithdraw"],
@@ -1756,11 +1756,11 @@ class TokenNetwork:
 
                 # The latest block can not be used reliably because of reorgs,
                 # therefore every call using this block has to handle pruned data.
-                failed_at = self.proxy.jsonrpc_client.get_block("latest")
+                failed_at = self.proxy.rpc_client.get_block("latest")
                 failed_at_blockhash = encode_hex(failed_at["hash"])
                 failed_at_blocknumber = failed_at["number"]
 
-                self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                self.proxy.rpc_client.check_for_insufficient_eth(
                     transaction_name="closeChannel",
                     transaction_executed=True,
                     required_gas=self.metadata.gas_measurements["TokenNetwork.closeChannel"],
@@ -2072,11 +2072,11 @@ class TokenNetwork:
 
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blockhash = encode_hex(failed_at["hash"])
             failed_at_blocknumber = failed_at["number"]
 
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="updateNonClosingBalanceProof",
                 transaction_executed=False,
                 required_gas=self.metadata.gas_measurements[
@@ -2276,11 +2276,11 @@ class TokenNetwork:
 
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blockhash = encode_hex(failed_at["hash"])
             failed_at_blocknumber = failed_at["number"]
 
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="unlock",
                 transaction_executed=False,
                 required_gas=UNLOCK_TX_GAS_LIMIT,
@@ -2486,7 +2486,7 @@ class TokenNetwork:
                 failed_at_blockhash = encode_hex(failed_receipt["blockHash"])
                 failed_at_blocknumber = failed_receipt["blockNumber"]
 
-                self.proxy.jsonrpc_client.check_for_insufficient_eth(
+                self.proxy.rpc_client.check_for_insufficient_eth(
                     transaction_name="settleChannel",
                     transaction_executed=True,
                     required_gas=self.metadata.gas_measurements["TokenNetwork.settleChannel"],
@@ -2573,7 +2573,7 @@ class TokenNetwork:
         else:
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blockhash = encode_hex(failed_at["hash"])
             failed_at_blocknumber = failed_at["number"]
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -334,7 +334,7 @@ class TokenNetworkRegistry:
         else:
             # The latest block can not be used reliably because of reorgs,
             # therefore every call using this block has to handle pruned data.
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blocknumber = failed_at["number"]
 
             max_token_networks = self.get_max_token_networks(
@@ -364,9 +364,9 @@ class TokenNetworkRegistry:
             required_gas = (
                 gas_limit
                 if gas_limit
-                else self.gas_measurements.get("TokenNetworkRegistry createERC20TokenNetwork")
+                else self.gas_measurements["TokenNetworkRegistry createERC20TokenNetwork"]
             )
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="createERC20TokenNetwork",
                 transaction_executed=False,
                 required_gas=required_gas,

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -207,10 +207,10 @@ class UserDeposit:
         )
 
         if not gas_limit:
-            failed_at = self.proxy.jsonrpc_client.get_block("latest")
+            failed_at = self.proxy.rpc_client.get_block("latest")
             failed_at_blocknumber = failed_at["number"]
 
-            self.proxy.jsonrpc_client.check_for_insufficient_eth(
+            self.proxy.rpc_client.check_for_insufficient_eth(
                 transaction_name="deposit",
                 transaction_executed=False,
                 required_gas=self.gas_measurements["UserDeposit.deposit"],

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from eth_utils import decode_hex, to_canonical_address, to_checksum_address
 from web3.contract import Contract
@@ -14,7 +14,10 @@ from raiden.exceptions import (
     ReplacementTransactionUnderpriced,
     TransactionAlreadyPending,
 )
-from raiden.utils import typing
+from raiden.utils.typing import TYPE_CHECKING, Address, BlockSpecification, TransactionHash
+
+if TYPE_CHECKING:
+    from raiden.network.rpc.client import JSONRPCClient
 
 
 class ClientErrorInspectResult(Enum):
@@ -28,7 +31,9 @@ class ClientErrorInspectResult(Enum):
     TRANSACTION_ALREADY_IMPORTED = 7
 
 
-def inspect_client_error(val_err: ValueError, eth_node: EthClient) -> ClientErrorInspectResult:
+def inspect_client_error(
+    val_err: ValueError, eth_node: Optional[EthClient]
+) -> ClientErrorInspectResult:
     # both clients return invalid json. They use single quotes while json needs double ones.
     # Also parity may return something like: 'data': 'Internal("Error message")' which needs
     # special processing
@@ -64,30 +69,30 @@ def inspect_client_error(val_err: ValueError, eth_node: EthClient) -> ClientErro
 
 
 class ContractProxy:
-    def __init__(self, jsonrpc_client, contract: Contract):
+    def __init__(self, rpc_client: "JSONRPCClient", contract: Contract) -> None:
         if contract is None:
             raise ValueError("Contract must not be None")
-        if jsonrpc_client is None:
+        if rpc_client is None:
             raise ValueError("JSONRPCClient must not be None")
-        self.jsonrpc_client = jsonrpc_client
+        self.rpc_client = rpc_client
         self.contract = contract
 
     def transact(
         self, function_name: str, startgas: int, *args: Any, **kwargs: Any
-    ) -> typing.TransactionHash:
+    ) -> TransactionHash:
         data = ContractProxy.get_transaction_data(
             abi=self.contract.abi, function_name=function_name, args=args, kwargs=kwargs
         )
 
         try:
-            txhash = self.jsonrpc_client.send_transaction(
+            tx_hash = self.rpc_client.send_transaction(
                 to=self.contract.address,
                 startgas=startgas,
                 value=kwargs.pop("value", 0),
                 data=decode_hex(data),
             )
         except ValueError as e:
-            action = inspect_client_error(e, self.jsonrpc_client.eth_node)
+            action = inspect_client_error(e, self.rpc_client.eth_node)
             if action == ClientErrorInspectResult.INSUFFICIENT_FUNDS:
                 raise InsufficientFunds("Insufficient ETH for transaction")
             elif action == ClientErrorInspectResult.TRANSACTION_UNDERPRICED:
@@ -109,29 +114,35 @@ class ContractProxy:
                 # https://github.com/raiden-network/raiden/issues/3211
                 # We will try to not crash by looking into the local parity
                 # transaction pool to retrieve the transaction hash
-                hex_address = to_checksum_address(self.jsonrpc_client.address)
-                txhash = self.jsonrpc_client.parity_get_pending_transaction_hash_by_nonce(
-                    address=hex_address, nonce=self.jsonrpc_client._available_nonce
+                hex_address = to_checksum_address(self.rpc_client.address)
+                maybe_tx_hash = self.rpc_client.parity_get_pending_transaction_hash_by_nonce(
+                    address=hex_address, nonce=self.rpc_client._available_nonce
                 )
-                if txhash:
+                if maybe_tx_hash:
                     raise TransactionAlreadyPending(
                         "Transaction was submitted via parity but parity saw it as"
                         " already pending. Could not find the transaction in the "
                         "local transaction pool. Bailing ..."
                     )
-                return txhash
 
             raise e
 
-        return txhash
+        return tx_hash
 
     @staticmethod
-    def get_transaction_data(abi: Dict, function_name: str, args: Any = None, kwargs: Any = None):
+    def get_transaction_data(
+        abi: Dict, function_name: str, args: Any = None, kwargs: Any = None
+    ) -> str:
         """Get encoded transaction data"""
         args = args or list()
         fn_abi = find_matching_fn_abi(abi, function_name, args=args, kwargs=kwargs)
         return encode_transaction_data(
-            None, function_name, contract_abi=abi, fn_abi=fn_abi, args=args, kwargs=kwargs
+            web3=None,
+            fn_identifier=function_name,
+            contract_abi=abi,
+            fn_abi=fn_abi,
+            args=args,
+            kwargs=kwargs,
         )
 
     def decode_transaction_input(self, transaction_hash: bytes) -> Dict:
@@ -140,15 +151,19 @@ class ContractProxy:
 
         return self.contract.decode_function_input(transaction["input"])
 
-    def decode_event(self, log: Dict):
+    def decode_event(self, log: Dict[str, Any]) -> Dict[str, Any]:
         return decode_event(self.contract.abi, log)
 
-    def encode_function_call(self, function: str, args: List = None):
+    def encode_function_call(self, function: str, args: List = None) -> str:
         return self.get_transaction_data(self.contract.abi, function, args)
 
     def estimate_gas(
-        self, block_identifier, function: str, *args, **kwargs
-    ) -> typing.Optional[int]:
+        self,
+        block_identifier: Optional[BlockSpecification],
+        function: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[int]:
         """Estimate the gas necessary to run the transaction.
 
         Returns `None` transaction would fail because it hit an assert/require,
@@ -156,8 +171,8 @@ class ContractProxy:
         """
 
         fn = getattr(self.contract.functions, function)
-        address = to_checksum_address(self.jsonrpc_client.address)
-        if self.jsonrpc_client.eth_node is constants.EthClient.GETH:
+        address = to_checksum_address(self.rpc_client.address)
+        if self.rpc_client.eth_node is constants.EthClient.GETH:
             # Unfortunately geth does not follow the ethereum JSON-RPC spec and
             # does not accept a block identifier argument for eth_estimateGas
             # parity and py-evm (trinity) do.
@@ -175,7 +190,7 @@ class ContractProxy:
                 transaction={"from": address}, block_identifier=block_identifier
             )
         except ValueError as err:
-            action = inspect_client_error(err, self.jsonrpc_client.eth_node)
+            action = inspect_client_error(err, self.rpc_client.eth_node)
             will_fail = action in (
                 ClientErrorInspectResult.INSUFFICIENT_FUNDS,
                 ClientErrorInspectResult.ALWAYS_FAIL,
@@ -186,5 +201,5 @@ class ContractProxy:
             raise err
 
     @property
-    def contract_address(self):
+    def contract_address(self) -> Address:
         return to_canonical_address(self.contract.address)

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -22,7 +22,7 @@ from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils import privatekey_to_address
 from raiden.utils.signer import LocalSigner
-from raiden.utils.typing import ChainID, List, Nonce, PrivateKey, TokenAmount
+from raiden.utils.typing import BlockNumber, ChainID, List, Nonce, PrivateKey, TokenAmount
 from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MIN, MessageTypeId
 from raiden_contracts.contract_manager import ContractManager
 
@@ -113,7 +113,7 @@ def test_payment_channel_proxy_basics(
     # estimate gas and at the time the latest block is the settle timeout block.
     # More info: https://github.com/raiden-network/raiden/pull/3699#discussion_r270477227
     proxy_manager.wait_until_block(
-        target_block_number=client.block_number() + TEST_SETTLE_TIMEOUT_MIN + 1
+        target_block_number=BlockNumber(client.block_number() + TEST_SETTLE_TIMEOUT_MIN + 1)
     )
 
     channel_proxy_1.settle(

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -131,7 +131,7 @@ def test_register_secret_batch_with_pruned_block(
     # Now wait until this block becomes pruned
     pruned_number = c1_proxy_manager.client.block_number()
     c1_proxy_manager.wait_until_block(
-        target_block_number=pruned_number + STATE_PRUNING_AFTER_BLOCKS
+        target_block_number=BlockNumber(pruned_number + STATE_PRUNING_AFTER_BLOCKS)
     )
     secret_registry_batch_happy_path(web3, secret_registry_proxy)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,8 @@ disallow_untyped_defs = False
 disallow_untyped_defs = True
 [mypy-raiden.network.proxies.*]
 disallow_untyped_defs = True
+[mypy-raiden.network.rpc.*]
+disallow_untyped_defs = True
 [mypy-raiden.network.transport.matrix.utils]
 disallow_untyped_defs = True
 [mypy-raiden.network.transport.matrix.transport]


### PR DESCRIPTION
Part of #4033 

## Description
Enables strict typing for `raiden.network.rpc`  module.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
