### PR TITLE
bugfix: invalid if statement

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -313,7 +313,7 @@ class UserAddressManager:
         new_address_reachability = USER_PRESENCE_TO_ADDRESS_REACHABILITY[new_presence]
 
         prev_reachability_state = self.get_address_reachability_state(address)
-        if new_address_reachability == prev_reachability_state:
+        if new_address_reachability == prev_reachability_state.reachability:
             return
 
         now = datetime.now()


### PR DESCRIPTION
The `if` statement was comparing values of different types, it was
always false. Thanks @ulope for the catch.