### PR TITLE
Bump pyinstaller to 3.6 - CVE-2019-16784

### DIFF
--- a/requirements/requirements-ci.in
+++ b/requirements/requirements-ci.in
@@ -1,4 +1,4 @@
 -r requirements-dev.txt
 
-pyinstaller
+pyinstaller>=3.6
 s3cmd

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -5,7 +5,7 @@
 #    './deps compile' (for details see README)
 #
 alabaster==0.7.12
-altgraph==0.16.1          # via macholib, pyinstaller
+altgraph==0.16.1          # via pyinstaller
 aniso8601==7.0.0
 apipkg==1.5
 appdirs==1.4.3
@@ -57,7 +57,6 @@ flask-cors==3.0.8
 flask-restful==0.3.7
 flask==1.0.3
 frozendict==1.2
-future==0.17.1            # via pefile
 gevent==1.3.7
 graphviz==0.13.2
 greenlet==0.4.15
@@ -78,7 +77,6 @@ jinja2==2.10.1
 jsonschema==3.0.1
 lazy-object-proxy==1.4.1
 lru-dict==1.1.6
-macholib==1.11            # via pyinstaller
 markupsafe==1.1.1
 marshmallow-dataclass==6.0.0
 marshmallow-enum==1.5.1
@@ -99,7 +97,6 @@ objgraph==3.4.1
 packaging==19.0
 parsimonious==0.8.1
 pdbpp==0.10.0
-pefile==2019.4.18         # via pyinstaller
 pexpect==4.7.0
 phonenumbers==8.10.13
 pickleshare==0.7.5
@@ -121,7 +118,7 @@ pycryptodome==3.8.2
 pyflakes==2.1.1
 pygments==2.4.2
 pyhamcrest==1.9.0
-pyinstaller==3.4
+pyinstaller==3.6
 pylint==2.3.1
 pymacaroons==0.13.0
 pynacl==1.3.0
@@ -186,4 +183,4 @@ zipp==0.5.1
 zope.interface==4.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==44.0.0        # via ipython, jsonschema, pyhamcrest, pyinstaller, sphinx, zope.interface
+# setuptools==45.0.0        # via ipython, jsonschema, pyhamcrest, pyinstaller, sphinx, zope.interface


### PR DESCRIPTION
## Description

Upgrade is needed to fix a vulnerability:
https://github.com/advisories/GHSA-7fcj-pq9j-wh2r

It's Windows only so it does not affect Raiden, but upgrading should be good nonetheless.

@ulope take a look please

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
