### PR TITLE
Only raise ValidationErrors in marshmallow fields

### DIFF
--- a/raiden/storage/serialization/fields.py
+++ b/raiden/storage/serialization/fields.py
@@ -11,24 +11,14 @@ from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.utils.typing import Address, Any, ChainID, ChannelID, Optional, Tuple
 
 
-class IntegerToStringField(marshmallow.fields.Field):
-    def _serialize(self, value: int, attr: Any, obj: Any, **kwargs: Any) -> str:
-        return str(value)
-
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> int:
-        return int(value)
+class IntegerToStringField(marshmallow.fields.Integer):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(as_string=True, **kwargs)
 
 
-class OptionalIntegerToStringField(marshmallow.fields.Field):
-    def _serialize(self, value: Optional[int], attr: Any, obj: Any, **kwargs: Any) -> str:
-        if value is None:
-            return ""
-        return str(value)
-
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> Optional[int]:
-        if value == "":
-            return None
-        return int(value)
+class OptionalIntegerToStringField(marshmallow.fields.Integer):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(as_string=True, required=False, **kwargs)
 
 
 class BytesField(marshmallow.fields.Field):
@@ -46,7 +36,10 @@ class BytesField(marshmallow.fields.Field):
     ) -> Optional[bytes]:
         if value is None:
             return value
-        return to_bytes(hexstr=value)
+        try:
+            return to_bytes(hexstr=value)
+        except (TypeError, ValueError):
+            raise self.make_error("validator_failed", input=value)
 
 
 class AddressField(marshmallow.fields.Field):
@@ -56,7 +49,10 @@ class AddressField(marshmallow.fields.Field):
         return to_checksum_address(value)
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> Address:
-        return to_canonical_address(value)
+        try:
+            return to_canonical_address(value)
+        except (TypeError, ValueError):
+            raise self.make_error("validator_failed", input=value)
 
 
 class QueueIdentifierField(marshmallow.fields.Field):
@@ -89,10 +85,14 @@ class QueueIdentifierField(marshmallow.fields.Field):
         )
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> QueueIdentifier:
-        str_recipient, str_canonical_id = value.split("-")
-        return QueueIdentifier(
-            to_canonical_address(str_recipient), self._canonical_id_from_string(str_canonical_id)
-        )
+        try:
+            str_recipient, str_canonical_id = value.split("-")
+            return QueueIdentifier(
+                to_canonical_address(str_recipient),
+                self._canonical_id_from_string(str_canonical_id),
+            )
+        except (TypeError, ValueError, AttributeError):
+            raise self.make_error("validator_failed", input=value)
 
 
 class PRNGField(marshmallow.fields.Field):
@@ -112,7 +112,10 @@ class PRNGField(marshmallow.fields.Field):
         return value.getstate()
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> Random:
-        return self.pseudo_random_generator_from_json(data)
+        try:
+            return self.pseudo_random_generator_from_json(data)
+        except (TypeError, ValueError):
+            raise self.make_error("validator_failed", input=value)
 
 
 class CallablePolyField(PolyField):
@@ -144,8 +147,11 @@ class NetworkXGraphField(marshmallow.fields.Field):
         )
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> networkx.Graph:
-        raw_data = json.loads(value)
-        canonical_addresses = [
-            (to_canonical_address(edge[0]), to_canonical_address(edge[1])) for edge in raw_data
-        ]
-        return networkx.Graph(canonical_addresses)
+        try:
+            raw_data = json.loads(value)
+            canonical_addresses = [
+                (to_canonical_address(edge[0]), to_canonical_address(edge[1])) for edge in raw_data
+            ]
+            return networkx.Graph(canonical_addresses)
+        except (TypeError, ValueError):
+            raise self.make_error("validator_failed", input=value)

--- a/raiden/tests/unit/storage/test_serialization.py
+++ b/raiden/tests/unit/storage/test_serialization.py
@@ -1,11 +1,14 @@
 import random
 from pathlib import Path
 
+import marshmallow
 import pytest
 
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.serialization.fields import (
+    AddressField,
     BytesField,
+    IntegerToStringField,
     OptionalIntegerToStringField,
     QueueIdentifierField,
 )
@@ -45,8 +48,20 @@ def test_queue_identifier_field_invalid_inputs(queue_identifier):
     # TODO check for address and chain/channel id validity in QueueIdentifier too, add tests here
 
     for string in (wrong_delimiter,):
-        with pytest.raises(ValueError):
+        with pytest.raises(marshmallow.exceptions.ValidationError):
             QueueIdentifierField()._deserialize(string, None, None)
+
+
+def test_deserialize_raises_validation_error_on_dict():
+    for field in [
+        IntegerToStringField(),
+        OptionalIntegerToStringField(),
+        BytesField(),
+        AddressField(),
+        QueueIdentifierField(),
+    ]:
+        with pytest.raises(marshmallow.exceptions.ValidationError):
+            field._deserialize({}, None, None)
 
 
 def test_optional_integer_to_string_field_roundtrip():


### PR DESCRIPTION
On any invalid input, marshmallow fields should only raise
ValidationErrors, not ValueErrors or TypeErrors. Otherwise problems like
https://github.com/raiden-network/raiden-services/issues/620 can happen.

Catching those exceptions in custom fields is consistent with the
builtin marshmallow fields and is preferable to catching those whenever
schemas are validated.

IntegerToStringField and OptionalIntegerToStringField are made more
robust by inheriting from the Integer field. They could also be done as
simply factory functions construction Integer fields, but I stayed with
classed for more consistency with the other fields.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
