### PR TITLE
Simplified joining of broadcast rooms

### DIFF
--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -4,6 +4,7 @@ import pytest
 
 from raiden.constants import DISCOVERY_DEFAULT_ROOM
 from raiden.network.transport import MatrixTransport
+from raiden.network.transport.matrix.utils import make_room_alias
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.utils.transport import generate_synapse_config, matrix_server_starter
 from raiden.utils.typing import Optional
@@ -29,14 +30,25 @@ def matrix_server_count():
 
 @pytest.fixture
 def local_matrix_servers(
-    request, transport_protocol, matrix_server_count, synapse_config_generator, port_generator
+    request,
+    transport_protocol,
+    matrix_server_count,
+    synapse_config_generator,
+    port_generator,
+    broadcast_rooms,
+    chain_id,
 ):
     if transport_protocol is not TransportProtocol.MATRIX:
         yield [None]
         return
 
+    broadcast_rooms_aliases = [
+        make_room_alias(chain_id, room_name) for room_name in broadcast_rooms
+    ]
+
     starter = matrix_server_starter(
         free_port_generator=port_generator,
+        broadcast_rooms_aliases=broadcast_rooms_aliases,
         count=matrix_server_count,
         config_generator=synapse_config_generator,
         log_context=request.node.name,

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -10,6 +10,7 @@ from matrix_client.errors import MatrixRequestError
 
 import raiden
 from raiden.constants import (
+    DISCOVERY_DEFAULT_ROOM,
     EMPTY_SIGNATURE,
     MONITORING_BROADCASTING_ROOM,
     PATH_FINDING_BROADCASTING_ROOM,
@@ -445,12 +446,15 @@ def test_matrix_discovery_room_offline_server(
     transport.get()
 
 
+@pytest.mark.parametrize(
+    "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, MONITORING_BROADCASTING_ROOM]]
+)
 def test_matrix_broadcast(
     local_matrix_servers, retries_before_backoff, retry_interval, private_rooms, broadcast_rooms
 ):
     transport = MatrixTransport(
         {
-            "broadcast_rooms": broadcast_rooms + [MONITORING_BROADCASTING_ROOM],
+            "broadcast_rooms": broadcast_rooms,
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],
@@ -486,6 +490,9 @@ def test_matrix_broadcast(
     transport.get()
 
 
+@pytest.mark.parametrize(
+    "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, MONITORING_BROADCASTING_ROOM]]
+)
 def test_monitoring_broadcast_messages(
     local_matrix_servers,
     private_rooms,
@@ -555,6 +562,9 @@ def test_monitoring_broadcast_messages(
 
 @pytest.mark.parametrize("matrix_server_count", [1])
 @pytest.mark.parametrize("route_mode", [RoutingMode.LOCAL, RoutingMode.PFS])
+@pytest.mark.parametrize(
+    "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]]
+)
 def test_pfs_broadcast_messages(
     local_matrix_servers,
     private_rooms,
@@ -570,7 +580,7 @@ def test_pfs_broadcast_messages(
     """
     transport = MatrixTransport(
         {
-            "broadcast_rooms": broadcast_rooms + [PATH_FINDING_BROADCASTING_ROOM],
+            "broadcast_rooms": broadcast_rooms,
             "retries_before_backoff": retries_before_backoff,
             "retry_interval": retry_interval,
             "server": local_matrix_servers[0],

--- a/raiden/tests/unit/test_matrix_transport.py
+++ b/raiden/tests/unit/test_matrix_transport.py
@@ -5,14 +5,12 @@ from urllib.parse import urlparse
 import pytest
 from eth_utils import decode_hex, encode_hex, to_canonical_address, to_normalized_address
 from matrix_client.errors import MatrixRequestError
-from matrix_client.room import Room
 from matrix_client.user import User
 
 import raiden.network.transport.matrix.client
 import raiden.network.transport.matrix.utils
 from raiden.exceptions import TransportError
 from raiden.network.transport.matrix.utils import (
-    join_broadcast_room,
     login_or_register,
     make_client,
     make_room_alias,
@@ -22,31 +20,6 @@ from raiden.network.transport.matrix.utils import (
 )
 from raiden.tests.utils.factories import make_signer
 from raiden.utils.signer import recover
-
-
-def test_join_broadcast_room():
-    """ join_broadcast_room should try joining, fail and then create broadcast public room """
-    ownserver = "https://ownserver.com"
-    api = Mock()
-    api.base_url = ownserver
-
-    client = Mock()
-    client.api = api
-
-    def create_room(alias, is_public=False, invitees=None):  # pylint: disable=unused-argument
-        room = Room(client, f"!room_id:ownserver.com")
-        room.canonical_alias = alias
-        return room
-
-    client.create_room = Mock(side_effect=create_room)
-    client.join_room = Mock(side_effect=MatrixRequestError(404))
-
-    room_name = "raiden_ropsten_discovery"
-
-    room = join_broadcast_room(client=client, name=room_name, servers=["https://invalid.server"])
-    assert client.join_room.call_count == 2  # room not found on own and invalid servers
-    client.create_room.assert_called_once_with(room_name, is_public=True)  # created successfuly
-    assert room and isinstance(room, Room)
 
 
 def test_login_or_register_default_user():

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -8,6 +8,7 @@ from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.storage.wal import WriteAheadLog
 from raiden.tests.utils import factories
+from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -32,7 +33,7 @@ class MockJSONRPCClient:
     def __init__(self, address: Address):
         # To be manually set by each test
         self.balances_mapping: Dict[Address, TokenAmount] = {}
-        self.chain_id = ChainID(17)
+        self.chain_id = ChainID(UNIT_CHAIN_ID)
         self.address = address
 
     @staticmethod

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -225,13 +225,15 @@ def setup_testchain(
 
 @contextmanager
 def setup_matrix_for_smoketest(
-    print_step: Callable, free_port_generator: Iterable[Port]
+    print_step: Callable,
+    free_port_generator: Iterable[Port],
+    broadcast_rooms_aliases: Iterable[str],
 ) -> Iterator[List["ParsedURL"]]:
     from raiden.tests.utils.transport import matrix_server_starter
 
     print_step("Starting Matrix transport")
 
-    with matrix_server_starter(free_port_generator=free_port_generator) as ctx:
+    with matrix_server_starter(free_port_generator, broadcast_rooms_aliases) as ctx:
         yield ctx
 
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -20,6 +20,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from raiden.app import App
 from raiden.constants import (
+    DISCOVERY_DEFAULT_ROOM,
     FLAT_MED_FEE_MIN,
     IMBALANCE_MED_FEE_MAX,
     IMBALANCE_MED_FEE_MIN,
@@ -31,6 +32,7 @@ from raiden.constants import (
 )
 from raiden.exceptions import EthereumNonceTooLow, ReplacementTransactionUnderpriced
 from raiden.log_config import configure_logging
+from raiden.network.transport.matrix.utils import make_room_alias
 from raiden.network.utils import get_free_port
 from raiden.settings import (
     DEFAULT_BLOCKCHAIN_QUERY_INTERVAL,
@@ -58,6 +60,7 @@ from raiden.utils.cli import (
     validate_option_dependencies,
 )
 from raiden.utils.typing import MYPY_ANNOTATION, TokenAddress
+from raiden_contracts.constants import NETWORKNAME_TO_ID
 
 from .runners import EchoNodeRunner, MatrixRunner
 
@@ -720,7 +723,11 @@ def smoketest(
             base_logdir=datadir,
         )
         matrix_manager: ContextManager[List[ParsedURL]] = setup_matrix_for_smoketest(
-            print_step=print_step, free_port_generator=free_port_generator
+            print_step=print_step,
+            free_port_generator=free_port_generator,
+            broadcast_rooms_aliases=[
+                make_room_alias(NETWORKNAME_TO_ID["smoketest"], DISCOVERY_DEFAULT_ROOM)
+            ],
         )
 
         # Do not redirect the stdout on a debug session, otherwise the REPL


### PR DESCRIPTION
## Description

The previous code tried to create a broadcast room and setup the alias
if either of these were missing. This introduce a serious race condition
for the discovery room setup for new servers deployment, which resulted
in the failure to run Raiden in our test network.

This commit removes that code that is susceptible to race conditions,
and instead move the responsibility of properly setting up the discovery
room and its alias to the Matrix operator.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
