### PR TITLE
Improve test for PFS update messages (also fixes a bug)

### DIFF
--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -1,3 +1,6 @@
+from raiden.utils.typing import List, TokenAddress
+
+
 class FlatList(list):
     """
     This class inherits from list and has the same interface as a list-type.
@@ -6,10 +9,10 @@ class FlatList(list):
     """
 
     @property
-    def data(self):
+    def data(self) -> List:
         return list(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}: {}>".format(self.__class__.__name__, list(self))
 
 
@@ -22,11 +25,11 @@ class PartnersPerTokenList(FlatList):
 
 
 class Address:
-    def __init__(self, token_address):
+    def __init__(self, token_address: TokenAddress) -> None:
         self.address = token_address
 
 
 class PartnersPerToken:
-    def __init__(self, partner_address, channel):
+    def __init__(self, partner_address: Address, channel: str) -> None:
         self.partner_address = partner_address
         self.channel = channel

--- a/raiden/messages/path_finding_service.py
+++ b/raiden/messages/path_finding_service.py
@@ -10,6 +10,7 @@ from raiden.transfer import channel
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.state import NettingChannelState
+from raiden.utils.formatting import to_checksum_address
 from raiden.utils.signing import pack_data
 from raiden.utils.typing import Address, BlockTimeout, Nonce, TokenAmount
 
@@ -62,6 +63,14 @@ class PFSCapacityUpdate(SignedMessage):
             (self.updating_capacity, "uint256"),
             (self.other_capacity, "uint256"),
             (self.reveal_timeout, "uint256"),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__}("
+            f"updating_participant={to_checksum_address(self.updating_participant)} "
+            f"updating_capacity={self.updating_capacity} "
+            f"other_capacity={self.other_capacity})>"
         )
 
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -93,6 +93,7 @@ from raiden.transfer.state_change import (
     ReceiveUnlock,
     ReceiveWithdrawConfirmation,
     ReceiveWithdrawExpired,
+    ReceiveWithdrawRequest,
 )
 from raiden.utils.formatting import lpex, to_checksum_address
 from raiden.utils.logging import redact_secret
@@ -129,6 +130,7 @@ ConnectionManagerDict = Dict[TokenNetworkAddress, ConnectionManager]
 PFS_UPDATE_STATE_CHANGES = (
     ContractReceiveChannelDeposit,
     ReceiveUnlock,
+    ReceiveWithdrawRequest,
     ReceiveWithdrawConfirmation,
     ReceiveWithdrawExpired,
     ReceiveTransferCancelRoute,
@@ -140,7 +142,6 @@ PFS_UPDATE_STATE_CHANGES = (
     # ActionInitTarget | Update triggered by SendLockedTransfer
     # ActionTransferReroute | Update triggered by SendLockedTransfer
     # ActionChannelWithdraw | Upd. triggered by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
-    # ReceiveWithdrawRequest | Upd. triggered by ReceiveWithdrawConfirmation/ReceiveWithdrawExpired
 )
 PFS_UPDATE_EVENTS = (SendUnlock, SendLockedTransfer)
 
@@ -733,6 +734,7 @@ class RaidenService(Runnable):
                     state_change,
                     (
                         ContractReceiveChannelDeposit,
+                        ReceiveWithdrawRequest,
                         ReceiveWithdrawConfirmation,
                         ReceiveWithdrawExpired,
                     ),

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -185,7 +185,8 @@ def get_best_routes(
 
         log.warning(
             "Request to Pathfinding Service was not successful. "
-            "No routes to the target are found."
+            "No routes to the target are found.",
+            pfs_message=pfs_error_msg,
         )
         return (pfs_error_msg, list(), None)
 

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -38,14 +38,24 @@ def send_pfs_update(
     capacity_msg = PFSCapacityUpdate.from_channel_state(channel_state)
     capacity_msg.sign(raiden.signer)
     raiden.transport.broadcast(constants.PATH_FINDING_BROADCASTING_ROOM, capacity_msg)
-    log.debug("Sent a PFS Capacity Update", message=capacity_msg, channel_state=channel_state)
+    log.debug(
+        "Sent a PFS Capacity Update",
+        node=to_checksum_address(raiden.address),
+        message=capacity_msg,
+        channel_state=channel_state,
+    )
 
     if update_fee_schedule:
         fee_msg = PFSFeeUpdate.from_channel_state(channel_state)
         fee_msg.sign(raiden.signer)
 
         raiden.transport.broadcast(constants.PATH_FINDING_BROADCASTING_ROOM, fee_msg)
-        log.debug("Sent a PFS Fee Update", message=fee_msg, channel_state=channel_state)
+        log.debug(
+            "Sent a PFS Fee Update",
+            node=to_checksum_address(raiden.address),
+            message=fee_msg,
+            channel_state=channel_state,
+        )
 
 
 def update_monitoring_service_from_balance_proof(
@@ -85,6 +95,7 @@ def update_monitoring_service_from_balance_proof(
 
     log.info(
         "Received new balance proof, creating message for Monitoring Service.",
+        node=to_checksum_address(raiden.address),
         balance_proof=new_balance_proof,
     )
 

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1122,6 +1122,7 @@ def test_matrix_ignore_messages_in_broadcast_rooms(matrix_transports):
             gevent.joinall({transport1.greenlet}, timeout=0.1, raise_error=True)
 
 
+@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5663")
 @pytest.mark.parametrize("number_of_transports", [3])
 @pytest.mark.parametrize("matrix_server_count", [1])
 @pytest.mark.parametrize("matrix_sync_timeout", [5_000])  # Shorten sync timeout to prevent timeout

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -199,6 +199,8 @@ def test_assumption_federation_works_after_original_server_goes_down(
     assert sorted(received.keys()) == [0, 1, 2]
     assert all("Message1" == m for m in received.values())
 
+    # Shut down the room_creator before we stop the server
+    user_room_creator.stop_listener_thread()
     # Shutdown server 0, the original creator of the room
     server: HTTPExecutor = local_matrix_servers_with_executor[0][1]
     server.stop()
@@ -213,7 +215,6 @@ def test_assumption_federation_works_after_original_server_goes_down(
     assert all("Message2" == m for m in received.values())
 
     # Shut down longrunning threads
-    user_room_creator.stop_listener_thread()
     user_federated_1.stop_listener_thread()
     user_federated_2.stop_listener_thread()
 

--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -5,6 +5,8 @@ import pytest
 from raiden.api.python import RaidenAPI
 from raiden.app import App
 from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, RoutingMode
+from raiden.messages.abstract import Message
+from raiden.messages.path_finding_service import PFSCapacityUpdate, PFSFeeUpdate
 from raiden.network.transport.matrix import make_room_alias
 from raiden.network.transport.matrix.client import Room
 from raiden.tests.utils.detect_failure import raise_on_failure
@@ -15,6 +17,7 @@ from raiden.tests.utils.transfer import (
     transfer,
     wait_assert,
 )
+from raiden.tests.utils.transport import TestMatrixTransport
 from raiden.transfer import views
 from raiden.utils.typing import (
     List,
@@ -44,32 +47,21 @@ def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
     a pfs matrix room is mocked to see what is sent to it
     """
     app0, app1, app2 = raiden_network
-    transport0 = app0.raiden.transport
-
-    pfs_room_name = make_room_alias(transport0.chain_id, PATH_FINDING_BROADCASTING_ROOM)
-
-    # Mock send_text on the PFS room
-    pfs_rooms: List[Room] = []
-    for app in [app0, app1, app2]:
-        transport = app.raiden.transport
-        pfs_room = transport._broadcast_rooms.get(pfs_room_name)
-        # need to assert for mypy that pfs_room is not None
-        assert isinstance(pfs_room, Room)
-        pfs_room.send_text = MagicMock(spec=pfs_room.send_text)
-        pfs_rooms.append(pfs_room)
-
     api0 = RaidenAPI(app0.raiden)
-
     api0.channel_open(
         token_address=token_addresses[0],
         registry_address=app0.raiden.default_registry.address,
         partner_address=app1.raiden.address,
     )
 
+    def get_messages(app: App) -> List[Message]:
+        assert isinstance(app.raiden.transport, TestMatrixTransport)
+        return app.raiden.transport.broadcast_messages[PATH_FINDING_BROADCASTING_ROOM]
+
     # the room should not have been called at channel opening
-    assert pfs_rooms[0].send_text.call_count == 0
-    assert pfs_rooms[1].send_text.call_count == 0
-    assert pfs_rooms[2].send_text.call_count == 0
+    assert len(get_messages(app0)) == 0
+    assert len(get_messages(app1)) == 0
+    assert len(get_messages(app2)) == 0
 
     api0.set_total_channel_deposit(
         token_address=token_addresses[0],
@@ -78,19 +70,20 @@ def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
         total_deposit=TokenAmount(10),
     )
 
-    # now we expect the room to be called the 1st time with a PFSCapacityUpdate
-    # and a PFSFeeUpdate after the deposit
-    assert pfs_rooms[0].send_text.call_count == 1
-    assert "PFSCapacityUpdate" in str(pfs_rooms[0].send_text.call_args_list[0])
-    assert "PFSFeeUpdate" in str(pfs_rooms[0].send_text.call_args_list[0])
+    # We expect a PFSCapacityUpdate and a PFSFeeUpdate after the deposit
+    messages0 = get_messages(app0)
+    assert len(messages0) == 2
+    assert len([x for x in messages0 if isinstance(x, PFSCapacityUpdate)]) == 1
+    assert len([x for x in messages0 if isinstance(x, PFSFeeUpdate)]) == 1
 
-    # we expect the same in the pfs room of app1
-    assert pfs_rooms[1].send_text.call_count == 1
-    assert "PFSCapacityUpdate" in str(pfs_rooms[1].send_text.call_args_list[0])
-    assert "PFSFeeUpdate" in str(pfs_rooms[1].send_text.call_args_list[0])
+    # We expect the same messages for the target
+    messages1 = get_messages(app1)
+    assert len(messages1) == 2
+    assert len([x for x in messages1 if isinstance(x, PFSCapacityUpdate)]) == 1
+    assert len([x for x in messages1 if isinstance(x, PFSFeeUpdate)]) == 1
 
     # Unrelated node should not send updates
-    assert pfs_rooms[2].send_text.call_count == 0
+    assert len(get_messages(app2)) == 0
 
     api0.set_total_channel_withdraw(
         token_address=token_addresses[0],
@@ -99,19 +92,20 @@ def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
         total_withdraw=WithdrawAmount(5),
     )
 
-    # now we expect the room to be called the 2nd time with a PFSCapacityUpdate
-    # after the withdraw
-    assert pfs_rooms[0].send_text.call_count == 2
-    assert "PFSCapacityUpdate" in str(pfs_rooms[0].send_text.call_args_list[1])
-    assert "PFSFeeUpdate" in str(pfs_rooms[0].send_text.call_args_list[1])
+    # We expect a PFSCapacityUpdate and a PFSFeeUpdate after the withdraw
+    messages0 = get_messages(app0)
+    assert len(messages0) == 4
+    assert len([x for x in messages0 if isinstance(x, PFSCapacityUpdate)]) == 2
+    assert len([x for x in messages0 if isinstance(x, PFSFeeUpdate)]) == 2
 
-    # we expect the same in the pfs room of app1
-    assert pfs_rooms[1].send_text.call_count == 2
-    assert "PFSCapacityUpdate" in str(pfs_rooms[1].send_text.call_args_list[1])
-    assert "PFSFeeUpdate" in str(pfs_rooms[1].send_text.call_args_list[1])
+    # We expect the same messages for the target
+    messages1 = get_messages(app1)
+    assert len(messages1) == 4
+    assert len([x for x in messages1 if isinstance(x, PFSCapacityUpdate)]) == 2
+    assert len([x for x in messages1 if isinstance(x, PFSFeeUpdate)]) == 2
 
     # Unrelated node should not send updates
-    assert pfs_rooms[2].send_text.call_count == 0
+    assert len(get_messages(app2)) == 0
 
 
 @raise_on_failure

--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -8,6 +8,7 @@ from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_R
 from raiden.network.transport.matrix import make_room_alias
 from raiden.network.transport.matrix.client import Room
 from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import (
     assert_succeeding_transfer_invariants,
     block_timeout_for_transfer_by_secrethash,
@@ -86,14 +87,16 @@ def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
     assert "PFSFeeUpdate" in str(pfs_room.send_text.call_args_list[1])
 
 
+
 @raise_on_failure
-@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("number_of_nodes", [3])
+@pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("broadcast_rooms", [[PATH_FINDING_BROADCASTING_ROOM]])
 @pytest.mark.parametrize("routing_mode", [RoutingMode.PFS])
 def test_pfs_send_capacity_updates_during_mediated_transfer(
     raiden_network, number_of_nodes, deposit, token_addresses, network_wait
 ):
-    app0, app1 = raiden_network
+    app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     chain_state = views.state_from_app(app0)
     token_network_registry_address = app0.raiden.default_registry.address
@@ -106,10 +109,10 @@ def test_pfs_send_capacity_updates_during_mediated_transfer(
 
     # Mock send_text on the PFS room
     pfs_rooms: List[Room] = []
-    for app in [app0, app1]:
+    for app in [app0, app1, app2]:
         transport = app.raiden.transport
         pfs_room = transport._broadcast_rooms.get(pfs_room_name)
-        # need to assert for mypy that pfs_room0 is not None
+        # need to assert for mypy that pfs_room is not None
         assert isinstance(pfs_room, Room)
         pfs_room.send_text = MagicMock(spec=pfs_room.send_text)
         pfs_rooms.append(pfs_room)
@@ -117,7 +120,7 @@ def test_pfs_send_capacity_updates_during_mediated_transfer(
     amount = PaymentAmount(10)
     secrethash = transfer(
         initiator_app=app0,
-        target_app=app1,
+        target_app=app2,
         token_address=token_address,
         amount=amount,
         identifier=PaymentID(1),
@@ -136,10 +139,31 @@ def test_pfs_send_capacity_updates_during_mediated_transfer(
             [],
         )
 
+    with block_timeout_for_transfer_by_secrethash(app1.raiden, secrethash):
+        wait_assert(
+            assert_succeeding_transfer_invariants,
+            token_network_address,
+            app1,
+            deposit - amount,
+            [],
+            app2,
+            deposit + amount,
+            [],
+        )
+
     # Initiator: we expect one PFSCapacityUpdate when locking and one when unlocking
     assert pfs_rooms[0].send_text.call_count == 2
     assert "PFSCapacityUpdate" in str(pfs_rooms[0].send_text.call_args_list[0])
+    assert "PFSFeeUpdate" not in str(pfs_rooms[0].send_text.call_args_list[0])
+
+    # Mediator:
+    #   incoming channel: we expect one PFSCapacityUpdate when locking and one when unlocking
+    #   outgoing channel: we expect one PFSCapacityUpdate when funds are unlocked
+    assert pfs_rooms[1].send_text.call_count == 3
+    assert "PFSCapacityUpdate" in str(pfs_rooms[1].send_text.call_args_list[0])
+    assert "PFSFeeUpdate" not in str(pfs_rooms[1].send_text.call_args_list[0])
 
     # Target: we expect one PFSCapacityUpdate when funds are unlocked
-    assert pfs_rooms[1].send_text.call_count == 1
-    assert "PFSCapacityUpdate" in str(pfs_rooms[1].send_text.call_args_list[0])
+    assert pfs_rooms[2].send_text.call_count == 1
+    assert "PFSCapacityUpdate" in str(pfs_rooms[2].send_text.call_args_list[0])
+    assert "PFSFeeUpdate" not in str(pfs_rooms[2].send_text.call_args_list[0])

--- a/raiden/tests/scenarios/ci/sp1/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/ci/sp1/bf2_long_running.yaml
@@ -200,7 +200,6 @@ scenario:
             - assert: {from: 0, to: 4, total_deposit: 10_000_000_000_000_000, balance: 10_000_000_000_000_000, state: "opened"}
             - assert: {from: 2, to: 4, total_deposit: 150_000_000_000_000_000, balance: 100_000_000_000_000_000, state: "opened"}
             - assert: {from: 4, to: 2, total_deposit: 0, balance: 50_000_000_000_000_000, state: "opened"}
-            - assert: {from: 0, to: 1, total_deposit: 100_000_000_000_000_000, balance: 40_000_000_000_000_000, state: "opened"}
       - parallel:
           name: "Check edge cases again"
           tasks:

--- a/raiden/tests/scenarios/ci/sp2/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/ci/sp2/pfs8_mediator_goes_offline.yaml
@@ -81,7 +81,7 @@ scenario:
             - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
-            # Assert that correct amount was tranferred on the correct path
+            # Assert that correct amount was transferred on the correct path
             - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
@@ -109,11 +109,11 @@ scenario:
       - serial:
           name: "Make payment from 0 to 3 after node4 is stopped"
           tasks:
-            # Check that a payment is made with the only availabe path [0, 1, 2, 3] from 0 to 3
+            # Check that a payment is made with the only available path [0, 1, 2, 3] from 0 to 3
             - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
-            # Assert that correct amount was tranferred on the correct path
+            # Assert that correct amount was transferred on the correct path
             - wait_blocks: 1
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -12,7 +12,6 @@ from raiden.app import App
 from raiden.constants import GENESIS_BLOCK_NUMBER, Environment, RoutingMode
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.network.transport import MatrixTransport
 from raiden.raiden_event_handler import RaidenEventHandler
 from raiden.raiden_service import RaidenService
 from raiden.settings import (
@@ -27,7 +26,7 @@ from raiden.settings import (
 from raiden.tests.utils.app import database_from_privatekey
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.tests.utils.protocol import HoldRaidenEventHandler, WaitForMessage
-from raiden.tests.utils.transport import ParsedURL
+from raiden.tests.utils.transport import ParsedURL, TestMatrixTransport
 from raiden.transfer import views
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.views import state_from_raiden
@@ -419,7 +418,8 @@ def create_apps(
         if user_deposit_address:
             user_deposit = proxy_manager.user_deposit(user_deposit_address)
 
-        transport = MatrixTransport(config=config.transport, environment=environment_type)
+        # Use `TestMatrixTransport` that saves sent messages for assertions in tests
+        transport = TestMatrixTransport(config=config.transport, environment=environment_type)
 
         raiden_event_handler = RaidenEventHandler()
         hold_handler = HoldRaidenEventHandler(raiden_event_handler)

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,8 +64,6 @@ disallow_untyped_defs = False
 disallow_untyped_defs = False
 [mypy-raiden.utils.http.*]
 disallow_untyped_defs = False
-[mypy-raiden.api.objects]
-disallow_untyped_defs = False
 [mypy-raiden.api.v1.encoding]
 disallow_untyped_defs = False
 


### PR DESCRIPTION
## Description

This fixes a bug with (not) sending PFSFeeUpdatesduring withdrawels.

A mixed bag of minor improvements made during looking into https://github.com/raiden-network/raiden/issues/5627

- Add PFS error message to log
- Remove duplicated line from bf2 scenario
- Test target and mediator in `test_pfs_send_capacity_updates_during_mediated_transfer`
-  Test target in `test_pfs_send_capacity_updates_on_deposit_and_withdraw`
- Improve tests by using `TestMatrixTransport` instead of monkey patching

Also fixes the first two tasks of https://github.com/raiden-network/raiden/issues/5652

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
