### PR TITLE
Better pfs error msgs

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -135,7 +135,7 @@ def initiator_init(
         lock_timeout=lock_timeout,
     )
 
-    pfs_msg, routes, feedback_token = routing.get_best_routes(
+    error_msg, routes, feedback_token = routing.get_best_routes(
         chain_state=views.state_from_raiden(raiden),
         token_network_address=token_network_address,
         one_to_n_address=raiden.default_one_to_n_address,
@@ -152,7 +152,7 @@ def initiator_init(
         for route_state in routes:
             raiden.route_to_feedback_token[tuple(route_state.route)] = feedback_token
 
-    return pfs_msg, ActionInitInitiator(transfer_state, routes)
+    return error_msg, ActionInitInitiator(transfer_state, routes)
 
 
 def mediator_init(raiden: "RaidenService", transfer: LockedTransfer) -> ActionInitMediator:
@@ -1215,7 +1215,7 @@ class RaidenService(Runnable):
             )
             self.targets_to_identifiers_to_statuses[target][identifier] = payment_status
 
-        pfs_msg, init_initiator_statechange = initiator_init(
+        error_msg, init_initiator_statechange = initiator_init(
             raiden=self,
             transfer_identifier=identifier,
             transfer_amount=amount,
@@ -1228,7 +1228,7 @@ class RaidenService(Runnable):
 
         # FIXME: Dispatch the state change even if there are no routes to
         # create the wal entry.
-        if pfs_msg is None:
+        if error_msg is None:
             self.handle_and_track_state_changes([init_initiator_statechange])
         else:
             failed = EventPaymentSentFailed(
@@ -1236,7 +1236,7 @@ class RaidenService(Runnable):
                 token_network_address=token_network_address,
                 identifier=identifier,
                 target=target,
-                reason=pfs_msg,
+                reason=error_msg,
             )
             payment_status.payment_done.set(failed)
 

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from heapq import heappop, heappush
 from uuid import UUID
 
@@ -29,12 +28,6 @@ from raiden.utils.typing import (
 )
 
 log = structlog.get_logger(__name__)
-
-
-class ErrorDirectChannel(Enum):
-    NONE = None
-    CLOSED = "closed"
-    NO_CAPACITY = "no capacity"
 
 
 def get_best_routes(
@@ -86,13 +79,13 @@ def get_best_routes(
         ]:
             channel_state = token_network.channelidentifiers_to_channels[channel_id]
 
-            # direct channels dont have fees
+            # direct channels don't have fees
             payment_with_fee_amount = PaymentWithFeeAmount(amount)
             is_usable = channel.is_channel_usable_for_new_transfer(
                 channel_state, payment_with_fee_amount, None
             )
 
-            if is_usable is channel.IsChannelUsable.YES:
+            if is_usable is channel.ChannelUsability.USABLE:
                 direct_route = RouteState(
                     route=[Address(from_address), Address(to_address)],
                     forward_channel_id=channel_state.canonical_identifier.channel_identifier,

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -93,6 +93,11 @@ def get_best_routes(
         )
 
         if not pfs_erro_msg:
+            # As of version 0.5 it is possible for the PFS to return an empty
+            # list of routes without an error message.
+            if not pfs_routes:
+                return ("PFS could not find any routes", list(), None)
+
             log.info(
                 "Received route(s) from PFS", routes=pfs_routes, feedback_token=pfs_feedback_token
             )

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -1,5 +1,5 @@
+from enum import Enum
 from heapq import heappop, heappush
-from typing import List, Tuple
 from uuid import UUID
 
 import networkx
@@ -18,14 +18,23 @@ from raiden.utils.typing import (
     ChannelID,
     FeeAmount,
     InitiatorAddress,
+    List,
     NamedTuple,
     Optional,
     PaymentAmount,
+    PaymentWithFeeAmount,
     TargetAddress,
     TokenNetworkAddress,
+    Tuple,
 )
 
 log = structlog.get_logger(__name__)
+
+
+class ErrorDirectChannel(Enum):
+    NONE = None
+    CLOSED = "closed"
+    NO_CAPACITY = "no capacity"
 
 
 def get_best_routes(
@@ -40,47 +49,124 @@ def get_best_routes(
     privkey: bytes,
 ) -> Tuple[Optional[str], List[RouteState], Optional[UUID]]:
 
-    is_direct_partner = to_address in views.all_neighbour_nodes(chain_state)
-    can_use_pfs = pfs_config is not None and one_to_n_address is not None
+    token_network = views.get_token_network_by_address(chain_state, token_network_address)
+    assert token_network, "The token network must be validated and exist."
 
-    log.debug(
-        "Getting route for payment",
-        source=to_checksum_address(from_address),
-        target=to_checksum_address(to_address),
-        amount=amount,
-        target_is_direct_partner=is_direct_partner,
-        can_use_pfs=can_use_pfs,
-    )
-
-    # the pfs should not be requested when the target is linked via a direct channel
-    if is_direct_partner:
-        internal_routes = get_best_routes_internal(
-            chain_state=chain_state,
-            token_network_address=token_network_address,
-            from_address=from_address,
-            to_address=to_address,
+    try:
+        # networkx returns a generator, consume the result since it will be
+        # iterated over multiple times.
+        all_neighbors = list(
+            networkx.all_neighbors(token_network.network_graph.network, from_address)
+        )
+    except networkx.NetworkXError:
+        # If `our_address` is not in the graph, no channels opened with the
+        # address.
+        log.debug(
+            "Node does not have a channel in the requested token network.",
+            source=to_checksum_address(from_address),
+            target=to_checksum_address(to_address),
             amount=amount,
-            previous_address=previous_address,
         )
-        channel_state = views.get_channelstate_by_token_network_and_partner(
-            chain_state=chain_state,
-            token_network_address=token_network_address,
-            partner_address=Address(to_address),
-        )
+        return ("Node does not have a channel in the requested token network.", list(), None)
 
-        for route_state in internal_routes:
-            if to_address == route_state.next_hop_address and (
-                channel_state
-                # other conditions about e.g. channel state are checked in best routes internal
-                and channel.get_distributable(
-                    sender=channel_state.our_state, receiver=channel_state.partner_state
+    error_closed = 0
+    error_no_route = 0
+    error_no_capacity = 0
+    error_direct = None
+    shortest_routes: List[Neighbour] = list()
+
+    # Always use a direct channel if available:
+    # - There are no race conditions and the capacity is guaranteed to be
+    #   available.
+    # - There will be no mediation fees
+    # - The transfer will be faster
+    if to_address in all_neighbors:
+        for channel_id in token_network.partneraddresses_to_channelidentifiers[
+            Address(to_address)
+        ]:
+            channel_state = token_network.channelidentifiers_to_channels[channel_id]
+
+            # direct channels dont have fees
+            payment_with_fee_amount = PaymentWithFeeAmount(amount)
+            is_usable = channel.is_channel_usable_for_new_transfer(
+                channel_state, payment_with_fee_amount, None
+            )
+
+            if is_usable is channel.IsChannelUsable.YES:
+                direct_route = RouteState(
+                    route=[Address(from_address), Address(to_address)],
+                    forward_channel_id=channel_state.canonical_identifier.channel_identifier,
+                    estimated_fee=FeeAmount(0),
                 )
-                >= amount
-            ):
-                return (None, [route_state], None)
+                return (None, [direct_route], None)
+
+            error_direct = is_usable
+
+    for partner_address in all_neighbors:
+        for channel_id in token_network.partneraddresses_to_channelidentifiers[partner_address]:
+            channel_state = token_network.channelidentifiers_to_channels[channel_id]
+
+            if channel.get_status(channel_state) != ChannelState.STATE_OPENED:
+                error_closed += 1
+                continue
+
+            try:
+                route = networkx.shortest_path(
+                    token_network.network_graph.network, partner_address, to_address
+                )
+            except (networkx.NetworkXNoPath, networkx.NodeNotFound):
+                error_no_route += 1
+            else:
+                distributable = channel.get_distributable(
+                    channel_state.our_state, channel_state.partner_state
+                )
+
+                if distributable < amount:
+                    error_no_capacity += 1
+                else:
+                    nonrefundable = amount > channel.get_distributable(
+                        channel_state.partner_state, channel_state.our_state
+                    )
+
+                    # The complete route includes the initiator, add it to the beginning
+                    complete_route = [Address(from_address)] + route
+                    neighbour = Neighbour(
+                        length=len(route),
+                        nonrefundable=nonrefundable,
+                        partner_address=partner_address,
+                        channelid=channel_state.identifier,
+                        route=complete_route,
+                    )
+                    heappush(shortest_routes, neighbour)
+
+    if not shortest_routes:
+        qty_channels = sum(
+            len(token_network.partneraddresses_to_channelidentifiers[partner_address])
+            for partner_address in all_neighbors
+        )
+        error_msg = (
+            f"None of the existing channels could be used to complete the "
+            f"transfer. From the {qty_channels} existing channels. "
+            f"{error_closed} are closed. {error_no_route} don't have a route to "
+            f"the target in the given token network. {error_no_capacity} don't "
+            f"have enough capacity for the requested transfer."
+        )
+        if error_direct is not None:
+            error_msg += "direct channel {error_direct}."
+
+        log.warning(
+            "None of the existing channels could be used to complete the transfer",
+            from_address=to_checksum_address(from_address),
+            to_address=to_checksum_address(to_address),
+            error_closed=error_closed,
+            error_no_route=error_no_route,
+            error_no_capacity=error_no_capacity,
+            error_direct=error_direct,
+        )
+        return (error_msg, list(), None)
 
     if pfs_config is not None and one_to_n_address is not None:
-        pfs_erro_msg, pfs_routes, pfs_feedback_token = get_best_routes_pfs(
+        pfs_error_msg, pfs_routes, pfs_feedback_token = get_best_routes_pfs(
             chain_state=chain_state,
             token_network_address=token_network_address,
             one_to_n_address=one_to_n_address,
@@ -92,7 +178,7 @@ def get_best_routes(
             privkey=privkey,
         )
 
-        if not pfs_erro_msg:
+        if not pfs_error_msg:
             # As of version 0.5 it is possible for the PFS to return an empty
             # list of routes without an error message.
             if not pfs_routes:
@@ -101,24 +187,37 @@ def get_best_routes(
             log.info(
                 "Received route(s) from PFS", routes=pfs_routes, feedback_token=pfs_feedback_token
             )
-            return (pfs_erro_msg, pfs_routes, pfs_feedback_token)
+            return (pfs_error_msg, pfs_routes, pfs_feedback_token)
 
         log.warning(
             "Request to Pathfinding Service was not successful. "
             "No routes to the target are found."
         )
-        return (pfs_erro_msg, list(), None)
+        return (pfs_error_msg, list(), None)
 
-    # else non-pfs so let's use internal routing
-    routes = get_best_routes_internal(
-        chain_state=chain_state,
-        token_network_address=token_network_address,
-        from_address=from_address,
-        to_address=to_address,
-        amount=amount,
-        previous_address=previous_address,
-    )
-    return (None, routes, None)
+    else:
+        available_routes = list()
+
+        while shortest_routes:
+            neighbour = heappop(shortest_routes)
+
+            # https://github.com/raiden-network/raiden/issues/4751
+            # Internal routing doesn't know how much fees the initiator will be charged,
+            # so it should set a percentage on top of the original amount
+            # for the whole route.
+            estimated_fee = FeeAmount(round(INTERNAL_ROUTING_DEFAULT_FEE_PERC * amount))
+            if neighbour.length == 1:  # Target is our direct neighbour, pay no fees.
+                estimated_fee = FeeAmount(0)
+
+            available_routes.append(
+                RouteState(
+                    route=neighbour.route,
+                    forward_channel_id=neighbour.channelid,
+                    estimated_fee=estimated_fee,
+                )
+            )
+
+        return (None, available_routes, None)
 
 
 class Neighbour(NamedTuple):
@@ -127,110 +226,6 @@ class Neighbour(NamedTuple):
     partner_address: Address
     channelid: ChannelID
     route: List[Address]
-
-
-def get_best_routes_internal(
-    chain_state: ChainState,
-    token_network_address: TokenNetworkAddress,
-    from_address: InitiatorAddress,
-    to_address: TargetAddress,
-    amount: int,
-    previous_address: Optional[Address],
-) -> List[RouteState]:
-    """ Returns a list of channels that can be used to make a transfer.
-
-    This will filter out channels that are not open and don't have enough
-    capacity.
-    """
-    # TODO: Route ranking.
-    # Rate each route to optimize the fee price/quality of each route and add a
-    # rate from in the range [0.0,1.0].
-
-    available_routes = list()
-
-    token_network = views.get_token_network_by_address(chain_state, token_network_address)
-
-    if not token_network:
-        return list()
-
-    neighbors_heap: List[Neighbour] = list()
-    try:
-        all_neighbors = networkx.all_neighbors(token_network.network_graph.network, from_address)
-    except networkx.NetworkXError:
-        # If `our_address` is not in the graph, no channels opened with the
-        # address
-        return list()
-
-    for partner_address in all_neighbors:
-        # don't send the message backwards
-        if partner_address == previous_address:
-            continue
-
-        channel_state = views.get_channelstate_by_token_network_and_partner(
-            chain_state, token_network_address, partner_address
-        )
-
-        if not channel_state:
-            continue
-
-        if channel.get_status(channel_state) != ChannelState.STATE_OPENED:
-            log.info(
-                "Channel is not opened, ignoring",
-                from_address=to_checksum_address(from_address),
-                partner_address=to_checksum_address(partner_address),
-                routing_source="Internal Routing",
-            )
-            continue
-
-        nonrefundable = amount > channel.get_distributable(
-            channel_state.partner_state, channel_state.our_state
-        )
-
-        try:
-            route = networkx.shortest_path(
-                token_network.network_graph.network, partner_address, to_address
-            )
-            neighbour = Neighbour(
-                length=len(route),
-                nonrefundable=nonrefundable,
-                partner_address=partner_address,
-                channelid=channel_state.identifier,
-                route=route,
-            )
-            heappush(neighbors_heap, neighbour)
-        except (networkx.NetworkXNoPath, networkx.NodeNotFound):
-            pass
-
-    if not neighbors_heap:
-        log.warning(
-            "No routes available",
-            from_address=to_checksum_address(from_address),
-            to_address=to_checksum_address(to_address),
-        )
-        return list()
-
-    while neighbors_heap:
-        neighbour = heappop(neighbors_heap)
-        # The complete route includes the initiator, add it to the beginning
-        complete_route = [Address(from_address)] + neighbour.route
-
-        # https://github.com/raiden-network/raiden/issues/4751
-        # Internal routing doesn't know how much fees the initiator will be charged,
-        # so it should set a percentage on top of the original amount
-        # for the whole route.
-        estimated_fee = FeeAmount(round(INTERNAL_ROUTING_DEFAULT_FEE_PERC * amount))
-        if neighbour.length == 1:  # Target is our direct neighbour, pay no fees.
-            estimated_fee = FeeAmount(0)
-
-        available_routes.append(
-            RouteState(
-                route=complete_route,
-                forward_channel_id=neighbour.channelid,
-                estimated_fee=estimated_fee,
-            )
-        )
-
-    return available_routes
 
 
 def get_best_routes_pfs(

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -842,7 +842,7 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         address4: NetworkState.REACHABLE,
     }
 
-    _, routes1, _ = get_best_routes(
+    error_msg, routes1, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -853,8 +853,9 @@ def test_routing_issue2663(chain_state, token_network_state, one_to_n_address, o
         pfs_config=None,
         privkey=b"",  # not used if pfs is not configured
     )
-    assert routes1[0].next_hop_address == address1
-    assert routes1[1].next_hop_address == address2
+    assert routes1, error_msg
+    assert routes1[0].next_hop_address == address1, error_msg
+    assert routes1[1].next_hop_address == address2, error_msg
 
     # test routing with node 2 offline
     chain_state.nodeaddresses_to_networkstates = {
@@ -1074,7 +1075,7 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         address3: NetworkState.REACHABLE,
     }
 
-    _, routes, _ = get_best_routes(
+    error_msg, routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -1085,8 +1086,9 @@ def test_routing_priority(chain_state, token_network_state, one_to_n_address, ou
         pfs_config=None,
         privkey=b"",
     )
-    assert routes[0].next_hop_address == address1
-    assert routes[1].next_hop_address == address2
+    assert routes, error_msg
+    assert routes[0].next_hop_address == address1, error_msg
+    assert routes[1].next_hop_address == address2, error_msg
 
     # number of hops overwrites refunding capacity (route over node 2 involves less hops)
     chain_state.nodeaddresses_to_networkstates = {
@@ -1191,7 +1193,7 @@ def test_internal_routing_mediation_fees(
     assert routes[0].estimated_fee == 0
 
     # Routing to our address2 through address1 would charge 2%
-    _, routes, _ = get_best_routes(
+    error_msg, routes, _ = get_best_routes(
         chain_state=chain_state,
         token_network_address=token_network_state.address,
         one_to_n_address=one_to_n_address,
@@ -1202,4 +1204,5 @@ def test_internal_routing_mediation_fees(
         pfs_config=None,
         privkey=b"",  # not used if pfs is not configured
     )
-    assert routes[0].estimated_fee == round(INTERNAL_ROUTING_DEFAULT_FEE_PERC * 50)
+    assert routes, error_msg
+    assert routes[0].estimated_fee == round(INTERNAL_ROUTING_DEFAULT_FEE_PERC * 50), error_msg

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -134,8 +134,8 @@ class UnlockGain(NamedTuple):
     from_partner_locks: TokenAmount
 
 
-class IsChannelUsable(Enum):
-    YES = True
+class ChannelUsability(Enum):
+    USABLE = True
     NOT_OPENED = "channel is not open"
     INVALID_SETTLE_TIMEOUT = "channel settle timeout is too low"
     CHANNEL_REACHED_PENDING_LIMIT = "channel reached limit of pending transfers"
@@ -220,14 +220,14 @@ def is_channel_usable_for_mediation(
         channel_state, transfer_amount, lock_timeout
     )
 
-    return channel_usable is IsChannelUsable.YES
+    return channel_usable is ChannelUsability.USABLE
 
 
 def is_channel_usable_for_new_transfer(
     channel_state: NettingChannelState,
     transfer_amount: PaymentWithFeeAmount,
     lock_timeout: Optional[BlockTimeout],
-) -> IsChannelUsable:
+) -> ChannelUsability:
     """True if the channel can be used to start a new transfer.
 
     This will make sure that:
@@ -261,24 +261,24 @@ def is_channel_usable_for_new_transfer(
     is_valid_settle_timeout = channel_state.settle_timeout >= channel_state.reveal_timeout * 2
 
     if get_status(channel_state) != ChannelState.STATE_OPENED:
-        return IsChannelUsable.NOT_OPENED
+        return ChannelUsability.NOT_OPENED
 
     if not is_valid_settle_timeout:
-        return IsChannelUsable.INVALID_SETTLE_TIMEOUT
+        return ChannelUsability.INVALID_SETTLE_TIMEOUT
 
     if pending_transfers >= MAXIMUM_PENDING_TRANSFERS:
-        return IsChannelUsable.CHANNEL_REACHED_PENDING_LIMIT
+        return ChannelUsability.CHANNEL_REACHED_PENDING_LIMIT
 
     if transfer_amount > distributable:
-        return IsChannelUsable.CHANNEL_DOESNT_HAVE_ENOUGH_DISTRIBUTABLE
+        return ChannelUsability.CHANNEL_DOESNT_HAVE_ENOUGH_DISTRIBUTABLE
 
     if not is_valid_amount(channel_state.our_state, transfer_amount):
-        return IsChannelUsable.CHANNEL_BALANCE_PROOF_WOULD_OVERFLOW
+        return ChannelUsability.CHANNEL_BALANCE_PROOF_WOULD_OVERFLOW
 
     if not lock_timeout_valid:
-        return IsChannelUsable.LOCKTIMEOUT_MISMATCH
+        return ChannelUsability.LOCKTIMEOUT_MISMATCH
 
-    return IsChannelUsable.YES
+    return ChannelUsability.USABLE
 
 
 def is_lock_pending(end_state: NettingChannelEndState, secrethash: SecretHash) -> bool:

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -267,7 +267,7 @@ def try_new_route(
             transfer_amount=amount_with_fee,
             lock_timeout=transfer_description.lock_timeout,
         )
-        if is_channel_usable is channel.IsChannelUsable.YES:
+        if is_channel_usable is channel.ChannelUsability.USABLE:
             channel_state = candidate_channel_state
             route_state = reachable_route_state
             break

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -267,7 +267,7 @@ def try_new_route(
             transfer_amount=amount_with_fee,
             lock_timeout=transfer_description.lock_timeout,
         )
-        if is_channel_usable:
+        if is_channel_usable is channel.IsChannelUsable.YES:
             channel_state = candidate_channel_state
             route_state = reachable_route_state
             break


### PR DESCRIPTION
    Extended routing error messages

    Now the node will always validate the transfer before doing a PFS
    request. If the node does not have channels that can even start the
    transfers, then an error is reported and the PFS is not requested, this
    includes:

    - If there are no channels open
    - If there are no channels with enough distributable to start to mediate
      the transfer (this assumes transfers are not split)
    - If there is no route to the target with any of the existing channels
      (this assumes the route will always be in the same token network).