### PR TITLE
Remove unused code from the ProxyManager

### DIFF
--- a/raiden/network/proxies/proxy_manager.py
+++ b/raiden/network/proxies/proxy_manager.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import gevent
-from eth_utils import decode_hex, is_binary_address, to_checksum_address
+from eth_utils import decode_hex, is_binary_address
 from gevent.lock import Semaphore
 
 from raiden.network.proxies.metadata import SmartContractMetadata
@@ -17,7 +17,6 @@ from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.typing import (
     Address,
     BlockNumber,
-    BlockSpecification,
     ChannelID,
     Dict,
     EVMBytecode,
@@ -116,11 +115,6 @@ class ProxyManager:
         delta = last_timestamp - first_timestamp
         return delta / interval
 
-    def next_block(self) -> BlockNumber:
-        target_block_number = BlockNumber(self.client.block_number() + 1)
-        self.wait_until_block(target_block_number=target_block_number)
-        return target_block_number
-
     def wait_until_block(self, target_block_number: BlockNumber) -> BlockNumber:
         current_block = self.client.block_number()
 
@@ -170,49 +164,6 @@ class ProxyManager:
                 )
 
         return self.address_to_token_network_registry[address]
-
-    def token_network_from_registry(
-        self,
-        token_network_registry_address: TokenNetworkRegistryAddress,
-        token_address: TokenAddress,
-        block_identifier: BlockSpecification = "latest",
-    ) -> TokenNetwork:
-        token_network_registry = self.token_network_registry(token_network_registry_address)
-        token_network_address = token_network_registry.get_token_network(
-            token_address=token_address, block_identifier=block_identifier
-        )
-
-        if token_network_address is None:
-            raise ValueError(
-                f"{to_checksum_address(token_network_registry_address)} does not "
-                f"have the token {to_checksum_address(token_address)} "
-                f"registered."
-            )
-
-        with self._token_network_creation_lock:
-            if token_network_address not in self.address_to_token_network:
-                metadata = TokenNetworkMetadata(
-                    deployed_at=None,
-                    address=Address(token_network_address),
-                    abi=self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
-                    gas_measurements=gas_measurements(self.contract_manager.contracts_version),
-                    runtime_bytecode=EVMBytecode(
-                        decode_hex(
-                            self.contract_manager.get_runtime_hexcode(CONTRACT_TOKEN_NETWORK)
-                        )
-                    ),
-                    token_network_registry_address=token_network_registry_address,
-                    filters_start_at=token_network_registry.metadata.filters_start_at,
-                )
-
-                self.address_to_token_network[token_network_address] = TokenNetwork(
-                    jsonrpc_client=self.client,
-                    contract_manager=self.contract_manager,
-                    proxy_manager=self,
-                    metadata=metadata,
-                )
-
-        return self.address_to_token_network[token_network_address]
 
     def token_network(self, address: TokenNetworkAddress) -> TokenNetwork:
         if not is_binary_address(address):

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -802,7 +802,10 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit):
     # claim the token from the channel A1 - H
 
     # the attacker settles the contract
-    app2.raiden.proxy_manager.next_block()
+    app2proxymanager = app2.raiden.proxy_manager
+    app2proxymanager.wait_until_block(
+        target_block_number=app2proxymanager.client.block_number() + 1
+    )
 
     attack_channel.netting_channel.settle(token, attack_contract)
 
@@ -820,7 +823,10 @@ def test_start_end_attack(token_addresses, raiden_chain, deposit):
     # locked transfer between H-A2 than A1-H. For A2 to acquire the token
     # it needs to make the secret public in the blockchain so it publishes the
     # secret through an event and the Hub is able to require its funds
-    app1.raiden.proxy_manager.next_block()
+    app1proxymanager = app1.raiden.proxy_manager
+    app1proxymanager.wait_until_block(
+        target_block_number=app1proxymanager.client.block_number() + 1
+    )
 
     # XXX: verify that the Hub has found the secret, close and settle the channel
 


### PR DESCRIPTION
## Description 

- Removes unused function token_network_from_registry()
- next_block() was only used by an old test and is replaced by wait_until_block()


## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
