### PR TITLE
Batch event processing

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1,6 +1,7 @@
 import json
 import time
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Counter as CounterType
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -89,6 +90,12 @@ RETRY_INTERVAL_MULTIPLIER = 1.55
 RETRY_QUEUE_IDLE_AFTER = 10
 
 
+@dataclass
+class MessagesQueue:
+    queue_identifier: QueueIdentifier
+    messages: List[Message]
+
+
 class _RetryQueue(Runnable):
     """ A helper Runnable to send batched messages to receiver through transport """
 
@@ -133,36 +140,43 @@ class _RetryQueue(Runnable):
             while now() < _next:  # yield False while next is still in the future
                 yield False
 
-    def enqueue(self, queue_identifier: QueueIdentifier, message: Message) -> None:
+    def enqueue(self, queue_identifier: QueueIdentifier, messages: List[Message]) -> None:
         """ Enqueue a message to be sent, and notify main loop """
         assert queue_identifier.recipient == self.receiver
+
         with self._lock:
-            already_queued = any(
-                queue_identifier == data.queue_identifier and message == data.message
-                for data in self._message_queue
-            )
-            if already_queued:
-                self.log.warning(
-                    "Message already in queue - ignoring",
-                    receiver=to_checksum_address(self.receiver),
-                    queue=queue_identifier,
-                    message=redact_secret(DictSerializer.serialize(message)),
-                )
-                return
             timeout_generator = timeout_exponential_backoff(
                 self.transport._config.retries_before_backoff,
                 self.transport._config.retry_interval_initial,
                 self.transport._config.retry_interval_max,
             )
-            expiration_generator = self._expiration_generator(timeout_generator)
-            self._message_queue.append(
-                _RetryQueue._MessageData(
-                    queue_identifier=queue_identifier,
-                    message=message,
-                    text=MessageSerializer.serialize(message),
-                    expiration_generator=expiration_generator,
+
+            encoded_messages = list()
+            for message in messages:
+                already_queued = any(
+                    queue_identifier == data.queue_identifier and message == data.message
+                    for data in self._message_queue
                 )
-            )
+
+                if already_queued:
+                    self.log.warning(
+                        "Message already in queue - ignoring",
+                        receiver=to_checksum_address(self.receiver),
+                        queue=queue_identifier,
+                        message=redact_secret(DictSerializer.serialize(message)),
+                    )
+                else:
+                    expiration_generator = self._expiration_generator(timeout_generator)
+                    data = _RetryQueue._MessageData(
+                        queue_identifier=queue_identifier,
+                        message=message,
+                        text=MessageSerializer.serialize(message),
+                        expiration_generator=expiration_generator,
+                    )
+                    encoded_messages.append(data)
+
+            self._message_queue.extend(encoded_messages)
+
         self.notify()
 
     def enqueue_unordered(self, message: Message) -> None:
@@ -171,7 +185,7 @@ class _RetryQueue(Runnable):
             queue_identifier=QueueIdentifier(
                 recipient=self.receiver, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
             ),
-            message=message,
+            messages=[message],
         )
 
     def notify(self) -> None:
@@ -200,7 +214,11 @@ class _RetryQueue(Runnable):
         if self.transport._prioritize_broadcast_messages:
             self.transport._broadcast_queue.join()
 
-        self.log.debug("Retrying message(s)", receiver=to_checksum_address(self.receiver))
+        self.log.debug(
+            "Retrying message(s)",
+            receiver=to_checksum_address(self.receiver),
+            queue_size=len(self._message_queue),
+        )
         status = self.transport._address_mgr.get_address_reachability(self.receiver)
         if status is not AddressReachability.REACHABLE:
             # if partner is not reachable, return
@@ -620,35 +638,48 @@ class MatrixTransport(Runnable):
 
             self.immediate_health_check_for(self._healthcheck_queue.get())
 
-    def send_async(self, queue_identifier: QueueIdentifier, message: Message) -> None:
-        """Queue the message for sending to recipient in the queue_identifier
+    def send_async(self, message_queues: List[MessagesQueue]) -> None:
+        """Queue messages to be sent.
 
         It may be called before transport is started, to initialize message queues
         The actual sending is started only when the transport is started
         """
-        # even if transport is not started, can run to enqueue messages to send when it starts
-        receiver_address = queue_identifier.recipient
-
-        if not is_binary_address(receiver_address):
-            raise ValueError("Invalid address {}".format(to_checksum_address(receiver_address)))
-
-        # These are not protocol messages, but transport specific messages
-        if isinstance(message, (Delivered, Ping, Pong)):
-            raise ValueError(f"Do not use send_async for {message.__class__.__name__} messages")
-
-        self.log.debug(
-            "Send async",
-            receiver_address=to_checksum_address(receiver_address),
-            message=redact_secret(DictSerializer.serialize(message)),
-            queue_identifier=queue_identifier,
-        )
-
-        if self._environment is Environment.DEVELOPMENT and isinstance(message, RetrieableMessage):
+        if self._environment is Environment.DEVELOPMENT:
             assert self._message_timing_keeper is not None, MYPY_ANNOTATION
-            self._counters["send"][(message.__class__.__name__, message.message_identifier)] += 1
-            self._message_timing_keeper.add_message(message)
 
-        self._send_with_retry(queue_identifier, message)
+        for queue in message_queues:
+            receiver_address = queue.queue_identifier.recipient
+
+            if not is_binary_address(receiver_address):
+                raise ValueError(
+                    "Invalid address {}".format(to_checksum_address(receiver_address))
+                )
+
+            # These are not protocol messages, but transport specific messages
+            for message in queue.messages:
+                if isinstance(message, (Delivered, Ping, Pong)):
+                    raise ValueError(
+                        f"Do not use send_async for {message.__class__.__name__} messages"
+                    )
+
+                is_development = self._environment is Environment.DEVELOPMENT
+                if is_development and isinstance(message, RetrieableMessage):
+                    assert self._message_timing_keeper is not None, MYPY_ANNOTATION
+                    self._counters["send"][
+                        (message.__class__.__name__, message.message_identifier)
+                    ] += 1
+                    self._message_timing_keeper.add_message(message)
+
+            self.log.debug(
+                "Send async",
+                receiver_address=to_checksum_address(receiver_address),
+                messages=[
+                    redact_secret(DictSerializer.serialize(message)) for message in queue.messages
+                ],
+                queue_identifier=queue.queue_identifier,
+            )
+
+            self._send_with_retry(queue)
 
     def broadcast(self, room: str, message: Message) -> None:
         """Broadcast a message to a public room.
@@ -1083,9 +1114,9 @@ class MatrixTransport(Runnable):
             retrier.greenlet.link_exception(self.on_error)
         return retrier
 
-    def _send_with_retry(self, queue_identifier: QueueIdentifier, message: Message) -> None:
-        retrier = self._get_retrier(queue_identifier.recipient)
-        retrier.enqueue(queue_identifier=queue_identifier, message=message)
+    def _send_with_retry(self, queue: MessagesQueue) -> None:
+        retrier = self._get_retrier(queue.queue_identifier.recipient)
+        retrier.enqueue(queue_identifier=queue.queue_identifier, messages=queue.messages)
 
     def _send_raw(self, receiver_address: Address, data: str) -> None:
         room = self._get_room_for_address(receiver_address, require_online_peer=True)

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -471,8 +471,8 @@ def test_secret_revealed_on_chain(
         triggered_by_block_hash=app0.raiden.rpc_client.blockhash_from_blocknumber("latest"),
     )
     current_state = app2.raiden.wal.state_manager.current_state
-    app2.raiden.raiden_event_handler.on_raiden_event(
-        raiden=app2.raiden, chain_state=current_state, event=channel_close_event
+    app2.raiden.raiden_event_handler.on_raiden_events(
+        raiden=app2.raiden, chain_state=current_state, events=[channel_close_event]
     )
 
     settle_expiration = (

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -454,16 +454,16 @@ def test_different_view_of_last_bp_during_unlock(
         )
 
     count = 0
-    on_raiden_event_original = app1.raiden.raiden_event_handler.on_raiden_event
+    on_raiden_events_original = app1.raiden.raiden_event_handler.on_raiden_events
 
-    def patched_on_raiden_event(raiden, chain_state, event):
-        if type(event) == ContractSendChannelUpdateTransfer:
-            nonlocal count
-            count += 1
+    def patched_on_raiden_events(raiden, chain_state, events):
+        nonlocal count
 
-        on_raiden_event_original(raiden, chain_state, event)
+        count += sum(1 for event in events if type(event) == ContractSendChannelUpdateTransfer)
 
-    setattr(app1.raiden.raiden_event_handler, "on_raiden_event", patched_on_raiden_event)  # NOQA
+        on_raiden_events_original(raiden, chain_state, events)
+
+    setattr(app1.raiden.raiden_event_handler, "on_raiden_events", patched_on_raiden_events)  # NOQA
 
     # and now app1 comes back online
     restart_node(app1)

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -113,8 +113,8 @@ def test_handle_contract_send_channelunlock_already_unlocked():
     )
 
     # This should not throw an unrecoverable error
-    RaidenEventHandler().on_raiden_event(
-        raiden=raiden, chain_state=raiden.wal.state_manager.current_state, event=event
+    RaidenEventHandler().on_raiden_events(
+        raiden=raiden, chain_state=raiden.wal.state_manager.current_state, events=[event]
     )
 
 
@@ -173,10 +173,10 @@ def test_pfs_handler_handle_routefailed_with_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(
+        pfs_handler.on_raiden_events(
             raiden=raiden,
             chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
-            event=route_failed_event,
+            events=[route_failed_event],
         )
     assert pfs_feedback_handler.called
     assert pfs_feedback_handler.call_args == call(
@@ -199,10 +199,10 @@ def test_pfs_handler_handle_routefailed_without_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(
+        pfs_handler.on_raiden_events(
             raiden=raiden,
             chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
-            event=route_failed_event,
+            events=[route_failed_event],
         )
     assert not pfs_feedback_handler.called
 
@@ -233,10 +233,10 @@ def test_pfs_handler_handle_paymentsentsuccess_with_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(
+        pfs_handler.on_raiden_events(
             raiden=raiden,
             chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
-            event=route_failed_event,
+            events=[route_failed_event],
         )
     assert pfs_feedback_handler.called
     assert pfs_feedback_handler.call_args == call(
@@ -275,9 +275,9 @@ def test_pfs_handler_handle_paymentsentsuccess_without_feedback_token():
     )
 
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
-        pfs_handler.on_raiden_event(
+        pfs_handler.on_raiden_events(
             raiden=raiden,
             chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
-            event=route_failed_event,
+            events=[route_failed_event],
         )
     assert not pfs_feedback_handler.called

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -209,6 +209,7 @@ class MockRaidenService:
         )
 
         self.wal.log_and_dispatch([state_change])
+        self.transport = Mock()
 
     def on_messages(self, messages):
         if self.message_handler:

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -21,8 +21,8 @@ from twisted.internet import defer
 
 from raiden.constants import Environment
 from raiden.messages.abstract import Message
-from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix.client import GMatrixClient, MatrixSyncMessages, Room
+from raiden.network.transport.matrix.transport import MatrixTransport, MessagesQueue
 from raiden.settings import MatrixTransportConfig
 from raiden.tests.utils.factories import make_signer
 from raiden.transfer.identifiers import QueueIdentifier
@@ -432,7 +432,8 @@ class TestMatrixTransport(MatrixTransport):
 
         super().broadcast(room, message)
 
-    def send_async(self, queue_identifier: QueueIdentifier, message: Message) -> None:
-        self.send_messages[queue_identifier].append(message)
+    def send_async(self, message_queues: List[MessagesQueue]) -> None:
+        for queue in message_queues:
+            self.send_messages[queue.queue_identifier].extend(queue.messages)
 
-        super().send_async(queue_identifier, message)
+        super().send_async(message_queues)


### PR DESCRIPTION
During initialization of the Raiden node events are restored from the
snapshot and pushed to the transport layer. Each message was queued
individually, which depending on how the greenlets are scheduled by the
gevent's hub may result into multiple unnecessary HTTP requests to push
the messages to Matrix. This results in a slow restart of nodes in the
stress test, which may have lots of pending messages in the queue.

This commit fixes the above by pushing the events in batch, which
doesn't rely on the greenlet scheduling to reduce the number of HTTP
requests.