### PR TITLE
Change Matrix API to enable admin rights for ServerAdmins in Broadcast Rooms

### DIFF
--- a/raiden/tests/utils/synapse_config.yaml.template
+++ b/raiden/tests/utils/synapse_config.yaml.template
@@ -93,6 +93,10 @@ password_providers:
   - module: 'raiden.tests.utils.transport.NoTLSFederationMonkeyPatchProvider'
     config:
       enabled: true
+  - module: 'raiden.tests.utils.transport.AdminUserAuthProvider'
+    config:
+      enabled: true
+      admin_credentials: {admin_credentials}
 
 # Whether to allow non server admins to create groups on this server
 enable_group_creation: false


### PR DESCRIPTION
## Description
Server Admins should be able to purge inactive users from broadcast rooms. In order to do so they need the respective power levels (at least Moderator >= 50). The first Server in the list of known servers will create the broadcast rooms. Upon creating the room, the API allows adding multiple parameters to the request to modify the room settings. Currently the python sdk does not expose this feature.

## What the PR does

In order to enable **server side inactive user purging** the room creator aka the first server in the list of known servers must be able to set the power levels upon creating the room. This PR exposes the API feature to do so to the matrix client. When creating the room it will give the respective rights to the other server admins to be able to purge inactive users. 

> **_NOTE:_** This PR needs to be merged before [this PR](https://github.com/raiden-network/raiden-service-bundle/pull/89) is merged into the Raiden Service Bundle as it depends on the newly exposed feature!