### PR TITLE
Extend message logging for Matrix

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -122,11 +122,11 @@ class UserAddressManager:
         self._reset_state()
 
     @property
-    def known_addresses(self) -> List[Address]:
+    def known_addresses(self) -> Set[Address]:
         """ Return all addresses we keep track of """
         # This must return a copy of the current keys, because the container
         # may be modified while these values are used. Issue: #5240
-        return list(self._address_to_userids)
+        return set(self._address_to_userids)
 
     def is_address_known(self, address: Address) -> bool:
         """ Is the given ``address`` reachability being monitored? """


### PR DESCRIPTION
Review after #5241 

## Description

The default `__repr__` is missing a lot of information from the message
(currently the format is `<{klass} [msghash={msghash}]>`). This makes it
harder to correlate the logs from the sender with the receiver. This
just uses the DictSerializer so that all fields will be available.


## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
