### PR TITLE
Assumption test for estimate gas on depend transactions

### DIFF
--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -74,8 +74,11 @@ def web3(
 @pytest.fixture
 def deploy_client(deploy_key, web3, blockchain_type):
     if blockchain_type == "parity":
-        return JSONRPCClient(web3, deploy_key, gas_estimate_correction=lambda gas: 2 * gas)
-    return JSONRPCClient(web3, deploy_key)
+        return JSONRPCClient(
+            web3=web3, privkey=deploy_key, gas_estimate_correction=lambda gas: 2 * gas
+        )
+
+    return JSONRPCClient(web3=web3, privkey=deploy_key)
 
 
 @pytest.fixture

--- a/raiden/tests/smart_contracts/RpcWithStorageTest.sol
+++ b/raiden/tests/smart_contracts/RpcWithStorageTest.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.3;
 
 contract RpcWithStorageTest {
+    uint256 current_counter;
     uint256[] data;
 
     event RpcEvent(
@@ -34,5 +35,17 @@ contract RpcWithStorageTest {
             data.push(i);
         }
         emit RpcEvent(i);
+    }
+
+    function next(uint256 next_counter, uint256 iterations) public {
+        assert(current_counter + 1 == next_counter);
+
+        uint256 i;
+
+        for (i=0; i<iterations; i++) {
+            data.push(i);
+        }
+
+        current_counter = next_counter;
     }
 }


### PR DESCRIPTION
A reliable strategy is necessary to avoid race conditions on
approve+setTotalDeposit. Polling for the transaction to be mined seems
to be the only reliable way the test could pass