### PR TITLE
Provide list of CLI params for use in SP

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -605,7 +605,7 @@ def run(ctx: Context, **kwargs: Any) -> None:
             profiler.stop()
 
 
-# List of available options, use by the scenario player
+# List of available options, used by the scenario player
 FLAG_OPTIONS = {param.name.replace("_", "-") for param in run.params if param.is_flag}
 FLAG_OPTIONS = FLAG_OPTIONS.union({"no-" + opt for opt in FLAG_OPTIONS})
 KNOWN_OPTIONS = {param.name.replace("_", "-") for param in run.params}.union(FLAG_OPTIONS)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -605,6 +605,12 @@ def run(ctx: Context, **kwargs: Any) -> None:
             profiler.stop()
 
 
+# List of available options, use by the scenario player
+FLAG_OPTIONS = {param.name.replace("_", "-") for param in run.params if param.is_flag}
+FLAG_OPTIONS = FLAG_OPTIONS.union({"no-" + opt for opt in FLAG_OPTIONS})
+KNOWN_OPTIONS = {param.name.replace("_", "-") for param in run.params}.union(FLAG_OPTIONS)
+
+
 @run.command()
 @option("--short", is_flag=True, help="Only display Raiden version")
 def version(short: bool) -> None:


### PR DESCRIPTION
@nlsdfnbch expressed interest in having a full list of all cli flags for
use in the SP in https://github.com/raiden-network/raiden/issues/5158.
This is provided in this commit, including the negative flags for
boolean parameters.

Closes https://github.com/raiden-network/raiden/issues/5158.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
