### PR TITLE
Handle the token network maximum being reached

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`5779` Handle the API exception when no further token networks can be registered by returning 403 FORBIDDEN.
 * :bug:`5583` The connection manager no longer opens channels with offline nodes when trying to connect to a token network.
 * :feature:`5589` The Rest API now includes the token address in all returned payment related events.
 * :bug:`5591` Rest API payment events can now be properly filtered by token address.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -157,6 +157,7 @@ Deploying
 
    :statuscode 201: A token network for the token has been successfully created.
    :statuscode 402: Insufficient ETH to pay for the gas of the register on-chain transaction
+   :statuscode 403: Maximum of allowed token networks reached. No new token networks can be registered.
    :statuscode 404: The given token address is invalid.
    :statuscode 409:
     - The token was already registered before, or

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -62,6 +62,7 @@ from raiden.exceptions import (
     AddressWithoutCode,
     AlreadyRegisteredTokenAddress,
     APIServerPortInUseError,
+    BrokenPreconditionError,
     DepositMismatch,
     DepositOverLimit,
     DuplicatedChannelError,
@@ -560,6 +561,7 @@ class RestAPI:  # pragma: no unittest
         conflict_exceptions = (
             AddressWithoutCode,
             AlreadyRegisteredTokenAddress,
+            BrokenPreconditionError,
             InvalidBinaryAddress,
             InvalidToken,
             InvalidTokenAddress,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -79,6 +79,7 @@ from raiden.exceptions import (
     InvalidSettleTimeout,
     InvalidToken,
     InvalidTokenAddress,
+    MaxTokenNetworkNumberReached,
     MintFailed,
     PaymentConflict,
     RaidenRecoverableError,
@@ -126,6 +127,7 @@ from raiden.utils.typing import (
 log = structlog.get_logger(__name__)
 
 ERROR_STATUS_CODES = [
+    HTTPStatus.FORBIDDEN,
     HTTPStatus.CONFLICT,
     HTTPStatus.REQUEST_TIMEOUT,
     HTTPStatus.PAYMENT_REQUIRED,
@@ -580,6 +582,8 @@ class RestAPI:  # pragma: no unittest
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
         except InsufficientEth as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
+        except MaxTokenNetworkNumberReached as e:
+            return api_error(errors=str(e), status_code=HTTPStatus.FORBIDDEN)
 
         return api_response(
             result=dict(token_network_address=to_checksum_address(token_network_address)),

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -185,11 +185,15 @@ class AlreadyRegisteredTokenAddress(RaidenError):
 
 
 class InvalidToken(RaidenError):
-    """ Raised if the token does not follow the ERC20 standard """
+    """ Raised if the token does not follow the ERC20 standard. """
+
+
+class MaxTokenNetworkNumberReached(RaidenError):
+    """ Raised if the maximum amount of token networks has been registered. """
 
 
 class InvalidTokenAddress(RaidenError):
-    """ Raised if the token address is invalid """
+    """ Raised if the token address is invalid. """
 
 
 class InvalidTokenNetworkDepositLimit(RaidenError):

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -12,6 +12,7 @@ from raiden.exceptions import (
     InvalidToken,
     InvalidTokenAddress,
     InvalidTokenNetworkDepositLimit,
+    MaxTokenNetworkNumberReached,
     RaidenRecoverableError,
     RaidenUnrecoverableError,
 )
@@ -164,8 +165,8 @@ class TokenNetworkRegistry:
             raise_on_call_returned_empty(given_block_identifier)
         else:
             if token_networks_created >= max_token_networks:
-                raise BrokenPreconditionError(
-                    f"Number of token networks will exceed the max of {max_token_networks}"
+                raise MaxTokenNetworkNumberReached(
+                    f"Number of token networks will exceed the maximum of {max_token_networks}"
                 )
 
             if token_supply is None:

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -6,7 +6,6 @@ from eth_utils import is_same_address, to_canonical_address, to_normalized_addre
 from raiden.constants import GENESIS_BLOCK_NUMBER, NULL_ADDRESS_BYTES, UINT256_MAX
 from raiden.exceptions import (
     AddressWithoutCode,
-    BrokenPreconditionError,
     InvalidToken,
     InvalidTokenAddress,
     MaxTokenNetworkNumberReached,

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -9,6 +9,7 @@ from raiden.exceptions import (
     BrokenPreconditionError,
     InvalidToken,
     InvalidTokenAddress,
+    MaxTokenNetworkNumberReached,
     RaidenRecoverableError,
 )
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
@@ -225,7 +226,7 @@ def test_token_network_registry_allows_the_last_slot_to_be_used(
 
     # Tries to register a new valid token after all slots have been used. This
     # has to fail.
-    with pytest.raises(BrokenPreconditionError):
+    with pytest.raises(MaxTokenNetworkNumberReached):
         token_network_registry_proxy.add_token(
             token_address=second_token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),


### PR DESCRIPTION
This introduces a new exception for this case and handles it in the API.
Fixes #5779

