### PR TITLE
Create consistent Filtering model on sync()

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -693,7 +693,7 @@ class GMatrixClient(MatrixClient):
         self.token = self.api.token = token
 
     def set_sync_filter_id(self, sync_filter_id: Optional[int]) -> Optional[int]:
-        """ Sets the events limit per room for sync and return previous limit """
+        """ Sets the sync filter to the given id and returns previous filters id """
         prev_id = self._sync_filter_id
         self._sync_filter_id = sync_filter_id
         return prev_id

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -250,9 +250,12 @@ def test_assumption_matrix_returns_same_id_for_same_filter_payload(chain_id, loc
 
     assert client._sync_filter_id is None
 
-    client.create_sync_filter(broadcast_rooms={broadcast_room.name: broadcast_room})
-    current_sync_filter_id = client._sync_filter_id
+    first_sync_filter_id = client.create_sync_filter(
+        broadcast_rooms={broadcast_room.name: broadcast_room}
+    )
 
     # Try again and make sure the filter has the same ID
-    client.create_sync_filter(broadcast_rooms={broadcast_room.name: broadcast_room})
-    assert client._sync_filter_id == current_sync_filter_id
+    second_sync_filter_id = client.create_sync_filter(
+        broadcast_rooms={broadcast_room.name: broadcast_room}
+    )
+    assert first_sync_filter_id == second_sync_filter_id


### PR DESCRIPTION
## Description

There was some inconsistency of how filters are used upon `sync()` request.

- Filtering Broadcast Rooms: Filtering events from broadcast rooms was done by creating a server-side filter and then passing the received `filter_id` upon sync.
- Limiting timeline events upon first sync (to remove long first sync periods) to zero events was done by setting the sync_filter (json) within the client

This introduced a little bug because upon sync. The `sync()` method always got the `filter_id` passed. Therefore the first sync was actually never been filtered.



## What has been done

All filters are handled by server-side filtering. Filters are applied by using the `filter_id` consistently.
The client has a `filter_id_to_filter` dictionary.   Whenever a filter is created the filter gets stored in the dictionary. 

Also `test_transport_does_not_receive_broadcast_rooms_updates` is flaky probably due to inconsistency of filtering. Should be fixed. 

Get rid of `_client.sync_filter` redundancy and use a property annotation to grab the filter out of the dictionary

Fixes: #5663, #5677
