### PR TITLE
Download all services logs, faster.

### DIFF
--- a/tools/debugging/extract_sp_exceptions.sh
+++ b/tools/debugging/extract_sp_exceptions.sh
@@ -40,7 +40,6 @@ else
 fi
 
 DESTINATION_DIR="$(realpath -s "${DESTINATION_DIR}")/$(date +%m-%d-%Y)"
-mkdir -p "$DESTINATION_DIR"
 
 function download_service_logs {
     sources=()
@@ -78,7 +77,7 @@ function download_server_logs {
 function search_for_failures {
     mkdir -p "${DESTINATION_DIR}/errors/"
     echo -e "${BOLD}Looking for failures${RESET}"
-    scenarios_dir="${DESTINATION_DIR}/scenarios"
+    scenarios_dir="${DESTINATION_DIR}"
 
     for scenario_dir in "${scenarios_dir}"/*; do
         scenario=$(basename "${scenario_dir}")
@@ -111,10 +110,15 @@ function search_for_failures {
     done;
 }
 
-print_bold "Downloading services logs"
-download_service_logs ms-goerli-backup.gz ms-goerli.gz msrc-goerli-backup.gz msrc-goerli.gz pfs-goerli-with-fee.gz pfs-goerli.gz
+[ ! -d "$DESTINATION_DIR" ] && {
+    mkdir -p "$DESTINATION_DIR"
 
-print_bold "Downloading scenarios list"
-download_server_logs $SCENARIO_REMOTE_URL_1
-download_server_logs $SCENARIO_REMOTE_URL_2
+    print_bold "Downloading services logs"
+    download_service_logs ms-goerli-backup.gz ms-goerli.gz msrc-goerli-backup.gz msrc-goerli.gz pfs-goerli-with-fee.gz pfs-goerli.gz
+
+    print_bold "Downloading scenarios list"
+    download_server_logs $SCENARIO_REMOTE_URL_1
+    download_server_logs $SCENARIO_REMOTE_URL_2
+}
+
 search_for_failures

--- a/tools/debugging/extract_sp_exceptions.sh
+++ b/tools/debugging/extract_sp_exceptions.sh
@@ -44,13 +44,13 @@ fi
 DESTINATION_DIR="$(realpath -s "${DESTINATION_DIR}")/$(date +%m-%d-%Y)"
 mkdir -p "$DESTINATION_DIR"
 
-function download_pfs_logs {
-    container=$1
-    ssh root@services-dev.raiden.network "cd raiden-services/deployment/; docker-compose logs ${container} | gzip" > "${DESTINATION_DIR}/${container}.log.gz"
-    if [[ $? -ne 0 ]]; then
-        echo "Error: failed to download pfs-goerli logs"
-        exit 1
-    fi
+function download_service_logs {
+    sources=()
+    for file in "$@"; do
+        sources+=("root@services-dev.raiden.network:/home/services/${file}")
+    done
+
+    scp "${sources[@]}" "${DESTINATION_DIR}"
 }
 
 function download_nodes_logs {
@@ -123,11 +123,8 @@ function search_for_failures {
 export -f download_pfs_logs
 export -f download_server_logs
 
-print_bold "Downloading PFS logs"
-
-download_pfs_logs pfs-goerli &
-download_pfs_logs pfs-goerli-with-fee &
-wait
+print_bold "Downloading services logs"
+download_service_logs ms-goerli-backup.gz ms-goerli.gz msrc-goerli-backup.gz msrc-goerli.gz pfs-goerli-with-fee.gz pfs-goerli.gz
 
 print_bold "Downloading scenarios list"
 download_server_logs $SCENARIO_REMOTE_URL_1


### PR DESCRIPTION
The run-nightlies script was changed to automatically compress the logs
of the services, this results in a significant shorter download time.
The logs of the MSs were also added, and now they can be downloaded with
a single `scp` command, which provides a nice progress bar.