### PR TITLE
Respect Matrix max event size (redux)

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -4,7 +4,7 @@ from binascii import Error as DecodeError
 from collections import defaultdict
 from enum import Enum
 from operator import attrgetter
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -50,6 +50,9 @@ USERID_RE = re.compile(r"^@(0x[0-9a-f]{40})(?:\.[0-9a-f]{8})?(?::.+)?$")
 DISPLAY_NAME_HEX_RE = re.compile(r"^0x[0-9a-fA-F]{130}$")
 ROOM_NAME_SEPARATOR = "_"
 ROOM_NAME_PREFIX = "raiden"
+# The maximum matrix event size is 65 kB. Since events are larger than just the message
+# content we chose a conservative value
+MATRIX_MAX_BATCH_SIZE = 50_000
 
 
 class UserPresence(Enum):
@@ -791,3 +794,26 @@ def my_place_or_yours(our_address: Address, partner_address: Address) -> Address
         raise ValueError("Addresses to compare must differ")
     sorted_addresses = sorted([our_address, partner_address])
     return sorted_addresses[0]
+
+
+def make_message_batches(
+    message_texts: Iterable[str], _max_batch_size: int = MATRIX_MAX_BATCH_SIZE
+) -> Generator[str, None, None]:
+    """ Group messages into newline separated batches not exceeding ``_max_batch_size``. """
+    current_batch: List[str] = []
+    size = 0
+    for message_text in message_texts:
+        if size + len(message_text) > _max_batch_size:
+            if size == 0:
+                # A single message exceeds the maximum batch size. This should not happen.
+                raise TransportError(
+                    f"Message exceeds batch size. Size: {len(message_text)}, "
+                    f"Max: {MATRIX_MAX_BATCH_SIZE}, Message: {message_text}"
+                )
+            yield "\n".join(current_batch)
+            current_batch = []
+            size = 0
+        current_batch.append(message_text)
+        size += len(message_text)
+    if current_batch:
+        yield "\n".join(current_batch)

--- a/raiden/tests/unit/test_matrix_transport.py
+++ b/raiden/tests/unit/test_matrix_transport.py
@@ -13,6 +13,7 @@ from raiden.exceptions import TransportError
 from raiden.network.transport.matrix.utils import (
     login,
     make_client,
+    make_message_batches,
     make_room_alias,
     my_place_or_yours,
     sort_servers_closest,
@@ -196,3 +197,26 @@ def test_invite_tiebreaker():
 
     assert my_place_or_yours(address, address1) == address
     assert my_place_or_yours(address1, address2) == address1
+
+
+@pytest.mark.parametrize("max_batch_size", [20])
+@pytest.mark.parametrize(
+    ["message_list", "expected_batch_count", "should_raise"],
+    [
+        (["a" * 10] * 4, 2, False),
+        (["a" * 10] * 5, 3, False),
+        (["a" * 15] * 5, 5, False),
+        (["a"] * 5, 1, False),
+        (["a" * 20], 1, False),
+        (["a" * 21], 0, True),
+    ],
+)
+def test_make_message_batches(message_list, expected_batch_count, should_raise, max_batch_size):
+    if should_raise:
+        with pytest.raises(TransportError):
+            list(make_message_batches(message_list, _max_batch_size=max_batch_size))
+    else:
+        batches = list(make_message_batches(message_list, _max_batch_size=max_batch_size))
+
+        assert len(batches) == expected_batch_count
+        assert sum(len(batch.split("\n")) for batch in batches) == len(message_list)


### PR DESCRIPTION
## Description

Fixes: #3512

Prevent message batches exceeding max Matrix event size.

(This time without dependency on #5604 ;))