### PR TITLE
Upgrade cryptography to 2.8

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -5,7 +5,7 @@
 #    './deps compile' (for details see README)
 #
 alabaster==0.7.12
-altgraph==0.16.1          # via pyinstaller
+altgraph==0.16.1          # via macholib, pyinstaller
 aniso8601==7.0.0
 apipkg==1.5
 appdirs==1.4.3
@@ -33,7 +33,7 @@ colorama==0.4.1
 colour==0.1.5
 constantly==15.1.0
 coverage==4.5.3
-cryptography==2.7
+cryptography==2.8
 cytoolz==0.10.1
 daemonize==2.5.0
 decorator==4.4.0

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -32,7 +32,7 @@ colorama==0.4.1
 colour==0.1.5
 constantly==15.1.0        # via twisted
 coverage==4.5.3
-cryptography==2.7         # via pyopenssl, service-identity
+cryptography==2.8         # via pyopenssl, service-identity
 cytoolz==0.10.1
 daemonize==2.5.0          # via matrix-synapse
 decorator==4.4.0


### PR DESCRIPTION
## Description

Upgrade cryptography to fix a openssl dependency issue on macOS:
https://github.com/pypa/pip/issues/7254
