### PR TITLE
Sync Helper to control the sync and response processing in tests

### DIFF
--- a/raiden/network/transport/matrix/sync_progress.py
+++ b/raiden/network/transport/matrix/sync_progress.py
@@ -1,0 +1,94 @@
+from datetime import datetime
+from uuid import UUID
+
+from gevent.event import Event
+
+from raiden.utils.notifying_queue import NotifyingQueue
+from raiden.utils.typing import Any, Dict, List, Optional, Tuple
+
+JSONResponse = Dict[str, Any]
+
+
+class SyncEvent(Event):
+    """
+    Sync Event is a slightly modified version of gevent's Event.
+    It is used to indicate a sync loop for the long polling sync to matrix servers.
+    When setting the event a list of response_tokens are passed as arguments.
+    When waiting for the event the token gets passed to the recipient.
+    This is supposed to help the recipient to be able to wait for a specific sync to be processed.
+    """
+
+    def __init__(self) -> None:
+        super(Event, self).__init__()
+        self.tokens: List[UUID] = list()
+
+    def set(self, tokens: List[UUID]) -> None:
+        self.tokens = tokens
+        super().set()
+
+    def wait(self, timeout: Optional[float] = None) -> Optional[List[UUID]]:
+        super().wait()
+        return self.tokens
+
+
+class SyncProgress:
+    """
+    SyncProgress tracks the current progress of matrix's long polling sync.
+    Its main purpose is to help controlled synchronization / providing information
+    when writing integration tests
+    A SyncProgress instance provides an interface to easily wait for a sync to be processed.
+    Currently a response of a sync response can be still in the response_queue
+    and is not be processed. This can lead to flaky tests on CI.
+    Every response has a unique response token.
+    Every token will run through the synced_event and processed_event
+    cycle (set->wait) exactly once.
+
+    Args:
+        response_queue: queue for responses passed to the response_handler
+        by the sync_request worker
+    """
+
+    def __init__(
+        self, response_queue: NotifyingQueue[Tuple[UUID, JSONResponse, datetime]]
+    ) -> None:
+        self.synced_event = SyncEvent()
+        self.processed_event = SyncEvent()
+        self.sync_iteration = 0
+        self.processed_iteration = 0
+        self.last_synced: Optional[UUID] = None
+        self.last_processed: Optional[UUID] = None
+        self.response_queue = response_queue
+
+    def set_synced(self, token: UUID) -> None:
+        self.sync_iteration += 1
+        self.last_synced = token
+        self.synced_event.set([token])
+        self.synced_event.clear()
+
+    def set_processed(self, tokens: List[UUID]) -> None:
+        self.processed_iteration += len(tokens)
+        self.last_processed = tokens[-1]
+        self.processed_event.set(tokens)
+        self.processed_event.clear()
+
+    def is_processed(self, response_token: UUID) -> bool:
+        response_list = list(self.response_queue.queue.queue)
+        for response_data in response_list:
+            token = response_data[0]
+            if token == response_token:
+                return False
+        return True
+
+    def wait_for_processed(self, token: UUID, offset: int = 0) -> Optional[UUID]:
+        counter = 0
+
+        while not self.is_processed(token):
+            processed_token = self.processed_event.wait()
+            if token == processed_token:
+                break
+
+        while counter < offset:
+            self.processed_event.wait()
+            counter += 1
+
+        return self.last_processed

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -13,14 +13,13 @@ from raiden.api.rest import APIServer, RestAPI
 from raiden.log_config import configure_logging
 from raiden.raiden_service import RaidenService
 from raiden.tasks import check_gas_reserve, check_network_id, check_rdn_deposits, check_version
+from raiden.ui.app import run_app
+from raiden.ui.config import dump_cmd_options, dump_module
+from raiden.utils.gevent import spawn_named
 from raiden.utils.http import split_endpoint
 from raiden.utils.runnable import Runnable
 from raiden.utils.system import get_system_spec
 from raiden.utils.typing import Port
-
-from ..utils.gevent import spawn_named
-from .app import run_app
-from .config import dump_cmd_options, dump_module
 
 log = structlog.get_logger(__name__)
 DOC_URL = "http://raiden-network.readthedocs.io/en/stable/rest_api.html"


### PR DESCRIPTION
## Description

This is a proposal to introduce a new Helper Class to make writing tests easier and prevent flakiness. This is achieved by the helper class storing information about the current sync process and if responses are already processed or not.

## Motivation

I experienced that some integration tests are flaky due to the fact of asynchronicity between the nodes, matrix servers as well as the chain and the difficulty to handle a proper synchronization. When a test, i.e. relies on a message to arrive at another node, one has to wait for the syncing and processing of the response to be done properly. Since we have some upper bounds for syncs (block time, matrix sync timeout) we use the time as an indicator that a message should have arrived. Especially when you do not know the system on where the test runs (aka CircleCI) raw timing is can lead to flakiness if servers are overloaded (or whatever the reason is). Another example could be that the message already arrived but is not processed yet by the Raiden node.

For Testing purposes, we already have the variable `synced` and `sync_iteration` and a unique token for each response in [`raiden.network.transport.matrix.client`](https://github.com/raiden-network/raiden/blob/develop/raiden/network/transport/matrix/client.py). The recent introduction of a response queue to decouple the sync request and the processing of response the meaning of these helper variables got somewhat blurry. To take this a step further `SyncProgress` is introduced, keeping track of sync and their state of being processed or not. This can help to make it simpler writing tests and prevent possible flakiness in the future.

## Sync Events
SyncEvents are gevent's Events with simple addition. When setting the event a list of tokens has to be passed. Everybody who is waiting for that event to be set receives this list as the return value of the `wait()` method. 

## SyncProgress
SyncProgress is supposed to be the interface for the test writer to access information about the current state of sync for specific response tokens. The SyncProgress class should make it easily possible to wait for a response to be processed independently of the time it consumes. 

### Example

To show how this looks like here is a snippet from a test which is checking matrix's filtering. `Transport0` is sending a message to `transport1` and `transport2` via a broadcast room. In order to check if the message was received or not we need to wait for the sync to be processed. If for whatever reason the process takes to long or there was a sync inbetween it can cause flakiness in the tests. 

```
transport2._client._sync_filter_id = None

# Send another message to the broadcast room, if transport1 listens on the room it will
# throw an exception
message = Processed(message_identifier=1, signature=EMPTY_SIGNATURE)
message_text = MessageSerializer.serialize(message)
pfs_broadcast_room_t0.send_text(message_text)

with Timeout(matrix_sync_timeout + 2):
    sync_iteration = transport2._client.sync_iteration
    while sync_iteration == transport2._client.sync_iteration:
        gevent.joinall({transport2.greenlet}, timeout=0.1, raise_error=True)

    sync_iteration = transport1._client.sync_iteration
    while sync_iteration == transport1._client.sync_iteration:
        gevent.joinall({transport1.greenlet}, timeout=0.1, raise_error=True)
```

With `SyncProgress` the code snippet of interest would look like this:

```
# get the last sync tokens to control the processed state later
last_synced_token1 = sync_progress1.last_synced
last_synced_token2 = sync_progress2.synced_event.wait()[0]

# Send another message to the broadcast room if transport1 listens on the room it will
# throw an exception
message = Processed(message_identifier=1, signature=EMPTY_SIGNATURE)
message_text = MessageSerializer.serialize(message)
pfs_broadcast_room_t0.send_text(message_text)

# wait for the current tokens to be processed + 1 additional sync
# this must be done because the message should be in the sync after the stored token
sync_progress1.wait_for_processed(last_synced_token1, 1)
sync_progress2.wait_for_processed(last_synced_token2, 1)
```

Since `SyncProgress` has information about the unique response tokens it is able to wait for the `response_event` to happen.

Note, that this is a work in progress and open for discussion. My intention is to create a little helper tool to make sure flakiness (at least caused by asynchronicity) does not happen anymore. Therefore it should be easy to control the message flow in writing tests. Ideas are welcome.
### Visual Illustrations
![Untitled Diagram (1)](https://user-images.githubusercontent.com/10088275/72975560-531ba000-3dd1-11ea-9d2b-c2795ed0ee20.jpg)
![SyncProgressScheme](https://user-images.githubusercontent.com/10088275/72975800-b7d6fa80-3dd1-11ea-9f37-21c47b825eb9.jpg)

