### PR TITLE
Catches exception if tranferring to myself

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -22,6 +22,7 @@ from raiden.exceptions import (
     InvalidSettleTimeout,
     InvalidTokenAddress,
     RaidenRecoverableError,
+    SamePeerAddress,
     TokenNetworkDeprecated,
     TokenNotRegistered,
     UnexpectedChannelState,
@@ -1058,6 +1059,9 @@ class RaidenAPI:  # pragma: no unittest
 
         if not isinstance(amount, int):  # pragma: no unittest
             raise InvalidAmount("Amount not a number")
+
+        if Address(target) == self.address:
+            raise SamePeerAddress("Address must be different than ours")
 
         if amount <= 0:
             raise InvalidAmount("Amount negative")

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1119,6 +1119,7 @@ class RestAPI:  # pragma: no unittest
             InvalidSecretHash,
             InvalidPaymentIdentifier,
             PaymentConflict,
+            SamePeerAddress,
             UnknownTokenAddress,
         ) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -167,8 +167,7 @@ class InvalidPaymentIdentifier(RaidenError):
 
 
 class SamePeerAddress(RaidenError):
-    """ Raised when a user tries to create a channel where the address of both
-    peers is the same.
+    """ Raised when a user tries to perform an action that requires two different partners
     """
 
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1199,14 +1199,14 @@ class MatrixTransport(Runnable):
 
         assert self._raiden_service is not None, "_raiden_service not set"
 
-        # The rooms creation is assymetric, only the node with the lower
+        # The rooms creation is asymmetric, only the node with the lower
         # address is responsible to create the room. This fixes race conditions
         # were the two nodes try to create a room with each other at the same
         # time, leading to communications problems if the nodes choose a
         # different room.
         #
         # This does not introduce a new attack vector, since not creating the
-        # room is the same as being unresponsible.
+        # room is the same as being unresponsive.
         room_creator_address = my_place_or_yours(
             our_address=self._raiden_service.address, partner_address=address
         )

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -17,6 +17,7 @@ from raiden.exceptions import (
     InvalidBinaryAddress,
     InvalidSettleTimeout,
     RaidenRecoverableError,
+    SamePeerAddress,
     TokenNotRegistered,
     UnexpectedChannelState,
     UnknownTokenAddress,
@@ -844,3 +845,22 @@ def test_raidenapi_channel_lifecycle(
         },
         retry_timeout,
     )
+
+
+@raise_on_failure
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("channels_per_node", [1])
+def test_same_addresses_for_payment(raiden_network, token_addresses):
+    app0, _ = raiden_network
+    api0 = RaidenAPI(app0.raiden)
+    registry_address = app0.raiden.default_registry.address
+    token_address = token_addresses[0]
+    address_of_app0 = app0.raiden.address
+
+    with pytest.raises(SamePeerAddress):
+        api0.transfer(
+            registry_address=registry_address,
+            token_address=token_address,
+            target=address_of_app0,
+            amount=PaymentAmount(0),
+        )

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -855,12 +855,11 @@ def test_same_addresses_for_payment(raiden_network, token_addresses):
     api0 = RaidenAPI(app0.raiden)
     registry_address = app0.raiden.default_registry.address
     token_address = token_addresses[0]
-    address_of_app0 = app0.raiden.address
 
     with pytest.raises(SamePeerAddress):
         api0.transfer(
             registry_address=registry_address,
             token_address=token_address,
-            target=address_of_app0,
-            amount=PaymentAmount(0),
+            target=app0.raiden.address,
+            amount=PaymentAmount(1),
         )


### PR DESCRIPTION
## Description
Raiden crashed when we tried to send a payment to ourself at the room_creating here https://github.com/raiden-network/raiden/blob/561370ae3406e90b4d7e2d62ac12c0f46587875e/raiden/network/transport/matrix/utils.py#L896-L903

We should catch this error already in the api when a user tries to transfer to himself.

Fixes: #5922 

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
