### PR TITLE
Do not write debug logfile in the current directory

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`5050` Raiden's argument --debug-logfile-name has been renamed to --debug-logfile-path to better reflect the argument's function.
 * :bug:`5050` Raiden now works on OSX Catalina. Debug logfile is no longer written in the current directory.
 * :feature:`5278` Always use private rooms in the matrix transport.
 * :feature:`5217` Fully support infura as an underlying ethereum rpc node.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`5050` Raiden now works on OSX Catalina. Debug logfile is no longer written in the current directory.
 * :feature:`5278` Always use private rooms in the matrix transport.
 * :feature:`5217` Fully support infura as an underlying ethereum rpc node.
 * :bug:`5064` Display a user-friendly error message when the PFS info request fails.

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -148,6 +148,9 @@ def configure_debug_logfile_path(debug_log_file_name: Optional[str]) -> str:
     else:
         raise RuntimeError("Unsupported Operating System")
 
+    if not os.path.exists(datadir):
+        os.makedirs(datadir)
+
     return os.path.join(datadir, debug_log_file_name)
 
 

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -135,10 +135,12 @@ def configure_debug_logfile_path(debug_log_file_path: Optional[str]) -> str:
     """Determine the pathname for the debug logfile based on the given argument and user's OS"""
 
     if debug_log_file_path is not None:
-        given_dir = os.path.basename(debug_log_file_path)
-        if not os.path.isdir(given_dir):
+        given_dir = os.path.dirname(debug_log_file_path)
+        # If it's not just a filename relative to the current directory make sure
+        # that the directory exists
+        if given_dir != "" and not os.path.isdir(given_dir):
             click.secho(
-                f"The provided directory {given_dir} for the debug logfilename "
+                f"The provided directory {given_dir} for the debuglog filename "
                 f"either does not exist or is not a directory",
                 fg="red",
             )

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -140,7 +140,7 @@ def configure_debug_logfile_path(debug_log_file_name: Optional[str]) -> str:
     if home == "~":  # Could not expand user path, just use /tmp
         datadir = "/tmp"
     if sys.platform == "darwin":
-        datadir = os.path.join(home, "Library", "Raiden")
+        datadir = os.path.join(home, "Library", "Logs", "Raiden")
     elif sys.platform == "win32" or sys.platform == "cygwin":
         datadir = os.path.join(home, "AppData", "Roaming", "Raiden")
     elif os.name == "posix":

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -261,7 +261,7 @@ def logging_level(request, logs_storage):
         colorize=not request.config.option.plain_log,
         log_file=request.config.option.log_file,
         cache_logger_on_first_use=False,
-        debug_log_file_name=debug_path,
+        debug_log_file_path=debug_path,
     )
     log.info("Running test", nodeid=request.node.nodeid)
 

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -94,7 +94,7 @@ def cli_args(logs_storage, raiden_testchain, removed_args, changed_args, environ
         "--gas-price",
         "1000000000",
         "--no-sync-check",
-        f"--debug-logfile-name={base_logfile}",
+        f"--debug-logfile-path={base_logfile}",
         "--routing-mode",
         "local",
     ]

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import pytest
 import structlog
@@ -115,6 +116,14 @@ def test_basic_logging(capsys, module, level, logger, disabled_debug, tmpdir):
         assert "test event" in captured.err
         assert "key=value" in captured.err
         assert "foo=bar" in captured.err
+
+
+def test_debug_logfile_invalid_dir():
+    """Test that providing an invalid directory for the debug logfile throws an error"""
+    with pytest.raises(SystemExit):
+        configure_logging(
+            {"": "DEBUG"}, debug_log_file_path=os.path.join("notarealdir", "raiden-debug.log")
+        )
 
 
 def test_redacted_request(capsys, tmpdir):

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -101,7 +101,7 @@ def test_basic_logging(capsys, module, level, logger, disabled_debug, tmpdir):
     configure_logging(
         {module: level},
         disable_debug_logfile=disabled_debug,
-        debug_log_file_name=str(tmpdir / "raiden-debug.log"),
+        debug_log_file_path=str(tmpdir / "raiden-debug.log"),
     )
     log = structlog.get_logger(logger).bind(foo="bar")
     log.debug("test event", key="value")
@@ -118,7 +118,7 @@ def test_basic_logging(capsys, module, level, logger, disabled_debug, tmpdir):
 
 
 def test_redacted_request(capsys, tmpdir):
-    configure_logging({"": "DEBUG"}, debug_log_file_name=str(tmpdir / "raiden-debug.log"))
+    configure_logging({"": "DEBUG"}, debug_log_file_path=str(tmpdir / "raiden-debug.log"))
     token = "my_access_token123"
 
     # use logging, as 'urllib3/requests'
@@ -133,7 +133,7 @@ def test_redacted_request(capsys, tmpdir):
 
 
 def test_redacted_state_change(capsys, tmpdir):
-    configure_logging({"": "DEBUG"}, debug_log_file_name=str(tmpdir / "raiden-debug.log"))
+    configure_logging({"": "DEBUG"}, debug_log_file_path=str(tmpdir / "raiden-debug.log"))
     auth_token = (
         "MDAxZGxvY2F0aW9uIGxvY2FsaG9zdDo2NDAzMwowMDEzaWRlbnRpZmllciBrZXkKMDAxMGNpZCBnZW4gPSAxCjAwN"
         "GVjaWQgdXNlcl9pZCA9IEAweDYyNjRkYThmMmViOGQ4MDM3NjM2OTEwYzFlYzAzODA0MzhmNGVmZWU6bG9jYWxob3"
@@ -157,7 +157,7 @@ def test_redacted_state_change(capsys, tmpdir):
 
 
 def test_that_secret_is_redacted(capsys, tmpdir):
-    configure_logging({"": "DEBUG"}, debug_log_file_name=str(tmpdir / "raiden-debug.log"))
+    configure_logging({"": "DEBUG"}, debug_log_file_path=str(tmpdir / "raiden-debug.log"))
 
     log = structlog.get_logger("raiden.network.transport.matrix.transport")
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -364,8 +364,14 @@ def options(func: Callable) -> Callable:
             ),
             option("--log-json", help="Output log lines in JSON format", is_flag=True),
             option(
-                "--debug-logfile-name",
-                help="The debug logfile name.",
+                "--debug-logfile-path",
+                help=(
+                    "The absolute path to the debug logfile. If not given defaults to:\n"
+                    " - OSX: ~/Library/Logs/Raiden/raiden_debug_XXX.log\n"
+                    " - Windows: ~/Appdata/Roaming/Raiden/raiden_debug_XXX.log\n"
+                    " - Linux: ~/.raiden/raiden_debug_XXX.log\n"
+                    "\nIf there is a problem with expanding home it is placed under /tmp"
+                ),
                 type=click.Path(dir_okay=False, writable=True, resolve_path=True),
             ),
             option(

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -61,7 +61,7 @@ class NodeRunner:
             log_json=self._options["log_json"],
             log_file=self._options["log_file"],
             disable_debug_logfile=self._options["disable_debug_logfile"],
-            debug_log_file_name=self._options["debug_logfile_name"],
+            debug_log_file_path=self._options["debug_logfile_path"],
         )
 
         log.info("Starting Raiden", **get_system_spec())


### PR DESCRIPTION
## Description

Fix #5050

In OSX Catalina the application is launching in a sandbox mode and as
such the current directory would be "/". Naturally raiden is not
allowed to write on the root directory and as such raiden crashes.

This commit attempts to address this by not writing the debug log file in
the current directory but in diffeent directories depending on the OS.

- OSX: ~/Library/Raiden
- Linux: ~/.raiden
- Windows: ~/AppData/Roaming/Raiden

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
