### PR TITLE
Add __repr__ function to classes needing it for better debugging

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -634,7 +634,7 @@ def post_pfs_feedback(
     log.info(
         "Sending routing feedback to Pathfinding Service",
         url=pfs_config.info.url,
-        token_network_address=token_network_address,
+        token_network_address=to_checksum_address(token_network_address),
         payload=payload,
     )
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1146,11 +1146,11 @@ class RaidenService(Runnable):
 
         log.debug(
             "Mediated transfer",
-            node=self.address,
-            target=target,
+            node=to_checksum_address(self.address),
+            target=to_checksum_address(target),
             amount=amount,
             identifier=identifier,
-            token_network_address=token_network_address,
+            token_network_address=to_checksum_address(token_network_address),
         )
 
         # We must check if the secret was registered against the latest block,

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -2,6 +2,8 @@
 from copy import deepcopy
 from dataclasses import dataclass, field
 
+from eth_utils import to_checksum_address, to_hex
+
 from raiden.constants import EMPTY_BALANCE_HASH, UINT64_MAX, UINT256_MAX
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.utils import hash_balance_data
@@ -401,6 +403,18 @@ class BalanceProofSignedState(State):
     @property
     def channel_identifier(self) -> ChannelID:
         return self.canonical_identifier.channel_identifier
+
+    def __repr__(self) -> str:
+        return (
+            f"BalanceProofSignedState< "
+            f"nonce: {self.nonce} transferred_amount: {self.transferred_amount} "
+            f"locked_amount: {self.locked_amount} locksroot: {to_hex(self.locksroot)} "
+            f"message_hash: {to_hex(self.message_hash)} signature: {to_hex(self.signature)} "
+            f"sender: {to_checksum_address(self.sender)} "
+            f"canonical_identifier: {self.canonical_identifier} "
+            f"balance_hash: {to_hex(self.balance_hash)} "
+            f">"
+        )
 
 
 class SuccessOrError:

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -406,7 +406,7 @@ class BalanceProofSignedState(State):
 
     def __repr__(self) -> str:
         return (
-            f"BalanceProofSignedState< "
+            f"{self.__class__.__name__}< "
             f"nonce: {self.nonce} transferred_amount: {self.transferred_amount} "
             f"locked_amount: {self.locked_amount} locksroot: {to_hex(self.locksroot)} "
             f"message_hash: {to_hex(self.message_hash)} signature: {to_hex(self.signature)} "

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from eth_utils import to_hex
+from eth_utils import to_checksum_address, to_hex
 
 from raiden.constants import UINT256_MAX
 from raiden.transfer.architecture import (
@@ -45,6 +45,14 @@ class SendWithdrawRequest(SendMessageEvent):
     expiration: BlockExpiration
     nonce: Nonce
 
+    def __repr__(self) -> str:
+        return (
+            f"SendWithdrawRequest<"
+            f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
+            f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
+            f">"
+        )
+
 
 @dataclass(frozen=True)
 class SendWithdrawConfirmation(SendMessageEvent):
@@ -55,6 +63,14 @@ class SendWithdrawConfirmation(SendMessageEvent):
     expiration: BlockExpiration
     nonce: Nonce
 
+    def __repr__(self) -> str:
+        return (
+            f"SendWithdrawConfirmation<"
+            f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
+            f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
+            f">"
+        )
+
 
 @dataclass(frozen=True)
 class SendWithdrawExpired(SendMessageEvent):
@@ -64,6 +80,14 @@ class SendWithdrawExpired(SendMessageEvent):
     participant: Address
     nonce: Nonce
     expiration: BlockExpiration
+
+    def __repr__(self) -> str:
+        return (
+            f"SendWithdrawExpired<"
+            f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
+            f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
+            f">"
+        )
 
 
 @dataclass(frozen=True)
@@ -82,6 +106,15 @@ class ContractSendChannelWithdraw(ContractSendEvent):
     @property
     def token_network_address(self) -> TokenNetworkAddress:
         return self.canonical_identifier.token_network_address
+
+    def __repr__(self) -> str:
+        return (
+            f"ContractSendChannelWithdraw<"
+            f"canonical_identifier: {self.canonical_identifier} "
+            f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
+            f"partner_signature: {to_hex(self.partner_signature)} "
+            f">"
+        )
 
 
 @dataclass(frozen=True)
@@ -194,6 +227,18 @@ class EventPaymentSentSuccess(Event):
     secret: Secret
     route: List[Address]
 
+    def __repr__(self) -> str:
+        route_str = ",".join(to_checksum_address(x) for x in self.route)
+        return (
+            f"EventPaymentSentSuccess<"
+            f"token_network_address: {to_checksum_address(self.token_network_address)} "
+            f"identifier: {self.identifier} amount: {self.amount} "
+            f"target: {to_checksum_address(self.target)} "
+            f"secret: {to_hex(self.secret)} "
+            f"route: [{route_str}] "
+            f">"
+        )
+
 
 @dataclass(frozen=True)
 class EventPaymentSentFailed(Event):
@@ -209,6 +254,16 @@ class EventPaymentSentFailed(Event):
     identifier: PaymentID
     target: TargetAddress
     reason: str
+
+    def __repr__(self) -> str:
+        return (
+            f"EventPaymentSentFailed<"
+            f"token_network_address: {to_checksum_address(self.token_network_address)} "
+            f"identifier: {self.identifier} "
+            f"target: {to_checksum_address(self.target)} "
+            f"reason: {self.reason} "
+            f">"
+        )
 
 
 @dataclass(frozen=True)
@@ -235,6 +290,15 @@ class EventPaymentReceivedSuccess(Event):
         if self.amount > UINT256_MAX:
             raise ValueError("transferred_amount is too large")
 
+    def __repr__(self) -> str:
+        return (
+            f"EventPaymentReceivedSuccess<"
+            f"token_network_address: {to_checksum_address(self.token_network_address)} "
+            f"identifier: {self.identifier} amount: {self.amount} "
+            f"initiator: {to_checksum_address(self.initiator)} "
+            f">"
+        )
+
 
 @dataclass(frozen=True)
 class EventInvalidReceivedTransferRefund(Event):
@@ -251,6 +315,14 @@ class EventInvalidReceivedLockExpired(Event):
     secrethash: SecretHash
     reason: str
 
+    def __repr__(self) -> str:
+        return (
+            f"EventInvalidReceivedLockExpired<"
+            f"secrethash: {to_hex(self.secrethash)} "
+            f"reason: {self.reason} "
+            f">"
+        )
+
 
 @dataclass(frozen=True)
 class EventInvalidReceivedLockedTransfer(Event):
@@ -266,6 +338,14 @@ class EventInvalidReceivedUnlock(Event):
 
     secrethash: SecretHash
     reason: str
+
+    def __repr__(self) -> str:
+        return (
+            f"EventInvalidReceivedUnlock<"
+            f"secrethash: {to_hex(self.secrethash)} "
+            f"reason: {self.reason} "
+            f">"
+        )
 
 
 @dataclass(frozen=True)

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -47,7 +47,7 @@ class SendWithdrawRequest(SendMessageEvent):
 
     def __repr__(self) -> str:
         return (
-            f"SendWithdrawRequest< "
+            f"{self.__class__.__name__}< "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
             f">"
@@ -65,7 +65,7 @@ class SendWithdrawConfirmation(SendMessageEvent):
 
     def __repr__(self) -> str:
         return (
-            f"SendWithdrawConfirmation< "
+            f"{self.__class__.__name__}< "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
             f">"
@@ -83,7 +83,7 @@ class SendWithdrawExpired(SendMessageEvent):
 
     def __repr__(self) -> str:
         return (
-            f"SendWithdrawExpired< "
+            f"{self.__class__.__name__}< "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
             f">"
@@ -109,7 +109,7 @@ class ContractSendChannelWithdraw(ContractSendEvent):
 
     def __repr__(self) -> str:
         return (
-            f"ContractSendChannelWithdraw< "
+            f"{self.__class__.__name__}< "
             f"canonical_identifier: {self.canonical_identifier} "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"partner_signature: {to_hex(self.partner_signature)} "
@@ -230,7 +230,7 @@ class EventPaymentSentSuccess(Event):
     def __repr__(self) -> str:
         route_str = ",".join(to_checksum_address(x) for x in self.route)
         return (
-            f"EventPaymentSentSuccess< "
+            f"{self.__class__.__name__}< "
             f"token_network_address: {to_checksum_address(self.token_network_address)} "
             f"identifier: {self.identifier} amount: {self.amount} "
             f"target: {to_checksum_address(self.target)} "
@@ -257,7 +257,7 @@ class EventPaymentSentFailed(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventPaymentSentFailed< "
+            f"{self.__class__.__name__}< "
             f"token_network_address: {to_checksum_address(self.token_network_address)} "
             f"identifier: {self.identifier} "
             f"target: {to_checksum_address(self.target)} "
@@ -292,7 +292,7 @@ class EventPaymentReceivedSuccess(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventPaymentReceivedSuccess< "
+            f"{self.__class__.__name__}< "
             f"token_network_address: {to_checksum_address(self.token_network_address)} "
             f"identifier: {self.identifier} amount: {self.amount} "
             f"initiator: {to_checksum_address(self.initiator)} "
@@ -317,7 +317,7 @@ class EventInvalidReceivedLockExpired(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventInvalidReceivedLockExpired< "
+            f"{self.__class__.__name__}< "
             f"secrethash: {to_hex(self.secrethash)} "
             f"reason: {self.reason} "
             f">"
@@ -341,7 +341,7 @@ class EventInvalidReceivedUnlock(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventInvalidReceivedUnlock< "
+            f"{self.__class__.__name__}< "
             f"secrethash: {to_hex(self.secrethash)} "
             f"reason: {self.reason} "
             f">"

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -47,7 +47,7 @@ class SendWithdrawRequest(SendMessageEvent):
 
     def __repr__(self) -> str:
         return (
-            f"SendWithdrawRequest<"
+            f"SendWithdrawRequest< "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
             f">"
@@ -65,7 +65,7 @@ class SendWithdrawConfirmation(SendMessageEvent):
 
     def __repr__(self) -> str:
         return (
-            f"SendWithdrawConfirmation<"
+            f"SendWithdrawConfirmation< "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
             f">"
@@ -83,7 +83,7 @@ class SendWithdrawExpired(SendMessageEvent):
 
     def __repr__(self) -> str:
         return (
-            f"SendWithdrawExpired<"
+            f"SendWithdrawExpired< "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"participant: {to_checksum_address(self.participant)} nonce: {self.nonce} "
             f">"
@@ -109,7 +109,7 @@ class ContractSendChannelWithdraw(ContractSendEvent):
 
     def __repr__(self) -> str:
         return (
-            f"ContractSendChannelWithdraw<"
+            f"ContractSendChannelWithdraw< "
             f"canonical_identifier: {self.canonical_identifier} "
             f"total_withdraw: {self.total_withdraw} expiration: {self.expiration} "
             f"partner_signature: {to_hex(self.partner_signature)} "
@@ -230,7 +230,7 @@ class EventPaymentSentSuccess(Event):
     def __repr__(self) -> str:
         route_str = ",".join(to_checksum_address(x) for x in self.route)
         return (
-            f"EventPaymentSentSuccess<"
+            f"EventPaymentSentSuccess< "
             f"token_network_address: {to_checksum_address(self.token_network_address)} "
             f"identifier: {self.identifier} amount: {self.amount} "
             f"target: {to_checksum_address(self.target)} "
@@ -257,7 +257,7 @@ class EventPaymentSentFailed(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventPaymentSentFailed<"
+            f"EventPaymentSentFailed< "
             f"token_network_address: {to_checksum_address(self.token_network_address)} "
             f"identifier: {self.identifier} "
             f"target: {to_checksum_address(self.target)} "
@@ -292,7 +292,7 @@ class EventPaymentReceivedSuccess(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventPaymentReceivedSuccess<"
+            f"EventPaymentReceivedSuccess< "
             f"token_network_address: {to_checksum_address(self.token_network_address)} "
             f"identifier: {self.identifier} amount: {self.amount} "
             f"initiator: {to_checksum_address(self.initiator)} "
@@ -317,7 +317,7 @@ class EventInvalidReceivedLockExpired(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventInvalidReceivedLockExpired<"
+            f"EventInvalidReceivedLockExpired< "
             f"secrethash: {to_hex(self.secrethash)} "
             f"reason: {self.reason} "
             f">"
@@ -341,7 +341,7 @@ class EventInvalidReceivedUnlock(Event):
 
     def __repr__(self) -> str:
         return (
-            f"EventInvalidReceivedUnlock<"
+            f"EventInvalidReceivedUnlock< "
             f"secrethash: {to_hex(self.secrethash)} "
             f"reason: {self.reason} "
             f">"


### PR DESCRIPTION
## Description

Some events when printed in the logs have attributes such as hashes or
addresses which are printed in binary.

By adding `__repr__` functions to these events the hex string
representation should be now visible in the logs making it easier
to debug.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
