### PR TITLE
Fix runtime error: dict modified while iterating

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from enum import Enum
 from operator import attrgetter, itemgetter
 from random import Random
-from typing import Any, Callable, Dict, Iterable, KeysView, List, Optional, Sequence, Set, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -122,9 +122,11 @@ class UserAddressManager:
         self._reset_state()
 
     @property
-    def known_addresses(self) -> KeysView[Address]:
+    def known_addresses(self) -> List[Address]:
         """ Return all addresses we keep track of """
-        return self._address_to_userids.keys()
+        # This must return a copy of the current keys, because the container
+        # may be modified while these values are used. Issue: #5240
+        return list(self._address_to_userids)
 
     def is_address_known(self, address: Address) -> bool:
         """ Is the given ``address`` reachability being monitored? """

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -172,7 +172,7 @@ def test_user_addr_mgr_basics(
     # Nothing again, due to using our own user
     dummy_matrix_client.trigger_presence_callback({USER0_ID: UserPresence.ONLINE})
 
-    assert user_addr_mgr.known_addresses == set()
+    assert not user_addr_mgr.known_addresses
     assert not user_addr_mgr.is_address_known(ADDR1)
     assert user_addr_mgr.get_userids_for_address(ADDR1) == set()
     assert user_addr_mgr.get_address_reachability(ADDR1) is AddressReachability.UNKNOWN
@@ -182,7 +182,7 @@ def test_user_addr_mgr_basics(
     user_addr_mgr.add_address(ADDR1)
     dummy_matrix_client.trigger_presence_callback({USER1_S1_ID: UserPresence.ONLINE})
 
-    assert user_addr_mgr.known_addresses == {ADDR1}
+    assert list(user_addr_mgr.known_addresses) == [ADDR1]
     assert user_addr_mgr.is_address_known(ADDR1)
     assert user_addr_mgr.get_userids_for_address(ADDR1) == {USER1_S1_ID}
     assert user_addr_mgr.get_address_reachability(ADDR1) is AddressReachability.REACHABLE
@@ -233,7 +233,7 @@ def test_user_addr_mgr_compound(
 
 def test_user_addr_mgr_force(user_addr_mgr, address_reachability, user_presence):
     assert not user_addr_mgr.is_address_known(ADDR1)
-    assert user_addr_mgr.known_addresses == set()
+    assert not user_addr_mgr.known_addresses
 
     user_addr_mgr.add_userid_for_address(ADDR1, USER1_S1_ID)
     # This only updates the internal user presense state, but calls no callbacks and also doesn't


### PR DESCRIPTION
Fixes: #5240

## Description

The container `_address_to_userids` is a defaultdict used to store the
known `UserId`s for a given `Address`. This container can be modified by
multiple threads (e.g. `UserAddressManager`, and blockchain event
handling that may start a whitelist/healthchecking), this can lead to
the container being modified while it is being iterated, which is a
runtime error.

This worksaround the problem by iterating over a copy of the keys,
instead of iterating over the dictionary key view.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
