### PR TITLE
Fix exception thrown due to MockRaidenService not stopping properly

### DIFF
--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -170,6 +170,12 @@ class MockRaidenService:
     def sign(self, message):
         message.sign(self.signer)
 
+    def stop(self):
+        self.wal.storage.close()
+
+    def __del__(self):
+        self.stop()
+
 
 def make_raiden_service_mock(
     token_network_registry_address: TokenNetworkRegistryAddress,


### PR DESCRIPTION
## Description


Before this fix all tests that were instantiating Mock Raiden services
had a warning of uncaught and ignored exception in the logs during teardown:

```
Exception ignored in: <function SQLiteStorage.__del__ at 0x7fed6e5fecb0>
Traceback (most recent call last):
  File "/home/lefteris/ew/raiden/raiden/storage/sqlite.py", line 731, in __del__
ImportError: sys.meta_path is None, Python is likely shutting down
Exception ignored in: <function SQLiteStorage.__del__ at 0x7fed6e5fecb0>
Traceback (most recent call last):
  File "/home/lefteris/ew/raiden/raiden/storage/sqlite.py", line 731, in __del__
ImportError: sys.meta_path is None, Python is likely shutting down
```

Adding a proper `stop()` of the service's WAL storage fixes that.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
