### PR TITLE
Fixes bad `check_gas_reserve` performance.

### DIFF
--- a/raiden/network/proxies/proxy_manager.py
+++ b/raiden/network/proxies/proxy_manager.py
@@ -95,8 +95,11 @@ class ProxyManager:
         self.contract_manager = contract_manager
         self.metadata = metadata
 
+        # exposing the lock since it is needed for a proper gas_reserve
+        # estimation
+        self.token_network_creation_lock = Semaphore()
+
         self._token_creation_lock = Semaphore()
-        self._token_network_creation_lock = Semaphore()
         self._token_network_registry_creation_lock = Semaphore()
         self._secret_registry_creation_lock = Semaphore()
         self._service_registry_creation_lock = Semaphore()
@@ -150,7 +153,7 @@ class ProxyManager:
         if not is_binary_address(address):
             raise ValueError("address must be a valid address")
 
-        with self._token_network_creation_lock:
+        with self.token_network_creation_lock:
             if address not in self.address_to_token_network:
                 metadata = TokenNetworkMetadata(
                     deployed_at=None,

--- a/raiden/utils/gas_reserve.py
+++ b/raiden/utils/gas_reserve.py
@@ -58,52 +58,52 @@ def _get_required_gas_estimate(
 
 
 def _get_required_gas_estimate_for_state(raiden: "RaidenService") -> int:
+    num_opening_channels = 0
+    num_opened_channels = 0
+    num_closing_channels = 0
+    num_closed_channels = 0
+    num_settling_channels = 0
+    num_settled_channels = 0
+
+    # Only use the token networks that have been instantiated. Instantiating
+    # the token networks here can have a high performance impacet for a token
+    # network registry with lots of registeres tokens.
+    with raiden.proxy_manager.token_network_creation_lock:
+        num_opening_channels = sum(
+            token_network.opening_channels_count
+            for token_network in raiden.proxy_manager.address_to_token_network.values()
+        )
+
     chain_state = views.state_from_raiden(raiden)
     registry_address = raiden.default_registry.address
     token_addresses = views.get_token_identifiers(chain_state, registry_address)
-    measurements = gas_measurements(raiden.contract_manager.contracts_version)
-
-    gas_estimate = 0
 
     for token_address in token_addresses:
-        token_network_address = views.get_token_network_address_by_token_address(
-            chain_state=chain_state,
-            token_network_registry_address=registry_address,
-            token_address=token_address,
-        )
-        if token_network_address is None:
-            continue
-
-        num_opening_channels = raiden.proxy_manager.token_network(
-            token_network_address
-        ).opening_channels_count
-        num_opened_channels = len(
+        num_opened_channels += len(
             views.get_channelstate_open(chain_state, registry_address, token_address)
         )
-        num_closing_channels = len(
+        num_closing_channels += len(
             views.get_channelstate_closing(chain_state, registry_address, token_address)
         )
-        num_closed_channels = len(
+        num_closed_channels += len(
             views.get_channelstate_closed(chain_state, registry_address, token_address)
         )
-        num_settling_channels = len(
+        num_settling_channels += len(
             views.get_channelstate_settling(chain_state, registry_address, token_address)
         )
-        num_settled_channels = len(
+        num_settled_channels += len(
             views.get_channelstate_settled(chain_state, registry_address, token_address)
         )
 
-        gas_estimate += _get_required_gas_estimate(
-            gas_measurements=measurements,
-            opening_channels=num_opening_channels,
-            opened_channels=num_opened_channels,
-            closing_channels=num_closing_channels,
-            closed_channels=num_closed_channels,
-            settling_channels=num_settling_channels,
-            settled_channels=num_settled_channels,
-        )
-
-    return gas_estimate
+    return _get_required_gas_estimate(
+        gas_measurements=gas_measurements(raiden.contract_manager.contracts_version),
+        opening_channels=num_opening_channels,
+        opened_channels=num_opened_channels,
+        closing_channels=num_closing_channels,
+        closed_channels=num_closed_channels,
+        settling_channels=num_settling_channels,
+        settled_channels=num_settled_channels,
+    )
 
 
 def get_required_gas_estimate(raiden: "RaidenService", channels_to_open: int = 0) -> int:


### PR DESCRIPTION
The task `check_gas_reserve` was creating a token network proxy for
every existing token network. This should be avoided because the proxy
constructor will check the target address`s bytecode, to detect
configuration errors. The problem is that for a large registry, e.g. >=100 
token networks, executing the aforementioned test will take a
while. This is specially bad since the tokens are only necessary to get
the counter of current pending channel opennings, which is 0 for new
token network proxy (If the proxy does not exist then there is no
pending transactoins for it).

This commit changes the code to, instead of looping over all token
network addresses, to loop over the currently instantiated proxies. This
means the cost of instantiating the proxies will be amortized and only
paid when necessary.

Note: This problem will go away after #1621 is implemented.