### PR TITLE
filter broadcast rooms at first sync

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -327,6 +327,8 @@ class GMatrixClient(MatrixClient):
         broadcast_room_filter: Dict[str, Dict] = {
             # Get all presence updates
             "presence": {"types": ["m.presence"]},
+            # filter account data
+            "account_data": {"not_types": ["*"]},
             # Ignore "message receipts" from all rooms
             "room": {"ephemeral": {"not_types": ["m.receipt"]}},
         }
@@ -780,7 +782,16 @@ class GMatrixClient(MatrixClient):
                 # number of members changed. Verify validity of room
                 if room_members_count != len(room._members):
                     self._handle_member_join_callback(room)
-                all_messages.append((room, sync_room["timeline"]["events"]))
+                all_messages.append(
+                    (
+                        room,
+                        [
+                            message
+                            for message in sync_room["timeline"]["events"]
+                            if message["type"] == "m.room.message"
+                        ],
+                    )
+                )
 
                 for event in sync_room["ephemeral"]["events"]:
                     event["room_id"] = room_id

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -528,7 +528,9 @@ def join_broadcast_room(client: GMatrixClient, broadcast_room_alias: str) -> Roo
     See: https://github.com/raiden-network/raiden-transport/issues/46
     """
     try:
-        return client.join_room(broadcast_room_alias)
+        room = client.join_room(broadcast_room_alias)
+        del client.rooms[room.room_id]
+        return room
     except MatrixRequestError:
         raise RaidenUnrecoverableError(
             f"Could not join broadcast room {broadcast_room_alias}. "

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -2,7 +2,7 @@ import json
 import random
 from datetime import datetime
 from functools import partial
-from typing import Any, Set
+from typing import Any
 from unittest.mock import MagicMock
 
 import gevent
@@ -1058,88 +1058,6 @@ def test_reproduce_handle_invite_send_race_issue_3588(matrix_transports):
     transport1.immediate_health_check_for(raiden_service0.address)
 
     assert ping_pong_message_success(transport0, transport1)
-
-
-@pytest.mark.parametrize("number_of_transports", [2])
-@pytest.mark.parametrize("matrix_server_count", [1])
-@pytest.mark.parametrize("matrix_sync_timeout", [5_000])  # Shorten sync timeout to prevent timeout
-@pytest.mark.parametrize(
-    "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]]
-)
-def test_matrix_ignore_messages_in_broadcast_rooms(matrix_transports):
-    """ Ensure the transport doesn't attach a message listener to broadcast rooms. """
-    raiden_service0 = MockRaidenService(None)
-    raiden_service1 = MockRaidenService(None)
-
-    transport0, transport1 = matrix_transports
-
-    # Remove PFS broadcast room from transport1 config so it doesn't join the room
-    transport1._config.broadcast_rooms.remove(PATH_FINDING_BROADCASTING_ROOM)
-
-    transport0.start(raiden_service0, [], None)
-    transport1.start(raiden_service1, [], None)
-
-    # Re-add the PFS broadcast room to transport1. Since `start()` has already been called
-    # it will not be joined automatically.
-    # We use this fact to wait on the room state to know when transport1 has processed the invite.
-    transport1._config.broadcast_rooms.append(PATH_FINDING_BROADCASTING_ROOM)
-
-    transport0.immediate_health_check_for(raiden_service1.address)
-    transport1.immediate_health_check_for(raiden_service0.address)
-
-    pfs_broadcast_room_alias = make_room_alias(transport0.chain_id, PATH_FINDING_BROADCASTING_ROOM)
-    pfs_broadcast_room_t0 = transport0._broadcast_rooms[pfs_broadcast_room_alias]
-
-    # Send a message to the broadcast room, if any transport listens on the room it will throw an
-    # exception
-    message = Processed(message_identifier=1, signature=EMPTY_SIGNATURE)
-    message_text = MessageSerializer.serialize(message)
-    pfs_broadcast_room_t0.send_text(message_text)
-
-    # Invite transport1 user. It should join the room but *not* attach a listener.
-    pfs_broadcast_room_t0.invite_user(transport1._user_id)
-
-    # Wait for transport1 to process the invite
-    with Timeout(TIMEOUT_MESSAGE_RECEIVE):
-        while True:
-            try:
-                room_state0 = transport0._client.api.get_room_state_type(
-                    pfs_broadcast_room_t0.room_id, "m.room.member", transport1._user_id
-                )
-                if room_state0["membership"] == "join":
-                    break
-            except MatrixRequestError:
-                pass
-            # Poll transport1 to ensure the message sent above did not raise an exception
-            try:
-                transport1.greenlet.get(timeout=0.1)
-            except Timeout:
-                pass
-
-    received_messages_t1_pfs: Set[str] = set()
-
-    def _handle_message_t1(_room: Room, event: Dict[str, Any]):
-        received_messages_t1_pfs.add(event["content"]["body"])
-
-    # Attach a message listener on transport1 so we know when the message has reached transport1
-    transport1._client.rooms[pfs_broadcast_room_t0.room_id].add_listener(
-        _handle_message_t1, "m.room.message"
-    )
-
-    # Send another message to the broadcast room, if transport1 listens on the room it will
-    # throw an exception
-    message = Processed(message_identifier=2, signature=EMPTY_SIGNATURE)
-    message_text = MessageSerializer.serialize(message)
-    pfs_broadcast_room_t0.send_text(message_text)
-
-    with Timeout(TIMEOUT_MESSAGE_RECEIVE):
-        while message_text not in received_messages_t1_pfs:
-            gevent.joinall({transport1.greenlet}, timeout=0.1, raise_error=True)
-        # Wait for the current transport1 sync loop to complete to ensure all server events
-        # have been processed (making sure no exception is raised late)
-        sync_iteration = transport1._client.sync_iteration
-        while sync_iteration == transport1._client.sync_iteration:
-            gevent.joinall({transport1.greenlet}, timeout=0.1, raise_error=True)
 
 
 @pytest.mark.parametrize("number_of_transports", [3])

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -189,6 +189,7 @@ def test_assumption_federation_works_after_original_server_goes_down(
 
     user_federated_1, _ = create_logged_in_client(local_matrix_servers_with_executor[1][0])
     room_server1 = join_broadcast_room(user_federated_1, room_name_full)
+    user_federated_1.rooms[room_server1.room_id] = room_server1
     user_federated_1.start_listener_thread(
         timeout_ms=DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
         latency_ms=DEFAULT_TRANSPORT_MATRIX_SYNC_LATENCY,
@@ -196,6 +197,7 @@ def test_assumption_federation_works_after_original_server_goes_down(
 
     user_federated_2, _ = create_logged_in_client(local_matrix_servers_with_executor[2][0])
     room_server2 = join_broadcast_room(user_federated_2, room_name_full)
+    user_federated_2.rooms[room_server2.room_id] = room_server2
     user_federated_2.start_listener_thread(
         timeout_ms=DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
         latency_ms=DEFAULT_TRANSPORT_MATRIX_SYNC_LATENCY,
@@ -229,6 +231,7 @@ def test_assumption_federation_works_after_original_server_goes_down(
     # Send message from client 1, check that client 2 receives it
     received = {}
     room_server1.send_text("Message2")
+
     while not len(received) == 2:
         gevent.sleep(0.1)
 

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -196,19 +196,6 @@ def room_with_members(mock_raiden_service, partner_config_for_room):
         ),
     ],
 )
-def test_unexpected_rooms_raise_assertion_error(mock_matrix: MatrixTransport, room_with_members):
-
-    room, should_leave = room_with_members
-    room.client = mock_matrix._client
-    mock_matrix._client.rooms[room.room_id] = room
-
-    # if an api happens a MatrixRequestError should be propagated and raising a TransportError
-    # This should only happen when a room is to be left
-    if should_leave:
-        with pytest.raises(AssertionError):
-            mock_matrix._initialize_room_inventory()
-
-
 @pytest.fixture
 def invite_state(signer, mock_matrix):
     invite_user = create_new_users_for_address(signer)[0]
@@ -227,6 +214,7 @@ def invite_state(signer, mock_matrix):
                 "content": {"membership": "invite"},
                 "type": "m.room.member",
             },
+            {"type": "m.room.join_rules", "content": {"join_rule": "invite"}},
             {
                 "content": {
                     "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
@@ -265,7 +253,6 @@ def test_reject_invite_of_invalid_room(
 
     with pytest.raises(AssertionError):
         mock_matrix._handle_invite(invalid_room_id, invite_state)
-
     assert leave_room_called
 
 


### PR DESCRIPTION
# Motivation

First sync for large rooms takes quite a while to process all state events (At 30000 state events ~ 5s). The only reason why we keep processing these events at first sync is to see if we already joined the broadcast rooms or not. This was done because it took a long time to join the rooms. This problem was recently fixed by #5892. 

## Description
Since the API call of joining broadcast rooms should be fast now (It used to download all 30000 state events) the transport can now simply call the `join_room()` API even if it already joined the room. 
Broadcast Rooms can be filtered even at first sync.
`Initialize_room_inventory` can be removed due to redundancy. 

Fixes: #5913 

## ToDos
- [ ] show performance improvement in stress tests