### PR TITLE
Revert "Workaround: skip presence check"

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1759,7 +1759,6 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
     assert search_for_item(iteration.events, SendLockExpired, {})
 
 
-@pytest.mark.skip(reason="presence workaround disables filtering")
 def test_filter_reachable_routes():
     """ Try to mediate a transfer where a node, that is part of the routes_order,
     was unreachable and became reachable before the locked transfer expired.

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate_regression.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
 import random
 
-import pytest
 from eth_utils import keccak
 
 from raiden.messages.decode import balanceproof_from_envelope
@@ -578,7 +577,6 @@ def test_regression_onchain_secret_reveal_must_update_channel_state():
     assert secrethash in payer_channel.partner_state.secrethashes_to_onchain_unlockedlocks
 
 
-@pytest.mark.skip(reason="presence workaround disables filtering")
 def test_regression_unavailable_nodes_must_be_properly_filtered():
     """The list of available routes provided must be filtered based on the
     network status of the partner node.

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -1,21 +1,17 @@
-from raiden.transfer.state import RouteState
+from raiden.transfer.state import NetworkState, RouteState
 from raiden.utils.typing import ChannelID, List, NodeNetworkStateMap
 
 
 def filter_reachable_routes(
-    route_states: List[RouteState],
-    nodeaddresses_to_networkstates: NodeNetworkStateMap,  # pylint: disable=unused-argument
+    route_states: List[RouteState], nodeaddresses_to_networkstates: NodeNetworkStateMap
 ) -> List[RouteState]:
     """ This function makes sure we use reachable routes only. """
 
-    return route_states
-
-    # Temporarily skipped, see https://github.com/raiden-network/raiden/issues/5156
-    # return [
-    #     route
-    #     for route in route_states
-    #     if nodeaddresses_to_networkstates.get(route.next_hop_address) == NetworkState.REACHABLE
-    # ]
+    return [
+        route
+        for route in route_states
+        if nodeaddresses_to_networkstates.get(route.next_hop_address) == NetworkState.REACHABLE
+    ]
 
 
 def filter_acceptable_routes(


### PR DESCRIPTION
This is what caused the regression for https://github.com/raiden-network/raiden/issues/5159 , node3 is trying to use a route that should work from the PFS perspective, however node3 cannot communicate with the node4 used by the PFS.