### PR TITLE
Check for node crashes in all integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -527,6 +527,14 @@ function, which will fill in appropriate defaults for each unspecified
 parameter. See the documentation of
 `raiden.tests.utils.factories.Properties` for further details.
 
+The `raiden.tests.utils.detect_failure` module contains two decorators
+for integration tests that run `RaidenService` instances. The use of one
+of the decorators is required on each such test and pytest will enforce it.
+`@raise_on_failure` will make sure every crash of a `RaidenService` leads
+to instant failure of the test, and `@expect_failure` indicates that we
+actually expect the crash of a `RaidenService` instance within the test
+and want to ignore it.
+
 ### Workflow
 
 When developing a feature, or a bug fix you should always start by writing a

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -33,6 +33,7 @@ from raiden.tests.integration.api.utils import create_api_server
 from raiden.tests.integration.fixtures.smartcontracts import RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
+from raiden.tests.utils.detect_failure import expect_failure, raise_on_failure
 from raiden.tests.utils.events import check_dict_nested_attrs, must_have_event, must_have_events
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
@@ -179,6 +180,7 @@ def test_address_field():
     assert field._deserialize("0x414D72a6f6E28F4950117696081450d63D56C354", attr, data) == address
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_payload_with_invalid_addresses(api_server_test_instance: APIServer, rest_api_port_number):
@@ -210,6 +212,7 @@ def test_payload_with_invalid_addresses(api_server_test_instance: APIServer, res
 @pytest.mark.xfail(
     strict=True, reason="Crashed app also crashes on teardown", raises=CustomException
 )
+@expect_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_crash_on_unhandled_exception(api_server_test_instance: APIServer) -> None:
@@ -227,6 +230,7 @@ def test_crash_on_unhandled_exception(api_server_test_instance: APIServer) -> No
     api_server_test_instance.greenlet.get(timeout=10)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_payload_with_address_invalid_chars(api_server_test_instance: APIServer):
@@ -244,6 +248,7 @@ def test_payload_with_address_invalid_chars(api_server_test_instance: APIServer)
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_payload_with_address_invalid_length(api_server_test_instance: APIServer):
@@ -261,6 +266,7 @@ def test_payload_with_address_invalid_length(api_server_test_instance: APIServer
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_payload_with_address_not_eip55(api_server_test_instance: APIServer):
@@ -278,6 +284,7 @@ def test_payload_with_address_not_eip55(api_server_test_instance: APIServer):
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_query_our_address(api_server_test_instance: APIServer):
@@ -289,6 +296,7 @@ def test_api_query_our_address(api_server_test_instance: APIServer):
     assert get_json_response(response) == {"our_address": to_checksum_address(our_address)}
 
 
+@raise_on_failure
 def test_api_get_raiden_version(api_server_test_instance: APIServer):
     request = grequests.get(api_url_for(api_server_test_instance, "versionresource"))
     response = request.send().response
@@ -299,6 +307,7 @@ def test_api_get_raiden_version(api_server_test_instance: APIServer):
     assert get_json_response(response) == {"version": raiden_version}
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_get_channel_list(
@@ -341,6 +350,7 @@ def test_api_get_channel_list(
     assert "token_network_address" in channel_info
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_channel_status_channel_nonexistant(
@@ -366,6 +376,7 @@ def test_api_channel_status_channel_nonexistant(
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_and_deposit_channel(
@@ -548,6 +559,7 @@ def test_api_open_and_deposit_channel(
     assert "The account balance is below the estimated amount" in json_response["errors"]
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_and_deposit_race(
@@ -647,6 +659,7 @@ def test_api_open_and_deposit_race(
     assert channel_info["total_deposit"] == str(deposit_amount)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_close_and_settle_channel(
@@ -746,6 +759,7 @@ def test_api_open_close_and_settle_channel(
     assert_proper_response(response, HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_close_insufficient_eth(
@@ -799,6 +813,7 @@ def test_api_close_insufficient_eth(
     assert "insufficient ETH" in json_response["errors"]
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_open_channel_invalid_input(
@@ -835,6 +850,7 @@ def test_api_open_channel_invalid_input(
     assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_api_channel_state_change_errors(
@@ -985,6 +1001,7 @@ def test_api_channel_state_change_errors(
     assert_response_with_error(response, HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [2])
@@ -1028,6 +1045,7 @@ def test_api_tokens(api_server_test_instance: APIServer, blockchain_services, to
     assert set(json_response) == set(expected_response)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_query_partners_by_token(
@@ -1094,6 +1112,7 @@ def test_query_partners_by_token(
     assert all(r in json_response for r in expected_response)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_target_error(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -1121,6 +1140,7 @@ def test_api_payments_target_error(
     app1.start()
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments(
     api_server_test_instance: APIServer, raiden_network, token_addresses, deposit
@@ -1202,6 +1222,7 @@ def test_api_payments(
     assert all("TimestampedEvent" in event for event in events)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_timestamp_format(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -1238,6 +1259,7 @@ def test_api_timestamp_format(
     assert log_timestamp_iso == log_timestamp, "log_time is not a valid ISO8601 string"
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_secret_hash_errors(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -1327,6 +1349,7 @@ def test_api_payments_secret_hash_errors(
     assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_secret_no_hash(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -1365,6 +1388,7 @@ def test_api_payments_with_secret_no_hash(
     assert secret == json_response["secret"]
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_hash_no_secret(
     api_server_test_instance, raiden_network, token_addresses
@@ -1401,6 +1425,7 @@ def test_api_payments_with_hash_no_secret(
     assert payment == payment
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("resolver_ports", [[None, 8000]])
 def test_api_payments_with_resolver(
@@ -1475,6 +1500,7 @@ def test_api_payments_with_resolver(
     assert payment == payment
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_secret_and_hash(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -1520,6 +1546,7 @@ def test_api_payments_with_secret_and_hash(
     assert secret_hash == json_response["secret_hash"]
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_conflicts(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -1555,6 +1582,7 @@ def test_api_payments_conflicts(
     assert all(response.status_code == HTTPStatus.OK for response in responses)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_tokens", [0])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -1584,6 +1612,7 @@ def test_register_token_mainnet(
     assert response is not None and response.status_code == HTTPStatus.NOT_IMPLEMENTED
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_tokens", [0])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -1661,6 +1690,7 @@ def test_register_token(
     assert_response_with_error(poor_response, HTTPStatus.PAYMENT_REQUIRED)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_tokens", [0])
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -1726,6 +1756,7 @@ def test_get_token_network_for_token(
     assert token_network_address == get_json_response(token_response)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -1785,6 +1816,7 @@ def test_get_connection_managers_info(api_server_test_instance: APIServer, token
     # assert set(result[token_address2].keys()) == {'funds', 'sum_deposits', 'channels'}
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -1805,6 +1837,7 @@ def test_connect_insufficient_reserve(api_server_test_instance: APIServer, token
     assert "The account balance is below the estimated amount" in json_response["errors"]
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_network_events(api_server_test_instance: APIServer, token_addresses):
@@ -1836,6 +1869,7 @@ def test_network_events(api_server_test_instance: APIServer, token_addresses):
     assert len(get_json_response(response)) > 0
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_token_events(api_server_test_instance: APIServer, token_addresses):
@@ -1868,6 +1902,7 @@ def test_token_events(api_server_test_instance: APIServer, token_addresses):
     assert len(get_json_response(response)) > 0
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_channel_events(api_server_test_instance: APIServer, token_addresses):
@@ -1901,6 +1936,7 @@ def test_channel_events(api_server_test_instance: APIServer, token_addresses):
     assert len(get_json_response(response)) > 0
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 def test_token_events_errors_for_unregistered_token(api_server_test_instance):
@@ -1930,6 +1966,7 @@ def test_token_events_errors_for_unregistered_token(api_server_test_instance):
     assert_response_with_error(response, status_code=HTTPStatus.NOT_FOUND)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("deposit", [DEPOSIT_FOR_TEST_API_DEPOSIT_LIMIT])
@@ -2000,6 +2037,7 @@ def test_api_deposit_limit(
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_payment_events_endpoints(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -2333,6 +2371,7 @@ def test_payment_events_endpoints(
     app2_server.stop()
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_channel_events_raiden(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -2356,6 +2395,7 @@ def test_channel_events_raiden(
     assert_proper_response(response)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_pending_transfers_endpoint(raiden_network, token_addresses):
@@ -2452,6 +2492,7 @@ def test_pending_transfers_endpoint(raiden_network, token_addresses):
     assert response.status_code == 404 and b"Channel" in response.content
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [1000])
 def test_api_withdraw(api_server_test_instance: APIServer, raiden_network, token_addresses):
@@ -2512,6 +2553,7 @@ def test_api_withdraw(api_server_test_instance: APIServer, raiden_network, token
     assert_response_with_error(response, HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [1])
@@ -2553,6 +2595,7 @@ def test_api_testnet_token_mint(api_server_test_instance: APIServer, token_addre
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_lock_timeout(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -2632,6 +2675,7 @@ def test_api_payments_with_lock_timeout(
     assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_api_payments_with_invalid_input(
     api_server_test_instance: APIServer, raiden_network, token_addresses
@@ -2684,6 +2728,7 @@ def test_api_payments_with_invalid_input(
     assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [0])
 def test_api_set_reveal_timeout(

--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -1,4 +1,28 @@
+import pytest
+
 from raiden.tests.integration.fixtures.blockchain import *  # noqa: F401,F403
 from raiden.tests.integration.fixtures.raiden_network import *  # noqa: F401,F403
 from raiden.tests.integration.fixtures.smartcontracts import *  # noqa: F401,F403
 from raiden.tests.integration.fixtures.transport import *  # noqa: F401,F403
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "expect_failure")
+
+
+def pytest_collection_finish(session):
+    def unsafe(item):
+        has_nodes = "raiden_network" in item.fixturenames or "raiden_chain" in item.fixturenames
+        is_secure = getattr(item.function, "_decorated_raise_on_failure", False)
+        is_exempt = item.get_closest_marker("expect_failure") is not None
+        return has_nodes and not (is_secure or is_exempt)
+
+    unsafe_tests = [item.originalname or item.name for item in session.items if unsafe(item)]
+
+    if unsafe_tests:
+        unsafe_tests_list = "\n- ".join(unsafe_tests)
+        pytest.exit(
+            f"\nERROR: Found {len(unsafe_tests)} tests with no clear node failure policy."
+            f"\nPlease decorate each of them with either @raise_on_failure or @expect_failure."
+            f"\n- {unsafe_tests_list}"
+        )

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -19,6 +19,7 @@ from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.tests.integration.api.utils import wait_for_listening_port
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.protocol import HoldRaidenEventHandler
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
@@ -346,6 +347,7 @@ def assert_channels(
 
 
 @pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/4803")
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("number_of_tokens", [1])
 @pytest.mark.parametrize("channels_per_node", [2])

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -29,6 +29,7 @@ from raiden.services import send_pfs_update, update_monitoring_service_from_bala
 from raiden.settings import MONITORING_REWARD
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
+from raiden.tests.utils.detect_failure import expect_failure
 from raiden.tests.utils.factories import HOP1, make_privkeys_ordered
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.tests.utils.transfer import wait_assert
@@ -261,6 +262,7 @@ def test_matrix_message_sync(matrix_transports):
         assert any(m.delivered_message_identifier == i for m in transport0_messages)
 
 
+@expect_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
 @pytest.mark.parametrize("number_of_tokens", [1])

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -23,7 +23,7 @@ from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
 )
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
-from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.tests.utils.detect_failure import expect_failure, raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import transfer
@@ -160,6 +160,7 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
     app0_restart.start()
 
 
+@expect_failure  # raise_on_failure will not work here since the apps are not started
 @pytest.mark.parametrize("start_raiden_apps", [False])
 @pytest.mark.parametrize("deposit", [0])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
@@ -208,6 +209,7 @@ def test_alarm_task_first_run_syncs_blockchain_events(raiden_network, blockchain
     # alarm task
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_fees_are_updated_during_startup(
     raiden_network, token_addresses, deposit, retry_timeout

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -9,6 +9,7 @@ from raiden.message_handler import MessageHandler
 from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
@@ -29,6 +30,7 @@ from raiden.utils.typing import BlockNumber, PaymentAmount, PaymentID
 
 
 @pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5133")
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
@@ -101,6 +103,7 @@ def test_recovery_happy_case(
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
@@ -192,6 +195,7 @@ def test_recovery_unhappy_case(
     )
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
@@ -251,6 +255,7 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
     assert search_for_item(restarted_state_changes, ContractReceiveChannelClosed, {})
 
 
+@raise_on_failure
 @pytest.mark.parametrize("deposit", [2])
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import Any, Callable, List
 
 import gevent
+import pytest
 import structlog
 from gevent.event import AsyncResult
 
@@ -57,4 +58,8 @@ def raise_on_failure(test_function: Callable) -> Callable:
 
             raise
 
+    wrapper._decorated_raise_on_failure = True  # type: ignore
     return wrapper
+
+
+expect_failure = pytest.mark.expect_failure


### PR DESCRIPTION
In some of our integration tests, it can happen that a node crashes silently and the test continues with a missing node. To make debugging flaky tests easier in the future, we want them to fail instantly and with a descriptive error message if that happens.

We already have a `@raise_on_failure` decorator for this, but it is not consistently used and easy to miss out on new tests. Therefore, this PR

- introduces a new decorator, `@expect_failure`, for integration tests where we actually expect node crashes
- enforces the use of either decorator on each test that runs `RaidenService` instances
- adds the appropriate decorators to all tests where it was missing.

Unfortunately, I did not find a way to set `raise_on_failure` as the default without getting too hacky with pytest hooks. The decorator spawns a new greenlet and runs the testfunction in it, which cannot be done from a fixture. This is why I propose this obligatory-decorator approach instead.

Closes #5387