### PR TITLE
More user friendly error message when PFS request fails

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`5064` Display a user-friendly error message when the PFS info request fails.
 * :bug:`5055` Fix withdraw messages deserialization when the messages are queued in `queueids_to_queues`.
 * :feature:`5053` Make mediation fees non-negative by default. This fixes some counter-intuitive behaviour.
 * :bug:`4835` Fix etherscan sync by passing user-agent in the HTTP request. The request was failing because etherscan is protected by Cloudflare.

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -151,8 +151,11 @@ def get_pfs_info(url: str) -> PFSInfo:
             operator=infos["operator"],
             version=infos["version"],
         )
+    except requests.exceptions.RequestException as e:
+        msg = "Selected Pathfinding Service did not respond"
+        raise ServiceRequestFailed(msg) from e
     except (json.JSONDecodeError, requests.exceptions.RequestException, KeyError) as e:
-        msg = "Selected Pathfinding service returned unexpected reply"
+        msg = "Selected Pathfinding Service returned unexpected reply"
         raise ServiceRequestFailed(msg) from e
 
 
@@ -239,10 +242,10 @@ def configure_pfs_or_exit(
     If pfs_url is provided we use that.
     If pfs_url is 'auto' then we randomly choose a PFS address from the registry
     """
-    msg = "Invalid code path; configure pfs needs routing mode PFS"
+    msg = "Invalid code path; configure_pfs needs routing mode PFS"
     assert routing_mode == RoutingMode.PFS, msg
 
-    msg = "With PFS routing mode we shouldn't get to configure pfs with pfs_address being None"
+    msg = "With PFS routing mode we shouldn't get to configure_pfs with pfs_address being None"
     assert pfs_url, msg
     if pfs_url == "auto":
         assert service_registry, "Should not get here without a service registry"
@@ -254,8 +257,8 @@ def configure_pfs_or_exit(
         )
         if maybe_pfs_url is None:
             click.secho(
-                "The service registry has no registered path finding service "
-                "and we don't use basic routing."
+                "The Service Registry has no registered Pathfinding Service "
+                "and basic routing is not used."
             )
             sys.exit(1)
         else:
@@ -265,47 +268,48 @@ def configure_pfs_or_exit(
         pathfinding_service_info = get_pfs_info(pfs_url)
     except ServiceRequestFailed as e:
         click.secho(
-            f"There is an error with the pathfinding service with address "
-            f"{pfs_url}. Error Message: {str(e)}. Raiden will shut down."
+            f"There was an error with the Pathfinding Service with address "
+            f"{pfs_url}. Raiden will shut down. Please try a different Pathfinding Service. \n"
+            f"Error Message: {str(e)}"
         )
         sys.exit(1)
 
     if pathfinding_service_info.price > 0 and not pathfinding_service_info.payment_address:
         click.secho(
-            f"The pathfinding service at {pfs_url} did not provide an eth address "
-            f"to pay it. Raiden will shut down. Please try a different PFS."
+            f"The Pathfinding Service at {pfs_url} did not provide a payment address. "
+            f"Raiden will shut down. Please try a different Pathfinding Service."
         )
         sys.exit(1)
 
     if not node_network_id == pathfinding_service_info.chain_id:
-        click.secho(f"Invalid reply from pathfinding service {pfs_url}", fg="red")
+        click.secho(f"Invalid reply from Pathfinding Service {pfs_url}", fg="red")
         click.secho(
-            f"PFS is not operating on the same network "
+            f"Pathfinding Service is not operating on the same network "
             f"({pathfinding_service_info.chain_id}) as your node is ({node_network_id}).\n"
-            f"Raiden will shut down. Please choose a different PFS."
+            f"Raiden will shut down. Please choose a different Pathfinding Service."
         )
         sys.exit(1)
 
     if pathfinding_service_info.token_network_registry_address != token_network_registry_address:
-        click.secho(f"Invalid reply from pathfinding service {pfs_url}", fg="red")
+        click.secho(f"Invalid reply from Pathfinding Service {pfs_url}", fg="red")
         click.secho(
-            f"PFS is not operating on the same Token Network Registry "
+            f"Pathfinding Service is not operating on the same Token Network Registry "
             f"({to_checksum_address(pathfinding_service_info.token_network_registry_address)})"
-            f" as your node is ({to_checksum_address(token_network_registry_address)}).\n"
-            f"Raiden will shut down. Please choose a different PFS."
+            f" as your node ({to_checksum_address(token_network_registry_address)}).\n"
+            f"Raiden will shut down. Please choose a different Pathfinding Service."
         )
         sys.exit(1)
     click.secho(
-        f"You have chosen the pathfinding service at {pfs_url}.\n"
+        f"You have chosen the Pathfinding Service at {pfs_url}.\n"
         f"Operator: {pathfinding_service_info.operator}, "
         f"running version: {pathfinding_service_info.version}, "
         f"chain_id: {pathfinding_service_info.chain_id}.\n"
         f"Fees will be paid to {to_checksum_address(pathfinding_service_info.payment_address)}. "
         f"Each request costs {to_rdn(pathfinding_service_info.price)} RDN.\n"
-        f"Message from the PFS:\n{pathfinding_service_info.message}"
+        f"Message from the Pathfinding Service:\n{pathfinding_service_info.message}"
     )
 
-    log.info("Using PFS", pfs_info=pathfinding_service_info)
+    log.info("Using Pathfinding Service", pfs_info=pathfinding_service_info)
 
     return pathfinding_service_info
 
@@ -320,8 +324,8 @@ def check_pfs_for_production(
     """
     if service_registry is None:
         click.secho(
-            f"Cannot verify registration of PFS because no service registry is set"
-            f"Raiden will shut down. Please set the service registry."
+            f"Cannot verify registration of Pathfinding Service because no Service Registry "
+            f"is set. Raiden will shut down. Please select a Service Registry."
         )
         sys.exit(1)
 
@@ -336,11 +340,11 @@ def check_pfs_for_production(
     pfs_url_matches = registered_pfs_url == pfs_info.url
     if not (pfs_registered and pfs_url_matches):
         click.secho(
-            f"The pathfinding service at {pfs_info.url} is not registered "
-            f"with the service registry at {to_checksum_address(service_registry.address)} "
+            f"The Pathfinding Service at {pfs_info.url} is not registered "
+            f"with the Service Registry at {to_checksum_address(service_registry.address)} "
             f"or the registered URL ({registered_pfs_url}) doesn't match the given URL "
             f"{pfs_info.url}. "
-            f"Raiden will shut down. Please try a registered PFS."
+            f"Raiden will shut down. Please select a registered Pathfinding Service."
         )
         sys.exit(1)
 
@@ -431,7 +435,7 @@ def update_iou(
     )
     if iou.signature != expected_signature:
         raise ServiceRequestFailed(
-            "Last IOU as given by the pathfinding service is invalid (signature does not match)"
+            "Last IOU as given by the Pathfinding Service is invalid (signature does not match)"
         )
 
     iou.amount = TokenAmount(iou.amount + added_amount)
@@ -501,7 +505,7 @@ def post_pfs_paths(
             response_json = get_response_json(response)
         except ValueError:
             raise ServiceRequestFailed(
-                "Pathfinding service returned error code (malformed json in response)", info
+                "Pathfinding Service returned error code (malformed json in response)", info
             )
         else:
             error = info["error"] = response_json.get("errors")
@@ -509,19 +513,19 @@ def post_pfs_paths(
             if PFSError.is_iou_rejected(error_code):
                 raise ServiceRequestIOURejected(error, error_code)
 
-        raise ServiceRequestFailed("Pathfinding service returned error code", info)
+        raise ServiceRequestFailed("Pathfinding Service returned error code", info)
 
     try:
         response_json = get_response_json(response)
         return response_json["result"], UUID(response_json["feedback_token"])
     except KeyError:
         raise ServiceRequestFailed(
-            "Answer from pathfinding service not understood ('result' field missing)",
+            "Answer from Pathfinding Service not understood ('result' field missing)",
             dict(response=get_response_json(response)),
         )
     except ValueError:
         raise ServiceRequestFailed(
-            "Pathfinding service returned invalid json",
+            "Pathfinding Service returned invalid json",
             dict(response_text=response.text, exc_info=True),
         )
 
@@ -591,15 +595,19 @@ def query_paths(
                 try:
                     new_info = get_pfs_info(pfs_config.info.url)
                 except ServiceRequestFailed:
-                    raise ServiceRequestFailed("Could not get updated fees from PFS.")
+                    raise ServiceRequestFailed(
+                        "Could not get updated fee information from Pathfinding Service."
+                    )
                 if new_info.price > pfs_config.maximum_fee:
                     raise ServiceRequestFailed("PFS fees too high.")
-                log.info(f"PFS increased fees", new_price=new_info.price)
+                log.info(f"Pathfinding Service increased fees", new_price=new_info.price)
                 pfs_config.info = new_info
             elif code == PFSError.NO_ROUTE_FOUND:
-                log.info(f"PFS cannot find a route: {error}.")
+                log.info(f"Pathfinding Service can not find a route: {error}.")
                 return list(), None
-            log.info(f"PFS rejected our IOU, reason: {error}. Attempting again.")
+            log.info(
+                f"Pathfinding Service rejected our payment. Reason: {error}. Attempting again."
+            )
 
     # If we got no results after MAX_PATHS_QUERY_ATTEMPTS return empty list of paths
     return list(), None

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -152,7 +152,8 @@ def get_pfs_info(url: str) -> PFSInfo:
             version=infos["version"],
         )
     except (json.JSONDecodeError, requests.exceptions.RequestException, KeyError) as e:
-        raise ServiceRequestFailed(str(e)) from e
+        msg = "Selected Pathfinding service returned unexpected reply"
+        raise ServiceRequestFailed(msg) from e
 
 
 def get_valid_pfs_url(

--- a/raiden/tests/unit/test_pfs_integration_refactored.py
+++ b/raiden/tests/unit/test_pfs_integration_refactored.py
@@ -67,7 +67,7 @@ def test_get_pfs_info_error():
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 
-        assert "Expecting property name enclosed in double quotes:" in str(error.value)
+        assert "Selected Pathfinding service returned unexpected reply" in str(error.value)
 
     # test RequestException
     with patch.object(requests, "get", side_effect=requests.RequestException()):
@@ -89,4 +89,4 @@ def test_get_pfs_info_error():
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 
-        assert "'price_info'" in str(error.value)
+        assert "Selected Pathfinding service returned unexpected reply" in str(error.value)

--- a/raiden/tests/unit/test_pfs_integration_refactored.py
+++ b/raiden/tests/unit/test_pfs_integration_refactored.py
@@ -67,7 +67,7 @@ def test_get_pfs_info_error():
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 
-        assert "Selected Pathfinding service returned unexpected reply" in str(error.value)
+        assert "Selected Pathfinding Service returned unexpected reply" == str(error.value)
 
     # test RequestException
     with patch.object(requests, "get", side_effect=requests.RequestException()):
@@ -89,4 +89,10 @@ def test_get_pfs_info_error():
         with pytest.raises(ServiceRequestFailed) as error:
             get_pfs_info("url")
 
-        assert "Selected Pathfinding service returned unexpected reply" in str(error.value)
+        assert "Selected Pathfinding Service returned unexpected reply" == str(error.value)
+
+    with patch.object(requests, "get", side_effect=requests.exceptions.RequestException):
+        with pytest.raises(ServiceRequestFailed) as error:
+            get_pfs_info("url")
+
+        assert "Selected Pathfinding Service did not respond" == str(error.value)


### PR DESCRIPTION
Fixes: #5064 

## Description

Displays a nicer error message instead of some cryptic parser error.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
