### PR TITLE
Closes #5127

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -197,7 +197,7 @@ class UserAddressManager:
         should **not** generally be used.
         """
         composite_presence = {
-            self._fetch_user_presence(uid) for uid in self._address_to_userids[address]
+            self._fetch_user_presence(uid) for uid in self._address_to_userids[address].copy()
         }
 
         # Iterate over UserPresence in definition order (most to least online) and pick

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -923,7 +923,6 @@ def test_matrix_user_roaming(matrix_transports):
     assert ping_pong_message_success(transport0, transport1)
 
 
-@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5127")
 @pytest.mark.parametrize("matrix_server_count", [3])
 @pytest.mark.parametrize("number_of_transports", [6])
 def test_matrix_multi_user_roaming(matrix_transports):


### PR DESCRIPTION
Fixes: #5127

## Description

We we're using `_address_to_userids` in `refresh_address_presence`. That could cause flakiness during teardown of tests when while we were iterating over it. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [x] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [x] Error conditions are handled
    - [x] Exceptions are propagated to the correct parent greenlet
    - [x] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [x] State changes are forward compatible
    - [x] Transport messages are backwards and forward compatible
- Commits
    - [x] Have good messages
    - [x] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [x] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [x] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [x] Changelog entry has been added
