### PR TITLE
Broadcast rooms are not left after multiple members joined

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -26,7 +26,7 @@ from raiden.utils.datastructures import merge_dict
 from raiden.utils.debugging import IDLE
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.notifying_queue import NotifyingQueue
-from raiden.utils.typing import AddressHex, RoomID
+from raiden.utils.typing import AddressHex
 
 log = structlog.get_logger(__name__)
 
@@ -215,7 +215,7 @@ class GMatrixClient(MatrixClient):
     def __init__(
         self,
         handle_messages_callback: Callable[[MatrixSyncMessages], bool],
-        handle_member_join_callback: Callable[[RoomID], None],
+        handle_member_join_callback: Callable[[Room], None],
         base_url: str,
         token: str = None,
         user_id: str = None,
@@ -713,7 +713,7 @@ class GMatrixClient(MatrixClient):
 
                 # number of members changed. Verify validity of room
                 if room_members_count != len(room._members):
-                    self._handle_member_join_callback(room.room_id)
+                    self._handle_member_join_callback(room)
                 all_messages.append((room, sync_room["timeline"]["events"]))
 
                 for event in sync_room["ephemeral"]["events"]:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -982,8 +982,10 @@ class MatrixTransport(Runnable):
         room.invite_only = private_room
         self._set_room_id_for_address(address=peer_address, room_id=room_id)
 
-    def _handle_member_join(self, room_id: RoomID) -> None:
-        room = self._client.rooms[room_id]
+    def _handle_member_join(self, room: Room) -> None:
+        if self._is_broadcast_room(room):
+            return
+
         partner_addresses = self._extract_partner_addresses(room.get_joined_members())
 
         if len(partner_addresses) > 1:

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -58,7 +58,7 @@ from raiden.network.utils import get_average_http_response_time
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.utils.gevent import spawn_named
 from raiden.utils.signer import Signer, recover
-from raiden.utils.typing import Address, ChainID, MessageID, RoomID, Signature
+from raiden.utils.typing import Address, ChainID, MessageID, Signature
 from raiden_contracts.constants import ID_TO_NETWORKNAME
 
 log = structlog.get_logger(__name__)
@@ -774,7 +774,7 @@ def sort_servers_closest(
 
 def make_client(
     handle_messages_callback: Callable[[MatrixSyncMessages], bool],
-    handle_member_join_callback: Callable[[RoomID], None],
+    handle_member_join_callback: Callable[[Room], None],
     servers: List[str],
     *args: Any,
     **kwargs: Any,


### PR DESCRIPTION
## Description

There was a little bug that the user tried to leave the broadcast rooms if multiple members joined which happens by definition. This is only a problem at first sync because we do not filter state events of broadcast rooms there. In all other syncs it shouldnt be a problem. Once we switch to filter the state events in all syncs this shouldnt be a problem, anymore. The doublecheck before leaving might be still worth to keep. 
