### PR TITLE
Hardened nonce usage

### DIFF
--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -90,8 +90,9 @@ def run_test_check_json_rpc_geth():
     # Test that patch version upgrades are not triggering the non-supported check
     g7, _, v7 = is_supported_client("Geth/v1.9.3-unstable-e9295163/linux-amd64/go1.9.1")
     g8, _, v8 = is_supported_client("Geth/v1.9.0-stable-52f24617/linux-amd64/go1.12.7")
+    g9, _, v9 = is_supported_client("Geth/v1.9.0-unstable-3d3e83ec-20190611/linux-amd64/go1.12.5")
     assert client is EthClient.GETH
-    assert all([g1, g2, g3, g7, g8])
+    assert all([g1, g2, g3, g7, g8, g9])
     assert not any([g4, g5, g6])
     assert v1 == "1.7.3"
     assert v2 == "1.7.2"
@@ -101,6 +102,7 @@ def run_test_check_json_rpc_geth():
     assert v6 == "999.999.999"
     assert v7 == "1.9.3"
     assert v8 == "1.9.0"
+    assert v9 == "1.9.0"
 
     b1, client, v1 = is_supported_client("Geth/v1.7.1-unstable-e9295163/linux-amd64/go1.9.1")
     b2, _, v2 = is_supported_client("Geth/v0.7.1-unstable-e9295163/linux-amd64/go1.9.1")

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 MYPY_ANNOTATION = "This assert is used to tell mypy what is the type of the variable"
 
 
-def typecheck(value: Any, expected: Type) -> None:
+def typecheck(value: Any, expected: Union[Type, Tuple[Type, ...]]) -> None:
     if not isinstance(value, expected):
         raise ValueError(f"Expected a value of type {expected}, got value of type {type(value)}")
 


### PR DESCRIPTION
```
The method `allocate_next_slot` existed for 3 reasons:

- Allow concurrent transaction to be instantiated (without waiting for
  the precondition/postcondition validation).
- Protect the `_available_nonce` with a lock, since the `nonce` must be
  used only once (ignoring transaction overwrites). The lock exists to
  ensure only one transaction will use the given nonce.
- Wrap the value of the `nonce` in a poors man linear type, to log and
  throw an exception when the allocated nonce is not used to avoid
  stalling the account's transaction queue.

However, the code had an annoying corner case. If a transaction is
created using values that cannot be correct serialized, or if the
blockchain node rejects the transaction, the nonce would be allocated
for a transaction that would never be sent. If another transaction is
allocated just after, to use the next nonce, which happens to be a
valid transaction, a hole into the transaction sequence would be
introduced leading to the stagnation of the transaction queue.

This removes the method `allocate_next_slot` since it is only used by
`transact`. But preserves the slot abstraction to make sure a log is
printed if any of the above happens. At the same time the critical
sectin of the `_nonce_lock` increase slightly to include the
`eth_sendRawTransaction` REST call, the nonce is only increment
afterwards. This should allow Raiden to gracefully recover from the
above, since the nonce is only incremented locally if the transaction
was effectively sent and accepted by the ethereum node.
```
```
If `TransactionSlotImplementation` is allocated with invalid values,
sending the transaction will fail but the slot will not be made
available. If that happens a hole will be created in the account's
nonces, and since every new transaction gets the next available nonce
the system will lock until the node is restarted. The asserts were added
to avoid this.
```