### PR TITLE
`_get_room_ids_for_address` changes

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1238,28 +1238,34 @@ class MatrixTransport(Runnable):
         If filter_private=None, filter according to self._private_rooms
         """
         address_hex: AddressHex = to_checksum_address(address)
+
         with self._account_data_lock:
             room_ids = self._client.account_data.get("network.raiden.rooms", {}).get(address_hex)
-            self.log.debug("Room ids for address", for_address=address_hex, room_ids=room_ids)
-            if not room_ids:  # None or empty
-                room_ids = list()
-            if not isinstance(room_ids, list):  # old version, single room
-                room_ids = [room_ids]
 
-            if filter_private is None:
-                filter_private = self._private_rooms
-            if not filter_private:
-                # existing rooms
-                room_ids = [room_id for room_id in room_ids if room_id in self._client.rooms]
-            else:
-                # existing and private rooms
-                room_ids = [
-                    room_id
-                    for room_id in room_ids
-                    if room_id in self._client.rooms and self._client.rooms[room_id].invite_only
-                ]
+        self.log.debug("Room ids for address", for_address=address_hex, room_ids=room_ids)
 
-            return room_ids
+        if not room_ids:
+            return list()
+
+        # `account_data` should be private to the user. These values will only
+        # be invalid if there is a bug in Raiden to push invalid data or if the
+        # Matrix server is corrupted/malicous.
+        invalid_input = any(not isinstance(room_id, str) for room_id in room_ids)
+        if invalid_input:
+            log.error("Unexpected account data, ignoring.")
+            return list()
+
+        if filter_private is None:
+            filter_private = self._private_rooms
+
+        if not filter_private:
+            return [room_id for room_id in room_ids if room_id in self._client.rooms]
+
+        return [
+            room_id
+            for room_id in room_ids
+            if room_id in self._client.rooms and self._client.rooms[room_id].invite_only
+        ]
 
     def _leave_unused_rooms(self, _address_to_room_ids: Dict[AddressHex, List[_RoomID]]) -> None:
         """


### PR DESCRIPTION
## Description

These changes are mostly cosmetic, at first I assumed that the metadata was shared and it could be an attack vector. However @andrevmatos explained that the metadata is private, and therefore can only be modified by a malicious matrix operator. I'm opening the PR anyways with a comment that explains the above and also:

- Removes the automatic upgrade for the value of `network.raiden.rooms`
to a list. Since Red Eyes this value is always a list of strings, the
old format where it contains just a single room_id doesn't have to be
supported anymore.
- Adds a check for every entry of the metadata. If the values are
corrupted either there is a Raiden bug or a malicious matrix server.
- Reduces the critical section of the self._account_data_lock to exactly
the lines that interact with the `client.account_data`.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
