### PR TITLE
Decrease log level for recoverable errors.

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -819,7 +819,7 @@ class RaidenService(Runnable):
                 raiden=self, chain_state=chain_state, event=raiden_event
             )
         except RaidenRecoverableError as e:
-            log.error(str(e))
+            log.info(str(e))
         except InvalidDBData:
             raise
         except (RaidenUnrecoverableError, BrokenPreconditionError) as e:


### PR DESCRIPTION
Recoverable errors are by definition expected and recoverable, it should
not be logged as an error since that leads to confusion.