### PR TITLE
upgrade structlog for py3.8

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -5,7 +5,7 @@
 #    './deps compile' (for details see README)
 #
 alabaster==0.7.12
-altgraph==0.16.1          # via macholib, pyinstaller
+altgraph==0.16.1          # via pyinstaller
 aniso8601==7.0.0
 apipkg==1.5
 appdirs==1.4.3
@@ -160,7 +160,7 @@ sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-httpexample==0.10.3
 sphinxcontrib-images==0.8.0
 sphinxcontrib-websupport==1.1.2
-structlog==19.1.0
+structlog==20.1.0
 toml==0.10.0
 toolz==0.9.0
 traitlets==4.3.2

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -65,7 +65,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==4.24.3
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.18  # via pluggy, pytest
+importlib-metadata==0.18  # via pluggy
 incremental==17.5.0       # via treq, twisted
 ipython-genutils==0.2.0
 ipython==4.2.1
@@ -154,7 +154,7 @@ sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-httpexample==0.10.3
 sphinxcontrib-images==0.8.0
 sphinxcontrib-websupport==1.1.2
-structlog==19.1.0
+structlog==20.1.0
 toml==0.10.0              # via black
 toolz==0.9.0
 traitlets==4.3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -71,7 +71,7 @@ semantic-version==2.6.0   # via py-geth, py-solc
 semver==2.8.1             # via raiden-contracts
 simplegeneric==0.8.1      # via ipython
 six==1.12.0               # via attrdict, flask-cors, flask-restful, parsimonious, structlog, traitlets
-structlog==19.1.0
+structlog==20.1.0
 toolz==0.9.0              # via cytoolz, eth-utils
 traitlets==4.3.2          # via ipython
 typing-extensions==3.7.4


### PR DESCRIPTION
The old version of structlog does not work with python3.8