### PR TITLE
Workaround: skip presence check

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1759,6 +1759,7 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
     assert search_for_item(iteration.events, SendLockExpired, {})
 
 
+@pytest.mark.skip(reason="presence workaround disables filtering")
 def test_filter_reachable_routes():
     """ Try to mediate a transfer where a node, that is part of the routes_order,
     was unreachable and became reachable before the locked transfer expired.

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
 import random
 
+import pytest
 from eth_utils import keccak
 
 from raiden.messages.decode import balanceproof_from_envelope
@@ -577,6 +578,7 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
     assert secrethash in payer_channel.partner_state.secrethashes_to_onchain_unlockedlocks
 
 
+@pytest.mark.skip(reason="presence workaround disables filtering")
 def test_regression_unavailable_nodes_must_be_properly_filtered():
     """The list of available routes provided must be filtered based on the
     network status of the partner node.

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -1,17 +1,21 @@
-from raiden.transfer.state import NetworkState, RouteState
+from raiden.transfer.state import RouteState
 from raiden.utils.typing import ChannelID, List, NodeNetworkStateMap
 
 
 def filter_reachable_routes(
-    route_states: List[RouteState], nodeaddresses_to_networkstates: NodeNetworkStateMap
+    route_states: List[RouteState],
+    nodeaddresses_to_networkstates: NodeNetworkStateMap,  # pylint: disable=unused-argument
 ) -> List[RouteState]:
     """ This function makes sure we use reachable routes only. """
 
-    return [
-        route
-        for route in route_states
-        if nodeaddresses_to_networkstates.get(route.next_hop_address) == NetworkState.REACHABLE
-    ]
+    return route_states
+
+    # Temporarily skipped, see https://github.com/raiden-network/raiden/issues/5156
+    # return [
+    #     route
+    #     for route in route_states
+    #     if nodeaddresses_to_networkstates.get(route.next_hop_address) == NetworkState.REACHABLE
+    # ]
 
 
 def filter_acceptable_routes(


### PR DESCRIPTION
The matrix presence information is currently not reliable. Temporarily
disable this check until it is fixed properly.

See https://github.com/raiden-network/raiden/issues/5156

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
