### PR TITLE
Add federation room assumption test

### DIFF
--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -22,7 +22,7 @@ def matrix_server_count():
 
 
 @pytest.fixture
-def local_matrix_servers(
+def local_matrix_servers_with_executor(
     request,
     transport_protocol,
     matrix_server_count,
@@ -46,8 +46,13 @@ def local_matrix_servers(
         config_generator=synapse_config_generator,
         log_context=request.node.name,
     )
-    with starter as server_urls:
-        yield server_urls
+    with starter as servers:
+        yield servers
+
+
+@pytest.fixture
+def local_matrix_servers(local_matrix_servers_with_executor):
+    yield [url for url, _ in local_matrix_servers_with_executor]
 
 
 @pytest.fixture

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -44,6 +44,7 @@ from raiden.transfer import channel, views
 from raiden.transfer.state import ChannelState
 from raiden.ui.app import run_app
 from raiden.utils import privatekey_to_address, split_endpoint
+from raiden.utils.http import HTTPExecutor
 from raiden.utils.typing import (
     TYPE_CHECKING,
     Address,
@@ -61,6 +62,7 @@ from raiden.utils.typing import (
     TokenAddress,
     TokenAmount,
     TokenNetworkRegistryAddress,
+    Tuple,
 )
 from raiden.waiting import wait_for_block
 from raiden_contracts.constants import (
@@ -228,7 +230,7 @@ def setup_matrix_for_smoketest(
     print_step: Callable,
     free_port_generator: Iterable[Port],
     broadcast_rooms_aliases: Iterable[str],
-) -> Iterator[List["ParsedURL"]]:
+) -> Iterator[List[Tuple["ParsedURL", HTTPExecutor]]]:
     from raiden.tests.utils.transport import matrix_server_starter
 
     print_step("Starting Matrix transport")

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -59,6 +59,7 @@ from raiden.utils.cli import (
     option_group,
     validate_option_dependencies,
 )
+from raiden.utils.http import HTTPExecutor
 from raiden.utils.typing import MYPY_ANNOTATION, TokenAddress
 from raiden_contracts.constants import NETWORKNAME_TO_ID
 
@@ -728,7 +729,9 @@ def smoketest(
             base_datadir=datadir,
             base_logdir=datadir,
         )
-        matrix_manager: ContextManager[List[ParsedURL]] = setup_matrix_for_smoketest(
+        matrix_manager: ContextManager[
+            List[Tuple[ParsedURL, HTTPExecutor]]
+        ] = setup_matrix_for_smoketest(
             print_step=print_step,
             free_port_generator=free_port_generator,
             broadcast_rooms_aliases=[


### PR DESCRIPTION
Check that a federated broadcast room keeps working after the original server goes down.

This creates a federation of three matrix servers and a client for each.
It then checks that all nodes receive messages from the broadcast room.
Then the first matrix server is shut down and a second message send to
the broadcast room, which should arrive at both remaining clients.

Fixes: #5355

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
