### PR TITLE
Parse nginx directory indexes

### DIFF
--- a/tools/debugging/extract_sp_exceptions.sh
+++ b/tools/debugging/extract_sp_exceptions.sh
@@ -29,7 +29,7 @@ function display_usage {
 }
 
 
-if [[  $1 == "--help" ]]; then 
+if [[  $1 == "--help" ]]; then
     display_usage
     exit 1
 fi
@@ -57,20 +57,21 @@ function download_nodes_logs {
     current_server=$2
     run_number=$3
 
-    nodes=$(${CURL_COMMAND} ${current_server}${scenario} | sed -e 's/<[^>]*>//g' | grep -v Directory | sed -e '/^$/d' | grep "^node_${run_number}")
+    nodes=$(${CURL_COMMAND} ${current_server}${scenario} | grep -P '^<a ' | cut -d\" -f2 | grep "^node_${run_number}")
     for node in $nodes; do
         $(${WGET_DIR} -q -P ${DESTINATION_DIR} ${current_server}${scenario}${node})
     done
 
-    latest_sp_log=$(${CURL_COMMAND} ${current_server}${scenario} | sed -e 's/<[^>]*>//g' | grep -v Directory | sed -e '/^$/d' | grep ".log$" | sort | tail -n 1)
+    latest_sp_log=$(${CURL_COMMAND} ${current_server}${scenario} | grep -P '^<a ' | cut -d\" -f2 | grep ".log$" | sort | tail -n 1)
     $(${WGET_DIR} -q -P ${DESTINATION_DIR} ${current_server}${scenario}${latest_sp_log})
 }
 
 function download_server_logs {
     current_server=$1
-    scenarios=$(${CURL_COMMAND} ${current_server} | sed -e 's/<[^>]*>//g' | grep -v Directory | sed -e '/^$/d')
+    scenarios=$(${CURL_COMMAND} ${current_server} | grep -P '^<a ' | cut -d\" -f2)
     for scenario in $scenarios; do
         run_number=$(${CURL_COMMAND} "${current_server}${scenario}run_number.txt")
+        [ -n "$run_number" ] || { echo 'Could not find run number!'; exit 1; }
         download_nodes_logs $scenario $current_server $run_number
         echo -e "\t - ${scenario}, run_number: ${run_number}"
     done;

--- a/tools/debugging/extract_sp_exceptions.sh
+++ b/tools/debugging/extract_sp_exceptions.sh
@@ -80,6 +80,7 @@ function download_server_logs {
 }
 
 function search_for_failures {
+    mkdir -p "${DESTINATION_DIR}/errors/"
     echo -e "${BOLD}Looking for failures${RESET}"
     scenarios_dir="${DESTINATION_DIR}/scenarios"
     for scenario in $(ls $scenarios_dir); do
@@ -94,6 +95,7 @@ function search_for_failures {
             if [[ $result != "" ]]; then
                 print_bold "- Found error in ${node_dir}"
                 echo -e "${result}"
+                echo ${result} > "${DESTINATION_DIR}/errors/${scenario}.node.log"
             fi
         done
         separator
@@ -101,6 +103,7 @@ function search_for_failures {
         if [[ $sp_error != "" ]]; then
             print_bold "- SP reported an error in ${scenario_dir}"
             echo -e "${sp_error}"
+                echo ${sp_error} > "${DESTINATION_DIR}/errors/${scenario}.sp.log"
         fi
         separator
     done;


### PR DESCRIPTION
We use regexes to parse the directory listings. The markup for those has
changed due to the switch to nginx. This commit parses the new markup.

HTTP is not well standardized for doing such operations. Using an scp
like tool with wildcards would be nicer and more robust.

I also added some code to write the errors into separate files in an `errors` dir.