### PR TITLE
Add a check to notify about the monitoring contract requirement

### DIFF
--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -320,6 +320,18 @@ def run_app(
             fg="yellow",
         )
 
+    monitoring_contract_required = (
+        enable_monitoring and CONTRACT_MONITORING_SERVICE not in contracts
+    )
+    if monitoring_contract_required:
+        click.secho(
+            "Monitoring is enabled but the contract for this ethereum network was not found. "
+            "Please provide monitoring service contract address using "
+            "--monitoring-service-address.",
+            fg="red",
+        )
+        sys.exit(1)
+
     # Only send feedback when PFS is used
     if routing_mode == RoutingMode.PFS:
         event_handler = PFSFeedbackEventHandler(event_handler)


### PR DESCRIPTION
Fixes: #5153 

## Description

This case is triggers when trying to use --enable monitoring
on a private ethereum network

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
