### PR TITLE
Send PFS update after unlock

### DIFF
--- a/raiden/messages/encode.py
+++ b/raiden/messages/encode.py
@@ -17,12 +17,12 @@ from raiden.transfer.events import (
     SendWithdrawRequest,
 )
 from raiden.transfer.mediated_transfer.events import (
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendRefundTransfer,
     SendSecretRequest,
     SendSecretReveal,
+    SendUnlock,
 )
 from raiden.utils.typing import MYPY_ANNOTATION
 
@@ -34,8 +34,8 @@ def message_from_sendevent(send_event: SendMessageEvent) -> Message:
     elif type(send_event) == SendSecretReveal:
         assert isinstance(send_event, SendSecretReveal), MYPY_ANNOTATION
         return RevealSecret.from_event(send_event)
-    elif type(send_event) == SendBalanceProof:
-        assert isinstance(send_event, SendBalanceProof), MYPY_ANNOTATION
+    elif type(send_event) == SendUnlock:
+        assert isinstance(send_event, SendUnlock), MYPY_ANNOTATION
         return Unlock.from_event(send_event)
     elif type(send_event) == SendSecretRequest:
         assert isinstance(send_event, SendSecretRequest), MYPY_ANNOTATION

--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -8,12 +8,12 @@ from raiden.messages.cmdid import CmdId
 from raiden.messages.metadata import Metadata, RouteMetadata
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import (
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendRefundTransfer,
     SendSecretRequest,
     SendSecretReveal,
+    SendUnlock,
 )
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils.packing import pack_balance_proof
@@ -280,7 +280,7 @@ class Unlock(EnvelopeMessage):
         return sha256(self.secret).digest()
 
     @classmethod
-    def from_event(cls, event: SendBalanceProof) -> "Unlock":
+    def from_event(cls, event: SendUnlock) -> "Unlock":
         balance_proof = event.balance_proof
         # pylint: disable=unexpected-keyword-arg
         return cls(

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -58,12 +58,12 @@ from raiden.transfer.mediated_transfer.events import (
     EventUnlockClaimSuccess,
     EventUnlockFailed,
     EventUnlockSuccess,
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendRefundTransfer,
     SendSecretRequest,
     SendSecretReveal,
+    SendUnlock,
 )
 from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import get_channelstate_by_token_network_and_partner
@@ -135,8 +135,8 @@ class RaidenEventHandler(EventHandler):
         elif type(event) == SendSecretReveal:
             assert isinstance(event, SendSecretReveal), MYPY_ANNOTATION
             self.handle_send_secretreveal(raiden, event)
-        elif type(event) == SendBalanceProof:
-            assert isinstance(event, SendBalanceProof), MYPY_ANNOTATION
+        elif type(event) == SendUnlock:
+            assert isinstance(event, SendUnlock), MYPY_ANNOTATION
             self.handle_send_balanceproof(raiden, event)
         elif type(event) == SendSecretRequest:
             assert isinstance(event, SendSecretRequest), MYPY_ANNOTATION
@@ -223,7 +223,7 @@ class RaidenEventHandler(EventHandler):
 
     @staticmethod
     def handle_send_balanceproof(
-        raiden: "RaidenService", balance_proof_event: SendBalanceProof
+        raiden: "RaidenService", balance_proof_event: SendUnlock
     ) -> None:  # pragma: no unittest
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -75,9 +75,6 @@ from raiden.transfer.mediated_transfer.mediation_fee import (
 from raiden.transfer.mediated_transfer.state import TransferDescriptionWithSecretState
 from raiden.transfer.mediated_transfer.state_change import (
     ActionInitInitiator,
-    ActionInitMediator,
-    ActionInitTarget,
-    ActionTransferReroute,
     ReceiveLockExpired,
     ReceiveTransferCancelRoute,
     ReceiveTransferRefund,
@@ -134,18 +131,18 @@ PFS_UPDATE_STATE_CHANGES = (
     ReceiveUnlock,
     ReceiveWithdrawConfirmation,
     ReceiveWithdrawExpired,
-    ActionInitMediator,
-    ActionInitTarget,
-    ActionTransferReroute,
     ReceiveTransferCancelRoute,
     ReceiveLockExpired,
     ReceiveTransferRefund,
     # State change | Reason why update is not needed
-    # ActionChannelWithdraw | Update done by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
-    # ActionInitInitiator | The update is done by the SendLockedTransfer event
-    # ReceiveWithdrawRequest | Update done by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
+    # ActionInitInitiator | Update triggered by SendLockedTransfer
+    # ActionInitMediator | Update triggered by SendLockedTransfer
+    # ActionInitTarget | Update triggered by SendLockedTransfer
+    # ActionTransferReroute | Update triggered by SendLockedTransfer
+    # ActionChannelWithdraw | Upd. triggered by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
+    # ReceiveWithdrawRequest | Upd. triggered by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
 )
-PFS_UPDATE_EVENTS = (SendUnlock,)
+PFS_UPDATE_EVENTS = (SendUnlock, SendLockedTransfer)
 
 
 def initiator_init(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -67,7 +67,7 @@ from raiden.transfer.architecture import BalanceProofSignedState, Event as Raide
 from raiden.transfer.channel import get_capacity
 from raiden.transfer.events import EventPaymentSentFailed
 from raiden.transfer.identifiers import CanonicalIdentifier
-from raiden.transfer.mediated_transfer.events import SendBalanceProof, SendLockedTransfer
+from raiden.transfer.mediated_transfer.events import SendLockedTransfer, SendUnlock
 from raiden.transfer.mediated_transfer.mediation_fee import (
     FeeScheduleState,
     calculate_imbalance_fees,
@@ -145,7 +145,7 @@ PFS_UPDATE_STATE_CHANGES = (
     # ActionInitInitiator | The update is done by the SendLockedTransfer event
     # ReceiveWithdrawRequest | Update done by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
 )
-PFS_UPDATE_EVENTS = (SendBalanceProof,)
+PFS_UPDATE_EVENTS = (SendUnlock,)
 
 
 def initiator_init(

--- a/raiden/storage/serialization/types.py
+++ b/raiden/storage/serialization/types.py
@@ -169,10 +169,10 @@ def message_event_schema_deserialization(
         from raiden.transfer.mediated_transfer.events import SendSecretReveal
 
         return SchemaCache.get_or_create_schema(SendSecretReveal)
-    elif message_type.endswith("SendBalanceProof"):
-        from raiden.transfer.mediated_transfer.events import SendBalanceProof
+    elif message_type.endswith("SendUnlock"):
+        from raiden.transfer.mediated_transfer.events import SendUnlock
 
-        return SchemaCache.get_or_create_schema(SendBalanceProof)
+        return SchemaCache.get_or_create_schema(SendUnlock)
     elif message_type.endswith("SendSecretRequest"):
         from raiden.transfer.mediated_transfer.events import SendSecretRequest
 

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -25,9 +25,9 @@ from raiden.transfer.channel import compute_locksroot
 from raiden.transfer.events import EventPaymentSentFailed, SendProcessed
 from raiden.transfer.mediated_transfer.events import (
     EventUnlockSuccess,
-    SendBalanceProof,
     SendLockedTransfer,
     SendSecretReveal,
+    SendUnlock,
 )
 from raiden.transfer.mediated_transfer.state import LockedTransferSignedState
 from raiden.transfer.mediated_transfer.state_change import (
@@ -649,7 +649,7 @@ class MediatorMixin:
             and self.channel_opened(recipient, our_address)
         ):
             assert event_types_match(
-                result.events, SendSecretReveal, SendBalanceProof, EventUnlockSuccess
+                result.events, SendSecretReveal, SendUnlock, EventUnlockSuccess
             )
             self.event("Unlock successful.")
             self.waiting_for_unlock[secret] = recipient

--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -90,7 +90,7 @@ def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("broadcast_rooms", [[PATH_FINDING_BROADCASTING_ROOM]])
 @pytest.mark.parametrize("routing_mode", [RoutingMode.PFS])
-def test_mediated_transfer(
+def test_pfs_send_capacity_updates_during_mediated_transfer(
     raiden_network, number_of_nodes, deposit, token_addresses, network_wait
 ):
     app0, app1 = raiden_network
@@ -131,5 +131,6 @@ def test_mediated_transfer(
             [],
         )
 
-    assert pfs_room.send_text.call_count == 1
+    # We expect one PFSCapacityUpdate when locking and one when unlocking
+    assert pfs_room.send_text.call_count == 2
     assert "PFSCapacityUpdate" in str(pfs_room.send_text.call_args_list[0])

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -23,10 +23,10 @@ from raiden.storage.sqlite import (
 )
 from raiden.tests.utils import factories
 from raiden.transfer.mediated_transfer.events import (
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendRefundTransfer,
+    SendUnlock,
 )
 from raiden.transfer.mediated_transfer.state_change import (
     ActionInitMediator,
@@ -308,7 +308,7 @@ def test_get_event_with_balance_proof():
         transfer=make_transfer_from_counter(counter),
         canonical_identifier=factories.make_canonical_identifier(),
     )
-    send_balance_proof = SendBalanceProof(
+    send_balance_proof = SendUnlock(
         recipient=partner_address,
         message_identifier=MessageID(next(counter)),
         payment_identifier=factories.make_payment_id(),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -39,10 +39,10 @@ from raiden.transfer.mediated_transfer.events import (
     EventRouteFailed,
     EventUnlockFailed,
     EventUnlockSuccess,
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendSecretReveal,
+    SendUnlock,
 )
 from raiden.transfer.mediated_transfer.initiator import (
     calculate_fee_margin,
@@ -469,7 +469,7 @@ def test_state_wait_unlock_valid():
 
     assert len(iteration.events) == 3
 
-    balance_proof = search_for_item(iteration.events, SendBalanceProof, {})
+    balance_proof = search_for_item(iteration.events, SendUnlock, {})
     complete = search_for_item(iteration.events, EventPaymentSentSuccess, {})
     assert search_for_item(iteration.events, EventUnlockSuccess, {})
     assert balance_proof
@@ -980,7 +980,7 @@ def test_handle_offchain_secretreveal():
     payment_identifier = initiator_state.transfer_description.payment_identifier
     balance_proof = search_for_item(
         iteration.events,
-        SendBalanceProof,
+        SendUnlock,
         {"message_identifier": message_identifier, "payment_identifier": payment_identifier},
     )
     assert balance_proof is not None
@@ -1212,7 +1212,7 @@ def test_initiator_handle_contract_receive_secret_reveal():
     payment_identifier = initiator_state.transfer_description.payment_identifier
     balance_proof = search_for_item(
         iteration.events,
-        SendBalanceProof,
+        SendUnlock,
         {"message_identifier": message_identifier, "payment_identifier": payment_identifier},
     )
     assert balance_proof is not None
@@ -1274,7 +1274,7 @@ def test_initiator_handle_contract_receive_secret_reveal_expired():
         pseudo_random_generator=setup.prng,
     )
 
-    assert search_for_item(iteration.events, SendBalanceProof, {}) is None
+    assert search_for_item(iteration.events, SendUnlock, {}) is None
 
 
 def test_initiator_handle_contract_receive_after_channel_closed():
@@ -1335,7 +1335,7 @@ def test_initiator_handle_contract_receive_after_channel_closed():
     assert secrethash in channel_state.our_state.secrethashes_to_onchain_unlockedlocks
 
     msg = "The channel is closed already, the balance proof must not be sent off-chain"
-    assert search_for_item(iteration.events, SendBalanceProof, {}) is None, msg
+    assert search_for_item(iteration.events, SendUnlock, {}) is None, msg
 
 
 def test_lock_expiry_updates_balance_proof():
@@ -1461,10 +1461,10 @@ def test_secret_reveal_cancel_other_transfers():
         block_number=block_number,
     )
 
-    assert search_for_item(iteration.events, SendBalanceProof, {}) is not None
+    assert search_for_item(iteration.events, SendUnlock, {}) is not None
     # An unlock should only be sent to the intended transfer that we received
     # a secret reveal for. So there should only be 1 balance proof to be sent
-    assert len(list(filter(lambda e: isinstance(e, SendBalanceProof), iteration.events))) == 1
+    assert len(list(filter(lambda e: isinstance(e, SendUnlock), iteration.events))) == 1
 
     rerouted_transfer = get_transfer_at_index(iteration.new_state, 0)
     assert rerouted_transfer.transfer_state == "transfer_cancelled"

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -56,11 +56,11 @@ from raiden.transfer.mediated_transfer.events import (
     EventUnlockClaimSuccess,
     EventUnlockFailed,
     EventUnlockSuccess,
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendRefundTransfer,
     SendSecretReveal,
+    SendUnlock,
 )
 from raiden.transfer.mediated_transfer.mediation_fee import (
     FeeScheduleState,
@@ -471,7 +471,7 @@ def test_events_for_balanceproof():
     )
     assert search_for_item(
         events,
-        SendBalanceProof,
+        SendUnlock,
         {
             "recipient": last_pair.payee_address,
             "message_identifier": msg_identifier,
@@ -552,7 +552,7 @@ def test_events_for_balanceproof_middle_secret():
         UNIT_SECRETHASH,
     )
 
-    assert search_for_item(events, SendBalanceProof, {"recipient": middle_pair.payee_address})
+    assert search_for_item(events, SendUnlock, {"recipient": middle_pair.payee_address})
     assert search_for_item(events, EventUnlockSuccess, {})
     assert middle_pair.payee_state == "payee_balance_proof"
 
@@ -750,7 +750,7 @@ def test_secret_learned():
     assert transfer_pair.payer_state == "payer_secret_revealed"
 
     assert search_for_item(iteration.events, SendSecretReveal, {})
-    assert search_for_item(iteration.events, SendBalanceProof, {})
+    assert search_for_item(iteration.events, SendUnlock, {})
 
 
 def test_secret_learned_with_refund():
@@ -1728,7 +1728,7 @@ def test_mediator_lock_expired_after_receive_secret_reveal():
     )
 
     # Mediator should NOT send balance proof
-    assert search_for_item(iteration.events, SendBalanceProof, {}) is None
+    assert search_for_item(iteration.events, SendUnlock, {}) is None
 
     # Make sure the lock was moved
     payer_channel, payee_channel = channels[0], channels[1]

--- a/raiden/tests/utils/protocol.py
+++ b/raiden/tests/utils/protocol.py
@@ -10,7 +10,7 @@ from raiden.raiden_event_handler import EventHandler
 from raiden.raiden_service import RaidenService
 from raiden.tests.utils.events import check_nested_attrs
 from raiden.transfer.architecture import Event as RaidenEvent, TransitionResult
-from raiden.transfer.mediated_transfer.events import SendBalanceProof, SendSecretRequest
+from raiden.transfer.mediated_transfer.events import SendSecretRequest, SendUnlock
 from raiden.transfer.state import ChainState
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Callable, Dict, List, NamedTuple, SecretHash, Set
@@ -150,7 +150,7 @@ class HoldRaidenEventHandler(EventHandler):
         return self.hold(SendSecretRequest, {"secrethash": secrethash})
 
     def hold_unlock_for(self, secrethash: SecretHash):
-        return self.hold(SendBalanceProof, {"secrethash": secrethash})
+        return self.hold(SendUnlock, {"secrethash": secrethash})
 
     def release_secretrequest_for(self, raiden: RaidenService, secrethash: SecretHash):
         for hold in self.eventtype_to_holdings[SendSecretRequest]:
@@ -158,7 +158,7 @@ class HoldRaidenEventHandler(EventHandler):
                 self.release(raiden, hold.event)
 
     def release_unlock_for(self, raiden: RaidenService, secrethash: SecretHash):
-        for hold in self.eventtype_to_holdings[SendBalanceProof]:
+        for hold in self.eventtype_to_holdings[SendUnlock]:
             if hold.attributes["secrethash"] == secrethash:
                 self.release(raiden, hold.event)
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -30,10 +30,10 @@ from raiden.transfer.events import (
 )
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, CanonicalIdentifier
 from raiden.transfer.mediated_transfer.events import (
-    SendBalanceProof,
     SendLockedTransfer,
     SendLockExpired,
     SendRefundTransfer,
+    SendUnlock,
     refund_from_sendmediated,
 )
 from raiden.transfer.mediated_transfer.mediation_fee import (
@@ -125,7 +125,7 @@ if TYPE_CHECKING:
 PendingLocksStateOrError = Tuple[bool, Optional[str], Optional[PendingLocksState]]
 EventsOrError = Tuple[bool, List[Event], Optional[str]]
 BalanceProofData = Tuple[Locksroot, Nonce, TokenAmount, TokenAmount]
-SendUnlockAndPendingLocksState = Tuple[SendBalanceProof, PendingLocksState]
+SendUnlockAndPendingLocksState = Tuple[SendUnlock, PendingLocksState]
 
 
 class UnlockGain(NamedTuple):
@@ -1502,7 +1502,7 @@ def create_unlock(
         canonical_identifier=channel_state.canonical_identifier,
     )
 
-    unlock_lock = SendBalanceProof(
+    unlock_lock = SendUnlock(
         recipient=recipient,
         message_identifier=message_identifier,
         payment_identifier=payment_identifier,
@@ -1595,7 +1595,7 @@ def send_unlock(
     payment_identifier: PaymentID,
     secret: Secret,
     secrethash: SecretHash,
-) -> SendBalanceProof:
+) -> SendUnlock:
     lock = get_lock(channel_state.our_state, secrethash)
     assert lock, "caller must ensure the lock exists"
 

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -91,7 +91,7 @@ class SendSecretReveal(SendMessageEvent):
 
 
 @dataclass(frozen=True)
-class SendBalanceProof(SendMessageEvent):
+class SendUnlock(SendMessageEvent):
     """ Event to send a balance-proof to the counter-party, used after a lock
     is unlocked locally allowing the counter-party to claim it.
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1294,7 +1294,7 @@ def handle_offchain_secretreveal(
     block_number: BlockNumber,
     block_hash: BlockHash,
 ) -> TransitionResult[MediatorTransferState]:
-    """ Handles the secret reveal and sends SendBalanceProof/RevealSecret if necessary. """
+    """ Handles the secret reveal and sends SendUnlock/RevealSecret if necessary. """
     is_valid_reveal = is_valid_secret_reveal(
         state_change=mediator_state_change, transfer_secrethash=mediator_state.secrethash
     )

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -175,7 +175,7 @@ class MediationPairState(State):
     #   valid from all but the `payee_expired` state.
     #
     # payee_balance_proof:
-    #   This node has sent a SendBalanceProof to the payee with the balance
+    #   This node has sent a SendUnlock to the payee with the balance
     #   updated.
     #
     # payee_expired:


### PR DESCRIPTION
This has been broken in 0e9e3f5.

Closes #5612.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
