### PR TITLE
Forwarding PFS message to the API caller

### DIFF
--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -143,7 +143,7 @@ def test_participant_selection(raiden_network, token_addresses):
         for target in raiden_network:
             if target.raiden.address == app.raiden.address:
                 continue
-            routes, _ = routing.get_best_routes(
+            _, routes, _ = routing.get_best_routes(
                 chain_state=node_state,
                 token_network_address=network_state.address,
                 one_to_n_address=one_to_n_address,

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -139,7 +139,7 @@ def get_best_routes_with_iou_request_mocked(
         return mocked_json_response(response_data=iou_json_data)
 
     with patch.object(requests, "get", side_effect=iou_side_effect) as patched:
-        best_routes, feedback_token = get_best_routes(
+        _, best_routes, feedback_token = get_best_routes(
             chain_state=chain_state,
             token_network_address=token_network_state.address,
             one_to_n_address=one_to_n_address,
@@ -637,8 +637,8 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
     # with the transfer of 50 the direct channel should be returned,
     # so there must be not a pfs call
     with patch("raiden.routing.get_best_routes_pfs") as pfs_request:
-        pfs_request.return_value = True, [], "feedback_token"
-        routes, _ = get_best_routes(
+        pfs_request.return_value = None, [], "feedback_token"
+        _, routes, _ = get_best_routes(
             chain_state=chain_state,
             token_network_address=token_network_state.address,
             one_to_n_address=one_to_n_address,
@@ -656,7 +656,7 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
     # with the transfer of 51 the direct channel should not be returned,
     # so there must be a pfs call
     with patch("raiden.routing.get_best_routes_pfs") as pfs_request:
-        pfs_request.return_value = True, [], "feedback_token"
+        pfs_request.return_value = None, [], "feedback_token"
         get_best_routes(
             chain_state=chain_state,
             token_network_address=token_network_state.address,

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -842,7 +842,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         address4: NetworkState.REACHABLE,
     }
 
-    routes1, _ = get_best_routes(
+    _, routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -864,7 +864,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         address4: NetworkState.REACHABLE,
     }
 
-    routes1, _ = get_best_routes(
+    _, routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -886,7 +886,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         address4: NetworkState.REACHABLE,
     }
 
-    routes1, _ = get_best_routes(
+    _, routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -908,7 +908,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         address4: NetworkState.REACHABLE,
     }
 
-    routes1, _ = get_best_routes(
+    _, routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -1074,7 +1074,7 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         address3: NetworkState.REACHABLE,
     }
 
-    routes, _ = get_best_routes(
+    _, routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -1096,7 +1096,7 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         address4: NetworkState.REACHABLE,
     }
 
-    routes, _ = get_best_routes(
+    _, routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -1177,7 +1177,7 @@ def test_internal_routing_mediation_fees(
     }
 
     # Routing to our direct partner would require 0 mediation fees.x
-    routes, _ = get_best_routes(
+    _, routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -1191,7 +1191,7 @@ def test_internal_routing_mediation_fees(
     assert routes[0].estimated_fee == 0
 
     # Routing to our address2 through address1 would charge 2%
-    routes, _ = get_best_routes(
+    _, routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1949,11 +1949,11 @@ def test_initiator_init():
     feedback_token = uuid.uuid4()
 
     with patch(
-        "raiden.routing.get_best_routes", return_value=(route_states, feedback_token)
+        "raiden.routing.get_best_routes", return_value=(None, route_states, feedback_token)
     ) as best_routes:
         assert len(service.route_to_feedback_token) == 0
 
-        state = initiator_init(
+        _, init_state_change = initiator_init(
             raiden=service,
             transfer_identifier=1,
             transfer_amount=PaymentAmount(100),
@@ -1967,7 +1967,7 @@ def test_initiator_init():
         assert len(service.route_to_feedback_token) == 1
         assert service.route_to_feedback_token[tuple(route_states[0].route)] == feedback_token
 
-        assert state.routes == route_states
+        assert init_state_change.routes == route_states
 
 
 def test_calculate_safe_amount_with_fee():


### PR DESCRIPTION
The message generated by the Raiden node is too generic, which makes it
harder to understand why a failure happened in the PFS. This change
forwards the error message given by the PFS to the Raiden API consumer,
which should help with understanding why something failed.