### PR TITLE
Handle matrix user presence in greenlets

### DIFF
--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -1,3 +1,4 @@
+import itertools
 import uuid
 from typing import Callable, Dict, Iterator, List, Optional
 
@@ -24,6 +25,7 @@ class DummyMatrixClient:
         self._user_directory_content = user_directory_content if user_directory_content else []
         # This is only used in `get_user_presence()`
         self._user_presence: Dict[str, str] = {}
+        self._presence_update_ids: Iterator[int] = itertools.count()
 
     def add_presence_listener(self, callback: Callable) -> uuid.UUID:
         if self._presence_callback is not None:
@@ -57,7 +59,7 @@ class DummyMatrixClient:
                 "type": "m.presence",
                 "content": {"presence": presence.value},
             }
-            self._presence_callback(event)
+            self._presence_callback(event, next(self._presence_update_ids))
 
 
 class NonValidatingUserAddressManager(UserAddressManager):
@@ -221,7 +223,7 @@ def test_user_addr_mgr_force(user_addr_mgr, address_reachability, user_presence)
     assert not user_addr_mgr.known_addresses
 
     user_addr_mgr.add_userid_for_address(ADDR1, USER1_S1_ID)
-    # This only updates the internal user presense state, but calls no callbacks and also doesn't
+    # This only updates the internal user presence state, but calls no callbacks and also doesn't
     # update the address reachability
     user_addr_mgr.force_user_presence(USER1_S1, UserPresence.ONLINE)
 
@@ -301,8 +303,8 @@ def test_user_addr_mgr_populate(user_addr_mgr, address_reachability, user_presen
     assert user_addr_mgr.get_userids_for_address(ADDR2) == {USER2_S1_ID, USER2_S2_ID}
     assert user_addr_mgr.get_address_reachability(ADDR2) is AddressReachability.UNKNOWN
 
-    user_addr_mgr._set_user_presence(USER2_S1_ID, UserPresence.ONLINE)
-    user_addr_mgr._set_user_presence(USER2_S2_ID, UserPresence.UNKNOWN)
+    user_addr_mgr._set_user_presence(USER2_S1_ID, UserPresence.ONLINE, 0)
+    user_addr_mgr._set_user_presence(USER2_S2_ID, UserPresence.UNKNOWN, 1)
 
     user_addr_mgr.track_address_presence(ADDR2, {USER2_S2_ID, USER2_S2_ID})
 


### PR DESCRIPTION
The presence handling was blocking the sync processing and thus causing
delayed message processing. Now we handle the presence asynchronously.
The updates are numbered to prevent old updates from overwriting more
recent ones.

The counter and pool would be nicer to have in the UserAddressManager. But that involved making that a greenlet. Let's see if this helps with our problems before spending too much time on it.

This should fix at least some cases of https://github.com/raiden-network/raiden-services/issues/673

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
