### PR TITLE
Renamed CANONICAL_IDENTIFIER_GLOBAL_QUEUE

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -154,7 +154,7 @@ class _RetryQueue(Runnable):
         self.notify()
 
     def enqueue_unordered(self, message: Message) -> None:
-        """ Helper to enqueue a message in the global queue (e.g. Delivered) """
+        """ Helper to enqueue a message in the unordered queue. """
         self.enqueue(
             queue_identifier=QueueIdentifier(
                 recipient=self.receiver, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
@@ -194,7 +194,7 @@ class _RetryQueue(Runnable):
                 status=status,
             )
             return
-        # sort output by channel_identifier (so global/unordered queue goes first)
+        # sort output by channel_identifier (so queue goes first)
         # inside queue, preserve order in which messages were enqueued
         ordered_queue = sorted(
             self._message_queue, key=lambda d: d.queue_identifier.canonical_identifier

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -41,7 +41,7 @@ from raiden.network.transport.matrix.utils import (
 from raiden.network.transport.utils import timeout_exponential_backoff
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.transfer import views
-from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, QueueIdentifier
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
 from raiden.transfer.state import NetworkState, QueueIdsToQueues
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
@@ -153,11 +153,11 @@ class _RetryQueue(Runnable):
             )
         self.notify()
 
-    def enqueue_global(self, message: Message) -> None:
+    def enqueue_unordered(self, message: Message) -> None:
         """ Helper to enqueue a message in the global queue (e.g. Delivered) """
         self.enqueue(
             queue_identifier=QueueIdentifier(
-                recipient=self.receiver, canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+                recipient=self.receiver, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
             ),
             message=message,
         )
@@ -902,7 +902,7 @@ class MatrixTransport(Runnable):
 
         if message.sender:  # Ignore unsigned messages
             retrier = self._get_retrier(message.sender)
-            retrier.enqueue_global(delivered_message)
+            retrier.enqueue_unordered(delivered_message)
             self._raiden_service.on_message(message)
 
     def _receive_to_device(self, to_device: ToDevice) -> None:

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -30,7 +30,7 @@ from raiden.tests.utils.factories import HOP1
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.tests.utils.transfer import wait_assert
 from raiden.transfer import views
-from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, QueueIdentifier
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
 from raiden.transfer.state_change import ActionChannelClose, ActionUpdateTransportAuthData
 from raiden.utils.typing import Address
 
@@ -49,12 +49,12 @@ class MessageHandler:
 def ping_pong_message_success(transport0, transport1):
     queueid0 = QueueIdentifier(
         recipient=transport0._raiden_service.address,
-        canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+        canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     )
 
     queueid1 = QueueIdentifier(
         recipient=transport1._raiden_service.address,
-        canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+        canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     )
 
     transport0_raiden_queues = views.get_all_messagequeues(
@@ -303,7 +303,7 @@ def test_matrix_message_retry(
     ] = AddressReachability.REACHABLE
 
     queueid = QueueIdentifier(
-        recipient=partner_address, canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+        recipient=partner_address, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
     )
     chain_state = raiden_service.wal.state_manager.current_state
 
@@ -314,7 +314,7 @@ def test_matrix_message_retry(
     message = Processed(message_identifier=0, signature=EMPTY_SIGNATURE)
     transport._raiden_service.sign(message)
     chain_state.queueids_to_queues[queueid] = [message]
-    retry_queue.enqueue_global(message)
+    retry_queue.enqueue_unordered(message)
 
     gevent.idle()
     assert transport._send_raw.call_count == 1

--- a/raiden/tests/unit/test_node_queue.py
+++ b/raiden/tests/unit/test_node_queue.py
@@ -5,7 +5,7 @@ from raiden.tests.utils import factories
 from raiden.transfer import node, state, state_change
 from raiden.transfer.events import SendWithdrawRequest
 from raiden.transfer.identifiers import (
-    CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+    CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     CanonicalIdentifier,
     QueueIdentifier,
 )
@@ -30,7 +30,7 @@ def test_delivered_message_must_clean_unordered_messages(chain_id):
         chain_id=chain_id,
     )
     queue_identifier = QueueIdentifier(
-        recipient=recipient, canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+        recipient=recipient, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
     )
 
     # Regression test:
@@ -76,7 +76,7 @@ def test_withdraw_request_message_cleanup(chain_id, token_network_state):
         our_address=our_address,
         chain_id=chain_id,
     )
-    queue_identifier = QueueIdentifier(recipient1, CANONICAL_IDENTIFIER_GLOBAL_QUEUE)
+    queue_identifier = QueueIdentifier(recipient1, CANONICAL_IDENTIFIER_UNORDERED_QUEUE)
 
     withdraw_message = SendWithdrawRequest(
         message_identifier=message_identifier,

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -23,7 +23,7 @@ from raiden.transfer.events import (
     ContractSendSecretReveal,
 )
 from raiden.transfer.identifiers import (
-    CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+    CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     CanonicalIdentifier,
     QueueIdentifier,
 )
@@ -442,7 +442,7 @@ def test_inplace_delete_message_queue(chain_state):
     processed_state_change = ReceiveProcessed(sender=sender, message_identifier=message_id)
 
     global_identifier = QueueIdentifier(
-        recipient=sender, canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+        recipient=sender, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
     )
 
     chain_state.queueids_to_queues[global_identifier] = None

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -28,7 +28,7 @@ from raiden.transfer.events import (
     SendWithdrawExpired,
     SendWithdrawRequest,
 )
-from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE, CanonicalIdentifier
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import (
     SendBalanceProof,
     SendLockedTransfer,
@@ -1988,7 +1988,7 @@ def handle_receive_withdraw_confirmation(
             SendProcessed(
                 recipient=channel_state.partner_state.address,
                 message_identifier=withdraw.message_identifier,
-                canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+                canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
             )
         ]
 
@@ -2054,7 +2054,7 @@ def handle_receive_withdraw_expired(
         send_processed = SendProcessed(
             recipient=channel_state.partner_state.address,
             message_identifier=withdraw_expired.message_identifier,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
         events = [send_processed]
     else:
@@ -2093,7 +2093,7 @@ def handle_refundtransfer(
         send_processed = SendProcessed(
             recipient=refund.transfer.balance_proof.sender,
             message_identifier=refund.transfer.message_identifier,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
         events = [send_processed]
     else:
@@ -2130,7 +2130,7 @@ def handle_receive_lock_expired(
         send_processed = SendProcessed(
             recipient=state_change.balance_proof.sender,
             message_identifier=state_change.message_identifier,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
         events = [send_processed]
     else:
@@ -2170,7 +2170,7 @@ def handle_receive_lockedtransfer(
         send_processed = SendProcessed(
             recipient=mediated_transfer.balance_proof.sender,
             message_identifier=mediated_transfer.message_identifier,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
         events = [send_processed]
     else:
@@ -2207,7 +2207,7 @@ def handle_unlock(channel_state: NettingChannelState, unlock: ReceiveUnlock) -> 
         send_processed = SendProcessed(
             recipient=unlock.balance_proof.sender,
             message_identifier=unlock.message_identifier,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
         events: List[Event] = [send_processed]
     else:

--- a/raiden/transfer/identifiers.py
+++ b/raiden/transfer/identifiers.py
@@ -53,6 +53,6 @@ class QueueIdentifier:
         )
 
 
-CANONICAL_IDENTIFIER_GLOBAL_QUEUE = CanonicalIdentifier(
+CANONICAL_IDENTIFIER_UNORDERED_QUEUE = CanonicalIdentifier(
     ChainID(0), TokenNetworkAddress(EMPTY_ADDRESS), ChannelID(0)
 )

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -15,7 +15,7 @@ from raiden.transfer.events import (
     EventPaymentSentFailed,
     EventPaymentSentSuccess,
 )
-from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE
 from raiden.transfer.mediated_transfer.events import (
     EventRouteFailed,
     EventUnlockFailed,
@@ -407,7 +407,7 @@ def handle_secretrequest(
             recipient=Address(recipient),
             message_identifier=message_identifier,
             secret=transfer_description.secret,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
 
         initiator_state.transfer_state = "transfer_secret_revealed"

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -8,7 +8,7 @@ from raiden.transfer import channel, routes, secret_registry
 from raiden.transfer.architecture import Event, StateChange, SuccessOrError, TransitionResult
 from raiden.transfer.channel import get_balance
 from raiden.transfer.events import SendProcessed
-from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE
 from raiden.transfer.mediated_transfer.events import (
     EventUnexpectedSecretReveal,
     EventUnlockClaimFailed,
@@ -753,7 +753,7 @@ def events_for_secretreveal(
                 recipient=payer_transfer.balance_proof.sender,
                 message_identifier=message_identifier,
                 secret=secret,
-                canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+                canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
             )
 
             events.append(revealsecret)
@@ -1426,7 +1426,7 @@ def handle_unlock(
                     send_processed = SendProcessed(
                         recipient=balance_proof_sender,
                         message_identifier=state_change.message_identifier,
-                        canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+                        canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
                     )
                     events.append(send_processed)
 

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -3,7 +3,7 @@ import random
 from raiden.transfer import channel, secret_registry
 from raiden.transfer.architecture import Event, StateChange, TransitionResult
 from raiden.transfer.events import EventPaymentReceivedSuccess, SendProcessed
-from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_GLOBAL_QUEUE
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockClaimFailed,
     EventUnlockClaimSuccess,
@@ -130,7 +130,7 @@ def handle_inittarget(
                 amount=PaymentAmount(transfer.lock.amount),
                 expiration=transfer.lock.expiration,
                 secrethash=transfer.lock.secrethash,
-                canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+                canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
             )
             channel_events.append(secret_request)
 
@@ -183,7 +183,7 @@ def handle_offchain_secretreveal(
             recipient=recipient,
             message_identifier=message_identifier,
             secret=target_state.secret,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
 
         iteration = TransitionResult(target_state, [reveal])
@@ -247,7 +247,7 @@ def handle_unlock(
         send_processed = SendProcessed(
             recipient=balance_proof_sender,
             message_identifier=state_change.message_identifier,
-            canonical_identifier=CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+            canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
 
         events.extend([payment_received_success, unlock_success, send_processed])

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -19,7 +19,7 @@ from raiden.transfer.events import (
     SendWithdrawRequest,
 )
 from raiden.transfer.identifiers import (
-    CANONICAL_IDENTIFIER_GLOBAL_QUEUE,
+    CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     CanonicalIdentifier,
     QueueIdentifier,
 )
@@ -575,7 +575,7 @@ def handle_receive_delivered(
     chain_state: ChainState, state_change: ReceiveDelivered
 ) -> TransitionResult[ChainState]:
     """ Check if the "Delivered" message exists in the global queue and delete if found."""
-    queueid = QueueIdentifier(state_change.sender, CANONICAL_IDENTIFIER_GLOBAL_QUEUE)
+    queueid = QueueIdentifier(state_change.sender, CANONICAL_IDENTIFIER_UNORDERED_QUEUE)
     inplace_delete_message_queue(chain_state, state_change, queueid)
     return TransitionResult(chain_state, [])
 


### PR DESCRIPTION
The function `enqueue_global` could be a bit confusing since there are
both global queues and global rooms. The function `enqueue_global` is
used to put a `Delivered` message into the global queue (which is not
sent to the global room).

To avoid the above confusion this changes from "global queue" to
"unordered queue".

The unordered queue is used to send messages that don't need to be
processed in a given order to the partner node. Which is different from
a global room, which is used to broadcast messages to multiple nodes
(particularly the services).

## Description

This is just a naming change, the goal is to clarify the different between global rooms and global queues.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
