### PR TITLE
skip set display name if not necessary

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -576,7 +576,11 @@ def first_login(client: GMatrixClient, signer: Signer, username: str) -> User:
     signature_hex = encode_hex(signature_bytes)
 
     user = client.get_user(client.user_id)
-    user.set_display_name(signature_hex)
+    current_display_name = user.get_display_name()
+
+    # Only set the display name if necessary, since this is a slow operation.
+    if current_display_name != signature_hex:
+        user.set_display_name(signature_hex)
 
     log.debug(
         "Logged in",


### PR DESCRIPTION
Setting the display name is a bit slow (as measured with mitmproxy
![20200128_17h44m52s_grim](https://user-images.githubusercontent.com/310139/73285176-f0be0780-41f5-11ea-8a48-5a74c1116f1b.png)