### PR TITLE
Simplify by avoiding a greenlet

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -659,12 +659,6 @@ class MatrixTransport(Runnable):
         self._client._sync()
         self._client.set_sync_limit(prev_sync_limit)
 
-        # Wait on the thread from the sync above, to guarantee the rooms are
-        # populated
-        thread = self._client._handle_thread
-        if thread:
-            thread.get()
-
         for room in self._client.rooms.values():
             room_aliases = set(room.aliases)
             if room.canonical_alias:


### PR DESCRIPTION
Replaces https://github.com/raiden-network/raiden/pull/5425, which can't be reopened.

It is not important to call `_handle_response` in a greenlet. We wait
for it to finish anyway before calling it the next time.

However, this will increase the latency a bit because we only do the
next sync after the handling has been done. The different should not be
noticeable in most cases, but it's hard to tell for sure.

If you think this PR provides a bad simplicity/latency tradeoff, please close.
## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
