### PR TITLE
Ignore Matrix servers with non 2xx HTTP status

### DIFF
--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -107,9 +107,9 @@ def get_http_rtt(
     durations = []
     for _ in range(samples):
         try:
-            durations.append(
-                requests.request(method, url, timeout=timeout).elapsed.total_seconds()
-            )
+            response = requests.request(method, url, timeout=timeout)
+            response.raise_for_status()
+            durations.append(response.elapsed.total_seconds())
         except (OSError, requests.RequestException):
             return None
         # Slight delay to avoid overloading

--- a/raiden/tests/unit/fixtures.py
+++ b/raiden/tests/unit/fixtures.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+import responses
 
 from raiden.tests.utils import factories
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
@@ -120,3 +121,10 @@ def netting_channel_state(chain_state, token_network_state, token_network_regist
     token_network_state.channelidentifiers_to_channels[channel_id] = channel_state
 
     return channel_state
+
+
+@pytest.fixture
+def requests_responses():
+    """ Uses ``responses`` to provide easy requests tests. """
+    with responses.RequestsMock() as mock_responses:
+        yield mock_responses

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -144,6 +144,7 @@ raiden-webui==0.11.0
 readme-renderer==24.0
 releases==1.6.1
 requests==2.22.0
+responses==0.10.9
 rlp==1.1.0
 s3cmd==2.0.2
 semantic-version==2.6.0
@@ -185,4 +186,4 @@ zipp==0.5.1
 zope.interface==4.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via ipython, jsonschema, pyhamcrest, pyinstaller, sphinx, zope.interface
+# setuptools==44.0.0        # via ipython, jsonschema, pyhamcrest, pyinstaller, sphinx, zope.interface

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -28,6 +28,7 @@ pytest-xdist
 grequests
 pexpect
 hypothesis
+responses
 
 # Debugging
 pdbpp

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -137,6 +137,7 @@ raiden-webui==0.11.0
 readme-renderer==24.0
 releases==1.6.1
 requests==2.22.0
+responses==0.10.9
 rlp==1.1.0
 semantic-version==2.6.0
 semver==2.8.1
@@ -177,4 +178,4 @@ zipp==0.5.1               # via importlib-metadata
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via ipython, jsonschema, pyhamcrest, sphinx, zope.interface
+# setuptools==44.0.0        # via ipython, jsonschema, pyhamcrest, sphinx, zope.interface

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -33,4 +33,4 @@ urllib3==1.25.3           # via requests
 wheel==0.33.4             # via astunparse
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via sphinx
+# setuptools==44.0.0        # via sphinx

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -83,4 +83,4 @@ websockets==6.0           # via web3
 werkzeug==0.15.4          # via flask
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via ipython
+# setuptools==44.0.0        # via ipython


### PR DESCRIPTION
## Description

The `get_http_rtt()` utility method did not check the return code of the passed URL.
This lead to servers returning error status codes (4xx, 5xx) to still be considered usable.

Related: 
- #5544
- raiden-network/raiden-service-bundle#76