### PR TITLE
Codecov: post to github after coverage is complete

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,6 @@ coverage:
         target: 55%
         flags: unit
     patch: no
+
+comment:
+  after_n_builds: 5  # only post github comment after all 5 coverage reports have been submitted


### PR DESCRIPTION
Our jobs submit code coverage separately and codecov.com merges them for
us. Without this change, the coverage informations is posted to github
as soon as it is submitted to codecov. This can irritate developers who
see low coverage for a while until the remaining CI jobs finish and add
their coverage.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
