### PR TITLE
Fix pre-commit wrapper for mypy and pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,11 +65,11 @@ repos:
     hooks:
       - id: mypy
         entry: tools/pre-commit/pre-commit-wrapper.py mypy
-        additional_dependencies: ["pip-tools==4.1.0"]
+        additional_dependencies: ["pip-tools==4.2.0"]
 
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:
       - id: pylint
         entry: tools/pre-commit/pre-commit-wrapper.py pylint
-        additional_dependencies: ["pip-tools==4.1.0"]
+        additional_dependencies: ["pip-tools==4.2.0"]


### PR DESCRIPTION
## Description

Using pre-commit wrapper fails due to wrong pip-tools dependency. The latest pip (>=19.3) needs pip-tools 4.2.0. 

This is a quick fix binding the additional dependency for pip-tools in `.pre-commit-config.yaml`  to `4.2.0`
