### PR TITLE
Dont download server list if an URL is provided

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -158,6 +158,7 @@ DEFAULT_HTTP_REQUEST_TIMEOUT = 10.0  # seconds
 DISCOVERY_DEFAULT_ROOM = "discovery"
 MONITORING_BROADCASTING_ROOM = "monitoring"
 PATH_FINDING_BROADCASTING_ROOM = "path_finding"
+MATRIX_AUTO_SELECT_SERVER = "auto"
 
 # According to the smart contracts as of 07/08:
 # https://github.com/raiden-network/raiden-contracts/blob/fff8646ebcf2c812f40891c2825e12ed03cc7628/raiden_contracts/contracts/TokenNetwork.sol#L213

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -12,7 +12,12 @@ import structlog
 from eth_utils import decode_hex, encode_hex, to_canonical_address, to_hex
 from web3 import Web3
 
-from raiden.constants import DEFAULT_HTTP_REQUEST_TIMEOUT, ZERO_TOKENS, RoutingMode
+from raiden.constants import (
+    DEFAULT_HTTP_REQUEST_TIMEOUT,
+    MATRIX_AUTO_SELECT_SERVER,
+    ZERO_TOKENS,
+    RoutingMode,
+)
 from raiden.exceptions import RaidenError, ServiceRequestFailed, ServiceRequestIOURejected
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.utils import get_response_json
@@ -259,7 +264,7 @@ def configure_pfs_or_exit(
 
     msg = "With PFS routing mode we shouldn't get to configure_pfs with pfs_address being None"
     assert pfs_url, msg
-    if pfs_url == "auto":
+    if pfs_url == MATRIX_AUTO_SELECT_SERVER:
         if service_registry is None:
             raise RaidenError(
                 "Raiden was started with routing mode set to PFS, the pathfinding service address "

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -14,7 +14,7 @@ from gevent.pool import Pool
 from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixHttpLibError, MatrixRequestError
 
-from raiden.constants import EMPTY_SIGNATURE, Environment
+from raiden.constants import EMPTY_SIGNATURE, MATRIX_AUTO_SELECT_SERVER, Environment
 from raiden.exceptions import RaidenUnrecoverableError, TransportError
 from raiden.messages.abstract import Message, RetrieableMessage, SignedRetrieableMessage
 from raiden.messages.healthcheck import Ping, Pong
@@ -317,12 +317,15 @@ class MatrixTransport(Runnable):
         self._environment = environment
         self._raiden_service: Optional["RaidenService"] = None
 
-        if config.server == "auto":
+        if config.server == MATRIX_AUTO_SELECT_SERVER:
             available_servers = config.available_servers
         elif urlparse(config.server).scheme in {"http", "https"}:
             available_servers = [config.server]
         else:
-            raise TransportError('Invalid matrix server specified (valid values: "auto" or a URL)')
+            raise TransportError(
+                f"Invalid matrix server specified (valid values: "
+                f"'{MATRIX_AUTO_SELECT_SERVER}' or a URL)"
+            )
 
         def _http_retry_delay() -> Iterable[float]:
             # below constants are defined in raiden.app.App.DEFAULT_CONFIG

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from eth_utils import denoms, to_hex
 
 import raiden_contracts.constants
-from raiden.constants import DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, Environment
+from raiden.constants import (
+    DISCOVERY_DEFAULT_ROOM,
+    MATRIX_AUTO_SELECT_SERVER,
+    PATH_FINDING_BROADCASTING_ROOM,
+    Environment,
+)
 from raiden.network.pathfinding import PFSConfig
 from raiden.utils.typing import (
     Address,
@@ -175,7 +180,7 @@ class RaidenConfig:
         retries_before_backoff=DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
         retry_interval_initial=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL_INITIAL,
         retry_interval_max=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL_MAX,
-        server="auto",
+        server=MATRIX_AUTO_SELECT_SERVER,
         sync_timeout=DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
     )
 

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -7,7 +7,7 @@ from typing import Iterable
 import pexpect
 import pytest
 
-from raiden.constants import Environment, EthClient
+from raiden.constants import MATRIX_AUTO_SELECT_SERVER, Environment, EthClient
 from raiden.settings import RAIDEN_CONTRACT_VERSION
 from raiden.tests.utils.ci import get_artifacts_storage
 from raiden.tests.utils.smoketest import setup_raiden, setup_testchain
@@ -46,7 +46,7 @@ def raiden_testchain(
     with testchain_manager as testchain:
         result = setup_raiden(
             transport="matrix",
-            matrix_server="auto",
+            matrix_server=MATRIX_AUTO_SELECT_SERVER,
             print_step=lambda x: None,
             contracts_version=cli_tests_contracts_version,
             eth_client=testchain["eth_client"],

--- a/raiden/tests/integration/network/test_pathfinding.py
+++ b/raiden/tests/integration/network/test_pathfinding.py
@@ -9,7 +9,7 @@ from eth_utils import (
     to_checksum_address,
 )
 
-from raiden.constants import RoutingMode
+from raiden.constants import MATRIX_AUTO_SELECT_SERVER, RoutingMode
 from raiden.exceptions import RaidenError
 from raiden.network.pathfinding import PFSInfo, check_pfs_for_production, configure_pfs_or_exit
 from raiden.settings import DEFAULT_PATHFINDING_MAX_FEE
@@ -76,7 +76,7 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
     patch_random = patch("raiden.network.pathfinding.get_random_pfs", return_value="http://foo")
     with patch.object(requests, "get", return_value=response), patch_random:
         config = configure_pfs_or_exit(
-            pfs_url="auto",
+            pfs_url=MATRIX_AUTO_SELECT_SERVER,
             routing_mode=RoutingMode.PFS,
             service_registry=service_registry,
             node_network_id=chain_id,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -12,6 +12,7 @@ from raiden.accounts import AccountManager
 from raiden.app import App
 from raiden.constants import (
     GENESIS_BLOCK_NUMBER,
+    MATRIX_AUTO_SELECT_SERVER,
     MONITORING_BROADCASTING_ROOM,
     PATH_FINDING_BROADCASTING_ROOM,
     RAIDEN_DB_VERSION,
@@ -89,7 +90,7 @@ def setup_matrix(
     environment_type: Environment,
     routing_mode: RoutingMode,
 ) -> MatrixTransport:
-    if not transport_config.available_servers:
+    if transport_config.server == MATRIX_AUTO_SELECT_SERVER:
         # fetch list of known servers from raiden-network/raiden-tranport repo
         available_servers_url = DEFAULT_MATRIX_KNOWN_SERVERS[environment_type]
         available_servers = get_matrix_servers(available_servers_url)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -27,6 +27,7 @@ from raiden.constants import (
     FLAT_MED_FEE_MIN,
     IMBALANCE_MED_FEE_MAX,
     IMBALANCE_MED_FEE_MIN,
+    MATRIX_AUTO_SELECT_SERVER,
     PATH_FINDING_BROADCASTING_ROOM,
     PROPORTIONAL_MED_FEE_MAX,
     PROPORTIONAL_MED_FEE_MIN,
@@ -319,12 +320,13 @@ def options(func: Callable) -> Callable:
             option(
                 "--pathfinding-service-address",
                 help=(
-                    "URL to the Raiden path finding service to request paths from.\n"
-                    "Example: https://pfs-ropsten.services-dev.raiden.network\n"
-                    'Can also be given the "auto" value so that raiden chooses a '
-                    "PFS randomly from the service registry contract"
+                    f"URL to the Raiden path finding service to request paths from.\n "
+                    f"Example: https://pfs-ropsten.services-dev.raiden.network\n "
+                    f"Can also be given the '{MATRIX_AUTO_SELECT_SERVER}' value "
+                    f"so that raiden chooses a PFS randomly from the service "
+                    f"registry contract."
                 ),
-                default="auto",
+                default=MATRIX_AUTO_SELECT_SERVER,
                 type=str,
                 show_default=True,
             ),
@@ -361,13 +363,13 @@ def options(func: Callable) -> Callable:
             option(
                 "--matrix-server",
                 help=(
-                    "Matrix homeserver to use for communication.\n"
-                    "Valid values:\n"
-                    '"auto" - automatically select a suitable homeserver\n'
-                    "A URL pointing to a Raiden matrix homeserver"
+                    f"Matrix homeserver to use for communication.\n"
+                    f"Valid values:\n"
+                    f"'{MATRIX_AUTO_SELECT_SERVER}' - automatically select a suitable homeserver\n"
+                    f"A URL pointing to a Raiden matrix homeserver"
                 ),
-                default="auto",
-                type=MatrixServerType(["auto", "<url>"]),
+                default=MATRIX_AUTO_SELECT_SERVER,
+                type=MatrixServerType([MATRIX_AUTO_SELECT_SERVER, "<url>"]),
                 show_default=True,
             ),
         ),


### PR DESCRIPTION
During `setup_matrix` the yaml with the servers URLs should only be
downloaded if the configuration was set to auto.

This also removed the magic constant.