### PR TITLE
increase settle timeout for MS scenarios [skip tests]

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -60,7 +60,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 40
+      - wait_blocks: 80
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -68,7 +68,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500, but we've already waited 400 blocks, leaving 100 blocks
+      ## Settlement timeout is 100, but we've already waited 80 blocks, leaving 20 blocks
       ## To make sure the transactions gets mined in time, 10 additional blocks are added
-      - wait_blocks: 10
+      - wait_blocks: 30
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: 100
     default-reveal-timeout: 20
 
 # This is the MS1 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -60,7 +60,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 80
+      - wait_blocks: 100
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -70,5 +70,5 @@ scenario:
       ## Monitored channel must be settled before the monitoring service can claim its reward
       ## Settlement timeout is 100, but we've already waited 80 blocks, leaving 20 blocks
       ## To make sure the transactions gets mined in time, 10 additional blocks are added
-      - wait_blocks: 30
+      - wait_blocks: 10
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -60,7 +60,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 40
+      - wait_blocks: 80
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -72,6 +72,6 @@ scenario:
       - start_node: 1
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## To make sure the transactions gets mined in time, 10 additional blocks are added
-      - wait_blocks: 5
+      ## To make sure the transactions gets mined in time, 20 additional blocks are added
+      - wait_blocks: 20
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: 100
     default-reveal-timeout: 20
 
 # This is the MS2 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -60,7 +60,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 80
+      - wait_blocks: 100
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -72,6 +72,6 @@ scenario:
       - start_node: 1
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## To make sure the transactions gets mined in time, 20 additional blocks are added
-      - wait_blocks: 20
+      ## To make sure the transactions gets mined in time, 10 additional blocks are added
+      - wait_blocks: 10
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -62,7 +62,7 @@ scenario:
 
       ## node1 gets back online before the MS reacts
       ## node1 should call updateNonClosingBalanceProof in this case and the MS wont react
-      - wait_blocks: 20
+      - wait_blocks: 10
       - start_node: 1
 
       ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 100 = 80
@@ -75,7 +75,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 100 blocks, but we already waited 40 blocks.
-      - wait_blocks: 60
+      ## Settlement timeout is 100 blocks, but we already waited 30 blocks.
+      - wait_blocks: 70
       # will fail for now since channel was closed by node1.
       - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -62,12 +62,12 @@ scenario:
 
       ## node1 gets back online before the MS reacts
       ## node1 should call updateNonClosingBalanceProof in this case and the MS wont react
-      - wait_blocks: 10
+      - wait_blocks: 20
       - start_node: 1
 
-      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 500 = 400
+      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 100 = 80
       ## But we just need to check for the event from node1 before the monitoring service reacts
-      - wait_blocks: 10
+      - wait_blocks: 20
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -75,7 +75,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 500 blocks, but we already waited 40 blocks.
-      - wait_blocks: 20
-      # will fail for now since channel was closed by node1. We should add functionality to assert a fail
+      ## Settlement timeout is 100 blocks, but we already waited 40 blocks.
+      - wait_blocks: 60
+      # will fail for now since channel was closed by node1.
       - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: 100
     default-reveal-timeout: 20
 
 # This is the MS3 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: 100
     default-reveal-timeout: 20
 
 ## This scenario tests that the MS does not kick in, if the node requesting monitoring does

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -83,7 +83,7 @@ scenario:
           name: "Wait for MS to not react"
           tasks:
             # The MS reacts within the settle_timeout
-            - wait_blocks: 40
+            - wait_blocks: 100
             # Note that 0 events are expected
             - assert_events:
                 contract_name: "TokenNetwork"
@@ -96,7 +96,7 @@ scenario:
           tasks:
             # Monitored channel must be settled before the monitoring service can claim its reward
             # To make sure the transactions gets mined in time, 10 additional blocks are added
-            - wait_blocks: 5
+            - wait_blocks: 20
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "NonClosingBalanceProofUpdated"


### PR DESCRIPTION
## Description

Fixes: https://github.com/raiden-network/raiden/issues/5818

This increases the `settlement_timeout` of the MS scenarios in order to make sure that the MS has time to kick in. We should keep in mind that this is just temporary until we are sure that the MS is fast enough to always react. Or alternatively, make the lowest allowed `settlement_timeout` higher in the contracts.