### PR TITLE
Use datetime in switch tracing

### DIFF
--- a/raiden/utils/profiling/greenlets.py
+++ b/raiden/utils/profiling/greenlets.py
@@ -1,6 +1,6 @@
 import json
 import sys
-import time
+from datetime import datetime
 from typing import Any
 
 import greenlet
@@ -38,7 +38,7 @@ def install_switch_log():
                         "origin": str(origin),
                         "target": str(target),
                         "target_callstack": callstack,
-                        "time": time.time(),
+                        "time": datetime.utcnow().isoformat(),
                     }
                 )
             )


### PR DESCRIPTION
This makes it easier to find the corresponding entries in other logs.