### PR TITLE
Remove monkey patching from `storage/sqlite.py`

### DIFF
--- a/raiden/storage/serialization/fields.py
+++ b/raiden/storage/serialization/fields.py
@@ -143,9 +143,10 @@ class NetworkXGraphField(marshmallow.fields.Field):
     """ Converts networkx.Graph objects to a string """
 
     def _serialize(self, value: networkx.Graph, attr: Any, obj: Any, **kwargs: Any) -> str:
-        return json.dumps(
-            [(to_checksum_address(edge[0]), to_checksum_address(edge[1])) for edge in value.edges]
-        )
+        # We use bytes.hex it's fast (33x as fast as eth_utils.to_hex and 500x
+        # as fast as to_checksum_address) and works just as well as input for
+        # to_canonical_address.
+        return json.dumps([(edge[0].hex(), edge[1].hex()) for edge in value.edges])
 
     def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> networkx.Graph:
         try:

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -7,9 +7,7 @@ from types import TracebackType
 from typing import Generator
 
 import gevent
-from eth_utils import to_checksum_address, to_hex
 
-import raiden.storage.serialization.fields as fields
 from raiden.constants import RAIDEN_DB_VERSION, SQLITE_MIN_REQUIRED_VERSION
 from raiden.exceptions import InvalidDBData, InvalidNumberInput
 from raiden.storage.serialization import SerializationBase
@@ -789,12 +787,7 @@ class SerializedSQLiteStorage:
     def write_state_snapshot(
         self, snapshot: State, statechange_id: StateChangeID, statechange_qty: int
     ) -> SnapshotID:
-        # `to_checksum_address` is slow and is not necessary for our internal serialization.
-        # FIXME: We should be able to adapt the serialization without this evil
-        #        monkey patching, but right now there is no simple way to do it.
-        fields.to_checksum_address = to_hex
         serialized_data = self.serializer.serialize(snapshot)
-        fields.to_checksum_address = to_checksum_address  # type: ignore
 
         return self.database.write_state_snapshot(serialized_data, statechange_id, statechange_qty)
 


### PR DESCRIPTION
This not only broke some filtering code which looked for checksum
encoded addresses, due to the monkeypatching it broke it in a way that
was not detected by the tests because the tests exercised the unpatched
code.

To gain back at least some of the speed improvement, we use
`bytes.hex()` for the networkx graphs when serializing.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
