### PR TITLE
Simplify by avoiding a greenlet

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -8,7 +8,6 @@ from urllib.parse import quote
 import gevent
 import structlog
 from eth_utils import to_checksum_address
-from gevent import Greenlet
 from gevent.lock import Semaphore
 from matrix_client.api import MatrixHttpApi
 from matrix_client.client import CACHE, MatrixClient
@@ -454,29 +453,8 @@ class GMatrixClient(MatrixClient):
         prev_sync_token = self.sync_token
         self.sync_token = response["next_batch"]
 
-        if self._handle_thread is not None:
-            # if previous _handle_thread is still running, wait for it and re-raise if needed
-            self._handle_thread.get()
-
         is_first_sync = prev_sync_token is None
-        self._handle_thread = gevent.Greenlet(self._handle_response, response, is_first_sync)
-        self._handle_thread.name = (
-            f"GMatrixClient._sync user_id:{self.user_id} sync_token:{prev_sync_token}"
-        )
-
-        def kill_sync_thread(greenlet: Greenlet) -> None:
-            if self.sync_thread:
-                self.sync_thread.kill(greenlet.exception)
-
-        self._handle_thread.link_exception(kill_sync_thread)
-        log.debug(
-            "Starting handle greenlet",
-            node=node_address_from_userid(self.user_id),
-            first_sync=is_first_sync,
-            sync_token=prev_sync_token,
-            current_user=self.user_id,
-        )
-        self._handle_thread.start()
+        self._handle_response(response, is_first_sync)
 
         if self._post_hook_func is not None and self.sync_token is not None:
             self._post_hook_func(self.sync_token)


### PR DESCRIPTION
It is not important to call `_handle_response` in a greenlet. We wait
for it to finish anyway before calling it the next time.

However, this will increase the latency a bit because we only do the
next sync after the handling has been done. The different should not be
noticeable in most cases, but it's hard to tell for sure.

If you think this PR provides a bad simplicity/latency tradeoff, please close.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
