### PR TITLE
Reduce scenario waits

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -103,7 +103,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 3 to 0"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 0, balance_sum: 2_010_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 1_990_000_000_000_000_000}
       - serial:
@@ -114,14 +114,14 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 1 to 4"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 1, balance_sum: 1_990_000_000_000_000_000}
             - assert_sum: {from: 4, balance_sum: 2_010_000_000_000_000_000}
       - serial:
           name: "Check that IOUs exist after the payments"
           tasks:
             # Add a wait until all ious are processed correctly
-            - wait: 100
+            - wait: 30
             - assert_pfs_history: {source: 3, target: 0, request_count: 10}
             - assert_pfs_iou: {source: 3, amount: 1000}
             - assert_pfs_history: {source: 1, target: 4, request_count: 10}
@@ -144,7 +144,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 2 to 4"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 2, balance_sum: 1_890_000_000_000_000_000}
             - assert_sum: {from: 4, balance_sum: 2_020_000_000_000_000_000}
       - serial:
@@ -155,7 +155,7 @@ scenario:
       - serial:
           name: "Assert after 5 payments from 0 to 2"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 2, balance_sum: 1_895_000_000_000_000_000}
             - assert_sum: {from: 0, balance_sum: 2_005_000_000_000_000_000}
       - parallel:
@@ -165,7 +165,7 @@ scenario:
       - serial:
           name: "Assert after deposit from 2 to 3"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert: {from: 2, to: 3, total_deposit: 1_100_000_000_000_000_000, total_withdraw: 100_000_000_000_000_000, state: "opened"}
       - parallel:
           name: "1 deposits extra 10% in the channel with 0"
@@ -174,7 +174,7 @@ scenario:
       - serial:
           name: "Assert after deposit from 1 to 0"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert: {from: 1, to: 0, total_deposit: 1_100_000_000_000_000_000, state: "opened"}
       - serial:
           name: "Make 100 payments from 0 to 3"
@@ -184,16 +184,16 @@ scenario:
       - serial:
           name: "Assert after 100 payments from 0 to 3"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 0, balance_sum: 1_905_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_090_000_000_000_000_000}
       - serial:
           name: "Stop node 0 and wait 100s, then start it again"
           tasks:
             - stop_node: 0
-            - wait: 100
+            - wait: 30
             - start_node: 0
-            - wait: 100
+            - wait: 30
       - serial:
           name: "Make 10 payments from 0 to 3 after restart"
           repeat: 10
@@ -202,7 +202,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 0 to 3"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 0, balance_sum: 1_895_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_100_000_000_000_000_000}
       - serial:
@@ -213,7 +213,7 @@ scenario:
       - serial:
           name: "Assert after 100 payments from 3 to 0"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_sum: {from: 0, balance_sum: 1_995_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_000_000_000_000_000_000}
       - serial:
@@ -223,7 +223,7 @@ scenario:
       - serial:
           name: "Assert after closing channel between 0 and 4"
           tasks:
-            - wait: 100
+            - wait: 30
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "ChannelClosed"

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -95,7 +95,7 @@ scenario:
       - serial:
           name: "Give the nodes time to complete the earlier deposits and channel opening"
           tasks:
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Checking for the channel state to be unchanged"
           tasks:
@@ -109,14 +109,14 @@ scenario:
           name: "node2 does different cases of deposit with node4"
           tasks:
             - open_channel: {from: 2, to: 4, total_deposit: 0, expected_http_status: 201}
-            - wait: 100
+            - wait: 30
             - deposit: {from: 2, to: 4, total_deposit: 100_000_000_000_000_000}
-            - wait: 100
+            - wait: 30
             # Try to make a deposit smaller than the amount that was deposited
             - deposit: {from: 2, to: 4, total_deposit: 30_000_000_000_000_000, expected_http_status: 409}
             # Make a deposit bigger than the deposited amount
             - deposit: {from: 2, to: 4, total_deposit: 150_000_000_000_000_000}
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Verify the channels"
           tasks:
@@ -137,10 +137,10 @@ scenario:
             - assert: {from: 0, to: 4, total_deposit: 10_000_000_000_000_000, balance: 10_000_000_000_000_000, state: "opened"}
             # node4 deposits tokens into the node0-node4 channel
             - deposit: {from: 4, to: 0, total_deposit: 25_000_000_000_000_000}
-            - wait: 100
+            - wait: 30
             # node0 performs a payment to node4 (path 0<->1<->2<->4)
             - transfer: {from: 0, to: 4, amount: 50_000_000_000_000_000, expected_http_status: 200, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
             - assert: {from: 0, to: 1, total_deposit: 100_000_000_000_000_000, balance: 50_000_000_000_000_000, state: "opened"}
             - assert: {from: 1, to: 0, total_deposit: 100_000_000_000_000_000, balance: 150_000_000_000_000_000, state: "opened"}
             - assert: {from: 1, to: 2, total_deposit: 100_000_000_000_000_000, balance: 50_000_000_000_000_000, state: "opened"}
@@ -149,12 +149,12 @@ scenario:
             - assert: {from: 4, to: 2, total_deposit: 0, balance: 50_000_000_000_000_000, state: "opened"}
             # node2 sends all of its tokens to node1 (one transfer)
             - transfer: {from: 2, to: 1, amount: 150_000_000_000_000_000, expected_http_status: 200, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
             - assert: {from: 2, to: 1, total_deposit: 100_000_000_000_000_000, balance: 0, state: "opened"}
             - assert: {from: 1, to: 2, total_deposit: 100_000_000_000_000_000, balance: 200_000_000_000_000_000, state: "opened"}
             # node2 tries to send another tokens payment to node1 (fail no route with enough capacity)
             - transfer: {from: 2, to: 1, amount: 150_000_000_000_000_000, expected_http_status: 409, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
       - serial:
           name: "Multiple multi hop payments"
           repeat: 10
@@ -164,7 +164,7 @@ scenario:
       - serial:
           name: "Allow nodes to process the payments"
           tasks:
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Sanity check"
           tasks:
@@ -183,13 +183,13 @@ scenario:
           tasks:
             - stop_node: 1
             # give it time to shutdown
-            - wait: 100
+            - wait: 30
       - serial:
           name: "Multi hop payment node2"
           tasks:
             # node0 sends 10 tokens to node2 (using the 0 <-> 4 <-> 2 route)
             - transfer: {from: 0, to: 2, amount: 10_000_000_000_000_000, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Assert transfer was executed correctly"
           tasks:
@@ -221,7 +221,7 @@ scenario:
           name: "Payment from node3 to node2"
           tasks:
             - transfer: {from: 3, to: 2, amount: 99_000_000_000_000_000, lock_timeout: 30}
-      - wait: 100
+      - wait: 30
       - serial:
           name: "Checking if payments were made successfully"
           tasks:
@@ -229,7 +229,7 @@ scenario:
             - assert: {from: 3, to: 2, total_deposit: 101_000_000_000_000_000, balance: 2_000_000_000_000_000, state: "opened"}
             # Also node0 makes a deposit to node0 <-> node1 channel
             - deposit: {from: 0, to: 1, total_deposit: 260_000_000_000_000_000}
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Also check if node0 -> node1 -> node2 -> node3 path has enough capacity for transfer of 200_000_000_000_000_000"
           tasks:
@@ -243,14 +243,14 @@ scenario:
           name: "Closing down channel node4 <-> node2"
           tasks:
             - close_channel: {from: 4, to: 2}
-            - wait: 100
+            - wait: 30
             - assert: {from: 2, to: 4, total_deposit: 150_000_000_000_000_000, balance: 100_000_000_000_000_000, state: "closed"}
             - assert: {from: 4, to: 2, total_deposit: 0, balance: 50_000_000_000_000_000, state: "closed"}
       - serial:
           name: "Payment from node0 to node3"
           tasks:
             - transfer: {from: 0, to: 3, amount: 200_000_000_000_000_000, lock_timeout: 30}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert channels after transfers"
           tasks:
@@ -265,20 +265,20 @@ scenario:
           tasks:
             # node2 tries to make a deposit to the channel that is being closed (fail 409)
             - deposit: {from: 2, to: 4, total_deposit: 200_000_000_000_000_000, expected_http_status: 409}
-            - wait: 100
+            - wait: 30
             # node2 sends tokens to node1
             - transfer: {from: 2, to: 1, amount: 10_000_000_000_000_000, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
             - assert: {from: 1, to: 2, total_deposit: 100_000_000_000_000_000, balance: 10_000_000_000_000_000, state: "opened"}
             - assert: {from: 2, to: 1, total_deposit: 100_000_000_000_000_000, balance: 190_000_000_000_000_000, state: "opened"}
             # node1 sends tokens to node0
             - transfer: {from: 1, to: 0, amount: 10_000_000_000_000_000, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
             - assert: {from: 0, to: 1, total_deposit: 260_000_000_000_000_000, balance: 10_000_000_000_000_000, state: "opened"}
             - assert: {from: 1, to: 0, total_deposit: 100_000_000_000_000_000, balance: 350_000_000_000_000_000, state: "opened"}
             # node4 sends tokens to node2 (0 -> 1-> 2)
             - transfer: {from: 4, to: 2, amount: 10_000_000_000_000_000, lock_timeout: 30}
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Assert for the channel states after mediated transfers were completed"
           tasks:
@@ -292,7 +292,7 @@ scenario:
           name: "node4 Closes his channel with node0"
           tasks:
             - close_channel: {from: 4, to: 0}
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Check if channel was closed"
           tasks:
@@ -310,7 +310,7 @@ scenario:
           tasks:
             - leave_network: {from: 0}
             - leave_network: {from: 1}
-            - wait: 100
+            - wait: 30
       - serial:
           name: "Check that channel node2 <-> node3 is still open"
           tasks:
@@ -320,7 +320,7 @@ scenario:
           name: "node2 closes the channel with node3"
           tasks:
             - close_channel: {from: 2, to: 3}
-            - wait: 100
+            - wait: 30
       - parallel:
           name: "Check final state of the channels"
           tasks:

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -66,7 +66,7 @@ scenario:
             - deposit: {from: 2, to: 1, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
             - deposit: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
             - deposit: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100  # Wait for the PFS to receive and process the capacity updates
+      - wait: 30  # Wait for the PFS to receive and process the capacity updates
       - parallel:
           name: "Assert after deposits"
           tasks:
@@ -87,7 +87,7 @@ scenario:
                 repeat: 100
                 tasks:
                   - transfer: {from: 4, to: 0, amount: 1_000_000_000_000_000}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert that all balances are the same as before the payments, since same amounts are sent in both directions"
           tasks:

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -56,7 +56,7 @@ scenario:
             - open_channel: {from: 1, to: 3, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 201}
             - open_channel: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 201}
             - open_channel: {from: 4, to: 5, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 201}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after channel openings"
           tasks:
@@ -84,7 +84,7 @@ scenario:
                 tasks:
                   - transfer: {from: 0, to: 5, amount: 1_000_000_000_000_000, lock_timeout: 30}
       # Make sure that all transfers are finalized before asserting
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert balances after transfers"
           tasks:

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -128,7 +128,7 @@ scenario:
       - serial:
           name: "Make sure that all transfers finish"
           tasks:
-            - wait: 200
+            - wait: 30
       - parallel:
           name: "Assert after transfers. Should be the same as before the transfers were made"
           tasks:

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -81,7 +81,7 @@ scenario:
             - open_channel: {from: 8, to: 0, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 201}
             - open_channel: {from: 9, to: 0, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 201}
       # Make sure the PFS has all balance updates
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after channel openings"
           tasks:
@@ -116,7 +116,7 @@ scenario:
             - transfer: {from: 8, to: 0, amount: 500_000_000_000_000_000, expected_http_status: 200}
             - transfer: {from: 9, to: 0, amount: 500_000_000_000_000_000, expected_http_status: 200}
       # Make sure the PFS has all balance updates
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after balancing channels"
           tasks:
@@ -151,7 +151,7 @@ scenario:
             - transfer: {from: 8, to: 4, amount: 1_000_000_000_000_000, expected_http_status: 200}
             - transfer: {from: 9, to: 5, amount: 1_000_000_000_000_000, expected_http_status: 200}
       # Make sure the PFS has all balance updates
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after first round of payments through node0"
           tasks:

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -145,7 +145,7 @@ scenario:
           name: "Make one transfer from node0 to node1"
           tasks:
             - transfer: {from: 0, to: 1, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node1"
           tasks:
@@ -155,7 +155,7 @@ scenario:
           name: "Make one transfer from node1 to node0"
           tasks:
             - transfer: {from: 1, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node1 to node0"
           tasks:
@@ -165,7 +165,7 @@ scenario:
           name: "Make one transfer from node0 to node2"
           tasks:
             - transfer: {from: 0, to: 2, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node2"
           tasks:
@@ -175,7 +175,7 @@ scenario:
           name: "Make one transfer from 2 to 0"
           tasks:
             - transfer: {from: 2, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node2 to node0"
           tasks:
@@ -185,7 +185,7 @@ scenario:
           name: "Make one transfer from node0 to node3"
           tasks:
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node3"
           tasks:
@@ -195,7 +195,7 @@ scenario:
           name: "Make one transfer from node3 to node0"
           tasks:
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node3 to node0"
           tasks:
@@ -205,7 +205,7 @@ scenario:
           name: "Make one transfer from node0 to node4"
           tasks:
             - transfer: {from: 0, to: 4, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node4"
           tasks:
@@ -215,7 +215,7 @@ scenario:
           name: "Make one transfer from node4 to node0"
           tasks:
             - transfer: {from: 4, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node4 to node0"
           tasks:
@@ -225,7 +225,7 @@ scenario:
           name: "Make one transfer from node0 to node5"
           tasks:
             - transfer: {from: 0, to: 5, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node5"
           tasks:
@@ -235,7 +235,7 @@ scenario:
           name: "Make one transfer from node5 to node0"
           tasks:
             - transfer: {from: 5, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node5 to node0"
           tasks:
@@ -245,7 +245,7 @@ scenario:
           name: "Make one transfer from node0 to node6"
           tasks:
             - transfer: {from: 0, to: 6, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node6"
           tasks:
@@ -255,7 +255,7 @@ scenario:
           name: "Make one transfer from node6 to node0"
           tasks:
             - transfer: {from: 6, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node6 to node0"
           tasks:
@@ -265,7 +265,7 @@ scenario:
           name: "Make one transfer from node0 to node7"
           tasks:
             - transfer: {from: 0, to: 7, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node7"
           tasks:
@@ -275,7 +275,7 @@ scenario:
           name: "Make one transfer from node7 to node0"
           tasks:
             - transfer: {from: 7, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node7 to node0"
           tasks:
@@ -285,7 +285,7 @@ scenario:
           name: "Make one transfer from node0 to node8"
           tasks:
             - transfer: {from: 0, to: 8, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node8"
           tasks:
@@ -295,7 +295,7 @@ scenario:
           name: "Make one transfer from node8 to node0"
           tasks:
             - transfer: {from: 8, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node8 to node0"
           tasks:
@@ -305,7 +305,7 @@ scenario:
           name: "Make one transfer from node0 to node9"
           tasks:
             - transfer: {from: 0, to: 9, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node9"
           tasks:
@@ -315,7 +315,7 @@ scenario:
           name: "Make one transfer from node9 to node0"
           tasks:
             - transfer: {from: 9, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node9 to node0"
           tasks:
@@ -325,7 +325,7 @@ scenario:
           name: "Make one transfer from node0 to node10"
           tasks:
             - transfer: {from: 0, to: 10, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node10"
           tasks:
@@ -335,7 +335,7 @@ scenario:
           name: "Make one transfer from node10 to node0"
           tasks:
             - transfer: {from: 10, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node10 to node0"
           tasks:
@@ -345,7 +345,7 @@ scenario:
           name: "Make one transfer from node0 to node11"
           tasks:
             - transfer: {from: 0, to: 11, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node11"
           tasks:
@@ -355,7 +355,7 @@ scenario:
           name: "Make one transfer from node11 to node0"
           tasks:
             - transfer: {from: 11, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node11 to node0"
           tasks:
@@ -365,7 +365,7 @@ scenario:
           name: "Make one transfer from node0 to node12"
           tasks:
             - transfer: {from: 0, to: 12, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node12"
           tasks:
@@ -375,7 +375,7 @@ scenario:
           name: "Make one transfer from node12 to node0"
           tasks:
             - transfer: {from: 12, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node12 to node0"
           tasks:
@@ -385,7 +385,7 @@ scenario:
           name: "Make one transfer from node0 to node13"
           tasks:
             - transfer: {from: 0, to: 13, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node13"
           tasks:
@@ -395,7 +395,7 @@ scenario:
           name: "Make one transfer from node13 to node0"
           tasks:
             - transfer: {from: 13, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node13 to node0"
           tasks:
@@ -405,7 +405,7 @@ scenario:
           name: "Make one transfer from node0 to node14"
           tasks:
             - transfer: {from: 0, to: 14, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node0 to node14"
           tasks:
@@ -415,7 +415,7 @@ scenario:
           name: "Make one transfer from node14 to node0"
           tasks:
             - transfer: {from: 14, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-      - wait: 100
+      - wait: 30
       - parallel:
           name: "Assert after one transfer from node14 to node0"
           tasks:

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -93,7 +93,7 @@ scenario:
             # Perform a couple of more transfers
             - assert_pfs_history: {source: 0, request_count: 0}
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
-            - wait: 10
+            - wait: 30
             - assert_pfs_history: {source: 0, target: 3, request_count: 1}
             - assert_pfs_iou: {source: 0, amount: 100}
             - assert_pfs_iou: {source: 1, iou_exists: false}
@@ -101,7 +101,7 @@ scenario:
             - assert_pfs_iou: {source: 3, amount: 200}
 
             - transfer: {from: 2, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-            - wait: 10
+            - wait: 30
             - assert_pfs_history: {source: 2, target: 0, request_count: 1}
             - assert_pfs_iou: {source: 2, amount: 100}
 

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -61,7 +61,7 @@ scenario:
       - serial:
           name: "adding a wait before the asserts"
           tasks:
-            - wait: 60
+            - wait: 30
       - parallel:
           name: "Assert after opening and depositing"
           tasks:
@@ -85,7 +85,7 @@ scenario:
       - serial:
           name: "Assert after 100 payments from 0 to 3"
           tasks:
-            - wait: 10
+            - wait: 30
             - assert_sum: {from: 0, balance_sum: 500_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 3_500_000_000_000_000_000}
       - serial:


### PR DESCRIPTION
## Description

Reduce waits in scenarios.

- This improves runtime of all scenarios (in sequence) by 91mins
- It should be safe as we use `wait_blocks: 2` (which is max. 30s on goerli) in other scenarios for a while already
