### PR TITLE
Fix access to confirmed_block_number in PFS resp.

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -161,7 +161,7 @@ def get_pfs_info(url: str) -> PFSInfo:
             message=infos["message"],
             operator=infos["operator"],
             version=infos["version"],
-            confirmed_block_number=infos["network_info"]["confirmed_block"],
+            confirmed_block_number=infos["network_info"]["confirmed_block"]["number"],
         )
     except requests.exceptions.RequestException as e:
         msg = "Selected Pathfinding Service did not respond"

--- a/raiden/tests/integration/network/test_pathfinding.py
+++ b/raiden/tests/integration/network/test_pathfinding.py
@@ -39,7 +39,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
                 token_network_registry_address_test_default
             ),
             "user_deposit_address": to_checksum_address(privatekey_to_address(private_keys[1])),
-            "confirmed_block": 10,
+            "confirmed_block": {"number": 10},
         },
         "message": "This is your favorite pathfinding service",
         "operator": "John Doe",

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -142,7 +142,7 @@ def get_best_routes_with_iou_request_mocked(
                             factories.make_token_network_registry_address()
                         ),
                         "user_deposit_address": to_checksum_address(factories.make_address()),
-                        "confirmed_block": 11,
+                        "confirmed_block": {"number": 11},
                     },
                     "version": "0.0.3",
                     "operator": "John Doe",
@@ -893,7 +893,7 @@ def test_no_iou_when_pfs_price_0(query_paths_args):
             token_network_registry_address=factories.make_token_network_registry_address(),
             user_deposit_address=factories.make_address(),
             payment_address=factories.make_address(),
-            confirmed_block_number=BlockNumber(1),
+            confirmed_block_number=dict(number=BlockNumber(1)),
             message="",
             operator="",
             version="",

--- a/raiden/tests/unit/test_pfs_integration_refactored.py
+++ b/raiden/tests/unit/test_pfs_integration_refactored.py
@@ -26,7 +26,7 @@ def test_get_pfs_info_success():
             "chain_id": 42,
             "token_network_registry_address": pfs_test_default_registry_address,
             "user_deposit_address": pfs_test_default_user_deposit_address,
-            "confirmed_block": 11,
+            "confirmed_block": {"number": 11},
         },
         "version": "0.0.3",
         "operator": "John Doe",


### PR DESCRIPTION
We assumed a different response from the PFS in
https://github.com/raiden-network/raiden/pull/5671 than is actually
returned.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.

## PR review check list

Quality check list that cannot be automatically verified.

- Safety
    - [ ] The changes respect the necessary conditions for safety (https://raiden-network-specification.readthedocs.io/en/latest/smart_contracts.html#protocol-values-constraints)
-  Code quality
    - [ ] Error conditions are handled
    - [ ] Exceptions are propagated to the correct parent greenlet
    - [ ] Exceptions are correctly classified as recoverable or unrecoverable
- Compatibility
    - [ ] State changes are forward compatible
    - [ ] Transport messages are backwards and forward compatible
- Commits
    - [ ] Have good messages
    - [ ] Squashed unecessary commits
- If it's a bug fix:
    - Regression test for the bug
        - [ ] Properly covers the bug
        - [ ] If an integration test is used, it could not be written as a unit test
- Documentation
    - [ ] A new CLI flag was introduced, is there documentation that explains usage?
- Specs
    - [ ] If this is a protocol change, are the specs updated accordingly? If so, please link PR from the specs repo.
- Is it a user facing feature/bug fix?
    - [ ] Changelog entry has been added
