### PR TITLE
Removed random user id / Assume Matrix auth plugin

### DIFF
--- a/raiden/network/transport/matrix/__init__.py
+++ b/raiden/network/transport/matrix/__init__.py
@@ -3,7 +3,7 @@ from raiden.network.transport.matrix.utils import (  # noqa
     AddressReachability,
     UserPresence,
     join_broadcast_room,
-    login_or_register,
+    login,
     make_client,
     make_room_alias,
     sort_servers_closest,

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 
 import gevent
 import structlog
+from eth_utils import to_checksum_address
 from gevent.lock import Semaphore
 from matrix_client.api import MatrixHttpApi
 from matrix_client.client import CACHE, MatrixClient
@@ -20,6 +21,13 @@ log = structlog.get_logger(__name__)
 
 
 SHUTDOWN_TIMEOUT = 35
+
+
+def node_address_from_userid(user_id: Optional[str]) -> Optional[str]:
+    if user_id:
+        return to_checksum_address(user_id.split(":", 1)[0][1:])
+
+    return None
 
 
 class Room(MatrixRoom):
@@ -256,20 +264,32 @@ class GMatrixClient(MatrixClient):
                 self._sync(timeout_ms)
                 _bad_sync_timeout = bad_sync_timeout
             except MatrixRequestError as e:
-                log.warning("A MatrixRequestError occured during sync.")
+                log.warning(
+                    "A MatrixRequestError occured during sync.",
+                    node=node_address_from_userid(self.user_id),
+                )
                 if e.code >= 500:
-                    log.warning("Problem occured serverside. Waiting", wait_for=_bad_sync_timeout)
+                    log.warning(
+                        "Problem occured serverside. Waiting",
+                        node=node_address_from_userid(self.user_id),
+                        wait_for=_bad_sync_timeout,
+                    )
                     gevent.sleep(_bad_sync_timeout)
                     _bad_sync_timeout = min(_bad_sync_timeout * 2, self.bad_sync_timeout_limit)
                 else:
                     raise
             except MatrixHttpLibError:
-                log.exception("A MatrixHttpLibError occured during sync.")
+                log.exception(
+                    "A MatrixHttpLibError occured during sync.",
+                    node=node_address_from_userid(self.user_id),
+                )
                 if self.should_listen:
                     gevent.sleep(_bad_sync_timeout)
                     _bad_sync_timeout = min(_bad_sync_timeout * 2, self.bad_sync_timeout_limit)
             except Exception as e:
-                log.exception("Exception thrown during sync")
+                log.exception(
+                    "Exception thrown during sync", node=node_address_from_userid(self.user_id)
+                )
                 if exception_handler is not None:
                     exception_handler(e)
                 else:
@@ -295,20 +315,32 @@ class GMatrixClient(MatrixClient):
         self.should_listen = False
         if self.sync_thread:
             self.sync_thread.kill()
-            log.debug("Waiting on sync greenlet", current_user=self.user_id)
+            log.debug(
+                "Waiting on sync greenlet",
+                node=node_address_from_userid(self.user_id),
+                current_user=self.user_id,
+            )
             exited = gevent.joinall({self.sync_thread}, timeout=SHUTDOWN_TIMEOUT, raise_error=True)
             if not exited:
                 raise RuntimeError("Timeout waiting on sync greenlet during transport shutdown.")
             self.sync_thread.get()
         if self._handle_thread is not None:
-            log.debug("Waiting on handle greenlet", current_user=self.user_id)
+            log.debug(
+                "Waiting on handle greenlet",
+                node=node_address_from_userid(self.user_id),
+                current_user=self.user_id,
+            )
             exited = gevent.joinall(
                 {self._handle_thread}, timeout=SHUTDOWN_TIMEOUT, raise_error=True
             )
             if not exited:
                 raise RuntimeError("Timeout waiting on handle greenlet during transport shutdown.")
             self._handle_thread.get()
-        log.debug("Listener greenlet exited", current_user=self.user_id)
+        log.debug(
+            "Listener greenlet exited",
+            node=node_address_from_userid(self.user_id),
+            current_user=self.user_id,
+        )
         self.sync_thread = None
         self._handle_thread = None
 
@@ -402,7 +434,9 @@ class GMatrixClient(MatrixClient):
 
     def _sync(self, timeout_ms=30000):
         """ Reimplements MatrixClient._sync, add 'account_data' support to /sync """
-        log.debug("Sync called", current_user=self.user_id)
+        log.debug(
+            "Sync called", node=node_address_from_userid(self.user_id), current_user=self.user_id
+        )
 
         response = self.api.sync(self.sync_token, timeout_ms)
         prev_sync_token = self.sync_token
@@ -420,6 +454,7 @@ class GMatrixClient(MatrixClient):
         self._handle_thread.link_exception(lambda g: self.sync_thread.kill(g.exception))
         log.debug(
             "Starting handle greenlet",
+            node=node_address_from_userid(self.user_id),
             first_sync=is_first_sync,
             sync_token=prev_sync_token,
             current_user=self.user_id,
@@ -433,7 +468,10 @@ class GMatrixClient(MatrixClient):
         # We must ignore the stop flag during first_sync
         if not self.should_listen and not first_sync:
             log.warning(
-                "Aborting handle response", reason="Transport stopped", current_user=self.user_id
+                "Aborting handle response",
+                node=node_address_from_userid(self.user_id),
+                reason="Transport stopped",
+                current_user=self.user_id,
             )
             return
         # Handle presence after rooms

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -431,15 +431,6 @@ def login_with_token(client: GMatrixClient, user_id: str, access_token: str) -> 
         log.debug("Couldn't use previous login credentials", prev_user_id=user_id, _exception=ex)
         return None
 
-    # Login suceeded. Sync with the server to fetch the inventory rooms
-    # and new invites. At this point the messages themselves should not
-    # be processed because the transport is not fully initialized (i.e.
-    # the callbacks to process the messages are not installed yet), so
-    # limit the sync to preventing fetching the messages.
-    prev_sync_limit = client.set_sync_limit(0)
-    client._sync()
-    client.set_sync_limit(prev_sync_limit)
-
     log.debug("Success. Valid previous credentials", user_id=user_id)
     return client.get_user(client.user_id)
 

--- a/raiden/tests/unit/test_matrix_transport.py
+++ b/raiden/tests/unit/test_matrix_transport.py
@@ -11,7 +11,7 @@ import raiden.network.transport.matrix.client
 import raiden.network.transport.matrix.utils
 from raiden.exceptions import TransportError
 from raiden.network.transport.matrix.utils import (
-    login_or_register,
+    login,
     make_client,
     make_room_alias,
     my_place_or_yours,
@@ -22,7 +22,7 @@ from raiden.tests.utils.factories import make_signer
 from raiden.utils.signer import recover
 
 
-def test_login_or_register_default_user():
+def test_login_for_the_first_time_must_set_the_display_name():
     ownserver = "https://ownserver.com"
     api = Mock()
     api.base_url = ownserver
@@ -46,11 +46,11 @@ def test_login_or_register_default_user():
 
     signer = make_signer()
 
-    user = login_or_register(client=client, signer=signer)
+    user = login(client=client, signer=signer)
 
     # client.user_id will be set by login
     assert client.user_id.startswith(f"@{to_normalized_address(signer.address)}")
-    # login_or_register returns our own user object
+    # login returns our own user object
     assert isinstance(user, User)
     # get_user must have been called once to generate above user
     client.get_user.assert_called_once_with(client.user_id)


### PR DESCRIPTION
Random user IDs with the random sufix are not accepted by the current
version of the `eth_auth_provider`, any attempt to use that user name
would result in a crash. Therefore its usage was removed.

This changes the login process to assume the server will always have our
authentication plugin installed as requested by @ulope. The assumption
here is the Matrix servers used with Raiden are not part of the normal
Matrix federation, otheriwse these servers would replicate normal chat
messages that are not of interest to the Raiden network. Since we assume
there is this initial configuration step, it is also assume the plugin
will be installed.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
