### PR TITLE
using explicit type for pfs config

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -142,7 +142,7 @@ def initiator_init(
         to_address=target_address,
         amount=transfer_amount,
         previous_address=None,
-        config=raiden.config,
+        pfs_config=raiden.config.get("pfs_config", None),
         privkey=raiden.privkey,
     )
 

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -1,5 +1,5 @@
 from heapq import heappop, heappush
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 from uuid import UUID
 
 import networkx
@@ -35,11 +35,9 @@ def get_best_routes(
     to_address: TargetAddress,
     amount: PaymentAmount,
     previous_address: Optional[Address],
-    config: Dict[str, Any],
+    pfs_config: Optional[PFSConfig],
     privkey: bytes,
 ) -> Tuple[List[RouteState], Optional[UUID]]:
-    pfs_config = config.get("pfs_config", None)
-
     is_direct_partner = to_address in views.all_neighbour_nodes(chain_state)
     can_use_pfs = pfs_config is not None and one_to_n_address is not None
 
@@ -79,8 +77,7 @@ def get_best_routes(
             ):
                 return [route_state], None
 
-    if can_use_pfs:
-        assert one_to_n_address  # mypy doesn't realize this has been checked above
+    if pfs_config is not None and one_to_n_address is not None:
         pfs_answer_ok, pfs_routes, pfs_feedback_token = get_best_routes_pfs(
             chain_state=chain_state,
             token_network_address=token_network_address,

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -151,7 +151,7 @@ def test_participant_selection(raiden_network, token_addresses):
                 to_address=target.raiden.address,
                 amount=PaymentAmount(1),
                 previous_address=None,
-                config={},
+                pfs_config=None,
                 privkey=b"",  # not used if pfs is not configured
             )
             assert routes is not None

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -147,7 +147,7 @@ def get_best_routes_with_iou_request_mocked(
             to_address=to_address,
             amount=amount,
             previous_address=None,
-            config=CONFIG,
+            pfs_config=PFS_CONFIG,
             privkey=PRIVKEY,
         )
         assert_checksum_address_in_url(patched.call_args[0][0])
@@ -646,7 +646,7 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
             to_address=address1,
             amount=PaymentAmount(50),
             previous_address=None,
-            config=CONFIG,
+            pfs_config=PFS_CONFIG,
             privkey=PRIVKEY,
         )
         assert routes[0].next_hop_address == address1
@@ -665,7 +665,7 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
             to_address=address1,
             amount=PaymentAmount(51),
             previous_address=None,
-            config=CONFIG,
+            pfs_config=PFS_CONFIG,
             privkey=PRIVKEY,
         )
 

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -850,7 +850,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         to_address=address4,
         amount=50,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",  # not used if pfs is not configured
     )
     assert routes1[0].next_hop_address == address1
@@ -872,7 +872,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         to_address=address4,
         amount=50,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",
     )
     assert routes1[0].next_hop_address == address1
@@ -894,7 +894,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         to_address=address4,
         amount=50,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",
     )
     assert routes1[0].next_hop_address == address1
@@ -916,7 +916,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         to_address=address3,
         amount=50,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",
     )
     # right now the channel to 1 gets filtered out as it is offline
@@ -1082,7 +1082,7 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         to_address=address3,
         amount=1,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",
     )
     assert routes[0].next_hop_address == address1
@@ -1104,7 +1104,7 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         to_address=address4,
         amount=1,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",
     )
     assert routes[0].next_hop_address == address2
@@ -1185,7 +1185,7 @@ def test_internal_routing_mediation_fees(
         to_address=address1,
         amount=50,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",  # not used if pfs is not configured
     )
     assert routes[0].estimated_fee == 0
@@ -1199,7 +1199,7 @@ def test_internal_routing_mediation_fees(
         to_address=address2,
         amount=50,
         previous_address=None,
-        config={},
+        pfs_config=None,
         privkey=b"",  # not used if pfs is not configured
     )
     assert routes[0].estimated_fee == round(INTERNAL_ROUTING_DEFAULT_FEE_PERC * 50)

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -128,7 +128,7 @@ class MockRaidenService:
 
         self.message_handler = message_handler
         self.routing_mode = RoutingMode.PRIVATE
-        self.config = config
+        self.config = config or dict()
 
         self.user_deposit = Mock()
         self.default_registry = Mock()


### PR DESCRIPTION
Small change, this just uses the `PFSConfig` type instead of the generic `Dict[str, Any]`