### PR TITLE
Fix pytest warning about TestClass collection

### DIFF
--- a/raiden/tests/unit/api/test_encoding.py
+++ b/raiden/tests/unit/api/test_encoding.py
@@ -3,7 +3,7 @@ import datetime
 from raiden.api.v1.encoding import BaseSchema, TimeStampField
 
 
-class TestSchema(BaseSchema):
+class SchemaTest(BaseSchema):
     timestamp = TimeStampField()
 
     class Meta:
@@ -15,8 +15,8 @@ class TestSchema(BaseSchema):
 def test_timestamp_field():
     now = datetime.datetime.now()
     assert (
-        TestSchema().dump({}) == {}
+        SchemaTest().dump({}) == {}
     ), "timestamp fields should only be serialized when the date is provided"
-    assert TestSchema().dump({"timestamp": now}) == {
+    assert SchemaTest().dump({"timestamp": now}) == {
         "timestamp": now.isoformat()
     }, "timestamp fields should be formatted as ISO8601"


### PR DESCRIPTION
pytest will interpret every class starting with `TestXXXX` as a test
class during test discovery,

From the [docs](https://pytest.readthedocs.io/en/2.8.7/goodpractices.html)

> Test prefixed test classes (without an __init__ method)

And that's why we were getting a warning:

```
raiden/tests/unit/api/test_encoding.py:6
  /home/lefteris/ew/raiden/raiden/tests/unit/api/test_encoding.py:6: PytestCollectionWarning: cannot collect test class 'TestSchema' because it has a __init__ constructor (from: raiden/tests/unit/api/test_encoding.py)
    class TestSchema(BaseSchema):
```

Since TestSchema appeared like a Test class to pytest and also had a
constructor via BaseSchema. Just changed the name to remove the warning.