### PR TITLE
Adding transport04 to bf1, bf5, bf7

### DIFF
--- a/raiden/tests/scenarios/ci/sp1/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/ci/sp1/bf1_basic_functionality.yaml
@@ -47,9 +47,9 @@ nodes:
     2:
       matrix-server: https://transport03.raiden.network
     3:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: https://transport04.raiden.network
     4:
-      matrix-server: https://transport02.raiden.network
+      matrix-server: https://transport01.raiden.network
 
 scenario:
   serial:

--- a/raiden/tests/scenarios/ci/sp2/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/ci/sp2/bf5_join_and_leave.yaml
@@ -49,7 +49,7 @@ nodes:
     2:
       matrix-server: https://transport03.raiden.network
     3:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: https://transport04.raiden.network
 
 # This is the BF5 scenario. It sets up a simple topology of two nodes and then uses
 # `join_network` to add more nodes to the network. It tests that nodes can join the network

--- a/raiden/tests/scenarios/ci/sp2/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/ci/sp2/bf7_long_path.yaml
@@ -40,6 +40,37 @@ nodes:
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20
+  node_options:
+    0:
+      matrix-server: https://transport01.raiden.network
+    1:
+      matrix-server: https://transport02.raiden.network
+    2:
+      matrix-server: https://transport03.raiden.network
+    3:
+      matrix-server: https://transport04.raiden.network
+    4:
+      matrix-server: https://transport01.raiden.network
+    5:
+      matrix-server: https://transport02.raiden.network
+    6:
+      matrix-server: https://transport03.raiden.network
+    7:
+      matrix-server: https://transport04.raiden.network
+    8:
+      matrix-server: https://transport01.raiden.network
+    9:
+      matrix-server: https://transport02.raiden.network
+    10:
+      matrix-server: https://transport03.raiden.network
+    11:
+      matrix-server: https://transport04.raiden.network
+    12:
+      matrix-server: https://transport01.raiden.network
+    13:
+      matrix-server: https://transport02.raiden.network
+    14:
+      matrix-server: https://transport03.raiden.network
 
 # This is the bf7 scenario. It tests long paths. There are a total of 15 nodes in the scenario.
 # A topology with deposits in both directions are created as [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]


### PR DESCRIPTION
## Description

Fixes: #5451 

According to the issue the PR adds the transport04 server in the `node_options` for each node.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
