### PR TITLE
Avoid flakyness in test_get_http_rtt_happy

### DIFF
--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -71,7 +71,7 @@ def test_get_http_rtt_happy(requests_responses):
     requests_responses.add_callback(responses.GET, "http://url", callback=response)
 
     result = get_average_http_response_time(url="http://url", method="get", samples=3)
-    assert round(result[1], 2) == 0.10
+    assert 0.1 <= result[1] < 0.11  # exact answer is 0.1, but we have some overhead
 
 
 def test_get_http_rtt_ignore_failing(requests_responses):


### PR DESCRIPTION
The test failed in
https://app.circleci.com/jobs/github/raiden-network/raiden/110849

I doubled the safety margin for this test, which should be enough
considering that it rarely failed in the past.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
