### PR TITLE
make lint: Run flake8 before other checks and don't run mypy twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,7 @@ ISORT_PARAMS = --ignore-whitespace --settings-path ./ --skip-glob '*/node_module
 
 lint: ISORT_CHECK_PARAMS := --diff --check-only
 lint: BLACK_CHECK_PARAMS := --check --diff
-lint: mypy mypy-all isort black
-	flake8 $(JOBS_ARG) $(LINT_PATHS)
-	pylint $(JOBS_ARG) $(LINT_PATHS)
+lint: format flake8 mypy pylint
 
 mypy:
 	mypy raiden
@@ -64,6 +62,12 @@ mypy-all:
 	# Be aware, that we currently ignore all mypy errors in `raiden.tests.*` through `setup.cfg`.
 	# Remaining errors in tests:
 	mypy --config-file /dev/null raiden --ignore-missing-imports | grep error | wc -l
+
+flake8:
+	flake8 $(JOBS_ARG) $(LINT_PATHS)
+
+pylint:
+	pylint $(JOBS_ARG) $(LINT_PATHS)
 
 isort:
 	isort $(JOBS_ARG) $(ISORT_PARAMS) $(ISORT_CHECK_PARAMS)


### PR DESCRIPTION
## Description

make lint: Run flake8 before other checks and don't run mypy twice

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
