### PR TITLE
Approve with minimal critical section

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -839,11 +839,20 @@ class TokenNetwork:
             except BadFunctionCallOutput:
                 raise_on_call_returned_empty(given_block_identifier)
             else:
+                if preconditions_data.channel_identifier is None:
+                    msg = (
+                        f"There is no channel open between "
+                        f"{to_checksum_address(self.node_address)} and "
+                        f"{to_checksum_address(partner)} with the channel identifier "
+                        f"{channel_identifier}."
+                    )
+                    raise BrokenPreconditionError(msg)
+
                 if preconditions_data.channel_identifier != channel_identifier:
                     msg = (
                         f"There is a channel open between "
                         f"{to_checksum_address(self.node_address)} and "
-                        f"{to_checksum_address(partner)}. However the channel id "
+                        f"{to_checksum_address(partner)}. However the channel identifier "
                         f"on-chain {preconditions_data.channel_identifier} and the provided "
                         f"id {channel_identifier} do not match."
                     )
@@ -883,10 +892,11 @@ class TokenNetwork:
                     )
                     raise BrokenPreconditionError(msg)
 
-                if (
+                is_over_token_network_limit = (
                     preconditions_data.network_total_deposit + amount_to_deposit
                     > preconditions_data.token_network_deposit_limit
-                ):
+                )
+                if is_over_token_network_limit:
                     msg = (
                         f"Deposit of {amount_to_deposit} will have "
                         f"exceeded the token network deposit limit."

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -418,7 +418,12 @@ class UserDeposit:
             # Wait until the node processes the approve transaction, this is
             # necessary because the `setTotalDeposit` transaction depends on
             # the side-effects of `approve` to work.
-            self.client.wait_for_transaction(approve.transaction_hash)
+            #
+            # Here, it is necessary to wait for the transaction to be mined and
+            # confirmed. See test
+            # `test_estimate_gas_for_dependent_transactions_needs_a_mined_transaction`
+            # for more details.
+            approve.poll(token)
 
             gas_limit = self.proxy.estimate_gas(
                 checking_block, "deposit", beneficiary, total_deposit
@@ -431,8 +436,6 @@ class UserDeposit:
                 transaction_hash = self.proxy.transact(
                     "deposit", gas_limit, beneficiary, total_deposit
                 )
-
-        approve.poll(token)
 
         if transaction_hash:
             receipt = self.client.poll(transaction_hash)

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -287,7 +287,7 @@ class UserDeposit:
         # we have enough capacity for both, we acquire the lock
         # for the token proxy. Example: A user deposit and a channel deposit
         # for the same token.
-        with self.deposit_lock, token.token_lock:
+        with self.deposit_lock:
             # check preconditions
             try:
                 previous_total_deposit = self.get_total_deposit(
@@ -372,80 +372,24 @@ class UserDeposit:
         amount_to_deposit: TokenAmount,
         log_details: Dict[str, Any],
     ) -> None:
-        token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
-
-        checking_block = self.client.get_checking_block()
-        gas_limit = self.proxy.estimate_gas(checking_block, "deposit", beneficiary, total_deposit)
-
-        if not gas_limit:
-            failed_at = self.proxy.rpc_client.get_block("latest")
-            failed_at_blocknumber = failed_at["number"]
-
-            self.proxy.rpc_client.check_for_insufficient_eth(
-                transaction_name="deposit",
-                transaction_executed=False,
-                required_gas=self.gas_measurements["UserDeposit.deposit"],
-                block_identifier=failed_at_blocknumber,
+        with token.approve_transaction(
+            allowed_address=Address(self.address), allowance=amount_to_deposit
+        ) as pending_approve:
+            checking_block = self.client.get_checking_block()
+            gas_limit = self.proxy.estimate_gas(
+                checking_block, "deposit", beneficiary, total_deposit
             )
 
-            latest_deposit = self.get_total_deposit(
-                address=self.node_address, block_identifier=failed_at_blocknumber
-            )
-            amount_to_deposit = TokenAmount(total_deposit - latest_deposit)
+            if not gas_limit:
+                failed_at = self.proxy.rpc_client.get_block("latest")
+                failed_at_blocknumber = failed_at["number"]
 
-            allowance = token.allowance(
-                owner=self.node_address,
-                spender=Address(self.address),
-                block_identifier=failed_at_blocknumber,
-            )
-            whole_balance = self.whole_balance(block_identifier=failed_at_blocknumber)
-            whole_balance_limit = self.whole_balance_limit(block_identifier=failed_at_blocknumber)
-
-            if allowance < amount_to_deposit:
-                msg = (
-                    "The allowance is insufficient. Check concurrent deposits "
-                    "for the same user deposit but different proxies."
+                self.proxy.rpc_client.check_for_insufficient_eth(
+                    transaction_name="deposit",
+                    transaction_executed=False,
+                    required_gas=self.gas_measurements["UserDeposit.deposit"],
+                    block_identifier=failed_at_blocknumber,
                 )
-                raise RaidenRecoverableError(msg)
-
-            if token.balance_of(self.node_address, failed_at_blocknumber) < amount_to_deposit:
-                msg = "The address doesnt have enough tokens"
-                raise RaidenRecoverableError(msg)
-
-            if latest_deposit < total_deposit:
-                msg = "Deposit amount did not increase after deposit transaction"
-                raise RaidenRecoverableError(msg)
-
-            if whole_balance + amount_to_deposit > UINT256_MAX:
-                msg = (
-                    f"Current whole balance is {whole_balance}. "
-                    f"The new deposit of {amount_to_deposit} would lead to an overflow."
-                )
-                raise RaidenRecoverableError(msg)
-
-            if whole_balance + amount_to_deposit > whole_balance_limit:
-                msg = (
-                    f"Current whole balance is {whole_balance}. "
-                    f"With the new deposit of {amount_to_deposit}, the deposit "
-                    f"limit of {whole_balance_limit} would be exceeded."
-                )
-                raise RaidenRecoverableError(msg)
-
-            raise RaidenRecoverableError("Deposit failed of unknown reason")
-
-        else:
-            gas_limit = safe_gas_limit(gas_limit)
-            log_details["gas_limit"] = gas_limit
-
-            transaction_hash = self.proxy.transact(
-                "deposit", gas_limit, beneficiary, total_deposit
-            )
-
-            receipt = self.client.poll(transaction_hash)
-            failed_receipt = check_transaction_threw(receipt=receipt)
-
-            if failed_receipt:
-                failed_at_blocknumber = failed_receipt["blockNumber"]
 
                 latest_deposit = self.get_total_deposit(
                     address=self.node_address, block_identifier=failed_at_blocknumber
@@ -457,37 +401,30 @@ class UserDeposit:
                     spender=Address(self.address),
                     block_identifier=failed_at_blocknumber,
                 )
-
                 whole_balance = self.whole_balance(block_identifier=failed_at_blocknumber)
                 whole_balance_limit = self.whole_balance_limit(
                     block_identifier=failed_at_blocknumber
                 )
 
-                if latest_deposit >= total_deposit:
-                    msg = "Deposit amount already increased after another transaction"
-                    raise RaidenRecoverableError(msg)
-
                 if allowance < amount_to_deposit:
                     msg = (
                         "The allowance is insufficient. Check concurrent deposits "
-                        "for the same token network but different proxies."
+                        "for the same user deposit but different proxies."
                     )
                     raise RaidenRecoverableError(msg)
 
-                # Because we acquired the lock for the token, and the gas estimation succeeded,
-                # We know that the account had enough balance for the deposit transaction.
                 if token.balance_of(self.node_address, failed_at_blocknumber) < amount_to_deposit:
-                    msg = (
-                        f"Transaction failed and balance decreased unexpectedly. "
-                        f"This could be a bug in Raiden or a mallicious "
-                        f"ERC20 Token."
-                    )
+                    msg = "The address doesnt have enough tokens"
+                    raise RaidenRecoverableError(msg)
+
+                if latest_deposit < total_deposit:
+                    msg = "Deposit amount did not increase after deposit transaction"
                     raise RaidenRecoverableError(msg)
 
                 if whole_balance + amount_to_deposit > UINT256_MAX:
                     msg = (
                         f"Current whole balance is {whole_balance}. "
-                        f"The new deposit of {amount_to_deposit} caused an overflow."
+                        f"The new deposit of {amount_to_deposit} would lead to an overflow."
                     )
                     raise RaidenRecoverableError(msg)
 
@@ -495,12 +432,84 @@ class UserDeposit:
                     msg = (
                         f"Current whole balance is {whole_balance}. "
                         f"With the new deposit of {amount_to_deposit}, the deposit "
-                        f"limit of {whole_balance_limit} was exceeded."
+                        f"limit of {whole_balance_limit} would be exceeded."
                     )
                     raise RaidenRecoverableError(msg)
 
-                if latest_deposit < total_deposit:
-                    msg = "Deposit amount did not increase after deposit transaction"
-                    raise RaidenRecoverableError(msg)
-
                 raise RaidenRecoverableError("Deposit failed of unknown reason")
+
+            else:
+                gas_limit = safe_gas_limit(gas_limit)
+                log_details["gas_limit"] = gas_limit
+
+                pending_approve.send(token.proxy)
+                transaction_hash = self.proxy.transact(
+                    "deposit", gas_limit, beneficiary, total_deposit
+                )
+
+                receipt = self.client.poll(transaction_hash)
+                failed_receipt = check_transaction_threw(receipt=receipt)
+
+                if failed_receipt:
+                    failed_at_blocknumber = failed_receipt["blockNumber"]
+
+                    latest_deposit = self.get_total_deposit(
+                        address=self.node_address, block_identifier=failed_at_blocknumber
+                    )
+                    amount_to_deposit = TokenAmount(total_deposit - latest_deposit)
+
+                    allowance = token.allowance(
+                        owner=self.node_address,
+                        spender=Address(self.address),
+                        block_identifier=failed_at_blocknumber,
+                    )
+
+                    whole_balance = self.whole_balance(block_identifier=failed_at_blocknumber)
+                    whole_balance_limit = self.whole_balance_limit(
+                        block_identifier=failed_at_blocknumber
+                    )
+
+                    if latest_deposit >= total_deposit:
+                        msg = "Deposit amount already increased after another transaction"
+                        raise RaidenRecoverableError(msg)
+
+                    if allowance < amount_to_deposit:
+                        msg = (
+                            "The allowance is insufficient. Check concurrent deposits "
+                            "for the same token network but different proxies."
+                        )
+                        raise RaidenRecoverableError(msg)
+
+                    # Because we acquired the lock for the token, and the gas estimation succeeded,
+                    # We know that the account had enough balance for the deposit transaction.
+                    if (
+                        token.balance_of(self.node_address, failed_at_blocknumber)
+                        < amount_to_deposit
+                    ):
+                        msg = (
+                            f"Transaction failed and balance decreased unexpectedly. "
+                            f"This could be a bug in Raiden or a mallicious "
+                            f"ERC20 Token."
+                        )
+                        raise RaidenRecoverableError(msg)
+
+                    if whole_balance + amount_to_deposit > UINT256_MAX:
+                        msg = (
+                            f"Current whole balance is {whole_balance}. "
+                            f"The new deposit of {amount_to_deposit} caused an overflow."
+                        )
+                        raise RaidenRecoverableError(msg)
+
+                    if whole_balance + amount_to_deposit > whole_balance_limit:
+                        msg = (
+                            f"Current whole balance is {whole_balance}. "
+                            f"With the new deposit of {amount_to_deposit}, the deposit "
+                            f"limit of {whole_balance_limit} was exceeded."
+                        )
+                        raise RaidenRecoverableError(msg)
+
+                    if latest_deposit < total_deposit:
+                        msg = "Deposit amount did not increase after deposit transaction"
+                        raise RaidenRecoverableError(msg)
+
+                    raise RaidenRecoverableError("Deposit failed of unknown reason")

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -651,7 +651,7 @@ class JSONRPCClient:
         transaction = None
         while not transaction:
             transaction = self.web3.eth.getTransaction(transaction_hash)
-            gevent.sleep(1.0)
+            gevent.sleep(0.1)
 
     def poll(self, transaction_hash: TransactionHash) -> Dict[str, Any]:
         """ Wait until the `transaction_hash` is mined, confirmed, handling

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -638,6 +638,21 @@ class JSONRPCClient:
             receipt,
         )
 
+    def wait_for_transaction(self, transaction_hash: bytes) -> Dict[str, Any]:
+        """ Wait until the `transaction_hash` is available in the client's
+        pool.
+
+        Could return None for a short period of time, until the transaction is
+        added to the pool
+        """
+        if len(transaction_hash) != 32:
+            raise ValueError("transaction_hash must be a 32 byte hash")
+
+        transaction = None
+        while not transaction:
+            transaction = self.web3.eth.getTransaction(transaction_hash)
+            gevent.sleep(1.0)
+
     def poll(self, transaction_hash: TransactionHash) -> Dict[str, Any]:
         """ Wait until the `transaction_hash` is mined, confirmed, handling
         reorgs.

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -1,13 +1,14 @@
 import pytest
 
 from raiden.constants import RECEIPT_FAILURE_CODE
+from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 from raiden.utils.formatting import to_checksum_address
 
 SSTORE_COST = 20000
 
 
-def test_estimate_gas_fail(deploy_client):
+def test_estimate_gas_fail(deploy_client: JSONRPCClient) -> None:
     """ A JSON RPC estimate gas call for a throwing transaction returns None"""
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
@@ -23,9 +24,11 @@ def test_estimate_gas_fail(deploy_client):
     assert contract_proxy.estimate_gas(check_block, "fail_require") is None, msg
 
 
-def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(deploy_client):
+def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(
+    deploy_client: JSONRPCClient,
+) -> None:
     """ Gas estimation fails if the transaction execution requires more gas
-    then the block's gas limit.
+    than the block's gas limit.
     """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
 
@@ -48,7 +51,7 @@ def test_estimate_gas_fails_if_startgas_is_higher_than_blockgaslimit(deploy_clie
 
 
 @pytest.mark.xfail(reason="The pending block is not taken into consideration")
-def test_estimate_gas_defaults_to_pending(deploy_client):
+def test_estimate_gas_defaults_to_pending(deploy_client: JSONRPCClient) -> None:
     """Estimating gas without an explicit block identifier always return an
     usable value.
 
@@ -77,3 +80,41 @@ def test_estimate_gas_defaults_to_pending(deploy_client):
     assert second_receipt["gasLimit"] < deploy_client.get_block("latest")["gasLimit"]
     assert first_receipt["status"] != RECEIPT_FAILURE_CODE
     assert second_receipt["status"] != RECEIPT_FAILURE_CODE
+
+
+def test_estimate_gas_for_dependent_transactions_needs_a_mined_transaction(
+    deploy_client: JSONRPCClient,
+) -> None:
+    """Gas estimation for a transaction that depends on another works afte
+    eth_getTransaction returns a valid value.
+
+    This test makes sure that consecutive transactions which depends on the
+    changes from pending ones can have their gas estimate after
+    `eth_getTransaction` returns. This assumption is important for the fast
+    handling of `approve` and `setTotalDeposit` transactions, where the
+    `setTotalDeposit` needs the result of an estimate_gas just after sending an
+    approve transaction.
+    """
+    contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
+
+    next_counter = 0
+    iterations = 100
+
+    # Do enough transactions so that they won't fit in a single block.
+    for _ in range(20):
+        next_counter += 1
+
+        gaslimit = contract_proxy.estimate_gas("pending", "next", next_counter, iterations)
+        msg = (
+            "gas estimation should not have failed, this means the side-effects "
+            "of the previous transaction have not been accounted for and the "
+            "strategy of polling is not sufficient to avoid race conditins."
+        )
+        assert gaslimit, msg
+
+        tx = contract_proxy.transact("next", gaslimit, next_counter, iterations)
+
+        # Neither `eth_getTransaction` and `eth_pendingTransactions` are
+        # sufficient here, it still possible to have race conditoins with both
+        # of these RPC calls.
+        deploy_client.poll(tx)

--- a/raiden/tests/smart_contracts/RpcWithStorageTest.sol
+++ b/raiden/tests/smart_contracts/RpcWithStorageTest.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.4;
 
 contract RpcWithStorageTest {
+    uint256 current_counter;
     uint256[] data;
 
     event RpcEvent(
@@ -37,5 +38,17 @@ contract RpcWithStorageTest {
             data[data.length++] = i;
         }
         emit RpcEvent(i);
+    }
+
+    function next(uint256 next_counter, uint256 iterations) public {
+        assert(current_counter + 1 == next_counter);
+
+        uint256 i;
+
+        for (i=0; i<iterations; i++) {
+            data[data.length++] = i;
+        }
+
+        current_counter = next_counter;
     }
 }

--- a/tools/transfer_eth.py
+++ b/tools/transfer_eth.py
@@ -44,9 +44,9 @@ def main(keystore_file, password, rpc_url, eth_amount, targets_file) -> None:
 
     print("Sending {} eth to:".format(eth_amount))
 
-    slot = client.get_next_transaction()
     for target in targets:
         print("  - {}".format(target))
+        slot = client.get_next_transaction()
         slot.send_transaction(to=target, startgas=21000, value=eth_amount * WEI_TO_ETH)
 
 


### PR DESCRIPTION
Reduce the critical section were the token's approve lock is acquired, this is currently increasing latency of the fixture setup which make the setup of every test and scenario run slower.