### PR TITLE
Fixing a bug with the Semaphore

### DIFF
--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -9,8 +9,6 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
         balance_per_node: 100_000_000_000_000_000_000
         min_balance: 5_000_000_000_000_000_000


### PR DESCRIPTION
## Description
The Semaphore was not set properly. Every transfer started its own semaphore within the for loop before. We changed that to a global Semaphore within the module.

Fixes: #5951 

We might think about a follow-up issue to establish a more elaborated semaphore handling like described in the issue. However, this quick fix seems to solve the problem. 