### PR TITLE
Add `synced` event to matrix client

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -249,6 +249,7 @@ class GMatrixClient(MatrixClient):
             long_paths=("/sync",),
         )
         self.api.validate_certificate(valid_cert_check)
+        self.synced = gevent.event.Event()  # Set at the end of every sync, then cleared
 
     def listen_forever(
         self,
@@ -557,6 +558,9 @@ class GMatrixClient(MatrixClient):
             # can happen.
             for event in response["account_data"]["events"]:
                 self.account_data[event["type"]] = event["content"]
+
+        self.synced.set()
+        self.synced.clear()
 
     def set_account_data(self, type_: str, content: Dict[str, Any]) -> Dict:
         """ Use this to set a key: value pair in account_data to keep it synced on server """


### PR DESCRIPTION
This allows to wait for the next sync to make sure that you're working
on sufficiently up-to-date data.

This is required to make the PFS wait for the first sync until it
calculated routes. Otherwise it won't have valid presence information
for a while (see https://github.com/raiden-network/raiden-services/issues/658). But it's probably also useful in other cases.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
