### PR TITLE
Remove nightly docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,16 +648,6 @@ jobs:
           command: |
             twine upload -u $PYPI_USER -p $PYPI_PASSWORD dist/*.{tar.gz,whl}
 
-  build-nightly-image:
-    executor:
-      name: docker
-
-    steps:
-      - run:
-          name: Trigger nightly automated build on Docker Hub.
-          command: >
-            curl -H "Content-Type: application/json" --data '{"docker_tag":"nightly"}' -X POST ${NIGHTLY_BUILD_TRIGGER}
-
 workflows:
   raiden-default:
     jobs:
@@ -1004,11 +994,6 @@ workflows:
           architecture: "aarch64"
           requires:
             - finalize
-
-      - build-nightly-image:
-          requires:
-            - finalize
-            - prepare-python-linux-3.7
 
       - prepare-system-macos:
           requires:


### PR DESCRIPTION
This is already done by after each commit in the tag `latest` and it didn't work either.

Part of https://github.com/raiden-network/raiden/issues/5737