### PR TITLE
Adding a wait of 5s before stopping the API

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -493,7 +493,13 @@ class APIServer(Runnable):  # pragma: no unittest
         )
 
         if self.wsgiserver is not None:
-            self.wsgiserver.stop()
+            # It is very important to have a timeout here, the existing endpoints only return
+            # once the operation is completed, which for a deposit it means waiting for the
+            # transaction to be mined and confirmed, which can potentially take a few minutes.
+            # If a timeout is not provided here, that would lead to a very and unpredictable
+            # shutdown timeout, which leads to problems with our scenario player tooling.
+
+            self.wsgiserver.stop(timeout=5)
             self.wsgiserver = None
 
         log.debug(


### PR DESCRIPTION
## Description

Partly fixes: #5472 
It is very important to have a timeout when stopping the wsgiserver, the existing endpoints only return once the operation is completed, which for a deposit it means waiting for the transaction to be mined and confirmed, which can potentially take a few minutes. If a timeout is not provided here, that would lead to a very and unpredictable shutdown timeout, which leads to problems with our scenario player tooling.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
