### PR TITLE
Remove unused function from smartcontract_proxy

### DIFF
--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -169,12 +169,6 @@ class ContractProxy:
             kwargs=kwargs,
         )
 
-    def decode_transaction_input(self, transaction_hash: bytes) -> Dict:
-        """Return inputs of a method call"""
-        transaction = self.contract.web3.eth.getTransaction(transaction_hash)
-
-        return self.contract.decode_function_input(transaction["input"])
-
     def decode_event(self, log: Dict[str, Any]) -> Dict[str, Any]:
         return decode_event(self.contract.abi, log)
 


### PR DESCRIPTION
## Description

The `decode_transaction_input()` function is not used anywhere

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
