### PR TITLE
Temporarily disable Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,9 +388,6 @@ jobs:
           name: Run tests
           command: |
             .circleci/run_tests.sh "test-reports/test-<< parameters.test-type >>-<< parameters.transport-layer >>-<< parameters.py-version >>" "<< parameters.blockchain-type >>" "<< parameters.test-type >>" << parameters.additional-args >>
-      - run:
-          name: Report coverage
-          command: .circleci/report_coverage.sh << parameters.test-type >>
 
       - save_cache:
           key: ethash-{{ checksum "~/.local/bin/geth" }}


### PR DESCRIPTION
The current version of Codecov keeps sending failed status reports to
github for no reason. This will be reverted when their next version is
released.
