### PR TITLE
Upload all logs as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ jobs:
             done
 
             # For unknown reasons, this is not only tarred but also gzipped
-            tar cf /tmp/tests-logs.tar.gz $files
+            tar cf /tmp/tests-logs.tar.gz "${files[@]}"
 
       - store_artifacts:
           path: /tmp/tests-logs.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,12 +413,12 @@ jobs:
               fi
             done
 
+            mkdir /tmp/artifacts
             # For unknown reasons, this is not only tarred but also gzipped
-            tar cf /tmp/tests-logs.tar.gz "${files[@]}"
+            tar cf /tmp/artifacts/test-logs-$CIRCLE_PR_NUMBER-$CIRCLE_NODE_INDEX.tar.gz "${files[@]}"
 
       - store_artifacts:
-          path: /tmp/tests-logs.tar.gz
-          destination: tests-logs.tar.gz
+          path: /tmp/artifacts
 
   finalize:
     parameters:


### PR DESCRIPTION
bash only uses the first element when you write `$list`, you need
`${list[@]}` instead.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
