### PR TITLE
Factor out smoketest setup into contextmanager

### DIFF
--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -54,9 +54,8 @@ def raiden_testchain(
             base_datadir=testchain["base_datadir"],
             keystore=testchain["keystore"],
         )
-        result["ethereum_nodes"] = testchain["node_executors"]
 
-        args = result["args"]
+        args = result.args
         # The setup of the testchain returns a TextIOWrapper but
         # for the tests we need a filename
         args["password_file"] = args["password_file"].name

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import subprocess
 from contextlib import ExitStack, contextmanager
-from datetime import datetime
 from typing import ContextManager, Iterator
 
 import gevent
@@ -202,15 +201,10 @@ def geth_keystore(datadir: str) -> str:
     return os.path.join(datadir, "keystore")
 
 
-def geth_keyfile(datadir: str, address: Address) -> str:
+def geth_keyfile(datadir: str) -> str:
     keystore = geth_keystore(datadir)
     os.makedirs(keystore, exist_ok=True)
-
-    address_hex = remove_0x_prefix(encode_hex(address))
-    broken_iso_8601 = datetime.now().isoformat().replace(":", "-")
-    account = f"UTC--{broken_iso_8601}000Z--{address_hex}"
-
-    return os.path.join(keystore, account)
+    return os.path.join(keystore, "keyfile")
 
 
 def eth_create_account_file(keyfile_path: str, privkey: bytes) -> None:
@@ -522,7 +516,7 @@ def run_private_blockchain(
         for config in nodes_configuration:
             if config.get("mine"):
                 datadir = eth_node_to_datadir(config["address"], base_datadir)
-                keyfile_path = geth_keyfile(datadir, config["address"])
+                keyfile_path = geth_keyfile(datadir)
                 eth_create_account_file(keyfile_path, config["nodekey"])
 
     elif blockchain_type == "parity":

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -1,5 +1,5 @@
-import json
 import contextlib
+import json
 import os
 import random
 import shutil
@@ -34,10 +34,9 @@ from raiden.constants import (
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.network.transport.matrix.utils import make_room_alias
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, RAIDEN_CONTRACT_VERSION
 from raiden.tests.fixtures.constants import DEFAULT_BALANCE, DEFAULT_PASSPHRASE
-
-from raiden.network.transport.matrix.utils import make_room_alias
 from raiden.tests.utils.eth_node import (
     AccountDescription,
     EthNodeDescription,
@@ -79,7 +78,7 @@ from raiden.utils.typing import (
 )
 from raiden.waiting import wait_for_block
 from raiden_contracts.constants import (
-    CONTRACT_HUMAN_STANDARD_TOKEN,
+    CONTRACT_CUSTOM_TOKEN,
     CONTRACT_MONITORING_SERVICE,
     CONTRACT_ONE_TO_N,
     CONTRACT_SECRET_REGISTRY,
@@ -359,7 +358,7 @@ def setup_raiden(
         decimals=0,
         token_name="TKN",
         token_symbol="TKN",
-        token_contract_name=CONTRACT_HUMAN_STANDARD_TOKEN,
+        token_contract_name=CONTRACT_CUSTOM_TOKEN,
     )
     contract_addresses = deploy_smoketest_contracts(
         client=client,
@@ -503,11 +502,6 @@ def setup_smoketest(
     stdout: IO = None,
     append_report: Callable = print,
 ) -> Iterator[Dict[str, Any]]:
-    from raiden.tests.utils.smoketest import (
-        setup_raiden,
-        setup_matrix_for_smoketest,
-        setup_testchain_for_smoketest,
-    )
 
     make_requests_insecure()
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -566,3 +566,21 @@ def setup_smoketest(
                         logfile.flush()
                         logfile.seek(0)
                         append_report("Ethereum Node log output", logfile.read())
+
+
+@contextmanager
+def step_printer(step_count, stdout):
+    step = 0
+
+    def print_step(description: str, error: bool = False) -> None:
+        nonlocal step
+        step += 1
+        click.echo(
+            "{} {}".format(
+                click.style(f"[{step}/{step_count}]", fg="blue"),
+                click.style(description, fg="green" if not error else "red"),
+            ),
+            file=stdout,
+        )
+
+    yield print_step

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -16,6 +16,8 @@ from urllib.parse import urljoin, urlsplit
 import requests
 from eth_utils import encode_hex, to_normalized_address
 from gevent import subprocess
+from requests.packages import urllib3
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from synapse.handlers.auth import AuthHandler
 from twisted.internet import defer
 
@@ -284,6 +286,7 @@ def make_requests_insecure():
     # Disable verification in requests by replacing the 'verify'
     # attribute with non-writable property that always returns `False`
     requests.Session.verify = property(lambda self: False, lambda self, val: None)  # type: ignore
+    urllib3.disable_warnings(InsecureRequestWarning)
 
 
 @contextmanager

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -755,18 +755,14 @@ def smoketest(
             debug=debug,
             stdout=raiden_stdout,
             append_report=append_report,
-        ) as result:
-            args = result["args"]
-            contract_addresses = result["contract_addresses"]
-            token = result["token"]
-
+        ) as setup:
+            args = setup.args
             port = next(free_port_generator)
 
             args["api_address"] = f"localhost:{port}"
             args["environment_type"] = environment_type
 
             # Matrix server
-            args["matrix_server"] = result["matrix_server_url"]
             args["one_to_n_contract_address"] = "0x" + "1" * 40
             args["routing_mode"] = RoutingMode.LOCAL
             args["flat_fee"] = ()
@@ -779,12 +775,7 @@ def smoketest(
                 else:
                     args[option_.name] = option_.default
 
-            run_smoketest(
-                print_step=print_step,
-                args=args,
-                contract_addresses=contract_addresses,
-                token=token,
-            )
+            run_smoketest(print_step=print_step, setup=setup)
 
         append_report("Raiden Node stdout", raiden_stdout.getvalue())
 


### PR DESCRIPTION
This encapsulates a large part of the smoketest setup into its own reusable contextmanager. This simplifies the code in `raiden/ui/cli.py` and allows progress on https://github.com/raiden-network/scenario-player/issues/491