### PR TITLE
Opening an already existing channel returns 200 after #5770

### DIFF
--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -203,8 +203,8 @@ scenario:
       - parallel:
           name: "Check edge cases again"
           tasks:
-            # try to open a channel with an offline node, but the channel already exists
-            - open_channel: {from: 0, to: 1, total_deposit: 200_000_000_000_000_000, expected_http_status: 409}
+            # Try to open a channel with an offline node, but the channel already exists, we will get a 200
+            - open_channel: {from: 0, to: 1, total_deposit: 200_000_000_000_000_000, expected_http_status: 200}
             # Try to make a payment to an offline node
             - transfer: {from: 0, to: 1, amount: 1_000_000_000_000_000, expected_http_status: 409, lock_timeout: 30}
       - serial:


### PR DESCRIPTION
## Description
Fixes bf2 scenario after #5770 Opening an already existing channel will return a 200

