### PR TITLE
Fix analyze_sp_logs script

### DIFF
--- a/tools/debugging/analyze_sp_logs.py
+++ b/tools/debugging/analyze_sp_logs.py
@@ -83,9 +83,12 @@ class ScenarioItems:
 
 def detect_scenario_player_log(fn: os.PathLike) -> bool:
     with open(fn) as f:
-        for line in f.readlines():
-            if json.loads(line).get("logger") == "scenario_player.main":
-                return True
+        try:
+            for line in f.readlines():
+                if json.loads(line).get("logger") == "scenario_player.main":
+                    return True
+        except (UnicodeDecodeError, AttributeError):
+            return False
     return False
 
 
@@ -164,7 +167,7 @@ def select_by_number(options: Any, caption: str) -> Any:
 def main(ctx: Any, folder: os.PathLike, run_number: Optional[int]) -> None:
     scenario = ScenarioItems()
     content: List[os.PathLike] = cast(List[os.PathLike], os.listdir(folder))
-    for fn in content:
+    for fn in sorted(content, reverse=True):
         file = os.path.join(folder, fn)
         if os.path.isfile(file) and detect_scenario_player_log(file):
             scenario.scenario_log = file


### PR DESCRIPTION
## Description

I ran into this while checking https://github.com/raiden-network/raiden/issues/5235

The problem was that the script didn't look for the latest log file.
This is fixed by ordering the files before selecting the latest ones.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
