### PR TITLE
Always return an error code if the node dies with an exception

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -470,7 +470,7 @@ class APIServer(Runnable):  # pragma: no unittest
             wsgiserver.init_socket()
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
-                raise APIServerPortInUseError()
+                raise APIServerPortInUseError(f"{self.config['host']}:{self.config['port']}")
             raise
 
         self.wsgiserver = wsgiserver

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -684,6 +684,7 @@ def run(ctx: Context, **kwargs: Any) -> None:
     except RaidenUnrecoverableError as ex:
         click.secho(f"FATAL: An un-recoverable error happen, Raiden is bailing {ex}", fg="red")
         write_stack_trace(ex)
+        sys.exit(ReturnCode.FATAL)
     except APIServerPortInUseError as ex:
         click.secho(
             f"ERROR: API Address {ex} is in use. Use --api-address <host:port> "


### PR DESCRIPTION
Without this, the orchestration tools cannot tell if the node is being
restarted or it crashed. This is a problem for the stress test and
scenario player.