### PR TITLE
Update on flaky tests

### DIFF
--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -364,7 +364,7 @@ def test_stress(
 ) -> None:
     token_address = token_addresses[0]
     rest_apis = start_apiserver_for_network(raiden_network, port_generator)
-    identifier_generator = count()
+    identifier_generator = count(start=1)
 
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_app(raiden_network[0]),

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -29,7 +29,6 @@ from raiden.utils.transfers import create_default_identifier
 from raiden.utils.typing import BlockNumber, PaymentAmount, PaymentID
 
 
-@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5133")
 @raise_on_failure
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])

--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -53,7 +53,6 @@ def open_and_wait_for_channels(app_channels, registry_address, token, deposit, s
     wait_for_channels(app_channels, registry_address, [token], deposit)
 
 
-@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5195")
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [5])
 @pytest.mark.parametrize("channels_per_node", [0])

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -24,7 +24,6 @@ from raiden.utils.typing import BlockNumber, PaymentID, TokenAmount
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
-@pytest.mark.skip("Issue: #4312")
 def test_send_queued_messages(  # pylint: disable=unused-argument
     raiden_network, deposit, token_addresses, network_wait
 ):

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -245,7 +245,7 @@ def test_mediated_transfer_with_entire_deposit(
         )
 
 
-@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/4804")
+@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/4694")
 @raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])


### PR DESCRIPTION
Unskips three integration tests that seem to be no longer flaky. (10 test builds plus local runs with no failures.) These tests have been skipped since September 2019 or longer; since then, multiple changes to make the integration tests more reliable have happened, as well as changes in the tested code.

Also a minor correction of the stress test (make sure 0 isn't used as a payment identifier).

Closes #5133 
Closes #5195 
Related issue: #4312 (already closed)