### PR TITLE
Revert "displayname cache rewrite."

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1171,7 +1171,7 @@ class MatrixTransport(Runnable):
         assert self._raiden_service is not None, "_raiden_service not set"
         return self._raiden_service.signer.sign(data=data)
 
-    def _get_user(self, user_or_userid: Union[User, str]) -> User:
+    def _get_user(self, user: Union[User, str]) -> User:
         """ Returns a cached `User` instance with the `displayname` set.
 
         This function maintains a cache of `User` instances with the
@@ -1182,38 +1182,20 @@ class MatrixTransport(Runnable):
         All users are supposed to be in discovery room, so just reuse the
         `_members` dict already present from the Matrix SDK.
         """
-        if isinstance(user_or_userid, User):
-            user = user_or_userid
-            user_id = user.user_id
-            displayname = user.displayname
-        else:
-            user = None
-            user_id = user_or_userid
-            displayname = None
-
-        assert user_id, "user_id must be available"
-
+        user_id: str = getattr(user, "user_id", user)
         discovery_room = self._broadcast_rooms.get(
             make_room_alias(self.chain_id, DISCOVERY_DEFAULT_ROOM)
         )
-
-        # There is no discovery room to reuse the cache, so just return the
-        # user. This happens when the cache is used before the transport is
-        # fully initialized, e.g. by the `UserAddressManager` thread.
-        if discovery_room is None:
-            return user or self._client.get_user(user_id)
-
-        cached_user = discovery_room._members.setdefault(user_id, user)
-
-        if cached_user.displayname is None:
-            if displayname is not None:
-                cached_user.displayname = displayname
-            else:
-                cached_user.get_display_name()
-
-        assert cached_user.displayname, "The cached user must have a displayname set."
-
-        return cached_user
+        if discovery_room and user_id in discovery_room._members:
+            duser = discovery_room._members[user_id]
+            # if handed a User instance with displayname set, update the discovery room cache
+            if getattr(user, "displayname", None):
+                assert isinstance(user, User)
+                duser.displayname = user.displayname
+            user = duser
+        elif not isinstance(user, User):
+            user = self._client.get_user(user_id)
+        return user
 
     def _set_room_id_for_address(
         self, address: Address, room_id: Optional[_RoomID] = None

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -13,7 +13,7 @@ from gevent.lock import Semaphore
 from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixRequestError
 
-from raiden.constants import EMPTY_SIGNATURE
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, EMPTY_SIGNATURE
 from raiden.exceptions import TransportError
 from raiden.message_handler import MessageHandler
 from raiden.messages.abstract import (
@@ -29,7 +29,6 @@ from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.transport.matrix.utils import (
     JOIN_RETRIES,
     AddressReachability,
-    DisplayNameCache,
     UserAddressManager,
     UserPresence,
     join_broadcast_room,
@@ -311,7 +310,6 @@ class MatrixTransport(Runnable):
         self.greenlets: List[gevent.Greenlet] = list()
 
         self._address_to_retrier: Dict[Address, _RetryQueue] = dict()
-        self._displayname_cache = DisplayNameCache()
 
         self._broadcast_rooms: Dict[str, Optional[Room]] = dict()
         self._broadcast_queue: JoinableQueue[Tuple[str, Message]] = JoinableQueue()
@@ -329,7 +327,7 @@ class MatrixTransport(Runnable):
 
         self._address_mgr: UserAddressManager = UserAddressManager(
             client=self._client,
-            displayname_cache=self._displayname_cache,
+            get_user_callable=self._get_user,
             address_reachability_changed_callback=self._address_reachability_changed,
             user_presence_changed_callback=self._user_presence_changed,
             _log_context={"transport_uuid": str(self._uuid)},
@@ -511,9 +509,10 @@ class MatrixTransport(Runnable):
             node_address_hex = to_normalized_address(node_address)
             self.log.debug("Healthcheck", peer_address=to_checksum_address(node_address))
 
-            candidates = self._client.search_user_directory(node_address_hex)
-            self._displayname_cache.warm_users(candidates)
-
+            candidates = [
+                self._get_user(user)
+                for user in self._client.search_user_directory(node_address_hex)
+            ]
             user_ids = {
                 user.user_id
                 for user in candidates
@@ -680,8 +679,7 @@ class MatrixTransport(Runnable):
             self.log.debug("Invite: no invite event found", room_id=room_id)
             return  # there should always be one and only one invite membership event for us
         sender = invite_event["sender"]
-        user = self._client.get_user(sender)
-        self._displayname_cache.warm_users([user])
+        user = self._get_user(sender)
         peer_address = validate_userid_signature(user)
 
         if not peer_address:
@@ -775,9 +773,7 @@ class MatrixTransport(Runnable):
             # Ignore our own messages
             return False
 
-        user = self._client.get_user(sender_id)
-        self._displayname_cache.warm_users([user])
-
+        user = self._get_user(sender_id)
         peer_address = validate_userid_signature(user)
         if not peer_address:
             self.log.debug(
@@ -978,8 +974,9 @@ class MatrixTransport(Runnable):
         room_name = make_room_alias(self.chain_id, *address_pair)
 
         # no room with expected name => create one and invite peer
-        peer_candidates = self._client.search_user_directory(address_hex)
-        self._displayname_cache.warm_users(peer_candidates)
+        peer_candidates = [
+            self._get_user(user) for user in self._client.search_user_directory(address_hex)
+        ]
 
         # filter peer_candidates
         peers = [user for user in peer_candidates if validate_userid_signature(user) == address]
@@ -1174,6 +1171,50 @@ class MatrixTransport(Runnable):
         assert self._raiden_service is not None, "_raiden_service not set"
         return self._raiden_service.signer.sign(data=data)
 
+    def _get_user(self, user_or_userid: Union[User, str]) -> User:
+        """ Returns a cached `User` instance with the `displayname` set.
+
+        This function maintains a cache of `User` instances with the
+        `displayname` variable set. This can reduce the number of HTTP requests
+        since the displayname is used in multiple places to validate the
+        partner node.
+
+        All users are supposed to be in discovery room, so just reuse the
+        `_members` dict already present from the Matrix SDK.
+        """
+        if isinstance(user_or_userid, User):
+            user = user_or_userid
+            user_id = user.user_id
+            displayname = user.displayname
+        else:
+            user = None
+            user_id = user_or_userid
+            displayname = None
+
+        assert user_id, "user_id must be available"
+
+        discovery_room = self._broadcast_rooms.get(
+            make_room_alias(self.chain_id, DISCOVERY_DEFAULT_ROOM)
+        )
+
+        # There is no discovery room to reuse the cache, so just return the
+        # user. This happens when the cache is used before the transport is
+        # fully initialized, e.g. by the `UserAddressManager` thread.
+        if discovery_room is None:
+            return user or self._client.get_user(user_id)
+
+        cached_user = discovery_room._members.setdefault(user_id, user)
+
+        if cached_user.displayname is None:
+            if displayname is not None:
+                cached_user.displayname = displayname
+            else:
+                cached_user.get_display_name()
+
+        assert cached_user.displayname, "The cached user must have a displayname set."
+
+        return cached_user
+
     def _set_room_id_for_address(
         self, address: Address, room_id: Optional[_RoomID] = None
     ) -> None:
@@ -1288,9 +1329,7 @@ class MatrixTransport(Runnable):
             # Ignore non-messages and our own messages
             return False
 
-        user = self._client.get_user(sender_id)
-        self._displayname_cache.warm_users([user])
-
+        user = self._get_user(sender_id)
         peer_address = validate_userid_signature(user)
         if not peer_address:
             self.log.debug(

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -243,16 +243,10 @@ class UserAddressManager:
         if event["type"] != "m.presence" or user_id == self._user_id:
             return
 
-        try:
-            user = User(self._client.api, user_id, event["content"].get("displayname"))
-        except ValueError:
-            log.error("Matrix server returned an invalid user_id.")
-            return
-
         # provide the displayname since that may warm the cache
-        cached_user = self._get_user(user)
+        user = self._get_user(User(self._client.api, user_id, event["content"].get("displayname")))
 
-        address = self._validate_userid_signature(cached_user)
+        address = self._validate_userid_signature(user)
         if not address:
             # Malformed address - skip
             return
@@ -277,7 +271,7 @@ class UserAddressManager:
         self.refresh_address_presence(address)
 
         if self._user_presence_changed_callback:
-            self._user_presence_changed_callback(cached_user, new_state)
+            self._user_presence_changed_callback(user, new_state)
 
     def refresh_presence(self) -> None:
         while not self._stop_event.ready():

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -243,9 +243,8 @@ class UserAddressManager:
         if event["type"] != "m.presence" or user_id == self._user_id:
             return
 
-        # provide the displayname since that may warm the cache
-        user = self._get_user(User(self._client.api, user_id, event["content"].get("displayname")))
-
+        user = self._get_user(user_id)
+        user.displayname = event["content"].get("displayname") or user.displayname
         address = self._validate_userid_signature(user)
         if not address:
             # Malformed address - skip

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import pytest
 
@@ -54,6 +54,9 @@ def mock_matrix(monkeypatch, retry_interval, retries_before_backoff):
         transport_module, "make_client", lambda url, *a, **kw: GMatrixClient(url[0])
     )
 
+    def mock_get_user(klass, user: Union[User, str]) -> User:  # pylint: disable=unused-argument
+        return User(None, USERID1)
+
     def mock_get_room_ids_for_address(  # pylint: disable=unused-argument
         klass, address: Address, filter_private: bool = None
     ) -> List[str]:
@@ -88,6 +91,7 @@ def mock_matrix(monkeypatch, retry_interval, retries_before_backoff):
     transport._address_mgr.add_userid_for_address(factories.HOP1, USERID1)
     transport._client.user_id = USERID0
 
+    monkeypatch.setattr(MatrixTransport, "_get_user", mock_get_user)
     monkeypatch.setattr(
         MatrixTransport, "_get_room_ids_for_address", mock_get_room_ids_for_address
     )


### PR DESCRIPTION
Reverts raiden-network/raiden#5225 , this may the reason for the latest scenario player failures. Reverting the changes to test the hypothesis.