### PR TITLE
StateManager requires initial state

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -261,6 +261,7 @@ class MessageHandler:
         raiden: "RaidenService", message: RefundTransfer
     ) -> List[StateChange]:
         chain_state = views.state_from_raiden(raiden)
+
         from_transfer = lockedtransfersigned_from_message(message=message)
 
         role = views.get_transfer_role(

--- a/raiden/network/resolver/client.py
+++ b/raiden/network/resolver/client.py
@@ -33,7 +33,7 @@ def reveal_secret_with_resolver(
     log.debug("Using resolver to fetch secret", resolver_endpoint=resolver_endpoint)
 
     assert isinstance(raiden.wal, WriteAheadLog), "RaidenService has not been started"
-    current_state = raiden.wal.state_manager.current_state
+    current_state = raiden.wal.get_current_state()
 
     if current_state is None:
         return False

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -30,7 +30,6 @@ from raiden.connection_manager import ConnectionManager
 from raiden.constants import (
     ABSENT_SECRET,
     DOC_URL,
-    EMPTY_TRANSACTION_HASH,
     GENESIS_BLOCK_NUMBER,
     SECRET_LENGTH,
     SNAPSHOT_STATE_CHANGES_COUNT,
@@ -63,10 +62,16 @@ from raiden.services import send_pfs_update, update_monitoring_service_from_bala
 from raiden.settings import RaidenConfig
 from raiden.storage import sqlite, wal
 from raiden.storage.serialization import DictSerializer, JSONSerializer
+from raiden.storage.sqlite import HIGH_STATECHANGE_ULID, Range
 from raiden.storage.wal import WriteAheadLog
 from raiden.tasks import AlarmTask
 from raiden.transfer import node, views
-from raiden.transfer.architecture import BalanceProofSignedState, Event as RaidenEvent, StateChange
+from raiden.transfer.architecture import (
+    BalanceProofSignedState,
+    Event as RaidenEvent,
+    StateChange,
+    StateManager,
+)
 from raiden.transfer.channel import get_capacity
 from raiden.transfer.events import EventPaymentSentFailed
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -88,11 +93,9 @@ from raiden.transfer.state_change import (
     ActionChangeNodeNetworkState,
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
-    ActionInitChain,
     BalanceProofStateChange,
     Block,
     ContractReceiveChannelDeposit,
-    ContractReceiveNewTokenNetworkRegistry,
     ReceiveUnlock,
     ReceiveWithdrawConfirmation,
     ReceiveWithdrawExpired,
@@ -501,21 +504,26 @@ class RaidenService(Runnable):
         storage.update_version()
         storage.log_run()
 
+        initial_state = self.make_initial_state()
+
         try:
             (
+                state_snapshot,
+                state_change_start,
                 state_change_qty_snapshot,
-                state_change_qty_pending,
-                restore_wal,
-            ) = wal.restore_to_state_change(
-                transition_function=node.state_transition,
-                storage=storage,
-                state_change_identifier=sqlite.HIGH_STATECHANGE_ULID,
-                node_address=self.address,
+            ) = wal.restore_or_init_snapshot(
+                storage=storage, node_address=self.address, initial_state=initial_state
             )
 
-            self.wal = restore_wal
-            self.state_change_qty_snapshot = state_change_qty_snapshot
-            self.state_change_qty = state_change_qty_snapshot + state_change_qty_pending
+            unapplied_state_changes_range = Range(state_change_start, HIGH_STATECHANGE_ULID)
+
+            (state_change_qty_unapplied, snapshot_state) = wal.replay_unapplied_state_changes(
+                transition_function=node.state_transition,
+                storage=storage,
+                unapplied_state_changes_range=unapplied_state_changes_range,
+                node_address=self.address,
+                state_snapshot=state_snapshot,
+            )
         except SerializationError:
             raise RaidenUnrecoverableError(
                 "Could not restore state. "
@@ -524,70 +532,42 @@ class RaidenService(Runnable):
                 "version of the Raiden client."
             )
 
-        if self.wal.state_manager.current_state is None:
+        if state_change_qty_snapshot == 0:
             print(
                 "This is the first time Raiden is being used with this address. "
                 "Processing all the events may take some time. Please wait ..."
             )
-            log.debug(
-                "No recoverable state available, creating initial state.",
-                node=to_checksum_address(self.address),
-            )
 
-            # On first run Raiden needs to fetch all events for the payment
-            # network, to reconstruct all token network graphs and find opened
-            # channels
-            last_log_block_number = self.query_start_block
-            last_log_block_hash = self.rpc_client.blockhash_from_blocknumber(last_log_block_number)
+        self.state_change_qty_snapshot = state_change_qty_snapshot
+        self.state_change_qty = state_change_qty_snapshot + state_change_qty_unapplied
 
-            # The value `self.query_start_block` is an optimization, because
-            # Raiden has to poll all events until the last confirmed block,
-            # using the genesis block would result in fetchs for a few million
-            # of unnecessary blocks. Instead of querying all these unnecessary
-            # blocks, the configuration variable `query_start_block` is used to
-            # start at the block which `TokenNetworkRegistry`  was deployed.
-            init_state_change = ActionInitChain(
-                pseudo_random_generator=random.Random(),
-                block_number=last_log_block_number,
-                block_hash=last_log_block_hash,
-                our_address=self.address,
-                chain_id=self.rpc_client.chain_id,
-            )
-            token_network_registry = TokenNetworkRegistryState(
-                self.default_registry.address,
-                [],  # empty list of token network states as it's the node's startup
-            )
-            new_network_state_change = ContractReceiveNewTokenNetworkRegistry(
-                transaction_hash=EMPTY_TRANSACTION_HASH,
-                token_network_registry=token_network_registry,
-                block_number=last_log_block_number,
-                block_hash=last_log_block_hash,
-            )
+        msg = "The snapshot_state must be a ChainState instance."
+        assert isinstance(snapshot_state, ChainState), msg
 
-            self.handle_and_track_state_changes([init_state_change, new_network_state_change])
-        else:
-            # The `Block` state change is dispatched only after all the events
-            # for that given block have been processed, filters can be safely
-            # installed starting from this position without losing events.
-            last_log_block_number = views.block_number(self.wal.state_manager.current_state)
-            log.debug(
-                "Restored state from WAL",
-                last_restored_block=last_log_block_number,
-                node=to_checksum_address(self.address),
-            )
+        state_manager = StateManager(node.state_transition, snapshot_state, [])
+        self.wal = WriteAheadLog(state_manager, storage)
+        current_state = self.wal.get_current_state()
 
-            known_networks = views.get_token_network_registry_address(
-                views.state_from_raiden(self)
+        # The `Block` state change is dispatched only after all the events
+        # for that given block have been processed, filters can be safely
+        # installed starting from this position without losing events.
+        last_log_block_number = views.block_number(current_state)
+        log.debug(
+            "Querying blockchain from block",
+            last_restored_block=last_log_block_number,
+            node=to_checksum_address(self.address),
+        )
+
+        known_networks = views.get_token_network_registry_address(views.state_from_raiden(self))
+        if known_networks and self.default_registry.address not in known_networks:
+            configured_registry = to_checksum_address(self.default_registry.address)
+            known_registries = lpex(known_networks)
+            raise RuntimeError(
+                f"Token network address mismatch.\n"
+                f"Raiden is configured to use the smart contract "
+                f"{configured_registry}, which conflicts with the current known "
+                f"smart contracts {known_registries}"
             )
-            if known_networks and self.default_registry.address not in known_networks:
-                configured_registry = to_checksum_address(self.default_registry.address)
-                known_registries = lpex(known_networks)
-                raise RuntimeError(
-                    f"Token network address mismatch.\n"
-                    f"Raiden is configured to use the smart contract "
-                    f"{configured_registry}, which conflicts with the current known "
-                    f"smart contracts {known_registries}"
-                )
 
         # Restore the current snapshot group
         state_change_qty = self.wal.storage.count_state_changes()
@@ -664,6 +644,38 @@ class RaidenService(Runnable):
 
         self.alarm.register_callback(self._callback_new_block)
 
+    def make_initial_state(self) -> ChainState:
+        # On first run Raiden needs to fetch all events for the payment
+        # network, to reconstruct all token network graphs and find opened
+        # channels
+        #
+        # The value `self.query_start_block` is an optimization, because
+        # Raiden has to poll all events until the last confirmed block,
+        # using the genesis block would result in fetchs for a few million
+        # of unnecessary blocks. Instead of querying all these unnecessary
+        # blocks, the configuration variable `query_start_block` is used to
+        # start at the block which `TokenNetworkRegistry`  was deployed.
+        last_log_block_number = self.query_start_block
+        last_log_block_hash = self.rpc_client.blockhash_from_blocknumber(last_log_block_number)
+
+        initial_state = ChainState(
+            pseudo_random_generator=random.Random(),
+            block_number=last_log_block_number,
+            block_hash=last_log_block_hash,
+            our_address=self.address,
+            chain_id=self.rpc_client.chain_id,
+        )
+        token_network_registry_address = self.default_registry.address
+        token_network_registry = TokenNetworkRegistryState(
+            token_network_registry_address,
+            [],  # empty list of token network states as it's the node's startup
+        )
+        initial_state.identifiers_to_tokennetworkregistries[
+            token_network_registry_address
+        ] = token_network_registry
+
+        return initial_state
+
     def _start_alarm_task(self) -> None:
         """Start the alarm task.
 
@@ -711,7 +723,7 @@ class RaidenService(Runnable):
 
     def get_block_number(self) -> BlockNumber:
         assert self.wal, f"WAL object not yet initialized. node:{self!r}"
-        return views.block_number(self.wal.state_manager.current_state)  # type: ignore
+        return views.block_number(self.wal.get_current_state())
 
     def on_messages(self, messages: List[Message]) -> None:
         self.message_handler.on_messages(self, messages)

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -330,6 +330,16 @@ class SQLiteStorage:
 
         return int(result[0][0])
 
+    def count_snapshots(self) -> int:
+        cursor = self.conn.cursor()
+        query = cursor.execute("SELECT COUNT(1) FROM state_snapshot")
+        result = query.fetchall()
+
+        if len(result) == 0:
+            return 0
+
+        return int(result[0][0])
+
     def write_state_changes(self, state_changes: List[str]) -> List[StateChangeID]:
         """Write `state_changes` to the database and returns the correspoding IDs."""
         ulid_factory = self._ulid_factory(StateChangeID)
@@ -346,6 +356,21 @@ class SQLiteStorage:
         self.maybe_commit()
 
         return state_change_ids
+
+    def write_first_state_snapshot(self, snapshot: str) -> SnapshotID:
+        if self.count_snapshots() != 0:
+            raise RuntimeError("write_state_snapshot can only be used for an unitialized node.")
+
+        snapshot_id = self._ulid_factory(SnapshotID).new()
+
+        query = (
+            "INSERT INTO state_snapshot (identifier, statechange_id, statechange_qty, data) "
+            "VALUES(?, NULL, 0, ?)"
+        )
+        self.conn.execute(query, (snapshot_id, snapshot))
+        self.maybe_commit()
+
+        return snapshot_id
 
     def write_state_snapshot(
         self, snapshot: str, statechange_id: StateChangeID, statechange_qty: int
@@ -407,7 +432,7 @@ class SQLiteStorage:
 
         cursor = self.conn.execute(
             "SELECT identifier, statechange_qty, statechange_id, data FROM state_snapshot "
-            "WHERE statechange_id <= ? "
+            "WHERE statechange_id <= ? OR statechange_id IS NULL "
             "ORDER BY identifier DESC LIMIT 1",
             (state_change_identifier,),
         )
@@ -784,6 +809,11 @@ class SerializedSQLiteStorage:
         ]
         return self.database.write_state_changes(serialized_data)
 
+    def write_first_state_snapshot(self, snapshot: State) -> SnapshotID:
+        serialized_data = self.serializer.serialize(snapshot)
+
+        return self.database.write_first_state_snapshot(serialized_data)
+
     def write_state_snapshot(
         self, snapshot: State, statechange_id: StateChangeID, statechange_qty: int
     ) -> SnapshotID:
@@ -818,7 +848,7 @@ class SerializedSQLiteStorage:
             result = SnapshotRecord(
                 row.identifier,
                 row.state_change_qty,
-                row.state_change_identifier,
+                row.state_change_identifier or LOW_STATECHANGE_ULID,
                 deserialized_data,
             )
         else:

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS state_changes (
 DB_CREATE_SNAPSHOT = """
 CREATE TABLE IF NOT EXISTS state_snapshot (
     identifier ULID PRIMARY KEY NOT NULL,
-    statechange_id ULID NOT NULL,
+    statechange_id ULID UNIQUE,
     statechange_qty INTEGER,
     data JSON,
     timestamp TIMESTAMP DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) NOT NULL,

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -5,6 +5,7 @@ import structlog
 
 from raiden.storage.serialization import DictSerializer
 from raiden.storage.sqlite import (
+    HIGH_STATECHANGE_ULID,
     LOW_STATECHANGE_ULID,
     Range,
     SerializedSQLiteStorage,
@@ -27,14 +28,17 @@ from raiden.utils.typing import (
 log = structlog.get_logger(__name__)
 
 
-def restore_to_state_change(
-    transition_function: Callable,
-    storage: SerializedSQLiteStorage,
-    state_change_identifier: StateChangeID,
-    node_address: Address,
-) -> Tuple[int, int, "WriteAheadLog"]:
-    chain_state: Optional[State]
-    from_identifier: StateChangeID
+def restore_or_init_snapshot(
+    storage: SerializedSQLiteStorage, node_address: Address, initial_state: State
+) -> Tuple[State, StateChangeID, int]:
+    """ Restore the latest snapshot.
+
+    Returns the ULID of the state change that is not applied and the
+    accumulated number of state_changes applied to this snapshot so far.  If
+    there is no snapshot the state will be primed with `initial_state`.
+    """
+
+    state_change_identifier = HIGH_STATECHANGE_ULID
 
     snapshot = storage.get_snapshot_before_state_change(
         state_change_identifier=state_change_identifier
@@ -42,42 +46,86 @@ def restore_to_state_change(
 
     if snapshot is not None:
         log.debug(
-            "Restoring from snapshot",
+            "Snapshot found",
             from_state_change_id=snapshot.state_change_identifier,
             to_state_change_id=state_change_identifier,
             node=to_checksum_address(node_address),
         )
-        from_identifier = snapshot.state_change_identifier
-        chain_state = snapshot.data
-        state_change_qty = snapshot.state_change_qty
+        return (snapshot.data, snapshot.state_change_identifier, snapshot.state_change_qty)
     else:
         log.debug(
-            "No snapshot found, replaying all state changes",
+            "No snapshot found, initializing the node state",
             to_state_change_id=state_change_identifier,
             node=to_checksum_address(node_address),
         )
-        from_identifier = LOW_STATECHANGE_ULID
-        chain_state = None
-        state_change_qty = 0
+        # The initial state must be saved to preserve the state of the PRNG
+        storage.write_first_state_snapshot(initial_state)
+        return (initial_state, LOW_STATECHANGE_ULID, 0)
 
-    state_manager = StateManager(transition_function, chain_state)
-    wal = WriteAheadLog(state_manager, storage)
+
+def replay_unapplied_state_changes(
+    transition_function: Callable,
+    storage: SerializedSQLiteStorage,
+    unapplied_state_changes_range: Range,
+    node_address: Address,
+    state_snapshot: State,
+) -> Tuple[int, State]:
+    """Applies the state changes in the range `unapplied_state_changes_range`
+    into the `snapshot_state`.
+    """
+
+    unapplied_state_changes = storage.get_statechanges_by_range(unapplied_state_changes_range)
+
+    log.debug(
+        "Replaying state changes",
+        replayed_state_changes=[
+            redact_secret(DictSerializer.serialize(state_change))
+            for state_change in unapplied_state_changes
+        ],
+        node=to_checksum_address(node_address),
+    )
+
+    state_manager = StateManager(transition_function, state_snapshot, unapplied_state_changes)
+
+    return (len(unapplied_state_changes), state_manager.current_state)
+
+
+def restore_state(
+    transition_function: Callable,
+    storage: SerializedSQLiteStorage,
+    state_change_identifier: StateChangeID,
+    node_address: Address,
+) -> Optional[State]:
+    snapshot = storage.get_snapshot_before_state_change(
+        state_change_identifier=state_change_identifier
+    )
+
+    if snapshot is None:
+        return None
+
+    log.debug(
+        "Snapshot found",
+        from_state_change_id=snapshot.state_change_identifier,
+        to_state_change_id=state_change_identifier,
+        node=to_checksum_address(node_address),
+    )
 
     unapplied_state_changes = storage.get_statechanges_by_range(
-        Range(from_identifier, state_change_identifier)
+        Range(snapshot.state_change_identifier, state_change_identifier)
     )
-    if unapplied_state_changes:
-        log.debug(
-            "Replaying state changes",
-            replayed_state_changes=[
-                redact_secret(DictSerializer.serialize(state_change))
-                for state_change in unapplied_state_changes
-            ],
-            node=to_checksum_address(node_address),
-        )
-        wal.state_manager.dispatch(unapplied_state_changes)
 
-    return state_change_qty, len(unapplied_state_changes), wal
+    log.debug(
+        "Replaying state changes",
+        replayed_state_changes=[
+            redact_secret(DictSerializer.serialize(state_change))
+            for state_change in unapplied_state_changes
+        ],
+        node=to_checksum_address(node_address),
+    )
+
+    state_manager = StateManager(transition_function, snapshot.data, unapplied_state_changes)
+
+    return state_manager.current_state
 
 
 ST = TypeVar("ST", bound=State)
@@ -99,7 +147,7 @@ class WriteAheadLog(Generic[ST]):
     saved_state: SavedState[ST]
 
     def __init__(self, state_manager: StateManager[ST], storage: SerializedSQLiteStorage) -> None:
-        self.state_manager = state_manager
+        self._state_manager = state_manager
         self.storage = storage
 
         # The state changes must be applied in the same order as they are saved
@@ -121,7 +169,7 @@ class WriteAheadLog(Generic[ST]):
         with self._lock:
             all_state_change_ids = self.storage.write_state_changes(state_changes)
 
-            latest_state, all_events = self.state_manager.dispatch(state_changes)
+            latest_state, all_events = self._state_manager.dispatch(state_changes)
             latest_state_change_id = all_state_change_ids[-1]
 
             # The update must be done with a single operation, to make sure
@@ -146,12 +194,16 @@ class WriteAheadLog(Generic[ST]):
         restart or a crash.
         """
         with self._lock:
-            current_state = self.state_manager.current_state
+            current_state = self._state_manager.current_state
             state_change_id = self.saved_state.state_change_id
 
             # otherwise no state change was dispatched
             if state_change_id and current_state is not None:
                 self.storage.write_state_snapshot(current_state, state_change_id, statechange_qty)
+
+    def get_current_state(self) -> ST:
+        """Returns a copy of the current node state."""
+        return self._state_manager.current_state
 
     @property
     def version(self) -> RaidenDBVersion:

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -470,7 +470,7 @@ def test_secret_revealed_on_chain(
         balance_proof=balance_proof,
         triggered_by_block_hash=app0.raiden.rpc_client.blockhash_from_blocknumber("latest"),
     )
-    current_state = app2.raiden.wal.state_manager.current_state
+    current_state = app2.raiden.wal.get_current_state()
     app2.raiden.raiden_event_handler.on_raiden_event(
         raiden=app2.raiden, chain_state=current_state, event=channel_close_event
     )

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -327,9 +327,6 @@ def test_batch_unlock(
     alice_initial_balance = token_proxy.balance_of(alice_app.raiden.address)
     bob_initial_balance = token_proxy.balance_of(bob_app.raiden.address)
 
-    # Take snapshot before transfer
-    alice_app.raiden.snapshot()
-
     alice_to_bob_amount = 10
     identifier = 1
     secret = Secret(keccak(bob_address))

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -338,7 +338,7 @@ def test_matrix_message_retry(
     queueid = QueueIdentifier(
         recipient=partner_address, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
     )
-    chain_state = raiden_service.wal.state_manager.current_state
+    chain_state = raiden_service.wal.get_current_state()
 
     retry_queue: _RetryQueue = transport._get_retrier(partner_address)
     assert bool(retry_queue), "retry_queue not running"

--- a/raiden/tests/unit/storage/test_serialization.py
+++ b/raiden/tests/unit/storage/test_serialization.py
@@ -1,4 +1,3 @@
-import random
 from pathlib import Path
 
 import marshmallow
@@ -20,8 +19,8 @@ from raiden.transfer.events import (
     SendWithdrawRequest,
 )
 from raiden.transfer.identifiers import QueueIdentifier
-from raiden.transfer.state_change import ActionInitChain
-from raiden.utils.typing import BlockExpiration, BlockNumber, ChainID, Nonce, WithdrawAmount
+from raiden.transfer.state_change import Block
+from raiden.utils.typing import BlockExpiration, BlockGasLimit, BlockNumber, Nonce, WithdrawAmount
 
 
 def assert_roundtrip(field, value):
@@ -84,12 +83,10 @@ def test_events_loaded_from_storage_should_deserialize(tmp_path):
     # Satisfy the foreign-key constraint for state change ID
     ids = storage.write_state_changes(
         [
-            ActionInitChain(
-                pseudo_random_generator=random.Random(),
+            Block(
                 block_number=BlockNumber(1),
+                gas_limit=BlockGasLimit(1),
                 block_hash=factories.make_block_hash(),
-                our_address=factories.make_address(),
-                chain_id=ChainID(1),
             )
         ]
     )

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -114,7 +114,7 @@ def test_handle_contract_send_channelunlock_already_unlocked():
 
     # This should not throw an unrecoverable error
     RaidenEventHandler().on_raiden_event(
-        raiden=raiden, chain_state=raiden.wal.state_manager.current_state, event=event
+        raiden=raiden, chain_state=raiden.wal.get_current_state(), event=event
     )
 
 
@@ -175,7 +175,7 @@ def test_pfs_handler_handle_routefailed_with_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_event(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             event=route_failed_event,
         )
     assert pfs_feedback_handler.called
@@ -201,7 +201,7 @@ def test_pfs_handler_handle_routefailed_without_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_event(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             event=route_failed_event,
         )
     assert not pfs_feedback_handler.called
@@ -235,7 +235,7 @@ def test_pfs_handler_handle_paymentsentsuccess_with_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_event(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             event=route_failed_event,
         )
     assert pfs_feedback_handler.called
@@ -277,7 +277,7 @@ def test_pfs_handler_handle_paymentsentsuccess_without_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_event(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             event=route_failed_event,
         )
     assert not pfs_feedback_handler.called

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -17,8 +17,9 @@ from raiden.messages.withdraw import WithdrawConfirmation, WithdrawExpired, With
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.tests.utils import factories
-from raiden.transfer import state, state_change
+from raiden.transfer import state
 from raiden.utils.signer import LocalSigner
+from raiden.utils.typing import BlockNumber, ChainID
 
 # Required for test_message_identical. It would be better to have a set of
 # messages that don't depend on randomness for that test. But right now, we
@@ -208,8 +209,8 @@ def test_serialization_networkx_graph():
     assert instance.graph.edges == restored_instance.graph.edges
 
 
-def test_actioninitchain_restore():
-    """ ActionInitChain *must* restore the previous pseudo random generator
+def test_chainstate_restore():
+    """ ChainState *must* restore the previous pseudo random generator
     state.
 
     Message identifiers are used for confirmation messages, e.g. delivered and
@@ -225,36 +226,12 @@ def test_actioninitchain_restore():
     will not match the previous IDs and the message queues won't be properly
     cleared up.
     """
-    pseudo_random_generator = random.Random()
-    block_number = 577
-    our_address = factories.make_address()
-    chain_id = 777
-
-    original_obj = state_change.ActionInitChain(
-        pseudo_random_generator=pseudo_random_generator,
-        block_number=block_number,
-        block_hash=factories.make_block_hash(),
-        our_address=our_address,
-        chain_id=chain_id,
-    )
-
-    decoded_obj = JSONSerializer.deserialize(JSONSerializer.serialize(original_obj))
-
-    assert original_obj == decoded_obj
-
-
-def test_chainstate_restore():
-    pseudo_random_generator = random.Random()
-    block_number = 577
-    our_address = factories.make_address()
-    chain_id = 777
-
     original_obj = state.ChainState(
-        pseudo_random_generator=pseudo_random_generator,
-        block_number=block_number,
+        pseudo_random_generator=random.Random(),
+        block_number=BlockNumber(10),
         block_hash=factories.make_block_hash(),
-        our_address=our_address,
-        chain_id=chain_id,
+        our_address=factories.make_address(),
+        chain_id=ChainID(777),
     )
 
     decoded_obj = JSONSerializer.deserialize(JSONSerializer.serialize(original_obj))

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -15,7 +15,7 @@ from raiden.storage.sqlite import (
     StateChangeID,
 )
 from raiden.storage.utils import TimestampedEvent
-from raiden.storage.wal import WriteAheadLog, restore_to_state_change
+from raiden.storage.wal import WriteAheadLog, restore_state
 from raiden.tests.utils.factories import (
     make_address,
     make_block_hash,
@@ -45,16 +45,18 @@ class AccState(State):
 
 
 def state_transtion_acc(state, state_change):
-    state = state or AccState()
+    state = state
     state.state_changes.append(state_change)
     return TransitionResult(state, list())
 
 
 def new_wal(state_transition: Callable, state: State = None) -> WriteAheadLog:
     serializer = JSONSerializer()
+    state = state or Empty()
 
-    state_manager = StateManager(state_transition, state)
+    state_manager = StateManager(state_transition, state, [])
     storage = SerializedSQLiteStorage(":memory:", serializer)
+    storage.write_first_state_snapshot(state)
     wal = WriteAheadLog(state_manager, storage)
     return wal
 
@@ -168,7 +170,7 @@ def test_write_read_events():
 
 
 def test_restore_without_snapshot():
-    wal = new_wal(state_transition_noop)
+    wal = new_wal(state_transition_noop, AccState())
 
     block1 = Block(block_number=5, gas_limit=1, block_hash=make_transaction_hash())
     wal.log_and_dispatch([block1])
@@ -179,38 +181,36 @@ def test_restore_without_snapshot():
     block3 = Block(block_number=8, gas_limit=1, block_hash=make_transaction_hash())
     wal.log_and_dispatch([block3])
 
-    _, _, newwal = restore_to_state_change(
+    aggregate = restore_state(
         transition_function=state_transtion_acc,
         storage=wal.storage,
         state_change_identifier=HIGH_STATECHANGE_ULID,
         node_address=make_address(),
     )
 
-    aggregate = newwal.state_manager.current_state
     assert aggregate.state_changes == [block1, block2, block3]
 
 
 def test_restore_without_snapshot_in_batches():
-    wal = new_wal(state_transition_noop)
+    wal = new_wal(state_transition_noop, AccState())
 
     block1 = Block(block_number=5, gas_limit=1, block_hash=make_transaction_hash())
     block2 = Block(block_number=7, gas_limit=1, block_hash=make_transaction_hash())
     block3 = Block(block_number=8, gas_limit=1, block_hash=make_transaction_hash())
     wal.log_and_dispatch([block1, block2, block3])
 
-    _, _, newwal = restore_to_state_change(
+    aggregate = restore_state(
         transition_function=state_transtion_acc,
         storage=wal.storage,
         state_change_identifier=HIGH_STATECHANGE_ULID,
         node_address=make_address(),
     )
 
-    aggregate = newwal.state_manager.current_state
     assert aggregate.state_changes == [block1, block2, block3]
 
 
 def test_get_snapshot_before_state_change() -> None:
-    wal = new_wal(state_transtion_acc)
+    wal = new_wal(state_transtion_acc, AccState())
 
     block1 = Block(
         block_number=BlockNumber(5), gas_limit=BlockGasLimit(1), block_hash=make_block_hash()

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -27,7 +27,6 @@ from raiden.utils.typing import (
     Locksroot,
     MessageID,
     Nonce,
-    Optional,
     Signature,
     T_Address,
     T_BlockHash,
@@ -228,20 +227,27 @@ class StateManager(Generic[ST]):
 
     def __init__(
         self,
-        state_transition: Callable[[Optional[ST], StateChange], TransitionResult[ST]],
-        current_state: Optional[ST],
+        state_transition: Callable[[ST, StateChange], TransitionResult[ST]],
+        current_state: ST,
+        unapplied_state_changes: List[StateChange],
     ) -> None:
         """ Initialize the state manager.
 
         Args:
             state_transition: function that can apply a StateChange message.
             current_state: current application state.
+            unapplied_state_changes: state changes that should be applied
+            during initialization because they are not part of the
+            `current_state`.
         """
         if not callable(state_transition):  # pragma: no unittest
             raise ValueError("state_transition must be a callable")
 
         self.state_transition = state_transition
         self.current_state = current_state
+
+        if unapplied_state_changes:
+            self.dispatch(unapplied_state_changes)
 
     def dispatch(self, state_changes: List[StateChange]) -> Tuple[ST, List[List[Event]]]:
         """ Apply the `state_change` in the current machine and return the
@@ -268,7 +274,7 @@ class StateManager(Generic[ST]):
         # Update the current state by applying the state changes
         events: List[List[Event]] = list()
         for state_change in state_changes:
-            iteration = self.state_transition(next_state, state_change)
+            iteration = self.state_transition(self.current_state, state_change)
 
             assert isinstance(iteration, TransitionResult)
             assert all(isinstance(e, Event) for e in iteration.events)

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 from dataclasses import dataclass, field
-from random import Random
 
 from raiden.constants import EMPTY_SECRETHASH
 from raiden.settings import MediationFeeConfig
@@ -37,7 +36,6 @@ from raiden.utils.typing import (
     SecretRegistryAddress,
     Signature,
     T_Address,
-    T_BlockHash,
     T_BlockNumber,
     T_Secret,
     T_SecretHash,
@@ -145,20 +143,6 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
     @property
     def token_network_address(self) -> TokenNetworkAddress:
         return self.canonical_identifier.token_network_address
-
-
-@dataclass(frozen=True)
-class ActionInitChain(StateChange):
-    pseudo_random_generator: Random = field(compare=False)
-    block_number: BlockNumber
-    block_hash: BlockHash
-    our_address: Address
-    chain_id: ChainID
-
-    def __post_init__(self) -> None:
-        typecheck(self.block_number, T_BlockNumber)
-        typecheck(self.block_hash, T_BlockHash)
-        typecheck(self.chain_id, int)
 
 
 @dataclass(frozen=True)

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -77,8 +77,7 @@ def count_token_network_channels(
 
 def state_from_raiden(raiden: "RaidenService") -> ChainState:  # pragma: no unittest
     assert raiden.wal, "raiden.wal not set"
-    # TODO: current_state should not be optional
-    return raiden.wal.state_manager.current_state  # type: ignore
+    return raiden.wal.get_current_state()
 
 
 def state_from_app(app: "App") -> ChainState:  # pragma: no unittest
@@ -296,6 +295,7 @@ def get_channelstate_by_canonical_identifier(
     chain_state: ChainState, canonical_identifier: CanonicalIdentifier
 ) -> Optional[NettingChannelState]:
     """ Return the NettingChannelState if it exists, None otherwise. """
+
     token_network = get_token_network_by_address(
         chain_state, canonical_identifier.token_network_address
     )

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -281,7 +281,7 @@ def transfer_and_assert_successful(
 
     assert response is not None
     is_json = response.headers["Content-Type"] == "application/json"
-    assert is_json, response.headers["Content-Type"]
+    assert is_json, (response.headers["Content-Type"], response.text)
     assert response.status_code == HTTPStatus.OK, response.json()
 
     log.debug("Payment done", url=post_url, json=json, time=elapsed)


### PR DESCRIPTION



    Make State required

    Changes the type signature of the `StateManager` to require an initial
    state, this removes lots of checks for `None` from the code, since now
    it is know there is always a state set in the manager.