### PR TITLE
Add pylint checker that disallows __del__ methods

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@ jobs=4
 persistent=yes
 suggestion-mode=yes
 unsafe-load-any-extension=no
-load-plugins=tools.pylint.gevent_checker,tools.pylint.assert_checker
+load-plugins=tools.pylint.gevent_checker,tools.pylint.assert_checker,tools.pylint.del_method_checker
 
 # Blacklist files or directories (basenames, not paths)
 ignore=

--- a/pylintrc
+++ b/pylintrc
@@ -30,6 +30,8 @@ disable=all
 enable=
     assert-message,
     bad-except-order,
+    del-method-used,
+    exception-in-del,
     expression-not-assigned,
     gevent-joinall,
     import-self,

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -737,10 +737,6 @@ class SQLiteStorage:
         self.conn.close()
         del self.conn
 
-    def __del__(self) -> None:
-        if hasattr(self, "conn"):
-            raise RuntimeError("The database connection was not closed.")
-
     def __enter__(self) -> "SQLiteStorage":
         return self
 

--- a/raiden/utils/profiling/timer.py
+++ b/raiden/utils/profiling/timer.py
@@ -38,11 +38,6 @@ class Timer:
 
         signal.signal(TIMER_SIGNAL, signal.SIG_IGN)
 
-    def __del__(self) -> None:
-        assert not hasattr(
-            self, "_callback"
-        ), "Timer must be stopped cleanly, or the signal handler will keep running"
-
     def __bool__(self) -> bool:
         # we're always truthy
         return True

--- a/tools/pylint/del_method_checker.py
+++ b/tools/pylint/del_method_checker.py
@@ -1,0 +1,51 @@
+from astroid import FunctionDef
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+from . import find_parent, ignore_tests
+
+ID_DEL_METHOD = "del-method-used"
+ID_EXCEPTION_IN_DEL = "exception-in-del"
+MSG_DEL_METHOD = "Avoid using __del__ methods."
+MSG_EXCEPTION_IN_DEL = "Don't raise Exceptions in __del__ methods."
+
+
+def register(linter):
+    linter.register_checker(DelMethod(linter))
+
+
+class DelMethod(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = "del-method"
+    priority = -1
+    msgs = {
+        "C6493": (
+            MSG_DEL_METHOD,
+            ID_DEL_METHOD,
+            (
+                "__del__ methods are unreliable and should be avoided. "
+                "Consider using a context manager instead."
+            ),
+        ),
+        "E6494": (
+            MSG_EXCEPTION_IN_DEL,
+            ID_EXCEPTION_IN_DEL,
+            (
+                "Exceptions raised in __del__ methods are not propagated. See the warning "
+                "at the end of https://docs.python.org/3.7/reference/datamodel.html#object.__del__"
+            ),
+        ),
+    }
+
+    @ignore_tests
+    def visit_functiondef(self, node):
+        if node.name == "__del__" and node.is_method():
+            self.add_message(ID_DEL_METHOD, node=node)
+
+    @ignore_tests
+    def visit_raise(self, node):
+        function_node = find_parent(node, FunctionDef)
+        if function_node is not None:
+            if function_node.name == "__del__" and function_node.is_method():
+                self.add_message(ID_EXCEPTION_IN_DEL, node=node)


### PR DESCRIPTION
(Based on #5564, merge after)

## Description

`__del__` methods are notoriously unreliable and have caused multiple issues in the past (#5561, #4346, #3559).
We should avoid using them in the code base in general.

This adds a pylint plugin that adds two new checks:
- C6493: A `C`onvention level check that recommends against using `__del__` methods in general
- E6494 An `E`rror level check that warns against raising exceptions in `__del__` methods