### PR TITLE
Added Matrix sync response queue

### DIFF
--- a/raiden/messages/synchronization.py
+++ b/raiden/messages/synchronization.py
@@ -55,6 +55,9 @@ class Processed(SignedRetrieableMessage):
             (self.message_identifier, "uint64"),
         )
 
+    def __repr__(self) -> str:
+        return f"<Processed(msg_id={self.message_identifier})>"
+
 
 @dataclass(repr=False, eq=False)
 class Delivered(SignedMessage):
@@ -78,3 +81,6 @@ class Delivered(SignedMessage):
             (b"\x00" * 3, "bytes"),  # padding
             (self.delivered_message_identifier, "uint64"),
         )
+
+    def __repr__(self) -> str:
+        return f"<Delivered(msg_id={self.delivered_message_identifier})>"

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -506,6 +506,10 @@ class GMatrixClient(MatrixClient):
             gevent.wait({response_queue, stop_event}, count=1)
 
             if stop_event.is_set():
+                log.debug(
+                    "Handling worker exiting, stop is set",
+                    node=node_address_from_userid(self.user_id),
+                )
                 return
 
             while response_queue:

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -596,7 +596,8 @@ class GMatrixClient(MatrixClient):
             for event in sync_room["account_data"]["events"]:
                 room.account_data[event["type"]] = event["content"]
 
-        self.handle_messages_callback(all_messages)
+        if len(all_messages) > 0:
+            self.handle_messages_callback(all_messages)
 
         if first_sync:
             # Only update the local account data on first sync to avoid races.

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -485,12 +485,12 @@ class GMatrixClient(MatrixClient):
         self._sync_iteration += 1
 
     def _handle_process_worker(self, response_queue: NotifyingQueue, event_stop: Event) -> None:
-        """Worker to process network messages from the asynchronous transport.
+        """ Worker to process network messages from the asynchronous transport.
 
-        Note that his worker will process the messages in the order of
-        delivery, however, the underlying protocol may not guarantee that
+        Note that this worker will process the messages in the order of
+        delivery. However, the underlying protocol may not guarantee that
         messages are delivered in-order in which they were sent. The transport
-        layer has to implement retries to guarantee that a message will
+        layer has to implement retries to guarantee that a message is
         eventually processed. This introduces a cost in terms of latency.
         """
         data_or_stop = event_first_of(response_queue, event_stop)
@@ -501,7 +501,7 @@ class GMatrixClient(MatrixClient):
             # Clear the event's internal state for the next iteration.
             #
             # This *must* be done before any context switch, otherwise
-            # cuncurrent actions can be missed. Examples:
+            # concurrent actions can be missed. Examples:
             # - If a new element is added to the queue while `_handle_response`
             # is executing, and the `data_or_stop` is cleared after that
             # context-switch, then the new element will be missed.
@@ -517,7 +517,7 @@ class GMatrixClient(MatrixClient):
             #
             # Here `peek` is used to implement delivery at-least-once
             # semantics. At-most-once would also be acceptable because of
-            # message retries, however has the pontential of introducing
+            # message retries, however has the potential of introducing
             # latency.
             response: JSONResponse = response_queue.peek(block=False)
 
@@ -528,7 +528,7 @@ class GMatrixClient(MatrixClient):
             if response is not None:
                 self._handle_response(response)
 
-            # Pop up the processed message, if the process is kill right at
+            # Pop up the processed message, if the process is killed right
             # before this call, on the next transport start the same message
             # will be processed again, that is why this is at-least-once
             # semantics.

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -653,6 +653,8 @@ class MatrixTransport(Runnable):
         # callbacks are not installed yet (this is done bellow). The sync limit
         # prevents fetching the messages.
         prev_sync_limit = self._client.set_sync_limit(0)
+        # Need to reset this here, otherwise we might run into problems after a restart
+        self._client.last_sync = float("inf")
         self._client._sync()
         self._client.set_sync_limit(prev_sync_limit)
         # Process the result from the sync executed above

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -657,7 +657,8 @@ class MatrixTransport(Runnable):
         # Process the result from the sync executed above
         response_queue = self._client.response_queue
         while response_queue:
-            self._client._handle_response(response_queue.get(block=False), first_sync=True)
+            token_response = response_queue.get(block=False)
+            self._client._handle_response(token_response[1], first_sync=True)
 
     def _initialize_room_inventory(self) -> None:
         msg = "The rooms can only be inventoried after the first sync."

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -657,7 +657,7 @@ class MatrixTransport(Runnable):
         # Process the result from the sync executed above
         response_queue = self._client.response_queue
         while response_queue:
-            self._client._handle_response(response_queue.get(block=False))
+            self._client._handle_response(response_queue.get(block=False), first_sync=True)
 
     def _initialize_room_inventory(self) -> None:
         msg = "The rooms can only be inventoried after the first sync."

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import gevent
 import structlog
@@ -21,6 +21,7 @@ from raiden.messages.healthcheck import Ping, Pong
 from raiden.messages.synchronization import Delivered, Processed
 from raiden.network.transport.matrix.client import (
     GMatrixClient,
+    JSONResponse,
     MatrixMessage,
     MatrixSyncMessages,
     Room,
@@ -657,7 +658,7 @@ class MatrixTransport(Runnable):
         # Process the result from the sync executed above
         response_queue = self._client.response_queue
         while response_queue:
-            token_response = response_queue.get(block=False)
+            token_response: Tuple[UUID, JSONResponse] = response_queue.get(block=False)
             self._client._handle_response(token_response[1], first_sync=True)
 
     def _initialize_room_inventory(self) -> None:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -903,7 +903,7 @@ class MatrixTransport(Runnable):
 
         self._raiden_service.on_messages(all_messages)
 
-        return bool(all_messages)
+        return len(all_messages) > 0
 
     def _get_retrier(self, receiver: Address) -> _RetryQueue:
         """ Construct and return a _RetryQueue for receiver """

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1114,6 +1114,6 @@ def test_matrix_ignore_messages_in_broadcast_rooms(matrix_transports):
             gevent.joinall({transport1.greenlet}, timeout=0.1, raise_error=True)
         # Wait for the current transport1 sync loop to complete to ensure all server events
         # have been processed (making sure no exception is raised late)
-        sync_iteration = transport1._client._sync_iteration
-        while sync_iteration == transport1._client._sync_iteration:
+        sync_iteration = transport1._client.sync_iteration
+        while sync_iteration == transport1._client.sync_iteration:
             gevent.joinall({transport1.greenlet}, timeout=0.1, raise_error=True)

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -104,14 +104,14 @@ def test_send_queued_messages_after_restart(  # pylint: disable=unused-argument
     app0_restart.start()
 
     # XXX: There is no synchronization among the app and the test, so it is
-    # possible between `start` and the check bellow that some of the transfers
+    # possible between `start` and the check below that some of the transfers
     # have completed, making it flaky.
     #
     # Make sure the transfers are in the queue and fail otherwise.
-    # chain_state = views.state_from_raiden(app0_restart.raiden)
-    # for _, _, _, secrethash in transfers:
-    #     msg = "The secrethashes of the pending transfers must be in the queue after a restart."
-    #     assert secrethash in chain_state.payment_mapping.secrethashes_to_task, msg
+    chain_state = views.state_from_raiden(app0_restart.raiden)
+    for _, _, _, secrethash in transfers:
+        msg = "The secrethashes of the pending transfers must be in the queue after a restart."
+        assert secrethash in chain_state.payment_mapping.secrethashes_to_task, msg
 
     with watch_for_unlock_failures(*raiden_network):
         exception = RuntimeError("Timeout while waiting for balance update for app0")

--- a/raiden/tests/unit/test_notifyingqueue.py
+++ b/raiden/tests/unit/test_notifyingqueue.py
@@ -1,7 +1,4 @@
-import gevent
-from gevent.event import Event
-
-from raiden.utils.notifying_queue import NotifyingQueue, event_first_of
+from raiden.utils.notifying_queue import NotifyingQueue
 
 
 def add_element_to_queue(queue, element):
@@ -22,18 +19,6 @@ def test_queue():
 
     assert queue.get() == 1, "get should return first item"
     assert queue.peek() == 2, "get must remove first item"
-
-
-def test_event_must_be_set():
-    queue = NotifyingQueue()
-    event_stop = Event()
-
-    data_or_stop = event_first_of(queue, event_stop)
-
-    spawn_after_seconds = 1
-    element = 1
-    gevent.spawn_later(spawn_after_seconds, add_element_to_queue, queue, element)
-    assert data_or_stop.wait()
 
 
 def test_not_empty():

--- a/raiden/tests/unit/test_notifyingqueue.py
+++ b/raiden/tests/unit/test_notifyingqueue.py
@@ -8,7 +8,7 @@ def add_element_to_queue(queue, element):
     queue.put(element)
 
 
-def test_copy():
+def test_queue():
     queue = NotifyingQueue()
     assert queue.copy() == []
 
@@ -18,6 +18,10 @@ def test_copy():
 
     queue.put(2)
     assert queue.copy() == [1, 2], "copy must preserve the items order"
+    assert queue.peek() == 1, "copy must preserve the queue"
+
+    assert queue.get() == 1, "get should return first item"
+    assert queue.peek() == 2, "get must remove first item"
 
 
 def test_event_must_be_set():
@@ -33,5 +37,8 @@ def test_event_must_be_set():
 
 
 def test_not_empty():
+    queue = NotifyingQueue()
+    assert not queue.is_set()
+
     queue = NotifyingQueue(items=[1, 2])
     assert queue.is_set()

--- a/raiden/tests/unit/test_notifyingqueue.py
+++ b/raiden/tests/unit/test_notifyingqueue.py
@@ -1,0 +1,37 @@
+import gevent
+from gevent.event import Event
+
+from raiden.utils.notifying_queue import NotifyingQueue, event_first_of
+
+
+def add_element_to_queue(queue, element):
+    queue.put(element)
+
+
+def test_copy():
+    queue = NotifyingQueue()
+    assert queue.copy() == []
+
+    queue.put(1)
+    assert queue.copy() == [1]
+    assert queue.peek() == 1, "copy must preserve the queue"
+
+    queue.put(2)
+    assert queue.copy() == [1, 2], "copy must preserve the items order"
+
+
+def test_event_must_be_set():
+    queue = NotifyingQueue()
+    event_stop = Event()
+
+    data_or_stop = event_first_of(queue, event_stop)
+
+    spawn_after_seconds = 1
+    element = 1
+    gevent.spawn_later(spawn_after_seconds, add_element_to_queue, queue, element)
+    assert data_or_stop.wait()
+
+
+def test_not_empty():
+    queue = NotifyingQueue(items=[1, 2])
+    assert queue.is_set()

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -24,6 +24,10 @@ def event_first_of(*events: _AbstractLinkable) -> Event:
 
 
 class NotifyingQueue(Event):
+    """This is not the same as a JoinableQueue. Here, instead of waiting for
+    all the work to be processed, the wait is for work to be available.
+    """
+
     def __init__(self, maxsize: int = None, items: Iterable[T] = ()) -> None:
         super().__init__()
         self._queue = Queue(maxsize, items)

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -61,3 +61,6 @@ class NotifyingQueue(Event):
         while not copy.empty():
             result.append(copy.get_nowait())
         return result
+
+    def __repr__(self) -> str:
+        return f"NotifyingQueue(num_items={len(self._queue)})"

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -1,0 +1,59 @@
+from typing import Iterable, List, TypeVar
+
+from gevent.event import Event, _AbstractLinkable
+from gevent.queue import Queue
+
+T = TypeVar("T")
+
+
+def event_first_of(*events: _AbstractLinkable) -> Event:
+    """ Waits until one of `events` is set.
+
+    The event returned is /not/ cleared with any of the `events`, this value
+    must not be reused if the clearing behavior is used.
+    """
+    first_finished = Event()
+
+    if not all(isinstance(e, _AbstractLinkable) for e in events):
+        raise ValueError("all events must be linkable")
+
+    for event in events:
+        event.rawlink(lambda _: first_finished.set())
+
+    return first_finished
+
+
+class NotifyingQueue(Event):
+    def __init__(self, maxsize: int = None, items: Iterable[T] = ()) -> None:
+        super().__init__()
+        self._queue = Queue(maxsize, items)
+
+        if items:
+            self.set()
+
+    def put(self, item: T) -> None:
+        """ Add new item to the queue. """
+        self._queue.put(item)
+        self.set()
+
+    def get(self, block: bool = True, timeout: float = None) -> T:
+        """ Removes and returns an item from the queue. """
+        value = self._queue.get(block, timeout)
+        if self._queue.empty():
+            self.clear()
+        return value
+
+    def peek(self, block: bool = True, timeout: float = None) -> T:
+        return self._queue.peek(block, timeout)
+
+    def __len__(self) -> int:
+        return len(self._queue)
+
+    def copy(self) -> List[T]:
+        """ Copies the current queue items. """
+        copy = self._queue.copy()
+
+        result = list()
+        while not copy.empty():
+            result.append(copy.get_nowait())
+        return result

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -1,26 +1,9 @@
 from typing import Iterable, List, TypeVar
 
-from gevent.event import Event, _AbstractLinkable
+from gevent.event import Event
 from gevent.queue import Queue
 
 T = TypeVar("T")
-
-
-def event_first_of(*events: _AbstractLinkable) -> Event:
-    """ Waits until one of `events` is set.
-
-    The event returned is /not/ cleared with any of the `events`, this value
-    must not be reused if the clearing behavior is used.
-    """
-    first_finished = Event()
-
-    if not all(isinstance(e, _AbstractLinkable) for e in events):
-        raise ValueError("all events must be linkable")
-
-    for event in events:
-        event.rawlink(lambda _: first_finished.set())
-
-    return first_finished
 
 
 class NotifyingQueue(Event):


### PR DESCRIPTION
~Review/Merge after #5216~ done

## Description

The `_sync` has to be done often enough because that is the mechanism
used by the Raiden node to keep it's status as online with the Matrix
server. If a `_sync` returns a huge amount of data that has to be
processed by the node, which may lead to the processing thread taking a
long time to process the server's response, it is possible for the time
in between `_sync` calls can be too large, leading to problems with the
presence checking of the node.

This introduces a message queue, guaranteeing the server responses are
processed in order, since that is necessary for the client state to be
consistent, and that the processing thread will not block the synching
thread.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
