### PR TITLE
Use block timeouts in integration tests

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -38,7 +38,7 @@ from raiden.tests.utils.events import check_dict_nested_attrs, must_have_event, 
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import WaitForMessage
 from raiden.tests.utils.smartcontracts import deploy_contract_web3
-from raiden.tests.utils.transfer import watch_for_unlock_failures
+from raiden.tests.utils.transfer import block_offset_timeout, watch_for_unlock_failures
 from raiden.transfer import views
 from raiden.transfer.mediated_transfer.initiator import calculate_fee_margin
 from raiden.transfer.state import ChannelState
@@ -2110,7 +2110,6 @@ def test_payment_events_endpoints(
         json={"amount": str(amount1), "identifier": str(identifier1), "secret": to_hex(secret1)},
     )
     request.send()
-
     # app0 is sending some tokens to target 2
     identifier2 = PaymentID(43)
     amount2 = PaymentAmount(10)
@@ -2141,10 +2140,10 @@ def test_payment_events_endpoints(
     )
     request.send()
 
-    exception = ValueError("Waiting for transfer received success in the WAL timed out")
-    with watch_for_unlock_failures(*raiden_network), gevent.Timeout(
-        seconds=60, exception=exception
-    ):
+    timeout = block_offset_timeout(
+        app2.raiden, "Waiting for transfer received success in the WAL timed out"
+    )
+    with watch_for_unlock_failures(*raiden_network), timeout:
         result = wait_for_received_transfer_result(
             app1.raiden, identifier1, amount1, app1.raiden.alarm.sleep_time, secrethash1
         )

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -23,6 +23,7 @@ from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.protocol import HoldRaidenEventHandler
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
+    block_offset_timeout,
     get_channelstate,
     watch_for_unlock_failures,
 )
@@ -441,7 +442,7 @@ def test_secret_revealed_on_chain(
         secret=secret,
     )
 
-    with watch_for_unlock_failures(*raiden_chain), gevent.Timeout(10):
+    with watch_for_unlock_failures(*raiden_chain), block_offset_timeout(app0.raiden):
         wait_for_state_change(
             app2.raiden, ReceiveSecretReveal, {"secrethash": secrethash}, retry_interval_initial
         )
@@ -557,8 +558,7 @@ def test_clear_closed_queue(raiden_network: List[App], token_addresses, network_
     # A ChannelClose event will be generated, this will be polled by both apps
     RaidenAPI(app0.raiden).channel_close(registry_address, token_address, app1.raiden.address)
 
-    exception = ValueError("Could not get close event")
-    with gevent.Timeout(seconds=30, exception=exception):
+    with block_offset_timeout(app0.raiden, "Could not get close event"):
         waiting.wait_for_close(
             app0.raiden,
             registry_address,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -550,8 +550,7 @@ def test_channel_withdraw_expired(
     wait_for_unlock = bob_app.raiden.message_handler.wait_for_message(
         Unlock, {"payment_identifier": identifier}
     )
-    transfer_timeout = block_offset_timeout(alice_app.raiden)
-    with transfer_timeout:
+    with block_offset_timeout(alice_app.raiden):
         wait_for_unlock.get()
         msg = (
             f"transfer from {to_checksum_address(alice_app.raiden.address)} "
@@ -566,7 +565,7 @@ def test_channel_withdraw_expired(
         total_withdraw=total_withdraw,
     )
 
-    with transfer_timeout:
+    with block_offset_timeout(bob_app.raiden):
         send_withdraw_confirmation_event.wait()
 
     # Make sure proper withdraw state is set in both channel states

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -118,9 +118,8 @@ def test_send_queued_messages_after_restart(  # pylint: disable=unused-argument
         msg = "The secrethashes of the pending transfers must be in the queue after a restart."
         assert secrethash in chain_state.payment_mapping.secrethashes_to_task, msg
 
-    timeout = block_offset_timeout(app1.raiden)
+    timeout = block_offset_timeout(app1.raiden, "Timeout waiting for balance update of app0")
     with watch_for_unlock_failures(*raiden_network), timeout:
-        timeout.exception_to_throw = ValueError("Timeout waiting for balance update of app0")
         waiting.wait_for_payment_balance(
             raiden=app0_restart.raiden,
             token_network_registry_address=token_network_registry_address,


### PR DESCRIPTION
Many integration tests have ad-hoc timeouts of 10 or 30 seconds when waiting for transfer-related events, so they may become flaky in case of performance issues. So we replace these timeouts with `BlockTimeout`s and wait until the settle_timeout of the channel in question.

Follow-up to #4579
Fixes #4524