### PR TITLE
Check sync timeout during all iterations

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -526,7 +526,7 @@ class GMatrixClient(MatrixClient):
         # afterwards.
         # As the runtime is evaluated in the subsequent run, we only run this
         # after the second iteration is finished.
-        if timeout_reached and self.sync_iteration > 2:
+        if timeout_reached:
             if IDLE:
                 IDLE.log()
 


### PR DESCRIPTION
The exemption has been introduced when we counted the time between sync
starts. This was a problem for initial (potentially slow) syncs. Now we
check the time between syncs, which will only fail when the raiden node
is blocked by too high load or a bug. We do want an error in those
cases, so the exemption does not make sense anymore and only masks the
problem which will manifest as nodes being treated as offline.

Closes https://github.com/raiden-network/raiden/issues/5898

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
