### PR TITLE
Adds settle & reveal timeout back to Raiden Config

### DIFF
--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -262,12 +262,12 @@ def try_new_route(
             route_fee_exceeds_max = True
             continue
 
-        is_channel_usable = channel.is_channel_usable_for_new_transfer(
+        channel_usability_state = channel.is_channel_usable_for_new_transfer(
             channel_state=candidate_channel_state,
             transfer_amount=amount_with_fee,
             lock_timeout=transfer_description.lock_timeout,
         )
-        if is_channel_usable is channel.ChannelUsability.USABLE:
+        if channel_usability_state is channel.ChannelUsability.USABLE:
             channel_state = candidate_channel_state
             route_state = reachable_route_state
             break

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -65,6 +65,7 @@ from raiden.utils.mediation_fees import prepare_mediation_fee_config
 from raiden.utils.typing import (
     Address,
     BlockNumber,
+    BlockTimeout,
     ChainID,
     Endpoint,
     FeeAmount,
@@ -183,6 +184,8 @@ def run_app(
     pathfinding_max_paths: int,
     enable_monitoring: bool,
     resolver_endpoint: str,
+    default_reveal_timeout: BlockTimeout,
+    default_settle_timeout: BlockTimeout,
     routing_mode: RoutingMode,
     flat_fee: Tuple[Tuple[TokenAddress, FeeAmount], ...],
     proportional_fee: Tuple[Tuple[TokenAddress, ProportionalFeeAmount], ...],
@@ -241,6 +244,9 @@ def run_app(
     config.api_host = api_host
     config.api_port = api_port
     config.resolver_endpoint = resolver_endpoint
+
+    config.reveal_timeout = default_reveal_timeout
+    config.settle_timeout = default_settle_timeout
 
     contracts = load_deployed_contracts_data(config, network_id)
 


### PR DESCRIPTION
## Description

Fixes: #5575

We forgot to set `settle_timout` and `reveal_timout` in the config after https://github.com/raiden-network/raiden/pull/5548 so this fixes it. 

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
