### PR TITLE
Fix fee update datetime type

### DIFF
--- a/raiden/messages/path_finding_service.py
+++ b/raiden/messages/path_finding_service.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from datetime import datetime, timezone
+from dataclasses import dataclass, field
+from datetime import datetime
 
 import marshmallow.fields
 import rlp
@@ -72,7 +72,7 @@ class PFSFeeUpdate(SignedMessage):
     canonical_identifier: CanonicalIdentifier
     updating_participant: Address
     fee_schedule: FeeScheduleState
-    timestamp: datetime
+    timestamp: datetime = field(metadata={"marshmallow_field": marshmallow.fields.NaiveDateTime()})
 
     def __post_init__(self) -> None:
         if self.signature is None:
@@ -89,7 +89,7 @@ class PFSFeeUpdate(SignedMessage):
             (self.fee_schedule.proportional, "uint256"),
             (rlp.encode(self.fee_schedule.imbalance_penalty or 0), "bytes"),
             (
-                marshmallow.fields.DateTime()._serialize(self.timestamp, "timestamp", self),
+                marshmallow.fields.NaiveDateTime()._serialize(self.timestamp, "timestamp", self),
                 "string",
             ),
         )
@@ -100,6 +100,6 @@ class PFSFeeUpdate(SignedMessage):
             canonical_identifier=channel_state.canonical_identifier,
             updating_participant=channel_state.our_state.address,
             fee_schedule=channel_state.fee_schedule,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.utcnow(),
             signature=EMPTY_SIGNATURE,
         )


### PR DESCRIPTION
Merge after #5249 

## Description

This changes the FeeUpdates timestamp to have no timezone.
This is related to raiden-network/raiden-services#619

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
