### PR TITLE
Extended docs for `_get_user` [skip tests]

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1171,9 +1171,16 @@ class MatrixTransport(Runnable):
         return self._raiden_service.signer.sign(data=data)
 
     def _get_user(self, user: Union[User, str]) -> User:
-        """Creates an User from an user_id, if none, or fetch a cached User
+        """ Returns a cached `User` instance with the `displayname` set.
 
-        As all users are supposed to be in discovery room, its members dict is used for caching"""
+        This function maintains a cache of `User` instances with the
+        `displayname` variable set. This can reduce the number of HTTP requests
+        since the displayname is used in multiple places to validate the
+        partner node.
+
+        All users are supposed to be in discovery room, so just reuse the
+        `_members` dict already present from the Matrix SDK.
+        """
         user_id: str = getattr(user, "user_id", user)
         discovery_room = self._broadcast_rooms.get(
             make_room_alias(self.chain_id, DISCOVERY_DEFAULT_ROOM)


### PR DESCRIPTION
## Description

This just extends the docstring of the function `_get_user` after @ulope clarified it's usage.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
