### PR TITLE
Cache metadata hashes

### DIFF
--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import rlp
 from eth_utils import keccak
 
+from raiden.messages.abstract import cached_property
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, List
 
@@ -11,7 +12,7 @@ from raiden.utils.typing import Address, List
 class RouteMetadata:
     route: List[Address]
 
-    @property
+    @cached_property
     def hash(self) -> bytes:
         return keccak(rlp.encode(self.route))
 
@@ -23,7 +24,7 @@ class RouteMetadata:
 class Metadata:
     routes: List[RouteMetadata]
 
-    @property
+    @cached_property
     def hash(self) -> bytes:
         return keccak(rlp.encode([r.hash for r in self.routes]))
 


### PR DESCRIPTION
These dataclasses are frozen, so it's safe to use `cached_property`.
Otherwise, the hashes get recalculated each time messages containing
metadata are used in a comparison, e.g. in
https://github.com/karlb/raiden/blob/1021fde2412bf16ac72885ffe6138e38c617e719/raiden/network/transport/matrix/transport.py#L140-L143

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
