### PR TITLE
Removed ActionUpdateTransportAuthData

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -48,10 +48,7 @@ from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
 from raiden.transfer.state import NetworkState, QueueIdsToQueues
-from raiden.transfer.state_change import (
-    ActionChangeNodeNetworkState,
-    ActionUpdateTransportAuthData,
-)
+from raiden.transfer.state_change import ActionChangeNodeNetworkState
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.logging import redact_secret
 from raiden.utils.runnable import Runnable
@@ -439,11 +436,9 @@ class MatrixTransport(Runnable):
         """ Runnable main method, perform wait on long-running subtasks """
         # dispatch auth data on first scheduling after start
         assert self._raiden_service is not None, "_raiden_service not set"
-        state_change = ActionUpdateTransportAuthData(f"{self._user_id}/{self._client.api.token}")
         self.greenlet.name = (
             f"MatrixTransport._run node:{to_checksum_address(self._raiden_service.address)}"
         )
-        self._raiden_service.handle_and_track_state_changes([state_change])
         try:
             # waits on _stop_event.ready()
             self._broadcast_worker()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -483,11 +483,7 @@ class RaidenService(Runnable):
             node=to_checksum_address(self.address),
         )
 
-        self.transport.start(
-            raiden_service=self,
-            prev_auth_data=chain_state.last_transport_authdata,
-            whitelist=whitelist,
-        )
+        self.transport.start(raiden_service=self, prev_auth_data=None, whitelist=whitelist)
 
         for neighbour in views.all_neighbour_nodes(chain_state):
             if neighbour != ConnectionManager.BOOTSTRAP_ADDR:

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -37,7 +37,7 @@ from raiden.tests.utils.mocks import MockRaidenService
 from raiden.tests.utils.transfer import wait_assert
 from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
-from raiden.transfer.state_change import ActionChannelClose, ActionUpdateTransportAuthData
+from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, Dict, List, cast
 
@@ -189,14 +189,6 @@ def test_matrix_message_sync(matrix_transports):
     transport0.start(raiden_service0, [], None)
     transport1.start(raiden_service1, [], None)
 
-    latest_auth_data = f"{transport1._user_id}/{transport1._client.api.token}"
-    update_transport_auth_data = ActionUpdateTransportAuthData(latest_auth_data)
-    with gevent.Timeout(2):
-        wait_assert(
-            raiden_service1.handle_and_track_state_changes.assert_called_with,
-            [update_transport_auth_data],
-        )
-
     transport0.start_health_check(transport1._raiden_service.address)
     transport1.start_health_check(transport0._raiden_service.address)
 
@@ -236,8 +228,6 @@ def test_matrix_message_sync(matrix_transports):
 
     wait_for_peer_unreachable(transport0, transport1._raiden_service.address)
 
-    assert latest_auth_data
-
     # Send more messages while the other end is offline
     for i in range(10, 15):
         message = Processed(message_identifier=i, signature=EMPTY_SIGNATURE)
@@ -246,7 +236,7 @@ def test_matrix_message_sync(matrix_transports):
         transport0.send_async(queue_identifier, message)
 
     # Should fetch the 5 messages sent while transport1 was offline
-    transport1.start(transport1._raiden_service, [], latest_auth_data)
+    transport1.start(transport1._raiden_service, [], None)
     transport1.start_health_check(transport0._raiden_service.address)
 
     with gevent.Timeout(TIMEOUT_MESSAGE_RECEIVE):

--- a/raiden/tests/unit/test_data/db_statechanges.json
+++ b/raiden/tests/unit/test_data/db_statechanges.json
@@ -666,14 +666,6 @@
         }
     ],
     [
-        4,
-        {
-            "auth_data": "@0x3503221a95028173969fc1f36b2e4f0705a3cc8b:localhost:8500/MDAxY2xvY2F0aW9uIGxvY2FsaG9zdDo4NTAwCjAwMTNpZGVudGlmaWVyIGtleQowMDEwY2lkIGdlbiA9IDEKMDA0ZGNpZCB1c2VyX2lkID0gQDB4MzUwMzIyMWE5NTAyODE3Mzk2OWZjMWYzNmIyZTRmMDcwNWEzY2M4Yjpsb2NhbGhvc3Q6ODUwMAowMDE2Y2lkIHR5cGUgPSBhY2Nlc3MKMDAyMWNpZCBub25jZSA9IE9OYnVLc0pFOFdhVG1HIzEKMDAyZnNpZ25hdHVyZSAHqWpHj5FvGs3HXnd1wA1Tj_wP8L3yX5plLyVjCY8iBAo",
-            "_type": "raiden.transfer.state_change.ActionUpdateTransportAuthData",
-            "_version": 0
-        }
-    ],
-    [
         5,
         {
             "transaction_hash": "0x7b671bf88558f7da9c76c5b89b2551b59d95f4f23ea50bad641931968aa82f84",

--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -141,30 +141,6 @@ def test_redacted_request(capsys, tmpdir):
     assert "access_token=<redacted>" in captured.err
 
 
-def test_redacted_state_change(capsys, tmpdir):
-    configure_logging({"": "DEBUG"}, debug_log_file_path=str(tmpdir / "raiden-debug.log"))
-    auth_token = (
-        "MDAxZGxvY2F0aW9uIGxvY2FsaG9zdDo2NDAzMwowMDEzaWRlbnRpZmllciBrZXkKMDAxMGNpZCBnZW4gPSAxCjAwN"
-        "GVjaWQgdXNlcl9pZCA9IEAweDYyNjRkYThmMmViOGQ4MDM3NjM2OTEwYzFlYzAzODA0MzhmNGVmZWU6bG9jYWxob3"
-        "N0OjY0MDMzCjAwMTZjaWQgdHlwZSA9IGFjY2VzcwowMDIxY2lkIG5vbmNlID0gSlhjfjI4YVA9clZmbzZUSQowMDJ"
-        "mc2lnbmF0dXJlIKQ1WCUJ-1Mv6rN6yjnb2w5R2BqH7iew7RwFiKuMcYosCg"
-    )
-    auth_user = "@0x0123456789abcdef0123456789abcdef01234567:localhost:64033"
-    state_changes = [
-        {
-            "auth_data": f"{auth_user}/{auth_token}",
-            "_type": "raiden.transfer.state_change.ActionUpdateTransportAuthData",
-        }
-    ]
-    log = structlog.get_logger("raiden.raiden_service")
-    log.debug("State changes", state_changes=state_changes)
-
-    captured = capsys.readouterr()
-
-    assert auth_token not in captured.err
-    assert f"{auth_user}/<redacted>" in captured.err
-
-
 def test_that_secret_is_redacted(capsys, tmpdir):
     configure_logging({"": "DEBUG"}, debug_log_file_path=str(tmpdir / "raiden-debug.log"))
 

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -460,7 +460,7 @@ def test_batch_query_state_changes():
     )
 
     # Test that querying the state changes in batches of 10 works
-    state_changes_num = 87
+    state_changes_num = 86
     state_changes = []
     for state_changes_batch in storage.batch_query_state_changes(batch_size=10):
         state_changes.extend(state_changes_batch)

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -48,7 +48,6 @@ from raiden.transfer.state_change import (
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
     ActionInitChain,
-    ActionUpdateTransportAuthData,
     Block,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -767,14 +766,6 @@ def handle_receive_unlock(
     return subdispatch_to_paymenttask(chain_state, state_change, secrethash)
 
 
-def handle_action_update_transport_auth_data(
-    chain_state: ChainState, state_change: ActionUpdateTransportAuthData
-) -> TransitionResult[ChainState]:
-    assert chain_state is not None, "chain_state must be set"
-    chain_state.last_transport_authdata = state_change.auth_data
-    return TransitionResult(chain_state, list())
-
-
 def handle_state_change(
     chain_state: Optional[ChainState], state_change: StateChange
 ) -> TransitionResult[ChainState]:  # pragma: no cover
@@ -816,9 +807,6 @@ def handle_state_change(
         elif type(state_change) == ActionInitTarget:
             assert isinstance(state_change, ActionInitTarget), MYPY_ANNOTATION
             iteration = handle_action_init_target(chain_state, state_change)
-        elif type(state_change) == ActionUpdateTransportAuthData:
-            assert isinstance(state_change, ActionUpdateTransportAuthData), MYPY_ANNOTATION
-            iteration = handle_action_update_transport_auth_data(chain_state, state_change)
         elif type(state_change) == ReceiveTransferCancelRoute:
             assert isinstance(state_change, ReceiveTransferCancelRoute), MYPY_ANNOTATION
             iteration = handle_receive_transfer_cancel_route(chain_state, state_change)

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -76,17 +76,6 @@ class Block(StateChange):
 
 
 @dataclass(frozen=True)
-class ActionUpdateTransportAuthData(StateChange):
-    """ Holds the last "timestamp" at which we synced
-    with the transport. The timestamp could be a date/time value
-    or any other value provided by the transport backend.
-    Can be used later to filter the messages which have not been processed.
-    """
-
-    auth_data: str
-
-
-@dataclass(frozen=True)
 class ActionCancelPayment(StateChange):
     """ The user requests the transfer to be cancelled.
     This state change can fail, it depends on the node's role and the current


### PR DESCRIPTION
This value doesn't have to be synchronized with the protocol messages
and therefore doesn't have to go through the heavy weight code path of
the state machine.