### PR TITLE
Revert scenario timeouts

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -232,7 +232,7 @@ scenario:
                 event_args: {closing_participant: 0}
             - assert: {from: 0, to: 4, state: "closed"}
             # Make sure that channel between 0 and 4 is also settled
-            - wait_blocks: 500
+            - wait_blocks: 40
       - serial:
           name: "Close channel between 3 and 4 while 4 is offline"
           tasks:
@@ -248,7 +248,7 @@ scenario:
                 event_args: {closing_participant: 3}
 
             ## The MS reacts within the settle_timeout
-            - wait_blocks: 500
+            - wait_blocks: 40
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -37,7 +37,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
   node_options:
     0:

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -27,7 +27,7 @@ nodes:
   default_options:
     gas-price: fast
     environment-type: development
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
     proportional-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -37,7 +37,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the bf4 scenario. It sets up a topology of [ [0, 1, 2], [0, 1, 3], [0, 4, 5] ]

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -38,7 +38,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
   node_options:

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -61,7 +61,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 500
+      - wait_blocks: 40
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -35,7 +35,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the MS1 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -61,7 +61,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 500
+      - wait_blocks: 40
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -35,7 +35,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the MS2 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -35,7 +35,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the MS3 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -77,6 +77,6 @@ scenario:
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
       ## Settlement timeout is 500 blocks, but we already waited 40 blocks.
-      - wait_blocks: 500
+      - wait_blocks: 20
       # will fail for now since channel was closed by node1. We should add functionality to assert a fail
       - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -35,7 +35,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    #default-settle-timeout: 40
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 ## This scenario tests that the MS does not kick in, if the node requesting monitoring does

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -84,7 +84,7 @@ scenario:
           name: "Wait for MS to not react"
           tasks:
             # The MS reacts within the settle_timeout
-            - wait_blocks: 500
+            - wait_blocks: 40
             # Note that 0 events are expected
             - assert_events:
                 contract_name: "TokenNetwork"


### PR DESCRIPTION
The timeouts have only been temporarily changed to accommodate stricter values in a specific contracts deployment. With the latest deployment, this is not needed, anymore.

Also fixed https://github.com/raiden-network/raiden/issues/5741, which only a result of the temporary changes. 