### PR TITLE
Enable python specific hunk-header

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sol linguist-language=Solidity
+*.py diff=python


### PR DESCRIPTION
The hunk-header is a bit of text used to contextualized a hunk (a
change).

Example, if a class named `App` has one of its class attributes changed,
the hunk header will be similar to:

    @ raiden/app.py:54 @ class App:  # pylint: disable=too-few-public-methods

The test after the second at-sign, `class App:...` is costumizable, and
it is used to give context about the change.

This value is determined by a regular expression. The default regex does
work on some cases, like the example above, but if fails on many cases,
for instance, when a method of the class is changed, the context should
be the function, but with the default regex the class is used as
context. Example, if the method `_check_and_send` from the `_RetryQueue`
is modified, with the default regex this is the hunk header:

    @ raiden/network/transport/matrix/transport.py:183 @ class _RetryQueue(Runnable):

With the custom attribute set by this commit, the header becames:

    @ raiden/network/transport/matrix/transport.py:183 @ def _check_and_send(self) -> None:

This change allows one to use `git log -L` to search for changes in a
single function, e.g.:

    git log -L :_check_and_send:raiden/network/transport/matrix/transport.py

will now list all the changes to the `_check_and_send` function