### PR TITLE
Remove Concept of Whitelisting

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -458,7 +458,7 @@ class RaidenService(Runnable):
             node=to_checksum_address(self.address),
         )
 
-        self.transport.start(raiden_service=self, prev_auth_data=None, whitelist=whitelist)
+        self.transport.start(raiden_service=self, prev_auth_data=None, health_check_list=whitelist)
 
         for neighbour in views.all_neighbour_nodes(chain_state):
             if neighbour != ConnectionManager.BOOTSTRAP_ADDR:


### PR DESCRIPTION
## Description

We had two separate concepts of whitelisting and health_checking addresses. These concepts are quite similar and had to coexist. By recent optimizations it is not necessary anymore to keep the difference between the two of them. We can now merge it together and just call it healthchecking. We only healthcheck users of interest and "whitelist" them therefor. The UserAddressManager keeps this information about known nodes. 



Fixes: #5858 
