### PR TITLE
Tightned signature of `_collect_x_values`

### DIFF
--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -55,17 +55,15 @@ def sign(x: Union[float, Fraction]) -> int:
 
 
 def _collect_x_values(
-    schedule_in: "FeeScheduleState",
-    schedule_out: "FeeScheduleState",
+    penalty_func_in: Interpolate,
+    penalty_func_out: Interpolate,
     balance_in: Balance,
     balance_out: Balance,
     max_x: int,
 ) -> List[Fraction]:
     """ Collect all relevant x values (edges of piece wise linear sections) """
-    assert schedule_in._penalty_func
-    assert schedule_out._penalty_func
-    all_x_vals = [x - balance_in for x in schedule_in._penalty_func.x_list] + [
-        balance_out - x for x in schedule_out._penalty_func.x_list
+    all_x_vals = [x - balance_in for x in penalty_func_in.x_list] + [
+        balance_out - x for x in penalty_func_out.x_list
     ]
     limited_x_vals = (max(min(x, balance_out, max_x), 0) for x in all_x_vals)
     return sorted(set(Fraction(x) for x in limited_x_vals))
@@ -123,8 +121,8 @@ def _mediation_fee_func(
         schedule_out._penalty_func = Interpolate([0, balance_out], [0, 0])
 
     x_list = _collect_x_values(
-        schedule_in=schedule_in,
-        schedule_out=schedule_out,
+        penalty_func_in=schedule_in._penalty_func,
+        penalty_func_out=schedule_out._penalty_func,
         balance_in=balance_in,
         balance_out=balance_out,
         max_x=receivable if amount_with_fees is None else balance_out,

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -61,7 +61,24 @@ def _collect_x_values(
     balance_out: Balance,
     max_x: int,
 ) -> List[Fraction]:
-    """ Collect all relevant x values (edges of piece wise linear sections) """
+    """ Normalizes the x-axis of the penalty functions around the amount of
+    tokens being transferred.
+
+    A penalty function maps the participant's balance to a fee. These functions
+    are then used to penalize transfers that unbalance the node's channels, and
+    as a consequence incentivize transfers that re-balance the channels.
+
+    Here the x-axis of the penalty functions normalized around the current
+    channel's capacity. So that instead of computing:
+
+        penalty(current_capacity + amount_being_transferred)
+
+    One can simply compute:
+
+        penalty(amount_being_transferred)
+
+    To find the penalty fee for the current transfer.
+    """
     all_x_vals = [x - balance_in for x in penalty_func_in.x_list] + [
         balance_out - x for x in penalty_func_out.x_list
     ]


### PR DESCRIPTION
Since a `None` value is not acceptable, instead of having two asserts
that may result in runtime errors, this enforces the function to be
called with a non-optional value, allowing mypy to catch call errors.