### PR TITLE
Matrix simplify registration

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -362,19 +362,9 @@ class MatrixTransport(Runnable):
         self._raiden_service = raiden_service
         self._message_handler = message_handler
 
-        prev_user_id: Optional[str]
-        prev_access_token: Optional[str]
-        if prev_auth_data and prev_auth_data.count("/") == 1:
-            prev_user_id, _, prev_access_token = prev_auth_data.partition("/")
-        else:
-            prev_user_id = prev_access_token = None
-
         self._address_mgr.start()
         login_or_register(
-            client=self._client,
-            signer=self._raiden_service.signer,
-            prev_user_id=prev_user_id,
-            prev_access_token=prev_access_token,
+            client=self._client, signer=self._raiden_service.signer, prev_auth_data=prev_auth_data
         )
         self.log = log.bind(
             current_user=self._user_id,

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -400,7 +400,7 @@ def register(client: GMatrixClient, signer: Signer, base_username: str) -> User:
     # A deterministic userid cannot be used since that would allow a DoS
     # attack, where an attacker registers the userid before the real user.  To
     # fix this a random number is added to the username.
-    username = f"{base_username}.{Random().randint(0, 0xffffffff):08x}"
+    username = f"{base_username}:{Random().randint(0, 0xffffffff):08x}"
     password = encode_hex(signer.sign(server_name.encode()))
 
     # Register will call sync internally, however, since this is a new account
@@ -415,7 +415,7 @@ def register(client: GMatrixClient, signer: Signer, base_username: str) -> User:
     user.set_display_name(signature_hex)
 
     log.debug(
-        "Matrix new user regsitered",
+        "Matrix new user registered",
         homeserver=server_name,
         server_url=server_url,
         username=username,

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -397,9 +397,9 @@ def register(client: GMatrixClient, signer: Signer, base_username: str) -> User:
     server_url = client.api.base_url
     server_name = urlparse(server_url).netloc
 
-    # A deterministic userid cannot be used since that would be allow for an
-    # DoS attack, were an attacker registers the userid before the real user.
-    # To fix this a random number is added to the username.
+    # A deterministic userid cannot be used since that would allow a DoS
+    # attack, where an attacker registers the userid before the real user.  To
+    # fix this a random number is added to the username.
     username = f"{base_username}.{Random().randint(0, 0xffffffff):08x}"
     password = encode_hex(signer.sign(server_name.encode()))
 

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -453,21 +453,22 @@ def login(client: GMatrixClient, user_id: str, access_token: str) -> Optional[Us
 
 
 def login_or_register(client: GMatrixClient, signer: Signer, prev_auth_data: str = None) -> User:
-    """Login to a Raiden matrix server with password and displayname proof-of-keys
+    """ Tries to login to a matrix server with the using the provided
+    authentication data. If there is not preexisting authentication data or the
+    authentication fails a new random account is created.
 
-    - Username is in the format: 0x<eth_address>(.<suffix>)?, where the suffix is not required,
-    but a deterministic (per-account) random 8-hex string to prevent DoS by other users registering
-    our address
-    - Password is the signature of the server hostname, verified by the server to prevent account
-    creation spam
-    - Displayname currently is the signature of the whole user_id (including homeserver), to be
-    verified by other peers. May include in the future other metadata such as protocol version
+    - Username is in the format: 0x<eth_address>.<random-suffix>.
+    - Password is the signature of the server hostname, verified by the server
+      to prevent account creation spam.
+    - Displayname currently is the signature of the whole user_id (including
+      homeserver), to be verified by other peers. May include in the future
+      other metadata such as protocol version.
 
     Params:
-        client: GMatrixClient instance configured with desired homeserver
-        signer: raiden.utils.signer.Signer instance for signing password and displayname
-        prev_user_id: (optional) previously persisted client.user_id. Must match signer's account
-        prev_access_token: (optional) previously persisted client.access_token for prev_user_id
+        client: GMatrixClient instance configured with desired homeserver.
+        signer: Signer used to sign the password and displayname.
+        prev_auth_data: Previously persisted authentication using the format "{user}/{password}".
+
     Returns:
         Own matrix_client.User
     """

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -403,6 +403,9 @@ def register(client: GMatrixClient, signer: Signer, base_username: str) -> User:
     username = f"{base_username}.{Random().randint(0, 0xffffffff):08x}"
     password = encode_hex(signer.sign(server_name.encode()))
 
+    # Register will call sync internally, however, since this is a new account
+    # and therefore it has no existing events, it is not necessary to set the
+    # sync limit.
     client.register_with_password(username, password)
 
     signature_bytes = signer.sign(client.user_id.encode())


### PR DESCRIPTION
    Simplified registration code

    The registration code had a hard coded number of retries, were each
    retry used a new userid for registration. This code had a few issues:

    - The code was introduced to prevent a DoS attack, were an attacker
    would discover the user's username from previous iterations, and if the
    matrix federation changed, the attacker would register these usernames
    before the user. It is not know how difficult is for someone to perform
    this attack, however since there was code in place to protected against
    it, I assume it is possible to happen. This change the code so that it
    is not possible for the attack happen after a bound number of iteration,
    by completely removing the usage of the seed for the PRNG.
    - Because of the above change, a loop is not necessary anymore, making
    the code slightly shorter and easier to understand.
    - Because now a registration will always use a new userid, it is not
    necessary anymore to try to login to one of the existing accounts.