### PR TITLE
Fixtures parallel smart contract deployment

### DIFF
--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -106,7 +106,7 @@ def assert_proper_response(response, status_code=HTTPStatus.OK):
         response is not None
         and response.status_code == status_code
         and response.headers["Content-Type"] == "application/json"
-    )
+    ), response.text
 
 
 def assert_payment_secret_and_hash(response, payment):
@@ -1021,7 +1021,7 @@ def test_api_channel_state_change_errors(
 @pytest.mark.parametrize("number_of_nodes", [1])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_tokens", [2])
-@pytest.mark.parametrize("environment_type", [Environment.DEVELOPMENT])
+@pytest.mark.parametrize("environment_type", [Environment.PRODUCTION])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_api_tokens(api_server_test_instance: APIServer, blockchain_services, token_addresses):
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
@@ -1040,7 +1040,6 @@ def test_api_tokens(api_server_test_instance: APIServer, blockchain_services, to
     response = request.send().response
     assert_proper_response(response, HTTPStatus.CREATED)
 
-    partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
     settle_timeout = 1650
     channel_data_obj = {
         "partner_address": partner_address,
@@ -1655,6 +1654,7 @@ def test_register_token_mainnet(
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("max_token_networks", [1])
 @pytest.mark.parametrize("environment_type", [Environment.DEVELOPMENT])
+@pytest.mark.parametrize("register_tokens", [False])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_register_token(
     api_server_test_instance,

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -21,6 +21,9 @@ from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIME
 from raiden_contracts.contract_manager import ContractManager
 
 
+# Disable the default tokens
+@pytest.mark.parametrize("number_of_tokens", [0])
+@pytest.mark.parametrize("register_tokens", [False])
 def test_token_network_registry(
     deploy_client: JSONRPCClient,
     contract_manager: ContractManager,
@@ -172,6 +175,8 @@ def test_token_network_registry_with_zero_token_address(
 
 
 @pytest.mark.parametrize("max_token_networks", [1])
+@pytest.mark.parametrize("number_of_tokens", [0])
+@pytest.mark.parametrize("register_tokens", [False])
 def test_token_network_registry_allows_the_last_slot_to_be_used(
     deploy_client, token_network_registry_address, contract_manager, token_contract_name
 ):

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -356,7 +356,7 @@ def create_apps(
     one_to_n_address: Optional[OneToNAddress],
     secret_registry_address: SecretRegistryAddress,
     service_registry_address: Optional[ServiceRegistryAddress],
-    user_deposit_address: UserDepositAddress,
+    user_deposit_address: Optional[UserDepositAddress],
     monitoring_service_contract_address: MonitoringServiceAddress,
     reveal_timeout: BlockTimeout,
     settle_timeout: BlockTimeout,


### PR DESCRIPTION
Review/Merge after: https://github.com/raiden-network/raiden/pull/5886

With this change the smart contracts are deployed in parallel during fixture setup.

Before (measured on e3ff9b4c5fa1c3304f7bd695b3451e95a65a51c8):
```
38.57s setup    raiden/tests/integration/test_blockchainservice.py::test_channel_with_self[0-1]
0.60s teardown raiden/tests/integration/test_blockchainservice.py::test_channel_with_self[0-1]
0.05s call     raiden/tests/integration/test_blockchainservice.py::test_channel_with_self[0-1]
```
After
```
24.32s setup    raiden/tests/integration/test_blockchainservice.py::test_channel_with_self[0-1]
0.72s teardown raiden/tests/integration/test_blockchainservice.py::test_channel_with_self[0-1]
0.09s call     raiden/tests/integration/test_blockchainservice.py::test_channel_with_self[0-1]
```