### PR TITLE
fixtures: simplified blockchain fixtures

### DIFF
--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
@@ -6,8 +6,9 @@ from web3.exceptions import TransactionNotFound
 from raiden.constants import RECEIPT_FAILURE_CODE
 from raiden.exceptions import EthereumNonceTooLow, ReplacementTransactionUnderpriced
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.tests.utils.eth_node import EthNodeDescription
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
-from raiden.utils.typing import Callable, Dict, GasPrice, List, Port, PrivateKey
+from raiden.utils.typing import Callable, Dict, GasPrice, List, PrivateKey
 
 
 def make_fixed_gas_price_strategy(gas_price: GasPrice) -> Callable:
@@ -164,13 +165,21 @@ def test_local_transaction_with_zero_gasprice_is_mined(deploy_client: JSONRPCCli
 
 @pytest.mark.parametrize("blockchain_number_of_nodes", [2])
 def test_remote_transaction_with_zero_gasprice_is_not_mined(
-    web3: Web3, deploy_key: PrivateKey, blockchain_rpc_ports: List[Port], blockchain_type: str
+    web3: Web3,
+    deploy_key: PrivateKey,
+    eth_nodes_configuration: List[EthNodeDescription],
+    blockchain_type: str,
 ) -> None:
     """ If the non-local transaction is sent with a gas price set to zero it is
     not mined.
     """
     host = "127.0.0.1"
-    miner_rpc_port, rpc_port = blockchain_rpc_ports
+
+    assert eth_nodes_configuration[0].miner
+    miner_rpc_port = eth_nodes_configuration[0].rpc_port
+
+    assert not eth_nodes_configuration[1].miner
+    rpc_port = eth_nodes_configuration[1].rpc_port
 
     miner_web3 = Web3(HTTPProvider(f"http://{host}:{miner_rpc_port}"))
     miner_client = JSONRPCClient(miner_web3, deploy_key)

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -19,17 +19,7 @@ from raiden.utils.ethereum_clients import parse_geth_version
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.http import JSONRPCExecutor
 from raiden.utils.keys import privatekey_to_address, privatekey_to_publickey
-from raiden.utils.typing import (
-    Address,
-    Any,
-    ChainID,
-    Dict,
-    List,
-    NamedTuple,
-    Port,
-    PrivateKey,
-    TokenAmount,
-)
+from raiden.utils.typing import Address, Any, ChainID, Dict, List, NamedTuple, Port, TokenAmount
 
 log = structlog.get_logger(__name__)
 
@@ -39,7 +29,7 @@ _GETH_VERBOSITY_LEVEL = {"error": 1, "warn": 2, "info": 3, "debug": 4}
 
 
 class EthNodeDescription(NamedTuple):
-    private_key: PrivateKey
+    private_key: bytes
     rpc_port: Port
     p2p_port: Port
     miner: bool
@@ -223,7 +213,7 @@ def geth_keyfile(datadir: str, address: Address) -> str:
     return os.path.join(keystore, account)
 
 
-def eth_create_account_file(keyfile_path: str, privkey: PrivateKey) -> None:
+def eth_create_account_file(keyfile_path: str, privkey: bytes) -> None:
     keyfile_json = create_keyfile_json(privkey, bytes(DEFAULT_PASSPHRASE, "utf-8"))
 
     # Parity expects a string of length 32 here, but eth_keyfile does not pad
@@ -318,7 +308,7 @@ def eth_check_balance(web3: Web3, accounts_addresses: List[Address], retries: in
 
 
 def eth_node_config(
-    node_pkey: PrivateKey, p2p_port: Port, rpc_port: Port, **extra_config: Any
+    node_pkey: bytes, p2p_port: Port, rpc_port: Port, **extra_config: Any
 ) -> Dict[str, Any]:
     address = privatekey_to_address(node_pkey)
     pub = privatekey_to_publickey(node_pkey).hex()

--- a/raiden/utils/keys.py
+++ b/raiden/utils/keys.py
@@ -1,10 +1,10 @@
 from eth_keys import keys
 
 from raiden.utils.predicates import ishash
-from raiden.utils.typing import Address, PrivateKey, PublicKey
+from raiden.utils.typing import Address, PublicKey
 
 
-def privatekey_to_publickey(private_key_bin: PrivateKey) -> PublicKey:
+def privatekey_to_publickey(private_key_bin: bytes) -> PublicKey:
     """ Returns public key in bitcoins 'bin' encoding. """
     if not ishash(private_key_bin):
         raise ValueError("private_key_bin format mismatch. maybe hex encoded?")


### PR DESCRIPTION
Replaced these 3 fixtures:

- blockchain_private_keys
- blockchain_rpc_ports
- blockchain_p2p_ports

With just a fixture named `eth_nodes_configuration`. The same data is
available but through a datastructure.