### PR TITLE
Don't encode addresses as checksums with web3

### DIFF
--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -62,9 +62,9 @@ class Token:
         self, owner: Address, spender: Address, block_identifier: BlockSpecification
     ) -> TokenAmount:
         return TokenAmount(
-            self.proxy.contract.functions.allowance(
-                to_checksum_address(owner), to_checksum_address(spender)
-            ).call(block_identifier=block_identifier)
+            self.proxy.contract.functions.allowance(owner, spender).call(
+                block_identifier=block_identifier
+            )
         )
 
     def approve(self, allowed_address: Address, allowance: TokenAmount) -> None:
@@ -93,7 +93,7 @@ class Token:
                 checking_block = self.client.get_checking_block()
                 error_prefix = "Call to approve will fail"
                 gas_limit = self.proxy.estimate_gas(
-                    checking_block, "approve", to_checksum_address(allowed_address), allowance
+                    checking_block, "approve", allowed_address, allowance
                 )
 
                 if gas_limit:
@@ -101,7 +101,7 @@ class Token:
                     gas_limit = safe_gas_limit(gas_limit)
                     log_details["gas_limit"] = gas_limit
                     transaction_hash = self.proxy.transact(
-                        "approve", gas_limit, to_checksum_address(allowed_address), allowance
+                        "approve", gas_limit, allowed_address, allowance
                     )
 
                     receipt = self.client.poll(transaction_hash)
@@ -173,7 +173,7 @@ class Token:
         self, address: Address, block_identifier: BlockSpecification = "latest"
     ) -> Balance:
         """ Return the balance of `address`. """
-        return self.proxy.contract.functions.balanceOf(to_checksum_address(address)).call(
+        return self.proxy.contract.functions.balanceOf(address).call(
             block_identifier=block_identifier
         )
 
@@ -220,9 +220,7 @@ class Token:
 
             with log_transaction(log, "transfer", log_details):
                 checking_block = self.client.get_checking_block()
-                gas_limit = self.proxy.estimate_gas(
-                    checking_block, "transfer", to_checksum_address(to_address), amount
-                )
+                gas_limit = self.proxy.estimate_gas(checking_block, "transfer", to_address, amount)
                 failed_receipt = None
 
                 if gas_limit is not None:
@@ -230,7 +228,7 @@ class Token:
                     log_details["gas_limit"] = gas_limit
 
                     transaction_hash = self.proxy.transact(
-                        "transfer", gas_limit, to_checksum_address(to_address), amount
+                        "transfer", gas_limit, to_address, amount
                     )
 
                     receipt = self.client.poll(transaction_hash)

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -446,9 +446,7 @@ class TokenNetwork:
         raise_if_invalid_address_pair(detail_for, partner)
 
         data = self.proxy.contract.functions.getChannelParticipantInfo(
-            channel_identifier=channel_identifier,
-            participant=to_checksum_address(detail_for),
-            partner=to_checksum_address(partner),
+            channel_identifier=channel_identifier, participant=detail_for, partner=partner
         ).call(block_identifier=block_identifier)
 
         return ParticipantDetails(
@@ -492,8 +490,8 @@ class TokenNetwork:
 
         channel_data = self.proxy.contract.functions.getChannelInfo(
             channel_identifier=channel_identifier,
-            participant1=to_checksum_address(participant1),
-            participant2=to_checksum_address(participant2),
+            participant1=participant1,
+            participant2=participant2,
         ).call(block_identifier=block_identifier)
 
         return ChannelData(

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -79,9 +79,9 @@ class TokenNetworkRegistry:
         """
         typecheck(token_address, T_TargetAddress)
 
-        address = self.proxy.contract.functions.token_to_token_networks(
-            to_checksum_address(token_address)
-        ).call(block_identifier=block_identifier)
+        address = self.proxy.contract.functions.token_to_token_networks(token_address).call(
+            block_identifier=block_identifier
+        )
         address = to_canonical_address(address)
 
         if address == NULL_ADDRESS_BYTES:

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -188,10 +188,7 @@ class UserDeposit:
     ) -> None:
         checking_block = self.client.get_checking_block()
         gas_limit = self.proxy.estimate_gas(
-            checking_block,
-            "init",
-            to_checksum_address(monitoring_service_address),
-            to_checksum_address(one_to_n_address),
+            checking_block, "init", monitoring_service_address, one_to_n_address
         )
 
         if not gas_limit:
@@ -232,10 +229,7 @@ class UserDeposit:
             log_details["gas_limit"] = gas_limit
 
             transaction_hash = self.proxy.transact(
-                "init",
-                gas_limit,
-                to_checksum_address(monitoring_service_address),
-                to_checksum_address(one_to_n_address),
+                "init", gas_limit, monitoring_service_address, one_to_n_address
             )
 
             receipt = self.client.poll(transaction_hash)
@@ -379,9 +373,7 @@ class UserDeposit:
         token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
 
         checking_block = self.client.get_checking_block()
-        gas_limit = self.proxy.estimate_gas(
-            checking_block, "deposit", to_checksum_address(beneficiary), total_deposit
-        )
+        gas_limit = self.proxy.estimate_gas(checking_block, "deposit", beneficiary, total_deposit)
 
         if not gas_limit:
             failed_at = self.proxy.rpc_client.get_block("latest")
@@ -444,7 +436,7 @@ class UserDeposit:
             log_details["gas_limit"] = gas_limit
 
             transaction_hash = self.proxy.transact(
-                "deposit", gas_limit, to_checksum_address(beneficiary), total_deposit
+                "deposit", gas_limit, beneficiary, total_deposit
             )
 
             receipt = self.client.poll(transaction_hash)


### PR DESCRIPTION
This isn't necessary since https://github.com/ethereum/web3.py/pull/893