### PR TITLE
Do not fallback to internal routing if PFS request fails

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -98,12 +98,14 @@ def get_best_routes(
                 "Received route(s) from PFS", routes=pfs_routes, feedback_token=pfs_feedback_token
             )
             return pfs_routes, pfs_feedback_token
-        else:
-            log.warning(
-                "Request to Pathfinding Service was not successful, "
-                "falling back to internal routing."
-            )
 
+        log.warning(
+            "Request to Pathfinding Service was not successful. "
+            "No routes to the target are found."
+        )
+        return list(), None
+
+    # else non-pfs so let's use internal routing
     return (
         get_best_routes_internal(
             chain_state=chain_state,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -268,11 +268,10 @@ def test_routing_mocked_pfs_happy_path_with_updated_iou(
 def test_routing_mocked_pfs_request_error(
     chain_state, token_network_state, one_to_n_address, our_address
 ):
-    token_network_state, addresses, channel_states = create_square_network_topology(
+    token_network_state, addresses, _ = create_square_network_topology(
         token_network_state=token_network_state, our_address=our_address
     )
     address1, address2, address3, address4 = addresses
-    channel_state1, channel_state2 = channel_states
 
     # test routing with all nodes available
     chain_state.nodeaddresses_to_networkstates = {
@@ -290,24 +289,18 @@ def test_routing_mocked_pfs_request_error(
             to_address=address4,
             amount=50,
         )
-        # PFS doesn't work, so internal routing is used, so two possible routes are returned,
-        # whereas the path via address1 is shorter
-        # (even if the route is not possible from a global perspective)
-        assert routes[0].next_hop_address == address1
-        assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].next_hop_address == address2
-        assert routes[1].forward_channel_id == channel_state2.identifier
+        # Request to PFS failed, but we do not fall back to internal routing
+        assert len(routes) == 0
         assert feedback_token is None
 
 
 def test_routing_mocked_pfs_bad_http_code(
     chain_state, token_network_state, one_to_n_address, our_address
 ):
-    token_network_state, addresses, channel_states = create_square_network_topology(
+    token_network_state, addresses, _ = create_square_network_topology(
         token_network_state=token_network_state, our_address=our_address
     )
     address1, address2, address3, address4 = addresses
-    channel_state1, channel_state2 = channel_states
 
     # test routing with all nodes available
     chain_state.nodeaddresses_to_networkstates = {
@@ -342,25 +335,18 @@ def test_routing_mocked_pfs_bad_http_code(
             to_address=address4,
             amount=50,
         )
-        # PFS doesn't work, so internal routing is used, so two possible routes are returned,
-        # whereas the path via address1 is shorter (
-        # even if the route is not possible from a global perspective)
-        # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].next_hop_address == address1
-        assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].next_hop_address == address2
-        assert routes[1].forward_channel_id == channel_state2.identifier
+        # Request to PFS failed, but we do not fall back to internal routing
+        assert len(routes) == 0
         assert feedback_token is None
 
 
 def test_routing_mocked_pfs_invalid_json(
     chain_state, token_network_state, one_to_n_address, our_address
 ):
-    token_network_state, addresses, channel_states = create_square_network_topology(
+    token_network_state, addresses, _ = create_square_network_topology(
         token_network_state=token_network_state, our_address=our_address
     )
     address1, address2, address3, address4 = addresses
-    channel_state1, channel_state2 = channel_states
 
     # test routing with all nodes available
     chain_state.nodeaddresses_to_networkstates = {
@@ -380,25 +366,18 @@ def test_routing_mocked_pfs_invalid_json(
             to_address=address4,
             amount=50,
         )
-        # PFS doesn't work, so internal routing is used, so two possible routes are returned,
-        # whereas the path via address1 is shorter (
-        # even if the route is not possible from a global perspective)
-        # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].next_hop_address == address1
-        assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].next_hop_address == address2
-        assert routes[1].forward_channel_id == channel_state2.identifier
+        # Request to PFS failed, but we do not fall back to internal routing
+        assert len(routes) == 0
         assert feedback_token is None
 
 
 def test_routing_mocked_pfs_invalid_json_structure(
     chain_state, one_to_n_address, token_network_state, our_address
 ):
-    token_network_state, addresses, channel_states = create_square_network_topology(
+    token_network_state, addresses, _ = create_square_network_topology(
         token_network_state=token_network_state, our_address=our_address
     )
     address1, address2, address3, address4 = addresses
-    channel_state1, channel_state2 = channel_states
 
     # test routing with all nodes available
     chain_state.nodeaddresses_to_networkstates = {
@@ -418,14 +397,8 @@ def test_routing_mocked_pfs_invalid_json_structure(
             to_address=address4,
             amount=50,
         )
-        # PFS doesn't work, so internal routing is used, so two possible routes are returned,
-        # whereas the path via address1 is shorter (
-        # even if the route is not possible from a global perspective)
-        # in case the mocked pfs response were used, we would not see address1 on the route
-        assert routes[0].next_hop_address == address1
-        assert routes[0].forward_channel_id == channel_state1.identifier
-        assert routes[1].next_hop_address == address2
-        assert routes[1].forward_channel_id == channel_state2.identifier
+        # Request to PFS failed, but we do not fall back to internal routing
+        assert len(routes) == 0
         assert feedback_token is None
 
 


### PR DESCRIPTION
Fixes: #5184 

## Description

When a request to the PFS has failed we no longer fall back to internal routing. Also modified the tests to confirm that we don't.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
