### PR TITLE
Big event fetches done in batches.

### DIFF
--- a/raiden/blockchain/filters.py
+++ b/raiden/blockchain/filters.py
@@ -7,7 +7,7 @@ from web3.utils.abi import filter_by_type
 from web3.utils.events import get_event_data
 from web3.utils.filters import construct_event_filter_params
 
-from raiden.constants import GENESIS_BLOCK_NUMBER
+from raiden.constants import FILTER_MAX_BLOCK_RANGE, GENESIS_BLOCK_NUMBER
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     ABI,
@@ -25,12 +25,6 @@ from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
 from raiden_contracts.contract_manager import ContractManager
 
 log = structlog.get_logger(__name__)
-
-# The maximum block range to query in a single filter query
-# Helps against timeout errors that occur if you query a filter for
-# the mainnet from Genesis to latest head as we see in:
-# https://github.com/raiden-network/raiden/issues/3558
-FILTER_MAX_BLOCK_RANGE = 100_000
 
 
 def get_filter_args_for_specific_event_from_channel(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from raiden.raiden_service import RaidenService  # noqa: F401
 
 
-def after_new_token_network_create_filter(
+def on_new_token_network_create_filter(
     raiden: "RaidenService", state_change: ContractReceiveNewTokenNetwork
 ) -> None:
     """ Handles the creation of a new token network.
@@ -87,11 +87,7 @@ def after_new_deposit_join_network(
 
 
 def after_blockchain_statechange(raiden: "RaidenService", state_change: StateChange) -> None:
-    if type(state_change) == ContractReceiveNewTokenNetwork:
-        assert isinstance(state_change, ContractReceiveNewTokenNetwork), MYPY_ANNOTATION
-        after_new_token_network_create_filter(raiden, state_change)
-
-    elif type(state_change) == ContractReceiveChannelNew:
+    if type(state_change) == ContractReceiveChannelNew:
         assert isinstance(state_change, ContractReceiveChannelNew), MYPY_ANNOTATION
         after_new_channel_start_healthcheck(raiden, state_change)
 

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -84,6 +84,12 @@ STATE_PRUNING_AFTER_BLOCKS = 64
 STATE_PRUNING_SAFETY_MARGIN = 8
 NO_STATE_QUERY_AFTER_BLOCKS = STATE_PRUNING_AFTER_BLOCKS - STATE_PRUNING_SAFETY_MARGIN
 
+# The maximum block range to query in a single filter query
+# Helps against timeout errors that occur if you query a filter for
+# the mainnet from Genesis to latest head as we see in:
+# https://github.com/raiden-network/raiden/issues/3558
+FILTER_MAX_BLOCK_RANGE = 100_000
+
 NULL_ADDRESS_BYTES = bytes(20)
 NULL_ADDRESS_HEX = to_checksum_address(NULL_ADDRESS_BYTES)
 


### PR DESCRIPTION
The first run can take a bit of time, depending on the number of token
networks registered and when the original registry smart contract was
deployed. This does not improve how long it takes to synchronize with
these old and full registries, but it does make sure that while doing
so, less memory is used, and the work is not lost if the node is
restarted.

This was achieve by using the same approach from the StatelessFilter, in
there the queries are done in batches to avoid timeouts while doing the
request, in the first run this can be used to limit the number of state
changes that are currently held in memory. In order to make sure the
batches of the RaidenService and the underlying filters are alined, the
same constant for the batch size was used.

This does fix one bug, the issue #4498 fixed the problem of not fetching
the events from a newly registered token network on the same batch, but
only for the initialiation and without taking into account the
recoverability. This fixes that bug in a general way, by handling this
corner case in the `synchronize_to_confirmed_block_in_batches` method.
Once that method returns it is known that all events for all the smart
contracts of interest have been handled. And on an event of a crash it
is safe to use the block number from the state machine.

Note that this does not solve the above problem in general, only for
newly registered token networks. The problem in general is a bit harder
since potentially there may be many layers of smart contracts, when
there is a tree of smart contracts that would have to be recursively
followed. The general case would require a form of recursion to handle
all cases