### PR TITLE
Increase waits in BF1 before assert_sum tasks [skip tests]

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -103,7 +103,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 3 to 0"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 0, balance_sum: 2_010_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 1_990_000_000_000_000_000}
       - serial:
@@ -114,7 +114,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 1 to 4"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 1, balance_sum: 1_990_000_000_000_000_000}
             - assert_sum: {from: 4, balance_sum: 2_010_000_000_000_000_000}
       - serial:
@@ -144,7 +144,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 2 to 4"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 2, balance_sum: 1_890_000_000_000_000_000}
             - assert_sum: {from: 4, balance_sum: 2_020_000_000_000_000_000}
       - serial:
@@ -155,7 +155,7 @@ scenario:
       - serial:
           name: "Assert after 5 payments from 0 to 2"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 2, balance_sum: 1_895_000_000_000_000_000}
             - assert_sum: {from: 0, balance_sum: 2_005_000_000_000_000_000}
       - parallel:
@@ -184,7 +184,7 @@ scenario:
       - serial:
           name: "Assert after 100 payments from 0 to 3"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 0, balance_sum: 1_905_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_090_000_000_000_000_000}
       - serial:
@@ -202,7 +202,7 @@ scenario:
       - serial:
           name: "Assert after 10 payments from 0 to 3"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 0, balance_sum: 1_895_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_100_000_000_000_000_000}
       - serial:
@@ -213,7 +213,7 @@ scenario:
       - serial:
           name: "Assert after 100 payments from 3 to 0"
           tasks:
-            - wait: 100
+            - wait: 300
             - assert_sum: {from: 0, balance_sum: 1_995_000_000_000_000_000}
             - assert_sum: {from: 3, balance_sum: 2_000_000_000_000_000_000}
       - serial:


### PR DESCRIPTION
Tonight the BF1 scenario failed because some `assert_sum` tasks failed. This increases the wait before.
