### PR TITLE
Make config strongly typed

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -375,10 +375,10 @@ class RaidenAPI:  # pragma: no unittest
         with the given `token_address`.
         """
         if settle_timeout is None:
-            settle_timeout = self.raiden.config["settle_timeout"]
+            settle_timeout = self.raiden.config.settle_timeout
 
         if reveal_timeout is None:
-            reveal_timeout = self.raiden.config["reveal_timeout"]
+            reveal_timeout = self.raiden.config.reveal_timeout
 
         if reveal_timeout <= 0:
             raise InvalidRevealTimeout("reveal_timeout should be larger than zero")

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -400,14 +400,14 @@ class APIServer(Runnable):  # pragma: no unittest
 
             web3 = self.flask_app.config.get("WEB3_ENDPOINT")
             if "config." in file_name and file_name.endswith(".json"):
-                environment_type = self.rest_api.raiden_api.raiden.config[
-                    "environment_type"
-                ].name.lower()
+                environment_type = (
+                    self.rest_api.raiden_api.raiden.config.environment_type.name.lower()
+                )
                 config = {
                     "raiden": self._api_prefix,
                     "web3": web3,
-                    "settle_timeout": self.rest_api.raiden_api.raiden.config["settle_timeout"],
-                    "reveal_timeout": self.rest_api.raiden_api.raiden.config["reveal_timeout"],
+                    "settle_timeout": self.rest_api.raiden_api.raiden.config.settle_timeout,
+                    "reveal_timeout": self.rest_api.raiden_api.raiden.config.reveal_timeout,
                     "environment_type": environment_type,
                 }
 
@@ -549,7 +549,7 @@ class RestAPI:  # pragma: no unittest
     def register_token(
         self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress
     ) -> Response:
-        if self.raiden_api.raiden.config["environment_type"] == Environment.PRODUCTION:
+        if self.raiden_api.raiden.config.environment_type == Environment.PRODUCTION:
             return api_error(
                 errors="Registering a new token is currently disabled in production mode",
                 status_code=HTTPStatus.NOT_IMPLEMENTED,
@@ -593,7 +593,7 @@ class RestAPI:  # pragma: no unittest
         value: TokenAmount,
         contract_method: MintingMethod,
     ) -> Response:
-        if self.raiden_api.raiden.config["environment_type"] == Environment.PRODUCTION:
+        if self.raiden_api.raiden.config.environment_type == Environment.PRODUCTION:
             return api_error(
                 errors="Minting a token is currently disabled in production mode",
                 status_code=HTTPStatus.NOT_IMPLEMENTED,

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -22,16 +22,11 @@ from raiden.settings import (
     DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
     RAIDEN_CONTRACT_VERSION,
     MatrixTransportConfig,
+    RaidenConfig,
     ServiceConfig,
 )
 from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import (
-    BlockNumber,
-    Dict,
-    MonitoringServiceAddress,
-    OneToNAddress,
-    Optional,
-)
+from raiden.utils.typing import BlockNumber, MonitoringServiceAddress, OneToNAddress, Optional
 from raiden_contracts.contract_manager import contracts_precompiled_path
 
 log = structlog.get_logger(__name__)
@@ -68,7 +63,7 @@ class App:  # pylint: disable=too-few-public-methods
 
     def __init__(
         self,
-        config: Dict,
+        config: RaidenConfig,
         rpc_client: JSONRPCClient,
         proxy_manager: ProxyManager,
         query_start_block: BlockNumber,
@@ -104,9 +99,9 @@ class App:  # pylint: disable=too-few-public-methods
         settlement_timeout_min = default_registry.settlement_timeout_min("latest")
         settlement_timeout_max = default_registry.settlement_timeout_max("latest")
         invalid_settle_timeout = (
-            config["settle_timeout"] < settlement_timeout_min
-            or config["settle_timeout"] > settlement_timeout_max
-            or config["settle_timeout"] < config["reveal_timeout"] * 2
+            config.settle_timeout < settlement_timeout_min
+            or config.settle_timeout > settlement_timeout_max
+            or config.settle_timeout < config.reveal_timeout * 2
         )
         if invalid_settle_timeout:
             raise InvalidSettleTimeout(
@@ -117,7 +112,7 @@ class App:  # pylint: disable=too-few-public-methods
                     to_checksum_address(default_registry.address),
                     settlement_timeout_min,
                     settlement_timeout_max,
-                    config["settle_timeout"],
+                    config.settle_timeout,
                 )
             )
 

--- a/raiden/app.py
+++ b/raiden/app.py
@@ -1,6 +1,6 @@
 import structlog
 
-from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, RoutingMode
+from raiden.constants import RoutingMode
 from raiden.exceptions import InvalidSettleTimeout
 from raiden.message_handler import MessageHandler
 from raiden.network.proxies.proxy_manager import ProxyManager
@@ -12,55 +12,14 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.transport.matrix.transport import MatrixTransport
 from raiden.raiden_event_handler import EventHandler
 from raiden.raiden_service import RaidenService
-from raiden.settings import (
-    DEFAULT_BLOCKCHAIN_QUERY_INTERVAL,
-    DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
-    DEFAULT_REVEAL_TIMEOUT,
-    DEFAULT_SETTLE_TIMEOUT,
-    DEFAULT_SHUTDOWN_TIMEOUT,
-    DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
-    DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
-    RAIDEN_CONTRACT_VERSION,
-    MatrixTransportConfig,
-    RaidenConfig,
-    ServiceConfig,
-)
+from raiden.settings import RaidenConfig
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import BlockNumber, MonitoringServiceAddress, OneToNAddress, Optional
-from raiden_contracts.contract_manager import contracts_precompiled_path
 
 log = structlog.get_logger(__name__)
 
 
 class App:  # pylint: disable=too-few-public-methods
-    DEFAULT_CONFIG = {
-        "reveal_timeout": DEFAULT_REVEAL_TIMEOUT,
-        "settle_timeout": DEFAULT_SETTLE_TIMEOUT,
-        "contracts_path": contracts_precompiled_path(RAIDEN_CONTRACT_VERSION),
-        "database_path": "",
-        "transport_type": "matrix",
-        "blockchain": {
-            "confirmation_blocks": DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
-            "query_interval": DEFAULT_BLOCKCHAIN_QUERY_INTERVAL,
-        },
-        "transport": MatrixTransportConfig(
-            # None causes fetching from url in raiden.settings.py::DEFAULT_MATRIX_KNOWN_SERVERS
-            available_servers=[],
-            # TODO: Remove `PATH_FINDING_BROADCASTING_ROOM` when implementing #3735
-            #       and fix the conditional in `raiden.ui.app:_setup_matrix`
-            #       as well as the tests
-            broadcast_rooms=[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM],
-            retries_before_backoff=DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
-            retry_interval=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL,
-            server="auto",
-            server_name=None,
-        ),
-        "rpc": True,
-        "console": False,
-        "shutdown_timeout": DEFAULT_SHUTDOWN_TIMEOUT,
-        "services": ServiceConfig(),
-    }
-
     def __init__(
         self,
         config: RaidenConfig,

--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -366,9 +366,9 @@ def blockchainevent_to_statechange(
         )
 
         if new_channel_details is not None:
-            fee_config: MediationFeeConfig = raiden.config["mediation_fees"]
+            fee_config: MediationFeeConfig = raiden.config.mediation_fees
             channel_config = ChannelConfig(
-                reveal_timeout=raiden.config["reveal_timeout"],
+                reveal_timeout=raiden.config.reveal_timeout,
                 fee_schedule=FeeScheduleState(
                     cap_fees=fee_config.cap_meditation_fees,
                     flat=fee_config.get_flat_fee(new_channel_details.token_address),
@@ -384,13 +384,11 @@ def blockchainevent_to_statechange(
             state_changes.append(contractreceiveroutenew_from_event(event))
 
     elif event_name == ChannelEvent.DEPOSIT:
-        deposit = contractreceivechanneldeposit_from_event(event, raiden.config["mediation_fees"])
+        deposit = contractreceivechanneldeposit_from_event(event, raiden.config.mediation_fees)
         state_changes.append(deposit)
 
     elif event_name == ChannelEvent.WITHDRAW:
-        withdraw = contractreceivechannelwithdraw_from_event(
-            event, raiden.config["mediation_fees"]
-        )
+        withdraw = contractreceivechannelwithdraw_from_event(event, raiden.config.mediation_fees)
         state_changes.append(withdraw)
 
     elif event_name == ChannelEvent.BALANCE_PROOF_UPDATED:

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -267,8 +267,8 @@ class ConnectionManager:  # pragma: no unittest
                 raise
             except RaidenUnrecoverableError as e:
                 should_crash = (
-                    self.raiden.config["environment_type"] != Environment.PRODUCTION
-                    or self.raiden.config["unrecoverable_error_should_crash"]
+                    self.raiden.config.environment_type != Environment.PRODUCTION
+                    or self.raiden.config.unrecoverable_error_should_crash
                 )
                 if should_crash:
                     raise
@@ -355,8 +355,8 @@ class ConnectionManager:  # pragma: no unittest
             )
         except RaidenUnrecoverableError:
             should_crash = (
-                self.raiden.config["environment_type"] != Environment.PRODUCTION
-                or self.raiden.config["unrecoverable_error_should_crash"]
+                self.raiden.config.environment_type != Environment.PRODUCTION
+                or self.raiden.config.unrecoverable_error_should_crash
             )
             if should_crash:
                 raise

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -23,9 +23,9 @@ from raiden.utils.typing import (
     Any,
     BlockNumber,
     BlockSpecification,
+    BlockTimeout,
     ChainID,
     Dict,
-    FeeAmount,
     InitiatorAddress,
     List,
     OneToNAddress,
@@ -61,7 +61,7 @@ class PFSInfo:
 class PFSConfig:
     info: PFSInfo
     maximum_fee: TokenAmount
-    iou_timeout: BlockNumber
+    iou_timeout: BlockTimeout
     max_paths: int
 
 
@@ -168,7 +168,7 @@ def get_valid_pfs_url(
     service_registry: ServiceRegistry,
     index_in_service_registry: int,
     block_identifier: BlockSpecification,
-    pathfinding_max_fee: FeeAmount,
+    pathfinding_max_fee: TokenAmount,
 ) -> Optional[str]:
     """Returns the URL for the PFS identified by the given index
 
@@ -205,7 +205,7 @@ def get_valid_pfs_url(
 def get_random_pfs(
     service_registry: ServiceRegistry,
     block_identifier: BlockSpecification,
-    pathfinding_max_fee: FeeAmount,
+    pathfinding_max_fee: TokenAmount,
 ) -> Optional[str]:
     """Selects a random PFS from service_registry.
 
@@ -238,7 +238,7 @@ def configure_pfs_or_exit(
     service_registry: Optional[ServiceRegistry],
     node_network_id: ChainID,
     token_network_registry_address: TokenNetworkRegistryAddress,
-    pathfinding_max_fee: FeeAmount,
+    pathfinding_max_fee: TokenAmount,
 ) -> PFSInfo:
     """
     Take in the given pfs_address argument, the service registry and find out a

--- a/raiden/network/resolver/client.py
+++ b/raiden/network/resolver/client.py
@@ -26,7 +26,7 @@ def reveal_secret_with_resolver(
     raiden: "RaidenService", chain_state: ChainState, secret_request_event: SendSecretRequest
 ) -> bool:
 
-    resolver_endpoint = raiden.config.get("resolver_endpoint")
+    resolver_endpoint = raiden.config.resolver_endpoint
     if not resolver_endpoint:
         return False
 

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -764,7 +764,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
         raiden: "RaidenService", route_failed_event: EventRouteFailed
     ) -> None:  # pragma: no unittest
         feedback_token = raiden.route_to_feedback_token.get(tuple(route_failed_event.route))
-        pfs_config = raiden.config.get("pfs_config")
+        pfs_config = raiden.config.pfs_config
 
         if feedback_token and pfs_config:
             log.debug(
@@ -789,7 +789,7 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
         feedback_token = raiden.route_to_feedback_token.get(
             tuple(payment_sent_success_event.route)
         )
-        pfs_config = raiden.config.get("pfs_config")
+        pfs_config = raiden.config.pfs_config
 
         if feedback_token and pfs_config:
             log.debug(

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -72,7 +72,7 @@ def update_monitoring_service_from_balance_proof(
     new_balance_proof: BalanceProofSignedState,
     non_closing_participant: Address,
 ) -> None:
-    if raiden.config["services"].monitoring_enabled is False:
+    if raiden.config.services.monitoring_enabled is False:
         return
 
     msg = f"Monitoring is enabled but the default monitoring service address is None."

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -3,12 +3,10 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
 from types import TracebackType
 from typing import Generator
 
 import gevent
-from typing_extensions import Literal
 
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
@@ -19,6 +17,7 @@ from raiden.transfer.architecture import Event, State, StateChange
 from raiden.utils.system import get_system_spec
 from raiden.utils.typing import (
     Any,
+    DatabasePath,
     Dict,
     Generic,
     Iterator,
@@ -211,7 +210,7 @@ def _query_to_string(query: FilteredDBQuery) -> Tuple[str, List[str]]:
 
 
 class SQLiteStorage:
-    def __init__(self, database_path: Union[Path, Literal[":memory:"]]):
+    def __init__(self, database_path: DatabasePath):
         sqlite3.register_adapter(ULID, adapt_ulid_identifier)
         sqlite3.register_converter("ULID", convert_ulid_identifier)
 
@@ -763,9 +762,7 @@ class SerializedSQLiteStorage:
     applied the automatic encoding/deconding will not work.
     """
 
-    def __init__(
-        self, database_path: Union[Path, Literal[":memory:"]], serializer: SerializationBase
-    ) -> None:
+    def __init__(self, database_path: DatabasePath, serializer: SerializationBase) -> None:
         self.database = SQLiteStorage(database_path)
         self.serializer = serializer
 

--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from raiden.settings import RAIDEN_CONTRACT_VERSION
@@ -5,7 +7,7 @@ from raiden_contracts.contract_manager import ContractManager, contracts_precomp
 
 
 @pytest.fixture
-def contracts_path():
+def contracts_path() -> Path:
     version = RAIDEN_CONTRACT_VERSION
     return contracts_precompiled_path(version)
 

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -700,7 +700,7 @@ def test_raidenapi_channel_lifecycle(
         )
 
     address_for_lowest_settle_timeout = make_address()
-    lowest_valid_settle_timeout = node1.raiden.config["reveal_timeout"] * 2
+    lowest_valid_settle_timeout = node1.raiden.config.reveal_timeout * 2
 
     # Make sure a small settle timeout is not accepted when opening a channel
     with pytest.raises(InvalidSettleTimeout):

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -33,7 +33,6 @@ def web3(
     private_keys,
     account_genesis_eth_balance,
     random_marker,
-    request,
     tmpdir,
     chain_id,
     logs_storage,

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from pathlib import Path
 
 import gevent
 import pytest
@@ -65,7 +66,7 @@ def raiden_chain(
     unrecoverable_error_should_crash: bool,
     local_matrix_servers: List[ParsedURL],
     blockchain_type: str,
-    contracts_path: str,
+    contracts_path: Path,
     user_deposit_address: UserDepositAddress,
     monitoring_service_contract_address: MonitoringServiceAddress,
     broadcast_rooms: List[str],
@@ -192,7 +193,7 @@ def raiden_network(
     unrecoverable_error_should_crash: bool,
     local_matrix_servers: List[ParsedURL],
     blockchain_type: str,
-    contracts_path: str,
+    contracts_path: Path,
     user_deposit_address: UserDepositAddress,
     monitoring_service_contract_address: MonitoringServiceAddress,
     broadcast_rooms: List[str],

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -85,7 +85,7 @@ def start_apiserver_for_network(
 
 def restart_app(app: App) -> App:
     new_transport = MatrixTransport(
-        config=app.raiden.config["transport"], environment=app.raiden.config["environment_type"]
+        config=app.raiden.config.transport, environment=app.raiden.config.environment_type
     )
     raiden_event_handler = RaidenEventHandler()
     hold_handler = HoldRaidenEventHandler(raiden_event_handler)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -25,7 +25,7 @@ from raiden.network.transport.matrix import AddressReachability, MatrixTransport
 from raiden.network.transport.matrix.client import Room
 from raiden.network.transport.matrix.utils import UserPresence, make_room_alias, my_place_or_yours
 from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
-from raiden.settings import MONITORING_REWARD, MatrixTransportConfig, ServiceConfig
+from raiden.settings import MONITORING_REWARD, MatrixTransportConfig, RaidenConfig, ServiceConfig
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.detect_failure import expect_failure
@@ -542,7 +542,11 @@ def test_monitoring_broadcast_messages(
     transport._client.api.retry_timeout = 0
     transport._send_raw = MagicMock()
     raiden_service = MockRaidenService(None)
-    raiden_service.config = dict(services=ServiceConfig(monitoring_enabled=True))
+    raiden_service.config = RaidenConfig(
+        chain_id=1234,
+        environment_type=Environment.DEVELOPMENT,
+        services=ServiceConfig(monitoring_enabled=True),
+    )
 
     transport.start(raiden_service, [], None)
 
@@ -614,7 +618,7 @@ def test_pfs_broadcast_messages(
     transport._client.api.retry_timeout = 0
     transport._send_raw = MagicMock()
     raiden_service = MockRaidenService(None)
-    raiden_service.config = dict(services=dict(monitoring_enabled=True))
+    raiden_service.config.services.monitoring_enabled = True
     raiden_service.routing_mode = route_mode
 
     transport.start(raiden_service, [], None)

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -87,7 +87,7 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
     Regression test for: https://github.com/raiden-network/raiden/issues/3656.
     """
     app0, app1 = raiden_network
-    app0.config["services"].monitoring_enabled = True
+    app0.config.services.monitoring_enabled = True
     # Send a transfer to make sure the state has a balance proof to broadcast
     token_address = token_addresses[0]
 
@@ -105,7 +105,7 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
     app0.stop()
 
     transport = MatrixTransport(
-        config=app0.raiden.config["transport"], environment=app0.raiden.config["environment_type"]
+        config=app0.raiden.config.transport, environment=app0.raiden.config.environment_type
     )
     transport.send_async = Mock()  # type: ignore
     transport._send_raw = Mock()  # type: ignore
@@ -255,13 +255,13 @@ def test_fees_are_updated_during_startup(
     assert channel_state.fee_schedule.proportional == DEFAULT_MEDIATION_PROPORTIONAL_FEE
     assert channel_state.fee_schedule.imbalance_penalty == default_imbalance_penalty
 
-    orginal_config = app0.raiden.config.copy()
+    original_config = deepcopy(app0.raiden.config)
 
     # Now restart app0, and set new flat fee for that token network
     flat_fee = FeeAmount(100)
     app0.stop()
-    app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_flat_fee = {token_address: flat_fee}
+    app0.raiden.config = deepcopy(original_config)
+    app0.raiden.config.mediation_fees.token_to_flat_fee[token_address] = flat_fee
     app0.start()
 
     channel_state = get_channel_state(app0)
@@ -272,8 +272,8 @@ def test_fees_are_updated_during_startup(
     # Now restart app0, and set new proportional fee
     prop_fee = ProportionalFeeAmount(123)
     app0.stop()
-    app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_proportional_fee = {token_address: prop_fee}
+    app0.raiden.config = deepcopy(original_config)
+    app0.raiden.config.mediation_fees.token_to_proportional_fee[token_address] = prop_fee
     app0.start()
 
     channel_state = get_channel_state(app0)
@@ -283,10 +283,8 @@ def test_fees_are_updated_during_startup(
 
     # Now restart app0, and set new proportional imbalance fee
     app0.stop()
-    app0.raiden.config = deepcopy(orginal_config)
-    app0.raiden.config["mediation_fees"].token_to_proportional_imbalance_fee = {
-        token_address: 0.05e6
-    }
+    app0.raiden.config = deepcopy(original_config)
+    app0.raiden.config.mediation_fees.token_to_proportional_imbalance_fee[token_address] = 0.05e6
     app0.start()
 
     channel_state = get_channel_state(app0)

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -133,7 +133,7 @@ def test_recovery_unhappy_case(
     app0.raiden.stop()
 
     new_transport = MatrixTransport(
-        config=app0.raiden.config["transport"], environment=app0.raiden.config["environment_type"]
+        config=app0.raiden.config.transport, environment=app0.raiden.config.environment_type
     )
 
     app0.stop()
@@ -208,7 +208,7 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
     app0.raiden.stop()
 
     new_transport = MatrixTransport(
-        config=app0.raiden.config["transport"], environment=app0.raiden.config["environment_type"]
+        config=app0.raiden.config.transport, environment=app0.raiden.config.environment_type
     )
 
     app1_api = RaidenAPI(app1.raiden)

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -65,7 +65,7 @@ def test_send_queued_messages(  # pylint: disable=unused-argument
 
     # Restart the app. The pending transfers must be processed.
     new_transport = MatrixTransport(
-        config=app0.raiden.config["transport"], environment=app0.raiden.config["environment_type"]
+        config=app0.raiden.config.transport, environment=app0.raiden.config.environment_type
     )
     raiden_event_handler = RaidenEventHandler()
     message_handler = MessageHandler()
@@ -191,8 +191,7 @@ def test_payment_statuses_are_restored(  # pylint: disable=unused-argument
         default_one_to_n_address=app0.raiden.default_one_to_n_address,
         default_msc_address=app0.raiden.default_msc_address,
         transport=MatrixTransport(
-            config=app0.raiden.config["transport"],
-            environment=app0.raiden.config["environment_type"],
+            config=app0.raiden.config.transport, environment=app0.raiden.config.environment_type
         ),
         raiden_event_handler=RaidenEventHandler(),
         message_handler=MessageHandler(),

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -36,7 +36,7 @@ from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     BlockExpiration,
-    BlockNumber,
+    BlockTimeout,
     FeeAmount,
     PaymentAmount,
     PaymentID,
@@ -357,7 +357,7 @@ def test_mediated_transfer_calls_pfs(raiden_chain: List[App], token_addresses: L
         assert not patched.called
 
         # Setup PFS config
-        app0.raiden.config["pfs_config"] = PFSConfig(
+        app0.raiden.config.pfs_config = PFSConfig(
             info=PFSInfo(
                 url="mock-address",
                 chain_id=app0.raiden.rpc_client.chain_id,
@@ -370,7 +370,7 @@ def test_mediated_transfer_calls_pfs(raiden_chain: List[App], token_addresses: L
                 price=TokenAmount(0),
             ),
             maximum_fee=TokenAmount(100),
-            iou_timeout=BlockNumber(100),
+            iou_timeout=BlockTimeout(100),
             max_paths=5,
         )
 

--- a/raiden/tests/unit/storage/test_storage.py
+++ b/raiden/tests/unit/storage/test_storage.py
@@ -55,7 +55,7 @@ def test_upgrade_manager_transaction_rollback(tmp_path, monkeypatch):
             m.setattr("raiden.storage.sqlite.RAIDEN_DB_VERSION", 2)
             upgrade_list = [UpgradeRecord(from_version=1, function=failure)]
             m.setattr("raiden.utils.upgrades.UPGRADES_LIST", upgrade_list)
-            manager = UpgradeManager(FORMAT.format(2))
+            manager = UpgradeManager(Path(FORMAT.format(2)))
             manager.run()
 
     storage = SQLiteStorage(Path(FORMAT.format(2)))
@@ -81,7 +81,7 @@ def test_regression_delete_should_not_commit_the_upgrade_transaction(tmp_path, m
             m.setattr("raiden.storage.sqlite.RAIDEN_DB_VERSION", 2)
             upgrade_list = [UpgradeRecord(from_version=1, function=failure)]
             m.setattr("raiden.utils.upgrades.UPGRADES_LIST", upgrade_list)
-            manager = UpgradeManager(FORMAT.format(2))
+            manager = UpgradeManager(Path(FORMAT.format(2)))
             manager.run()
 
     storage = SQLiteStorage(Path(FORMAT.format(2)))

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -33,6 +33,7 @@ from raiden.utils.typing import (
     Address,
     Any,
     BlockNumber,
+    BlockTimeout,
     ChainID,
     Dict,
     PaymentAmount,
@@ -112,7 +113,7 @@ PFS_CONFIG = PFSConfig(
         version="",
     ),
     maximum_fee=TokenAmount(100),
-    iou_timeout=BlockNumber(100),
+    iou_timeout=BlockTimeout(100),
     max_paths=5,
 )
 CONFIG = {"pfs_config": PFS_CONFIG}

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -145,7 +145,7 @@ def setup_pfs_handler_test(
 
     # Set PFS config and feedback token
     pfs_config = True  # just a truthy value
-    raiden.config["pfs_config"] = pfs_config
+    raiden.config.pfs_config = pfs_config
 
     feedback_uuid = None
     if set_feedback_token:
@@ -179,7 +179,7 @@ def test_pfs_handler_handle_routefailed_with_feedback_token():
         )
     assert pfs_feedback_handler.called
     assert pfs_feedback_handler.call_args == call(
-        pfs_config=raiden.config["pfs_config"],
+        pfs_config=raiden.config.pfs_config,
         route=route,
         routing_mode=RoutingMode.PRIVATE,
         successful=False,
@@ -239,7 +239,7 @@ def test_pfs_handler_handle_paymentsentsuccess_with_feedback_token():
         )
     assert pfs_feedback_handler.called
     assert pfs_feedback_handler.call_args == call(
-        pfs_config=raiden.config["pfs_config"],
+        pfs_config=raiden.config.pfs_config,
         route=route,
         routing_mode=RoutingMode.PRIVATE,
         successful=True,

--- a/raiden/tests/unit/test_startup.py
+++ b/raiden/tests/unit/test_startup.py
@@ -8,7 +8,7 @@ from raiden.constants import Environment, RoutingMode
 from raiden.exceptions import RaidenError
 from raiden.network import pathfinding
 from raiden.network.pathfinding import PFSInfo
-from raiden.settings import ServiceConfig
+from raiden.settings import RaidenConfig, ServiceConfig
 from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.mocks import MockProxyManager, MockWeb3
 from raiden.ui.checks import check_ethereum_network_id
@@ -72,70 +72,70 @@ def service_contracts_in_data(contracts: Dict[str, Any]) -> bool:
 
 def test_setup_contracts():
     # Mainnet production: contracts are not deployed
-    config = {"environment_type": Environment.PRODUCTION}
+    config = RaidenConfig(chain_id=1, environment_type=Environment.PRODUCTION)
     contracts = load_deployed_contracts_data(config, 1)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # Mainnet development -- NOT allowed
-    config = {"environment_type": Environment.DEVELOPMENT}
+    config = RaidenConfig(chain_id=1, environment_type=Environment.DEVELOPMENT)
     with pytest.raises(RaidenError):
         contracts = load_deployed_contracts_data(config, 1)
 
     # Ropsten production
-    config = {"environment_type": Environment.PRODUCTION}
+    config = RaidenConfig(chain_id=3, environment_type=Environment.PRODUCTION)
     contracts = load_deployed_contracts_data(config, 3)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # Ropsten development
-    config = {"environment_type": Environment.DEVELOPMENT}
+    config = RaidenConfig(chain_id=3, environment_type=Environment.DEVELOPMENT)
     contracts = load_deployed_contracts_data(config, 3)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # Rinkeby production
-    config = {"environment_type": Environment.PRODUCTION}
+    config = RaidenConfig(chain_id=4, environment_type=Environment.PRODUCTION)
     contracts = load_deployed_contracts_data(config, 4)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # Rinkeby development
-    config = {"environment_type": Environment.DEVELOPMENT}
+    config = RaidenConfig(chain_id=4, environment_type=Environment.DEVELOPMENT)
     contracts = load_deployed_contracts_data(config, 4)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # Goerli production
-    config = {"environment_type": Environment.PRODUCTION}
+    config = RaidenConfig(chain_id=5, environment_type=Environment.PRODUCTION)
     contracts = load_deployed_contracts_data(config, 5)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # Goerli development
-    config = {"environment_type": Environment.DEVELOPMENT}
+    config = RaidenConfig(chain_id=5, environment_type=Environment.DEVELOPMENT)
     contracts = load_deployed_contracts_data(config, 5)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert raiden_contracts_in_data(contracts)
     assert service_contracts_in_data(contracts)
 
     # random private network production
-    config = {"environment_type": Environment.PRODUCTION}
+    config = RaidenConfig(chain_id=5257, environment_type=Environment.PRODUCTION)
     contracts = load_deployed_contracts_data(config, 5257)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert not raiden_contracts_in_data(contracts)
     assert not service_contracts_in_data(contracts)
 
     # random private network development
-    config = {"environment_type": Environment.DEVELOPMENT}
+    config = RaidenConfig(chain_id=5257, environment_type=Environment.DEVELOPMENT)
     contracts = load_deployed_contracts_data(config, 5257)
-    assert "contracts_path" in config
+    assert config.contracts_path is not None
     assert not raiden_contracts_in_data(contracts)
     assert not service_contracts_in_data(contracts)
 
@@ -144,10 +144,9 @@ def test_setup_proxies_raiden_addresses_are_given():
     """
     Test that startup for proxies works fine if only raiden addresses are given
     """
-
-    network_id = 5
-    config = {"environment_type": Environment.DEVELOPMENT, "chain_id": network_id, "services": {}}
-    contracts = load_deployed_contracts_data(config, network_id)
+    chain_id = ChainID(5)
+    config = RaidenConfig(chain_id=chain_id, environment_type=Environment.DEVELOPMENT)
+    contracts = load_deployed_contracts_data(config, chain_id)
     proxy_manager = MockProxyManager(node_address=make_address())
 
     deployed_addresses = load_deployment_addresses_from_contracts(contracts)
@@ -176,10 +175,9 @@ def test_setup_proxies_all_addresses_are_given():
     """
     Test that startup for proxies works fine if all addresses are given and routing is local
     """
-
-    network_id = 5
-    config = {"environment_type": Environment.DEVELOPMENT, "chain_id": network_id, "services": {}}
-    contracts = load_deployed_contracts_data(config, network_id)
+    chain_id = ChainID(5)
+    config = RaidenConfig(chain_id=chain_id, environment_type=Environment.DEVELOPMENT)
+    contracts = load_deployed_contracts_data(config, chain_id)
     proxy_manager = MockProxyManager(node_address=make_address())
 
     deployed_addresses = load_deployment_addresses_from_contracts(contracts)
@@ -209,16 +207,9 @@ def test_setup_proxies_all_addresses_are_known():
     """
     Test that startup for proxies works fine if all addresses are given and routing is basic
     """
-
-    network_id = 5
-    config = {
-        "environment_type": Environment.DEVELOPMENT,
-        "chain_id": network_id,
-        "services": ServiceConfig(
-            pathfinding_max_fee=100, pathfinding_iou_timeout=500, pathfinding_max_paths=5
-        ),
-    }
-    contracts = load_deployed_contracts_data(config, network_id)
+    chain_id = ChainID(5)
+    config = RaidenConfig(chain_id=chain_id, environment_type=Environment.DEVELOPMENT)
+    contracts = load_deployed_contracts_data(config, chain_id)
     proxy_manager = MockProxyManager(node_address=make_address())
     PFS_INFO = PFSInfo(
         url="my-pfs",
@@ -263,16 +254,15 @@ def test_setup_proxies_no_service_registry_but_pfs():
 
     Regression test for https://github.com/raiden-network/raiden/issues/3740
     """
-
-    network_id = 5
-    config = {
-        "environment_type": Environment.DEVELOPMENT,
-        "chain_id": network_id,
-        "services": ServiceConfig(
+    chain_id = ChainID(5)
+    config = RaidenConfig(
+        chain_id=chain_id,
+        environment_type=Environment.DEVELOPMENT,
+        services=ServiceConfig(
             pathfinding_max_fee=100, pathfinding_iou_timeout=500, pathfinding_max_paths=5
         ),
-    }
-    contracts = load_deployed_contracts_data(config, network_id)
+    )
+    contracts = load_deployed_contracts_data(config, chain_id)
     proxy_manager = MockProxyManager(node_address=make_address())
 
     PFS_INFO = PFSInfo(
@@ -308,15 +298,15 @@ def test_setup_proxies_no_service_registry_and_no_pfs_address_but_requesting_pfs
     then the client exits with an error message
     """
 
-    network_id = 5
-    config = {
-        "environment_type": environment_type,
-        "chain_id": network_id,
-        "services": ServiceConfig(
+    chain_id = ChainID(5)
+    config = RaidenConfig(
+        chain_id=chain_id,
+        environment_type=environment_type,
+        services=ServiceConfig(
             pathfinding_max_fee=100, pathfinding_iou_timeout=500, pathfinding_max_paths=5
         ),
-    }
-    contracts = load_deployed_contracts_data(config, network_id)
+    )
+    contracts = load_deployed_contracts_data(config, chain_id)
     proxy_manager = MockProxyManager(node_address=make_address())
 
     with pytest.raises(RaidenError):

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -53,13 +53,11 @@ class AccountDescription(NamedTuple):
 
 
 class GenesisDescription(NamedTuple):
-    """Genesis configuration for a geth PoA private chain.
+    """ Genesis configuration for a geth PoA private chain.
 
     Args:
         prefunded_accounts: iterable list of privatekeys whose
             corresponding accounts will have a premined balance available.
-        seal_address: Address of the ethereum account that can seal
-            blocks in the PoA chain.
         random_marker: A unique used to preventing interacting with the wrong
             chain.
         chain_id: The id of the private chain.
@@ -489,15 +487,12 @@ def run_private_blockchain(
 
     Args:
         web3: A Web3 instance used to check when the private chain is running.
-        accounts_to_fund: Accounts that will start with funds in
-            the private chain.
         eth_nodes: A list of geth node
             description, containing the details of each node of the private
             chain.
         base_datadir: Directory used to store the geth databases.
         log_dir: Directory used to store the geth logs.
         verbosity: Verbosity used by the geth nodes.
-        random_marker: A random marked used to identify the private chain.
     """
     # pylint: disable=too-many-locals,too-many-statements,too-many-arguments,too-many-branches
 

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -3,7 +3,8 @@ import random
 from collections import defaultdict
 from unittest.mock import Mock, PropertyMock
 
-from raiden.constants import RoutingMode
+from raiden.constants import Environment, RoutingMode
+from raiden.settings import RaidenConfig
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.storage.wal import WriteAheadLog
@@ -150,7 +151,7 @@ class MockChainState:
 
 
 class MockRaidenService:
-    def __init__(self, message_handler=None, state_transition=None, private_key=None, config=None):
+    def __init__(self, message_handler=None, state_transition=None, private_key=None):
         if private_key is None:
             self.privkey, self.address = factories.make_privkey_address()
         else:
@@ -163,7 +164,9 @@ class MockRaidenService:
 
         self.message_handler = message_handler
         self.routing_mode = RoutingMode.PRIVATE
-        self.config = config or dict()
+        self.config = RaidenConfig(
+            chain_id=self.rpc_client.chain_id, environment_type=Environment.DEVELOPMENT
+        )
 
         self.user_deposit = Mock()
         self.default_registry = Mock()
@@ -218,7 +221,7 @@ def make_raiden_service_mock(
     channel_identifier: ChannelID,
     partner: Address,
 ):
-    raiden_service = MockRaidenService(config={})
+    raiden_service = MockRaidenService()
     chain_state = MockChainState()
     wal = Mock()
     wal.state_manager.current_state = chain_state

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -1,7 +1,7 @@
 """ Utilities to set-up a Raiden network. """
 from collections import namedtuple
-from copy import deepcopy
 from itertools import product
+from pathlib import Path
 
 import gevent
 import structlog
@@ -18,8 +18,11 @@ from raiden.raiden_service import RaidenService
 from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     DEFAULT_RETRY_TIMEOUT,
+    BlockchainConfig,
     MatrixTransportConfig,
     MediationFeeConfig,
+    RaidenConfig,
+    ServiceConfig,
 )
 from raiden.tests.utils.app import database_from_privatekey
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
@@ -28,7 +31,6 @@ from raiden.tests.utils.transport import ParsedURL
 from raiden.transfer import views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.views import state_from_raiden
-from raiden.utils.datastructures import merge_dict
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
@@ -343,7 +345,7 @@ def create_sequential_channels(raiden_apps: List[App], channels_per_node: int) -
 
 def create_apps(
     chain_id: ChainID,
-    contracts_path: str,
+    contracts_path: Path,
     blockchain_services: BlockchainServices,
     token_network_registry_address: TokenNetworkRegistryAddress,
     one_to_n_address: Optional[OneToNAddress],
@@ -374,45 +376,37 @@ def create_apps(
         assert len(resolver_ports) > idx
         resolver_port = resolver_ports[idx]
 
-        config = {
-            "chain_id": chain_id,
-            "environment_type": environment_type,
-            "unrecoverable_error_should_crash": unrecoverable_error_should_crash,
-            "reveal_timeout": reveal_timeout,
-            "settle_timeout": settle_timeout,
-            "contracts_path": contracts_path,
-            "database_path": database_path,
-            "blockchain": {
-                "confirmation_blocks": DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
-                "query_interval": blockchain_query_interval,
-            },
-            "transport": {},
-            "rpc": True,
-            "console": False,
-            "mediation_fees": MediationFeeConfig(),
-        }
+        config = RaidenConfig(
+            chain_id=chain_id,
+            environment_type=environment_type,
+            unrecoverable_error_should_crash=unrecoverable_error_should_crash,
+            reveal_timeout=reveal_timeout,
+            settle_timeout=settle_timeout,
+            contracts_path=contracts_path,
+            database_path=database_path,
+            blockchain=BlockchainConfig(
+                confirmation_blocks=DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
+                query_interval=blockchain_query_interval,
+            ),
+            mediation_fees=MediationFeeConfig(),
+            services=ServiceConfig(monitoring_enabled=False),
+            rpc=True,
+            console=False,
+            transport_type="matrix",
+        )
 
         if local_matrix_url is not None:
-            merge_dict(
-                config,
-                {
-                    "transport_type": "matrix",
-                    "transport": MatrixTransportConfig(
-                        broadcast_rooms=broadcast_rooms,
-                        retries_before_backoff=retries_before_backoff,
-                        retry_interval=retry_interval,
-                        server=local_matrix_url,
-                        server_name=local_matrix_url.netloc,
-                        available_servers=[],
-                    ),
-                },
+            config.transport = MatrixTransportConfig(
+                broadcast_rooms=broadcast_rooms,
+                retries_before_backoff=retries_before_backoff,
+                retry_interval=retry_interval,
+                server=local_matrix_url,
+                server_name=local_matrix_url.netloc,
+                available_servers=[],
             )
 
         if resolver_port is not None:
-            merge_dict(config, {"resolver_endpoint": "http://localhost:" + str(resolver_port)})
-
-        config_copy = deepcopy(App.DEFAULT_CONFIG)
-        config_copy.update(config)
+            config.resolver_endpoint = f"http://localhost:{resolver_port}"
 
         registry = proxy_manager.token_network_registry(token_network_registry_address)
         secret_registry = proxy_manager.secret_registry(secret_registry_address)
@@ -425,14 +419,14 @@ def create_apps(
         if user_deposit_address:
             user_deposit = proxy_manager.user_deposit(user_deposit_address)
 
-        transport = MatrixTransport(config=config["transport"], environment=environment_type)
+        transport = MatrixTransport(config=config.transport, environment=environment_type)
 
         raiden_event_handler = RaidenEventHandler()
         hold_handler = HoldRaidenEventHandler(raiden_event_handler)
         message_handler = WaitForMessage()
 
         app = App(
-            config=config_copy,
+            config=config,
             rpc_client=proxy_manager.client,
             proxy_manager=proxy_manager,
             query_start_block=BlockNumber(0),

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -10,16 +10,7 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.network.rpc.smartcontract_proxy import ContractProxy
 from raiden.network.rpc.transactions import check_transaction_threw
 from raiden.utils.smart_contracts import deploy_contract_web3
-from raiden.utils.typing import (
-    Address,
-    Any,
-    Dict,
-    FeeAmount,
-    List,
-    TokenAddress,
-    TokenAmount,
-    Tuple,
-)
+from raiden.utils.typing import Address, Any, Dict, List, TokenAddress, TokenAmount, Tuple
 from raiden_contracts.contract_manager import ContractManager
 
 
@@ -118,7 +109,7 @@ def deploy_service_registry_and_set_urls(
     )
 
     # Test that getting a random service for an empty registry returns None
-    pfs_address = get_random_pfs(c1_service_proxy, "latest", pathfinding_max_fee=FeeAmount(1))
+    pfs_address = get_random_pfs(c1_service_proxy, "latest", pathfinding_max_fee=TokenAmount(1))
     assert pfs_address is None
 
     # Test that setting the urls works

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -453,7 +453,7 @@ def run_smoketest(
         assert distributable == channel_state.our_state.contract_balance
         assert channel.get_status(channel_state) == ChannelState.STATE_OPENED
 
-        port_number = raiden_service.config["api_port"]
+        port_number = raiden_service.config.api_port
         response = requests.get(f"http://localhost:{port_number}/api/v1/channels")
 
         assert response.status_code == HTTPStatus.OK

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -6,7 +6,6 @@ import signal
 import sys
 import textwrap
 import traceback
-from copy import deepcopy
 from enum import Enum
 from io import StringIO
 from subprocess import TimeoutExpired
@@ -22,7 +21,6 @@ from requests.packages import urllib3
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from urllib3.exceptions import ReadTimeoutError
 
-from raiden.app import App
 from raiden.constants import (
     DISCOVERY_DEFAULT_ROOM,
     FLAT_MED_FEE_MIN,
@@ -349,6 +347,7 @@ def options(func: Callable) -> Callable:
             option(
                 "--enable-monitoring",
                 help="Enable broadcasting of balance proofs to the monitoring services.",
+                default=False,
                 is_flag=True,
             ),
         ),
@@ -840,7 +839,6 @@ def smoketest(
             port = next(free_port_generator)
 
             args["api_address"] = f"localhost:{port}"
-            args["config"] = deepcopy(App.DEFAULT_CONFIG)
             args["environment_type"] = environment_type
             args["extra_config"] = {"transport": {"available_servers": server_urls}}
             args["one_to_n_contract_address"] = "0x" + "1" * 40

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -26,6 +26,7 @@ from raiden.constants import (
     FLAT_MED_FEE_MIN,
     IMBALANCE_MED_FEE_MAX,
     IMBALANCE_MED_FEE_MIN,
+    PATH_FINDING_BROADCASTING_ROOM,
     PROPORTIONAL_MED_FEE_MAX,
     PROPORTIONAL_MED_FEE_MIN,
     Environment,
@@ -807,7 +808,8 @@ def smoketest(
             print_step=print_step,
             free_port_generator=free_port_generator,
             broadcast_rooms_aliases=[
-                make_room_alias(NETWORKNAME_TO_ID["smoketest"], DISCOVERY_DEFAULT_ROOM)
+                make_room_alias(NETWORKNAME_TO_ID["smoketest"], DISCOVERY_DEFAULT_ROOM),
+                make_room_alias(NETWORKNAME_TO_ID["smoketest"], PATH_FINDING_BROADCASTING_ROOM),
             ],
         )
 
@@ -840,7 +842,11 @@ def smoketest(
 
             args["api_address"] = f"localhost:{port}"
             args["environment_type"] = environment_type
-            args["extra_config"] = {"transport": {"available_servers": server_urls}}
+
+            # Matrix server
+            # TODO: do we need more than one here?
+            first_server = server_urls[0]
+            args["matrix_server"] = first_server[0]
             args["one_to_n_contract_address"] = "0x" + "1" * 40
             args["routing_mode"] = RoutingMode.LOCAL
             args["flat_fee"] = ()

--- a/raiden/ui/config.py
+++ b/raiden/ui/config.py
@@ -42,11 +42,6 @@ def _clean_non_serializables(data: Dict) -> Dict:
     return copy
 
 
-def dump_config(config: Dict) -> None:
-    print(pytoml.dumps({"configs": _clean_non_serializables(config)}))
-    print()
-
-
 def dump_cmd_options(options: Dict) -> None:
     print(pytoml.dumps({"options": _clean_non_serializables(options)}))
     print()

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -19,7 +19,7 @@ from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
-from raiden.settings import RAIDEN_CONTRACT_VERSION
+from raiden.settings import RAIDEN_CONTRACT_VERSION, RaidenConfig
 from raiden.ui.checks import DeploymentAddresses, check_pfs_configuration, check_raiden_environment
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
@@ -137,20 +137,18 @@ class ServicesBundle:
             )
 
 
-def load_deployed_contracts_data(config: Dict[str, Any], network_id: ChainID) -> Dict[str, Any]:
+def load_deployed_contracts_data(config: RaidenConfig, network_id: ChainID) -> Dict[str, Any]:
     """Sets the contract deployment data depending on the network id and environment type
 
     If an invalid combination of network id and environment type is provided, exits
     the program with an error
     """
-    environment_type = config["environment_type"]
-
-    check_raiden_environment(network_id, environment_type)
+    check_raiden_environment(network_id, config.environment_type)
 
     deployed_contracts_data: Dict[str, Any] = dict()
     contracts_version = RAIDEN_CONTRACT_VERSION
 
-    config["contracts_path"] = contracts_precompiled_path(contracts_version)
+    config.contracts_path = contracts_precompiled_path(contracts_version)
 
     if network_id in ID_TO_NETWORKNAME and ID_TO_NETWORKNAME[network_id] != "smoketest":
         deployment_data = get_contracts_deployment_info(
@@ -294,7 +292,7 @@ def raiden_bundle_from_contracts_deployment(
 
 
 def services_bundle_from_contracts_deployment(
-    config: Dict[str, Any],
+    config: RaidenConfig,
     proxy_manager: ProxyManager,
     routing_mode: RoutingMode,
     deployed_addresses: DeploymentAddresses,
@@ -311,8 +309,8 @@ def services_bundle_from_contracts_deployment(
 
     Also depending on the given arguments populate config with PFS related settings
     """
-    node_network_id = config["chain_id"]
-    environment_type = config["environment_type"]
+    node_network_id = config.chain_id
+    environment_type = config.environment_type
 
     user_deposit_address = deployed_addresses.user_deposit_address
     service_registry_address = deployed_addresses.service_registry_address
@@ -362,7 +360,7 @@ def services_bundle_from_contracts_deployment(
             token_network_registry_address=TokenNetworkRegistryAddress(
                 token_network_registry_address
             ),
-            pathfinding_max_fee=config["services"].pathfinding_max_fee,
+            pathfinding_max_fee=config.services.pathfinding_max_fee,
         )
         msg = "Eth address of selected pathfinding service is unknown."
         assert pfs_info.payment_address is not None, msg
@@ -373,14 +371,14 @@ def services_bundle_from_contracts_deployment(
                 service_registry=proxies["service_registry"], pfs_info=pfs_info
             )
 
-        config["pfs_config"] = PFSConfig(
+        config.pfs_config = PFSConfig(
             info=pfs_info,
-            maximum_fee=config["services"].pathfinding_max_fee,
-            iou_timeout=config["services"].pathfinding_iou_timeout,
-            max_paths=config["services"].pathfinding_max_paths,
+            maximum_fee=config.services.pathfinding_max_fee,
+            iou_timeout=config.services.pathfinding_iou_timeout,
+            max_paths=config.services.pathfinding_max_paths,
         )
     else:
-        config["pfs_config"] = None
+        config.pfs_config = None
 
     return ServicesBundle(
         user_deposit=cast(UserDeposit, proxies.get("user_deposit")),

--- a/raiden/utils/mediation_fees.py
+++ b/raiden/utils/mediation_fees.py
@@ -29,10 +29,11 @@ def prepare_mediation_fee_config(
 ) -> MediationFeeConfig:
     """ Converts the mediation fee CLI args to proper per-channel
     mediation fees. """
-    tn_to_flat_fee: Dict[TokenAddress, FeeAmount] = {}
-    # Add the defaults for flat fees for DAI/WETH
-    tn_to_flat_fee[WETH_TOKEN_ADDRESS] = FeeAmount(DEFAULT_WETH_FLAT_FEE // 2)
-    tn_to_flat_fee[DAI_TOKEN_ADDRESS] = FeeAmount(DEFAULT_DAI_FLAT_FEE // 2)
+    tn_to_flat_fee: Dict[TokenAddress, FeeAmount] = {
+        # Add the defaults for flat fees for DAI/WETH
+        WETH_TOKEN_ADDRESS: FeeAmount(DEFAULT_WETH_FLAT_FEE // 2),
+        DAI_TOKEN_ADDRESS: FeeAmount(DEFAULT_DAI_FLAT_FEE // 2),
+    }
 
     # Store the flat fee settings for the given token addresses
     # The given flat fee is for the whole mediation, but that includes two channels.

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -1,7 +1,9 @@
+from pathlib import Path
 from typing import *  # NOQA pylint:disable=wildcard-import,unused-wildcard-import
 from typing import TYPE_CHECKING, Any, Dict, List, NewType, Tuple, Type, Union
 
 from eth_typing import Address, ChecksumAddress
+from typing_extensions import Literal
 
 from raiden_contracts.contract_manager import CompiledContract  # NOQA pylint:disable=unused-import
 from raiden_contracts.utils.type_aliases import (  # NOQA pylint:disable=unused-import
@@ -195,3 +197,5 @@ Endpoint = NewType("Endpoint", str)
 LockType = Union["HashTimeLockState", "UnlockPartialProofState"]
 ErrorType = Union[Type["RaidenRecoverableError"], Type["RaidenUnrecoverableError"]]
 LockedTransferType = Union["LockedTransferUnsignedState", "LockedTransferSignedState"]
+
+DatabasePath = Union[Path, Literal[":memory:"]]

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -10,7 +10,7 @@ import structlog
 from raiden.constants import RAIDEN_DB_VERSION
 from raiden.storage.sqlite import SQLiteStorage
 from raiden.storage.versions import VERSION_RE, filter_db_names, latest_db_file
-from raiden.utils.typing import Any, Callable, List, NamedTuple
+from raiden.utils.typing import Any, Callable, DatabasePath, List, NamedTuple
 
 
 class UpgradeRecord(NamedTuple):
@@ -118,7 +118,7 @@ class UpgradeManager:
       to proceed or not.
     """
 
-    def __init__(self, db_filename: str, **kwargs: Any) -> None:
+    def __init__(self, db_filename: DatabasePath, **kwargs: Any) -> None:
         base_name = os.path.basename(db_filename)
         match = VERSION_RE.match(base_name)
         assert match, f'Database name "{base_name}" does not match our format'


### PR DESCRIPTION
## Description

Fixes: https://github.com/raiden-network/raiden/issues/4069

Switch from `dict`s to `dataclass`es for the config. In the past is was unclear which entries were there or not and what types they had.

Also fixes the smoketests to use the local matrix server instead of the hosted ones.