### PR TITLE
Faster data packing for synchronization messages

### DIFF
--- a/raiden/messages/synchronization.py
+++ b/raiden/messages/synchronization.py
@@ -4,7 +4,6 @@ from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.abstract import SignedMessage, SignedRetrieableMessage
 from raiden.messages.cmdid import CmdId
 from raiden.transfer.architecture import SendMessageEvent
-from raiden.utils.signing import pack_data
 from raiden.utils.typing import ClassVar, MessageID
 
 
@@ -49,10 +48,8 @@ class Processed(SignedRetrieableMessage):
         return cls(message_identifier=event.message_identifier, signature=EMPTY_SIGNATURE)
 
     def _data_to_sign(self) -> bytes:
-        return pack_data(
-            (self.cmdid.value, "uint8"),
-            (b"\x00" * 3, "bytes"),  # padding
-            (self.message_identifier, "uint64"),
+        return bytes([self.cmdid.value, 0, 0, 0]) + self.message_identifier.to_bytes(
+            64, byteorder="big"
         )
 
     def __repr__(self) -> str:
@@ -76,10 +73,8 @@ class Delivered(SignedMessage):
     delivered_message_identifier: MessageID
 
     def _data_to_sign(self) -> bytes:
-        return pack_data(
-            (self.cmdid.value, "uint8"),
-            (b"\x00" * 3, "bytes"),  # padding
-            (self.delivered_message_identifier, "uint64"),
+        return bytes([self.cmdid.value, 0, 0, 0]) + self.delivered_message_identifier.to_bytes(
+            64, byteorder="big"
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
I've seen a flame graph where >50% of the time was spent just packing
these two message types for signing. Using the python builtins is much
faster than using `map_abi_data`.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
