### PR TITLE
We're where we were (fix typos) [skip tests]

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1016,7 +1016,7 @@ class MatrixTransport(Runnable):
             )
             return []
 
-        # rooms we created and invited user, or were invited specifically by them
+        # rooms we created and invited user, or we're invited specifically by them
         room_ids = self._get_room_ids_for_address(peer_address)
 
         if room.room_id not in room_ids:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -715,7 +715,7 @@ class RaidenService(Runnable):
 
         # For safety of the mediation the monitoring service must be updated
         # before the balance proof is sent. Otherwise a timing attack would be
-        # possible, were an attacker would mediate a transfer through a node,
+        # possible, where an attacker would mediate a transfer through a node,
         # and try to DoS it, with the expectation that the victim would
         # forward the payment, but wouldn't be able to send a transaction to
         # the blockchain nor update a MS.

--- a/raiden/tests/integration/api/utils.py
+++ b/raiden/tests/integration/api/utils.py
@@ -32,7 +32,7 @@ def create_api_server(raiden_app: App, port_number: int) -> APIServer:
     api_server.flask_app.config["SERVER_NAME"] = f"localhost:{port_number}"
     api_server.start()
 
-    # Fixes flaky test, were requests are done prior to the server initializing
+    # Fixes flaky test, where requests are done prior to the server initializing
     # the listening socket.
     # https://github.com/raiden-network/raiden/issues/389#issuecomment-305551563
     wait_for_listening_port(port_number)

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -266,7 +266,7 @@ def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
     raiden_network, restart_node, token_addresses, network_wait, number_of_nodes, retry_timeout
 ):
     """ A test case related to https://github.com/raiden-network/raiden/issues/4639
-    Where a node sends a withdraw transaction, is stopped before the transaction is completed.
+    where a node sends a withdraw transaction, is stopped before the transaction is completed.
     Meanwhile, the partner node closes the channel so when the stopped node is back up, it tries to
     execute the pending withdraw transaction and fails because the channel was closed.
     Expected behaviour: Channel closed state change should cancel a withdraw transaction.

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -207,7 +207,7 @@ def is_channel_usable_for_mediation(
     lower than the block gas limit constraints.
 
     The lock expiration has to be smaller than the channel's settlement window
-    because otherwise it is possible to employ attacks. Where an attacker open
+    because otherwise it is possible to employ attacks, where an attacker opens
     two channels to the victim, with different settlement windows. The channel
     with lower settlement is used to start a payment to the other channel, if
     the lock's expiration is allowed to be larger than the settlement window,

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -48,7 +48,7 @@ WAIT_FOR_SOCKET_TO_BE_AVAILABLE = 60
 # restore the channel state.
 PartialTransferPlan = Iterator[Amount]
 
-# A transfer plan is a list of transfer amounts were every transfer WILL be
+# A transfer plan is a list of transfer amounts where every transfer WILL be
 # **successfully** executed and the channels restored to their initial state.
 TransferPlan = Iterator[Amount]
 


### PR DESCRIPTION
## Description

Fixes a number of typos in lines that match `/wh?e.?re/i`.