### PR TITLE
Gzip CI artifacts only once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,11 +413,12 @@ jobs:
               fi
             done
 
-            tar czf /tmp/tests-logs.tar.gz $files
+            # For unknown reasons, this is not only tarred but also gzipped
+            tar cf /tmp/tests-logs.tar.gz $files
 
       - store_artifacts:
           path: /tmp/tests-logs.tar.gz
-          destination: tests-logs
+          destination: tests-logs.tar.gz
 
   finalize:
     parameters:


### PR DESCRIPTION
For unknown reasons, the previous version caused tar files that were
gzipped twice. I did not find out why that was the case, but this code
results in a tar that is only gzipped once.

I also changed the name of the download to include the `.tar.gz` ending.