### PR TITLE
Bugfix: Left over of the authdata removal

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -25,7 +25,7 @@ LATEST = "https://api.github.com/repos/raiden-network/raiden/releases/latest"
 RELEASE_PAGE = "https://github.com/raiden-network/raiden/releases"
 SECURITY_EXPRESSION = r"\[CRITICAL UPDATE.*?\]"
 
-RAIDEN_DB_VERSION = RaidenDBVersion(24)
+RAIDEN_DB_VERSION = RaidenDBVersion(25)
 SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
 PROTOCOL_VERSION = RaidenProtocolVersion(1)
 

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -521,7 +521,6 @@ class ChainState(State):
     payment_mapping: PaymentMappingState = field(repr=False, default_factory=PaymentMappingState)
     pending_transactions: List[ContractSendEvent] = field(repr=False, default_factory=list)
     queueids_to_queues: QueueIdsToQueues = field(repr=False, default_factory=dict)
-    last_transport_authdata: Optional[str] = field(repr=False, default=None)
     tokennetworkaddresses_to_tokennetworkregistryaddresses: Dict[
         TokenNetworkAddress, TokenNetworkRegistryAddress
     ] = field(repr=False, default_factory=dict)


### PR DESCRIPTION
- The attribute last_transport_authdata is not set/used anymore.
- The state change for setting the auth data was removed, meaning the db
  version has to be bumped (the previous state change can not be
  decoded).

[skip tests]