### PR TITLE
Allow user to configure pfs url

### DIFF
--- a/raiden/utils/profiling/stack.py
+++ b/raiden/utils/profiling/stack.py
@@ -1,6 +1,5 @@
 """ Stack and trace extraction utilities """
 import linecache
-
 # This code is heavilly based on the raven-python from the Sentry Team.
 #
 # :copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.

--- a/raiden/utils/profiling/stack.py
+++ b/raiden/utils/profiling/stack.py
@@ -1,9 +1,11 @@
-""" Stack and trace extraction utilities """
+""" Stack and trace extraction utilities.
+
+This code is heavilly based on the raven-python from the Sentry Team.
+
+:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
 import linecache
-# This code is heavilly based on the raven-python from the Sentry Team.
-#
-# :copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
-# :license: BSD, see LICENSE for more details.
 import sys
 
 

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -535,10 +535,10 @@ def main() -> None:
             node = defaults.copy()
             node.update(
                 {
-                    "--keystore-path": node_config["keystore"],
+                    "--keystore-path": node_config["keystore-path"],
                     "--password-file": node_config["password-file"],
-                    "--eth-rpc-endpoint": node_config["ethnode"],
-                    "--network-id": node_config["networkid"],
+                    "--eth-rpc-endpoint": node_config["eth-rpc-endpoint"],
+                    "--network-id": node_config["network-id"],
                     "--address": address,
                     "--api-address": api_url,
                 }


### PR DESCRIPTION
Adds an option `pathfinding-service-address` in the `ini` used by the stress script, so that a user can configure the pfs that is used by the nodes.