### PR TITLE
APIServer not inheriting from Runnable.

### DIFF
--- a/raiden/tests/integration/api/utils.py
+++ b/raiden/tests/integration/api/utils.py
@@ -4,7 +4,7 @@ import gevent
 import psutil
 
 from raiden.api.python import RaidenAPI
-from raiden.api.rest import APIServer, RestAPI
+from raiden.api.rest import APIConfig, APIServer, RestAPI
 from raiden.app import App
 
 
@@ -28,9 +28,9 @@ def wait_for_listening_port(
 def create_api_server(raiden_app: App, port_number: int) -> APIServer:
     raiden_api = RaidenAPI(raiden_app.raiden)
     rest_api = RestAPI(raiden_api)
-    api_server = APIServer(rest_api, config={"host": "localhost", "port": port_number})
+    api_config = APIConfig(host="localhost", port=port_number, api_prefix="api", webui_config=None)
+    api_server = APIServer(rest_api, api_config)
     api_server.flask_app.config["SERVER_NAME"] = f"localhost:{port_number}"
-    api_server.start()
 
     # Fixes flaky test, were requests are done prior to the server initializing
     # the listening socket.

--- a/raiden/tests/integration/long_running/test_stress.py
+++ b/raiden/tests/integration/long_running/test_stress.py
@@ -12,7 +12,7 @@ from flask import url_for
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI
-from raiden.api.rest import APIServer, RestAPI
+from raiden.api.rest import APIConfig, APIServer, RestAPI
 from raiden.app import App
 from raiden.constants import RoutingMode
 from raiden.message_handler import MessageHandler
@@ -65,12 +65,16 @@ def _url_for(apiserver: APIServer, endpoint: str, **kwargs) -> str:
 def start_apiserver(raiden_app: App, rest_api_port_number: Port) -> APIServer:
     raiden_api = RaidenAPI(raiden_app.raiden)
     rest_api = RestAPI(raiden_api)
-    api_server = APIServer(rest_api, config={"host": "localhost", "port": rest_api_port_number})
+
+    api_server = APIServer(
+        rest_api,
+        api_config=APIConfig(
+            host="localhost", port=rest_api_port_number, api_prefix="api", webui_config=None
+        ),
+    )
 
     # required for url_for
     api_server.flask_app.config["SERVER_NAME"] = f"localhost:{rest_api_port_number}"
-
-    api_server.start()
 
     wait_for_listening_port(rest_api_port_number)
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -15,7 +15,7 @@ from web3.middleware import geth_poa_middleware
 
 from raiden.accounts import AccountManager
 from raiden.api.python import RaidenAPI
-from raiden.api.rest import APIServer, RestAPI
+from raiden.api.rest import APIConfig, APIServer, RestAPI
 from raiden.connection_manager import ConnectionManager
 from raiden.constants import (
     EMPTY_ADDRESS,
@@ -397,8 +397,9 @@ def run_smoketest(
         raiden_api = RaidenAPI(app.raiden)
         rest_api = RestAPI(raiden_api)
         (api_host, api_port) = split_endpoint(args["api_address"])
-        api_server = APIServer(rest_api, config={"host": api_host, "port": api_port})
-        api_server.start()
+
+        api_config = APIConfig(host=api_host, port=api_port, api_prefix="api", webui_config=None)
+        api_server = APIServer(rest_api, api_config)
 
         block = BlockNumber(app.raiden.get_block_number() + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS)
         # Proxies now use the confirmed block hash to query the chain for


### PR DESCRIPTION
Part of https://github.com/raiden-network/raiden/issues/5601

This is the first step to remove the Runnable interface.

The Runnable interface has start/stop methods, in theory one should be
allowed to call `stop` and then `start` on the same instance, which
would restart the service. This however has led to multiple, hard to
debug bugs, because of improper cleanup in `stop`, and partial
initialization in `start`. (E.g. Race conditions among the RestAPI and
RaidenService, invalid re-initialization of the wal and WSGI server,
etc.).

Additionally the Runnable interface introduce cross cutting dependencies.
E.g. the `stop` event must be initialized as part of the `start`
function, otherwise a `stop`/`start` cycle would not work, however, the
`stop_event` is shared across all services, to guarantee that all
services are stopped together, this means a Runnable must not clear the
event, because it does not own it, meaning it is not possible to
implement proper initialization in the `start` methods. (This led to
test failures in the transport layer).