### PR TITLE
Replaced deepcopy with faster implementation

### DIFF
--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -6,7 +6,6 @@ with sanitized input, to avoid the risk of exploits.
 """
 import importlib
 import json
-from copy import deepcopy
 from dataclasses import is_dataclass
 from json import JSONDecodeError
 from typing import Mapping
@@ -15,6 +14,7 @@ from marshmallow import ValidationError
 
 from raiden.exceptions import SerializationError
 from raiden.storage.serialization.types import MESSAGE_NAME_TO_QUALIFIED_NAME, SchemaCache
+from raiden.utils.copy import deepcopy
 from raiden.utils.typing import Any, Dict
 
 

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -1,5 +1,4 @@
 from collections import Counter, defaultdict
-from copy import deepcopy
 from dataclasses import dataclass, field
 from hashlib import sha256
 from random import Random
@@ -53,6 +52,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelSettled,
 )
 from raiden.utils import typing
+from raiden.utils.copy import deepcopy
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.transfers import random_secret
 

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from unittest.mock import Mock
 
 import pytest
@@ -30,6 +29,7 @@ from raiden.tests.utils.transfer import transfer
 from raiden.transfer import views
 from raiden.transfer.state import NettingChannelState
 from raiden.transfer.state_change import Block
+from raiden.utils.copy import deepcopy
 from raiden.utils.typing import (
     BlockNumber,
     FeeAmount,

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1,7 +1,6 @@
 # pylint: disable=too-many-locals,too-many-statements,too-many-lines
 import random
 from collections import namedtuple
-from copy import deepcopy
 from hashlib import sha256
 from itertools import cycle
 
@@ -82,6 +81,7 @@ from raiden.transfer.state_change import (
     ReceiveWithdrawExpired,
     ReceiveWithdrawRequest,
 )
+from raiden.utils.copy import deepcopy
 from raiden.utils.packing import pack_withdraw
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.signer import LocalSigner

--- a/raiden/tests/unit/test_tokennetwork.py
+++ b/raiden/tests/unit/test_tokennetwork.py
@@ -1,4 +1,3 @@
-import copy
 import random
 from hashlib import sha256
 
@@ -29,6 +28,7 @@ from raiden.transfer.state_change import (
     ContractReceiveRouteClosed,
     ContractReceiveRouteNew,
 )
+from raiden.utils.copy import deepcopy
 from raiden.utils.signing import sha3
 
 
@@ -61,7 +61,7 @@ def test_contract_receive_channelnew_must_be_idempotent(channel_properties):
 
     properties, _ = channel_properties
     channel_state1 = factories.create(properties)
-    channel_state2 = copy.deepcopy(channel_state1)
+    channel_state2 = deepcopy(channel_state1)
 
     state_change1 = ContractReceiveChannelNew(
         transaction_hash=factories.make_transaction_hash(),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name,too-few-public-methods,too-many-arguments,too-many-locals
 import random
 import uuid
-from copy import deepcopy
 from typing import NamedTuple
 from unittest.mock import patch
 
@@ -71,6 +70,7 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
 )
 from raiden.utils import typing
+from raiden.utils.copy import deepcopy
 from raiden.utils.signing import sha3
 from raiden.utils.transfers import random_secret
 from raiden.utils.typing import (

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1,6 +1,5 @@
 # pylint: disable=invalid-name,too-many-locals,too-many-arguments,too-many-lines
 import random
-from copy import deepcopy
 from dataclasses import replace
 from typing import List, Optional, Tuple
 
@@ -93,6 +92,7 @@ from raiden.transfer.state_change import (
     ContractReceiveSecretReveal,
     ReceiveUnlock,
 )
+from raiden.utils.copy import deepcopy
 from raiden.utils.transfers import random_secret
 from raiden.utils.typing import BlockExpiration, BlockNumber, FeeAmount, TokenAmount
 

--- a/raiden/tests/unit/transfer/test_channel.py
+++ b/raiden/tests/unit/transfer/test_channel.py
@@ -1,5 +1,4 @@
 import random
-from copy import deepcopy
 from dataclasses import replace
 from hashlib import sha256
 
@@ -42,6 +41,7 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelSettled,
 )
+from raiden.utils.copy import deepcopy
 from raiden.utils.mediation_fees import prepare_mediation_fee_config
 from raiden.utils.signing import sha3
 from raiden.utils.typing import BlockExpiration, TokenAmount

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -1,5 +1,3 @@
-import copy
-
 import pytest
 
 import raiden.transfer.node
@@ -69,6 +67,7 @@ from raiden.transfer.state_change import (
     ReceiveProcessed,
 )
 from raiden.transfer.views import get_networks
+from raiden.utils.copy import deepcopy
 
 
 def test_is_transaction_effect_satisfied(
@@ -332,7 +331,7 @@ def test_subdispatch_by_canonical_id(chain_state):
         canonical_identifier.token_network_address
     ] = token_network_registry.address
     # dispatching a Block will be ignored
-    previous_state = copy.deepcopy(chain_state)
+    previous_state = deepcopy(chain_state)
     state_change = Block(
         block_number=chain_state.block_number,
         gas_limit=GAS_LIMIT,

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 import pytest
 
 from raiden.tests.utils import factories
@@ -24,6 +22,7 @@ from raiden.transfer.views import (
     get_transfer_secret,
     role_from_transfer_task,
 )
+from raiden.utils.copy import deepcopy
 
 
 def test_filter_channels_by_partneraddress_empty(chain_state):

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -1,5 +1,4 @@
 # pylint: disable=too-few-public-methods
-import pickle
 import time
 from dataclasses import dataclass, field
 
@@ -9,6 +8,7 @@ from eth_utils import to_hex
 from raiden.constants import EMPTY_BALANCE_HASH, UINT64_MAX, UINT256_MAX
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.utils import hash_balance_data
+from raiden.utils.copy import deepcopy
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     AdditionalHash,
@@ -260,7 +260,7 @@ class StateManager(Generic[ST]):
         # The state objects must be treated as immutable, so make a copy of the
         # current state and pass the copy to the state machine to be modified.
         before_copy = time.time()
-        next_state = pickle.loads(pickle.dumps(self.current_state, pickle.HIGHEST_PROTOCOL))
+        next_state = deepcopy(self.current_state)
         log.debug("Copied state before applying state changes", duration=time.time() - before_copy)
 
         # Update the current state by applying the state changes

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -1,5 +1,3 @@
-import copy
-
 from raiden.transfer import channel, token_network, views
 from raiden.transfer.architecture import (
     ContractReceiveStateChange,
@@ -68,6 +66,7 @@ from raiden.transfer.state_change import (
     ReceiveWithdrawExpired,
     ReceiveWithdrawRequest,
 )
+from raiden.utils.copy import deepcopy
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
     BlockHash,
@@ -678,7 +677,7 @@ def handle_action_transfer_reroute(
         state_change.transfer.lock.secrethash
     ]
     chain_state.payment_mapping.secrethashes_to_task.update(
-        {new_secrethash: copy.deepcopy(current_payment_task)}
+        {new_secrethash: deepcopy(current_payment_task)}
     )
 
     return subdispatch_to_paymenttask(chain_state, state_change, new_secrethash)

--- a/raiden/utils/copy.py
+++ b/raiden/utils/copy.py
@@ -1,0 +1,13 @@
+import pickle
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def deepcopy(data: T) -> T:
+    """ Profiling `deepcopy.deepcopy` show that this function is very slow for
+    largish objects (around 1MB of data). Since most of our objects don't use
+    nested classes, this can be circumvented by using pickle to serialize and
+    deserialize a new copy of the objects.
+    """
+    return pickle.loads(pickle.dumps(data, pickle.HIGHEST_PROTOCOL))

--- a/raiden/utils/echo_node.py
+++ b/raiden/utils/echo_node.py
@@ -1,4 +1,3 @@
-import copy
 import random
 from collections import deque
 from typing import Any, Deque, Dict, List, Set
@@ -16,6 +15,7 @@ from raiden.tasks import REMOVE_CALLBACK
 from raiden.transfer import channel, views
 from raiden.transfer.events import EventPaymentReceivedSuccess
 from raiden.transfer.state import ChannelState
+from raiden.utils.copy import deepcopy
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     Optional,
@@ -133,7 +133,7 @@ class EchoNode:  # pragma: no unittest
                     ]
 
                     for event in received_transfers:
-                        transfer = copy.deepcopy(event)
+                        transfer = deepcopy(event)
                         self.received_transfers.put(transfer)
 
                     # set last_poll_block after events are enqueued (timeout safe)


### PR DESCRIPTION
After profiling @karlb found out that deepcopy is measurably slow, the fix is to use a different approach to deepcopy the data, which can be done using a serialize/deserialize cycle. This is not optimal, but it is significantly better than deepcopy, this just changes the other places that still used the stdlib implementation.