### PR TITLE
Duplicate Scenarios for Ansible Testruns

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/bf1_basic_functionality.yaml

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/bf2_long_running.yaml

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/bf3_multi_directional_payment.yaml

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/bf4_multi_payments_same_node.yaml

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/bf5_join_and_leave.yaml

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/bf6_stress_hub_node.yaml

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/bf7_long_path.yaml

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/mfee1_flat_fee.yaml

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/mfee2_proportional_fees.yaml

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/mfee3_only_imbalance_fees.yaml

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/mfee4_combined_fees.yaml

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/ms1_simple_monitoring.yaml

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/ms2_simple_monitoring.yaml

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/ms3_simple_monitoring.yaml

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/ms4_udc_too_low.yaml

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs1_get_a_simple_path.yaml

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs2_simple_no_path.yaml

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs3_multiple_paths.yaml

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs4_use_best_path.yaml

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/pfs5_too_low_capacity.yaml

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp1/pfs6_simple_path_rewards.yaml

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs7_multiple_payments.yaml

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs8_mediator_goes_offline.yaml

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -1,0 +1,1 @@
+/home/nls/devel/raiden/raiden/tests/scenarios/ci/sp2/pfs9_partial_withdraw.yaml


### PR DESCRIPTION
Duplicates scenarios for Asnible-setup testing.
Scenarios are no longer divided up on the project level, and all scenarios are supplied by default in the docker container to run the nightlies. The distinction between sp1 and sp2 will therefore become deprecated and removed after migration is complete.
