### PR TITLE
Reduce critical section of approve

### DIFF
--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -748,7 +748,7 @@ class TokenNetwork:
         # approve + deposit + deposit`, since the second approve will overwrite
         # the first and at least one of the deposits will fail. Because of
         # this, the allowance can not change until the deposit is done.
-        with self.channel_operations_lock[partner], self.token.token_lock:
+        with self.channel_operations_lock[partner]:
             try:
                 queried_channel_identifier = self.get_channel_identifier_or_none(
                     participant1=self.node_address,
@@ -915,33 +915,37 @@ class TokenNetwork:
         # in which case the second `approve` will overwrite the first,
         # and the first `setTotalDeposit` will consume the allowance,
         # making the second deposit fail.
-        self.token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
+        transaction_hash = None
+        with self.token.token_lock:
+            self.token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
 
-        gas_limit = self.client.estimate_gas(
-            self.proxy,
-            checking_block,
-            "setTotalDeposit",
-            channel_identifier=channel_identifier,
-            participant=self.node_address,
-            total_deposit=total_deposit,
-            partner=partner,
-        )
-
-        if gas_limit:
-            gas_limit = safe_gas_limit(
-                gas_limit, self.metadata.gas_measurements["TokenNetwork.setTotalDeposit"]
-            )
-            log_details["gas_limit"] = gas_limit
-
-            transaction_hash = self.client.transact(
+            gas_limit = self.client.estimate_gas(
                 self.proxy,
+                checking_block,
                 "setTotalDeposit",
-                gas_limit,
                 channel_identifier=channel_identifier,
                 participant=self.node_address,
                 total_deposit=total_deposit,
                 partner=partner,
             )
+
+            if gas_limit:
+                gas_limit = safe_gas_limit(
+                    gas_limit, self.metadata.gas_measurements["TokenNetwork.setTotalDeposit"]
+                )
+                log_details["gas_limit"] = gas_limit
+
+                transaction_hash = self.proxy.transact(
+                    self.proxy,
+                    "setTotalDeposit",
+                    gas_limit,
+                    channel_identifier=channel_identifier,
+                    participant=self.node_address,
+                    total_deposit=total_deposit,
+                    partner=partner,
+                )
+
+        if transaction_hash:
             receipt = self.client.poll(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -917,7 +917,15 @@ class TokenNetwork:
         # making the second deposit fail.
         transaction_hash = None
         with self.token.token_lock:
-            self.token.approve(allowed_address=Address(self.address), allowance=amount_to_deposit)
+            # HACK: The hack bellow is necessary to make sure the gas
+            # estimation of an approve works concurrently with the mining of a
+            # deposit. If the *exact* amount is used, the storage of the smart
+            # contract will be set to `0` once the `deposit` is mined, this
+            # means the gas estimation of the concurrent `approve` will be mis
+            # by the 20_000 required by the `SSTORE` to change the value from
+            # `0`.
+            allowance = TokenAmount(amount_to_deposit + 1)
+            self.token.approve(allowed_address=Address(self.address), allowance=allowance)
 
             gas_limit = self.client.estimate_gas(
                 self.proxy,
@@ -935,10 +943,10 @@ class TokenNetwork:
                 )
                 log_details["gas_limit"] = gas_limit
 
-                transaction_hash = self.proxy.transact(
+                transaction_hash = self.client.transact(
                     self.proxy,
-                    "setTotalDeposit",
-                    gas_limit,
+                    function_name="setTotalDeposit",
+                    startgas=gas_limit,
                     channel_identifier=channel_identifier,
                     participant=self.node_address,
                     total_deposit=total_deposit,


### PR DESCRIPTION
## Description

Fixes: #5447

Only hold the lock until the set_total_deposit is sent, the transaction should be correctly ordered because of the nonces.


This is a test PR, the change seems to fail with the concurrent deposit test.