### PR TITLE
Shorten MS scenarios

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 100
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the MS1 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
@@ -60,7 +60,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 100
+      - wait_blocks: 40
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"
@@ -68,7 +68,6 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 100, but we've already waited 80 blocks, leaving 20 blocks
       ## To make sure the transactions gets mined in time, 10 additional blocks are added
       - wait_blocks: 10
       - assert_ms_claim: {channel_info_key: "MS Test Channel"}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 100
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the MS2 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
@@ -60,7 +60,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 100
+      - wait_blocks: 40
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 100
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 # This is the MS3 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
@@ -62,10 +62,11 @@ scenario:
 
       ## node1 gets back online before the MS reacts
       ## node1 should call updateNonClosingBalanceProof in this case and the MS wont react
-      - wait_blocks: 10
+      - wait_blocks: 2
       - start_node: 1
 
-      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 100 = 80
+      ## The MS reacts after 0.3 * settle_timeout at the earliest. 0.3 * 40 = 12
+      ## The MS reacts after 0.8 * settle_timeout at the latest. 0.8 * 40 = 32
       ## But we just need to check for the event from node1 before the monitoring service reacts
       - wait_blocks: 20
       - assert_events:
@@ -75,7 +76,8 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 100 blocks, but we already waited 30 blocks.
-      - wait_blocks: 70
+      ## Settlement timeout is 40 blocks, but we already waited 22 blocks.
+      ## Add 10 blocks as safety margin: 18 + 10 = 28
+      - wait_blocks: 28
       # will fail for now since channel was closed by node1.
       - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"
       - 0
-    default-settle-timeout: 100
+    default-settle-timeout: 40
     default-reveal-timeout: 20
 
 ## This scenario tests that the MS does not kick in, if the node requesting monitoring does
@@ -83,7 +83,7 @@ scenario:
           name: "Wait for MS to not react"
           tasks:
             # The MS reacts within the settle_timeout
-            - wait_blocks: 100
+            - wait_blocks: 40
             # Note that 0 events are expected
             - assert_events:
                 contract_name: "TokenNetwork"
@@ -96,7 +96,7 @@ scenario:
           tasks:
             # Monitored channel must be settled before the monitoring service can claim its reward
             # To make sure the transactions gets mined in time, 10 additional blocks are added
-            - wait_blocks: 20
+            - wait_blocks: 10
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "NonClosingBalanceProofUpdated"


### PR DESCRIPTION
Increasing the settle timeout doesn't help, because the MS has to assume
the minimal possible settle timeout anyways.
This makes the scenatios a bit faster to run.

@karlb Feel free to stall this while investigating #5919 