### PR TITLE
Fix contract for one_to_n proxy and remove wrong check on startup

### DIFF
--- a/raiden/network/proxies/one_to_n.py
+++ b/raiden/network/proxies/one_to_n.py
@@ -3,7 +3,7 @@ from eth_utils import decode_hex, is_binary_address, to_canonical_address
 
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
 from raiden.utils.typing import Address, BlockSpecification, OneToNAddress, TokenAddress
-from raiden_contracts.constants import CONTRACT_MONITORING_SERVICE
+from raiden_contracts.constants import CONTRACT_ONE_TO_N
 from raiden_contracts.contract_manager import ContractManager
 
 log = structlog.get_logger(__name__)
@@ -23,14 +23,14 @@ class OneToN:
         check_address_has_code(
             client=jsonrpc_client,
             address=Address(one_to_n_address),
-            contract_name=CONTRACT_MONITORING_SERVICE,
+            contract_name=CONTRACT_ONE_TO_N,
             expected_code=decode_hex(
-                contract_manager.get_runtime_hexcode(CONTRACT_MONITORING_SERVICE)
+                contract_manager.get_runtime_hexcode(CONTRACT_ONE_TO_N)
             ),
         )
 
         proxy = jsonrpc_client.new_contract_proxy(
-            abi=self.contract_manager.get_contract_abi(CONTRACT_MONITORING_SERVICE),
+            abi=self.contract_manager.get_contract_abi(CONTRACT_ONE_TO_N),
             contract_address=Address(one_to_n_address),
         )
 
@@ -38,10 +38,3 @@ class OneToN:
         self.proxy = proxy
         self.client = jsonrpc_client
         self.node_address = self.client.address
-
-    def token_address(self, block_identifier: BlockSpecification) -> TokenAddress:
-        return TokenAddress(
-            to_canonical_address(
-                self.proxy.contract.functions.token().call(block_identifier=block_identifier)
-            )
-        )

--- a/raiden/network/proxies/one_to_n.py
+++ b/raiden/network/proxies/one_to_n.py
@@ -1,8 +1,8 @@
 import structlog
-from eth_utils import decode_hex, is_binary_address, to_canonical_address
+from eth_utils import decode_hex, is_binary_address
 
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
-from raiden.utils.typing import Address, BlockSpecification, OneToNAddress, TokenAddress
+from raiden.utils.typing import Address, OneToNAddress
 from raiden_contracts.constants import CONTRACT_ONE_TO_N
 from raiden_contracts.contract_manager import ContractManager
 
@@ -24,9 +24,7 @@ class OneToN:
             client=jsonrpc_client,
             address=Address(one_to_n_address),
             contract_name=CONTRACT_ONE_TO_N,
-            expected_code=decode_hex(
-                contract_manager.get_runtime_hexcode(CONTRACT_ONE_TO_N)
-            ),
+            expected_code=decode_hex(contract_manager.get_runtime_hexcode(CONTRACT_ONE_TO_N)),
         )
 
         proxy = jsonrpc_client.new_contract_proxy(

--- a/raiden/tests/unit/test_app.py
+++ b/raiden/tests/unit/test_app.py
@@ -12,7 +12,7 @@ def test_rpc_normalized_endpoint():
     assert res == "https://goerli.infura.io/v3/11111111111111111111111111111111"
 
     # if the endpoint does not have a scheme, append http scheme
-    res = rpc_normalized_endpoint("127.0.0.1:5454")
+    res = rpc_normalized_endpoint("//127.0.0.1:5454")
     assert res == "http://127.0.0.1:5454"
     res = rpc_normalized_endpoint("http://127.0.0.1:5454")
     assert res == "http://127.0.0.1:5454"

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -152,7 +152,11 @@ def rpc_normalized_endpoint(eth_rpc_endpoint: str) -> str:
     if parsed_eth_rpc_endpoint.scheme:
         return eth_rpc_endpoint
 
-    return f"http://{eth_rpc_endpoint}"
+    scheme = "http://"
+    if eth_rpc_endpoint.startswith("//"):
+        scheme = "http:"
+
+    return f"{scheme}{eth_rpc_endpoint}"
 
 
 def run_app(

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -126,16 +126,6 @@ class ServicesBundle:
                 f"MonitoringService contract {monitoring_service_address}."
             )
 
-        token_address_matches_one_to_n = token_address == self.one_to_n.token_address(
-            block_identifier
-        )
-        if not token_address_matches_one_to_n:
-            raise RaidenError(
-                f"The token used in the provided user deposit contract "
-                f"{user_deposit_address} does not match the one in the OneToN "
-                f"service contract {monitoring_service_address}."
-            )
-
         token_address_matches_service_registry = (
             token_address == self.service_registry.token_address(block_identifier)
         )


### PR DESCRIPTION
## Description

Fixes: #5550 

This PR removes a check during startup that looked for a token address from the one_to_n contract, but that contract doesn't have a token_address specified. 
It also fixes the initial problem that was introduced by what seems to be a copy/paste bug where the one_to_n proxy used the contract ABI of the monitoring services.

I am not sure if this is the best fix for this problem, but it works as a temporary fix during christmas time so that the nightlies start running again. At least the scenarios and Raiden itself now run locally again.