### PR TITLE
Fix type of reveal_timeout in PFSCapacityUpdate

### DIFF
--- a/raiden/messages/path_finding_service.py
+++ b/raiden/messages/path_finding_service.py
@@ -11,7 +11,7 @@ from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.state import NettingChannelState
 from raiden.utils.signing import pack_data
-from raiden.utils.typing import Address, Nonce, TokenAmount
+from raiden.utils.typing import Address, BlockTimeout, Nonce, TokenAmount
 
 
 @dataclass(repr=False, eq=False)
@@ -25,7 +25,7 @@ class PFSCapacityUpdate(SignedMessage):
     other_nonce: Nonce
     updating_capacity: TokenAmount
     other_capacity: TokenAmount
-    reveal_timeout: int
+    reveal_timeout: BlockTimeout
 
     def __post_init__(self) -> None:
         if self.signature is None:


### PR DESCRIPTION
## Description

Just a minor fix for stricter typing.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
