### PR TITLE
Make @raise_on_failure work with node restarts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,6 +535,11 @@ to instant failure of the test, and `@expect_failure` indicates that we
 actually expect the crash of a `RaidenService` instance within the test
 and want to ignore it.
 
+Sometimes a test using `@raise_on_failure` needs to restart nodes or start
+new ones during the test. Simply calling `App.start` to achieve this will
+make `@raise_on_failure` lose track of the app. Therefore, such tests should
+always use the `restart_node` fixture and call `restart_node(app)` instead.
+
 ### Workflow
 
 When developing a feature, or a bug fix you should always start by writing a

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -1137,7 +1137,6 @@ def test_api_payments_target_error(
     )
     response = request.send().response
     assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
-    app1.start()
 
 
 @raise_on_failure

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -17,7 +17,7 @@ from raiden.storage.restore import channel_state_until_state_change
 from raiden.storage.sqlite import HIGH_STATECHANGE_ULID, RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.client import burn_eth
-from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.tests.utils.detect_failure import expect_failure, raise_on_failure
 from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldRaidenEventHandler, WaitForMessage
@@ -1093,7 +1093,7 @@ def test_batch_unlock_after_restart(raiden_network, restart_node, token_addresse
         )
 
 
-@raise_on_failure
+@expect_failure
 @pytest.mark.parametrize("number_of_nodes", (2,))
 @pytest.mark.parametrize("channels_per_node", (1,))
 def test_handle_insufficient_eth(raiden_network, restart_node, token_addresses, caplog):

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -931,7 +931,7 @@ def test_automatic_dispute(raiden_network, deposit, token_addresses):
 
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_batch_unlock_after_restart(raiden_network, token_addresses, deposit):
+def test_batch_unlock_after_restart(raiden_network, restart_node, token_addresses, deposit):
     """Simulate the case where:
     - A sends B a transfer
     - B sends A a transfer
@@ -1082,7 +1082,7 @@ def test_batch_unlock_after_restart(raiden_network, token_addresses, deposit):
             sender=alice_bob_channel_state.our_state.address,
         )
 
-    alice_app.start()
+    restart_node(alice_app)
 
     with gevent.Timeout(timeout):
         wait_for_batch_unlock(
@@ -1096,7 +1096,7 @@ def test_batch_unlock_after_restart(raiden_network, token_addresses, deposit):
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", (2,))
 @pytest.mark.parametrize("channels_per_node", (1,))
-def test_handle_insufficient_eth(raiden_network, token_addresses, caplog):
+def test_handle_insufficient_eth(raiden_network, restart_node, token_addresses, caplog):
     app0, app1 = raiden_network
     token = token_addresses[0]
     registry_address = app0.raiden.default_registry.address
@@ -1121,7 +1121,7 @@ def test_handle_insufficient_eth(raiden_network, token_addresses, caplog):
 
     app1.raiden.stop()
     burn_eth(app1.raiden.rpc_client)
-    app1.raiden.start()
+    restart_node(app1)
 
     settle_block_timeout = BlockTimeout(
         exception_to_throw=RuntimeError("Settle did not happen."),

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1238,7 +1238,7 @@ def test_transport_does_not_receive_broadcast_rooms_updates(
 @pytest.mark.parametrize(
     "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]]
 )
-def test_transport_presence_updates(raiden_network, retry_timeout):
+def test_transport_presence_updates(raiden_network, restart_node, retry_timeout):
     """
     Create transports and test that matrix delivers presence updates
     in the presence of filters which ignore all event updates
@@ -1274,7 +1274,7 @@ def test_transport_presence_updates(raiden_network, retry_timeout):
     )
 
     # Restart app0
-    app0.start()
+    restart_node(app0)
     app0.raiden.transport.immediate_health_check_for(app1.raiden.address)
     app0.raiden.transport.immediate_health_check_for(app2.raiden.address)
     wait_for_network_state(app1.raiden, app0.raiden.address, NetworkState.REACHABLE, retry_timeout)
@@ -1290,7 +1290,7 @@ def test_transport_presence_updates(raiden_network, retry_timeout):
     )
 
     # Restart app1
-    app1.start()
+    restart_node(app1)
     app1.raiden.transport.immediate_health_check_for(app0.raiden.address)
     app1.raiden.transport.immediate_health_check_for(app2.raiden.address)
     wait_for_network_state(app0.raiden, app1.raiden.address, NetworkState.REACHABLE, retry_timeout)

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -80,7 +80,12 @@ def test_regression_filters_must_be_installed_from_confirmed_block(raiden_networ
     [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM, MONITORING_BROADCASTING_ROOM]],
 )
 def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
-    raiden_network, number_of_nodes, token_addresses, network_wait, user_deposit_address
+    raiden_network,
+    restart_node,
+    number_of_nodes,
+    token_addresses,
+    network_wait,
+    user_deposit_address,
 ):
     """ Raiden must broadcast the latest known balance proof on restarts.
 
@@ -159,7 +164,7 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
             user_deposit_address, block_identifier="latest"
         ),
     )
-    app0_restart.start()
+    restart_node(app0_restart)
 
 
 @expect_failure  # raise_on_failure will not work here since the apps are not started
@@ -175,7 +180,7 @@ def test_alarm_task_first_run_syncs_blockchain_events(raiden_network, blockchain
     """
     app0, _ = raiden_network
 
-    # Make sure we get into app0.start() with a confirmed block that contains
+    # Make sure we get into the restart of app0 with a confirmed block that contains
     # the channel creation events
     target_block_num = (
         blockchain_services.proxy_manager.client.block_number()
@@ -197,7 +202,7 @@ def test_alarm_task_first_run_syncs_blockchain_events(raiden_network, blockchain
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_fees_are_updated_during_startup(
-    raiden_network, token_addresses, deposit, retry_timeout
+    raiden_network, restart_node, token_addresses, deposit, retry_timeout
 ) -> None:
     """
     Test that the supplied fee settings are correctly forwarded to all
@@ -264,7 +269,7 @@ def test_fees_are_updated_during_startup(
     app0.stop()
     app0.raiden.config = deepcopy(original_config)
     app0.raiden.config.mediation_fees.token_to_flat_fee[token_address] = flat_fee
-    app0.start()
+    restart_node(app0)
 
     channel_state = get_channel_state(app0)
     assert channel_state.fee_schedule.flat == flat_fee
@@ -276,7 +281,7 @@ def test_fees_are_updated_during_startup(
     app0.stop()
     app0.raiden.config = deepcopy(original_config)
     app0.raiden.config.mediation_fees.token_to_proportional_fee[token_address] = prop_fee
-    app0.start()
+    restart_node(app0)
 
     channel_state = get_channel_state(app0)
     assert channel_state.fee_schedule.flat == DEFAULT_MEDIATION_FLAT_FEE
@@ -287,7 +292,7 @@ def test_fees_are_updated_during_startup(
     app0.stop()
     app0.raiden.config = deepcopy(original_config)
     app0.raiden.config.mediation_fees.token_to_proportional_imbalance_fee[token_address] = 0.05e6
-    app0.start()
+    restart_node(app0)
 
     channel_state = get_channel_state(app0)
     assert channel_state.fee_schedule.flat == DEFAULT_MEDIATION_FLAT_FEE

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -34,7 +34,7 @@ from raiden.utils.typing import BlockNumber, PaymentAmount, PaymentID
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_recovery_happy_case(
-    raiden_network, number_of_nodes, deposit, token_addresses, network_wait
+    raiden_network, restart_node, number_of_nodes, deposit, token_addresses, network_wait
 ):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
@@ -64,7 +64,7 @@ def test_recovery_happy_case(
         app1.raiden, app0.raiden.address, NetworkState.UNREACHABLE, network_wait
     )
 
-    app0.start()
+    restart_node(app0)
 
     assert_synced_channel_state(
         token_network_address, app0, deposit - spent_amount, [], app1, deposit + spent_amount, []
@@ -107,7 +107,13 @@ def test_recovery_happy_case(
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [3])
 def test_recovery_unhappy_case(
-    raiden_network, number_of_nodes, deposit, token_addresses, network_wait, retry_timeout
+    raiden_network,
+    restart_node,
+    number_of_nodes,
+    deposit,
+    token_addresses,
+    network_wait,
+    retry_timeout,
 ):
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
@@ -177,7 +183,7 @@ def test_recovery_unhappy_case(
         routing_mode=RoutingMode.PRIVATE,
     )
     del app0  # from here on the app0_restart should be used
-    app0_restart.start()
+    restart_node(app0_restart)
     wal = app0_restart.raiden.wal
     assert wal
 
@@ -197,7 +203,7 @@ def test_recovery_unhappy_case(
 @pytest.mark.parametrize("deposit", [10])
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])
-def test_recovery_blockchain_events(raiden_network, token_addresses, network_wait):
+def test_recovery_blockchain_events(raiden_network, restart_node, token_addresses, network_wait):
     """ Close one of the two raiden apps that have a channel between them,
     have the counterparty close the channel and then make sure the restarted
     app sees the change
@@ -241,7 +247,7 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
 
     del app0  # from here on the app0_restart should be used
 
-    app0_restart.raiden.start()
+    restart_node(app0_restart)
     wal = app0_restart.raiden.wal
     assert wal
 
@@ -256,7 +262,7 @@ def test_recovery_blockchain_events(raiden_network, token_addresses, network_wai
 @pytest.mark.parametrize("deposit", [2])
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
-    raiden_network, token_addresses, network_wait, number_of_nodes, retry_timeout
+    raiden_network, restart_node, token_addresses, network_wait, number_of_nodes, retry_timeout
 ):
     """ A test case related to https://github.com/raiden-network/raiden/issues/4639
     Where a node sends a withdraw transaction, is stopped before the transaction is completed.
@@ -315,7 +321,7 @@ def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
         retry_timeout=retry_timeout,
     )
 
-    app0.raiden.start()
+    restart_node(app0)
 
     chain_state = views.state_from_app(app0)
 

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -38,7 +38,7 @@ STATE_PRUNING = {
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("blockchain_extra_config", [STATE_PRUNING])
 def test_locksroot_loading_during_channel_settle_handling(
-    raiden_chain, deploy_client, token_addresses
+    raiden_chain, restart_node, deploy_client, token_addresses
 ):
     app0, app1 = raiden_chain
     token_network_registry_address = app0.raiden.default_registry.address
@@ -141,7 +141,7 @@ def test_locksroot_loading_during_channel_settle_handling(
 
     # This must not raise when the settle event is being raised and the
     # locksroot is being recover (#3856)
-    app0.start()
+    restart_node(app0)
 
     assert wait_for_state_change(
         raiden=app0.raiden,

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -311,6 +311,7 @@ def test_refund_transfer(
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 def test_different_view_of_last_bp_during_unlock(
     raiden_chain: List[App],
+    restart_node,
     number_of_nodes,
     token_addresses,
     deposit,
@@ -481,7 +482,7 @@ def test_different_view_of_last_bp_during_unlock(
     setattr(app1.raiden.raiden_event_handler, "on_raiden_event", patched_on_raiden_event)  # NOQA
 
     # and now app1 comes back online
-    app1.raiden.start()
+    restart_node(app1)
     # test for https://github.com/raiden-network/raiden/issues/3216
     assert count == 1, "Update transfer should have only been called once during restart"
     channel_identifier = get_channelstate(app0, app1, token_network_address).identifier

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -42,6 +42,10 @@ def raise_on_failure(test_function: Callable) -> Callable:
                 "which uses neither `raiden_network` nor `raiden_chain` fixtures."
             )
 
+        restart_node = kwargs.get("restart_node", None)
+        if restart_node is not None:
+            restart_node.link_exception_to(result)
+
         # Do not use `link` or `link_value`, an app an be stopped to test restarts.
         for raiden in raiden_services:
             assert raiden, "The RaidenService must be started"

--- a/raiden/tests/utils/detect_failure.py
+++ b/raiden/tests/utils/detect_failure.py
@@ -46,7 +46,7 @@ def raise_on_failure(test_function: Callable) -> Callable:
         if restart_node is not None:
             restart_node.link_exception_to(result)
 
-        # Do not use `link` or `link_value`, an app an be stopped to test restarts.
+        # Do not use `link` or `link_value`, an app can be stopped to test restarts.
         for raiden in raiden_services:
             assert raiden, "The RaidenService must be started"
             raiden.greenlet.link_exception(result)


### PR DESCRIPTION
Some tests that use the `raiden_network` and `raiden_chain` fixtures stop and restart their nodes, which makes `raise_on_failure` lose track of uncaught exceptions that might happen inside of them. This PR adds a function for the safe restarting of nodes and applies it everywhere in the tests.

Fixes #5555