### PR TITLE
Remove getattr from runnable

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -431,8 +431,8 @@ class RaidenService(Runnable):
         # - React to incoming messages
         # - Send pending transactions
         # - Send pending message
-        self.alarm.link_exception(self.on_error)
-        self.transport.link_exception(self.on_error)
+        self.alarm.greenlet.link_exception(self.on_error)
+        self.transport.greenlet.link_exception(self.on_error)
         self._start_transport(chain_state)
         self._start_alarm_task()
 
@@ -470,8 +470,8 @@ class RaidenService(Runnable):
         self.transport.stop()
         self.alarm.stop()
 
-        self.transport.join()
-        self.alarm.join()
+        self.transport.greenlet.join()
+        self.alarm.greenlet.join()
 
         self.blockchain_events.uninstall_all_event_listeners()
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -273,7 +273,7 @@ class AlarmTask(Runnable):
         if self._stop_event:
             self._stop_event.set(True)
         log.debug("Alarm task stopped", node=to_checksum_address(self.rpc_client.address))
-        result = self.join()
+        result = self.greenlet.join()
         # Callbacks should be cleaned after join
         self.callbacks = []
         return result

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -1,7 +1,10 @@
 # pylint: disable=too-many-arguments,redefined-outer-name
 import pytest
 
+from raiden.api.rest import APIServer
+from raiden.app import App
 from raiden.tests.integration.api.utils import create_api_server
+from raiden.utils.typing import Iterable, List
 
 
 # TODO: Figure out why this fixture can't work as session scoped
@@ -9,7 +12,9 @@ from raiden.tests.integration.api.utils import create_api_server
 #       the server is no longer running even though the teardown has not
 #       been invoked.
 @pytest.fixture
-def api_server_test_instance(raiden_network, rest_api_port_number):
+def api_server_test_instance(
+    raiden_network: List[App], rest_api_port_number: int
+) -> Iterable[APIServer]:
     api_server = create_api_server(raiden_network[0], rest_api_port_number)
 
     yield api_server

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -15,6 +15,7 @@ from eth_utils import (
 )
 from flask import url_for
 
+from raiden.api.rest import APIServer
 from raiden.api.v1.encoding import AddressField, HexAddressConverter
 from raiden.constants import GENESIS_BLOCK_NUMBER, NULL_ADDRESS_HEX, SECRET_LENGTH, Environment
 from raiden.messages.transfers import LockedTransfer, Unlock
@@ -152,7 +153,7 @@ def test_address_field():
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_payload_with_invalid_addresses(api_server_test_instance, rest_api_port_number):
+def test_payload_with_invalid_addresses(api_server_test_instance: APIServer, rest_api_port_number):
     """ Addresses require leading 0x in the payload. """
     invalid_address = "61c808d82a3ac53231750dadc13c777b59310bd9"
     channel_data_obj = {
@@ -183,7 +184,7 @@ def test_payload_with_invalid_addresses(api_server_test_instance, rest_api_port_
 )
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_crash_on_unhandled_exception(api_server_test_instance):
+def test_crash_on_unhandled_exception(api_server_test_instance: APIServer) -> None:
     """ Crash when an unhandled exception happens on APIServer. """
 
     # as we should not have unhandled exceptions in our endpoints, create one to test
@@ -195,12 +196,12 @@ def test_crash_on_unhandled_exception(api_server_test_instance):
         url = url_for("error_endpoint")
     request = grequests.get(url)
     request.send()
-    api_server_test_instance.get(timeout=10)
+    api_server_test_instance.greenlet.get(timeout=10)
 
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_payload_with_address_invalid_chars(api_server_test_instance):
+def test_payload_with_address_invalid_chars(api_server_test_instance: APIServer):
     """ Addresses cannot have invalid characters in it. """
     invalid_address = "0x61c808d82a3ac53231750dadc13c777b59310bdg"  # g at the end is invalid
     channel_data_obj = {
@@ -217,7 +218,7 @@ def test_payload_with_address_invalid_chars(api_server_test_instance):
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_payload_with_address_invalid_length(api_server_test_instance):
+def test_payload_with_address_invalid_length(api_server_test_instance: APIServer):
     """ Encoded addresses must have the right length. """
     invalid_address = "0x61c808d82a3ac53231750dadc13c777b59310b"  # g at the end is invalid
     channel_data_obj = {
@@ -234,7 +235,7 @@ def test_payload_with_address_invalid_length(api_server_test_instance):
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_payload_with_address_not_eip55(api_server_test_instance):
+def test_payload_with_address_not_eip55(api_server_test_instance: APIServer):
     """ Provided addresses must be EIP55 encoded. """
     invalid_address = "0xf696209d2ca35e6c88e5b99b7cda3abf316bed69"
     channel_data_obj = {
@@ -251,7 +252,7 @@ def test_payload_with_address_not_eip55(api_server_test_instance):
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_api_query_our_address(api_server_test_instance):
+def test_api_query_our_address(api_server_test_instance: APIServer):
     request = grequests.get(api_url_for(api_server_test_instance, "addressresource"))
     response = request.send().response
     assert_proper_response(response)
@@ -260,7 +261,7 @@ def test_api_query_our_address(api_server_test_instance):
     assert get_json_response(response) == {"our_address": to_checksum_address(our_address)}
 
 
-def test_api_get_raiden_version(api_server_test_instance):
+def test_api_get_raiden_version(api_server_test_instance: APIServer):
     request = grequests.get(api_url_for(api_server_test_instance, "versionresource"))
     response = request.send().response
     assert_proper_response(response)
@@ -272,7 +273,9 @@ def test_api_get_raiden_version(api_server_test_instance):
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_api_get_channel_list(api_server_test_instance, token_addresses, reveal_timeout):
+def test_api_get_channel_list(
+    api_server_test_instance: APIServer, token_addresses, reveal_timeout
+):
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
 
     request = grequests.get(api_url_for(api_server_test_instance, "channelsresource"))
@@ -312,7 +315,9 @@ def test_api_get_channel_list(api_server_test_instance, token_addresses, reveal_
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_api_channel_status_channel_nonexistant(api_server_test_instance, token_addresses):
+def test_api_channel_status_channel_nonexistant(
+    api_server_test_instance: APIServer, token_addresses
+):
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
 
@@ -335,7 +340,9 @@ def test_api_channel_status_channel_nonexistant(api_server_test_instance, token_
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_api_open_and_deposit_channel(api_server_test_instance, token_addresses, reveal_timeout):
+def test_api_open_and_deposit_channel(
+    api_server_test_instance: APIServer, token_addresses, reveal_timeout
+):
 
     first_partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
@@ -516,7 +523,7 @@ def test_api_open_and_deposit_channel(api_server_test_instance, token_addresses,
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_and_deposit_race(
-    api_server_test_instance,
+    api_server_test_instance: APIServer,
     raiden_network,
     token_addresses,
     reveal_timeout,
@@ -613,7 +620,7 @@ def test_api_open_and_deposit_race(
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_close_and_settle_channel(
-    api_server_test_instance, token_addresses, reveal_timeout
+    api_server_test_instance: APIServer, token_addresses, reveal_timeout
 ):
     # let's create a new channel
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
@@ -675,7 +682,9 @@ def test_api_open_close_and_settle_channel(
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_api_close_insufficient_eth(api_server_test_instance, token_addresses, reveal_timeout):
+def test_api_close_insufficient_eth(
+    api_server_test_instance: APIServer, token_addresses, reveal_timeout
+):
 
     # let's create a new channel
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
@@ -726,7 +735,9 @@ def test_api_close_insufficient_eth(api_server_test_instance, token_addresses, r
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_api_open_channel_invalid_input(api_server_test_instance, token_addresses, reveal_timeout):
+def test_api_open_channel_invalid_input(
+    api_server_test_instance: APIServer, token_addresses, reveal_timeout
+):
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
     settle_timeout = TEST_SETTLE_TIMEOUT_MIN - 1
@@ -761,7 +772,7 @@ def test_api_open_channel_invalid_input(api_server_test_instance, token_addresse
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_channel_state_change_errors(
-    api_server_test_instance, token_addresses, reveal_timeout
+    api_server_test_instance: APIServer, token_addresses, reveal_timeout
 ):
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
@@ -912,7 +923,7 @@ def test_api_channel_state_change_errors(
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [2])
 @pytest.mark.parametrize("environment_type", [Environment.DEVELOPMENT])
-def test_api_tokens(api_server_test_instance, blockchain_services, token_addresses):
+def test_api_tokens(api_server_test_instance: APIServer, blockchain_services, token_addresses):
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address1 = token_addresses[0]
     token_address2 = token_addresses[1]
@@ -953,7 +964,9 @@ def test_api_tokens(api_server_test_instance, blockchain_services, token_address
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_query_partners_by_token(api_server_test_instance, blockchain_services, token_addresses):
+def test_query_partners_by_token(
+    api_server_test_instance: APIServer, blockchain_services, token_addresses
+):
     first_partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     second_partner_address = "0x29FA6cf0Cce24582a9B20DB94Be4B6E017896038"
     token_address = token_addresses[0]
@@ -1016,7 +1029,9 @@ def test_query_partners_by_token(api_server_test_instance, blockchain_services, 
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_api_payments_target_error(api_server_test_instance, raiden_network, token_addresses):
+def test_api_payments_target_error(
+    api_server_test_instance: APIServer, raiden_network, token_addresses
+):
     _, app1 = raiden_network
     amount = 200
     identifier = 42
@@ -1041,7 +1056,7 @@ def test_api_payments_target_error(api_server_test_instance, raiden_network, tok
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_api_payments(api_server_test_instance, raiden_network, token_addresses):
+def test_api_payments(api_server_test_instance: APIServer, raiden_network, token_addresses):
     _, app1 = raiden_network
     amount = 100
     identifier = 42
@@ -1075,7 +1090,9 @@ def test_api_payments(api_server_test_instance, raiden_network, token_addresses)
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_api_timestamp_format(api_server_test_instance, raiden_network, token_addresses):
+def test_api_timestamp_format(
+    api_server_test_instance: APIServer, raiden_network, token_addresses
+):
     _, app1 = raiden_network
     amount = 200
     identifier = 42
@@ -1110,7 +1127,7 @@ def test_api_timestamp_format(api_server_test_instance, raiden_network, token_ad
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_secret_hash_errors(
-    api_server_test_instance, raiden_network, token_addresses
+    api_server_test_instance: APIServer, raiden_network, token_addresses
 ):
     _, app1 = raiden_network
     amount = 200
@@ -1186,7 +1203,7 @@ def test_api_payments_secret_hash_errors(
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_secret_no_hash(
-    api_server_test_instance, raiden_network, token_addresses
+    api_server_test_instance: APIServer, raiden_network, token_addresses
 ):
     _, app1 = raiden_network
     amount = 100
@@ -1262,7 +1279,7 @@ def test_api_payments_with_hash_no_secret(
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("resolver_ports", [[None, 8000]])
 def test_api_payments_with_resolver(
-    api_server_test_instance, raiden_network, token_addresses, resolvers
+    api_server_test_instance: APIServer, raiden_network, token_addresses, resolvers
 ):
 
     _, app1 = raiden_network
@@ -1336,7 +1353,7 @@ def test_api_payments_with_resolver(
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_secret_and_hash(
-    api_server_test_instance, raiden_network, token_addresses
+    api_server_test_instance: APIServer, raiden_network, token_addresses
 ):
     _, app1 = raiden_network
     amount = 100
@@ -1401,7 +1418,9 @@ def assert_payment_conflict(responses):
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_api_payments_conflicts(api_server_test_instance, raiden_network, token_addresses):
+def test_api_payments_conflicts(
+    api_server_test_instance: APIServer, raiden_network, token_addresses
+):
     _, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.raiden.address
@@ -1438,7 +1457,11 @@ def test_api_payments_conflicts(api_server_test_instance, raiden_network, token_
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("environment_type", [Environment.PRODUCTION])
 def test_register_token_mainnet(
-    api_server_test_instance, token_amount, token_addresses, raiden_network, contract_manager
+    api_server_test_instance: APIServer,
+    token_amount,
+    token_addresses,
+    raiden_network,
+    contract_manager,
 ):
     app0 = raiden_network[0]
     new_token_address = deploy_contract_web3(
@@ -1605,7 +1628,7 @@ def test_get_token_network_for_token(
 @pytest.mark.parametrize("number_of_tokens", [1])
 # For non-red eyes mainnet code set number_of_tokens to 2 and uncomment the code
 # at the end of this test
-def test_get_connection_managers_info(api_server_test_instance, token_addresses):
+def test_get_connection_managers_info(api_server_test_instance: APIServer, token_addresses):
     # check that there are no registered tokens
     request = grequests.get(api_url_for(api_server_test_instance, "connectionsinforesource"))
     response = request.send().response
@@ -1662,7 +1685,7 @@ def test_get_connection_managers_info(api_server_test_instance, token_addresses)
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
-def test_connect_insufficient_reserve(api_server_test_instance, token_addresses):
+def test_connect_insufficient_reserve(api_server_test_instance: APIServer, token_addresses):
 
     # Burn all eth and then try to connect to a token network
     burn_eth(api_server_test_instance.rest_api.raiden_api.raiden.rpc_client)
@@ -1681,7 +1704,7 @@ def test_connect_insufficient_reserve(api_server_test_instance, token_addresses)
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_network_events(api_server_test_instance, token_addresses):
+def test_network_events(api_server_test_instance: APIServer, token_addresses):
     # let's create a new channel
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
@@ -1712,7 +1735,7 @@ def test_network_events(api_server_test_instance, token_addresses):
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_token_events(api_server_test_instance, token_addresses):
+def test_token_events(api_server_test_instance: APIServer, token_addresses):
     # let's create a new channel
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
@@ -1744,7 +1767,7 @@ def test_token_events(api_server_test_instance, token_addresses):
 
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
-def test_channel_events(api_server_test_instance, token_addresses):
+def test_channel_events(api_server_test_instance: APIServer, token_addresses):
     # let's create a new channel
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     token_address = token_addresses[0]
@@ -1875,7 +1898,9 @@ def test_api_deposit_limit(
 
 
 @pytest.mark.parametrize("number_of_nodes", [3])
-def test_payment_events_endpoints(api_server_test_instance, raiden_network, token_addresses):
+def test_payment_events_endpoints(
+    api_server_test_instance: APIServer, raiden_network, token_addresses
+):
     app0, app1, app2 = raiden_network
     amount1 = PaymentAmount(10)
     identifier1 = PaymentID(42)
@@ -2206,7 +2231,9 @@ def test_payment_events_endpoints(api_server_test_instance, raiden_network, toke
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_channel_events_raiden(api_server_test_instance, raiden_network, token_addresses):
+def test_channel_events_raiden(
+    api_server_test_instance: APIServer, raiden_network, token_addresses
+):
     _, app1 = raiden_network
     amount = 100
     identifier = 42
@@ -2324,7 +2351,7 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
 
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [1000])
-def test_api_withdraw(api_server_test_instance, raiden_network, token_addresses):
+def test_api_withdraw(api_server_test_instance: APIServer, raiden_network, token_addresses):
     _, app1 = raiden_network
     token_address = token_addresses[0]
     partner_address = app1.raiden.address
@@ -2386,7 +2413,7 @@ def test_api_withdraw(api_server_test_instance, raiden_network, token_addresses)
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("token_contract_name", [CONTRACT_CUSTOM_TOKEN])
-def test_api_testnet_token_mint(api_server_test_instance, token_addresses):
+def test_api_testnet_token_mint(api_server_test_instance: APIServer, token_addresses):
     user_address = factories.make_checksum_address()
     token_address = token_addresses[0]
     url = api_url_for(api_server_test_instance, "tokensmintresource", token_address=token_address)
@@ -2424,7 +2451,9 @@ def test_api_testnet_token_mint(api_server_test_instance, token_addresses):
 
 
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_api_payments_with_lock_timeout(api_server_test_instance, raiden_network, token_addresses):
+def test_api_payments_with_lock_timeout(
+    api_server_test_instance: APIServer, raiden_network, token_addresses
+):
     _, app1 = raiden_network
     amount = 100
     identifier = 42
@@ -2491,7 +2520,7 @@ def test_api_payments_with_lock_timeout(api_server_test_instance, raiden_network
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [0])
 def test_api_set_reveal_timeout(
-    api_server_test_instance, raiden_network, token_addresses, settle_timeout
+    api_server_test_instance: APIServer, raiden_network, token_addresses, settle_timeout
 ):
     app0, app1 = raiden_network
     token_address = token_addresses[0]

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -96,7 +96,7 @@ def matrix_transports(
     for transport in transports:
         # Calling `get()` on a never started Greenlet will block forever
         if transport._started:
-            transport.get()
+            transport.greenlet.get()
 
 
 @pytest.fixture

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 import gevent
 import pytest
 from eth_utils import is_list_like, to_checksum_address
@@ -7,6 +5,7 @@ from web3.utils.events import construct_event_topic_set
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
+from raiden.app import App
 from raiden.blockchain.events import (
     ALL_EVENTS,
     get_all_netting_channel_events,
@@ -21,6 +20,7 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import must_have_event, search_for_item, wait_for_state_change
 from raiden.tests.utils.network import CHAIN
+from raiden.tests.utils.protocol import HoldRaidenEventHandler
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
     get_channelstate,
@@ -38,7 +38,12 @@ from raiden.utils.typing import (
     Balance,
     BlockSpecification,
     ChannelID,
+    Dict,
+    List,
+    PaymentAmount,
+    PaymentID,
     Secret,
+    TargetAddress,
     TokenNetworkAddress,
 )
 from raiden_contracts.constants import (
@@ -483,11 +488,12 @@ def test_secret_revealed_on_chain(
 
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_clear_closed_queue(raiden_network, token_addresses, network_wait):
+def test_clear_closed_queue(raiden_network: List[App], token_addresses, network_wait):
     """ Closing a channel clears the respective message queue. """
     app0, app1 = raiden_network
 
     hold_event_handler = app1.raiden.raiden_event_handler
+    assert isinstance(hold_event_handler, HoldRaidenEventHandler)
 
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
@@ -512,21 +518,22 @@ def test_clear_closed_queue(raiden_network, token_addresses, network_wait):
     hold_event_handler.hold_secretrequest_for(secrethash=secrethash)
 
     # make an unconfirmed transfer to ensure the nodes have communicated
-    amount = 10
-    payment_identifier = 1337
+    amount = PaymentAmount(10)
+    payment_identifier = PaymentID(1337)
     app0.raiden.start_mediated_transfer_with_secret(
         token_network_address=token_network_address,
         amount=amount,
-        target=target,
+        target=TargetAddress(target),
         identifier=payment_identifier,
         secret=secret,
     )
 
     app1.raiden.transport.stop()
-    app1.raiden.transport.get()
+    app1.raiden.transport.greenlet.get()
 
     # make sure to wait until the queue is created
     def has_initiator_events():
+        assert app0.raiden.wal, "raiden server must have been started"
         initiator_events = app0.raiden.wal.storage.get_events()
         return search_for_item(initiator_events, SendLockedTransfer, {})
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -445,8 +445,8 @@ def run_smoketest(
     finally:
         if api_server is not None:
             api_server.stop()
-            api_server.get()
+            api_server.greenlet.get()
 
         if app is not None:
             app.stop()
-            app.raiden.get()
+            app.raiden.greenlet.get()

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -191,7 +191,7 @@ class NodeRunner:
 
         # quit if any task exits, successfully or not
         for task in tasks:
-            task.link(event)
+            task.greenlet.link(event)
 
         try:
             event.get()

--- a/raiden/utils/runnable.py
+++ b/raiden/utils/runnable.py
@@ -3,7 +3,7 @@ from typing import Any, Sequence
 import structlog
 from gevent import Greenlet, GreenletExit
 
-from raiden.utils.typing import Callable
+from raiden.utils.typing import Callable, List
 
 log = structlog.get_logger(__name__)
 
@@ -25,6 +25,7 @@ class Runnable:
 
         self.greenlet = Greenlet(self._run, *self.args, **self.kwargs)
         self.greenlet.name = f"{self.__class__.__name__}|{self.greenlet.name}"
+        self.greenlets: List[Greenlet] = list()
 
     def start(self) -> None:
         """ Synchronously start task
@@ -94,11 +95,6 @@ class Runnable:
         else:
             greenlet.start()
         return greenlet
-
-    # redirect missing members to underlying greenlet for compatibility
-    # but better use greenlet directly for now, to make use of the c extension optimizations
-    def __getattr__(self, item: str) -> Any:
-        return getattr(self.greenlet, item)
 
     def __bool__(self) -> bool:
         return bool(self.greenlet)

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,8 @@ disallow_untyped_defs = False
 # The factory code is hard to type correctly
 [mypy-raiden.tests.utils.factories]
 ignore_errors = True
+[mypy-raiden.tests.utils.detect_failure]
+disallow_untyped_defs = True
 
 # No need to be as strict for our tools and tests
 [mypy-tools.*]


### PR DESCRIPTION
## Description

The usage of getattr breaks the statically linting tools and let small
bugs cripple in.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
