### PR TITLE
Upgrade web3

### DIFF
--- a/raiden/blockchain/filters.py
+++ b/raiden/blockchain/filters.py
@@ -1,4 +1,5 @@
 import structlog
+from eth_abi.codec import ABICodec
 from eth_utils import decode_hex, event_abi_to_log_topic
 from web3._utils.abi import build_default_registry, filter_by_type
 from web3._utils.events import get_event_data
@@ -19,6 +20,8 @@ from raiden_contracts.contract_manager import ContractManager
 
 log = structlog.get_logger(__name__)
 
+ABI_CODEC = ABICodec(build_default_registry())
+
 
 def get_filter_args_for_specific_event_from_channel(
     token_network_address: TokenNetworkAddress,
@@ -36,6 +39,7 @@ def get_filter_args_for_specific_event_from_channel(
     # in the case of a token network, the first parameter is always the channel identifier
     _, event_filter_params = construct_event_filter_params(
         event_abi=event_abi,
+        abi_codec=ABI_CODEC,
         contract_address=token_network_address,
         argument_filters={"channel_identifier": channel_identifier},
         fromBlock=from_block,
@@ -89,4 +93,4 @@ def decode_event(abi: ABI, log: BlockchainEvent) -> Dict[str, Any]:
     events = filter_by_type("event", abi)
     topic_to_event_abi = {event_abi_to_log_topic(event_abi): event_abi for event_abi in events}
     event_abi = topic_to_event_abi[event_id]
-    return get_event_data(event_abi, log)
+    return get_event_data(ABI_CODEC, event_abi, log)

--- a/raiden/blockchain/filters.py
+++ b/raiden/blockchain/filters.py
@@ -1,8 +1,8 @@
 import structlog
 from eth_utils import decode_hex, event_abi_to_log_topic
-from web3.utils.abi import filter_by_type
-from web3.utils.events import get_event_data
-from web3.utils.filters import construct_event_filter_params
+from web3._utils.abi import build_default_registry, filter_by_type
+from web3._utils.events import get_event_data
+from web3._utils.filters import construct_event_filter_params
 
 from raiden.constants import GENESIS_BLOCK_NUMBER
 from raiden.utils.typing import (

--- a/raiden/connection_manager.py
+++ b/raiden/connection_manager.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Tuple
 
 import gevent
 import structlog
+from eth_typing import HexStr
 from eth_utils import to_canonical_address
 from gevent.lock import Semaphore
 
@@ -90,7 +91,7 @@ class ConnectionManager:  # pragma: no unittest
 
     # XXX Hack: for bootstrapping, the first node on a network opens a channel
     # with this address to become visible.
-    BOOTSTRAP_ADDR_HEX = AddressHex("0x" + "2" * 40)
+    BOOTSTRAP_ADDR_HEX = AddressHex(HexStr("0x" + "2" * 40))
     BOOTSTRAP_ADDR = to_canonical_address(BOOTSTRAP_ADDR_HEX)
 
     def __init__(self, raiden: "RaidenService", token_network_address: TokenNetworkAddress):

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -171,7 +171,7 @@ class SecretRegistry:
                 transaction_hash = self.client.transact(
                     self.proxy, "registerSecretBatch", gas_limit, secrets_to_register
                 )
-                receipt = self.client.poll(transaction_hash)
+                receipt = self.client.poll_transaction(transaction_hash)
             except Exception as e:  # pylint: disable=broad-except
                 msg = f"Unexpected exception {e} at sending registerSecretBatch transaction."
 

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -117,7 +117,7 @@ class ServiceRegistry:
             msg = "ServiceRegistry.deposit transaction fails"
             raise RaidenUnrecoverableError(msg)
         transaction_hash = self.client.transact(self.proxy, "deposit", gas_limit, limit_amount)
-        receipt = self.client.poll(transaction_hash)
+        receipt = self.client.poll_transaction(transaction_hash)
         failed_receipt = check_transaction_threw(receipt=receipt)
         if failed_receipt:
             msg = "ServiceRegistry.deposit transaction failed"
@@ -148,7 +148,7 @@ class ServiceRegistry:
 
             log_details["gas_limit"] = gas_limit
             transaction_hash = self.client.transact(self.proxy, "setURL", gas_limit, url)
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
             if failed_receipt:
                 msg = f"URL {url} is invalid"

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -100,7 +100,7 @@ class Token:
                         self.proxy, "approve", gas_limit, allowed_address, allowance
                     )
 
-                    receipt = self.client.poll(transaction_hash)
+                    receipt = self.client.poll_transaction(transaction_hash)
                     failed_receipt = check_transaction_threw(receipt=receipt)
 
                     if failed_receipt:
@@ -225,7 +225,7 @@ class Token:
                         self.proxy, "transfer", gas_limit, to_address, amount
                     )
 
-                    receipt = self.client.poll(transaction_hash)
+                    receipt = self.client.poll_transaction(transaction_hash)
                     # TODO: check Transfer event (issue: #2598)
                     failed_receipt = check_transaction_threw(receipt=receipt)
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -354,7 +354,7 @@ class TokenNetwork:
                 participant2=partner,
                 settle_timeout=settle_timeout,
             )
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
             if failed_receipt:
                 failed_at_blockhash = encode_hex(failed_receipt["blockHash"])
@@ -382,7 +382,7 @@ class TokenNetwork:
 
                 raise RaidenRecoverableError("Creating new channel failed.")
 
-        receipt = self.client.poll(transaction_hash)
+        receipt = self.client.poll_transaction(transaction_hash)
         channel_identifier: ChannelID = self._detail_channel(
             participant1=self.node_address,
             participant2=partner,
@@ -944,7 +944,7 @@ class TokenNetwork:
                 )
 
         if transaction_hash:
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:
@@ -1414,7 +1414,7 @@ class TokenNetwork:
                 partner_signature=partner_signature,
                 participant_signature=participant_signature,
             )
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:
@@ -1734,7 +1734,7 @@ class TokenNetwork:
                     non_closing_signature=non_closing_signature,
                     closing_signature=closing_signature,
                 )
-                receipt = self.client.poll(transaction_hash)
+                receipt = self.client.poll_transaction(transaction_hash)
                 failed_receipt = check_transaction_threw(receipt=receipt)
 
                 if failed_receipt:
@@ -2002,7 +2002,7 @@ class TokenNetwork:
                 non_closing_signature=non_closing_signature,
             )
 
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:
@@ -2275,7 +2275,7 @@ class TokenNetwork:
                 locks=leaves_packed,
             )
 
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:
@@ -2525,7 +2525,7 @@ class TokenNetwork:
                 channel_identifier=channel_identifier,
                 **kwargs,
             )
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -382,7 +382,7 @@ class TokenNetwork:
 
                 raise RaidenRecoverableError("Creating new channel failed.")
 
-        receipt = self.client.get_transaction_receipt(transaction_hash)
+        receipt = self.client.poll(transaction_hash)
         channel_identifier: ChannelID = self._detail_channel(
             participant1=self.node_address,
             participant2=partner,

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -257,7 +257,7 @@ class TokenNetworkRegistry:
                 self.proxy, "createERC20TokenNetwork", gas_limit, **kwargs
             )
 
-            receipt = self.rpc_client.poll(transaction_hash)
+            receipt = self.rpc_client.poll_transaction(transaction_hash)
 
             if check_transaction_threw(receipt=receipt):
                 failed_at_blocknumber = receipt["blockNumber"]

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -227,7 +227,7 @@ class UserDeposit:
                 self.proxy, "init", gas_limit, monitoring_service_address, one_to_n_address
             )
 
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:
@@ -437,7 +437,7 @@ class UserDeposit:
                 self.proxy, "deposit", gas_limit, beneficiary, total_deposit
             )
 
-            receipt = self.client.poll(transaction_hash)
+            receipt = self.client.poll_transaction(transaction_hash)
             failed_receipt = check_transaction_threw(receipt=receipt)
 
             if failed_receipt:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -820,6 +820,7 @@ class JSONRPCClient:
             receipt,
         )
 
+    # FIXME: Rename
     def poll(self, transaction_hash: TransactionHash) -> Dict[str, Any]:
         """ Wait until the `transaction_hash` is mined, confirmed, handling
         reorgs.

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -171,13 +171,15 @@ def check_address_has_code(
 
 
 def get_transaction_data(
-    abi: Dict, function_name: str, args: Any = None, kwargs: Any = None
+    web3: Web3, abi: Dict, function_name: str, args: Any = None, kwargs: Any = None
 ) -> str:
     """Get encoded transaction data"""
     args = args or list()
-    fn_abi = find_matching_fn_abi(abi, function_name, args=args, kwargs=kwargs)
+    fn_abi = find_matching_fn_abi(
+        abi=abi, abi_codec=web3.codec, fn_identifier=function_name, args=args, kwargs=kwargs
+    )
     return encode_transaction_data(
-        web3=None,
+        web3=web3,
         fn_identifier=function_name,
         contract_abi=abi,
         fn_abi=fn_abi,
@@ -731,7 +733,7 @@ class JSONRPCClient:
         self, contract: Contract, function_name: str, startgas: int, *args: Any, **kwargs: Any
     ) -> TransactionHash:
         data = get_transaction_data(
-            abi=contract.abi, function_name=function_name, args=args, kwargs=kwargs
+            web3=self.web3, abi=contract.abi, function_name=function_name, args=args, kwargs=kwargs
         )
 
         slot = self.get_next_transaction()

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -19,6 +19,7 @@ from web3._utils.contracts import (
 from web3._utils.empty import empty
 from web3.contract import Contract, ContractFunction
 from web3.eth import Eth
+from web3.exceptions import TransactionNotFound
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
 
@@ -844,7 +845,11 @@ class JSONRPCClient:
         transaction_hash_hex = encode_hex(transaction_hash)
 
         while True:
-            tx_receipt = self.web3.eth.getTransactionReceipt(transaction_hash_hex)
+            tx_receipt: Optional[TxReceipt] = None
+            try:
+                tx_receipt = self.web3.eth.getTransactionReceipt(transaction_hash_hex)
+            except TransactionNotFound:
+                pass
 
             # Parity (as of 2.5.7) always returns a receipt. When the
             # transaction is not mined in the canonical chain, the receipt will

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -22,6 +22,7 @@ from web3.eth import Eth
 from web3.exceptions import TransactionNotFound
 from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.middleware import geth_poa_middleware
+from web3.types import TxReceipt
 
 from raiden.constants import (
     NO_STATE_QUERY_AFTER_BLOCKS,
@@ -822,7 +823,7 @@ class JSONRPCClient:
         )
 
     # FIXME: Rename
-    def poll(self, transaction_hash: TransactionHash) -> Dict[str, Any]:
+    def poll(self, transaction_hash: TransactionHash) -> TxReceipt:
         """ Wait until the `transaction_hash` is mined, confirmed, handling
         reorgs.
 
@@ -875,6 +876,7 @@ class JSONRPCClient:
             is_transaction_mined = tx_receipt and tx_receipt.get("blockNumber") is not None
 
             if is_transaction_mined:
+                assert tx_receipt is not None
                 confirmation_block = (
                     tx_receipt["blockNumber"] + self.default_block_num_confirmations
                 )

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -807,7 +807,7 @@ class JSONRPCClient:
             startgas=self._gas_estimate_correction(contract_transaction["gas"]),
         )
 
-        receipt = self.poll(transaction_hash)
+        receipt = self.poll_transaction(transaction_hash)
         contract_address = receipt["contractAddress"]
 
         deployed_code = self.web3.eth.getCode(contract_address)
@@ -824,8 +824,7 @@ class JSONRPCClient:
             receipt,
         )
 
-    # FIXME: Rename
-    def poll(self, transaction_hash: TransactionHash) -> TxReceipt:
+    def poll_transaction(self, transaction_hash: TransactionHash) -> TxReceipt:
         """ Wait until the `transaction_hash` is mined, confirmed, handling
         reorgs.
 

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -507,7 +507,7 @@ class TransactionSlot:
             if to != b"":
                 transaction["to"] = to_checksum_address(to)
 
-            signed_txn = self._client.web3.eth.account.signTransaction(
+            signed_txn = self._client.web3.eth.account.sign_transaction(
                 transaction, self._client.privkey
             )
 

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 
 import gevent
 import structlog
+from eth_typing import HexStr
 from gevent import Greenlet
 from gevent.event import Event
 from gevent.lock import Semaphore
@@ -41,7 +42,7 @@ JSONResponse = Dict[str, Any]
 
 def node_address_from_userid(user_id: Optional[str]) -> Optional[AddressHex]:
     if user_id:
-        return AddressHex(user_id.split(":", 1)[0][1:])
+        return AddressHex(HexStr(user_id.split(":", 1)[0][1:]))
 
     return None
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -630,9 +630,9 @@ class RaidenService(Runnable):
             max_number_of_blocks_to_poll=BlockNumber(100_000),
         )
 
-        latest_block_num = self.rpc_client.get_block(block_identifier="latest")["number"]
-        latest_confirmed_block_number = max(
-            GENESIS_BLOCK_NUMBER, latest_block_num - self.confirmation_blocks
+        latest_block_num = self.rpc_client.block_number()
+        latest_confirmed_block_number = BlockNumber(
+            max(GENESIS_BLOCK_NUMBER, latest_block_num - self.confirmation_blocks)
         )
 
         # `blockchain_events` is a requirement for `_poll_until_target`, so it

--- a/raiden/storage/serialization/fields.py
+++ b/raiden/storage/serialization/fields.py
@@ -9,7 +9,15 @@ from marshmallow_polyfield import PolyField
 
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.utils.formatting import to_hex_address
-from raiden.utils.typing import Address, Any, ChainID, ChannelID, Optional, Tuple
+from raiden.utils.typing import (
+    Address,
+    Any,
+    ChainID,
+    ChannelID,
+    Optional,
+    TokenNetworkAddress,
+    Tuple,
+)
 
 
 class IntegerToStringField(marshmallow.fields.Integer):
@@ -65,7 +73,9 @@ class QueueIdentifierField(marshmallow.fields.Field):
             chain_id_str, token_network_address_hex, channel_id_str = string.split("|")
             return CanonicalIdentifier(
                 chain_identifier=ChainID(int(chain_id_str)),
-                token_network_address=to_bytes(hexstr=token_network_address_hex),
+                token_network_address=TokenNetworkAddress(
+                    to_canonical_address(token_network_address_hex)
+                ),
                 channel_identifier=ChannelID(int(channel_id_str)),
             )
         except ValueError:

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -123,7 +123,7 @@ def check_rdn_deposits(
 def check_network_id(network_id: ChainID, web3: Web3) -> None:  # pragma: no unittest
     """ Check periodically if the underlying ethereum client's network id has changed"""
     while True:
-        current_id = int(web3.version.network)
+        current_id = web3.eth.chainId
         if network_id != current_id:
             raise RuntimeError(
                 f"Raiden was running on network with id {network_id} and it detected "

--- a/raiden/tests/integration/fixtures/blockchain.py
+++ b/raiden/tests/integration/fixtures/blockchain.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from eth_typing import URI
 from web3 import HTTPProvider, Web3
 
 from raiden.constants import GENESIS_BLOCK_NUMBER, EthClient
@@ -47,7 +48,7 @@ def web3(
     host = "127.0.0.1"
     rpc_port = blockchain_rpc_ports[0]
     endpoint = f"http://{host}:{rpc_port}"
-    web3 = Web3(HTTPProvider(endpoint))
+    web3 = Web3(HTTPProvider(URI(endpoint)))
 
     assert len(blockchain_private_keys) == len(blockchain_rpc_ports)
     assert len(blockchain_private_keys) == len(blockchain_p2p_ports)

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -1,7 +1,7 @@
 import gevent
 import pytest
 from eth_utils import is_list_like, keccak
-from web3.utils.events import construct_event_topic_set
+from web3._utils.events import construct_event_topic_set
 
 from raiden import waiting
 from raiden.api.python import RaidenAPI

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -66,7 +66,9 @@ def get_netting_channel_closed_events(
     closed_event_abi = contract_manager.get_event_abi(CONTRACT_TOKEN_NETWORK, ChannelEvent.CLOSED)
 
     topic_set = construct_event_topic_set(
-        event_abi=closed_event_abi, arguments={"channel_identifier": netting_channel_identifier}
+        event_abi=closed_event_abi,
+        abi_codec=proxy_manager.client.web3.codec,
+        arguments={"channel_identifier": netting_channel_identifier},
     )
 
     if len(topic_set) == 1 and is_list_like(topic_set[0]):
@@ -96,7 +98,9 @@ def get_netting_channel_deposit_events(
         CONTRACT_TOKEN_NETWORK, ChannelEvent.DEPOSIT
     )
     topic_set = construct_event_topic_set(
-        event_abi=deposit_event_abi, arguments={"channel_identifier": netting_channel_identifier}
+        event_abi=deposit_event_abi,
+        abi_codec=proxy_manager.client.web3.codec,
+        arguments={"channel_identifier": netting_channel_identifier},
     )
 
     if len(topic_set) == 1 and is_list_like(topic_set[0]):
@@ -126,7 +130,9 @@ def get_netting_channel_settled_events(
         CONTRACT_TOKEN_NETWORK, ChannelEvent.SETTLED
     )
     topic_set = construct_event_topic_set(
-        event_abi=settled_event_abi, arguments={"channel_identifier": netting_channel_identifier}
+        event_abi=settled_event_abi,
+        abi_codec=proxy_manager.client.web3.codec,
+        arguments={"channel_identifier": netting_channel_identifier},
     )
 
     if len(topic_set) == 1 and is_list_like(topic_set[0]):

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -19,7 +19,7 @@ def test_geth_request_pruned_data_raises_an_exception(deploy_client, web3):
         )
         startgas = safe_gas_limit(startgas)
         transaction = deploy_client.transact(contract_proxy, "waste_storage", startgas, iterations)
-        return deploy_client.poll(transaction)
+        return deploy_client.poll_transaction(transaction)
 
     first_receipt = send_transaction()
     mined_block_number = first_receipt["blockNumber"]

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -19,8 +19,7 @@ def test_geth_request_pruned_data_raises_an_exception(deploy_client, web3):
         )
         startgas = safe_gas_limit(startgas)
         transaction = deploy_client.transact(contract_proxy, "waste_storage", startgas, iterations)
-        deploy_client.poll(transaction)
-        return deploy_client.get_transaction_receipt(transaction)
+        return deploy_client.poll(transaction)
 
     first_receipt = send_transaction()
     mined_block_number = first_receipt["blockNumber"]

--- a/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
@@ -34,7 +34,7 @@ def test_parity_request_pruned_data_raises_an_exception(deploy_client: JSONRPCCl
         assert startgas
         startgas = safe_gas_limit(startgas)
         transaction = deploy_client.transact(contract_proxy, "waste_storage", startgas, iterations)
-        return deploy_client.poll(transaction)
+        return deploy_client.poll_transaction(transaction)
 
     first_receipt = send_transaction()
     pruned_block_number = first_receipt["blockNumber"]

--- a/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
@@ -34,8 +34,7 @@ def test_parity_request_pruned_data_raises_an_exception(deploy_client: JSONRPCCl
         assert startgas
         startgas = safe_gas_limit(startgas)
         transaction = deploy_client.transact(contract_proxy, "waste_storage", startgas, iterations)
-        deploy_client.poll(transaction)
-        return deploy_client.get_transaction_receipt(transaction)
+        return deploy_client.poll(transaction)
 
     first_receipt = send_transaction()
     pruned_block_number = first_receipt["blockNumber"]

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
@@ -14,7 +14,7 @@ def test_call_invalid_selector(deploy_client: JSONRPCClient) -> None:
     address = contract_proxy.address
     assert len(deploy_client.web3.eth.getCode(address)) > 0
 
-    data = decode_hex(get_transaction_data(contract_proxy.abi, "ret", None))
+    data = decode_hex(get_transaction_data(deploy_client.web3, contract_proxy.abi, "ret", None))
     next_byte = chr(data[0] + 1).encode()
     data_with_wrong_selector = next_byte + data[1:]
     call = deploy_client.web3.eth.call

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_filters_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_filters_assumptions.py
@@ -13,9 +13,9 @@ def test_filter_start_block_inclusive(deploy_client: JSONRPCClient) -> None:
     assert startgas
     startgas = safe_gas_limit(startgas)
     transaction_1 = deploy_client.transact(contract_proxy, "createEvent", startgas, 1)
-    deploy_client.poll(transaction_1)
+    deploy_client.poll_transaction(transaction_1)
     transaction_2 = deploy_client.transact(contract_proxy, "createEvent", startgas, 2)
-    deploy_client.poll(transaction_2)
+    deploy_client.poll_transaction(transaction_2)
 
     result_1 = deploy_client.get_filter_events(contract_proxy.address)
     block_number_events = get_list_of_block_numbers(result_1)
@@ -46,9 +46,9 @@ def test_filter_end_block_inclusive(deploy_client: JSONRPCClient) -> None:
     assert startgas
     startgas = safe_gas_limit(startgas)
     transaction_1 = deploy_client.transact(contract_proxy, "createEvent", startgas, 1)
-    deploy_client.poll(transaction_1)
+    deploy_client.poll_transaction(transaction_1)
     transaction_2 = deploy_client.transact(contract_proxy, "createEvent", startgas, 2)
-    deploy_client.poll(transaction_2)
+    deploy_client.poll_transaction(transaction_2)
 
     result_1 = deploy_client.get_filter_events(contract_proxy.address)
     block_number_events = get_list_of_block_numbers(result_1)

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -75,8 +75,8 @@ def test_estimate_gas_defaults_to_pending(deploy_client: JSONRPCClient) -> None:
     assert second_gas, "gas estimation should not have failed"
     second_tx = deploy_client.transact(contract_proxy, "gas_increase_exponential", second_gas)
 
-    first_receipt = deploy_client.poll(first_tx)
-    second_receipt = deploy_client.poll(second_tx)
+    first_receipt = deploy_client.poll_transaction(first_tx)
+    second_receipt = deploy_client.poll_transaction(second_tx)
 
     assert second_receipt["gasLimit"] < deploy_client.get_block("latest")["gasLimit"]
     assert first_receipt["status"] != RECEIPT_FAILURE_CODE

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
@@ -82,7 +82,7 @@ def test_resending_mined_transaction_raises(deploy_client: JSONRPCClient) -> Non
     startgas = safe_gas_limit(gas_estimate)
 
     txhash = deploy_client.transact(contract_proxy, "ret", startgas)
-    deploy_client.poll(txhash)
+    deploy_client.poll_transaction(txhash)
 
     # At this point `client_invalid_nonce` has a nonce that is `1` too low,
     # since a transaction was sent using `deploy_client` above and these two
@@ -112,7 +112,7 @@ def test_reusing_nonce_from_a_mined_transaction_raises(deploy_client: JSONRPCCli
 
     # Wait for the transaction to be mined (concurrent transactions are tested
     # by test_local_transaction_with_zero_gasprice_is_mined)
-    deploy_client.poll(txhash)
+    deploy_client.poll_transaction(txhash)
 
     # At this point `client_invalid_nonce` has a nonce that is `1` too low,
     # since a transaction was sent using `deploy_client` above and these two
@@ -150,7 +150,7 @@ def test_local_transaction_with_zero_gasprice_is_mined(deploy_client: JSONRPCCli
     assert gas_estimate, "Gas estimation should not fail here"
 
     zerogas_txhash = deploy_client.transact(zero_gas_proxy, "ret", gas_estimate)
-    zerogas_receipt = deploy_client.poll(zerogas_txhash)
+    zerogas_receipt = deploy_client.poll_transaction(zerogas_txhash)
     zerogas_tx = deploy_client.web3.eth.getTransaction(zerogas_txhash)
 
     msg = "Even thought the transaction had a zero gas price, it is not removed from the pool"

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -21,7 +21,7 @@ def test_transact_opcode(deploy_client: JSONRPCClient) -> None:
     startgas = startgas * 2
 
     transaction = deploy_client.transact(contract_proxy, "ret", startgas)
-    receipt = deploy_client.poll(transaction)
+    receipt = deploy_client.poll_transaction(transaction)
 
     assert check_transaction_threw(receipt=receipt) is None, "must be empty"
 
@@ -37,12 +37,12 @@ def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
     startgas = safe_gas_limit(22000)
 
     transaction = deploy_client.transact(contract_proxy, "fail_assert", startgas)
-    receipt = deploy_client.poll(transaction)
+    receipt = deploy_client.poll_transaction(transaction)
 
     assert check_transaction_threw(receipt=receipt), "must not be empty"
 
     transaction = deploy_client.transact(contract_proxy, "fail_require", startgas)
-    receipt = deploy_client.poll(transaction)
+    receipt = deploy_client.poll_transaction(transaction)
 
     assert check_transaction_threw(receipt=receipt), "must not be empty"
 
@@ -61,7 +61,7 @@ def test_transact_opcode_oog(deploy_client: JSONRPCClient) -> None:
     startgas = safe_gas_limit(startgas) // 2
 
     transaction = deploy_client.transact(contract_proxy, "loop", startgas, 1000)
-    receipt = deploy_client.poll(transaction)
+    receipt = deploy_client.poll_transaction(transaction)
 
     assert check_transaction_threw(receipt=receipt), "must not be empty"
 

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -120,7 +120,7 @@ def test_locksroot_loading_during_channel_settle_handling(
         )
         startgas = safe_gas_limit(startgas)
         transaction = deploy_client.transact(contract_proxy, "waste_storage", startgas, iterations)
-        deploy_client.poll(transaction)
+        deploy_client.poll_transaction(transaction)
 
     for _ in range(10):
         send_transaction()

--- a/raiden/tests/utils/client.py
+++ b/raiden/tests/utils/client.py
@@ -12,4 +12,4 @@ def burn_eth(rpc_client: JSONRPCClient, amount_to_leave: int = 0) -> None:
 
     slot = rpc_client.get_next_transaction()
     transaction_hash = slot.send_transaction(to=Address(HOP1), value=value, startgas=21000)
-    rpc_client.poll(transaction_hash)
+    rpc_client.poll_transaction(transaction_hash)

--- a/raiden/tests/utils/genesis.py
+++ b/raiden/tests/utils/genesis.py
@@ -1,8 +1,10 @@
+from typing import Dict
+
 from eth_utils import encode_hex
 
 from raiden.settings import GAS_LIMIT_HEX
 
-GENESIS_STUB = {
+GENESIS_STUB: Dict = {
     "config": {
         "ChainID": 0,
         "homesteadBlock": 0,

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -272,6 +272,9 @@ def mocked_json_response(response_data: Optional[Dict] = None, status_code: int 
 
 
 class MockEth:
+    def __init__(self, chain_id):
+        self.chain_id = chain_id
+
     def getBlock(  # pylint: disable=unused-argument, no-self-use
         self, block_identifier: BlockSpecification
     ) -> Dict:
@@ -280,13 +283,11 @@ class MockEth:
             "hash": "0x8cb5f5fb0d888c03ec4d13f69d4eb8d604678508a1fa7c1a8f0437d0065b9b67",
         }
 
-
-class MockWeb3Version:
-    def __init__(self, netid):
-        self.network = netid
+    @property
+    def chainId(self):
+        return self.chain_id
 
 
 class MockWeb3:
-    def __init__(self, netid):
-        self.version = MockWeb3Version(netid)
-        self.eth = MockEth()
+    def __init__(self, chain_id):
+        self.eth = MockEth(chain_id=chain_id)

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -129,7 +129,7 @@ def deploy_service_registry_and_set_urls(
     # Test that setting the urls works
     c1_price = c1_service_proxy.current_price(block_identifier="latest")
     tx = c1_token_proxy.client.transact(c1_token_proxy.proxy, "mint", 1000000, c1_price)
-    receipt = c1_client.poll(tx)
+    receipt = c1_client.poll_transaction(tx)
     assert not check_transaction_threw(receipt=receipt)
     assert c1_token_proxy.balance_of(c1_client.address) > 0
     c1_token_proxy.approve(allowed_address=service_registry_address, allowance=c1_price)
@@ -138,7 +138,7 @@ def deploy_service_registry_and_set_urls(
 
     c2_price = c2_service_proxy.current_price(block_identifier="latest")
     tx = c2_token_proxy.client.transact(c2_token_proxy.proxy, "mint", 1000000, c2_price)
-    receipt = c2_client.poll(tx)
+    receipt = c2_client.poll_transaction(tx)
     assert not check_transaction_threw(receipt=receipt)
     assert c2_token_proxy.balance_of(c2_client.address) > 0
     c2_token_proxy.approve(allowed_address=service_registry_address, allowance=c2_price)
@@ -147,7 +147,7 @@ def deploy_service_registry_and_set_urls(
 
     c3_price = c3_service_proxy.current_price(block_identifier="latest")
     tx = c3_token_proxy.client.transact(c3_token_proxy.proxy, "mint", 1000000, c3_price)
-    receipt = c3_client.poll(tx)
+    receipt = c3_client.poll_transaction(tx)
     assert not check_transaction_threw(receipt=receipt)
     assert c3_token_proxy.balance_of(c3_client.address) > 0
     c3_token_proxy.approve(allowed_address=service_registry_address, allowance=c3_price)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -114,7 +114,10 @@ def deploy_smoketest_contracts(
     contract_manager: ContractManager,
     token_address: AddressHex,
 ) -> Dict[str, Address]:
-    client.web3.personal.unlockAccount(client.web3.eth.accounts[0], DEFAULT_PASSPHRASE)
+    if client.eth_node is EthClient.GETH:
+        client.web3.geth.personal.unlockAccount(client.web3.eth.accounts[0], DEFAULT_PASSPHRASE)
+    elif client.eth_node is EthClient.PARITY:
+        client.web3.parity.personal.unlockAccount(client.web3.eth.accounts[0], DEFAULT_PASSPHRASE)
 
     secret_registry_address = deploy_contract_web3(
         contract_name=CONTRACT_SECRET_REGISTRY,

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -219,7 +219,7 @@ def setup_testchain(
 
     eth_rpc_endpoint = f"http://127.0.0.1:{rpc_port}"
     web3 = Web3(HTTPProvider(endpoint_uri=eth_rpc_endpoint))
-    web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+    web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     eth_nodes = [
         EthNodeDescription(

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -55,7 +55,7 @@ def check_sql_version() -> None:
 
 def check_ethereum_client_is_supported(web3: Web3) -> None:
     try:
-        node_version = web3.version.node  # pylint: disable=no-member
+        node_version = web3.clientVersion  # pylint: disable=no-member-abc
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying ethereum node does not have the web3 rpc interface "
@@ -133,7 +133,7 @@ def check_ethereum_network_id(given_network_id: ChainID, web3: Web3) -> None:
     If they don't match, exits the program with an error. If they do adds it
     to the configuration and then returns it and whether it is a known network
     """
-    node_network_id = ChainID(int(web3.version.network))  # pylint: disable=no-member
+    node_network_id = ChainID(web3.eth.chainId)  # pylint: disable=no-member-abc
 
     if node_network_id != given_network_id:
         given_name = ID_TO_NETWORKNAME.get(given_network_id)

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -55,7 +55,7 @@ def check_sql_version() -> None:
 
 def check_ethereum_client_is_supported(web3: Web3) -> None:
     try:
-        node_version = web3.clientVersion  # pylint: disable=no-member-abc
+        node_version = web3.clientVersion
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying ethereum node does not have the web3 rpc interface "
@@ -133,7 +133,7 @@ def check_ethereum_network_id(given_network_id: ChainID, web3: Web3) -> None:
     If they don't match, exits the program with an error. If they do adds it
     to the configuration and then returns it and whether it is a known network
     """
-    node_network_id = ChainID(web3.eth.chainId)  # pylint: disable=no-member-abc
+    node_network_id = ChainID(web3.eth.chainId)
 
     if node_network_id != given_network_id:
         given_name = ID_TO_NETWORKNAME.get(given_network_id)

--- a/raiden/utils/ethereum_clients.py
+++ b/raiden/utils/ethereum_clients.py
@@ -15,7 +15,7 @@ from raiden.utils.typing import Optional, Tuple
 
 def parse_geth_version(client_version: str) -> Optional[tuple]:
     if client_version.startswith("Geth/"):
-        # then this is a geth client version from web3.version.node
+        # then this is a geth client version from web3.clientVersion
         matches = re.search(r"/v(\d+\.\d+\.\d+)", client_version)
     else:
         # result of `geth version`
@@ -51,14 +51,14 @@ def support_check(
 
 
 def is_supported_client(client_version: str) -> Tuple[bool, Optional[EthClient], Optional[str]]:
-    """Takes a client version string either from web3.version.node or from
+    """Takes a client version string either from `web3.clientVersion` or from
     `geth version` or `parity --version` and sees if it is supported.
 
     Returns a tuple with 3 elements:
     (supported_or_not, none_or_EthClient, none_or_our_version_str)
     """
     if client_version.startswith("Parity"):
-        # Parity has Parity// at web3.version.node and Parity/ prefix at parity --version
+        # Parity has Parity// at web3.clientVersion and Parity/ prefix at parity --version
         matches = re.search(r"/+v(\d+\.\d+\.\d+)", client_version)
         if matches is None:
             return False, None, None

--- a/raiden/utils/formatting.py
+++ b/raiden/utils/formatting.py
@@ -1,4 +1,5 @@
 from eth_hash.auto import keccak
+from eth_typing import HexStr
 from eth_utils import (
     encode_hex,
     is_0x_prefixed,
@@ -56,7 +57,7 @@ def to_checksum_address(address: AddressTypes) -> ChecksumAddress:
             out += char
         else:
             out += char.upper() if (v & (2 ** (255 - 4 * i))) else char.lower()
-    return ChecksumAddress(AddressHex("0x" + out))
+    return ChecksumAddress(AddressHex(HexStr("0x" + out)))
 
 
 def pex(data: bytes) -> str:
@@ -77,7 +78,7 @@ def optional_address_to_string(
 
 
 def to_hex_address(address: AddressTypes) -> AddressHex:
-    return AddressHex("0x" + address.hex())
+    return AddressHex(HexStr("0x" + address.hex()))
 
 
 def format_block_id(block_id: BlockSpecification) -> str:

--- a/raiden/utils/testnet.py
+++ b/raiden/utils/testnet.py
@@ -74,7 +74,7 @@ def call_minting_method(
         # that might fall through Contract.transact()'s exception handling.
         raise MintFailed(str(e))
 
-    receipt = client.poll(tx_hash)
+    receipt = client.poll_transaction(tx_hash)
     if check_transaction_threw(receipt=receipt):
         raise MintFailed(f"Call to contract method {method}: Transaction failed.")
 

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -13,10 +13,11 @@ asn1crypto==0.24.0
 astroid==2.2.5
 astunparse==1.6.2
 attrdict==2.0.1
-attrs==19.1.0
+attrs==19.3.0
 automat==0.7.0
 autopep8==1.4.4
 babel==2.7.0
+base58==2.0.0
 bcrypt==3.1.6
 black==19.3b0
 bleach==3.1.0
@@ -38,14 +39,14 @@ daemonize==2.5.0
 decorator==4.4.0
 docutils==0.14
 entrypoints==0.3
-eth-abi==1.3.0
-eth-account==0.3.0
+eth-abi==2.1.0
+eth-account==0.4.0
 eth-hash[pycryptodome]==0.2.0
 eth-keyfile==0.5.1
 eth-keys==0.2.4
 eth-rlp==0.1.2
-eth-typing==2.1.0
-eth-utils==1.8.1
+eth-typing==2.2.1
+eth-utils==1.8.4
 execnet==1.6.0
 fancycompleter==0.8
 filelock==3.0.12
@@ -66,14 +67,15 @@ hyperlink==19.0.0
 hypothesis==4.24.3
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.18
+importlib-metadata==1.5.0
 incremental==17.5.0
+ipfshttpclient==0.4.12
 ipython-genutils==0.2.0
 ipython==4.2.1
 isort==4.3.20
 itsdangerous==1.1.0
 jinja2==2.10.1
-jsonschema==3.0.1
+jsonschema==3.2.0
 lazy-object-proxy==1.4.1
 lru-dict==1.1.6
 macholib==1.14            # via pyinstaller
@@ -88,6 +90,7 @@ mccabe==0.6.1
 mirakuru==2.1.2
 more-itertools==7.0.0
 msgpack==0.6.1
+multiaddr==0.0.9
 mypy-extensions==0.4.1
 mypy==0.720
 netaddr==0.7.19
@@ -104,6 +107,7 @@ pillow==6.2.0
 pip-tools==4.4.0
 pluggy==0.12.0
 prometheus-client==0.3.1
+protobuf==3.11.3
 psutil==5.6.3
 ptyprocess==0.6.0
 py-ecc==1.4.7
@@ -125,7 +129,7 @@ pymacaroons==0.13.0
 pynacl==1.3.0
 pyopenssl==19.0.0
 pyparsing==2.4.0
-pyrsistent==0.15.2
+pyrsistent==0.15.7
 pysha3==1.0.2
 pytest-forked==1.1.3
 pytest-random==0.2
@@ -137,7 +141,7 @@ python-magic==0.4.15      # via s3cmd
 pytoml==0.1.20
 pytz==2019.1
 pyyaml==5.1.1
-raiden-contracts==0.36.0
+raiden-contracts==0.36.1
 raiden-webui==0.11.0
 readme-renderer==24.0
 releases==1.6.1
@@ -167,20 +171,21 @@ traitlets==4.3.2
 treq==18.6.0
 twisted[tls]==19.2.1
 typed-ast==1.4.0
-typing-extensions==3.7.4
+typing-extensions==3.7.4.1
 typing-inspect==0.4.0
 unpaddedbase64==1.1.0
 urllib3==1.25.3
+varint==1.0.2
 wcwidth==0.1.7
-web3==4.9.2
+web3==5.5.1
 webargs==5.3.1
 webencodings==0.5.1
-websockets==6.0
+websockets==8.1
 werkzeug==0.15.4
 wheel==0.33.4
 wmctrl==0.3
 wrapt==1.11.1
-zipp==0.5.1
+zipp==2.2.0
 zope.interface==4.6.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -12,10 +12,11 @@ asn1crypto==0.24.0
 astroid==2.2.5            # via pylint
 astunparse==1.6.2
 attrdict==2.0.1
-attrs==19.1.0             # via automat, black, flake8-bugbear, hypothesis, jsonschema, matrix-synapse, pytest, service-identity, treq, twisted
+attrs==19.3.0
 automat==0.7.0            # via twisted
 autopep8==1.4.4
 babel==2.7.0
+base58==2.0.0
 bcrypt==3.1.6             # via matrix-synapse
 black==19.3b0
 bleach==3.1.0             # via matrix-synapse, readme-renderer
@@ -37,14 +38,14 @@ daemonize==2.5.0          # via matrix-synapse
 decorator==4.4.0
 docutils==0.14
 entrypoints==0.3          # via flake8
-eth-abi==1.3.0
-eth-account==0.3.0
+eth-abi==2.1.0
+eth-account==0.4.0
 eth-hash[pycryptodome]==0.2.0
 eth-keyfile==0.5.1
 eth-keys==0.2.4
 eth-rlp==0.1.2
-eth-typing==2.1.0
-eth-utils==1.8.1
+eth-typing==2.2.1
+eth-utils==1.8.4
 execnet==1.6.0            # via pytest-xdist
 fancycompleter==0.8       # via pdbpp
 filelock==3.0.12
@@ -65,14 +66,15 @@ hyperlink==19.0.0         # via twisted
 hypothesis==4.24.3
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.18  # via pluggy, pytest
+importlib-metadata==1.5.0
 incremental==17.5.0       # via treq, twisted
+ipfshttpclient==0.4.12
 ipython-genutils==0.2.0
 ipython==4.2.1
 isort==4.3.20
 itsdangerous==1.1.0
 jinja2==2.10.1
-jsonschema==3.0.1         # via matrix-synapse
+jsonschema==3.2.0
 lazy-object-proxy==1.4.1  # via astroid
 lru-dict==1.1.6
 markupsafe==1.1.1
@@ -86,9 +88,10 @@ mccabe==0.6.1             # via flake8, pylint
 mirakuru==2.1.2
 more-itertools==7.0.0     # via pytest
 msgpack==0.6.1            # via matrix-synapse
+multiaddr==0.0.9
 mypy-extensions==0.4.1
 mypy==0.720
-netaddr==0.7.19           # via matrix-synapse
+netaddr==0.7.19
 netifaces==0.10.9
 networkx==2.3
 objgraph==3.4.1
@@ -102,6 +105,7 @@ pillow==6.2.0             # via matrix-synapse
 pip-tools==4.4.0
 pluggy==0.12.0            # via pytest
 prometheus-client==0.3.1  # via matrix-synapse
+protobuf==3.11.3
 psutil==5.6.3
 ptyprocess==0.6.0
 py-ecc==1.4.7
@@ -122,7 +126,7 @@ pymacaroons==0.13.0       # via matrix-synapse
 pynacl==1.3.0             # via matrix-synapse, pymacaroons, signedjson
 pyopenssl==19.0.0         # via matrix-synapse, twisted
 pyparsing==2.4.0
-pyrsistent==0.15.2        # via jsonschema
+pyrsistent==0.15.7
 pysha3==1.0.2
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-random==0.2
@@ -132,7 +136,7 @@ pytest==5.3.5
 pytoml==0.1.20
 pytz==2019.1
 pyyaml==5.1.1             # via matrix-synapse
-raiden-contracts==0.36.0
+raiden-contracts==0.36.1
 raiden-webui==0.11.0
 readme-renderer==24.0
 releases==1.6.1
@@ -161,20 +165,21 @@ traitlets==4.3.2
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==19.2.1      # via matrix-synapse, treq
 typed-ast==1.4.0          # via astroid, mypy
-typing-extensions==3.7.4
+typing-extensions==3.7.4.1
 typing-inspect==0.4.0
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3
+varint==1.0.2
 wcwidth==0.1.7            # via pytest
-web3==4.9.2
+web3==5.5.1
 webargs==5.3.1
 webencodings==0.5.1       # via bleach
-websockets==6.0
+websockets==8.1
 werkzeug==0.15.4
 wheel==0.33.4
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==0.5.1               # via importlib-metadata
+zipp==2.2.0
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -33,4 +33,4 @@ urllib3==1.25.3           # via requests
 wheel==0.33.4             # via astunparse
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==45.1.0        # via sphinx
+# setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,6 +7,8 @@
 aniso8601==7.0.0          # via flask-restful
 asn1crypto==0.24.0        # via coincurve
 attrdict==2.0.1           # via eth-account
+attrs==19.3.0             # via jsonschema
+base58==2.0.0             # via multiaddr
 cachetools==3.1.1
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via coincurve
@@ -14,16 +16,16 @@ chardet==3.0.4            # via requests
 click==7.0                # via flask, raiden-contracts
 coincurve==13.0.0
 colorama==0.4.1
-cytoolz==0.10.1           # via eth-keyfile, eth-utils, web3
+cytoolz==0.10.1           # via eth-keyfile, eth-utils
 decorator==4.4.0          # via ipython, networkx, traitlets
-eth-abi==1.3.0            # via web3
-eth-account==0.3.0        # via web3
+eth-abi==2.1.0            # via eth-account, raiden-contracts, web3
+eth-account==0.4.0        # via web3
 eth-hash[pycryptodome]==0.2.0  # via eth-utils, web3
 eth-keyfile==0.5.1
 eth-keys==0.2.4
 eth-rlp==0.1.2            # via eth-account
-eth-typing==2.1.0         # via eth-abi, eth-utils
-eth-utils==1.8.1
+eth-typing==2.2.1         # via eth-abi, eth-utils, raiden-contracts, web3
+eth-utils==1.8.4
 filelock==3.0.12
 flask-cors==3.0.8
 flask-restful==0.3.7
@@ -34,10 +36,13 @@ greenlet==0.4.15          # via gevent
 guppy3==3.0.9
 hexbytes==0.2.0           # via eth-account, eth-rlp, web3
 idna==2.8                 # via requests
+importlib-metadata==1.5.0  # via jsonschema
+ipfshttpclient==0.4.12    # via web3
 ipython-genutils==0.2.0   # via traitlets
 ipython==4.2.1
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
+jsonschema==3.2.0         # via web3
 lru-dict==1.1.6           # via web3
 markupsafe==1.1.1         # via jinja2
 marshmallow-dataclass==6.0.0
@@ -46,13 +51,16 @@ marshmallow-polyfield==5.8
 marshmallow==3.4.0
 matrix-client==0.3.2
 mirakuru==2.1.2
-mypy-extensions==0.4.1    # via raiden-contracts, typing-inspect
+multiaddr==0.0.9          # via ipfshttpclient
+mypy-extensions==0.4.1    # via typing-inspect
+netaddr==0.7.19           # via multiaddr
 netifaces==0.10.9
 networkx==2.3
 objgraph==3.4.1
 parsimonious==0.8.1       # via eth-abi
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
+protobuf==3.11.3          # via web3
 psutil==5.6.3
 ptyprocess==0.6.0         # via pexpect
 py-ecc==1.4.7             # via raiden-contracts
@@ -60,27 +68,30 @@ py-geth==2.1.0
 py-solc==3.2.0
 pycparser==2.19           # via cffi
 pycryptodome==3.8.2       # via eth-hash, eth-keyfile
+pyrsistent==0.15.7        # via jsonschema
 pysha3==1.0.2
 pytoml==0.1.20
 pytz==2019.1              # via flask-restful
-raiden-contracts==0.36.0
+raiden-contracts==0.36.1
 raiden-webui==0.11.0
 requests==2.22.0
-rlp==1.1.0                # via eth-rlp, raiden-contracts
+rlp==1.1.0                # via eth-account, eth-rlp, raiden-contracts
 semantic-version==2.6.0   # via py-geth, py-solc
 semver==2.8.1             # via raiden-contracts
 simplegeneric==0.8.1      # via ipython
-six==1.12.0               # via attrdict, flask-cors, flask-restful, parsimonious, structlog, traitlets
+six==1.12.0               # via attrdict, flask-cors, flask-restful, ipfshttpclient, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog, traitlets
 structlog==19.1.0
-toolz==0.9.0              # via cytoolz, eth-utils
+toolz==0.9.0              # via cytoolz
 traitlets==4.3.2          # via ipython
-typing-extensions==3.7.4
+typing-extensions==3.7.4.1
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
-web3==4.9.2
+varint==1.0.2             # via multiaddr
+web3==5.5.1
 webargs==5.3.1
-websockets==6.0           # via web3
+websockets==8.1           # via web3
 werkzeug==0.15.4          # via flask
+zipp==2.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description

Fixes: #5467

Updates web3 to the latest version. Docs are here: 
- Migrations docs: https://web3py.readthedocs.io/en/stable/v5_migration.html
- Release notes: https://web3py.readthedocs.io/en/stable/releases.html

Related update to contracts: https://github.com/raiden-network/raiden-contracts/pull/1339


This is quite straight forward in general:
- Certain operations now throw an exception instead of returning `None`. See https://github.com/raiden-network/raiden/pull/5890/commits/05ac866d3a75d7862c497121c085f05ba11d8f0d . We don't check this in a lot of other placed, e.g. `getBlock()`. I didn't change these, as this was broken before.
- Some decoding functions now use a `ABICodec`. It's available from the `web3` object, but not in all functions we need it. I went with the simple solution for now: https://github.com/raiden-network/raiden/pull/5890/commits/f04561ed8bd8afe6b5dc56a4bc84fd9265fdaf74

### Performance
 We agreed we should have a rough benchmark to make sure transfer times don't regress. I ran the same scenario with 80 mediated transfers on both `develop` and this branch and compared the transfer times in a histogram:
![Screenshot 2020-02-19 at 13 53 29](https://user-images.githubusercontent.com/90851/74836465-c1477a00-531f-11ea-8ad5-5310c49faa48.png)

I don't see any substantial changes there.