### PR TITLE
Removes lock_timeout from transfers [skip tests]

### DIFF
--- a/raiden/tests/scenarios/ci/sp1/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/ci/sp1/bf3_multi_directional_payment.yaml
@@ -82,12 +82,12 @@ scenario:
                 name: "Make 100 transfers from 0 to 4"
                 repeat: 100
                 tasks:
-                  - transfer: {from: 0, to: 4, amount: 1_000_000_000_000_000, lock_timeout: 30}
+                  - transfer: {from: 0, to: 4, amount: 1_000_000_000_000_000}
             - serial:
                 name: "Make 100 transfers from 4 to 0"
                 repeat: 100
                 tasks:
-                  - transfer: {from: 4, to: 0, amount: 1_000_000_000_000_000, lock_timeout: 30}
+                  - transfer: {from: 4, to: 0, amount: 1_000_000_000_000_000}
       - wait: 100
       - parallel:
           name: "Assert that all balances are the same as before the payments, since same amounts are sent in both directions"


### PR DESCRIPTION
## Description

I removed the shorter reveal and settle timeouts from this scenario in https://github.com/raiden-network/raiden/commit/eae27322a48d664be029bec49526e05b2d78873b but forgot to remove the lock_timeouts in the transfers. That led to a shorter lock_timeout 30 than the reveal timeout, which on default is 50.

The scenario, therefore, failed because no route could have been used.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
