### PR TITLE
Use raiden user agent string

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -133,6 +133,7 @@ class GMatrixHttpApi(MatrixHttpApi):
         retry_timeout: int = 60,
         retry_delay: Callable[[], Iterable[float]] = None,
         long_paths: Container[str] = (),
+        user_agent: str = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -144,6 +145,8 @@ class GMatrixHttpApi(MatrixHttpApi):
         self.session.mount("http://", http_adapter)
         self.session.mount("https://", https_adapter)
         self.session.hooks["response"].append(self._record_server_ident)
+        if user_agent:
+            self.session.headers.update({"User-Agent": user_agent})
 
         self._long_paths = long_paths
         if long_paths:
@@ -222,6 +225,7 @@ class GMatrixClient(MatrixClient):
         http_retry_timeout: int = 60,
         http_retry_delay: Callable[[], Iterable[float]] = lambda: repeat(1),
         environment: Environment = Environment.PRODUCTION,
+        user_agent: str = None,
     ) -> None:
 
         self.token: Optional[str] = None
@@ -240,6 +244,7 @@ class GMatrixClient(MatrixClient):
             retry_timeout=http_retry_timeout,
             retry_delay=http_retry_delay,
             long_paths=("/sync",),
+            user_agent=user_agent,
         )
         self.api.validate_certificate(valid_cert_check)
         self.synced = gevent.event.Event()  # Set at the end of every sync, then cleared

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import gevent
+import pkg_resources
 import structlog
 from eth_utils import is_binary_address, to_normalized_address
 from gevent.event import Event
@@ -14,6 +15,7 @@ from gevent.pool import Pool
 from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixHttpLibError, MatrixRequestError
 
+import raiden
 from raiden.constants import EMPTY_SIGNATURE, MATRIX_AUTO_SELECT_SERVER, Environment
 from raiden.exceptions import RaidenUnrecoverableError, TransportError
 from raiden.messages.abstract import Message, RetrieableMessage, SignedRetrieableMessage
@@ -335,6 +337,7 @@ class MatrixTransport(Runnable):
                 self._config.retry_interval_max,
             )
 
+        version = pkg_resources.require(raiden.__name__)[0].version
         self._client: GMatrixClient = make_client(
             self._handle_sync_messages,
             available_servers,
@@ -342,6 +345,7 @@ class MatrixTransport(Runnable):
             http_retry_timeout=40,
             http_retry_delay=_http_retry_delay,
             environment=environment,
+            user_agent=f"Raiden {version}",
         )
         self._server_url = self._client.api.base_url
         self._server_name = urlparse(self._server_url).netloc


### PR DESCRIPTION
Matrix requests will now use "Raiden" followed by the version number as
user agent string. This provides additional context when debugging and
is generally good behavior.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
