### PR TITLE
Cache parsed messages and their `sender`

### DIFF
--- a/raiden/messages/abstract.py
+++ b/raiden/messages/abstract.py
@@ -3,7 +3,35 @@ from dataclasses import dataclass
 from raiden.exceptions import InvalidSignature
 from raiden.messages.cmdid import CmdId
 from raiden.utils.signer import Signer, recover
-from raiden.utils.typing import Address, Any, ClassVar, MessageID, Optional, Signature
+from raiden.utils.typing import Address, Any, Callable, ClassVar, MessageID, Optional, Signature
+
+
+class cached_property:
+    """ Same as functools.cached_property in python 3.8
+
+    See https://docs.python.org/3/library/functools.html#functools.cached_property.
+    Remove after upgrading to python3.8
+    """
+
+    def __init__(self, func: Callable) -> None:
+        self.func = func
+        self.__doc__ = func.__doc__
+
+    def __get__(self, instance: Any, cls: Any = None) -> Any:
+        if instance is None:
+            return self
+        attrname = self.func.__name__
+        try:
+            cache = instance.__dict__
+        except AttributeError:  # objects with __slots__ have no __dict__
+            msg = (
+                f"No '__dict__' attribute on {type(instance).__name__!r} "
+                f"instance to cache {attrname!r} property."
+            )
+            raise TypeError(msg) from None
+        if attrname not in cache:
+            cache[attrname] = self.func(instance)
+        return cache[attrname]
 
 
 @dataclass(repr=False, eq=False)
@@ -51,8 +79,8 @@ class SignedMessage(AuthenticatedMessage):
         message_data = self._data_to_sign()
         self.signature = signer.sign(data=message_data)
 
-    @property
-    def sender(self) -> Optional[Address]:
+    @cached_property
+    def sender(self) -> Optional[Address]:  # type: ignore
         if not self.signature:
             return None
         data_that_was_signed = self._data_to_sign()

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from functools import lru_cache
 from operator import attrgetter, itemgetter
 from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set
 from urllib.parse import urlparse
@@ -46,6 +47,7 @@ from raiden.utils.typing import Address, ChainID, Signature
 from raiden_contracts.constants import ID_TO_NETWORKNAME
 
 log = structlog.get_logger(__name__)
+cached_deserialize = lru_cache()(MessageSerializer.deserialize)
 
 JOIN_RETRIES = 10
 USERID_RE = re.compile(r"^@(0x[0-9a-f]{40})(?:\.[0-9a-f]{8})?(?::.+)?$")
@@ -804,7 +806,7 @@ def validate_and_parse_message(data: Any, peer_address: Address) -> List[Message
         if not line:
             continue
         try:
-            message = MessageSerializer.deserialize(line)
+            message = cached_deserialize(line)
         except SerializationError as ex:
             log.warning(
                 "Not a valid Message",


### PR DESCRIPTION
This reduces the time we spend on checking message signatures.