### PR TITLE
Prefix ServiceRequestFailed errors with `PFS:`

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -247,9 +247,9 @@ def get_best_routes_pfs(
             value=amount,
         )
     except ServiceRequestFailed as e:
-        log_message = e.args[0]
+        log_message = ("PFS: " + e.args[0]) if e.args[0] else None
         log_info = e.args[1] if len(e.args) > 1 else {}
-        log.warning("An error with the path request occured", log_message=log_message, **log_info)
+        log.warning("An error with the path request occurred", log_message=log_message, **log_info)
         return log_message, [], None
 
     paths = []


### PR DESCRIPTION
This makes it obvious that this error originated in the PFS.

Are there any other cases that need prefixing? Logs like
```
"event": "Pathfinding Service rejected IOU"
"error": "ServiceRequestIOURejected('The provided payment is lower than service fee. (2104)')",
```
are already sufficiently descriptive IMO.

Closes https://github.com/raiden-network/raiden/issues/5645.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
