### PR TITLE
Fix pending transfers API call

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -124,24 +124,25 @@ def flatten_transfer(transfer: LockedTransferType, role: str) -> Dict[str, Any]:
 def get_transfer_from_task(
     secrethash: SecretHash, transfer_task: TransferTask
 ) -> Optional[LockedTransferType]:
-    transfer: LockedTransferType
     if isinstance(transfer_task, InitiatorTask):
-        if secrethash in transfer_task.manager_state.initiator_transfers:
-            transfer = transfer_task.manager_state.initiator_transfers[secrethash].transfer
-        else:
+        # Work around for https://github.com/raiden-network/raiden/issues/5480,
+        # can be removed when
+        # https://github.com/raiden-network/raiden/issues/5515 is done.
+        if secrethash not in transfer_task.manager_state.initiator_transfers:
             return None
+
+        return transfer_task.manager_state.initiator_transfers[secrethash].transfer
     elif isinstance(transfer_task, MediatorTask):
         pairs = transfer_task.mediator_state.transfers_pair
         if pairs:
-            transfer = pairs[-1].payer_transfer
-        elif transfer_task.mediator_state.waiting_transfer:
-            transfer = transfer_task.mediator_state.waiting_transfer.transfer
-    elif isinstance(transfer_task, TargetTask):
-        transfer = transfer_task.target_state.transfer
-    else:  # pragma: no unittest
-        raise ValueError("get_transfer_from_task for a non TransferTask argument")
+            return pairs[-1].payer_transfer
 
-    return transfer
+        assert transfer_task.mediator_state.waiting_transfer, "Invalid mediator_state"
+        return transfer_task.mediator_state.waiting_transfer.transfer
+    elif isinstance(transfer_task, TargetTask):
+        return transfer_task.target_state.transfer
+
+    raise ValueError("get_transfer_from_task for a non TransferTask argument")
 
 
 def transfer_tasks_view(

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1267,7 +1267,7 @@ class RaidenAPI:  # pragma: no unittest
         chain_state = views.state_from_raiden(self.raiden)
         transfer_tasks = views.get_all_transfer_tasks(chain_state)
         channel_id = None
-        confirmed_block_identifier = views.state_from_raiden(self.raiden).block_hash
+        confirmed_block_identifier = chain_state.block_hash
         if token_address is not None:
             token_network = self.raiden.default_registry.get_token_network(
                 token_address=token_address, block_identifier=confirmed_block_identifier
@@ -1275,11 +1275,14 @@ class RaidenAPI:  # pragma: no unittest
             if token_network is None:
                 raise UnknownTokenAddress(f"Token {token_address} not found.")
             if partner_address is not None:
-                partner_channel = self.get_channel(
-                    registry_address=self.raiden.default_registry.address,
+                partner_channel = views.get_channelstate_for(
+                    chain_state=chain_state,
+                    token_network_registry_address=self.raiden.default_registry.address,
                     token_address=token_address,
                     partner_address=partner_address,
                 )
+                if not partner_channel:
+                    raise ChannelNotFound(f"Channel with partner `partner_address not found.`")
                 channel_id = partner_channel.identifier
 
         return transfer_tasks_view(transfer_tasks, token_address, channel_id)


### PR DESCRIPTION
## Description

When doing a refund, the paymentmapping does not get cleaned up
properly. This causes an exception when querying the pending transfers
via API. This is just a work around the real fix will be #5515.

Closes #5480

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
