### PR TITLE
Fix pfs request race condition

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -29,6 +29,7 @@ from raiden.transfer.state import (
     FeeScheduleState,
     NettingChannelEndState,
     NettingChannelState,
+    SuccessfulTransactionState,
     TokenNetworkGraphState,
     TokenNetworkState,
     TransactionChannelDeposit,
@@ -143,9 +144,7 @@ def contractreceivechannelnew_from_event(
     our_state = NettingChannelEndState(new_channel_details.our_address, Balance(0))
     partner_state = NettingChannelEndState(new_channel_details.partner_address, Balance(0))
 
-    open_transaction = TransactionExecutionStatus(
-        None, block_number, TransactionExecutionStatus.SUCCESS
-    )
+    open_transaction = SuccessfulTransactionState(block_number, None)
 
     # If the node was offline for a long period, the channel may have been
     # closed already, if that is the case during initialization the node will

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -26,7 +26,7 @@ LATEST = "https://api.github.com/repos/raiden-network/raiden/releases/latest"
 RELEASE_PAGE = "https://github.com/raiden-network/raiden/releases"
 SECURITY_EXPRESSION = r"\[CRITICAL UPDATE.*?\]"
 
-RAIDEN_DB_VERSION = RaidenDBVersion(25)
+RAIDEN_DB_VERSION = RaidenDBVersion(26)
 SQLITE_MIN_REQUIRED_VERSION = (3, 9, 0)
 PROTOCOL_VERSION = RaidenProtocolVersion(1)
 

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -14,6 +14,7 @@ from raiden.transfer.state import ChainState, ChannelState, RouteState
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Address,
+    BlockNumber,
     ChannelID,
     FeeAmount,
     InitiatorAddress,

--- a/raiden/tests/integration/network/test_pathfinding.py
+++ b/raiden/tests/integration/network/test_pathfinding.py
@@ -39,6 +39,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
                 token_network_registry_address_test_default
             ),
             "user_deposit_address": to_checksum_address(privatekey_to_address(private_keys[1])),
+            "confirmed_block": 10,
         },
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",
@@ -163,6 +164,7 @@ def test_check_pfs_for_production(service_registry_address, private_keys, web3, 
         operator="",
         version="",
         user_deposit_address=privatekey_to_address(private_keys[1]),
+        confirmed_block_number=10,
     )
     with pytest.raises(RaidenError):
         check_pfs_for_production(service_registry=service_registry, pfs_info=pfs_info)
@@ -178,6 +180,7 @@ def test_check_pfs_for_production(service_registry_address, private_keys, web3, 
         operator="",
         version="",
         user_deposit_address=privatekey_to_address(private_keys[1]),
+        confirmed_block_number=10,
     )
     with pytest.raises(RaidenError):
         check_pfs_for_production(service_registry=service_registry, pfs_info=pfs_info)

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -366,6 +366,7 @@ def test_mediated_transfer_calls_pfs(raiden_chain: List[App], token_addresses: L
                 token_network_registry_address=token_network_registry_address,
                 user_deposit_address=factories.make_address(),
                 payment_address=factories.make_address(),
+                confirmed_block_number=chain_state.block_number,
                 message="",
                 operator="",
                 version="",

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -149,7 +149,7 @@ def create_channel_from_models(our_model, partner_model, partner_pkey):
                 balance=partner_model.balance,
                 pending_locks=PendingLocksState(partner_model.pending_locks),
             ),
-            open_transaction=TransactionExecutionStatusProperties(finished_block_number=1),
+            open_transaction=SuccessfulTransactionState(finished_block_number=1),
         )
     )
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -62,6 +62,7 @@ from raiden.transfer.state import (
     PendingLocksState,
     PendingWithdrawState,
     RouteState,
+    SuccessfulTransactionState,
     TransactionChannelDeposit,
     TransactionExecutionStatus,
     UnlockPartialProofState,
@@ -679,7 +680,7 @@ def test_invalid_timeouts():
     balance1 = 10
     balance2 = 10
 
-    opened_transaction = TransactionExecutionStatus(None, 1, TransactionExecutionStatus.SUCCESS)
+    opened_transaction = SuccessfulTransactionState(1, None)
     closed_transaction = None
     settled_transaction = None
 

--- a/raiden/tests/unit/test_pfs_integration_refactored.py
+++ b/raiden/tests/unit/test_pfs_integration_refactored.py
@@ -26,6 +26,7 @@ def test_get_pfs_info_success():
             "chain_id": 42,
             "token_network_registry_address": pfs_test_default_registry_address,
             "user_deposit_address": pfs_test_default_user_deposit_address,
+            "confirmed_block": 11,
         },
         "version": "0.0.3",
         "operator": "John Doe",
@@ -50,6 +51,7 @@ def test_get_pfs_info_success():
         assert pfs_info.message == "This is your favorite pathfinding service"
         assert pfs_info.operator == "John Doe"
         assert pfs_info.version == "0.0.3"
+        assert pfs_info.confirmed_block_number == 11
 
 
 def test_get_pfs_info_error():

--- a/raiden/tests/unit/test_startup.py
+++ b/raiden/tests/unit/test_startup.py
@@ -18,7 +18,7 @@ from raiden.ui.startup import (
     raiden_bundle_from_contracts_deployment,
     services_bundle_from_contracts_deployment,
 )
-from raiden.utils.typing import Address, TokenAmount, TokenNetworkRegistryAddress
+from raiden.utils.typing import Address, BlockNumber, TokenAmount, TokenNetworkRegistryAddress
 from raiden_contracts.constants import (
     CONTRACT_SECRET_REGISTRY,
     CONTRACT_SERVICE_REGISTRY,
@@ -43,6 +43,7 @@ PFS_INFO = PFSInfo(
     token_network_registry_address=token_network_registry_address_test_default,
     user_deposit_address=user_deposit_address_test_default,
     payment_address=pfs_payment_address_default,
+    confirmed_block_number=BlockNumber(1),
     message="This is your favorite pathfinding service",
     operator="John Doe",
     version="0.0.3",
@@ -220,6 +221,7 @@ def test_setup_proxies_all_addresses_are_known():
         ),
         user_deposit_address=user_deposit_address_test_default,
         payment_address=pfs_payment_address_default,
+        confirmed_block_number=BlockNumber(1),
         message="This is your favorite pathfinding service",
         operator="John Doe",
         version="0.0.3",
@@ -273,6 +275,7 @@ def test_setup_proxies_no_service_registry_but_pfs():
             contracts[CONTRACT_TOKEN_NETWORK_REGISTRY]["address"]
         ),
         user_deposit_address=user_deposit_address_test_default,
+        confirmed_block_number=BlockNumber(1),
         payment_address=pfs_payment_address_default,
         message="This is your favorite pathfinding service",
         operator="John Doe",

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -235,8 +235,8 @@ def test_initiator_skips_used_routes():
     defaults = factories.NettingChannelStateProperties(
         our_state=factories.NettingChannelEndStateProperties.OUR_STATE,
         partner_state=factories.NettingChannelEndStateProperties(balance=10),
-        open_transaction=factories.TransactionExecutionStatusProperties(
-            started_block_number=1, finished_block_number=2, result="success"
+        open_transaction=factories.SuccessfulTransactionStateProperties(
+            started_block_number=1, finished_block_number=2
         ),
     )
     properties = [
@@ -330,8 +330,8 @@ def test_mediator_skips_used_routes():
     defaults = factories.NettingChannelStateProperties(
         our_state=factories.NettingChannelEndStateProperties.OUR_STATE,
         partner_state=factories.NettingChannelEndStateProperties(balance=UNIT_TRANSFER_AMOUNT),
-        open_transaction=factories.TransactionExecutionStatusProperties(
-            started_block_number=1, finished_block_number=2, result="success"
+        open_transaction=factories.SuccessfulTransactionStateProperties(
+            started_block_number=1, finished_block_number=2
         ),
     )
     properties = [

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -43,9 +43,17 @@ def test_filter_channels_by_partneraddress_empty(chain_state):
 
 def test_filter_channels_by_status_empty_excludes():
     channel_states = factories.make_channel_set(number_of_channels=3).channels
-    channel_states[1].close_transaction = channel_states[1].open_transaction
-    channel_states[2].close_transaction = channel_states[2].open_transaction
-    channel_states[2].settle_transaction = channel_states[2].open_transaction
+    channel_states[1].close_transaction = TransactionExecutionStatus(
+        started_block_number=channel_states[1].open_transaction.started_block_number,
+        finished_block_number=channel_states[1].open_transaction.finished_block_number,
+        result=TransactionExecutionStatus.SUCCESS,
+    )
+    channel_states[2].close_transaction = TransactionExecutionStatus(
+        started_block_number=channel_states[2].open_transaction.started_block_number,
+        finished_block_number=channel_states[2].open_transaction.finished_block_number,
+        result=TransactionExecutionStatus.SUCCESS,
+    )
+    channel_states[2].settle_transaction = channel_states[2].close_transaction
     assert (
         filter_channels_by_status(channel_states=channel_states, exclude_states=None)
         == channel_states

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -389,7 +389,7 @@ class NettingChannelState(State):
     def __post_init__(self) -> None:
         typecheck(self.reveal_timeout, int)
         typecheck(self.settle_timeout, int)
-        typecheck(self.open_transaction, TransactionExecutionStatus)
+        typecheck(self.open_transaction, SuccessfulTransactionState)
         typecheck(self.canonical_identifier.channel_identifier, T_ChannelID)
 
         if self.our_state.address == self.partner_state.address:


### PR DESCRIPTION
The race happens because the default number of confirmations blocks is different on Raiden and the PFS.

This will check the reported confirmed block of the PFS and if the channel has not been seen by the PFS, Raide will wait before sending the PFS request.

This requires: https://github.com/raiden-network/raiden-services/pull/705