### PR TITLE
Matrix small startup speedups

### DIFF
--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ from eth_keys.exceptions import BadSignature, ValidationError
 from eth_utils import decode_hex, to_canonical_address
 
 from raiden.exceptions import InvalidSignature
-from raiden.network.utils import get_http_rtt
+from raiden.network.utils import return_after_retries
 from raiden.utils.keys import privatekey_to_publickey
 from raiden.utils.signer import LocalSigner, Signer, recover
 from raiden.utils.signing import pack_data, sha3
@@ -72,7 +72,9 @@ def test_get_http_rtt_happy(requests_responses):
     requests_responses.add_callback(responses.GET, "http://url", callback=response)
     requests_responses.add_callback(responses.GET, "http://url", callback=response)
     requests_responses.add_callback(responses.GET, "http://url", callback=response)
-    assert round(get_http_rtt(url="http://url", method="get", samples=3), 1) == 0.1
+
+    result = return_after_retries(url="http://url", timeout=1, method="get", samples=3)
+    assert round(result[1], 1) == 0.1
 
 
 def test_get_http_rtt_ignore_failing(requests_responses):
@@ -80,15 +82,15 @@ def test_get_http_rtt_ignore_failing(requests_responses):
 
     # RequestException (e.g. DNS not resolvable, server not reachable)
     requests_responses.add(responses.GET, "http://url1", body=requests.RequestException())
-    assert get_http_rtt(url="http://url1", method="get") is None
+    assert return_after_retries(url="http://url1", timeout=1, method="get") is None
 
     # Server misconfigured
     requests_responses.add(responses.GET, "http://url2", status=404)
-    assert get_http_rtt(url="http://url2", method="get") is None
+    assert return_after_retries(url="http://url2", timeout=1, method="get") is None
 
     # Internal server error
     requests_responses.add(responses.GET, "http://url3", status=500)
-    assert get_http_rtt(url="http://url3", method="get") is None
+    assert return_after_retries(url="http://url3", timeout=1, method="get") is None
 
 
 def test_pack_data():


### PR DESCRIPTION
This does two changes:

- When starting up, instead of waiting for all servers to be ranked on RTT, it returns the fastest. The problem with the previous approach is that the function would always degrade to the slowest server, which adds latency.
- When starting up, first handle the inventory rooms, if the user has joined a broadcast room in the past, don't do it again since joining is a slow operation