### PR TITLE
Skip flaky 'test_token_registered_race' [skip tests]

### DIFF
--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -143,6 +143,7 @@ def test_register_token_insufficient_eth(raiden_network, retry_timeout, unregist
         )
 
 
+@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5744")
 @raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_nodes", [2])


### PR DESCRIPTION
Skipping the test, the fix is tracked by https://github.com/raiden-network/raiden/issues/5744