### PR TITLE
Fixes for presence checking on first sync

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -13,7 +13,7 @@ from gevent.lock import Semaphore
 from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixHttpLibError, MatrixRequestError
 
-from raiden.constants import DISCOVERY_DEFAULT_ROOM, EMPTY_SIGNATURE
+from raiden.constants import EMPTY_SIGNATURE
 from raiden.exceptions import RaidenUnrecoverableError, TransportError
 from raiden.message_handler import MessageHandler
 from raiden.messages.abstract import (
@@ -29,6 +29,7 @@ from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.transport.matrix.utils import (
     JOIN_RETRIES,
     AddressReachability,
+    DisplayNameCache,
     UserAddressManager,
     UserPresence,
     join_broadcast_room,
@@ -310,6 +311,7 @@ class MatrixTransport(Runnable):
         self.greenlets: List[gevent.Greenlet] = list()
 
         self._address_to_retrier: Dict[Address, _RetryQueue] = dict()
+        self._displayname_cache = DisplayNameCache()
 
         self._broadcast_rooms: Dict[str, Optional[Room]] = dict()
         self._broadcast_queue: JoinableQueue[Tuple[str, Message]] = JoinableQueue()
@@ -327,7 +329,7 @@ class MatrixTransport(Runnable):
 
         self._address_mgr: UserAddressManager = UserAddressManager(
             client=self._client,
-            get_user_callable=self._get_user,
+            displayname_cache=self._displayname_cache,
             address_reachability_changed_callback=self._address_reachability_changed,
             user_presence_changed_callback=self._user_presence_changed,
             _log_context={"transport_uuid": str(self._uuid)},
@@ -506,10 +508,9 @@ class MatrixTransport(Runnable):
             node_address_hex = to_normalized_address(node_address)
             self.log.debug("Healthcheck", peer_address=to_checksum_address(node_address))
 
-            candidates = [
-                self._get_user(user)
-                for user in self._client.search_user_directory(node_address_hex)
-            ]
+            candidates = self._client.search_user_directory(node_address_hex)
+            self._displayname_cache.warm_users(candidates)
+
             user_ids = {
                 user.user_id
                 for user in candidates
@@ -696,7 +697,8 @@ class MatrixTransport(Runnable):
             self.log.debug("Invite: no invite event found", room_id=room_id)
             return  # there should always be one and only one invite membership event for us
         sender = invite_event["sender"]
-        user = self._get_user(sender)
+        user = self._client.get_user(sender)
+        self._displayname_cache.warm_users([user])
         peer_address = validate_userid_signature(user)
 
         if not peer_address:
@@ -790,7 +792,9 @@ class MatrixTransport(Runnable):
             # Ignore our own messages
             return False
 
-        user = self._get_user(sender_id)
+        user = self._client.get_user(sender_id)
+        self._displayname_cache.warm_users([user])
+
         peer_address = validate_userid_signature(user)
         if not peer_address:
             self.log.debug(
@@ -991,9 +995,8 @@ class MatrixTransport(Runnable):
         room_name = make_room_alias(self.chain_id, *address_pair)
 
         # no room with expected name => create one and invite peer
-        peer_candidates = [
-            self._get_user(user) for user in self._client.search_user_directory(address_hex)
-        ]
+        peer_candidates = self._client.search_user_directory(address_hex)
+        self._displayname_cache.warm_users(peer_candidates)
 
         # filter peer_candidates
         peers = [user for user in peer_candidates if validate_userid_signature(user) == address]
@@ -1188,32 +1191,6 @@ class MatrixTransport(Runnable):
         assert self._raiden_service is not None, "_raiden_service not set"
         return self._raiden_service.signer.sign(data=data)
 
-    def _get_user(self, user: Union[User, str]) -> User:
-        """ Returns a cached `User` instance with the `displayname` set.
-
-        This function maintains a cache of `User` instances with the
-        `displayname` variable set. This can reduce the number of HTTP requests
-        since the displayname is used in multiple places to validate the
-        partner node.
-
-        All users are supposed to be in discovery room, so just reuse the
-        `_members` dict already present from the Matrix SDK.
-        """
-        user_id: str = getattr(user, "user_id", user)
-        discovery_room = self._broadcast_rooms.get(
-            make_room_alias(self.chain_id, DISCOVERY_DEFAULT_ROOM)
-        )
-        if discovery_room and user_id in discovery_room._members:
-            duser = discovery_room._members[user_id]
-            # if handed a User instance with displayname set, update the discovery room cache
-            if getattr(user, "displayname", None):
-                assert isinstance(user, User)
-                duser.displayname = user.displayname
-            user = duser
-        elif not isinstance(user, User):
-            user = self._client.get_user(user_id)
-        return user
-
     def _set_room_id_for_address(
         self, address: Address, room_id: Optional[_RoomID] = None
     ) -> None:
@@ -1328,7 +1305,9 @@ class MatrixTransport(Runnable):
             # Ignore non-messages and our own messages
             return False
 
-        user = self._get_user(sender_id)
+        user = self._client.get_user(sender_id)
+        self._displayname_cache.warm_users([user])
+
         peer_address = validate_userid_signature(user)
         if not peer_address:
             self.log.debug(

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -1,5 +1,5 @@
 import random
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import pytest
 
@@ -54,9 +54,6 @@ def mock_matrix(monkeypatch, retry_interval, retries_before_backoff):
         transport_module, "make_client", lambda url, *a, **kw: GMatrixClient(url[0])
     )
 
-    def mock_get_user(klass, user: Union[User, str]) -> User:  # pylint: disable=unused-argument
-        return User(None, USERID1)
-
     def mock_get_room_ids_for_address(  # pylint: disable=unused-argument
         klass, address: Address, filter_private: bool = None
     ) -> List[str]:
@@ -91,7 +88,6 @@ def mock_matrix(monkeypatch, retry_interval, retries_before_backoff):
     transport._address_mgr.add_userid_for_address(factories.HOP1, USERID1)
     transport._client.user_id = USERID0
 
-    monkeypatch.setattr(MatrixTransport, "_get_user", mock_get_user)
     monkeypatch.setattr(
         MatrixTransport, "_get_room_ids_for_address", mock_get_room_ids_for_address
     )


### PR DESCRIPTION
This commit changes when the display name cache is warmed. The goal here
is to not have a cache for usernames that are not whitelisted, since
that is not of interest for the Raidne node and can have a negative
impact for the startup performance, the reason being that the first sync
of the matrix server returns the presence update of every user in a
shared room, and since all Raiden nodes are in the broadcast rooms the
presence a node will receive a presence update for every single node on
the first sync, if a HTTP request is done for each address it can result
in thousands of request to the Matrix server, which has very bad
performance implications.

Additionally this adds a try-except to handle a corner case for a Matrix
federation that has a given userid but the profile of the user is
missing, it seems that this can happen when a server federation is
not properly cleaned (the culprit seems to be a restart of the
federation, were the Matrix servers were cleared, implying in the
removal of the databases, but maybe the federation was not stoped before
the databases were cleared leading to partial synchronization, were some
of the userids were propagated but the profiles were not, so the request
for a given displayname fails with a missing profile error message).
This hypothesis was investigates by @ulope.

Fixes: #<issue>

## Description

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
