### PR TITLE
Remove idle timing

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -5,9 +5,7 @@ import os
 import signal
 import sys
 import textwrap
-import time
 import traceback
-from dataclasses import dataclass, field
 from enum import Enum
 from io import StringIO
 from subprocess import TimeoutExpired
@@ -16,7 +14,6 @@ from typing import Any, AnyStr, Callable, ContextManager, Dict, List, Optional, 
 
 import click
 import filelock
-import gevent
 import structlog
 from click import Context
 from requests.exceptions import ConnectionError as RequestsConnectionError, ConnectTimeout
@@ -119,42 +116,6 @@ class ReturnCode(Enum):
     PORT_ALREADY_IN_USE = 5
     ETH_ACCOUNT_ERROR = 6
     CONFIGURATION_ERROR = 7
-
-
-@dataclass
-class Idle:
-    interval: float
-    before: float = field(default_factory=time.time)
-    start: float = field(init=False)
-    measurements: List[float] = field(init=False, default_factory=list)
-
-    def __post_init__(self) -> None:
-        self._reset(time.time())
-
-    def _reset(self, start: float) -> None:
-        self.start = start
-        self.measurements.clear()  # pylint: disable=no-member
-
-    def before_poll(self) -> None:
-        self.before = time.time()
-
-    def after_poll(self) -> None:
-        curr_time = time.time()
-
-        self.measurements.append(curr_time - self.before)  # pylint: disable=no-member
-
-        if curr_time - self.start >= self.interval:
-            idled = sum(self.measurements)
-            log.debug(
-                "Idle",
-                start=self.start,
-                curr_time=curr_time,
-                interval=self.interval,
-                idled=idled,
-                idle_pct=idled / self.interval,
-            )
-
-            self._reset(curr_time)
 
 
 def write_stack_trace(ex: Exception) -> None:
@@ -604,13 +565,6 @@ def run(ctx: Context, **kwargs: Any) -> None:
 
     if switch_tracing is True:
         switch_monitor = SwitchMonitoring()
-
-    if kwargs["environment_type"] == Environment.DEVELOPMENT:
-        loop = gevent.get_hub().loop
-        idle = Idle(10)
-
-        loop.prepare().start(idle.before_poll)
-        loop.check().start(idle.after_poll)
 
     memory_logger = None
     log_memory_usage_interval = kwargs.pop("log_memory_usage_interval", 0)

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -13,6 +13,7 @@ from raiden.api.rest import APIServer, RestAPI
 from raiden.log_config import configure_logging
 from raiden.raiden_service import RaidenService
 from raiden.tasks import check_gas_reserve, check_network_id, check_rdn_deposits, check_version
+from raiden.utils.debugging import limit_thread_cpu_usage_by_time
 from raiden.utils.echo_node import EchoNode
 from raiden.utils.http import split_endpoint
 from raiden.utils.runnable import Runnable
@@ -160,6 +161,12 @@ class NodeRunner:
         assert isinstance(runnable_tasks[-1], RaidenService), msg
 
         try:
+            # Only enable the cpu limit after initialization has finished,
+            # since there wil be long running tasks during startup, which are
+            # not a problem for normal operation.
+            if self._options["environment_type"] == constants.Environment.DEVELOPMENT:
+                limit_thread_cpu_usage_by_time()
+
             stop_event.get()
             print("Signal received. Shutting down ...")
         finally:

--- a/raiden/utils/debugging.py
+++ b/raiden/utils/debugging.py
@@ -1,4 +1,10 @@
+import signal
 from typing import Any
+
+import gevent
+import gevent.util
+from gevent import GreenletExit
+from gevent.hub import Hub
 
 
 def enable_gevent_monitoring_signal() -> None:
@@ -11,10 +17,34 @@ def enable_gevent_monitoring_signal() -> None:
         # while test is running (or stopped in a pdb session):
         kill -SIGUSR1 $(pidof -x pytest)
     """
-    import gevent.util
-    import signal
 
     def on_signal(signalnum: Any, stack_frame: Any) -> None:  # pylint: disable=unused-argument
         gevent.util.print_run_info()
 
     signal.signal(signal.SIGUSR1, on_signal)
+
+
+def limit_thread_cpu_usage_by_time() -> None:
+    """This will enable Gevent's monitoring thread, and if a Greenlet uses the
+    CPU for longer than `max_blocking_time` it will be killed.
+
+    This will result in the whole process being killed, since exceptions are
+    propagate to the top-level. The goal here is to detect slow functions that
+    have to be optimized.
+    """
+    gevent.config.monitor_thread = True
+    gevent.config.max_blocking_time = 10.0
+
+    # The monitoring thread will use the trace api just like the TraceSampler
+    # and the SwitchMonitoring. Sadly there is no API to uninstall the thread,
+    # but this should not be a problem.
+    monitor_thread = gevent.get_hub().start_periodic_monitoring_thread()
+
+    def kill_offender(hub: Hub) -> None:
+        tracer = monitor_thread._greenlet_tracer
+
+        if tracer.did_block_hub(hub):
+            active_greenlet = tracer.active_greenlet
+            hub.loop.run_callback(lambda: active_greenlet.throw(GreenletExit()))
+
+    monitor_thread.add_monitoring_function(kill_offender, gevent.config.max_blocking_time)


### PR DESCRIPTION
    Removed Idle measuring

    The code did not work properly, the check watcher was scheduled after
    the gevent's Hub, which lead the measurement to include the actual
    processing done during the loop iteration. Priotizantion of the check
    handler didn't work with libev, and gevent's libuv wrapper does not
    support check watcher. The last try was to use loop.add_callback which
    is a FIFO execution queue, but I couldn't find an easy way of scheduling
    the callback only once.

    Because there was not reliable way of implementing the measurement this
    commit is removing it.

Review/Merge after: https://github.com/raiden-network/raiden/pull/5692