### PR TITLE
Fixes connections endpoint to return integers as strings

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -786,9 +786,13 @@ class RestAPI:  # pragma: no unittest
             if connection_manager is not None and open_channels:
                 connection_managers[to_checksum_address(connection_manager.token_address)] = {
                     "funds": str(connection_manager.funds),
-                    "sum_deposits": str(views.get_our_deposits_for_token_network(
-                        views.state_from_raiden(self.raiden_api.raiden), registry_address, token
-                    )),
+                    "sum_deposits": str(
+                        views.get_our_deposits_for_token_network(
+                            views.state_from_raiden(self.raiden_api.raiden),
+                            registry_address,
+                            token,
+                        )
+                    ),
                     "channels": str(len(open_channels)),
                 }
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -785,11 +785,11 @@ class RestAPI:  # pragma: no unittest
             )
             if connection_manager is not None and open_channels:
                 connection_managers[to_checksum_address(connection_manager.token_address)] = {
-                    "funds": connection_manager.funds,
-                    "sum_deposits": views.get_our_deposits_for_token_network(
+                    "funds": str(connection_manager.funds),
+                    "sum_deposits": str(views.get_our_deposits_for_token_network(
                         views.state_from_raiden(self.raiden_api.raiden), registry_address, token
-                    ),
-                    "channels": len(open_channels),
+                    )),
+                    "channels": str(len(open_channels)),
                 }
 
         return api_response(result=connection_managers)


### PR DESCRIPTION
## Description

This PR fixes the connections API endpoint to also return integers as strings.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
