### PR TITLE
Relax reveal timeout in flaky stress test

### DIFF
--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -340,12 +340,11 @@ def assert_channels(
         )
 
 
-@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/4803")
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [2])
 @pytest.mark.parametrize("deposit", [2])
-@pytest.mark.parametrize("reveal_timeout", [15])
+@pytest.mark.parametrize("reveal_timeout", [45])
 @pytest.mark.parametrize("settle_timeout", [120])
 def test_stress(
     raiden_network: List[App],

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -165,8 +165,13 @@ def transfer_and_assert(
 
     log.debug("PAYMENT RESPONSE", url=url, json=json, response=response, duration=duration)
 
-    assert getattr(request, "exception", None) is None
     assert response is not None
+
+    expired_lock = response.status_code == HTTPStatus.CONFLICT and "expired" in response.content
+    msg = "Stress test failed due to an expired lock in a transfer."
+    assert not expired_lock, msg
+
+    assert getattr(request, "exception", None) is None
     assert response.status_code == HTTPStatus.OK
     assert response.headers["Content-Type"] == "application/json"
 


### PR DESCRIPTION
Related issue: #4803 

The reason for the stress test flakiness turned out to be transfers completing too slowly until finally one expires. To be able to unskip the stress test, relax the reveal timeout temporarily. Issue #4803 remains open for discussing a better solution.