### PR TITLE
Check exit code when stopping node (stress test)

### DIFF
--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -297,7 +297,9 @@ def kill_restart_and_wait_for_server(
 
     # Wait for the process to completely shutdown, this is necessary because
     # concurrent usage of the database is not allowed.
-    node.process.result.get()
+    exit_code = node.process.result.get()
+    if exit_code != 0:
+        raise Exception(f"Node did not shut down cleanly {node!r}")
 
     return start_and_wait_for_server(nursery, port_generator, node.config, retry_timeout)
 


### PR DESCRIPTION
Without this check, the greenlet will continue past that point and start
the new node even when the old one did not exit cleanly. When starting
the new node, a switch happens right after the Popen, before the new
process is tracked in the nursery. This causes the process to be left
over when the stress test script stops.

To debug and test this error case, I just added an exception during the
raiden shutdown, which show the above behaviour completely reproducibly.

See https://github.com/raiden-network/raiden/issues/5790.

[skip tests]

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
