### PR TITLE
Log the transport queue event processing lag

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import gevent
 import structlog
@@ -21,7 +21,6 @@ from raiden.messages.healthcheck import Ping, Pong
 from raiden.messages.synchronization import Delivered, Processed
 from raiden.network.transport.matrix.client import (
     GMatrixClient,
-    JSONResponse,
     MatrixMessage,
     MatrixSyncMessages,
     Room,
@@ -683,7 +682,7 @@ class MatrixTransport(Runnable):
         # Process the result from the sync executed above
         response_queue = self._client.response_queue
         while response_queue:
-            token_response: Tuple[UUID, JSONResponse] = response_queue.get(block=False)
+            token_response = response_queue.get(block=False)
             self._client._handle_response(token_response[1], first_sync=True)
 
     def _initialize_room_inventory(self) -> None:

--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, TypeVar
+from typing import Generic, Iterable, List, TypeVar
 
 from gevent.event import Event
 from gevent.queue import Queue
@@ -6,7 +6,7 @@ from gevent.queue import Queue
 T = TypeVar("T")
 
 
-class NotifyingQueue(Event):
+class NotifyingQueue(Event, Generic[T]):
     """This is not the same as a JoinableQueue. Here, instead of waiting for
     all the work to be processed, the wait is for work to be available.
     """


### PR DESCRIPTION
## Description

This adds the time a particular response was received from the Matrix `/sync` call to the tuple stored in the queue.
Once that item is being processed the lag is logged.
