### PR TITLE
FIX-#5295Pull tags before building raiden.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,8 +25,7 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /app/raiden
-
-RUN make install
+RUN git fetch --tags && make install
 
 
 FROM python:3.7-slim as runner


### PR DESCRIPTION
A first attempt at fixing #5295

However, pulling tags does not appear to do the trick for now.