### PR TITLE
Terminal width fallback for replay_wal.py

### DIFF
--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -10,7 +10,6 @@ state changes until a channel is found with the provided token network address a
 The ignored state changes will still be applied, but they will just not be printed out.
 """
 import json
-import os
 import re
 from contextlib import closing
 from itertools import chain
@@ -200,7 +199,7 @@ def print_node_balances(
 
 
 def print_nl():
-    click.echo("-" * os.get_terminal_size()[0], nl=True)
+    click.echo("-" * click.get_terminal_size()[0], nl=True)
 
 
 def replay_wal(


### PR DESCRIPTION
Before, running the script failed for me when redirecting the script
output to a file with
```
Traceback (most recent call last):
  File "tools/debugging/replay_wal.py", line 289, in <module>
    main()  # pylint: disable=no-value-for-parameter
  File "/home/karl/tools/venv/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/karl/tools/venv/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/karl/tools/venv/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/karl/tools/venv/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "tools/debugging/replay_wal.py", line 284, in main
    translator=translator,
  File "tools/debugging/replay_wal.py", line 248, in replay_wal
    print_nl()                                                                                                                                                                                                                                                  File "tools/debugging/replay_wal.py", line 203, in print_nl
    click.echo("-" * os.get_terminal_size()[0], nl=True)
OSError: [Errno 25] Inappropriate ioctl for device
```

[skip tests]