### PR TITLE
Fix a type error in test utils

### DIFF
--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -121,7 +121,10 @@ def watch_for_unlock_failures(*apps, retry_timeout=DEFAULT_RETRY_TIMEOUT):
     """
 
     def watcher_function():
-        offset = {app.raiden.address: count_unlock_failures(app.raiden) for app in apps}
+        offset = {
+            app.raiden.address: count_unlock_failures(app.raiden.wal.storage.get_events())
+            for app in apps
+        }
         while True:
             for app in apps:
                 assert not has_unlock_failure(app.raiden, offset=offset[app.raiden.address])


### PR DESCRIPTION
Fixes a type error that was introduced in `raiden.tests.utils.watch_for_unlock_failures` a couple of days ago.