### PR TITLE
Reduce number of HTTP requests to the Matrix servers

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -299,11 +299,14 @@ class MatrixTransport(Runnable):
                 config["retry_interval"],
             )
 
+        self._displayname_cache = DisplayNameCache()
+
         self._client: GMatrixClient = make_client(
             available_servers,
             http_pool_maxsize=4,
             http_retry_timeout=40,
             http_retry_delay=_http_retry_delay,
+            display_name_cache_callback=self._displayname_cache.set_displayname,
         )
         self._server_url = self._client.api.base_url
         self._server_name = config.get("server_name", urlparse(self._server_url).netloc)
@@ -311,7 +314,6 @@ class MatrixTransport(Runnable):
         self.greenlets: List[gevent.Greenlet] = list()
 
         self._address_to_retrier: Dict[Address, _RetryQueue] = dict()
-        self._displayname_cache = DisplayNameCache()
 
         self._broadcast_rooms: Dict[str, Optional[Room]] = dict()
         self._broadcast_queue: JoinableQueue[Tuple[str, Message]] = JoinableQueue()

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -520,7 +520,7 @@ class MatrixTransport(Runnable):
 
             # Ensure network state is updated in case we already know about the user presences
             # representing the target node
-            self._address_mgr.refresh_address_presence(node_address)
+            self._address_mgr.refresh_address_presence(node_address, force_refresh=True)
 
     def send_async(self, queue_identifier: QueueIdentifier, message: Message) -> None:
         """Queue the message for sending to recipient in the queue_identifier

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -415,8 +415,8 @@ class MatrixTransport(Runnable):
 
         self.log.debug("Matrix started", config=self._config)
 
-        # Spawn a greenlet to periodically refresh UserPresences
-        self._schedule_new_greenlet(self._address_mgr.refresh_presence, in_seconds_from_now=1)
+        # Spawn a greenlet to periodically log user and address presence states
+        self._schedule_new_greenlet(self._address_mgr.log_status_message, in_seconds_from_now=30)
 
         # Handle any delayed invites in the future
         self._schedule_new_greenlet(self._process_queued_invites, in_seconds_from_now=1)

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -340,12 +340,8 @@ class UserAddressManager:
         if self._user_presence_changed_callback:
             self._user_presence_changed_callback(user, new_state)
 
-    def refresh_presence(self) -> None:
+    def log_status_message(self) -> None:
         while not self._stop_event.ready():
-            # Refresh our view of the presence of our peers
-            for address in self.known_addresses:
-                self.refresh_address_presence(address)
-
             addresses_uids_presence = {
                 to_checksum_address(address): {
                     user_id: self.get_userid_presence(user_id).value
@@ -355,7 +351,7 @@ class UserAddressManager:
             }
 
             self.log.debug(
-                "Presences refreshed - current Matrix address manager status:",
+                "Matrix address manager status",
                 addresses_uids_and_presence=addresses_uids_presence,
                 current_user=self._user_id,
             )

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -88,7 +88,19 @@ class DisplayNameCache:
     def __init__(self) -> None:
         self._userid_to_displayname: Dict[str, str] = dict()
 
-    def warm_users(self, users: List[User]) -> None:
+    def set_displayname(self, user_id: str, displayname: str) -> None:
+        """ Update displayname cache """
+        if user_id and displayname:
+            self._userid_to_displayname[user_id] = displayname
+
+    def warm_users(self, users: Iterable[User]) -> None:
+        """
+        Update the given user's displayname attributes
+
+        Either update the user objects from the cache or fetch the displayname from the server.
+        If we got a new displayname (either from the given user or fetched from the server) update
+        the cache with it.
+        """
         for user in users:
             user_id = user.user_id
             cached_displayname = self._userid_to_displayname.get(user_id)


### PR DESCRIPTION
This reduces the number of additional HTTP requests to the Matrix server we perform.

(Follow-up to #5273)

This is done by:
- Reverting most of #5116. Only force refresh presence in `start_health_check`. 
- Pre-seed the DisplayNameCache from `m.room.member` events during initial sync.

See the individual commits for more detailed explanation.
