### PR TITLE
Fixes scenarios after #5532 [skip tests]

### DIFF
--- a/raiden/tests/scenarios/ci/sp1/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/ci/sp1/bf1_basic_functionality.yaml
@@ -72,7 +72,7 @@ scenario:
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000, state: "opened"}
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000, state: "opened"}
       - serial:
-          name: "Make transfer in the direction with no deposit (should fail)"
+          name: "Make transfer in the direction with no deposit (should fail) - No IOU created"
           tasks:
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, lock_timeout: 30, expected_http_status: 409}
       - parallel:
@@ -123,8 +123,8 @@ scenario:
           tasks:
             # Add a wait until all ious are processed correctly
             - wait: 100
-            - assert_pfs_history: {source: 3, target: 0, request_count: 11}
-            - assert_pfs_iou: {source: 3, amount: 1100}
+            - assert_pfs_history: {source: 3, target: 0, request_count: 10}
+            - assert_pfs_iou: {source: 3, amount: 1000}
             - assert_pfs_history: {source: 1, target: 4, request_count: 10}
             - assert_pfs_iou: {source: 1, amount: 1000}
             # Make sure that a mediating node has not used the PFS

--- a/raiden/tests/scenarios/ci/sp1/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/ci/sp1/pfs6_simple_path_rewards.yaml
@@ -54,6 +54,8 @@ scenario:
 
             # Node3 cannot send tokens to node0 due to imbalanced channels
             # We expect the pfs not to send any route, but to charge for the information
+            # but the node can check if the direct channel is usable so we need a deposit
+            - deposit: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 409}
             - wait_blocks: 1
             - assert_pfs_history: {source: 3, target: 0, request_count: 1}
@@ -65,7 +67,6 @@ scenario:
           tasks:
             - deposit: {from: 1, to: 0, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
             - deposit: {from: 2, to: 1, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
-            - deposit: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
       - serial:
           name: "Assert on all channel deposits"
           tasks:

--- a/raiden/tests/scenarios/ci/sp2/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/ci/sp2/pfs2_simple_no_path.yaml
@@ -48,7 +48,9 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            # Check that the transfer fails, when there is no path from 3 to 0 
+            # Check that the transfer fails, when there is no path from 3 to 0
+            # We need to deposit into the direct channel, to pass the first internal check of the node
+            - deposit: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000}
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 409}
 
             # Assert that correct amount was tranferred


### PR DESCRIPTION
We introduced a check if the direct channel is usable for the transfer, so no IOU is sent in some scenarios, see #5532 