### PR TITLE
Docs and make-install-dev step for detecting faulty python in OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docs:
 install: check-pip-tools clean-pyc
 	cd requirements; pip-sync requirements.txt _raiden.txt
 
-install-dev: check-pip-tools clean-pyc force-pip-version osx-detect-proper-python
+install-dev: check-pip-tools clean-pyc osx-detect-proper-python force-pip-version
 	touch requirements/requirements-local.txt
 	cd requirements; pip-sync requirements-dev.txt _raiden-dev.txt
 	pip install -c requirements/requirements-dev.txt -r requirements/requirements-local.txt
@@ -102,10 +102,9 @@ force-pip-version:
 	pip install 'pip<19.2.0'
 
 osx-detect-proper-python:
-    UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S),Darwin)
-        python -c 'import time; time.clock_gettime_ns(time.CLOCK_MONOTONIC_RAW)' > /dev/null 2>&1 || echo "Not supported python version. Read https://raiden-network.readthedocs.io/en/latest/macos_install_guide.html#macos-development-setup for details."
-    endif
+ifeq ($(shell uname -s),Darwin)
+	python -c 'import time; time.clock_gettime_ns(time.CLOCK_MONOTONIC_RAW)' > /dev/null 2>&1 || (echo "Not supported python version. Read https://raiden-network.readthedocs.io/en/latest/macos_install_guide.html#macos-development-setup for details."; exit 1)
+endif
 
 GITHUB_ACCESS_TOKEN_ARG=
 ifdef GITHUB_ACCESS_TOKEN
@@ -129,7 +128,7 @@ bundle:
 
 check-venv:
 	@python3 -c 'import sys; sys.exit(not (hasattr(sys, "real_prefix") or sys.base_prefix != sys.prefix))' \
-		|| (echo "It appears you're not working inside a venv / virtualen\nIt's strongly recommended to install raiden into a virtual environment.\nSee the documentation for more details."; exit 1)
+		|| (echo "It appears you're not working inside a venv / virtualenv\nIt's strongly recommended to install raiden into a virtual environment.\nSee the documentation for more details."; exit 1)
 
 # Ensure pip-tools is installed
 check-pip-tools: check-venv

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docs:
 install: check-pip-tools clean-pyc
 	cd requirements; pip-sync requirements.txt _raiden.txt
 
-install-dev: check-pip-tools clean-pyc force-pip-version
+install-dev: check-pip-tools clean-pyc force-pip-version osx-detect-proper-python
 	touch requirements/requirements-local.txt
 	cd requirements; pip-sync requirements-dev.txt _raiden-dev.txt
 	pip install -c requirements/requirements-dev.txt -r requirements/requirements-local.txt
@@ -100,6 +100,12 @@ install-dev: check-pip-tools clean-pyc force-pip-version
 # This is necessary to circumvent #4585
 force-pip-version:
 	pip install 'pip<19.2.0'
+
+osx-detect-proper-python:
+    UNAME_S := $(shell uname -s)
+    ifeq ($(UNAME_S),Darwin)
+        python -c 'import time; time.clock_gettime_ns(time.CLOCK_MONOTONIC_RAW)' > /dev/null 2>&1 || echo "Not supported python version. Read https://raiden-network.readthedocs.io/en/latest/macos_install_guide.html#macos-development-setup for details."
+    endif
 
 GITHUB_ACCESS_TOKEN_ARG=
 ifdef GITHUB_ACCESS_TOKEN

--- a/docs/macos_install_guide.rst
+++ b/docs/macos_install_guide.rst
@@ -7,7 +7,7 @@ Development Setup on macOS
 
 .. :highlight: bash
 
-The following instructions will guide you from a clean installation of macOS to a working source checkout of raiden. Make sure that you are on OSX 10.12 or higher. This is needed since raiden uses the MONOTONICK_CLOCK_RAW attribute as seen `here
+The following instructions will guide you from a clean installation of macOS to a working source checkout of raiden. Make sure that you are on OSX 10.12 or higher. This is needed since raiden uses the MONOTONICK_CLOCK_RAW attribute as seen `here <https://github.com/raiden-network/raiden/issues/4679#issuecomment-526128654>`__
 
 #. Install C/C++ compiler infrastructure::
 

--- a/docs/macos_install_guide.rst
+++ b/docs/macos_install_guide.rst
@@ -7,8 +7,7 @@ Development Setup on macOS
 
 .. :highlight: bash
 
-The following instructions will guide you from a clean installation of macOS to a working source
-checkout of raiden.
+The following instructions will guide you from a clean installation of macOS to a working source checkout of raiden. Make sure that you are on OSX 10.12 or higher. This is needed since raiden uses the MONOTONICK_CLOCK_RAW attribute as seen `here
 
 #. Install C/C++ compiler infrastructure::
 
@@ -21,6 +20,14 @@ checkout of raiden.
     $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
    * Follow the instructions
+
+#. Obtain a MONOTONIC_CLOCK_RAW compatible python version
+
+   The precompiled Python versions for download on python.org are built on a too old macOS version which are not compatible with ``MONOTONIC_CLOCK_RAW``. As such you will have to manually obtain a python binary that supports it. There are three ways to achieve this:
+
+   * Use brew
+   * Use `pyenv <https://realpython.com/intro-to-pyenv/>`__
+   * Use `pythonz <https://github.com/saghul/pythonz>`__
 
 #. Install system packages needed for :code:`raiden` and its dependencies::
 


### PR DESCRIPTION
Fixes: #4679 

## Description

Add a Makefile check for OSX so that users that have python which can not import `MONOTONIC_CLOCK_RAW` can know what's wrong and visit the docs to find out how to fix it.

Also add a doc entry on the OSX installation letting the users know that they should manually install python if they encounter this problem.