### PR TITLE
Fix assertions during response_queue cleaning

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -684,10 +684,11 @@ class MatrixTransport(Runnable):
         # Process the result from the sync executed above
         response_queue = self._client.response_queue
 
-        queue_copy = response_queue.queue.queue.copy()
-        response_queue.queue.queue.clear()
+        pending_queue = []
+        while len(response_queue) > 0:
+            _, response, _ = response_queue.get()
+            pending_queue.append(response)
 
-        pending_queue = [response for _, response, _ in queue_copy]
         assert all(
             pending_queue
         ), "The queue must only have Matrix responses. None and empty are invalid values."


### PR DESCRIPTION
## Description
Removes the following warnings for me:

```
AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b780 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b690 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b780 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b0f0 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b780 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b140 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b780 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b690 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b780 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b0f0 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b780 stopped> failed with AssertionError

AssertionError
2020-01-20T15:42:30Z <callback at 0x10c68b140 stopped> failed with AssertionError
```
