### PR TITLE
Revert "Optimization: Healthcheck should be a noop on the second call"

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -570,8 +570,8 @@ class MatrixTransport(Runnable):
         self._address_mgr.add_address(address)
 
         # Start the room creation early on. This reduces latency for channel
-        # partners, by removing the latency of creating the room on the first
-        # message.
+        # partners, because by removing the latency of creating the room on the
+        # first message.
         #
         # This does not reduce latency for target<->initiator communication,
         # since the target may be the node with lower address, and therefore
@@ -606,10 +606,15 @@ class MatrixTransport(Runnable):
         It also whitelists the address to answer invites and listen for messages
         """
         self.whitelist(node_address)
+        node_address_hex = to_normalized_address(node_address)
         self.log.debug("Healthcheck", peer_address=to_checksum_address(node_address))
 
-        user_ids = self.get_user_ids_for_address(node_address)
+        candidates = self._client.search_user_directory(node_address_hex)
+        self._displayname_cache.warm_users(candidates)
 
+        user_ids = {
+            user.user_id for user in candidates if validate_userid_signature(user) == node_address
+        }
         # Ensure network state is updated in case we already know about the user presences
         # representing the target node
         self._address_mgr.track_address_presence(node_address, user_ids)

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -603,21 +603,16 @@ class MatrixTransport(Runnable):
     def immediate_health_check_for(self, node_address: Address) -> None:
         """Start healthcheck (status monitoring) for a peer
 
-        It also whitelists the address to answer invites and listen for messages.
+        It also whitelists the address to answer invites and listen for messages
         """
-        if self._address_mgr.is_address_known(node_address):
-            self.log.debug(
-                "Healthcheck already enabled", peer_address=to_checksum_address(node_address)
-            )
-        else:
-            self.log.debug("Healthcheck", peer_address=to_checksum_address(node_address))
+        self.whitelist(node_address)
+        self.log.debug("Healthcheck", peer_address=to_checksum_address(node_address))
 
-            self.whitelist(node_address)
+        user_ids = self.get_user_ids_for_address(node_address)
 
-            # Ensure network state is updated in case we already know about the user presences
-            # representing the target node
-            user_ids = self.get_user_ids_for_address(node_address)
-            self._address_mgr.track_address_presence(node_address, user_ids)
+        # Ensure network state is updated in case we already know about the user presences
+        # representing the target node
+        self._address_mgr.track_address_presence(node_address, user_ids)
 
     def _health_check_worker(self) -> None:
         """ Worker to process healthcheck requests. """


### PR DESCRIPTION
This PR seems to have introduce a lot of flakiness to the tests. Reverts raiden-network/raiden#5782