### PR TITLE
Don't listen on broadcast rooms even when invited

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -401,7 +401,7 @@ class MatrixTransport(Runnable):
             if greenlet in self.greenlets:
                 self.greenlets.remove(greenlet)
 
-        self._client.start_listener_thread()
+        self._client.start_listener_thread(timeout_ms=self._config.sync_timeout)
         assert isinstance(self._client.sync_thread, gevent.Greenlet)
         self._client.sync_thread.link_exception(self.on_error)
         self._client.sync_thread.link_value(on_success)

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -36,6 +36,7 @@ DEFAULT_TRANSPORT_THROTTLE_CAPACITY = 10.0
 DEFAULT_TRANSPORT_THROTTLE_FILL_RATE = 10.0
 # matrix gets spammed with the default retry-interval of 1s, wait a little more
 DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL = 5.0
+DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT = 20_000
 DEFAULT_MATRIX_KNOWN_SERVERS = {
     Environment.PRODUCTION: (
         "https://raw.githubusercontent.com/raiden-network/raiden-service-bundle"
@@ -121,12 +122,11 @@ class MediationFeeConfig:
 class MatrixTransportConfig:
     retries_before_backoff: int
     retry_interval: float
-
     broadcast_rooms: List[str]
-
     server: str
     available_servers: List[str]
-    server_name: Optional[str]
+    server_name: Optional[str] = None
+    sync_timeout: int = DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT
 
 
 @dataclass
@@ -171,6 +171,7 @@ class RaidenConfig:
         retry_interval=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
         server="auto",
         server_name=None,
+        sync_timeout=DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
     )
 
     shutdown_timeout: int = DEFAULT_SHUTDOWN_TIMEOUT

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -5,7 +5,7 @@ import pytest
 from raiden.constants import DISCOVERY_DEFAULT_ROOM, Environment
 from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix.utils import make_room_alias
-from raiden.settings import MatrixTransportConfig
+from raiden.settings import DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT, MatrixTransportConfig
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.utils.transport import ParsedURL, generate_synapse_config, matrix_server_starter
 from raiden.utils.http import HTTPExecutor
@@ -21,6 +21,11 @@ def synapse_config_generator():
 @pytest.fixture
 def matrix_server_count() -> int:
     return 1
+
+
+@pytest.fixture
+def matrix_sync_timeout() -> int:
+    return DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT
 
 
 @pytest.fixture
@@ -71,6 +76,7 @@ def matrix_transports(
     retry_interval: float,
     number_of_transports: int,
     broadcast_rooms: List[str],
+    matrix_sync_timeout: int,
 ) -> Iterable[List[MatrixTransport]]:
     transports = []
     local_matrix_servers_str = [str(server) for server in local_matrix_servers]
@@ -80,12 +86,13 @@ def matrix_transports(
         transports.append(
             MatrixTransport(
                 config=MatrixTransportConfig(
-                    broadcast_rooms=broadcast_rooms,
+                    broadcast_rooms=broadcast_rooms.copy(),
                     retries_before_backoff=retries_before_backoff,
                     retry_interval=retry_interval,
                     server=server,
                     server_name=server.netloc,
                     available_servers=local_matrix_servers_str,
+                    sync_timeout=matrix_sync_timeout,
                 ),
                 environment=Environment.DEVELOPMENT,
             )


### PR DESCRIPTION
## Description

Fixes: #5276
~Blocked-by: #5352~

Don't listen on broadcast rooms even when erroneously invited by a malfunctioning / rogue peer.
Also adds a a regression test to prevent this from reoccurring.