### PR TITLE
Catch error when message is not a dictionary

### DIFF
--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -128,6 +128,9 @@ class MessageSerializer(SerializationBase):
         except (UnicodeDecodeError, JSONDecodeError) as ex:
             raise SerializationError(f"Can't decode invalid JSON: {data}") from ex
 
+        if not isinstance(decoded_json, dict):
+            raise SerializationError(f"JSON is not a dictionary: {data}")
+
         try:
             msg_type = decoded_json.pop("type")
         except KeyError as ex:

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -269,6 +269,13 @@ def test_encoding_and_decoding():
         assert deserialized == message
 
 
+def test_bad_messages():
+    "SerializationErrors should be raised on all kinds of wrong messages"
+    for message in ["{}", "[]", '"foo"', "123"]:
+        with pytest.raises(SerializationError):
+            MessageSerializer.deserialize(message)
+
+
 def test_message_identical() -> None:
     """ Will fail if the messages changed since the committed version
 


### PR DESCRIPTION
You should not be able to crash a raiden node by sending bogus data, so
this must raise a SerializationError and no other exception.

Closes https://github.com/raiden-network/raiden-services/issues/717.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
