### PR TITLE
Idle: Added special case for blocking functions

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -422,7 +422,7 @@ class TokenNetworkRegistry:
 
             if deprecation_executor == NULL_ADDRESS_BYTES:
                 raise RaidenUnrecoverableError(
-                    "The deprecation executor property for the " "TokenNetworkRegistry is invalid."
+                    "The deprecation executor property for the TokenNetworkRegistry is invalid."
                 )
 
             if chain_id == 0:


### PR DESCRIPTION
Instead of letting the measurement list go empty, this handle the case were the last measurement was larger than the `measurement_interval`, and added a special log line for it.