### PR TITLE
Move channel close to after balance assert [skip ci]

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -214,7 +214,7 @@ scenario:
           name: "Assert after 100 payments from 3 to 0"
           tasks:
             - wait: 100
-            - assert_sum: {from: 0, balance_sum: 1_105_000_000_000_000_000}
+            - assert_sum: {from: 0, balance_sum: 1_995_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_000_000_000_000_000_000}
       - serial:
           name: "Close channel between 0 and 4"

--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -206,6 +206,17 @@ scenario:
             - assert_sum: {from: 0, balance_sum: 1_895_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_100_000_000_000_000_000}
       - serial:
+          name: "Make 100 payments from 3 to 0"
+          repeat: 100
+          tasks:
+            - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, lock_timeout: 30}
+      - serial:
+          name: "Assert after 100 payments from 3 to 0"
+          tasks:
+            - wait: 100
+            - assert_sum: {from: 0, balance_sum: 1_105_000_000_000_000_000}
+            - assert_sum: {from: 3, balance_sum: 2_000_000_000_000_000_000}
+      - serial:
           name: "Close channel between 0 and 4"
           tasks:
             - close_channel: {from: 0, to: 4}
@@ -221,17 +232,6 @@ scenario:
             - assert: {from: 0, to: 4, state: "closed"}
             # Make sure that channel between 0 and 4 is also settled
             - wait_blocks: 40
-      - serial:
-          name: "Make 100 payments from 3 to 0"
-          repeat: 100
-          tasks:
-            - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, lock_timeout: 30}
-      - serial:
-          name: "Assert after 100 payments from 3 to 0"
-          tasks:
-            - wait: 100
-            - assert_sum: {from: 0, balance_sum: 1_105_000_000_000_000_000}
-            - assert_sum: {from: 3, balance_sum: 2_000_000_000_000_000_000}
       - serial:
           name: "Close channel between 3 and 4 while 4 is offline"
           tasks:


### PR DESCRIPTION
Fixes: https://github.com/raiden-network/raiden/issues/5219

## Description
This PR moves the close call of the bf1 scenario to after the balance asserts in order to make the results predictable. 

Currently the PR has not run locally due to other problems, but I suggest we just merge it and then if the nightlies show problems with the scenario itself, we fix it.