### PR TITLE
Added token to identify the transaction.

### DIFF
--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional
 
 import structlog
-from eth_utils import to_canonical_address, to_checksum_address
+from eth_utils import to_canonical_address, to_checksum_address, to_hex
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.constants import NULL_ADDRESS_BYTES
@@ -199,7 +199,7 @@ class TokenNetworkRegistry:
             "node": to_checksum_address(self.node_address),
             "contract": to_checksum_address(self.address),
             "token_address": to_checksum_address(token_address),
-            "given_block_identifier": given_block_identifier,
+            "given_block_identifier": to_hex(given_block_identifier),
             "channel_participant_deposit_limit": channel_participant_deposit_limit,
             "token_network_deposit_limit": token_network_deposit_limit,
         }

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from eth_utils import decode_hex, to_hex
 from structlog import BoundLoggerBase
@@ -118,7 +119,8 @@ def get_onchain_locksroots(
 
 @contextmanager
 def log_transaction(log: BoundLoggerBase, description: str, details: Dict[Any, Any]) -> Generator:
-    bound_log = log.bind(description=description, **details)
+    token = uuid4()
+    bound_log = log.bind(description=description, token=token, **details)
     try:
         bound_log.debug("Entered")
         yield


### PR DESCRIPTION
This is useful when the same transaction is sent twice, which is the
case for some of our tests.