### PR TITLE
Update Red Eyes tutorial to Alderaan

### DIFF
--- a/docs/alderaan_mainnet_tutorial.rst
+++ b/docs/alderaan_mainnet_tutorial.rst
@@ -1,4 +1,4 @@
-Raiden Red Eyes Mainnet Tutorial
+Raiden Alderaan Mainnet Tutorial
 ########################################
 
 .. toctree::
@@ -6,21 +6,25 @@ Raiden Red Eyes Mainnet Tutorial
 
 Introduction
 =============
-In this tutorial we show how to use Raiden to do off chain payments using the Raiden Network on the Ethereum mainnet. For this tutorial we use the `Red Eyes release <https://github.com/raiden-network/raiden/releases/tag/v0.100.1>`_. More information on the Red Eyes release can be found `here <https://medium.com/raiden-network/red-eyes-mainnet-release-announcement-d48235bbef3c>`_. Since the Red Eyes release is a `bug bounty release <https://bounty.raiden.network>`_, certain limits have been made to the amount of tokens that can be deposited in channels. This is done in order to minimize the funds that are potentially lost in case something goes wrong.
+In this tutorial we show how to use Raiden to do off chain payments using the Raiden Network on the Ethereum mainnet. For this tutorial we use the upcoming Alderaan release. Since the Alderaan release is a `bug bounty release <https://bounty.raiden.network>`_, certain limits have been made to the amount of tokens that can be deposited in channels. This is done in order to minimize the funds that are potentially lost in case something goes wrong.
 
-Raiden has a Restful API with URL endpoints corresponding to actions that users can perform with their channels. The endpoints accept and return JSON encoded objects. The API URL path always contains the API version in order to differentiate queries to different API versions. All queries start with: ``/api/<version>/`` where ``<version>`` is an integer representing the current API version. The current version is version 1.
+Raiden has a Restful API with URL endpoints corresponding to actions that users can perform with their channels. The endpoints accept and return JSON encoded objects. The API URL path always contains the API version in order to differentiate queries to different API versions. All queries start with: ``/api/<version>/`` where ``<version>`` represents the current API version. The current version is version 1, so all queries start with ``/api/v1/``.
 
 Before getting started with this tutorial, please see the :doc:`Installation Guide <overview_and_guide>`, to make sure that Raiden is correctly installed and running.
 
 .. _about-weth:
 
-About W-ETH
-===========
+Whitelisted tokens
+==================
 
-For the Red Eyes Mainnet release only W-ETH can be used with the Raiden Network. W-ETH stands for wrapped Ether, meaning that Ether is packaged to conform to
+For the Alderaan Mainnet release, only two tokens can be used with the Raiden Network: W-ETH and DAI.
+
+W-ETH stands for wrapped Ether, meaning that Ether is packaged to conform to
 the ERC20 token guidelines which Raiden relies on. To learn more about W-ETH you can read the `announcement blog post <https://blog.0xproject.com/canonical-weth-a9aa7d0279dd>`_.
 
 To create W-ETH from your Ether you can either use interfaces like `0x OTC <https://0xproject.com/otc>`_ or `Radar Relay <https://radarrelay.com/>`_. You can also use the `contract <https://etherscan.io/address/0x2956356cd2a2bf3202f771f50d3d14a367b48070#code>`_ directly.
+
+DAI is a popular stablecoin, see `here <https://makerdao.com/en/dai>`_ for further information and for how to purchase it.
 
 
 .. _join-token-network:
@@ -58,8 +62,8 @@ In case we know of a specific address in the network that we will do frequent pa
    {
        "partner_address": "0x61C808D82A3Ac53231750daDc13c777b59310bD9",
        "token_address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-       "balance": "2000",
-       "settle_timeout": "500"
+       "total_deposit": 2000,
+       "settle_timeout": 500
    }
 
 At this point the specific value of the ``balance`` field isn't too important, since it's always possible to :ref:`deposit more tokens <topping-up-a-channel>` to a channel if need be.

--- a/docs/alderaan_mainnet_tutorial.rst
+++ b/docs/alderaan_mainnet_tutorial.rst
@@ -47,7 +47,9 @@ In order to do so, we need the address of the token and the initial amount of to
         "funds": "20000"
     }
 
-This automatically connects our node to 3 other nodes in the network with 20000 / 5 wei tokens in each channel.
+By default, Raiden connects automatically to 3 channels to other nodes and splits up 60% of the funds between them.
+The remaining 40% of tokens will be used to join channels that are automatically opened by other participants.
+So in our example, we will open three channels in the network and fund each of them with 4000 wrapped wei.
 
 We're now ready to start sending W-ETH tokens using the Raiden Network.
 
@@ -66,7 +68,7 @@ In case we know of a specific address in the network that we will do frequent pa
        "settle_timeout": 500
    }
 
-At this point the specific value of the ``balance`` field isn't too important, since it's always possible to :ref:`deposit more tokens <topping-up-a-channel>` to a channel if need be.
+At this point the specific value of the ``total_deposit`` field isn't too important, since it's always possible to :ref:`deposit more tokens <topping-up-a-channel>` to a channel if need be.
 
 Successfully opening a channel returns the following information:
 
@@ -103,7 +105,8 @@ Now that we have joined a token network, we can start making payments. For this,
         "amount": "42"
     }
 
-In this specific case the payment goes directly to one of our channel partners, since we have an open channel with ``0x61C808D82A3Ac53231750daDc13c777b59310bD9``. If we specify an address that we do not have a direct channel with, Raiden will try doing a mediated transfer with the help of either its internal routing or the given pathfinding service.
+This is an example of a direct transfer. Since we have an channel with the address we are sending to, ``0x61C808D82A3Ac53231750daDc13c777b59310bD9``, the payment goes straight to it. If we specify an address that we do not have a direct channel with, Raiden will try to do a mediated transfer, i. e.
+to find a path from us to the target address in the network of channels.
 
 It's as simple as that to do payments using the Raiden Network. The first payment is done after just two API calls - one to join the token network and one to do the payment. The third call to open a direct channel is optional.
 
@@ -137,7 +140,7 @@ If we spend more tokens than we receive and hence deplete our channels, it it po
         "total_deposit": "4000"
    }
 
-Notice that we need to specify the total deposit, not the amount we wish to top up: We initially deposited 2000 tokens and want to add 2000 more, so we give a ``total_deposit`` of 4000. This way the top-up request is idempotent - if it is sent repeatedly (by accident or as part of an attack) it will have no further effect.
+Notice that we need to specify the total deposit, not the amount we wish to top up: We initially deposited 2000 wei and want to add 2000 more, so we give a ``total_deposit`` of 4000. This way the top-up request is idempotent - if it is sent repeatedly (by accident or as part of an attack) it will have no further effect.
 
 .. _get-channel-status:
 

--- a/docs/alderaan_mainnet_tutorial.rst
+++ b/docs/alderaan_mainnet_tutorial.rst
@@ -6,11 +6,11 @@ Raiden Alderaan Mainnet Tutorial
 
 Introduction
 =============
-In this tutorial we show how to use Raiden to do off chain payments using the Raiden Network on the Ethereum mainnet. For this tutorial we use the upcoming Alderaan release. Since the Alderaan release is a `bug bounty release <https://bounty.raiden.network>`_, certain limits have been made to the amount of tokens that can be deposited in channels. This is done in order to minimize the funds that are potentially lost in case something goes wrong.
+In this tutorial we show how to use Raiden to do off chain payments using the Raiden Network on the Ethereum mainnet. It is based on the upcoming Alderaan release. Since the Alderaan release is a `bug bounty release <https://bounty.raiden.network>`_, certain limits have been made to the amount of tokens that can be deposited in channels. This is done in order to minimize the funds that are potentially lost in case something goes wrong.
 
-Raiden has a Restful API with URL endpoints corresponding to actions that users can perform with their channels. The endpoints accept and return JSON encoded objects. The API URL path always contains the API version in order to differentiate queries to different API versions. All queries start with: ``/api/<version>/`` where ``<version>`` represents the current API version. The current version is version 1, so all queries start with ``/api/v1/``.
+Raiden has a Restful API with URL endpoints corresponding to actions that users can perform with their channels. The endpoints accept and return JSON encoded objects. The API URL paths always start with: ``/api/``, followed by the current api version. The current version is version 1, so all queries start with ``/api/v1/``.
 
-Before getting started with this tutorial, please see the :doc:`Installation Guide <overview_and_guide>`, to make sure that Raiden is correctly installed and running.
+We assume that you have Raiden correctly installed and running in the desired configuration, see the :doc:`Installation Guide <overview_and_guide>`.
 
 .. _about-weth:
 
@@ -103,7 +103,7 @@ Now that we have joined a token network, we can start making payments. For this,
         "amount": "42"
     }
 
-In this specific case the payment goes directly to one of our channel partners, since we have an open channel with ``0x61C808D82A3Ac53231750daDc13c777b59310bD9``. If we specify an address that we do not have a direct channel with, the Raiden Network finds a path to the target address and use mediated transfers to make a payment from our address to the target address.
+In this specific case the payment goes directly to one of our channel partners, since we have an open channel with ``0x61C808D82A3Ac53231750daDc13c777b59310bD9``. If we specify an address that we do not have a direct channel with, Raiden will try doing a mediated transfer with the help of either its internal routing or the given pathfinding service.
 
 It's as simple as that to do payments using the Raiden Network. The first payment is done after just two API calls - one to join the token network and one to do the payment. The third call to open a direct channel is optional.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ Contents
   :caption: Using Raiden
 
   overview_and_guide
-  red_eyes_mainnet_tutorial
+  alderaan_mainnet_tutorial
   api_walkthrough
   webui_tutorial
   rest_api

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -16,13 +16,15 @@ To install Raiden you can either:
 
     * Use the `Raiden Wizard <https://docs.raiden.network/quick-start/>`_
     * Download a self contained application bundle from the `GitHub release page <https://github.com/raiden-network/raiden/releases>`_
+    * Use pip or, on macOS, homebrew
+    * Run a raiden docker image
 
-**If you're installing Raiden from the self contained application bundle the following sections will detail how to set up Raiden on various platforms.**
+Below we will give details on how to use the self contained application bundles on different platforms, as well as the other installation methods.
 
 Linux
 *****
 
-Download the latest :code:`raiden-<version>-linux-x86_64.tar.gz`, and extract it::
+`Download <https://github.com/raiden-network/raiden/releases>`_ the latest :code:`raiden-<version>-linux-x86_64.tar.gz`, and extract it::
 
     tar -xvzf raiden-<version>-linux-x86_64.tar.gz
 
@@ -30,12 +32,10 @@ The Raiden binary should work on most 64bit GNU/Linux distributions without any 
 than an Ethereum client installed in your system (see below). The Raiden binary takes the same command line
 arguments as the ``raiden`` script.
 
-Raiden is also available as a PyPi package and can be installed with ``pip install raiden``.
-
 macOS
 *****
 
-Download the latest :code:`raiden-<version>-macOS-x86_64.zip`, and extract it::
+`Download <https://github.com/raiden-network/raiden/releases>`_ the latest :code:`raiden-<version>-macOS-x86_64.zip`, and extract it::
 
     unzip raiden-<version>-macOS-x86_64.zip
 
@@ -95,11 +95,11 @@ Other flags such as the JSON-RPC endpoint to an Ethereum node can easily be chai
 
 Dependencies
 ************
-You will need to have an Ethereum client installed in your system. Alternatively, you can skip
-the setup of an ethereum node and use the :ref:`--eth-rpc-endpoint <using_rpc-endpoint>` argument to remotely use an ethereum node of your choice.
+You will need a local or remote Ethereum node to connect Raiden to.
 
-- Check `this link <https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum>`_ for instructions on the go-ethereum client.
-- Follow `these instructions <https://github.com/paritytech/parity#simple-one-line-installer-for-mac-and-ubuntu>`_ for  the parity client.
+- Check `this link <https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum>`_ to install the go-ethereum client.
+- Follow `these instructions <https://github.com/paritytech/parity#simple-one-line-installer-for-mac-and-ubuntu>`_ to install the parity client.
+- Or sign up at a service like `Infura <https://infura.io>` to set up a remote node.
 
 Now you are ready :ref:`to get started <running_raiden>`.
 
@@ -183,7 +183,6 @@ Firing it up
 To fire up Raiden you need at least
  1. a synced **Ethereum Node** - using geth, parity or infura
  2. an **Ethereum keystore file** - whereas the address holds ETH, RDN, and the ERC20 token you want to transfer
- 3. the address of your favorite **pathfinding service** - local routing is possible but no recommended
 
 We will provide you with the necessary cli arguments step by step. Full example is at the end of the page.
 
@@ -197,7 +196,7 @@ Run the Ethereum client and let it sync::
     geth --syncmode fast --rpc --rpcapi eth,net,web3
 
 .. note::
-    When you want to use a testnet add the ``--testnet`` or ``--rinkeby`` flags or set the network id with ``--networkid`` directly.
+    When you want to use a testnet add one of the ``--testnet``, ``--rinkeby`` or ``--goerli`` flags or set the network id with ``--networkid`` directly.
 
 Unless you already have an account you can also create one in the console by invoking ``personal.newAccount()``.
 
@@ -227,20 +226,44 @@ After account creation, launch Raiden with the path of your keystore supplied::
 
 - **Using Infura**
 
+Sign up with `Infura <https://infura.io/>`_ to get an API token. After that you can start using Raiden directly::
 
-In order to use Raiden with an rpc-endpoint provided by an Infura Ethereum node, sign up with `Infura <https://infura.io/>`_ to get an API token. After that you can start using Raiden on Ropsten directly::
+    raiden --keystore-path  ~/.ethereum/testnet/keystore --eth-rpc-endpoint "https://<network>.infura.io/v3/<yourToken>"
 
-    raiden --keystore-path  ~/.ethereum/testnet/keystore --eth-rpc-endpoint "https://ropsten.infura.io/v3/<yourToken>" --pathfinding-service-address $PFS_ADDRESS
-
-.. note::
-    When you want to use a testnet you need to update the URL of the infura endpoints, e.g. for the ropsten testnet use ``https://ropsten.infura.io/v3/<yourToken>``
+Where `<network>` can be mainnet, ropsten, etc.
 
 Select the desired Ethereum account when prompted, and type in the account's password.
 
-3. The Pathfinding Address
-***************************
+Optional CLI arguments
+**********************
 
-Raiden provides a pathfinding service for efficient transfer routing. The default option when starting the client is with the pathfinding service to be paid in RDN tokens.
+There are further CLI arguments with which you can control, among other things
+
+ 1. The choice of a pathfinding service
+ 2. The choice of a monitoring service
+ 3. Logging
+
+1. Pathfinding service
+~~~~~~~~~~~~~~~~~~~~~~
+
+A pathfinding service is a third party service helping your node with efficient transfer routing. It is usually paid in RDN tokens.
+
+Raiden can be configured to not use a pathfinding service and rely on its internal routing instead.
+This is discouraged since the node has less information about the network that it can use to find routes and compute fees.
+So transfers will be more likely to fail to route, and paid fees will often be unnecessarily high when internal routing is used.
+If you want to use internal routing anyway, you can do so with ``--routing-mode local``.
+
+.. note::
+    Although otherwise discouraged, ``--routing-mode local`` has to be used at the moment to try
+    out Raiden on the mainnet. The Raiden Service Bundle, with pathfinding service and registry,
+    will not be deployed on the mainnet until the Alderaan release.
+
+If you want to use a particular pathfinding service, e. g. one of the testnet pathfinding services given below, you can
+do so with ``--pathfinding-service-address <url>``. Otherwise Raiden will automatically pick one of the pathfinding
+services from the registry.
+
+The default setting for the pathfinding options is to use a pathfinding service and choose it automatically
+(``--routing-mode pfs --pathfinding-service-address auto``).
 
 There are pathfinding services running on every testnet at the moment, some that charge fees and some that are for free.
 
@@ -256,21 +279,17 @@ There are pathfinding services running on every testnet at the moment, some that
 | Rinkeby    | https://pfs-rinkeby-with-fee.services-dev.raiden.network | https://pfs-rinkeby.services-dev.raiden.network |
 +------------+----------------------------------------------------------+-------------------------------------------------+
 
-To start Raiden you need to provide a valid pathfinding service address, e.g. for Görli::
+For the mainnet we don't want to prefer and suggest specific pathfinding services.
 
-    raiden --keystore-path  ~/.ethereum/testnet/keystore --eth-rpc-endpoint "https://goerli.infura.io/v3/<yourToken>" --pathfinding-service-address "https://pfs-goerli.services-dev.raiden.network"
-
-
-Now that Raiden is up and running, head over to the :doc:`API walkthrough <api_walkthrough>` for further instructions on how to interact with Raiden. There's also a :doc:`Web UI tutorial <webui_tutorial>` available for people who prefer a graphical interface.
-
-
-Optional CLI arguments
-***************************
-
-In this section we will see how some optional CLI arguments work and what you can achieve by using them.
-
-Logging configuration
+2. Monitoring service
 ~~~~~~~~~~~~~~~~~~~~~
+
+A monitoring service watches a client's open channels while it is offline, and represents the client in case of settlement.
+Like the pathfinding service, it is paid in RDN tokens and can be automatically picked from a registry. If you want to use
+a monitoring service, use the option ``--enable-monitoring``.
+
+3. Logging configuration
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default raiden keeps a "debug" log file so that people who have not configured logging but are facing problems can still provide us with some logs to debug their problems.
 
@@ -287,3 +306,8 @@ Finally by default the output of the logs are in plain readable text format. In 
 Summing up these are the arguments you need to append if you want to disable the debug log and want to configure normal logging for up to debug statement in json inside a file called ``raiden.log``
 
 ``--disable-debug-logfile --log-config ":debug" --log-file raiden.log --log-json``
+
+Further reading
+***************
+
+Now that Raiden is up and running, head over to the :doc:`API walkthrough <api_walkthrough>` for further instructions on how to interact with Raiden. There's also a :doc:`Web UI tutorial <webui_tutorial>` available for people who prefer a graphical interface, and a :doc:`Mainnet tutorial <alderaan_mainnet_tutorial>` for your first mainnet transfers via API.

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -183,7 +183,7 @@ Firing it up
 To fire up Raiden you need at least
  1. a synced **Ethereum Node** - using geth, parity or infura
  2. an **Ethereum keystore file** - whereas the address holds ETH, RDN, and the ERC20 token you want to transfer
-
+ 3. (Only if you use services that charge fees) A deposit of RDN tokens to pay the services with.
 We will provide you with the necessary cli arguments step by step. Full example is at the end of the page.
 
 1. and 2. The synced Ethereum Node & Keystore
@@ -306,6 +306,24 @@ Finally by default the output of the logs are in plain readable text format. In 
 Summing up these are the arguments you need to append if you want to disable the debug log and want to configure normal logging for up to debug statement in json inside a file called ``raiden.log``
 
 ``--disable-debug-logfile --log-config ":debug" --log-file raiden.log --log-json``
+
+3. Depositing tokens to pay the services
+****************************************
+
+To pay the services, you have to lock some of your Raiden tokens in the ``UserDeposit`` contract.
+In this section, we will briefly explain how the ``UserDeposit`` contract can be interacted with manually
+so you are able to use Raiden without the Raiden Wizard or any auxilliary scripts.
+
+All services that are registered in the service registry of a given network will use one shared instance of ``UserDeposit``.
+You can obtain the address of the contract from
+``https://github.com/raiden-network/raiden-contracts/blob/master/raiden_contracts/data/deployment_services_<network>.json``,
+where ``network`` is one of ``mainnet``, ``ropsten``, ``rinkeby`` or ``goerli``.
+
+Log into MyEtherWallet, the geth console or any other Ethereum interface you like with an account
+that holds enough Raiden tokens, and call ``UserDeposit.deposit(<beneficiary>, <total_deposit>)``.
+
+Here ``total_deposit`` is the amount of Raiden tokens you wish to deposit and ``beneficiary`` is the
+Ethereum address of your Raiden node.
 
 Further reading
 ***************

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -1,5 +1,5 @@
 System Requirements and Installation Guide
-##################################################
+##########################################
 .. toctree::
   :maxdepth: 2
 
@@ -14,15 +14,23 @@ Installation
 
 To install Raiden you can either:
 
-    * Use the `Raiden Wizard <https://docs.raiden.network/quick-start/>`_
+    * Use the Raiden Wizard
     * Download a self contained application bundle from the `GitHub release page <https://github.com/raiden-network/raiden/releases>`_
     * Use pip or, on macOS, homebrew
     * Run a raiden docker image
 
 Below we will give details on how to use the self contained application bundles on different platforms, as well as the other installation methods.
 
+Installation via Raiden Wizard
+******************************
+
+See the `Raiden Wizard documentation <https://docs.raiden.network/quick-start/>`_.
+
+Installation from GitHub
+************************
+
 Linux
-*****
+~~~~~
 
 `Download <https://github.com/raiden-network/raiden/releases>`_ the latest :code:`raiden-<version>-linux-x86_64.tar.gz`, and extract it::
 
@@ -33,7 +41,7 @@ than an Ethereum client installed in your system (see below). The Raiden binary 
 arguments as the ``raiden`` script.
 
 macOS
-*****
+~~~~~
 
 `Download <https://github.com/raiden-network/raiden/releases>`_ the latest :code:`raiden-<version>-macOS-x86_64.zip`, and extract it::
 
@@ -53,7 +61,7 @@ arguments as the ``raiden`` script.
 Raiden is also available as a PyPi package and can be installed with ``pip install raiden``.
 
 Raspberry Pi
-************
+~~~~~~~~~~~~
 
 `Download <https://github.com/raiden-network/raiden/releases>`_ the latest :code:`raiden-<version>-linux-armv7l.tar.gz` or :code:`raiden-<version>-linux-aarch64.tar.gz` for the respective Raspberry Pi Model and extract it::
 
@@ -66,8 +74,8 @@ An Ethereum client is required in both cases. The Raiden binary takes the same c
 arguments as the ``raiden`` script.
 
 
-PIP
-***
+Installation using pip
+**********************
 
 To get the latest available stable version via `pip`::
 
@@ -77,8 +85,8 @@ If you'd like to give the pre-releases a spin, use pip's `--pre` flag::
 
     pip install --pre raiden
 
-Docker
-******
+Installation via Docker
+***********************
 
 There are two options to run a raiden docker image:
 
@@ -183,7 +191,10 @@ Firing it up
 To fire up Raiden you need at least
  1. a synced **Ethereum Node** - using geth, parity or infura
  2. an **Ethereum keystore file** - whereas the address holds ETH, RDN, and the ERC20 token you want to transfer
- 3. (Only if you use services that charge fees) A deposit of RDN tokens to pay the services with.
+ 3. If you want to use :doc:`Raiden services <raiden_services>` that charge a fee, a deposit of RDN tokens to pay the services with.
+
+More about the Raiden services (pathfinding and monitoring service) will be explained below. On the testnets there are also free services available, and on any network it is possible (though not recommended) to use Raiden without Raiden services.
+
 We will provide you with the necessary cli arguments step by step. Full example is at the end of the page.
 
 1. and 2. The synced Ethereum Node & Keystore
@@ -234,8 +245,48 @@ Where `<network>` can be mainnet, ropsten, etc.
 
 Select the desired Ethereum account when prompted, and type in the account's password.
 
+3. Depositing tokens to pay the services
+****************************************
+
+To pay the services, you have to lock some of your Raiden tokens in the ``UserDeposit`` contract.
+Normally the Raiden Wizard or some other auxilliary scripts would do the contract interaction for you.
+In this section, we will briefly explain how it can be done manually so you are able to use Raiden without them.
+
+All services that are registered in the service registry of a given network will use one shared instance of ``UserDeposit``.
+You can obtain the address of the contract from
+
+    ``https://github.com/raiden-network/raiden-contracts/blob/master/raiden_contracts/data/deployment_services_<network>.json``
+
+where ``network`` is one of ``mainnet``, ``ropsten``, ``rinkeby`` or ``goerli``.
+
+Log into MyEtherWallet, the geth console or any other Ethereum interface you like with an account
+that holds enough Raiden tokens, and call ``UserDeposit.deposit(<beneficiary>, <total_deposit>)``.
+
+Here ``total_deposit`` is the amount of Raiden tokens you wish to deposit and ``beneficiary`` is the
+Ethereum address of your Raiden node.
+
+For example, suppose we use Raiden with the address ``0x3040435D7F1012e861f0B0989422a47D1825F120`` on the mainnet and want
+to deposit 10 Raiden tokens (10**19 REI) for our Raiden node to use. We take a look at ``deployment_services_mainnet.json``, which yields:
+
+.. code-block:: none
+
+    {
+        "contracts_version": null, "chain_id": 1,
+        (...)
+        "UserDeposit": {
+            "address": "0x53Cc1decDD7d452c8844a5f383e23AD479A1f614",
+            (...)
+
+
+Using MyEtherWallet, we log into our account that holds the Raiden tokens (which must not be the same that we use
+for the Raiden node, since that is supposed to be used only by Raiden) and look up the ``UserDeposit`` contract at
+``0x53Cc1decDD7d452c8844a5f383e23AD479A1f614``, the address we found in the deployment JSON file.
+
+In the contract interface on MyEtherWallet, we set ``method`` to ``deposit``, ``beneficiary`` to our Raiden address
+``0x3040435D7F1012e861f0B0989422a47D1825F120`` and ``total_deposit`` to ``10000000000000000000`` and send the transaction.
+
 Optional CLI arguments
-**********************
+======================
 
 There are further CLI arguments with which you can control, among other things
 
@@ -244,7 +295,7 @@ There are further CLI arguments with which you can control, among other things
  3. Logging
 
 1. Pathfinding service
-~~~~~~~~~~~~~~~~~~~~~~
+**********************
 
 A pathfinding service is a third party service helping your node with efficient transfer routing. It is usually paid in RDN tokens.
 
@@ -258,7 +309,7 @@ If you want to use internal routing anyway, you can do so with ``--routing-mode 
     out Raiden on the mainnet. The Raiden Service Bundle, with pathfinding service and registry,
     will not be deployed on the mainnet until the Alderaan release.
 
-If you want to use a particular pathfinding service, e. g. one of the testnet pathfinding services given below, you can
+If you want to use a particular pathfinding service, e.g. one of the testnet pathfinding services given below, you can
 do so with ``--pathfinding-service-address <url>``. Otherwise Raiden will automatically pick one of the pathfinding
 services from the registry.
 
@@ -282,14 +333,14 @@ There are pathfinding services running on every testnet at the moment, some that
 For the mainnet we don't want to prefer and suggest specific pathfinding services.
 
 2. Monitoring service
-~~~~~~~~~~~~~~~~~~~~~
+*********************
 
 A monitoring service watches a client's open channels while it is offline, and represents the client in case of settlement.
-Like the pathfinding service, it is paid in RDN tokens and can be automatically picked from a registry. If you want to use
-a monitoring service, use the option ``--enable-monitoring``.
+Like the pathfinding service, it is paid in RDN tokens. If you want to use a monitoring service, use the option
+``--enable-monitoring`` and Raiden will automatically pick one from its service registry.
 
 3. Logging configuration
-~~~~~~~~~~~~~~~~~~~~~~~~
+************************
 
 By default raiden keeps a "debug" log file so that people who have not configured logging but are facing problems can still provide us with some logs to debug their problems.
 
@@ -307,25 +358,7 @@ Summing up these are the arguments you need to append if you want to disable the
 
 ``--disable-debug-logfile --log-config ":debug" --log-file raiden.log --log-json``
 
-3. Depositing tokens to pay the services
-****************************************
-
-To pay the services, you have to lock some of your Raiden tokens in the ``UserDeposit`` contract.
-In this section, we will briefly explain how the ``UserDeposit`` contract can be interacted with manually
-so you are able to use Raiden without the Raiden Wizard or any auxilliary scripts.
-
-All services that are registered in the service registry of a given network will use one shared instance of ``UserDeposit``.
-You can obtain the address of the contract from
-``https://github.com/raiden-network/raiden-contracts/blob/master/raiden_contracts/data/deployment_services_<network>.json``,
-where ``network`` is one of ``mainnet``, ``ropsten``, ``rinkeby`` or ``goerli``.
-
-Log into MyEtherWallet, the geth console or any other Ethereum interface you like with an account
-that holds enough Raiden tokens, and call ``UserDeposit.deposit(<beneficiary>, <total_deposit>)``.
-
-Here ``total_deposit`` is the amount of Raiden tokens you wish to deposit and ``beneficiary`` is the
-Ethereum address of your Raiden node.
-
 Further reading
-***************
+===============
 
 Now that Raiden is up and running, head over to the :doc:`API walkthrough <api_walkthrough>` for further instructions on how to interact with Raiden. There's also a :doc:`Web UI tutorial <webui_tutorial>` available for people who prefer a graphical interface, and a :doc:`Mainnet tutorial <alderaan_mainnet_tutorial>` for your first mainnet transfers via API.


### PR DESCRIPTION
Update the Red Eyes tutorial in the docs, and the installation guide it relies on, to Alderaan. The role of the services has changed, a new token will be whitelisted, and one of the example requests was outdated too.

Closes #5431