### PR TITLE
Skip flaky test

### DIFF
--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -41,6 +41,7 @@ def reset_messages(app: App) -> None:
     app.raiden.transport.broadcast_messages[PATH_FINDING_BROADCASTING_ROOM] = []
 
 
+@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5680")
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [0])


### PR DESCRIPTION
I thought I fixed the flakyness on `test_pfs_send_capacity_updates_on_deposit_and_withdraw`, but I was wrong.

Tracked in https://github.com/raiden-network/raiden/issues/5680