### PR TITLE
Refactoring in client.py/transport.py

### DIFF
--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -152,12 +152,8 @@ def test_assumption_user_goes_offline_if_sync_is_not_called_within_35s(local_mat
     client3, signer3 = create_logged_in_client(local_matrix_servers[0])
     client3.add_presence_listener(tracker3.presence_listener)
 
-    client1.blocking_sync(
-        timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
-    client2.blocking_sync(
-        timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
+    client1.blocking_sync(timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS)
+    client2.blocking_sync(timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS)
 
     msg = (
         "The client called sync but the nodes don't share a room, each node "
@@ -177,12 +173,8 @@ def test_assumption_user_goes_offline_if_sync_is_not_called_within_35s(local_mat
     client2.join_room(room.aliases[0])
     client3.join_room(room.aliases[0])
 
-    client1.blocking_sync(
-        timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
-    client2.blocking_sync(
-        timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
+    client1.blocking_sync(timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS)
+    client2.blocking_sync(timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS)
 
     msg = "All clients share a room, presence information must be available"
     assert tracker1.address_presence[signer1.address] == UserPresence.ONLINE, msg
@@ -199,9 +191,7 @@ def test_assumption_user_goes_offline_if_sync_is_not_called_within_35s(local_mat
     gevent.sleep(PRESENCE_TIMEOUT + CI_LATENCY)
 
     # Do a new sync, this time client1 must change status to offline
-    client2.blocking_sync(
-        timeout_ms=PRESENCE_TIMEOUT, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
+    client2.blocking_sync(timeout_ms=PRESENCE_TIMEOUT, latency_ms=SHORT_TIMEOUT_MS)
     assert tracker2.address_presence[signer1.address] == UserPresence.OFFLINE, msg
     assert tracker2.address_presence[signer2.address] == UserPresence.ONLINE, msg
     assert tracker2.address_presence[signer3.address] == UserPresence.OFFLINE, msg
@@ -236,12 +226,8 @@ def test_assumption_user_is_online_while_sync_is_blocking(local_matrix_servers):
     room: Room = client1.create_room("test", is_public=True)
     client2.join_room(room.aliases[0])
 
-    client2.blocking_sync(
-        timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
-    client1.blocking_sync(
-        timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-    )
+    client2.blocking_sync(timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS)
+    client1.blocking_sync(timeout_ms=SHORT_TIMEOUT_MS, latency_ms=SHORT_TIMEOUT_MS)
 
     def long_polling():
         timeout_secs = (LONG_TIMEOUT_MS - 100) / 1_000
@@ -258,9 +244,7 @@ def test_assumption_user_is_online_while_sync_is_blocking(local_matrix_servers):
         while long_running:
             gevent.sleep(1)
 
-            client2.blocking_sync(
-                timeout_ms=PRESENCE_TIMEOUT, latency_ms=SHORT_TIMEOUT_MS, first_sync=True
-            )
+            client2.blocking_sync(timeout_ms=PRESENCE_TIMEOUT, latency_ms=SHORT_TIMEOUT_MS)
             msg = "Client1 should be online while the sync is blocking"
             assert tracker2.address_presence[signer1.address] == UserPresence.ONLINE, msg
 

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -267,7 +267,6 @@ def test_leave_after_member_join(mock_matrix, room_with_members):
     user = create_new_users_for_address(make_signer())[0]
     room.client = mock_matrix._client
     mock_matrix._client.rooms[room.room_id] = room
-    mock_matrix._client.should_listen = True
 
     # response showing that user from another address joins the room
     response_list = list()

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -43,10 +43,6 @@ def test_cli_version(cli_runner):
     assert result_expected_keys == result_json.keys()
     assert result.exit_code == 0
 
-    result = cli_runner(cli.run, ["--version"])
-    assert "Hint: Use '" in result.output and "version' instead" in result.output
-    assert result.exit_code == 0
-
 
 def mock_raises(exception):
     def f(*_, **__):

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -6,11 +6,11 @@ from enum import EnumMeta
 from itertools import groupby
 from pathlib import Path
 from string import Template
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Union
 
 import click
 import requests
-from click import BadParameter, Choice, MissingParameter
+from click import Choice, MissingParameter
 from click._compat import term_len
 from click.formatting import iter_rows, measure_table, wrap_text
 from pytoml import TomlError, load


### PR DESCRIPTION
## Description
With the recent changes, some small refactorings and optimizations are possible to make the code more readable. 

This includes:

- remove the redundancy of `should_listen` and `stop_event`
- remove `first_sync` flag at sync
- prevent possible attack vector of joining rooms with large number of addresses due to ecrecover


Fixes: #5921