### PR TITLE
raise_on_error with transport support

### DIFF
--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -12,10 +12,15 @@ def pytest_configure(config):
 
 def pytest_collection_finish(session):
     def unsafe(item):
-        has_nodes = "raiden_network" in item.fixturenames or "raiden_chain" in item.fixturenames
+        has_runnable = (
+            "raiden_network" in item.fixturenames
+            or "raiden_chain" in item.fixturenames
+            or "api_server_test_instance" in item.fixturenames
+            or "matrix_transports" in item.fixturenames
+        )
         is_secure = getattr(item.function, "_decorated_raise_on_failure", False)
         is_exempt = item.get_closest_marker("expect_failure") is not None
-        return has_nodes and not (is_secure or is_exempt)
+        return has_runnable and not (is_secure or is_exempt)
 
     unsafe_tests = [item.originalname or item.name for item in session.items if unsafe(item)]
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -18,6 +18,7 @@ from raiden.settings import (
     DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
 )
 from raiden.tests.utils import factories
+from raiden.tests.utils.detect_failure import raise_on_failure
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.tests.utils.transport import (
@@ -268,6 +269,7 @@ def test_assumption_matrix_returns_same_id_for_same_filter_payload(chain_id, loc
     assert first_sync_filter_id == second_sync_filter_id
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_transports", [3])
 @pytest.mark.parametrize("matrix_server_count", [1])
 def test_admin_is_allowed_to_kick(matrix_transports, local_matrix_servers):
@@ -334,6 +336,7 @@ def test_admin_is_allowed_to_kick(matrix_transports, local_matrix_servers):
         kicked_transport._client.api.kick_user(room_id, non_admin_user_ids[1])
 
 
+@raise_on_failure
 @pytest.mark.parametrize("number_of_transports", [20])
 @pytest.mark.parametrize("matrix_server_count", [1])
 def test_assumption_receive_all_state_events_upon_first_sync_after_join(

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -1,15 +1,15 @@
 import traceback
 from functools import wraps
-from typing import Any, Callable, List
+from typing import Any, Callable, Set
 
 import gevent
 import pytest
 import structlog
 from gevent.event import AsyncResult
 
-from raiden.api.rest import APIServer
-from raiden.app import App
 from raiden.raiden_service import RaidenService
+from raiden.utils.runnable import Runnable
+from raiden.utils.typing import List
 
 log = structlog.get_logger(__name__)
 
@@ -24,32 +24,28 @@ def raise_on_failure(test_function: Callable) -> Callable:
     @wraps(test_function)
     def wrapper(**kwargs: Any) -> None:
         result = AsyncResult()
-        raiden_services: List[RaidenService] = []
 
-        apps: List[App] = kwargs.get("raiden_network", kwargs.get("raiden_chain"))
+        raiden_services: List[RaidenService] = list()
+        raiden_services.extend(app.raiden for app in kwargs.get("raiden_network", list()))
+        raiden_services.extend(app.raiden for app in kwargs.get("raiden_chain", list()))
 
-        if apps:
-            assert all(isinstance(app, App) for app in apps)
-            raiden_services = [app.raiden for app in apps]
-        else:
-            api_server = kwargs.get("api_server_test_instance")
-            if isinstance(api_server, APIServer):
-                raiden_services = [api_server.rest_api.raiden_api.raiden]
+        api_server = kwargs.get("api_server_test_instance")
+        if api_server:
+            raiden_services.append(api_server.rest_api.raiden_api.raiden)
 
-        if not raiden_services:
-            raise Exception(
-                f"Can't use `raise_on_failure` on test function {test_function.__name__} "
-                "which uses neither `raiden_network` nor `raiden_chain` fixtures."
-            )
+        for raiden in raiden_services:
+            assert raiden, "The RaidenService must be started"
+
+        runnables: Set[Runnable] = set()
+        runnables.update(kwargs.get("matrix_transports", list()))
+        runnables.update(raiden_services)
 
         restart_node = kwargs.get("restart_node", None)
         if restart_node is not None:
             restart_node.link_exception_to(result)
 
-        # Do not use `link` or `link_value`, an app can be stopped to test restarts.
-        for raiden in raiden_services:
-            assert raiden, "The RaidenService must be started"
-            raiden.greenlet.link_exception(result)
+        for task in runnables:
+            task.greenlet.link_exception(result)
 
         test_greenlet = gevent.spawn(test_function, **kwargs)
         test_greenlet.link(result)


### PR DESCRIPTION
The `raise_on_error` should work with any runnable, the transport was
not being properly handled.

This also removes the need for the runnable to be running, since the
goal of the decorator is to detect errors, it is okay if the task has
not started yet.