### PR TITLE
Update mfee scenarios

### DIFF
--- a/raiden/tests/scenarios/README.md
+++ b/raiden/tests/scenarios/README.md
@@ -102,9 +102,14 @@ This scenario creates a network with topology 0 -> 1 -> 2 -> 3 and only enables 
 It then checks whether a path is returned. It also checks that correct flat mediation fees are deducted.
 
 #### [mfee2_proportional_fees](./mfee2_proportional_fees.yaml)
-This is the MFEE2 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and checks
+The MFEE2 scenario creates a network with topology 0 -> 1 -> 2 -> 3 and checks
 whether a path is returned. It also checks that correct proportional mediation fees are deducted
 and received by the mediating parties. For every 1000 TKNs tranferred a fee of 10 TKN is expected.
+
+#### [mfee3_only_imbalance_fees](./mfee3_only_imbalance_fees.yaml)
+Make a transfer over a single mediator with enabled imbalance fees. The
+channels start at maximum imbalance, which causes negative fees. To test this,
+the mediator fee capping has been turned off.
 
 #### [mfee4_combined_fees](./mfee4_combined_fees.yaml)
 This scenario creates a network with topology 0 -> 1 -> 2 -> 3 and only enables all mediation fee components.

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -65,7 +65,9 @@ scenario:
                 expected_routes:
                   - [0, 1, 2, 3]
 
-            # 200 TKN fees are calculated and margin of 200 * 3% + 10000 * 0.05% = 11
+            # Flat fee: 2 * 100 = 200
+            # Fee margin: fee * 3% + amount * 0.05% = 200 * 3% + 10000 * 0.05% = 11
+            # Amount sent by initiator: 10_000 + 200 + 11 = 10_211
             - assert: {from: 0, to: 1, total_deposit: 100_000, balance: 89_789, state: "opened"}
             - assert: {from: 1, to: 0, total_deposit: 0, balance: 10_211, state: "opened"}
 

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -65,12 +65,12 @@ scenario:
                 expected_routes:
                   - [0, 1, 2, 3]
 
-            # 200 TKN fees are calculated, 5% margin of that is 10 TKN
-            - assert: {from: 0, to: 1, total_deposit: 100_000, balance: 89_790, state: "opened"}
-            - assert: {from: 1, to: 0, total_deposit: 0, balance: 10_210, state: "opened"}
+            # 200 TKN fees are calculated and margin of 200 * 3% + 10000 * 0.05% = 11
+            - assert: {from: 0, to: 1, total_deposit: 100_000, balance: 89_789, state: "opened"}
+            - assert: {from: 1, to: 0, total_deposit: 0, balance: 10_211, state: "opened"}
 
-            - assert: {from: 1, to: 2, total_deposit: 100_000, balance: 89_890, state: "opened"}
-            - assert: {from: 2, to: 1, total_deposit: 0, balance: 10_110, state: "opened"}
+            - assert: {from: 1, to: 2, total_deposit: 100_000, balance: 89_889, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 0, balance: 10_111, state: "opened"}
 
-            - assert: {from: 2, to: 3, total_deposit: 100_000, balance: 89_990, state: "opened"}
-            - assert: {from: 3, to: 2, total_deposit: 0, balance: 10_010, state: "opened"}
+            - assert: {from: 2, to: 3, total_deposit: 100_000, balance: 89_989, state: "opened"}
+            - assert: {from: 3, to: 2, total_deposit: 0, balance: 10_011, state: "opened"}

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -68,10 +68,12 @@ scenario:
 
             # Fees are set to 10 TKN per 1000 transferred. Hence for 10000, 100 TKN fee
             # should be paid, plus a 1% fee of fees per mediator.
-            # balance_minus_fee = deposit - transfer_amount - (transfer_amount / prop_fee * amount_of_hubs_to_target)
-            # balance_minus_fee_and_fee_margin = balance_minus_fee - (transfer_amount / prop_fee / 100 * fee_margin)
-            - assert: {from: 0, to: 1, total_deposit: 100_000, balance: 89_789, state: "opened"}
-            - assert: {from: 1, to: 0, total_deposit: 0, balance: 10_211, state: "opened"}
+            # Fee for second mediator = 10000 * 1% = 100
+            # Fee for first mediator = 10100 * 1% = 101
+            # Fee margin = ceil(201 * 3% + 10000 * 0.05%) = 12
+            # balance 0->1: 100000 - 10000 - 201 - 12 = 89787
+            - assert: {from: 0, to: 1, total_deposit: 100_000, balance: 89_787, state: "opened"}
+            - assert: {from: 1, to: 0, total_deposit: 0, balance: 10_213, state: "opened"}
 
             - assert: {from: 1, to: 2, total_deposit: 100_000, balance: 89_887, allow_balance_error: 1, state: "opened"}
             - assert: {from: 2, to: 1, total_deposit: 0, balance: 10_113, allow_balance_error: 1, state: "opened"}

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -38,8 +38,9 @@ nodes:
       - 10_000  # 1% imbalance fee on channel balance
     no-cap-mediation-fees: true
 
-## This is the MFEE3 scenario. It creates a network with topology 0 -> 1 -> 2 and checks
-## whether a path is returned. It also checks that correct imbalance fees are deducted.
+# Make a transfer over a single mediator with enabled imbalance fees. The
+# channels start at maximum imbalance, which causes negative fees. To test this,
+# the mediator fee capping has been turned off.
 
 scenario:
   serial:

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -36,8 +36,9 @@ nodes:
     proportional-imbalance-fee:
       - "0x62083c80353Df771426D209eF578619EE68D5C7A"
       - 10_000  # 1% imbalance fee on channel balance
+    no-cap-mediation-fees: true
 
-## This is the MFEE3 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and checks
+## This is the MFEE3 scenario. It creates a network with topology 0 -> 1 -> 2 and checks
 ## whether a path is returned. It also checks that correct imbalance fees are deducted.
 
 scenario:
@@ -54,6 +55,7 @@ scenario:
             - wait_blocks: 2
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 2, amount: 500_000_000_000_000_000, expected_http_status: 200}
+            - wait_blocks: 1  # Wait for balances being up to date
 
             ## Check that the path is indeed the expected one
             - assert_pfs_history:
@@ -63,11 +65,11 @@ scenario:
                 expected_routes:
                   - [0, 1, 2]
 
-            # -2000 TKN fees are calculated, no margin is added for negative fee values
-            - wait_blocks: 2
-            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 519_999_960_000_040_000, state: "opened"}
-            - assert: {from: 1, to: 0, total_deposit: 0, balance: 480_000_039_999_960_000, state: "opened"}
+            # -2000 TKN fees are calculated, but the actual value is closer to zero because
+            # 1. Due to the negative fee less tokens are transferred, resulting in a smaller negative fee
+            # 2. A fee margin is applied
+            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 519_149_961_200_077_600, state: "opened"}
+            - assert: {from: 1, to: 0, total_deposit: 0, balance: 480_850_038_799_922_400, state: "opened"}
 
-            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 500_000_000_000_000_000, state: "opened"}
-            - assert: {from: 2, to: 1, total_deposit: 0, balance: 500_000_000_000_000_000, state: "opened"}
-
+            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 499_150_001_199_997_600, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 0, balance: 500_849_998_800_002_400, state: "opened"}

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -36,6 +36,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x62083c80353Df771426D209eF578619EE68D5C7A"
       - 20_000  # 2% imbalance fee on channel balance
+    no-cap-mediation-fees: true
 
 ## This is the MFEE4 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and checks
 ## whether a path is returned. It also checks that correct fees are deducted.
@@ -58,6 +59,7 @@ scenario:
             - wait_blocks: 2
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 3, amount: 500_000_000_000_000_000, expected_http_status: 200}
+            - wait_blocks: 1  # Wait for balances being up to date
 
             ## Check that the path is indeed the expected one
             - assert_pfs_history:
@@ -67,16 +69,20 @@ scenario:
                 expected_routes:
                   - [0, 1, 2, 3]
 
-            - wait_blocks: 2
-            # 41_963_768_101_996_008 TKN fees are calculated which are 8.4% of the initial payment, 5% margin are added
-            # This results in a total fee of 44_061_956_507_095_808
-            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 455_938_043_492_904_366, state: "opened"}
-            - assert: {from: 1, to: 0, total_deposit: 1_000_000_000_000_000_000, balance: 1_544_061_956_507_095_634, state: "opened"}
+            # This calculation is too complicated to follow it manually. You
+            # can inspect the precise intermediate values in `test_mfee4` if necessary.
+            # Very rough calculation:
+            # Imbalance fees: 2 * 2 * 500e15 * 2% = 40e15
+            # Flat fees: 2 * 100 = 200
+            # Proportional fees: 2 * 500e15 * 1% = 10e15
+            # Total fees: 40e15 + 200 + 10e15 = 50e15
+            # Margin: 50e15 * 3% + 500e15 * 0.05% = 1.5e15 + 0.25e15 = 1.525e15
+            # Amount sent by initiator: 500e15 + 50e15 + 1.525e15 = 551e15
+            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 456_496_933_858_494_449, state: "opened"}
+            - assert: {from: 1, to: 0, total_deposit: 1_000_000_000_000_000_000, balance: 1_543_503_066_141_505_551, state: "opened"}
 
-            # update comment ...
-            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 478_064_586_391_421_968, state: "opened"}
-            - assert: {from: 2, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_521_935_413_608_578_032, state: "opened"}
+            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 478_587_602_916_613_423, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_521_412_397_083_386_577, state: "opened"}
 
-            # update comment ...
-            - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 498_254_201_118_912_876, state: "opened"}
-            - assert: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 1_501_745_798_881_087_124, state: "opened"}
+            - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 498_743_132_371_418_303, state: "opened"}
+            - assert: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 1_501_256_867_628_581_697, state: "opened"}


### PR DESCRIPTION
The following recent raiden changes force changes in the scenarios:
* Changed fee margin
* Changed default imbalance curve
* Mediation fee capping on by default

Includes the updated numbers due to https://github.com/raiden-network/raiden/pull/5197 for mfee4.

[skip tests]

Fixes: https://github.com/raiden-network/raiden/issues/5131

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
