### PR TITLE
Allow whitelisting rooms in matrix sync filter

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -436,9 +436,7 @@ class MatrixTransport(Runnable):
         self._initialize_room_inventory()
         self._initialize_broadcast_rooms()
 
-        broadcast_filter_id = self._client.create_sync_filter(
-            broadcast_rooms=self._broadcast_rooms
-        )
+        broadcast_filter_id = self._client.create_sync_filter(not_rooms=self._broadcast_rooms)
         self._client.set_sync_filter_id(broadcast_filter_id)
 
         def on_success(greenlet: gevent.Greenlet) -> None:

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -251,11 +251,11 @@ def test_assumption_matrix_returns_same_id_for_same_filter_payload(chain_id, loc
     assert client._sync_filter_id is None
 
     first_sync_filter_id = client.create_sync_filter(
-        broadcast_rooms={broadcast_room.name: broadcast_room}
+        not_rooms={broadcast_room.name: broadcast_room}
     )
 
     # Try again and make sure the filter has the same ID
     second_sync_filter_id = client.create_sync_filter(
-        broadcast_rooms={broadcast_room.name: broadcast_room}
+        not_rooms={broadcast_room.name: broadcast_room}
     )
     assert first_sync_filter_id == second_sync_filter_id


### PR DESCRIPTION
This will be used in the services to only listen to the rooms we want

Ref.: https://github.com/raiden-network/raiden-services/issues/713

