### PR TITLE
Use `Fraction`s to increase fee calculation accuracy

### DIFF
--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -1,3 +1,4 @@
+from fractions import Fraction
 from typing import Tuple
 
 import pytest
@@ -50,10 +51,10 @@ def test_interpolation():
     assert interp(90) == 30
     assert interp(99) == 48
 
-    interp = Interpolate((0, 100), (12.35, 67.2))
-    assert interp(0) == 12.35
+    interp = Interpolate((0, 100), (Fraction("12.35"), Fraction("67.2")))
+    assert interp(0) == Fraction("12.35")
     assert interp(50) == pytest.approx((12.35 + 67.2) / 2)
-    assert interp(100) == 67.2
+    assert interp(100) == Fraction("67.2")
 
 
 def test_imbalance_penalty():

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -442,10 +442,6 @@ def test_fee_round_trip(flat_fee, prop_fee, imbalance_fee, amount, balance1, bal
 )
 def test_fee_add_remove_invariant(flat_fee, prop_fee, imbalance_fee, amount, balance1, balance2):
     """ First adding and then removing fees must yield the original value """
-    # Find examples where there is a reasonable chance of succeeding
-    amount = int(min(amount, balance1 * 0.95 - 1, balance2 * 0.95 - 1))
-    assume(amount > 0)
-
     total_balance = TokenAmount(100_000_000_000_000_000_000)
     prop_fee_per_channel = ppm_fee_per_channel(ProportionalFeeAmount(prop_fee))
     imbalance_fee = calculate_imbalance_fees(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -356,9 +356,9 @@ def test_get_lock_amount_after_fees_imbalanced_channel(
     integers(min_value=0, max_value=100),
     integers(min_value=0, max_value=10_000),
     integers(min_value=0, max_value=50_000),
-    integers(min_value=1, max_value=90_000),
-    integers(min_value=1, max_value=100_000),
-    integers(min_value=1, max_value=100_000),
+    integers(min_value=1, max_value=90_000_000_000_000_000),
+    integers(min_value=1, max_value=100_000_000_000_000_000),
+    integers(min_value=1, max_value=100_000_000_000_000_000),
 )
 def test_fee_round_trip(flat_fee, prop_fee, imbalance_fee, amount, balance1, balance2):
     """ Tests mediation fee deduction.
@@ -372,7 +372,7 @@ def test_fee_round_trip(flat_fee, prop_fee, imbalance_fee, amount, balance1, bal
     amount = int(min(amount, balance1 * 0.95 - 1, balance2 * 0.95 - 1))
     assume(amount > 0)
 
-    total_balance = TokenAmount(100_000)
+    total_balance = TokenAmount(100_000_000_000_000_000_000)
     prop_fee_per_channel = ppm_fee_per_channel(ProportionalFeeAmount(prop_fee))
     imbalance_fee = calculate_imbalance_fees(
         channel_capacity=total_balance,
@@ -418,10 +418,6 @@ def test_fee_round_trip(flat_fee, prop_fee, imbalance_fee, amount, balance1, bal
     )
     assume(amount_without_margin_after_fees)  # We might lack capacity for the payment
     assert abs(amount - amount_without_margin_after_fees) <= 1  # Equal except for rounding errors
-
-    # We don't handle the case where mediation fees cancel each other out exactly to zero, yet.
-    # Remove this assume after https://github.com/raiden-network/raiden-services/issues/569.
-    assume(fee_calculation.mediation_fees[0] != 0 or imbalance_fee == 0)
 
     # If we add the fee margin, the mediator must always send at least `amount` to the target!
     amount_with_fee_and_margin = calculate_safe_amount_with_fee(

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediation_fee.py
@@ -483,10 +483,6 @@ def test_fee_add_remove_invariant(flat_fee, prop_fee, imbalance_fee, amount, bal
         amount_with_fees=amount_with_fees, channel_in=channel_in, channel_out=channel_out
     )
     assume(amount_without_fees)
-    fee_in = float(channel_in.fee_schedule.fee(total_balance - balance1, amount_with_fees))
-    fee_out = float(channel_out.fee_schedule.fee(balance2, -amount))
-    print(f"amount: {amount} with_fees: {amount_with_fees} without_fees: {amount_without_fees}")
-    print(f"fee parts: in {fee_in:.2f}, out {fee_out:.2f}, sum {fee_in + fee_out:.2f}")
     assert amount - 1 <= amount_without_fees <= amount + 1
 
 

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -68,7 +68,7 @@ def _collect_x_values(
         balance_out - x for x in schedule_out._penalty_func.x_list
     ]
     limited_x_vals = (max(min(x, balance_out, max_x), 0) for x in all_x_vals)
-    return sorted({Fraction(x) for x in limited_x_vals})
+    return sorted(set(Fraction(x) for x in limited_x_vals))
 
 
 def _cap_fees(

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -23,15 +23,17 @@ class Interpolate:  # pylint: disable=too-few-public-methods
     Based on https://stackoverflow.com/a/7345691/114926
     """
 
-    def __init__(self, x_list: Sequence, y_list: Sequence) -> None:
+    def __init__(
+        self, x_list: Sequence[Union[Fraction, int]], y_list: Sequence[Union[Fraction, int]]
+    ) -> None:
         if any(y - x <= 0 for x, y in zip(x_list, x_list[1:])):
             raise ValueError("x_list must be in strictly ascending order!")
-        self.x_list = [Fraction(x) for x in x_list]
-        self.y_list = [Fraction(y) for y in y_list]
+        self.x_list: List[Fraction] = [Fraction(x) for x in x_list]
+        self.y_list: List[Fraction] = [Fraction(y) for y in y_list]
         intervals = zip(self.x_list, self.x_list[1:], y_list, y_list[1:])
-        self.slopes = [(y2 - y1) / (x2 - x1) for x1, x2, y1, y2 in intervals]
+        self.slopes: List[Fraction] = [(y2 - y1) / (x2 - x1) for x1, x2, y1, y2 in intervals]
 
-    def __call__(self, x: float) -> Fraction:
+    def __call__(self, x: Union[Fraction, int]) -> Fraction:
         if not self.x_list[0] <= x <= self.x_list[-1]:
             raise ValueError("x out of bounds!")
         if x == self.x_list[-1]:

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1,6 +1,7 @@
 import itertools
 import operator
 import random
+from fractions import Fraction
 from typing import Callable
 
 from raiden.exceptions import UndefinedMediationFee
@@ -226,7 +227,7 @@ def get_pending_transfer_pairs(
     return pending_pairs
 
 
-def find_intersection(fee_func: Interpolate, line: Callable[[int], float]) -> Optional[float]:
+def find_intersection(fee_func: Interpolate, line: Callable[[int], Fraction]) -> Optional[float]:
     """ Returns the x value where both functions intersect
 
     `fee_func` is a piecewise linear function while `line` is a straight line

--- a/raiden/utils/mediation_fees.py
+++ b/raiden/utils/mediation_fees.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 from raiden.constants import DAI_TOKEN_ADDRESS, WETH_TOKEN_ADDRESS
 from raiden.settings import DEFAULT_DAI_FLAT_FEE, DEFAULT_WETH_FLAT_FEE, MediationFeeConfig
 from raiden.utils.typing import Dict, FeeAmount, ProportionalFeeAmount, TokenAddress, Tuple
@@ -13,8 +15,8 @@ def ppm_fee_per_channel(per_hop_fee: ProportionalFeeAmount) -> ProportionalFeeAm
     #converting-per-hop-proportional-fees-in-per-channel-proportional-fees
     for how to get to this formula.
     """
-    per_hop_ratio = per_hop_fee / 1e6
-    return ProportionalFeeAmount(round(per_hop_ratio / (per_hop_ratio + 2) * 1e6))
+    per_hop_ratio = Fraction(per_hop_fee, 10 ** 6)
+    return ProportionalFeeAmount(round(per_hop_ratio / (per_hop_ratio + 2) * 10 ** 6))
 
 
 def prepare_mediation_fee_config(


### PR DESCRIPTION
## Description

The standard double-precision floats can't precisely represent integers
larger than ~10**16. This has the effect that balances above that caused
relatively large inaccuracies even for small payments (errors of
multiple tokens for a single token transfer).

This is fixed by calculating with fractions instead of floats at the
cost of decreased performance. Benchmarks will follow to assess the
impact. This might especially problematic for the PFS when optimizing
routes.

To exercise this problem in the unit tests, the increase the amounts in `test_fee_round_trip` and add`test_fee_add_remove_invariant`.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
