### PR TITLE
Catch urlib3 Read-Timeout

### DIFF
--- a/raiden/tests/integration/cli/test_cli_production.py
+++ b/raiden/tests/integration/cli/test_cli_production.py
@@ -64,7 +64,7 @@ def test_cli_wrong_rpc_endpoint(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
 
     expect_cli_until_acknowledgment(child)
-    child.expect(".*Could not contact the Ethereum node through JSON-RPC.")
+    child.expect(".*Communicating with an external service failed.")
 
 
 @pytest.mark.timeout(TIMEOUT)


### PR DESCRIPTION
## Description

Fixes: #4610 

We are catching now the `ReadTimeoutError` in [runners.py](https://github.com/raiden-network/raiden/blob/develop/raiden/ui/runners.py). This can be caused if the transport server or the pathfinding service does fail to react to a request. 

The error message shown in that case is changed and is more generic now. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
