### PR TITLE
Fix slow stop of check_version greenlet

### DIFF
--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -65,12 +65,9 @@ def check_version(current_version: str) -> None:  # pragma: no unittest
     while True:
         try:
             _do_check_version(app_version)
-        except requests.exceptions.HTTPError as herr:
+        except (requests.exceptions.HTTPError, ValueError) as err:
             click.secho("Error while checking for version", fg="red")
-            print(herr)
-        except ValueError as verr:
-            click.secho("Error while checking the version", fg="red")
-            print(verr)
+            print(err)
 
         # repeat the process once every 3h
         gevent.sleep(CHECK_VERSION_INTERVAL)

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -71,9 +71,9 @@ def check_version(current_version: str) -> None:  # pragma: no unittest
         except ValueError as verr:
             click.secho("Error while checking the version", fg="red")
             print(verr)
-        finally:
-            # repeat the process once every 3h
-            gevent.sleep(CHECK_VERSION_INTERVAL)
+
+        # repeat the process once every 3h
+        gevent.sleep(CHECK_VERSION_INTERVAL)
 
 
 def check_gas_reserve(raiden: "RaidenService") -> None:  # pragma: no unittest


### PR DESCRIPTION
Killing a greenlet raises an exception. In `check_version`, this
exception can trigger the finally clause, causing the greenlet to wait
for three hours before terminating. Since the raiden client waits for
all greenlets to terminate, this will keep the whole raiden client from
terminating for three hours.