### PR TITLE
Add libffi-dev to build.Dockerfile

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -6,7 +6,7 @@ ARG GETH_URL_LINUX
 
 # install dependencies
 RUN apt-get update
-RUN apt-get install -y git-core wget xz-utils libgmp-dev
+RUN apt-get install -y git-core wget xz-utils libgmp-dev libffi-dev
 
 RUN wget -nv -O /usr/bin/solc ${SOLC_URL_LINUX} && \
     chmod +x /usr/bin/solc


### PR DESCRIPTION
This is a Hail Mary to see if perhaps #5511 can be fixed where the
dockerfile is not built for armv7l and aarch64.

