### PR TITLE
Ignoring slow funciton during startup

### DIFF
--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -13,6 +13,7 @@ from raiden.api.rest import APIServer, RestAPI
 from raiden.log_config import configure_logging
 from raiden.raiden_service import RaidenService
 from raiden.tasks import check_gas_reserve, check_network_id, check_rdn_deposits, check_version
+from raiden.utils.debugging import limit_thread_cpu_usage_by_time
 from raiden.utils.echo_node import EchoNode
 from raiden.utils.http import split_endpoint
 from raiden.utils.runnable import Runnable
@@ -160,6 +161,12 @@ class NodeRunner:
         assert isinstance(runnable_tasks[-1], RaidenService), msg
 
         try:
+            # Only enable the cpu limit after initialization has finished,
+            # since there wil be long running tasks during startup, which are
+            # not a problem for normal operation.
+            if self._options["environment_type"] == constants.Environment.DEVELOPMENT:
+                limit_thread_cpu_usage_by_time()
+
             stop_event.get()
             print("Signal received. Shutting down ...")
         finally:

--- a/raiden/utils/debugging.py
+++ b/raiden/utils/debugging.py
@@ -1,4 +1,10 @@
+import signal
 from typing import Any
+
+import gevent
+import gevent.util
+from gevent import GreenletExit
+from gevent.hub import Hub
 
 
 def enable_gevent_monitoring_signal() -> None:
@@ -11,10 +17,34 @@ def enable_gevent_monitoring_signal() -> None:
         # while test is running (or stopped in a pdb session):
         kill -SIGUSR1 $(pidof -x pytest)
     """
-    import gevent.util
-    import signal
 
     def on_signal(signalnum: Any, stack_frame: Any) -> None:  # pylint: disable=unused-argument
         gevent.util.print_run_info()
 
     signal.signal(signal.SIGUSR1, on_signal)
+
+
+def limit_thread_cpu_usage_by_time() -> None:
+    """This will enable Gevent's monitoring thread, and if a Greenlet uses the
+    CPU for longer than `max_blocking_time` it will be killed.
+
+    This will result in the whole process being killed, since exceptions are
+    propagate to the top-level. The goal here is to detect slow functions that
+    have to be optimized.
+    """
+    gevent.config.monitor_thread = True
+    gevent.config.max_blocking_time = 10.0
+
+    # The monitoring thread will use the trace api just like the TraceSampler
+    # and the SwitchMonitoring. Sadly there is no API to uninstall the thread,
+    # but this should not be a problem.
+    monitor_thread = gevent.get_hub().start_periodic_monitoring_thread()
+
+    def kill_offender(hub: Hub) -> None:
+        tracer = monitor_thread._greenlet_tracer
+
+        if tracer.did_block_hub(hub):
+            active_greenlet = tracer.active_greenlet
+            hub.loop.run_callback(lambda: active_greenlet.throw(GreenletExit()))
+
+    monitor_thread.add_monitoring_function(kill_offender, gevent.config.max_blocking_time)


### PR DESCRIPTION
During startup the node will synchronize with the blockchain, while
doing so it will fetch large batches of events that have to be decoded
and converted to internal state changes, which will take considerable
time. To avoid crashing the node during initialization the monitoring is
only enable after the runnables have started.