### PR TITLE
We need to remove the whole check after #5770 [skip tests]

### DIFF
--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -199,13 +199,6 @@ scenario:
             - assert: {from: 0, to: 4, total_deposit: 10_000_000_000_000_000, balance: 10_000_000_000_000_000, state: "opened"}
             - assert: {from: 2, to: 4, total_deposit: 150_000_000_000_000_000, balance: 100_000_000_000_000_000, state: "opened"}
             - assert: {from: 4, to: 2, total_deposit: 0, balance: 50_000_000_000_000_000, state: "opened"}
-      - parallel:
-          name: "Check edge cases again"
-          tasks:
-            # Try to open a channel with an offline node, but the channel already exists, we will get a 200
-            - open_channel: {from: 0, to: 1, total_deposit: 200_000_000_000_000_000, expected_http_status: 200}
-            # Try to make a payment to an offline node
-            - transfer: {from: 0, to: 1, amount: 1_000_000_000_000_000, expected_http_status: 409, lock_timeout: 30}
       - serial:
           name: "Restarting node1"
           tasks:


### PR DESCRIPTION
## Description
The deposit is successful to the existing channel,
that messes with the numbers. Test cases already covered in api tests

Fixes: #5801

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
