### PR TITLE
Don't retry messages unnecessarily

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -184,13 +184,15 @@ class _RetryQueue(Runnable):
             self.log.warning("Can't retry", reason="Transport stopped")
             return
 
+        assert self._lock.locked(), "RetryQueue lock must be held while messages are being sent"
+
         # On startup protocol messages must be sent only after the monitoring
         # services are updated. For more details refer to the method
         # `RaidenService._initialize_monitoring_services_queue`
         if self.transport._prioritize_broadcast_messages:
             self.transport._broadcast_queue.join()
 
-        self.log.debug("Retrying message", receiver=to_checksum_address(self.receiver))
+        self.log.debug("Retrying message(s)", receiver=to_checksum_address(self.receiver))
         status = self.transport._address_mgr.get_address_reachability(self.receiver)
         if status is not AddressReachability.REACHABLE:
             # if partner is not reachable, return
@@ -201,47 +203,47 @@ class _RetryQueue(Runnable):
             )
             return
 
-        message_texts = [
-            data.text
-            for data in self._message_queue
-            # if expired_gen generator yields False, message was sent recently, so skip it
-            if next(data.expiration_generator)
-        ]
-
-        def message_is_in_queue(data: _RetryQueue._MessageData) -> bool:
+        def message_is_in_queue(message_data: _RetryQueue._MessageData) -> bool:
+            if message_data.queue_identifier not in self.transport._queueids_to_queues:
+                # The Raiden queue for this queue identifier has been removed
+                return False
             return any(
-                isinstance(data.message, RetrieableMessage)
-                and send_event.message_identifier == data.message.message_identifier
-                for send_event in self.transport._queueids_to_queues[data.queue_identifier]
+                isinstance(message_data.message, RetrieableMessage)
+                and send_event.message_identifier == message_data.message.message_identifier
+                for send_event in self.transport._queueids_to_queues[message_data.queue_identifier]
             )
 
-        # clean after composing, so any queued messages (e.g. Delivered) are sent at least once
-        for msg_data in self._message_queue[:]:
+        message_texts: List[str] = list()
+        for message_data in self._message_queue[:]:
+            # Messages are sent on two conditions:
+            # - Non-retryable (e.g. Delivered)
+            #   - Those are immediately remove from the local queue since they are only sent once
+            # - Retryable
+            #   - Those are retried according to their retry generator as long as they haven't been
+            #     removed from the Raiden queue
             remove = False
-            if isinstance(msg_data.message, (Delivered, Ping, Pong)):
+            if isinstance(message_data.message, (Delivered, Ping, Pong)):
                 # e.g. Delivered, send only once and then clear
                 # TODO: Is this correct? Will a missed Delivered be 'fixed' by the
                 #       later `Processed` message?
                 remove = True
-            elif msg_data.queue_identifier not in self.transport._queueids_to_queues:
+                message_texts.append(message_data.text)
+            elif not message_is_in_queue(message_data):
                 remove = True
                 self.log.debug(
                     "Stopping message send retry",
-                    queue=msg_data.queue_identifier,
-                    message=msg_data.message,
-                    reason="Raiden queue is gone",
+                    queue=message_data.queue_identifier,
+                    message=message_data.message,
+                    reason="Message was removed from queue or queue was removed",
                 )
-            elif not message_is_in_queue(msg_data):
-                remove = True
-                self.log.debug(
-                    "Stopping message send retry",
-                    queue=msg_data.queue_identifier,
-                    message=msg_data.message,
-                    reason="Message was removed from queue",
-                )
+            else:
+                # The message is still eligible for retry, consult the expiration generator if
+                # it should be retried now
+                if next(message_data.expiration_generator):
+                    message_texts.append(message_data.text)
 
             if remove:
-                self._message_queue.remove(msg_data)
+                self._message_queue.remove(message_data)
 
         if message_texts:
             self.log.debug(

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -3,13 +3,14 @@ from typing import List, Optional
 
 import gevent
 import pytest
+from gevent import Timeout
 
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX, Environment
 from raiden.messages.transfers import SecretRequest
 from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix import AddressReachability
 from raiden.network.transport.matrix.client import Room
-from raiden.network.transport.matrix.transport import _RetryQueue
+from raiden.network.transport.matrix.transport import RETRY_QUEUE_IDLE_AFTER, _RetryQueue
 from raiden.network.transport.matrix.utils import UserAddressManager
 from raiden.settings import MatrixTransportConfig
 from raiden.storage.serialization.serializer import MessageSerializer
@@ -257,3 +258,50 @@ def test_retry_queue_does_not_resend_removed_messages(
         retry_queue._check_and_send()
 
     assert len(mock_matrix.sent_messages) == 1
+
+
+@pytest.mark.parametrize("retry_interval", [0.05])
+def test_retryqueue_idle_terminate(mock_matrix: MatrixTransport, retry_interval: int):
+    """ Ensure ``RetryQueue``s exit if they are idle for too long. """
+    retry_queue = mock_matrix._get_retrier(factories.HOP1)
+    idle_after = RETRY_QUEUE_IDLE_AFTER * retry_interval
+
+    with Timeout(idle_after + (retry_interval * 5)):
+        # Retry
+        while not gevent.wait([retry_queue.greenlet], idle_after / 2):
+            pass
+
+    assert retry_queue.greenlet.ready()
+    assert retry_queue._idle_since == RETRY_QUEUE_IDLE_AFTER
+    assert retry_queue.is_idle
+
+    retry_queue_2 = mock_matrix._get_retrier(factories.HOP1)
+
+    # Since the initial RetryQueue has exited `get_retrier()` must return a new instance
+    assert retry_queue_2 is not retry_queue
+
+
+@pytest.mark.parametrize("retry_interval", [0.05])
+def test_retryqueue_not_idle_with_messages(mock_matrix: MatrixTransport, retry_interval: int):
+    """ Ensure ``RetryQueue``s don't become idle while messages remain in the internal queue. """
+    retry_queue = mock_matrix._get_retrier(factories.HOP1)
+    idle_after = RETRY_QUEUE_IDLE_AFTER * retry_interval
+
+    queue_identifier = QueueIdentifier(
+        recipient=factories.HOP1, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
+    )
+    retry_queue.enqueue(queue_identifier, make_message())
+
+    # Without the `all_peers_reachable` fixture, the default reachability will be `UNREACHABLE`
+    # therefore the message will remain in the internal queue indefinitely.
+
+    # Wait for the idle timeout to expire
+    gevent.sleep(idle_after + (retry_interval * 5))
+
+    assert not retry_queue.greenlet.ready()
+    assert retry_queue._idle_since == 0
+    assert not retry_queue.is_idle
+
+    retry_queue_2 = mock_matrix._get_retrier(factories.HOP1)
+    # The first queue has never become idle, therefore the same object must be returned
+    assert retry_queue is retry_queue_2

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -1,21 +1,27 @@
 import random
 from typing import List, Optional
 
+import gevent
 import pytest
 
 from raiden.constants import EMPTY_SIGNATURE, UINT64_MAX, Environment
 from raiden.messages.transfers import SecretRequest
 from raiden.network.transport import MatrixTransport
+from raiden.network.transport.matrix import AddressReachability
 from raiden.network.transport.matrix.client import Room
+from raiden.network.transport.matrix.transport import _RetryQueue
+from raiden.network.transport.matrix.utils import UserAddressManager
 from raiden.settings import MatrixTransportConfig
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.tests.utils import factories
 from raiden.tests.utils.mocks import MockRaidenService
+from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
+from raiden.utils.formatting import to_checksum_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import Address
 
 USERID0 = "@0x1234567890123456789012345678901234567890:RestaurantAtTheEndOfTheUniverse"
-USERID1 = "@0x0987654321098765432109876543210987654321:Wonderland"
+USERID1 = f"@{to_checksum_address(factories.HOP1.hex())}:Wonderland"
 
 
 @pytest.fixture()
@@ -99,20 +105,53 @@ def mock_matrix(monkeypatch, retry_interval, retries_before_backoff):
     return transport
 
 
-def make_message(sign=True, overwrite_data=None):
+@pytest.fixture
+def all_peers_reachable(monkeypatch):
+    def mock_get_address_reachability(self, address: Address) -> AddressReachability:
+        return AddressReachability.REACHABLE
+
+    monkeypatch.setattr(
+        UserAddressManager, "get_address_reachability", mock_get_address_reachability
+    )
+
+
+@pytest.fixture
+def record_sent_messages(mock_matrix):
+    original_send_raw = mock_matrix._send_raw
+
+    sent_messages = list()
+
+    def send_raw(receiver_address: Address, data: str) -> None:
+        for message in data.split("\n"):
+            sent_messages.append((receiver_address, message))
+
+    mock_matrix._send_raw = send_raw
+    mock_matrix.sent_messages = sent_messages
+
+    yield
+
+    mock_matrix._send_raw = original_send_raw
+    del mock_matrix.sent_messages
+
+
+def make_message(sign=True):
+    message = SecretRequest(
+        message_identifier=random.randint(0, UINT64_MAX),
+        payment_identifier=1,
+        secrethash=factories.UNIT_SECRETHASH,
+        amount=1,
+        expiration=10,
+        signature=EMPTY_SIGNATURE,
+    )
+    if sign:
+        message.sign(LocalSigner(factories.HOP1_KEY))
+    return message
+
+
+def make_message_text(sign=True, overwrite_data=None):
     room = Room(None, "!roomID:server")
     if not overwrite_data:
-        message = SecretRequest(
-            message_identifier=random.randint(0, UINT64_MAX),
-            payment_identifier=1,
-            secrethash=factories.UNIT_SECRETHASH,
-            amount=1,
-            expiration=10,
-            signature=EMPTY_SIGNATURE,
-        )
-        if sign:
-            message.sign(LocalSigner(factories.HOP1_KEY))
-        data = MessageSerializer.serialize(message)
+        data = MessageSerializer.serialize(make_message(sign=sign))
     else:
         data = overwrite_data
 
@@ -125,7 +164,7 @@ def make_message(sign=True, overwrite_data=None):
 def test_normal_processing_json(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation
 ):
-    room, event = make_message()
+    room, event = make_message_text()
     assert mock_matrix._handle_sync_messages([(room, [event])])
 
 
@@ -133,21 +172,21 @@ def test_processing_invalid_json(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation
 ):
     invalid_json = '{"foo": 1,'
-    room, event = make_message(overwrite_data=invalid_json)
+    room, event = make_message_text(overwrite_data=invalid_json)
     assert not mock_matrix._handle_sync_messages([(room, [event])])
 
 
 def test_non_signed_message_is_rejected(
     mock_matrix, skip_userid_validation
 ):  # pylint: disable=unused-argument
-    room, event = make_message(sign=False)
+    room, event = make_message_text(sign=False)
     assert not mock_matrix._handle_sync_messages([(room, [event])])
 
 
 def test_sending_nonstring_body(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation
 ):
-    room, event = make_message(overwrite_data=b"somebinarydata")
+    room, event = make_message_text(overwrite_data=b"somebinarydata")
     assert not mock_matrix._handle_sync_messages([(room, [event])])
 
 
@@ -161,7 +200,7 @@ def test_sending_nonstring_body(  # pylint: disable=unused-argument
 def test_processing_invalid_message_json(  # pylint: disable=unused-argument
     mock_matrix, skip_userid_validation, message_input
 ):
-    room, event = make_message(overwrite_data=message_input)
+    room, event = make_message_text(overwrite_data=message_input)
     assert not mock_matrix._handle_sync_messages([(room, [event])])
 
 
@@ -169,5 +208,52 @@ def test_processing_invalid_message_type_json(  # pylint: disable=unused-argumen
     mock_matrix, skip_userid_validation
 ):
     invalid_message = '{"_type": "NonExistentMessage", "is": 3, "not_valid": 5}'
-    room, event = make_message(overwrite_data=invalid_message)
+    room, event = make_message_text(overwrite_data=invalid_message)
     assert not mock_matrix._handle_sync_messages([(room, [event])])
+
+
+@pytest.mark.parametrize("retry_interval", [0.01])
+def test_retry_queue_does_not_resend_removed_messages(
+    mock_matrix, record_sent_messages, retry_interval, all_peers_reachable
+):
+    """
+    Ensure the ``RetryQueue`` doesn't unnecessarily re-send messages.
+
+    Messages should only be retried while they are present in the respective Raiden queue.
+    Once they have been removed they should not be sent again.
+
+    In the past they could have been sent twice.
+    See: https://github.com/raiden-network/raiden/issue/4111
+    """
+    # Pretend the Transport greenlet is running
+    mock_matrix.greenlet = True
+
+    # This is intentionally not using ``MatrixTransport._get_retrier()`` since we don't want the
+    # greenlet to run but instead manually call its `_check_and_send()` method.
+    retry_queue = _RetryQueue(transport=mock_matrix, receiver=factories.HOP1)
+
+    message = make_message()
+    serialized_message = MessageSerializer.serialize(message)
+    queue_identifier = QueueIdentifier(
+        recipient=factories.HOP1, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
+    )
+    retry_queue.enqueue(queue_identifier, message)
+
+    mock_matrix._queueids_to_queues[queue_identifier] = [message]
+
+    with retry_queue._lock:
+        retry_queue._check_and_send()
+
+    assert len(mock_matrix.sent_messages) == 1
+    assert (factories.HOP1, serialized_message) in mock_matrix.sent_messages
+
+    mock_matrix._queueids_to_queues[queue_identifier].clear()
+
+    # Make sure the retry interval has elapsed
+    gevent.sleep(retry_interval * 5)
+
+    with retry_queue._lock:
+        # The message has been removed from the raiden queue and should therefore not be sent again
+        retry_queue._check_and_send()
+
+    assert len(mock_matrix.sent_messages) == 1


### PR DESCRIPTION
## Description

Fixes: #4111
Fixes: #4600

Changes the order of constructing the messages to be sent and their
removal from the RetryQueue. This prevents unnecessary duplicate sending.
Also adds a test for this behaviour.

Since this was touching the same places this additionally implements killing idle RetryQueues after a timeout (#4600).
