### PR TITLE
Improve `write_state_snapshot` performance

### DIFF
--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -7,7 +7,9 @@ from types import TracebackType
 from typing import Generator
 
 import gevent
+from eth_utils import to_checksum_address, to_hex
 
+import raiden.storage.serialization.fields as fields
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.serialization import SerializationBase
@@ -787,7 +789,13 @@ class SerializedSQLiteStorage:
     def write_state_snapshot(
         self, snapshot: State, statechange_id: StateChangeID, statechange_qty: int
     ) -> SnapshotID:
+        # `to_checksum_address` is slow and is not necessary for our internal serialization.
+        # FIXME: We should be able to adapt the serialization without this evil
+        #        monkey patching, but right now there is no simple way to do it.
+        fields.to_checksum_address = to_hex
         serialized_data = self.serializer.serialize(snapshot)
+        fields.to_checksum_address = to_checksum_address  # type: ignore
+
         return self.database.write_state_snapshot(serialized_data, statechange_id, statechange_qty)
 
     def write_events(self, events: List[Tuple[StateChangeID, Event]]) -> List[EventID]:


### PR DESCRIPTION
by using `to_hex` instead of `to_checksum_address` during serialization.

If someone has an idea how to do that without monkeypatching (and without rewriting half of the serialization), that would be great!