### PR TITLE
Correctly skip the first full sync

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -490,7 +490,9 @@ class GMatrixClient(MatrixClient):
         # The second sync is the first full sync and can be slow. This is
         # acceptable, we only want to know if we fail to sync quickly
         # afterwards.
-        if timeout_reached and self.sync_iteration > 1:
+        # As the runtime is evaluated in the subsequent run, we only run this
+        # after the second iteration is finished.
+        if timeout_reached and self.sync_iteration > 2:
             if IDLE:
                 IDLE.log()
 


### PR DESCRIPTION
## Description

I think we had a mental flaw here, the first sync is `sync_iteration` 0, that is measured when `sync_iteration` 1 is called.

So then the first "proper" sync is done, which will be evaluated in `sync_iteration` 2. Therefore we need to skip that one as well.
