### PR TITLE
Cache `to_checksum_address`

### DIFF
--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -5,10 +5,10 @@ from typing import Dict, Optional
 
 import structlog
 from eth_keyfile import decode_keyfile_json
-from eth_utils import decode_hex, encode_hex, to_checksum_address
+from eth_utils import decode_hex, encode_hex
 
 from raiden.exceptions import RaidenError
-from raiden.utils import privatekey_to_address, privatekey_to_publickey
+from raiden.utils import privatekey_to_address, privatekey_to_publickey, to_checksum_address
 from raiden.utils.typing import Address, AddressHex, PrivateKey, PublicKey
 
 log = structlog.get_logger(__name__)

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1,6 +1,6 @@
 import gevent
 import structlog
-from eth_utils import is_binary_address, to_checksum_address
+from eth_utils import is_binary_address
 
 import raiden.blockchain.events as blockchain_events
 from raiden import waiting
@@ -46,7 +46,7 @@ from raiden.transfer.state import (
     NetworkState,
 )
 from raiden.transfer.state_change import ActionChannelClose
-from raiden.utils import create_default_identifier
+from raiden.utils import create_default_identifier, to_checksum_address
 from raiden.utils.gas_reserve import has_enough_gas_reserve
 from raiden.utils.testnet import MintingMethod, call_minting_method, token_minting_proxy
 from raiden.utils.typing import (

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 import gevent
 import gevent.pool
 import structlog
-from eth_utils import encode_hex, to_checksum_address
+from eth_utils import encode_hex
 from flask import Flask, Request, Response, make_response, request, send_from_directory, url_for
 from flask.json import jsonify
 from flask_cors import CORS
@@ -102,6 +102,7 @@ from raiden.utils import (
     get_system_spec,
     optional_address_to_string,
     split_endpoint,
+    to_checksum_address,
 )
 from raiden.utils.runnable import Runnable
 from raiden.utils.testnet import MintingMethod

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,5 +1,4 @@
 import structlog
-from eth_utils import to_checksum_address
 
 from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, RoutingMode
 from raiden.exceptions import InvalidSettleTimeout
@@ -26,7 +25,7 @@ from raiden.settings import (
     DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
     RAIDEN_CONTRACT_VERSION,
 )
-from raiden.utils import typing
+from raiden.utils import to_checksum_address, typing
 from raiden.utils.typing import Address
 from raiden_contracts.contract_manager import contracts_precompiled_path
 

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 
 from raiden.blockchain.exceptions import UnknownRaidenEventType
 from raiden.blockchain.filters import (
@@ -16,6 +16,7 @@ from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.token_network import TokenNetwork
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     ABI,
     Address,

--- a/raiden/blockchain/filters.py
+++ b/raiden/blockchain/filters.py
@@ -1,6 +1,6 @@
 import structlog
 from eth_typing import ChecksumAddress
-from eth_utils import decode_hex, event_abi_to_log_topic, to_checksum_address
+from eth_utils import decode_hex, event_abi_to_log_topic
 from gevent.lock import Semaphore
 from web3 import Web3
 from web3.utils.abi import filter_by_type
@@ -8,6 +8,7 @@ from web3.utils.events import get_event_data
 from web3.utils.filters import construct_event_filter_params
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     ABI,
     Any,

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -20,7 +20,7 @@ well.
 """
 from dataclasses import dataclass
 
-from eth_utils import to_checksum_address, to_hex
+from eth_utils import to_hex
 
 from raiden.blockchain.events import DecodedEvent
 from raiden.exceptions import RaidenUnrecoverableError
@@ -34,6 +34,7 @@ from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.transfer import views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import ChainState, NettingChannelState
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List
 
 import gevent
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 from gevent.lock import Semaphore
 
 from raiden import waiting
@@ -23,7 +23,7 @@ from raiden.exceptions import (
 )
 from raiden.transfer import views
 from raiden.transfer.state import NettingChannelState
-from raiden.utils import typing
+from raiden.utils import to_checksum_address, typing
 from raiden.utils.typing import (
     Address,
     TokenAddress,

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,8 +1,9 @@
 import math
 from enum import Enum
 
-from eth_utils import keccak, to_canonical_address, to_checksum_address
+from eth_utils import keccak, to_canonical_address
 
+from raiden.utils import to_checksum_address
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     AdditionalHash,

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
 
 import rlp
-from eth_utils import to_checksum_address
 
-from raiden.utils import sha3
+from raiden.utils import sha3, to_checksum_address
 from raiden.utils.typing import Address, List
 
 

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -9,14 +9,14 @@ from uuid import UUID
 import click
 import requests
 import structlog
-from eth_utils import decode_hex, encode_hex, to_canonical_address, to_checksum_address, to_hex
+from eth_utils import decode_hex, encode_hex, to_canonical_address, to_hex
 from web3 import Web3
 
 from raiden.constants import DEFAULT_HTTP_REQUEST_TIMEOUT, ZERO_TOKENS, RoutingMode
 from raiden.exceptions import ServiceRequestFailed, ServiceRequestIOURejected
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.utils import get_response_json
-from raiden.utils import to_rdn
+from raiden.utils import to_checksum_address, to_rdn
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
     Address,

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -2,13 +2,14 @@ from urllib.parse import urlparse
 
 import structlog
 import web3
-from eth_utils import decode_hex, is_binary_address, to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, is_binary_address, to_canonical_address
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.exceptions import BrokenPreconditionError, RaidenUnrecoverableError
 from raiden.network.proxies.utils import log_transaction
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Address,
     Any,

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -1,5 +1,5 @@
 import structlog
-from eth_utils import encode_hex, is_binary_address, to_checksum_address
+from eth_utils import encode_hex, is_binary_address
 from gevent.lock import RLock
 
 from raiden.constants import GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL
@@ -8,7 +8,7 @@ from raiden.network.proxies.utils import log_transaction
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import safe_gas_limit
+from raiden.utils import safe_gas_limit, to_checksum_address
 from raiden.utils.typing import Address, Balance, BlockSpecification, TokenAddress, TokenAmount
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN
 from raiden_contracts.contract_manager import ContractManager

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -1,5 +1,5 @@
 import structlog
-from eth_utils import decode_hex, is_binary_address, to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, is_binary_address, to_canonical_address
 from gevent.lock import RLock
 from web3.exceptions import BadFunctionCallOutput
 
@@ -9,7 +9,7 @@ from raiden.network.proxies.token import Token
 from raiden.network.proxies.utils import log_transaction, raise_on_call_returned_empty
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.network.rpc.transactions import check_transaction_threw
-from raiden.utils import safe_gas_limit
+from raiden.utils import safe_gas_limit, to_checksum_address
 from raiden.utils.typing import (
     TYPE_CHECKING,
     Address,

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import gevent
 import structlog
-from eth_utils import encode_hex, is_checksum_address, to_canonical_address, to_checksum_address
+from eth_utils import encode_hex, is_checksum_address, to_canonical_address
 from gevent.lock import Semaphore
 from hexbytes import HexBytes
 from requests.exceptions import ReadTimeout
@@ -29,7 +29,7 @@ from raiden.exceptions import (
 )
 from raiden.network.rpc.middleware import block_hash_cache_middleware
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, to_checksum_address
 from raiden.utils.ethereum_clients import is_supported_client
 from raiden.utils.typing import (
     ABI,

--- a/raiden/network/rpc/smartcontract_proxy.py
+++ b/raiden/network/rpc/smartcontract_proxy.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from eth_utils import decode_hex, to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, to_canonical_address
 from web3.contract import Contract
 from web3.utils.contracts import encode_transaction_data, find_matching_fn_abi
 
@@ -15,6 +15,7 @@ from raiden.exceptions import (
     RaidenUnrecoverableError,
     ReplacementTransactionUnderpriced,
 )
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import TYPE_CHECKING, Address, BlockSpecification, TransactionHash
 
 if TYPE_CHECKING:

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -8,7 +8,6 @@ from urllib.parse import quote
 
 import gevent
 import structlog
-from eth_utils import to_checksum_address
 from gevent.lock import Semaphore
 from matrix_client.api import MatrixHttpApi
 from matrix_client.client import CACHE, MatrixClient
@@ -20,6 +19,7 @@ from requests.adapters import HTTPAdapter
 
 from raiden.constants import Environment
 from raiden.exceptions import MatrixSyncMaxTimeoutReached
+from raiden.utils import to_checksum_address
 
 log = structlog.get_logger(__name__)
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import gevent
 import structlog
-from eth_utils import is_binary_address, to_checksum_address, to_normalized_address
+from eth_utils import is_binary_address, to_normalized_address
 from gevent.event import Event
 from gevent.lock import RLock, Semaphore
 from gevent.pool import Pool
@@ -51,6 +51,7 @@ from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
     ActionUpdateTransportAuthData,
 )
+from raiden.utils import to_checksum_address
 from raiden.utils.logging import redact_secret
 from raiden.utils.runnable import Runnable
 from raiden.utils.typing import (

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import structlog
-from eth_utils import encode_hex, to_checksum_address, to_hex
+from eth_utils import encode_hex, to_hex
 
 from raiden.constants import (
     EMPTY_BALANCE_HASH,
@@ -69,6 +69,7 @@ from raiden.transfer.mediated_transfer.events import (
 )
 from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import get_channelstate_by_token_network_and_partner
+from raiden.utils import to_checksum_address
 from raiden.utils.packing import pack_signed_balance_proof, pack_withdraw
 from raiden.utils.typing import MYPY_ANNOTATION, Address, BlockSpecification, Nonce
 from raiden_contracts.constants import MessageTypeId

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import filelock
 import gevent
 import structlog
-from eth_utils import is_binary_address, to_checksum_address, to_hex
+from eth_utils import is_binary_address, to_hex
 from gevent import Greenlet
 from gevent.event import AsyncResult, Event
 
@@ -84,7 +84,7 @@ from raiden.transfer.state_change import (
     Block,
     ContractReceiveNewTokenNetworkRegistry,
 )
-from raiden.utils import lpex, random_secret
+from raiden.utils import lpex, random_secret, to_checksum_address
 from raiden.utils.logging import redact_secret
 from raiden.utils.runnable import Runnable
 from raiden.utils.secrethash import sha256_secrethash

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import networkx
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 
 from raiden.exceptions import ServiceRequestFailed
 from raiden.messages.metadata import RouteMetadata
@@ -12,6 +12,7 @@ from raiden.network.pathfinding import PFSConfig, query_paths
 from raiden.settings import INTERNAL_ROUTING_DEFAULT_FEE_PERC
 from raiden.transfer import channel, views
 from raiden.transfer.state import ChainState, ChannelState, RouteState
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Address,
     ChannelID,

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -1,7 +1,6 @@
 from typing import Union
 
 import structlog
-from eth_utils import to_checksum_address
 
 from raiden import constants
 from raiden.constants import RoutingMode
@@ -12,7 +11,7 @@ from raiden.transfer import views
 from raiden.transfer.architecture import BalanceProofSignedState, BalanceProofUnsignedState
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import ChainState
-from raiden.utils import to_rdn
+from raiden.utils import to_checksum_address, to_rdn
 from raiden.utils.typing import TYPE_CHECKING, Address
 
 if TYPE_CHECKING:

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -1,4 +1,4 @@
-from eth_utils import to_checksum_address, to_hex
+from eth_utils import to_hex
 
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.storage.sqlite import (
@@ -13,6 +13,7 @@ from raiden.storage.wal import restore_to_state_change
 from raiden.transfer import node, views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import NettingChannelState
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     TYPE_CHECKING,
     Address,

--- a/raiden/storage/serialization/fields.py
+++ b/raiden/storage/serialization/fields.py
@@ -4,10 +4,11 @@ from typing import Callable
 
 import marshmallow
 import networkx
-from eth_utils import to_bytes, to_canonical_address, to_checksum_address, to_hex
+from eth_utils import to_bytes, to_canonical_address, to_hex
 from marshmallow_polyfield import PolyField
 
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import Address, Any, ChainID, ChannelID, Optional, Tuple
 
 

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 import gevent.lock
 import structlog
-from eth_utils import to_checksum_address
 
 from raiden.storage.serialization import DictSerializer
 from raiden.storage.sqlite import (
@@ -12,6 +11,7 @@ from raiden.storage.sqlite import (
     StateChangeID,
 )
 from raiden.transfer.architecture import Event, State, StateChange, StateManager
+from raiden.utils import to_checksum_address
 from raiden.utils.logging import redact_secret
 from raiden.utils.typing import (
     Address,

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -5,7 +5,7 @@ import click
 import gevent
 import requests
 import structlog
-from eth_utils import to_checksum_address, to_hex
+from eth_utils import to_hex
 from gevent.event import AsyncResult
 from pkg_resources import parse_version
 from web3 import Web3
@@ -22,7 +22,7 @@ from raiden.constants import (
 from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.settings import MIN_REI_THRESHOLD
-from raiden.utils import gas_reserve, to_rdn
+from raiden.utils import gas_reserve, to_checksum_address, to_rdn
 from raiden.utils.runnable import Runnable
 from raiden.utils.typing import Any, BlockNumber, Callable, ChainID, List, Optional, Tuple
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -2,7 +2,6 @@ from typing import cast
 
 import gevent
 import pytest
-from eth_utils import to_checksum_address
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
@@ -42,7 +41,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelSettled,
     ContractReceiveNewTokenNetwork,
 )
-from raiden.utils import create_default_identifier
+from raiden.utils import create_default_identifier, to_checksum_address
 from raiden.utils.gas_reserve import (
     GAS_RESERVE_ESTIMATE_SECURITY_FACTOR,
     get_required_gas_estimate,

--- a/raiden/tests/integration/cli/test_cli_production.py
+++ b/raiden/tests/integration/cli/test_cli_production.py
@@ -1,5 +1,4 @@
 import pytest
-from eth_utils import to_checksum_address
 
 from raiden.constants import Environment
 from raiden.settings import RAIDEN_CONTRACT_VERSION
@@ -8,6 +7,7 @@ from raiden.tests.integration.cli.util import (
     expect_cli_successful_connected,
     expect_cli_until_acknowledgment,
 )
+from raiden.utils import to_checksum_address
 
 EXPECTED_DEFAULT_ENVIRONMENT = Environment.PRODUCTION
 

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -1,5 +1,5 @@
 import pytest
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 
 from raiden.constants import (
     EMPTY_ADDRESS,
@@ -19,7 +19,7 @@ from raiden.tests.utils.smartcontracts import (
     deploy_token,
     deploy_tokens_and_fund_accounts,
 )
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, to_checksum_address
 from raiden.utils.typing import (
     Address,
     ChainID,

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -1,6 +1,6 @@
 import gevent
 import pytest
-from eth_utils import is_list_like, to_checksum_address
+from eth_utils import is_list_like
 from web3.utils.events import construct_event_topic_set
 
 from raiden import waiting
@@ -31,7 +31,7 @@ from raiden.transfer.events import ContractSendChannelClose
 from raiden.transfer.mediated_transfer.events import SendLockedTransfer
 from raiden.transfer.mediated_transfer.state_change import ReceiveSecretReveal
 from raiden.transfer.state_change import ContractReceiveSecretReveal
-from raiden.utils import sha3, wait_until
+from raiden.utils import sha3, to_checksum_address, wait_until
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     Address,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -2,7 +2,6 @@ import random
 
 import gevent
 import pytest
-from eth_utils import to_checksum_address
 from gevent.timeout import Timeout
 
 from raiden import waiting
@@ -31,7 +30,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelClosed,
     ContractReceiveChannelSettled,
 )
-from raiden.utils import sha3
+from raiden.utils import sha3, to_checksum_address
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.timeout import BlockTimeout
 from raiden.utils.typing import BlockNumber, MessageID, PaymentAmount, PaymentID, Secret

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -7,7 +7,7 @@ import gevent
 import grequests
 import pytest
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 from flask import url_for
 
 from raiden import waiting
@@ -27,6 +27,7 @@ from raiden.tests.utils.transfer import (
     watch_for_unlock_failures,
 )
 from raiden.transfer import views
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/raiden/tests/integration/network/proxies/test_token.py
+++ b/raiden/tests/integration/network/proxies/test_token.py
@@ -1,8 +1,8 @@
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 
 from raiden.network.proxies.token import Token
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.utils import privatekey_to_address
+from raiden.utils import privatekey_to_address, to_checksum_address
 
 
 def test_token(deploy_client, token_proxy, private_keys, web3, contract_manager):

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -1,7 +1,7 @@
 import random
 
 import pytest
-from eth_utils import decode_hex, encode_hex, to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, encode_hex, to_canonical_address
 
 from raiden.constants import (
     EMPTY_BALANCE_HASH,
@@ -23,6 +23,7 @@ from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetad
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
 from raiden.tests.utils.factories import make_address
+from raiden.utils import to_checksum_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import T_ChannelID
 from raiden_contracts.constants import (

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import gevent
 import pytest
-from eth_utils import to_checksum_address
 from gevent import Timeout
 from matrix_client.errors import MatrixRequestError
 
@@ -36,6 +35,7 @@ from raiden.tests.utils.transfer import wait_assert
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
 from raiden.transfer.state_change import ActionChannelClose, ActionUpdateTransportAuthData
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import Address, List
 
 HOP1_BALANCE_PROOF = factories.BalanceProofSignedStateProperties(pkey=factories.HOP1_KEY)

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -3,7 +3,6 @@ from urllib.parse import urlsplit
 
 import gevent
 import pytest
-from eth_utils import to_checksum_address
 from matrix_client.errors import MatrixRequestError
 
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
@@ -14,6 +13,7 @@ from raiden.network.transport.matrix.utils import (
     make_room_alias,
 )
 from raiden.tests.utils import factories, transport
+from raiden.utils import to_checksum_address
 from raiden.utils.http import HTTPExecutor
 from raiden.utils.signer import Signer
 from raiden.utils.typing import Any, Dict, Tuple

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
@@ -1,8 +1,9 @@
 import pytest
-from eth_utils import decode_hex, to_checksum_address
+from eth_utils import decode_hex
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
+from raiden.utils import to_checksum_address
 
 
 def test_call_invalid_selector(deploy_client):

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -1,8 +1,8 @@
 import pytest
-from eth_utils import to_checksum_address
 
 from raiden.constants import RECEIPT_FAILURE_CODE
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
+from raiden.utils import to_checksum_address
 
 SSTORE_COST = 20000
 

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
@@ -1,13 +1,12 @@
 import gevent
 import pytest
-from eth_utils import to_checksum_address
 from web3 import HTTPProvider, Web3
 
 from raiden.constants import RECEIPT_FAILURE_CODE
 from raiden.exceptions import EthereumNonceTooLow, ReplacementTransactionUnderpriced
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
-from raiden.utils import safe_gas_limit
+from raiden.utils import safe_gas_limit, to_checksum_address
 from raiden.utils.typing import Callable, Dict, GasPrice, List, Port, PrivateKey
 
 

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -1,12 +1,11 @@
 import pytest
-from eth_utils import to_checksum_address
 
 from raiden.exceptions import InsufficientEth
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
-from raiden.utils import safe_gas_limit
+from raiden.utils import safe_gas_limit, to_checksum_address
 
 
 def test_transact_opcode(deploy_client: JSONRPCClient) -> None:

--- a/raiden/tests/integration/test_echo_node.py
+++ b/raiden/tests/integration/test_echo_node.py
@@ -1,7 +1,6 @@
 import gevent
 import pytest
 import structlog
-from eth_utils import to_checksum_address
 
 from raiden.api.python import RaidenAPI
 from raiden.messages.transfers import Unlock
@@ -12,7 +11,7 @@ from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.transfer import watch_for_unlock_failures
 from raiden.transfer.events import EventPaymentReceivedSuccess
-from raiden.utils import wait_until
+from raiden.utils import to_checksum_address, wait_until
 from raiden.utils.echo_node import EchoNode
 from raiden.utils.typing import MYPY_ANNOTATION, List, Optional, PaymentAmount, PaymentID
 from raiden.waiting import TransferWaitResult, wait_for_received_transfer_result

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import requests
-from eth_utils import is_checksum_address, is_hex, is_hex_address, to_checksum_address
+from eth_utils import is_checksum_address, is_hex, is_hex_address
 
 from raiden.constants import RoutingMode
 from raiden.exceptions import ServiceRequestFailed, ServiceRequestIOURejected
@@ -26,7 +26,7 @@ from raiden.routing import get_best_routes
 from raiden.tests.utils import factories
 from raiden.tests.utils.mocks import mocked_failed_response, mocked_json_response
 from raiden.transfer.state import NettingChannelState, NetworkState, TokenNetworkState
-from raiden.utils import privatekey_to_address, typing
+from raiden.utils import privatekey_to_address, to_checksum_address, typing
 from raiden.utils.typing import (
     Address,
     Any,

--- a/raiden/tests/unit/transfer/test_utils.py
+++ b/raiden/tests/unit/transfer/test_utils.py
@@ -1,11 +1,12 @@
 import pytest
-from eth_utils import decode_hex, to_checksum_address
+from eth_utils import decode_hex
 
 from raiden.constants import EMPTY_HASH, LOCKSROOT_OF_NO_LOCKS
 from raiden.tests.utils import factories
 from raiden.transfer.secret_registry import events_for_onchain_secretreveal
 from raiden.transfer.state import TransactionExecutionStatus
 from raiden.transfer.utils import hash_balance_data
+from raiden.utils import to_checksum_address
 
 
 @pytest.mark.parametrize(

--- a/raiden/tests/utils/client.py
+++ b/raiden/tests/utils/client.py
@@ -1,7 +1,6 @@
-from eth_utils import to_checksum_address
-
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.factories import HOP1
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import Address
 
 

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -9,13 +9,13 @@ from typing import ContextManager, Iterator
 import gevent
 import structlog
 from eth_keyfile import create_keyfile_json
-from eth_utils import encode_hex, remove_0x_prefix, to_checksum_address, to_normalized_address
+from eth_utils import encode_hex, remove_0x_prefix, to_normalized_address
 from pkg_resources import parse_version
 from web3 import Web3
 
 from raiden.tests.fixtures.constants import DEFAULT_PASSPHRASE
 from raiden.tests.utils.genesis import GENESIS_STUB, PARITY_CHAIN_SPEC_STUB
-from raiden.utils import privatekey_to_address, privatekey_to_publickey
+from raiden.utils import privatekey_to_address, privatekey_to_publickey, to_checksum_address
 from raiden.utils.ethereum_clients import parse_geth_version
 from raiden.utils.http import JSONRPCExecutor
 from raiden.utils.typing import (

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -5,7 +5,7 @@ from functools import singledispatch
 from hashlib import sha256
 from operator import itemgetter
 
-from eth_utils import keccak, to_checksum_address
+from eth_utils import keccak
 
 from raiden.constants import EMPTY_SIGNATURE, LOCKSROOT_OF_NO_LOCKS, UINT64_MAX, UINT256_MAX
 from raiden.messages.decode import balanceproof_from_envelope
@@ -40,7 +40,7 @@ from raiden.transfer.state import (
 )
 from raiden.transfer.state_change import ContractReceiveChannelNew, ContractReceiveRouteNew
 from raiden.transfer.utils import hash_balance_data
-from raiden.utils import privatekey_to_address, random_secret, sha3
+from raiden.utils import privatekey_to_address, random_secret, sha3, to_checksum_address
 from raiden.utils.packing import pack_balance_proof
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.signer import LocalSigner, Signer

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -5,7 +5,6 @@ from itertools import product
 
 import gevent
 import structlog
-from eth_utils import to_checksum_address
 from web3 import Web3
 
 from raiden import waiting
@@ -28,7 +27,7 @@ from raiden.tests.utils.transport import ParsedURL
 from raiden.transfer import views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.views import state_from_raiden
-from raiden.utils import merge_dict
+from raiden.utils import merge_dict, to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/raiden/tests/utils/protocol.py
+++ b/raiden/tests/utils/protocol.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from unittest.mock import patch
 
 import structlog
-from eth_utils import to_checksum_address
 from gevent.event import AsyncResult
 
 from raiden.message_handler import MessageHandler
@@ -13,6 +12,7 @@ from raiden.tests.utils.events import check_nested_attrs
 from raiden.transfer.architecture import Event as RaidenEvent, TransitionResult
 from raiden.transfer.mediated_transfer.events import SendBalanceProof, SendSecretRequest
 from raiden.transfer.state import ChainState
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import Callable, Dict, List, NamedTuple, SecretHash, Set
 
 log = structlog.get_logger(__name__)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 
 import click
 import requests
-from eth_utils import remove_0x_prefix, to_canonical_address, to_checksum_address
+from eth_utils import remove_0x_prefix, to_canonical_address
 from gevent import sleep
 from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
@@ -44,7 +44,7 @@ from raiden.tests.utils.smartcontracts import deploy_contract_web3, deploy_token
 from raiden.transfer import channel, views
 from raiden.transfer.state import ChannelState
 from raiden.ui.app import run_app
-from raiden.utils import privatekey_to_address, split_endpoint
+from raiden.utils import privatekey_to_address, split_endpoint, to_checksum_address
 from raiden.utils.http import HTTPExecutor
 from raiden.utils.typing import (
     TYPE_CHECKING,

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager, nullcontext
 from enum import Enum
 
 import gevent
-from eth_utils import to_checksum_address
 from gevent.timeout import Timeout
 
 from raiden.app import App
@@ -58,6 +57,7 @@ from raiden.transfer.state import (
     make_empty_pending_locks_state,
 )
 from raiden.transfer.state_change import ContractReceiveChannelDeposit, ReceiveUnlock
+from raiden.utils import to_checksum_address
 from raiden.utils.signer import LocalSigner, Signer
 from raiden.utils.timeout import BlockTimeout
 from raiden.utils.typing import (

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -2,11 +2,12 @@
 from copy import deepcopy
 from dataclasses import dataclass, field
 
-from eth_utils import to_checksum_address, to_hex
+from eth_utils import to_hex
 
 from raiden.constants import EMPTY_BALANCE_HASH, UINT64_MAX, UINT256_MAX
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.utils import hash_balance_data
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     AdditionalHash,
     Address,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -2,7 +2,7 @@
 import random
 from typing import TYPE_CHECKING
 
-from eth_utils import encode_hex, keccak, to_checksum_address, to_hex
+from eth_utils import encode_hex, keccak, to_hex
 
 from raiden.constants import LOCKSROOT_OF_NO_LOCKS, MAXIMUM_PENDING_TRANSFERS, UINT256_MAX
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, MediationFeeConfig
@@ -81,6 +81,7 @@ from raiden.transfer.state_change import (
     ReceiveWithdrawRequest,
 )
 from raiden.transfer.utils import hash_balance_data
+from raiden.utils import to_checksum_address
 from raiden.utils.packing import pack_balance_proof, pack_withdraw
 from raiden.utils.signer import recover
 from raiden.utils.typing import (

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from eth_utils import to_checksum_address, to_hex
+from eth_utils import to_hex
 
 from raiden.constants import UINT256_MAX
 from raiden.transfer.architecture import (
@@ -11,6 +11,7 @@ from raiden.transfer.architecture import (
 )
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import BalanceProofSignedState
+from raiden.utils import to_checksum_address
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     Address,

--- a/raiden/transfer/identifiers.py
+++ b/raiden/transfer/identifiers.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 
-from eth_utils import to_checksum_address
-
 from raiden.constants import EMPTY_ADDRESS, UINT256_MAX
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Address,
     ChainID,

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -6,7 +6,7 @@ from enum import Enum
 from random import Random
 
 import networkx
-from eth_utils import to_checksum_address, to_hex
+from eth_utils import to_hex
 
 from raiden.constants import (
     EMPTY_SECRETHASH,
@@ -25,7 +25,7 @@ from raiden.transfer.architecture import (
 )
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
-from raiden.utils import lpex
+from raiden.utils import lpex, to_checksum_address
 from raiden.utils.typing import (
     Address,
     Any,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import click
 import filelock
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 from web3 import HTTPProvider, Web3
 
 from raiden.accounts import AccountManager
@@ -50,7 +50,7 @@ from raiden.ui.prompt import (
     unlock_account_with_passwordprompt,
 )
 from raiden.ui.startup import setup_contracts_or_exit, setup_environment, setup_proxies_or_exit
-from raiden.utils import pex, split_endpoint
+from raiden.utils import pex, split_endpoint, to_checksum_address
 from raiden.utils.cli import get_matrix_servers
 from raiden.utils.mediation_fees import prepare_mediation_fee_config
 from raiden.utils.typing import (

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -2,7 +2,6 @@ import sys
 
 import click
 import structlog
-from eth_utils import to_checksum_address
 from web3 import Web3
 
 from raiden.accounts import AccountManager
@@ -23,6 +22,7 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.settings import ETHERSCAN_API, ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE
 from raiden.storage.sqlite import assert_sqlite_version
 from raiden.ui.sync import wait_for_sync
+from raiden.utils import to_checksum_address
 from raiden.utils.ethereum_clients import is_supported_client
 from raiden.utils.typing import Address, ChainID, Dict, Optional, TokenNetworkRegistryAddress
 from raiden_contracts.constants import ID_TO_NETWORKNAME

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -5,7 +5,7 @@ import time
 
 import gevent
 import IPython
-from eth_utils import decode_hex, to_canonical_address, to_checksum_address
+from eth_utils import decode_hex, to_canonical_address
 from IPython.lib.inputhook import inputhook_manager, stdin_ready
 
 from raiden import waiting
@@ -15,6 +15,7 @@ from raiden.constants import UINT256_MAX
 from raiden.network.proxies.token_network import TokenNetwork
 from raiden.raiden_service import RaidenService
 from raiden.settings import DEFAULT_RETRY_TIMEOUT
+from raiden.utils import to_checksum_address
 from raiden.utils.smart_contracts import deploy_contract_web3
 from raiden.utils.typing import (
     AddressHex,

--- a/raiden/ui/prompt.py
+++ b/raiden/ui/prompt.py
@@ -3,9 +3,9 @@ import sys
 from typing import TextIO
 
 import click
-from eth_utils import to_checksum_address
 
 from raiden.accounts import AccountManager, KeystoreFileNotFound
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import AddressHex, PrivateKey
 
 

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -2,7 +2,7 @@ import sys
 from typing import Any, Dict, NamedTuple, Optional
 
 import click
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address
 
 from raiden.constants import Environment, RoutingMode
 from raiden.exceptions import AddressWithoutCode, AddressWrongContract, ContractCodeMismatch
@@ -18,6 +18,7 @@ from raiden.ui.checks import (
     check_raiden_environment,
     check_smart_contract_addresses,
 )
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import Address, ChainID, TokenNetworkRegistryAddress
 from raiden_contracts.constants import (
     CONTRACT_SECRET_REGISTRY,

--- a/raiden/utils/__init__.py
+++ b/raiden/utils/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import os
 import random
 import re
@@ -7,6 +8,7 @@ import time
 from itertools import zip_longest
 from typing import Any, Callable
 
+import eth_utils
 import gevent
 from eth_keys import keys
 from eth_utils import (
@@ -15,7 +17,6 @@ from eth_utils import (
     is_checksum_address,
     remove_0x_prefix,
     to_canonical_address,
-    to_checksum_address,
 )
 
 import raiden
@@ -214,3 +215,7 @@ def safe_gas_limit(*estimates: int) -> int:
 def to_rdn(rei: int) -> float:
     """ Convert REI value to RDN. """
     return rei / 10 ** 18
+
+
+# to_checksum_address is slow, so let's cache the last 1000 results
+to_checksum_address = functools.lru_cache(maxsize=1000)(eth_utils.to_checksum_address)

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -5,7 +5,6 @@ from typing import Any, Deque, Dict, List, Set
 
 import gevent
 import structlog
-from eth_utils import to_checksum_address
 from gevent import Greenlet
 from gevent.event import Event
 from gevent.lock import BoundedSemaphore
@@ -17,6 +16,7 @@ from raiden.tasks import REMOVE_CALLBACK
 from raiden.transfer import channel
 from raiden.transfer.events import EventPaymentReceivedSuccess
 from raiden.transfer.state import ChannelState
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Optional,
     PaymentAmount,

--- a/raiden/utils/packing.py
+++ b/raiden/utils/packing.py
@@ -1,7 +1,7 @@
 from eth_typing.evm import HexAddress
-from eth_utils import to_checksum_address
 
 from raiden.transfer.identifiers import CanonicalIdentifier
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     AdditionalHash,
     Address,

--- a/raiden/utils/signer.py
+++ b/raiden/utils/signer.py
@@ -3,9 +3,10 @@ from typing import Callable
 
 from eth_keys import keys
 from eth_keys.exceptions import BadSignature, ValidationError
-from eth_utils import keccak, to_checksum_address
+from eth_utils import keccak
 
 from raiden.exceptions import InvalidSignature
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import Address, AddressHex, Signature
 
 

--- a/raiden/waiting.py
+++ b/raiden/waiting.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, List
 
 import gevent
 import structlog
-from eth_utils import to_checksum_address
 
 from raiden.storage.restore import get_state_change_with_transfer_by_secrethash
 from raiden.transfer import channel, views
@@ -21,6 +20,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelWithdraw,
     ContractReceiveSecretReveal,
 )
+from raiden.utils import to_checksum_address
 from raiden.utils.typing import (
     Address,
     BlockNumber,

--- a/tools/debugging/gather-test-addresses.py
+++ b/tools/debugging/gather-test-addresses.py
@@ -5,8 +5,9 @@ from json import JSONDecodeError
 from typing import Any, Dict, List, Optional, Set, TextIO
 
 import click
-from eth_utils import to_checksum_address
 from eth_utils.typing import ChecksumAddress
+
+from raiden.utils import to_checksum_address
 
 EVENT_FIELD_REGEXES = {
     "node": re.compile(r"(0x[0-9a-fA-F]{40})"),

--- a/tools/debugging/matrix/api_shell.py
+++ b/tools/debugging/matrix/api_shell.py
@@ -3,10 +3,11 @@ import os
 
 import click
 import IPython
-from eth_utils import encode_hex, to_checksum_address, to_normalized_address
+from eth_utils import encode_hex, to_normalized_address
 
 from raiden.accounts import AccountManager
 from raiden.network.transport.matrix.client import GMatrixHttpApi
+from raiden.utils import to_checksum_address
 from raiden.utils.cli import ADDRESS_TYPE
 from raiden.utils.signer import LocalSigner
 

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -2,12 +2,12 @@
 import json
 
 import click
-from eth_utils import to_checksum_address
 from web3 import HTTPProvider, Web3
 
 from raiden.accounts import Account
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
+from raiden.utils import to_checksum_address
 
 WEI_TO_ETH = 10 ** 18
 


### PR DESCRIPTION
This can be much faster if the same addresses are reused:

```
>>> import raiden.utils
>>> import eth_utils
>>> import timeit
>>> timeit.timeit(lambda: eth_utils.to_checksum_address(b'1'*20),
number=100000)
4.872557054972276
>>> timeit.timeit(lambda: raiden.utils.to_checksum_address(b'1'*20),
number=100000)
0.050127724069170654
```

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
