### PR TITLE
Skip fee calc when no tokens can be received

### DIFF
--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -126,7 +126,7 @@ def _mediation_fee_func(
     assert (
         amount_with_fees is None or amount_without_fees is None
     ), "Must be called with either amount_with_fees or amount_without_fees as None"
-    if balance_out == 0:
+    if balance_out == 0 or receivable == 0:
         raise UndefinedMediationFee()
 
     # Add dummy penalty funcs if none are set

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -126,6 +126,8 @@ def _mediation_fee_func(
     assert (
         amount_with_fees is None or amount_without_fees is None
     ), "Must be called with either amount_with_fees or amount_without_fees as None"
+
+    # If either channel can't transfer even a single token, there can be no mediation.
     if balance_out == 0 or receivable == 0:
         raise UndefinedMediationFee()
 


### PR DESCRIPTION
Calculating fees when the receiving channel is already "full" and can't receive a single token is an edge case that causes the calculation to misbehave. Just skip it like we do for the edge case of sending with a capacity of zero.

Regression test in https://github.com/raiden-network/raiden-services/pull/646.

Fixes https://github.com/raiden-network/raiden-services/issues/636.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
