### PR TITLE
Skip unnecessary track_address_presence calls

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -8,7 +8,19 @@ from datetime import datetime
 from enum import Enum
 from functools import lru_cache
 from operator import attrgetter, itemgetter
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -273,15 +285,24 @@ class UserAddressManager:
                 ),
             )
 
-    def track_address_presence(self, address: Address, user_ids: Set[str]) -> None:
+    def track_address_presence(
+        self, address: Address, user_ids: Union[Set[str], FrozenSet[str]] = frozenset()
+    ) -> None:
         """
         Update synthesized address presence state.
 
         Triggers callback (if any) in case the state has changed.
-
-        This method is only provided to cover an edge case in our use of the Matrix protocol and
-        should **not** generally be used.
         """
+        # Is this address already tracked for all given user_ids?
+        state_known = (
+            self.get_address_reachability_state(address).reachability
+            != AddressReachability.UNKNOWN
+        )
+        no_new_user_ids = user_ids.issubset(self._address_to_userids[address])
+        if state_known and no_new_user_ids:
+            return
+
+        # Update presence
         self.add_userids_for_address(address, user_ids)
         userids_to_presence = {}
         for uid in user_ids:

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -233,7 +233,7 @@ def test_user_addr_mgr_force(user_addr_mgr, address_reachability, user_presence)
     assert len(address_reachability) == 0
 
     # Update address presence from previously forced user state
-    user_addr_mgr.track_address_presence(ADDR1, [USER1_S1_ID])
+    user_addr_mgr.track_address_presence(ADDR1, {USER1_S1_ID})
 
     assert user_addr_mgr.get_address_reachability(ADDR1) is AddressReachability.REACHABLE
     assert len(user_presence) == 0
@@ -252,7 +252,7 @@ def test_user_addr_mgr_fetch_presence(
     assert dummy_matrix_client._user_presence[USER1_S1_ID] == UserPresence.ONLINE.value
     assert dummy_matrix_client.get_user_presence(USER1_S1_ID) == UserPresence.ONLINE.value
 
-    user_addr_mgr.track_address_presence(ADDR1, [USER1_S1_ID])
+    user_addr_mgr.track_address_presence(ADDR1, {USER1_S1_ID})
 
     assert user_addr_mgr._userid_to_presence[USER1_S1_ID] == UserPresence.ONLINE
 
@@ -267,7 +267,7 @@ def test_user_addr_mgr_fetch_presence_error(user_addr_mgr, address_reachability,
     # We have not provided or forced any explicit user presence,
     # therefore the client will be queried and return a 404 since we haven't setup a presence
     with pytest.raises(MatrixRequestError):
-        user_addr_mgr.track_address_presence(ADDR1, [USER1_S1_ID])
+        user_addr_mgr.track_address_presence(ADDR1, {USER1_S1_ID})
 
     assert user_addr_mgr.get_address_reachability(ADDR1) is AddressReachability.UNKNOWN
     assert len(user_presence) == 0


### PR DESCRIPTION
In my thought model, we can skip the call when we already know
the reachability. Please double check that this is actually true!

Alternatively, we could call `start_health_check` less often. I'm not
sure it's needed in `start_mediated_transfer_with_secret` and
`handle_message_lockedtransfer`.

Or we could do a similar check in `start_health_check` to avoid even more work.

This change makes transfers in the stress test twice as fast for me.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
