### PR TITLE
Enable pylint assert checker

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -28,24 +28,25 @@ logging-modules=logging,structlog
 
 disable=all
 enable=
-    no-value-for-parameter,
-    too-many-format-args,
-    no-member,
+    assert-message,
     bad-except-order,
-    redefined-builtin,
-    unused-variable,
-    no-self-use,
-    import-self,
-    gevent-joinall,
-    useless-object-inheritance,
-    unused-argument,
-    unexpected-keyword-arg,
     expression-not-assigned,
-    pointless-statement,
-    unused-import,
+    gevent-joinall,
+    import-self,
     inconsistent-return-statements,
+    no-member,
+    no-self-use,
+    no-value-for-parameter,
+    pointless-statement,
+    redefined-builtin,
     reimported,
-    too-many-function-args
+    too-many-format-args,
+    too-many-function-args,
+    unexpected-keyword-arg,
+    unused-argument,
+    unused-import,
+    unused-variable,
+    useless-object-inheritance,
 
 [REPORTS]
 

--- a/raiden/accounts.py
+++ b/raiden/accounts.py
@@ -125,7 +125,8 @@ class AccountManager:
             data = json.load(data_file)
 
         acc = Account(data, password, self.accounts[address])
-        assert acc.privkey is not None
+
+        assert acc.privkey is not None, f"Private key of account ({address}) not known."
         return acc.privkey
 
 
@@ -185,7 +186,7 @@ class Account:
         if "address" in self.keystore:
             self._address = Address(decode_hex(self.keystore["address"]))
         elif not self.locked:
-            assert self.privkey
+            assert self.privkey is not None, "`privkey` not set, maybe call `unlock` before."
             self._address = privatekey_to_address(self.privkey)
 
     @property
@@ -199,7 +200,7 @@ class Account:
     def pubkey(self) -> Optional[PublicKey]:
         """The account's public key or `None` if the account is locked"""
         if not self.locked:
-            assert self.privkey is not None
+            assert self.privkey is not None, "`privkey` not set, maybe call `unlock` before."
             return privatekey_to_publickey(self.privkey)
 
         return None

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -214,7 +214,8 @@ class RaidenAPI:  # pragma: no unittest
             raise InvalidBinaryAddress("Expected binary address format for partner in get_channel")
 
         channel_list = self.get_channel_list(registry_address, token_address, partner_address)
-        assert len(channel_list) <= 1
+        msg = f"Found {len(channel_list)} channels, but expected 0 or 1."
+        assert len(channel_list) <= 1, msg
 
         if not channel_list:
             msg = (
@@ -990,11 +991,10 @@ class RaidenAPI:  # pragma: no unittest
 
     def get_tokens_list(self, registry_address: TokenNetworkRegistryAddress) -> List[TokenAddress]:
         """Returns a list of tokens the node knows about"""
-        tokens_list = views.get_token_identifiers(
+        return views.get_token_identifiers(
             chain_state=views.state_from_raiden(self.raiden),
             token_network_registry_address=registry_address,
         )
-        return tokens_list
 
     def get_token_network_address_for_token_address(
         self, registry_address: TokenNetworkRegistryAddress, token_address: TokenAddress

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -106,6 +106,7 @@ from raiden.utils.runnable import Runnable
 from raiden.utils.system import get_system_spec
 from raiden.utils.transfers import create_default_identifier
 from raiden.utils.typing import (
+    MYPY_ANNOTATION,
     Address,
     Any,
     BlockSpecification,
@@ -124,6 +125,7 @@ from raiden.utils.typing import (
     TokenNetworkRegistryAddress,
     WithdrawAmount,
     cast,
+    typecheck,
 )
 
 log = structlog.get_logger(__name__)
@@ -836,7 +838,8 @@ class RestAPI:  # pragma: no unittest
         raiden_service_result = self.raiden_api.get_channel_list(
             registry_address, token_address, partner_address
         )
-        assert isinstance(raiden_service_result, list)
+        typecheck(raiden_service_result, list)
+
         result = [
             self.channel_schema.dump(channel_schema) for channel_schema in raiden_service_result
         ]
@@ -849,7 +852,8 @@ class RestAPI:  # pragma: no unittest
             registry_address=to_checksum_address(registry_address),
         )
         raiden_service_result = self.raiden_api.get_tokens_list(registry_address)
-        assert isinstance(raiden_service_result, list)
+        typecheck(raiden_service_result, list)
+
         tokens_list = AddressList(raiden_service_result)
         result = self.address_list_schema.dump(tokens_list)
         return api_response(result=result)
@@ -971,7 +975,7 @@ class RestAPI:  # pragma: no unittest
     def get_raiden_internal_events_with_timestamps(
         self, limit: Optional[int], offset: Optional[int]
     ) -> Response:
-        assert self.raiden_api.raiden.wal
+        assert self.raiden_api.raiden.wal, "Raiden Service has to be initialized"
         events = [
             str(e)
             for e in self.raiden_api.raiden.wal.storage.get_events_with_timestamps(
@@ -1126,7 +1130,7 @@ class RestAPI:  # pragma: no unittest
                 status_code=HTTPStatus.CONFLICT,
             )
 
-        assert isinstance(result, EventPaymentSentSuccess)
+        assert isinstance(result, EventPaymentSentSuccess), MYPY_ANNOTATION
         payment = {
             "initiator_address": self.raiden_api.address,
             "registry_address": registry_address,

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -165,7 +165,8 @@ def get_contractreceivechannelbatchunlock_data_from_event(
     locksroot = args["locksroot"]
 
     token_network_state = views.get_token_network_by_address(chain_state, token_network_address)
-    assert token_network_state is not None
+    msg = f"Could not find token network for address {to_checksum_address(token_network_address)}"
+    assert token_network_state is not None, msg
 
     if participant1 == chain_state.our_address:
         partner = participant2

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -104,8 +104,13 @@ class ConnectionManager:  # pragma: no unittest
             chain_state, token_network_address
         )
 
-        assert token_network_state
-        assert token_network_registry
+        msg = f"Token network for address {to_checksum_address(token_network_address)} not found."
+        assert token_network_state, msg
+        msg = (
+            f"Token network registry for token network address "
+            f"{to_checksum_address(token_network_address)} not found."
+        )
+        assert token_network_registry, msg
 
         # TODO:
         # - Add timeout for transaction polling, used to overwrite the RaidenAPI

--- a/raiden/messages/monitoring_service.py
+++ b/raiden/messages/monitoring_service.py
@@ -135,7 +135,7 @@ class RequestMonitoring(SignedMessage):
 
     def _data_to_sign(self) -> bytes:
         """ Return the binary data to be/which was signed """
-        assert self.non_closing_signature
+        assert self.non_closing_signature is not None, "Message is not signed yet."
         packed = pack_reward_proof(
             chain_id=self.balance_proof.chain_id,
             token_network_address=self.balance_proof.token_network_address,

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -17,6 +17,7 @@ from raiden.utils.typing import (
     NoReturn,
     Optional,
     Tuple,
+    typecheck,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
 from raiden_contracts.contract_manager import ContractManager
@@ -160,7 +161,7 @@ def check_transaction_gas_used(transaction: TransactionMined) -> None:
             contract_name = transaction.data.contract_name
             msg = f"Deploying {contract_name} failed because all the gas was used!"
         else:
-            assert isinstance(transaction.data, EthTransfer)
+            typecheck(transaction.data, EthTransfer)
             msg = f"EthTransfer failed!"
 
         # Keeping this around just in case the wrong value from the receipt is

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -48,6 +48,7 @@ from raiden.utils.keys import privatekey_to_address
 from raiden.utils.smart_contracts import safe_gas_limit
 from raiden.utils.typing import (
     ABI,
+    MYPY_ANNOTATION,
     Address,
     AddressHex,
     BlockHash,
@@ -170,7 +171,7 @@ def check_address_has_code(
 ) -> None:
     """ Checks that the given address contains code. """
     if is_bytes(given_block_identifier):
-        assert isinstance(given_block_identifier, bytes)
+        assert isinstance(given_block_identifier, bytes), MYPY_ANNOTATION
         block_hash = encode_hex(given_block_identifier)
         given_block_identifier = client.web3.eth.getBlock(block_hash).number
 
@@ -800,7 +801,11 @@ class JSONRPCClient:
         Checks the local tx pool for a transaction from a particular address and for
         a given nonce. If it exists it returns the transaction hash.
         """
-        assert self.eth_node is EthClient.PARITY
+        msg = {
+            "`parity` specific function must only be called when the client is parity. "
+            f"Client was {self.eth_node}."
+        }
+        assert self.eth_node is EthClient.PARITY, msg
         # https://wiki.parity.io/JSONRPC-parity-module.html?q=traceTransaction#parity_alltransactions
         transactions = self.web3.manager.request_blocking("parity_allTransactions", [])
         log.debug("RETURNED TRANSACTIONS", transactions=transactions)
@@ -1171,7 +1176,7 @@ class JSONRPCClient:
             is_transaction_mined = tx_receipt and tx_receipt.get("blockNumber") is not None
 
             if is_transaction_mined:
-                assert tx_receipt is not None
+                assert tx_receipt is not None, MYPY_ANNOTATION
                 confirmation_block = (
                     tx_receipt["blockNumber"] + self.default_block_num_confirmations
                 )

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -142,7 +142,11 @@ class _RetryQueue(Runnable):
 
     def enqueue(self, queue_identifier: QueueIdentifier, messages: List[Message]) -> None:
         """ Enqueue a message to be sent, and notify main loop """
-        assert queue_identifier.recipient == self.receiver
+        msg = (
+            f"queue_identifier.recipient ({to_checksum_address(queue_identifier.recipient)}) "
+            f" must match self.receiver ({to_checksum_address(self.receiver)})."
+        )
+        assert queue_identifier.recipient == self.receiver, msg
 
         with self._lock:
             timeout_generator = timeout_exponential_backoff(
@@ -471,11 +475,11 @@ class MatrixTransport(Runnable):
         self._client.start_listener_thread(
             timeout_ms=self._config.sync_timeout, latency_ms=self._config.sync_latency
         )
-        assert isinstance(self._client.sync_worker, gevent.Greenlet)
+        assert isinstance(self._client.sync_worker, gevent.Greenlet), MYPY_ANNOTATION
         self._client.sync_worker.link_exception(self.on_error)
         self._client.sync_worker.link_value(on_success)
 
-        assert isinstance(self._client.message_worker, gevent.Greenlet)
+        assert isinstance(self._client.message_worker, gevent.Greenlet), MYPY_ANNOTATION
         self._client.message_worker.link_exception(self.on_error)
         self._client.message_worker.link_value(on_success)
         self.greenlets = [self._client.sync_worker, self._client.message_worker]

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -583,7 +583,6 @@ class RaidenEventHandler(EventHandler):
                 canonical_identifier=canonical_identifier,
                 state_change_identifier=state_change_identifier,
             )
-            assert restored_channel_state is not None
 
             gain = get_batch_unlock_gain(restored_channel_state)
 
@@ -625,7 +624,6 @@ class RaidenEventHandler(EventHandler):
                 canonical_identifier=canonical_identifier,
                 state_change_identifier=state_change_identifier,
             )
-            assert restored_channel_state is not None
 
             gain = get_batch_unlock_gain(restored_channel_state)
 

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -81,7 +81,8 @@ def update_monitoring_service_from_balance_proof(
     )
     assert channel_state, msg
 
-    assert raiden.user_deposit is not None
+    msg = f"Monitoring is enabled but the `UserDeposit` contract is None."
+    assert raiden.user_deposit is not None, msg
     rei_balance = raiden.user_deposit.effective_balance(raiden.address, "latest")
     if rei_balance < MONITORING_REWARD:
         rdn_balance = to_rdn(rei_balance)

--- a/raiden/storage/restore.py
+++ b/raiden/storage/restore.py
@@ -34,7 +34,7 @@ def channel_state_until_state_change(
     raiden: "RaidenService",
     canonical_identifier: CanonicalIdentifier,
     state_change_identifier: StateChangeID,
-) -> Optional[NettingChannelState]:  # pragma: no unittest
+) -> NettingChannelState:  # pragma: no unittest
     """ Go through WAL state changes until a certain balance hash is found. """
     assert raiden.wal, "Raiden has not been started yet"
 
@@ -54,7 +54,7 @@ def channel_state_until_state_change(
         chain_state=chain_state, canonical_identifier=canonical_identifier
     )
 
-    if not channel_state:
+    if channel_state is None:
         raise RaidenUnrecoverableError(
             f"Channel was not found before state_change {state_change_identifier}"
         )

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -270,16 +270,17 @@ class StateManager(Generic[ST]):
         for state_change in state_changes:
             iteration = self.state_transition(next_state, state_change)
 
-            assert isinstance(iteration, TransitionResult)
-            assert all(isinstance(e, Event) for e in iteration.events)
-            assert isinstance(iteration.new_state, State)
+            typecheck(iteration, TransitionResult)
+            for e in iteration.events:
+                typecheck(e, Event)
+            typecheck(iteration.new_state, State)
 
             # Skipping the copy because this value is internal
             events.append(iteration.events)
             next_state = iteration.new_state
 
+        assert next_state is not None, "State transition did not yield new state"
         self.current_state = next_state
-        assert next_state is not None
 
         return iteration.new_state, events
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -240,13 +240,9 @@ def try_new_route(
     )
 
     for reachable_route_state in reachable_route_states:
-        forward_channel_id = reachable_route_state.forward_channel_id
-
-        candidate_channel_state = forward_channel_id and channelidentifiers_to_channels.get(
-            forward_channel_id
-        )
-
-        assert isinstance(candidate_channel_state, NettingChannelState)
+        candidate_channel_state = channelidentifiers_to_channels[
+            reachable_route_state.forward_channel_id
+        ]
 
         amount_with_fee = calculate_safe_amount_with_fee(
             payment_amount=transfer_description.amount,
@@ -293,7 +289,7 @@ def try_new_route(
         initiator_state = None
 
     else:
-        assert channel_state is not None
+        assert channel_state is not None, "We must have a channel_state if we have a route_state"
 
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
         lockedtransfer_event = send_lockedtransfer(
@@ -304,7 +300,6 @@ def try_new_route(
             route_state=route_state,
             route_states=reachable_route_states,
         )
-        assert lockedtransfer_event
 
         initiator_state = InitiatorTransferState(
             route=route_state,
@@ -326,7 +321,9 @@ def send_lockedtransfer(
     route_states: List[RouteState],
 ) -> SendLockedTransfer:
     """ Create a mediated transfer using channel. """
-    assert channel_state.token_network_address == transfer_description.token_network_address
+    assert (
+        channel_state.token_network_address == transfer_description.token_network_address
+    ), "token_network_address mismatch"
 
     lock_expiration = channel.get_safe_initial_expiration(
         block_number, channel_state.reveal_timeout, transfer_description.lock_timeout

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -378,7 +378,9 @@ def handle_offchain_secretreveal(
     if not initiator_state:
         return TransitionResult(payment_state, list())
 
-    assert initiator_state.transfer_state != "transfer_cancelled"
+    assert (
+        initiator_state.transfer_state != "transfer_cancelled"
+    ), "Can't handle reveal for cancelled transfer"
 
     sub_iteration = subdispatch_to_initiatortransfer(
         payment_state=payment_state,
@@ -406,7 +408,9 @@ def handle_onchain_secretreveal(
     if not initiator_state:
         return TransitionResult(payment_state, list())
 
-    assert initiator_state.transfer_state != "transfer_cancelled"
+    assert (
+        initiator_state.transfer_state != "transfer_cancelled"
+    ), "Must not reveal secret for cancelled payment"
 
     sub_iteration = subdispatch_to_initiatortransfer(
         payment_state=payment_state,

--- a/raiden/transfer/mediated_transfer/mediation_fee.py
+++ b/raiden/transfer/mediated_transfer/mediation_fee.py
@@ -12,6 +12,7 @@ from raiden.utils.typing import (
     PaymentWithFeeAmount,
     ProportionalFeeAmount,
     TokenAmount,
+    typecheck,
 )
 
 NUM_DISCRETISATION_POINTS = 21
@@ -185,7 +186,7 @@ class FeeScheduleState(State):
 
     def _update_penalty_func(self) -> None:
         if self.imbalance_penalty:
-            assert isinstance(self.imbalance_penalty, list)
+            typecheck(self.imbalance_penalty, list)
             x_list, y_list = tuple(zip(*self.imbalance_penalty))
             self._penalty_func = Interpolate(x_list, y_list)
 
@@ -245,8 +246,8 @@ class FeeScheduleState(State):
 
 def linspace(start: TokenAmount, stop: TokenAmount, num: int) -> List[TokenAmount]:
     """ Returns a list of num numbers from start to stop (inclusive). """
-    assert num > 1
-    assert start <= stop
+    assert num > 1, "Must generate at least one step"
+    assert start <= stop, "start must be smaller than stop"
 
     step = (stop - start) / (num - 1)
 
@@ -265,8 +266,8 @@ def calculate_imbalance_fees(
     The penalty term takes the following value at the extrema:
     channel_capacity * (proportional_imbalance_fee / 1_000_000)
     """
-    assert channel_capacity >= 0
-    assert proportional_imbalance_fee >= 0
+    assert channel_capacity >= 0, "channel_capacity must be larger than zero"
+    assert proportional_imbalance_fee >= 0, "prop. imbalance fee must be larger than zero"
 
     if proportional_imbalance_fee == 0:
         return None

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -96,7 +96,9 @@ def handle_inittarget(
     transfer = state_change.transfer
     route = state_change.from_hop
 
-    assert channel_state.identifier == transfer.balance_proof.channel_identifier
+    assert (
+        channel_state.identifier == transfer.balance_proof.channel_identifier
+    ), "channel_id mismatch in handle_inittarget"
     is_valid, channel_events, errormsg = channel.handle_receive_lockedtransfer(
         channel_state, transfer
     )
@@ -339,7 +341,7 @@ def state_transition(
             )
     elif type(state_change) == Block:
         assert isinstance(state_change, Block), MYPY_ANNOTATION
-        assert state_change.block_number == block_number
+        assert state_change.block_number == block_number, "Block number mismatch"
         assert target_state, "Block state changes should be accompanied by a valid target state"
 
         iteration = handle_block(

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -78,6 +78,7 @@ from raiden.utils.typing import (
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
     Union,
+    typecheck,
 )
 
 # All State changes that are subdispatched as token network actions
@@ -436,10 +437,6 @@ def maybe_add_tokennetwork(
         mapping[token_network_address] = token_network_registry_address
 
 
-def sanity_check(iteration: TransitionResult[ChainState]) -> None:
-    assert isinstance(iteration.new_state, ChainState)
-
-
 def inplace_delete_message_queue(
     chain_state: ChainState,
     state_change: Union[ReceiveDelivered, ReceiveProcessed, ReceiveWithdrawConfirmation],
@@ -582,9 +579,9 @@ def handle_action_change_node_network_state(
     chain_state.nodeaddresses_to_networkstates[node_address] = network_state
 
     for secrethash, subtask in list(chain_state.payment_mapping.secrethashes_to_task.items()):
-        # This assert would not have been needed if token_network_address, a common attribute
+        # This typecheck would not have been needed if token_network_address, a common attribute
         # for all TransferTasks was part of the TransferTasks superclass.
-        assert isinstance(subtask, (InitiatorTask, MediatorTask, TargetTask))
+        typecheck(subtask, (InitiatorTask, MediatorTask, TargetTask))
         result = subdispatch_mediatortask(
             chain_state=chain_state,
             state_change=state_change,
@@ -1149,6 +1146,6 @@ def state_transition(
     iteration = handle_state_change(chain_state, state_change)
 
     update_queues(iteration, state_change)
-    sanity_check(iteration)
+    typecheck(iteration.new_state, ChainState)
 
     return iteration

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -169,7 +169,7 @@ class RouteState(State):
 
     @property
     def next_hop_address(self) -> Address:
-        assert len(self.route) >= 1
+        assert len(self.route) >= 1, "Route has no next hop"
         return self.route[1]
 
     def __repr__(self) -> str:

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 def hash_balance_data(
     transferred_amount: TokenAmount, locked_amount: LockedAmount, locksroot: Locksroot
 ) -> BalanceHash:
-    assert locksroot != b""
-    assert len(locksroot) == 32
+    assert locksroot != b"", "Can't hash empty locksroot"
+    assert len(locksroot) == 32, "Locksroot has wrong length"
     if transferred_amount == 0 and locked_amount == 0 and locksroot == LOCKSROOT_OF_NO_LOCKS:
         return BalanceHash(EMPTY_HASH)
 

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -12,6 +12,7 @@ from raiden.transfer.state import (
     TokenNetworkState,
 )
 from raiden.utils.typing import (
+    MYPY_ANNOTATION,
     TYPE_CHECKING,
     Address,
     BlockHash,
@@ -418,7 +419,7 @@ def secret_from_transfer_task(
     transfer_task: TransferTask, secrethash: SecretHash
 ) -> Optional[Secret]:
     """Return the secret for the transfer, None on ABSENT_SECRET."""
-    assert isinstance(transfer_task, InitiatorTask)
+    assert isinstance(transfer_task, InitiatorTask), MYPY_ANNOTATION
 
     transfer_state = transfer_task.manager_state.initiator_transfers.get(secrethash)
 

--- a/raiden/utils/profiling/profiler.py
+++ b/raiden/utils/profiling/profiler.py
@@ -78,7 +78,7 @@ def ensure_call(curr, call):
 
 def ensure_thread_state(target, frame):
     global _state
-    assert _state
+    assert _state, "Global variable '_state' not set"
 
     if target not in _state:
         frame = frame
@@ -267,7 +267,7 @@ class ThreadState:
 
 def thread_profiler(frame, event, arg):
     global _state
-    assert _state
+    assert _state, "Global variable '_state' not set"
 
     now = clock()  # measure once and reuse it
 
@@ -301,7 +301,7 @@ def thread_profiler(frame, event, arg):
 
 def greenlet_profiler(event, args):
     global _state
-    assert _state
+    assert _state, "Global variable '_state' not set"
 
     if event in ("switch", "throw"):  # both events are in the target context
         now = clock()
@@ -326,7 +326,7 @@ def greenlet_profiler(event, args):
 
 def start_profiler():
     global _state
-    assert _state
+    assert _state, "Global variable '_state' not set"
 
     _state = GlobalState()
 
@@ -548,7 +548,7 @@ def print_thread_profile(thread_state):
 
 def print_merged():
     global _state
-    assert _state
+    assert _state, "Global variable '_state' not set"
 
     merged = merge_threadstates(*_state.values())
     print_info_tree(filter_fast(merged))
@@ -556,7 +556,7 @@ def print_merged():
 
 def print_all_threads():
     global _state
-    assert _state
+    assert _state, "Global variable '_state' not set"
 
     for thread_state in _state.values():
         print_thread_profile(thread_state)

--- a/raiden/utils/upgrades.py
+++ b/raiden/utils/upgrades.py
@@ -46,7 +46,8 @@ def get_file_version(db_path: Path) -> int:
 def get_db_version(db_filename: Path) -> int:
     """Return the version value stored in the db"""
 
-    assert os.path.exists(db_filename)
+    msg = f"Path '{db_filename}' expected, but not found"
+    assert os.path.exists(db_filename), msg
 
     # Perform a query directly through SQL rather than using
     # storage.get_version()

--- a/tools/pylint/__init__.py
+++ b/tools/pylint/__init__.py
@@ -1,0 +1,30 @@
+from functools import lru_cache, wraps
+from typing import Any, Callable, Optional, TypeVar
+
+from astroid import Module
+from astroid.node_classes import NodeNG
+
+RAIDEN_TESTS_MODULE = "raiden.tests"
+
+T_NODE = TypeVar("T_NODE", bound=NodeNG)
+
+
+@lru_cache(maxsize=None)
+def find_parent(node: NodeNG, scope_type: T_NODE) -> Optional[T_NODE]:
+    current_node = node
+    while current_node is not None and not isinstance(current_node, scope_type):
+        current_node = current_node.parent
+    return current_node
+
+
+def ignore_tests(func: Callable) -> Callable:
+    """ Decorator that ignores nodes below the raiden.tests module. """
+
+    @wraps(func)
+    def decorator(self, node: NodeNG) -> Any:
+        module_node = find_parent(node, Module)
+        if module_node is None or module_node.name.startswith(RAIDEN_TESTS_MODULE):
+            return None
+        return func(self, node)
+
+    return decorator

--- a/tools/pylint/assert_checker.py
+++ b/tools/pylint/assert_checker.py
@@ -1,6 +1,8 @@
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
 
+from . import ignore_tests
+
 ASSERT_ID = "assert-message"
 ASSERT_MSG = "Every assert must have a message describing the error to aid debugging"
 
@@ -16,6 +18,7 @@ class AssertMessage(BaseChecker):
     priority = -1
     msgs = {"E6492": (ASSERT_MSG, ASSERT_ID, "Assert without message.")}
 
+    @ignore_tests
     def visit_assert(self, node):
         if len(list(node.get_children())) != 2:
             self.add_message(ASSERT_ID, node=node)

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -23,8 +23,8 @@ def main(keystore_file, password, rpc_url, eth_amount, targets_file) -> None:
     with open(keystore_file, "r") as keystore:
         account = Account(json.load(keystore), password, keystore_file)
 
-    assert account.privkey
-    assert account.address
+    assert account.privkey, "Could not decode keystore file: wrong password"
+    assert account.address, "Could not decode keystore file: no 'address' field found"
     print("Using account:", to_checksum_address(account.address))
 
     client = JSONRPCClient(


### PR DESCRIPTION
## Description

Our custom pylint assert checker wasn't included in the list of enabled messages.

Because of this there are currently 89 `assert`s without messages in the main Raiden code.


The messages should be added to this PR before it's merged


#### Missing modules:
- [x] raiden.transfer.utils
- [x] raiden.transfer.channel
- [x] raiden.transfer.architecture
- [x] raiden.transfer.views
- [x] raiden.transfer.node
- [x] raiden.transfer.mediated_transfer.initiator
- [x] raiden.transfer.mediated_transfer.mediator
- [x] raiden.transfer.mediated_transfer.initiator_manager
- [x] raiden.transfer.mediated_transfer.mediation_fee
- [x] raiden.transfer.mediated_transfer.target
- [x] raiden.transfer.state
- [x] raiden.utils.upgrades
- [x] raiden.utils.profiling.profiler
- [x] raiden.blockchain.state
- [x] raiden.api.python
- [x] tools.transfer_eth
- [x] raiden.api.rest