### PR TITLE
4755: Setting mediation fees through REST API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         args: ['--remove']
       - id: flake8
         args: ["--config=setup.cfg"]
-        additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer",]
+        additional_dependencies: ["flake8-bugbear", "flake8-tuple", "readme-renderer",]
       - id: mixed-line-ending
       - id: no-commit-to-branch
         args: ['--branch', 'master', '--branch', 'develop']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         args: ['--remove']
       - id: flake8
         args: ["--config=setup.cfg"]
-        additional_dependencies: ["flake8-bugbear", "flake8-tuple", "readme-renderer",]
+        additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer",]
       - id: mixed-line-ending
       - id: no-commit-to-branch
         args: ['--branch', 'master', '--branch', 'develop']

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`4755` Set mediation fee schedules per channel and per-token network, through REST API
 * :feature:`5050` Raiden's argument --debug-logfile-name has been renamed to --debug-logfile-path to better reflect the argument's function.
 * :bug:`5050` Raiden now works on OSX Catalina. Debug logfile is no longer written in the current directory.
 * :feature:`5278` Always use private rooms in the matrix transport.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -63,6 +63,9 @@ Raiden Glossary
    balance proof
        Balance proof is any kind of message used in order to cryptographically prove on the blockchain what the latest :term:`transferred amount` and :term:`locked amount` received from a counter party is.
 
+   Imbalance fee
+      TBD
+
    hashlock
        A hashlock is the hashed secret that accompanies a locked message: ``sha3(secret)``.
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -30,7 +30,7 @@ Fee Schedule Object
    }
 
 
-A fee schedule object represents the current established fees that the node wants to collect for mediated transfers. The following parameters can be set:
+A fee schedule object represents the current established fees that the mediator node wants to charge for transfers. The following parameters can be set:
 
 - ``cap_fees`` should be a ``boolean`` indicating whether the fees paid to mediators should be capped
 - ``flat`` should be an ``integer`` indicating the fee cost (in wei) for every mediated transfer, regardless of transfer amount
@@ -62,7 +62,7 @@ Token Network Object
 - ``token_address`` should be a ``string`` containing the EIP55-encoded address of the
   token registered in the token network.
 
-- ``fee_schedule``: represents the `Fee Schedule Object` used for the configuration for all channels in this token network.
+- ``fee_schedule`` represents a `Fee Schedule Object`_ used for the configuration for all channels in this token network.
 
 
 
@@ -261,7 +261,7 @@ Querying Information About Channels and Tokens
               "reveal_timeout": 50,
               "fee_schedule": {
                   "cap_fees": true,
-                  "imbalance_penalty": [[0,60], [1000, 21], [2000, 6], (...),  [18000,6]], [19000,21], [20000,60]],
+                  "imbalance_penalty": [[0,60], [1000, 21], [2000, 6], [18000,6]], [19000,21], [20000,60]],
                   "proportional": 1280,
                   "flat": 50
                   }
@@ -303,7 +303,7 @@ Querying Information About Channels and Tokens
               "reveal_timeout": 50,
               "fee_schedule": {
                   "cap_fees": true,
-                  "imbalance_penalty": [[0,60], [1000, 21], [2000, 6], (...),  [18000,6]], [19000,21], [20000,60]],
+                  "imbalance_penalty": [[0,60], [1000, 21], [2000, 6], [18000,6]], [19000,21], [20000,60]],
                   "proportional": 1280,
                   "flat": 50
                   }
@@ -345,12 +345,12 @@ Querying Information About Channels and Tokens
           "settle_timeout": 500,
           "reveal_timeout": 50,
           "fee_schedule": {
-                  "cap_fees": true,
-                  "imbalance_penalty": [[0,60], [1000, 21], [2000, 6], (...),  [18000,6]], [19000,21], [20000,60]],
-                  "proportional": 1280,
-                  "flat": 50
-                  }
+              "cap_fees": true,
+              "imbalance_penalty": [[0,60], [1000, 21], [2000, 6], [18000,6]], [19000,21], [20000,60]],
+              "proportional": 1280,
+              "flat": 50
               }
+          }
       }
 
    :statuscode 200: Successful query

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -44,6 +44,7 @@ from raiden.transfer.state import (
     ChannelState,
     NettingChannelState,
     NetworkState,
+    TokenNetworkState,
 )
 from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils import create_default_identifier
@@ -259,6 +260,40 @@ class RaidenAPI:  # pragma: no unittest
         )
 
         return token_network_address
+
+    def set_token_network_fee_schedule(
+        self,
+        registry_address: TokenNetworkRegistryAddress,
+        token_address: TokenAddress,
+        fee_schedule: FeeScheduleState,
+    ) -> None:
+        chain_state = views.state_from_raiden(self.raiden)
+
+        token_addresses = views.get_token_identifiers(chain_state, registry_address)
+
+        if not is_binary_address(token_address):
+            raise InvalidBinaryAddress("Expected binary address format for token")
+
+        if token_address not in token_addresses:
+            raise UnknownTokenAddress("Unknown token address")
+
+        token_network_address = views.get_token_network_address_by_token_address(
+            chain_state=views.state_from_raiden(self.raiden),
+            token_network_registry_address=registry_address,
+            token_address=token_address,
+        )
+
+        if token_network_address is None:
+            raise UnknownTokenAddress(
+                f"Token {to_checksum_address(token_address)} is not registered "
+                f"with the network {to_checksum_address(registry_address)}."
+            )
+
+        self.raiden.set_token_network_fee_schedule(
+            registry_address=registry_address,
+            token_network_address=token_network_address,
+            fee_schedule=fee_schedule,
+        )
 
     def token_network_connect(
         self,
@@ -814,13 +849,13 @@ class RaidenAPI:  # pragma: no unittest
             canonical_identifier=channel_state.canonical_identifier, reveal_timeout=reveal_timeout
         )
 
-    def set_fee_schedule(
+    def set_channel_fee_schedule(
         self,
         registry_address: TokenNetworkRegistryAddress,
         token_address: TokenAddress,
         partner_address: Address,
         fee_schedule: FeeScheduleState,
-    ):
+    ) -> None:
         chain_state = views.state_from_raiden(self.raiden)
 
         token_addresses = views.get_token_identifiers(chain_state, registry_address)
@@ -847,7 +882,7 @@ class RaidenAPI:  # pragma: no unittest
         if channel_state is None:
             raise NonexistingChannel("No channel with partner_address for the given token")
 
-        self.raiden.set_fee_schedule(
+        self.raiden.set_channel_fee_schedule(
             canonical_identifier=channel_state.canonical_identifier, fee_schedule=fee_schedule
         )
 
@@ -1009,6 +1044,15 @@ class RaidenAPI:  # pragma: no unittest
         self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress
     ) -> Optional[TokenNetworkAddress]:
         return views.get_token_network_address_by_token_address(
+            chain_state=views.state_from_raiden(self.raiden),
+            token_network_registry_address=registry_address,
+            token_address=token_address,
+        )
+
+    def get_token_network_state_for_token_address(
+        self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress
+    ) -> Optional[TokenNetworkState]:
+        return views.get_token_network_by_token_address(
             chain_state=views.state_from_raiden(self.raiden),
             token_network_registry_address=registry_address,
             token_address=token_address,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1349,18 +1349,16 @@ class RestAPI:  # pragma: no unittest
             state=state,
         )
 
-        # Method to get list of attributes that were actually set on the request.
-        settable_attributes = [
-            "total_deposit",
-            "total_withdraw",
-            "reveal_timeout",
-            "fee_schedule",
-            "state",
-        ]
+        patch_arguments = dict(
+            total_deposit=total_deposit,
+            total_withdraw=total_withdraw,
+            reveal_timeout=reveal_timeout,
+            fee_schedule=fee_schedule,
+            state=state,
+        )
 
-        attrs = locals()
         changed_attributes = {
-            attr: attrs[attr] for attr in settable_attributes if attrs[attr] is not None
+            key: value for key, value in patch_arguments.items() if value is not None
         }
 
         if len(changed_attributes) > 1:
@@ -1382,19 +1380,12 @@ class RestAPI:  # pragma: no unittest
                 status_code=HTTPStatus.BAD_REQUEST,
             )
 
-        empty_request = all(
-            (
-                total_deposit is None,
-                state is None,
-                total_withdraw is None,
-                reveal_timeout is None,
-                fee_schedule is None,
-            )
-        )
+        empty_request = len(changed_attributes) == 0
+
         if empty_request:
-            attribute_name_list = ", ".join((f"'{attr}'" for attr in settable_attributes))
+            attribute_name_list = "/".join((f"'{attr}'" for attr in patch_arguments.keys()))
             return api_error(
-                errors=("Nothing to do. Should provide one of {attribute_name_list} arguments"),
+                errors=("Nothing to do. Should provide one of {attribute_name_list}"),
                 status_code=HTTPStatus.BAD_REQUEST,
             )
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1271,7 +1271,7 @@ class RestAPI:  # pragma: no unittest
         registry_address: TokenNetworkRegistryAddress,
         channel_state: NettingChannelState,
         fee_schedule: FeeScheduleState,
-    ):
+    ) -> Response:
         log.debug("Set fee schedule")
         if channel.get_status(channel_state) != ChannelState.STATE_OPENED:
             return api_error(

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -26,7 +26,7 @@ from raiden.constants import (
 from raiden.settings import DEFAULT_INITIAL_CHANNEL_TARGET, DEFAULT_JOINABLE_FUNDS_TARGET
 from raiden.transfer import channel
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
-from raiden.transfer.state import ChannelState, NettingChannelState
+from raiden.transfer.state import ChannelState, NettingChannelState, TokenNetworkState
 
 
 class InvalidEndpoint(NotFound):
@@ -280,6 +280,24 @@ class FeeScheduleSchema(BaseSchema):
     class Meta:
         strict = True
         decoding_class = FeeScheduleState
+
+
+class TokenNetworkStateSchema(BaseSchema):
+    address = AddressField(dump_only=True)
+    token_address = AddressField(dump_only=True)
+    fee_schedule = fields.Nested(FeeScheduleSchema, missing=None)
+
+    class Meta:
+        strict = True
+        decoding_class = TokenNetworkState
+
+
+class TokenNetworkStatePatchSchema(BaseSchema):
+    fee_schedule = fields.Nested(FeeScheduleSchema, missing=None)
+
+    class Meta:
+        strict = True
+        decoding_class = dict
 
 
 class ChannelStateSchema(BaseSchema):

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -25,6 +25,7 @@ from raiden.constants import (
 )
 from raiden.settings import DEFAULT_INITIAL_CHANNEL_TARGET, DEFAULT_JOINABLE_FUNDS_TARGET
 from raiden.transfer import channel
+from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.state import ChannelState, NettingChannelState
 
 
@@ -268,6 +269,19 @@ class MintTokenSchema(BaseSchema):
         decoding_class = dict
 
 
+class FeeScheduleSchema(BaseSchema):
+    cap_fees = fields.Boolean()
+    flat = fields.Integer(missing=0, validate=validate.Range(min=0, max=UINT256_MAX))
+    proportional = fields.Integer(missing=0, validate=validate.Range(min=0, max=1e21))
+    imbalance_penalty = fields.List(
+        fields.Tuple((fields.Integer(), fields.Integer())), dump_only=True
+    )
+
+    class Meta:
+        strict = True
+        decoding_class = FeeScheduleState
+
+
 class ChannelStateSchema(BaseSchema):
     channel_identifier = fields.Integer(attribute="identifier")
     token_network_address = AddressField()
@@ -275,6 +289,7 @@ class ChannelStateSchema(BaseSchema):
     partner_address = fields.Method("get_partner_address")
     settle_timeout = fields.Integer()
     reveal_timeout = fields.Integer()
+    fee_schedule = fields.Nested(FeeScheduleSchema, missing=None)
     balance = fields.Method("get_balance")
     state = fields.Method("get_state")
     total_deposit = fields.Method("get_total_deposit")
@@ -313,6 +328,7 @@ class ChannelPutSchema(BaseSchema):
     reveal_timeout = fields.Integer(missing=None)
     settle_timeout = fields.Integer(missing=None)
     total_deposit = fields.Integer(default=None, missing=None)
+    fee_schedule = fields.Nested(FeeScheduleSchema)
 
     class Meta:
         strict = True
@@ -324,6 +340,7 @@ class ChannelPatchSchema(BaseSchema):
     total_deposit = fields.Integer(default=None, missing=None)
     total_withdraw = fields.Integer(default=None, missing=None)
     reveal_timeout = fields.Integer(default=None, missing=None)
+    fee_schedule = fields.Nested(FeeScheduleSchema, default=None, missing=None)
     state = fields.String(
         default=None,
         missing=None,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -11,6 +11,8 @@ from raiden.api.v1.encoding import (
     MintTokenSchema,
     PaymentSchema,
     RaidenEventsRequestSchema,
+    TokenNetworkStatePatchSchema,
+    TokenNetworkStateSchema,
 )
 from raiden.utils import typing
 from raiden.utils.testnet import MintingMethod
@@ -91,6 +93,22 @@ class TokensResource(BaseResource):
         """
         return self.rest_api.get_tokens_list(
             self.rest_api.raiden_api.raiden.default_registry.address
+        )
+
+
+class TokenNetworkStateResource(BaseResource):
+    get_schema = TokenNetworkStateSchema
+    patch_schema = TokenNetworkStatePatchSchema
+
+    def get(self, token_address):
+        return self.rest_api.get_token_network_state_for_token(
+            self.rest_api.raiden_api.raiden.default_registry.address, token_address
+        )
+
+    @use_kwargs(patch_schema, locations=("json",))
+    def patch(self, token_address, **kwargs):
+        return self.rest_api.patch_token_network_state(
+            self.rest_api.raiden_api.raiden.default_registry.address, token_address, **kwargs
         )
 
 

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -237,6 +237,10 @@ class InvalidBlockNumberInput(RaidenError):
     """Raised when the user provided a block number that is  < 0 or > UINT64_MAX"""
 
 
+class InvalidFeeSchedule(RaidenError):
+    """Raised when the user provided invalid parameters for fee schedule"""
+
+
 class NoStateForBlockIdentifier(RaidenError):
     """
     Raised when we attempt to provide a block identifier older

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -77,6 +77,7 @@ from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.transfer.state import ChainState, HopState, NetworkState, TokenNetworkRegistryState
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
+    ActionChannelSetFeeSchedule,
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
     ActionInitChain,
@@ -983,7 +984,7 @@ class RaidenService(Runnable):
                 token_address=token_address,
             )
 
-            for channel in channels:
+            for channel in [c for c in channels if c.fee_schedule is None]:
                 # get the flat fee for this network if set, otherwise the default
                 flat_fee = fee_config.get_flat_fee(channel.token_address)
                 proportional_fee = fee_config.get_proportional_fee(channel.token_address)
@@ -1247,6 +1248,16 @@ class RaidenService(Runnable):
         )
 
         self.handle_and_track_state_changes([action_set_channel_reveal_timeout])
+
+    def set_fee_schedule(
+        self, canonical_identifier: CanonicalIdentifier, fee_schedule: FeeScheduleState
+    ) -> None:
+        action_set_fee_schedule = ActionChannelSetFeeSchedule(
+            canonical_identifier=canonical_identifier,
+            fee_schedule=fee_schedule,
+            fee_config=self.config["mediation_fees"],
+        )
+        self.handle_and_track_state_changes([action_set_fee_schedule])
 
     def maybe_upgrade_db(self) -> None:
         manager = UpgradeManager(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -81,6 +81,7 @@ from raiden.transfer.state_change import (
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
     ActionInitChain,
+    ActionTokenNetworkSetFeeSchedule,
     Block,
     ContractReceiveNewTokenNetworkRegistry,
 )
@@ -102,6 +103,7 @@ from raiden.utils.typing import (
     SecretHash,
     TargetAddress,
     TokenNetworkAddress,
+    TokenNetworkRegistryAddress,
     WithdrawAmount,
 )
 from raiden.utils.upgrades import UpgradeManager
@@ -1095,6 +1097,20 @@ class RaidenService(Runnable):
 
         return manager
 
+    def set_token_network_fee_schedule(
+        self,
+        registry_address: TokenNetworkRegistryAddress,
+        token_network_address: TokenNetworkAddress,
+        fee_schedule: FeeScheduleState,
+    ) -> None:
+        action_set_token_network_fee_schedule = ActionTokenNetworkSetFeeSchedule(
+            registry_address=registry_address,
+            token_network_address=token_network_address,
+            fee_schedule=fee_schedule,
+            fee_config=self.config["mediation_fees"],
+        )
+        self.handle_and_track_state_changes([action_set_token_network_fee_schedule])
+
     def mediated_transfer_async(
         self,
         token_network_address: TokenNetworkAddress,
@@ -1249,7 +1265,7 @@ class RaidenService(Runnable):
 
         self.handle_and_track_state_changes([action_set_channel_reveal_timeout])
 
-    def set_fee_schedule(
+    def set_channel_fee_schedule(
         self, canonical_identifier: CanonicalIdentifier, fee_schedule: FeeScheduleState
     ) -> None:
         action_set_fee_schedule = ActionChannelSetFeeSchedule(

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -2689,11 +2689,17 @@ def test_api_set_fee_schedule(
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(app0), app0.raiden.default_registry.address, token_address
     )
+
+    assert token_network_address is not None
+
     channel_state = views.get_channelstate_by_token_network_and_partner(
         chain_state=views.state_from_raiden(app0.raiden),
         token_network_address=token_network_address,
         partner_address=app1.raiden.address,
     )
+
+    assert channel_state is not None
+    assert channel_state.fee_schedule is not None
 
     assert channel_state.fee_schedule.flat == fee_schedule_data["flat"]
     assert channel_state.fee_schedule.proportional == fee_schedule_data["proportional"]

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -448,7 +448,7 @@ def test_api_open_and_deposit_channel(
         json={"total_deposit": -1000},
     )
     response = request.send().response
-    assert_proper_response(response, HTTPStatus.CONFLICT)
+    assert_proper_response(response, HTTPStatus.BAD_REQUEST)
 
     # let's deposit on the first channel
     request = grequests.patch(
@@ -2646,3 +2646,54 @@ def test_api_set_reveal_timeout(
     assert channel_state
 
     assert channel_state.reveal_timeout == reveal_timeout
+
+
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("deposit", [0])
+def test_api_set_fee_schedule(
+    api_server_test_instance, raiden_network, token_addresses, settle_timeout
+):
+    app0, app1 = raiden_network
+    token_address = token_addresses[0]
+    partner_address = app1.raiden.address
+
+    fee_schedule_data = dict(flat=25, proportional=1000)
+    reveal_timeout_data = settle_timeout + 1
+
+    # Trying to PATCH two attributes at the same time results in a CONFLICT error response
+    request = grequests.patch(
+        api_url_for(
+            api_server_test_instance,
+            "channelsresourcebytokenandpartneraddress",
+            token_address=token_address,
+            partner_address=partner_address,
+        ),
+        json={"fee_schedule": fee_schedule_data, "reveal_timeout": reveal_timeout_data},
+    )
+    response = request.send().response
+    assert_response_with_error(response, HTTPStatus.CONFLICT)
+
+    # Correct PATCH
+    request = grequests.patch(
+        api_url_for(
+            api_server_test_instance,
+            "channelsresourcebytokenandpartneraddress",
+            token_address=token_address,
+            partner_address=partner_address,
+        ),
+        json={"fee_schedule": fee_schedule_data},
+    )
+    response = request.send().response
+    assert_response_with_code(response, HTTPStatus.OK)
+
+    token_network_address = views.get_token_network_address_by_token_address(
+        views.state_from_app(app0), app0.raiden.default_registry.address, token_address
+    )
+    channel_state = views.get_channelstate_by_token_network_and_partner(
+        chain_state=views.state_from_raiden(app0.raiden),
+        token_network_address=token_network_address,
+        partner_address=app1.raiden.address,
+    )
+
+    assert channel_state.fee_schedule.flat == fee_schedule_data["flat"]
+    assert channel_state.fee_schedule.proportional == fee_schedule_data["proportional"]

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -1,9 +1,7 @@
-from copy import deepcopy
 from unittest.mock import Mock, patch
 
 import pytest
 
-from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.app import App
 from raiden.constants import (
@@ -14,30 +12,16 @@ from raiden.constants import (
 )
 from raiden.message_handler import MessageHandler
 from raiden.messages.monitoring_service import RequestMonitoring
-from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
-from raiden.settings import (
-    DEFAULT_MEDIATION_FLAT_FEE,
-    DEFAULT_MEDIATION_PROPORTIONAL_FEE,
-    DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
-)
+from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import transfer
-from raiden.transfer import views
-from raiden.transfer.state import NettingChannelState
 from raiden.transfer.state_change import Block
-from raiden.utils.typing import (
-    BlockNumber,
-    FeeAmount,
-    PaymentAmount,
-    PaymentID,
-    ProportionalFeeAmount,
-    Type,
-)
+from raiden.utils.typing import BlockNumber, PaymentAmount, PaymentID, Type
 
 
 @raise_on_failure
@@ -113,10 +97,8 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
     # Asserts the balance proofs are broadcasted before protocol messages
     def start_transport(*args, **kwargs):
         # Before restart the transport's broadcast queue should be initialized
-        # There should be 3 messages in the queue:
-        # - A `MonitorRequest` to the MS
-        # - A `PFSCapacityUpdate`
-        # - A `PFSFeeUpdate`
+        # There should be A `MonitorRequest` message to the MS in the queue:
+        # -
         queue_copy = transport._broadcast_queue.copy()
         queued_messages = list()
         for _ in range(len(transport._broadcast_queue)):
@@ -132,8 +114,6 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
             )
 
         assert num_matching_queued_messages(MONITORING_BROADCASTING_ROOM, RequestMonitoring) == 1
-        assert num_matching_queued_messages(PATH_FINDING_BROADCASTING_ROOM, PFSFeeUpdate) == 1
-        assert num_matching_queued_messages(PATH_FINDING_BROADCASTING_ROOM, PFSCapacityUpdate) == 1
 
         old_start_transport(*args, **kwargs)
 
@@ -204,130 +184,3 @@ def test_alarm_task_first_run_syncs_blockchain_events(raiden_network, blockchain
     # If all runs well and our first_run_with_check function runs then test passes
     # since that means channels were queriable right after the first run of the
     # alarm task
-
-
-@pytest.mark.parametrize("number_of_nodes", [2])
-def test_fees_are_updated_during_startup(
-    raiden_network, token_addresses, deposit, retry_timeout
-) -> None:
-    """
-    Test that the supplied fee settings are correctly forwarded to all
-    channels during node startup.
-    """
-    app0, app1 = raiden_network
-
-    token_address = token_addresses[0]
-
-    def get_channel_state(app) -> NettingChannelState:
-        chain_state = views.state_from_app(app)
-        token_network_registry_address = app.raiden.default_registry.address
-        token_network_address = views.get_token_network_address_by_token_address(
-            chain_state, token_network_registry_address, token_address
-        )
-        assert token_network_address
-        channel_state = views.get_channelstate_by_token_network_and_partner(
-            chain_state, token_network_address, app1.raiden.address
-        )
-        assert channel_state
-
-        return channel_state
-
-    waiting.wait_both_channel_deposit(
-        app0, app1, app0.raiden.default_registry.address, token_address, deposit, retry_timeout
-    )
-    # This is the imbalance penalty generated for the deposit
-    # with DEFAULT_MEDIATION_PROPORTIONAL_IMBALANCE_FEE
-    # once both channels have deposited the default (200) deposit
-    default_imbalance_penalty = [
-        (0, 1),
-        (20, 0),
-        (40, 0),
-        (60, 0),
-        (80, 0),
-        (100, 0),
-        (120, 0),
-        (140, 0),
-        (160, 0),
-        (180, 0),
-        (200, 0),
-        (220, 0),
-        (240, 0),
-        (260, 0),
-        (280, 0),
-        (300, 0),
-        (320, 0),
-        (340, 0),
-        (360, 0),
-        (380, 0),
-        (400, 1),
-    ]
-
-    # Check that the defaults are used
-    channel_state = get_channel_state(app0)
-    assert channel_state.fee_schedule.flat == DEFAULT_MEDIATION_FLAT_FEE
-    assert channel_state.fee_schedule.proportional == DEFAULT_MEDIATION_PROPORTIONAL_FEE
-    assert channel_state.fee_schedule.imbalance_penalty == default_imbalance_penalty
-
-    orginal_config = app0.raiden.config.copy()
-
-    # Now restart app0, and set new flat fee for that token network
-    flat_fee = FeeAmount(100)
-    app0.stop()
-    app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_flat_fee = {token_address: flat_fee}
-    app0.start()
-
-    channel_state = get_channel_state(app0)
-    assert channel_state.fee_schedule.flat == flat_fee
-    assert channel_state.fee_schedule.proportional == DEFAULT_MEDIATION_PROPORTIONAL_FEE
-    assert channel_state.fee_schedule.imbalance_penalty == default_imbalance_penalty
-
-    # Now restart app0, and set new proportional fee
-    prop_fee = ProportionalFeeAmount(123)
-    app0.stop()
-    app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_proportional_fee = {token_address: prop_fee}
-    app0.start()
-
-    channel_state = get_channel_state(app0)
-    assert channel_state.fee_schedule.flat == DEFAULT_MEDIATION_FLAT_FEE
-    assert channel_state.fee_schedule.proportional == prop_fee
-    assert channel_state.fee_schedule.imbalance_penalty == default_imbalance_penalty
-
-    # Now restart app0, and set new proportional imbalance fee
-    app0.stop()
-    app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_proportional_imbalance_fee = {
-        token_address: 0.05e6
-    }
-    app0.start()
-
-    channel_state = get_channel_state(app0)
-    assert channel_state.fee_schedule.flat == DEFAULT_MEDIATION_FLAT_FEE
-    assert channel_state.fee_schedule.proportional == DEFAULT_MEDIATION_PROPORTIONAL_FEE
-    # with 5% imbalance fee
-    full_imbalance_penalty = [
-        (0, 20),
-        (20, 18),
-        (40, 16),
-        (60, 14),
-        (80, 12),
-        (100, 10),
-        (120, 8),
-        (140, 6),
-        (160, 4),
-        (180, 2),
-        (200, 0),
-        (220, 2),
-        (240, 4),
-        (260, 6),
-        (280, 8),
-        (300, 10),
-        (320, 12),
-        (340, 14),
-        (360, 16),
-        (380, 18),
-        (400, 20),
-    ]
-
-    assert channel_state.fee_schedule.imbalance_penalty == full_imbalance_penalty

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -66,6 +66,7 @@ from raiden.transfer.state import (
 )
 from raiden.transfer.state_change import (
     ActionChannelClose,
+    ActionChannelSetFeeSchedule,
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
     Block,
@@ -1931,6 +1932,30 @@ def handle_action_set_reveal_timeout(
     return TransitionResult(channel_state, events)
 
 
+def handle_action_set_fee_schedule(
+    channel_state: NettingChannelState, state_change: ActionChannelSetFeeSchedule
+) -> TransitionResult[NettingChannelState]:
+
+    events: List[Event] = []
+    proportional_imbalance_fee = state_change.fee_config.get_proportional_imbalance_fee(
+        channel_state.token_address
+    )
+    imbalance_penalty = calculate_imbalance_fees(
+        channel_capacity=get_capacity(channel_state),
+        proportional_imbalance_fee=proportional_imbalance_fee,
+    )
+
+    channel_state.fee_schedule = FeeScheduleState(
+        cap_fees=state_change.fee_schedule.cap_fees,
+        flat=state_change.fee_schedule.flat,
+        proportional=state_change.fee_schedule.proportional,
+        imbalance_penalty=imbalance_penalty,
+    )
+
+    events.append(SendPFSFeeUpdate(canonical_identifier=channel_state.canonical_identifier))
+    return TransitionResult(channel_state, events)
+
+
 def handle_receive_withdraw_request(
     channel_state: NettingChannelState, withdraw_request: ReceiveWithdrawRequest
 ) -> TransitionResult[NettingChannelState]:
@@ -2551,6 +2576,11 @@ def state_transition(
     elif type(state_change) == ActionChannelSetRevealTimeout:
         assert isinstance(state_change, ActionChannelSetRevealTimeout), MYPY_ANNOTATION
         iteration = handle_action_set_reveal_timeout(
+            channel_state=channel_state, state_change=state_change
+        )
+    elif type(state_change) == ActionChannelSetFeeSchedule:
+        assert isinstance(state_change, ActionChannelSetFeeSchedule), MYPY_ANNOTATION
+        iteration = handle_action_set_fee_schedule(
             channel_state=channel_state, state_change=state_change
         )
     elif type(state_change) == ContractReceiveChannelClosed:

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -45,6 +45,7 @@ from raiden.transfer.state import ChainState, TokenNetworkRegistryState, TokenNe
 from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
     ActionChannelClose,
+    ActionChannelSetFeeSchedule,
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
     ActionInitChain,
@@ -805,6 +806,13 @@ def handle_state_change(
             )
         elif type(state_change) == ActionChannelSetRevealTimeout:
             assert isinstance(state_change, ActionChannelSetRevealTimeout), MYPY_ANNOTATION
+            iteration = subdispatch_by_canonical_id(
+                chain_state=chain_state,
+                canonical_identifier=state_change.canonical_identifier,
+                state_change=state_change,
+            )
+        elif type(state_change) == ActionChannelSetFeeSchedule:
+            assert isinstance(state_change, ActionChannelSetFeeSchedule), MYPY_ANNOTATION
             iteration = subdispatch_by_canonical_id(
                 chain_state=chain_state,
                 canonical_identifier=state_change.canonical_identifier,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -459,6 +459,7 @@ class TokenNetworkState(State):
     partneraddresses_to_channelidentifiers: Dict[Address, List[ChannelID]] = field(
         repr=False, default_factory=lambda: defaultdict(list)
     )
+    fee_schedule: Optional[FeeScheduleState] = field(repr=False, default=None)
 
     def __post_init__(self) -> None:
         typecheck(self.address, T_Address)

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -268,6 +268,27 @@ class ActionChannelSetFeeSchedule(StateChange):
     def token_network_address(self) -> TokenNetworkAddress:
         return self.canonical_identifier.token_network_address
 
+    def __post__init__(self) -> None:
+        typecheck(self.canonical_identifier, CanonicalIdentifier)
+        typecheck(self.fee_schedule, FeeScheduleState)
+        typecheck(self.fee_config, MediationFeeConfig)
+
+
+@dataclass(frozen=True)
+class ActionTokenNetworkSetFeeSchedule(StateChange):
+    """ Change the fee schedule for the whole token network state """
+
+    registry_address: TokenNetworkRegistryAddress
+    token_network_address: TokenNetworkAddress
+    fee_schedule: FeeScheduleState
+    fee_config: MediationFeeConfig
+
+    def __post__init__(self) -> None:
+        typecheck(self.registry_address, TokenNetworkRegistryAddress)
+        typecheck(self.token_network_address, TokenNetworkAddress)
+        typecheck(self.fee_schedule, FeeScheduleState)
+        typecheck(self.fee_config, MediationFeeConfig)
+
 
 @dataclass(frozen=True)
 class ContractReceiveNewTokenNetworkRegistry(ContractReceiveStateChange):

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -10,6 +10,7 @@ from raiden.transfer.architecture import (
     StateChange,
 )
 from raiden.transfer.identifiers import CanonicalIdentifier
+from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.state import (
     BalanceProofSignedState,
     NettingChannelState,
@@ -241,6 +242,23 @@ class ActionChannelSetRevealTimeout(StateChange):
 
     canonical_identifier: CanonicalIdentifier
     reveal_timeout: BlockTimeout
+
+    @property
+    def channel_identifier(self) -> ChannelID:
+        return self.canonical_identifier.channel_identifier
+
+    @property
+    def token_network_address(self) -> TokenNetworkAddress:
+        return self.canonical_identifier.token_network_address
+
+
+@dataclass(frozen=True)
+class ActionChannelSetFeeSchedule(StateChange):
+    """ Change the fee schedule of a given channel. """
+
+    canonical_identifier: CanonicalIdentifier
+    fee_schedule: FeeScheduleState
+    fee_config: MediationFeeConfig
 
     @property
     def channel_identifier(self) -> ChannelID:


### PR DESCRIPTION
Fixes #4755

Problem Definition:

Right now there is no way that the user can determine the set or change the mediation fees after  raiden has started. The only current method is through the cli parameter, and even this option only allows settings the fees for all existing open channels handled the node.

Solution:

This PR introduces the representation of a "Fee Schedule" to the REST API and makes it possible for the user to change the fee schedule at different granular levels.

 - By setting the fee schedule of a Channel Resource, the user can change the fee of a single channel. To do so a user can make a PATCH request to the "api/v1/channels/<token_address>/<partner_address>" endpoint.
 - By setting the fee schedule of a Token Resource, the user can change the fee schedule of all channels from that token network. To do so the user sends a PATCH request to "api/v1/tokens/<token_address>/settings"

NOTES:

 - the imbalance_fee attribute is currently read-only and it is using the formula to calculate imbalance fees as defined by the MediationFeeConfig class.
 - The "api/v1/token/<token_address>/settings" endpoint was added, but perhaps it makes more sense to just change the behavior/representation of the existing "/tokens" and "/tokens/<token_address>" endpoints to more than its string address. This hasn't been done here because this kind of change will also affect the webUI.
 - This commit also removes the method that sets the fee schedules during startup