### PR TITLE
Removed _getroom_lock

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -335,7 +335,6 @@ class MatrixTransport(Runnable):
         self._client.add_listener(self._handle_to_device_message, event_type="to_device")
 
         self._health_lock = Semaphore()
-        self._getroom_lock = Semaphore()
         self._account_data_lock = Semaphore()
 
         self._message_handler: Optional[MessageHandler] = None
@@ -930,8 +929,8 @@ class MatrixTransport(Runnable):
         retrier.enqueue(queue_identifier=queue_identifier, message=message)
 
     def _send_raw(self, receiver_address: Address, data: str) -> None:
-        with self._getroom_lock:
-            room = self._get_room_for_address(receiver_address)
+        room = self._get_room_for_address(receiver_address)
+
         if not room:
             self.log.error("No room for receiver", receiver=to_checksum_address(receiver_address))
             return


### PR DESCRIPTION
This lock is a large source of contention and from what I gathered from
@ulope it is not necessary. I don't completely understanding what was
the intention of the lock since there are no commits or comments that
explain the rationale, so I'm relying on @ulope's advice to remove the
lock.

Fixes: #5206

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
