### PR TITLE
Make `RetriableMessage` inherit from `Message`

### DIFF
--- a/raiden/messages/abstract.py
+++ b/raiden/messages/abstract.py
@@ -96,7 +96,7 @@ class SignedMessage(AuthenticatedMessage):
 
 
 @dataclass(repr=False, eq=False)
-class RetrieableMessage:
+class RetrieableMessage(Message):
     """ Message, that supports a retry-queue. """
 
     message_identifier: MessageID

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -370,9 +370,9 @@ class MatrixTransport(Runnable):
 
         self._health_lock = Semaphore()
 
-        self._counter_send: CounterType[MessageID] = Counter()
-        self._counter_retry: CounterType[MessageID] = Counter()
-        self._counter_dispatch: CounterType[MessageID] = Counter()
+        self._counter_send: CounterType[Tuple[str, MessageID]] = Counter()
+        self._counter_retry: CounterType[Tuple[str, MessageID]] = Counter()
+        self._counter_dispatch: CounterType[Tuple[str, MessageID]] = Counter()
 
         # Forbids concurrent room creation.
         self.room_creation_lock: Dict[Address, RLock] = defaultdict(RLock)


### PR DESCRIPTION
## Description

`RetriableMessage` is used as a mixin in `SignedRetrieableMessage`.
Since it didn't inherit from `Message` before checks of the form `if isinstance(message, RetrieableMessage):` (where `message` was annotated as `Message`) caused mypy to never evaluate the branch since the condition could never (from mypy's perspective) be true.

Since Python uses C3-linearization for multiple inheritance the resulting diamond MRO will not cause any issues.