### PR TITLE
User deposit without allowance

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -574,7 +574,7 @@ class RaidenAPI:  # pragma: no unittest
                 20 bytes long.
             RaidenUnrecoverableError: May happen for multiple reasons:
                 - During preconditions checks, if the channel was not open
-                  at the time of the set_total_deposit call.
+                  at the time of the approve_and_set_total_deposit call.
                 - If the transaction fails during gas estimation or
                   if a previous withdraw transaction with the same value
                    was already mined.
@@ -771,10 +771,8 @@ class RaidenAPI:  # pragma: no unittest
         if total_channel_deposit >= UINT256_MAX:
             raise DepositOverLimit("Deposit overflow")
 
-        # set_total_deposit calls approve
-        # token.approve(netcontract_address, addendum)
         try:
-            channel_proxy.set_total_deposit(
+            channel_proxy.approve_and_set_total_deposit(
                 total_deposit=total_deposit, block_identifier=blockhash
             )
         except RaidenRecoverableError as e:

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -128,10 +128,10 @@ class PaymentChannel:
             channel_identifier=self.channel_identifier,
         )
 
-    def set_total_deposit(
+    def approve_and_set_total_deposit(
         self, total_deposit: TokenAmount, block_identifier: BlockSpecification
     ) -> None:
-        self.token_network.set_total_deposit(
+        self.token_network.approve_and_set_total_deposit(
             given_block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
             total_deposit=total_deposit,

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -863,8 +863,8 @@ class TokenNetwork:
         # `setTotalDeposit` must be serialized. This is necessary otherwise
         # the deposit will fail.
         #
-        # Calls to approve and setTotalDeposit are serialized with the
-        # deposit_lock to avoid transaction failure, because with two
+        # Calls to `approve` and `setTotalDeposit` are serialized with the
+        # `deposit_lock` to avoid transaction failure, because with two
         # concurrent deposits, we may have the transactions executed in the
         # following order
         #

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -864,7 +864,7 @@ class TokenNetwork:
         # the deposit will fail.
         #
         # Calls to `approve` and `setTotalDeposit` are serialized with the
-        # `deposit_lock` to avoid transaction failure, because with two
+        # `token_lock` to avoid transaction failure, because with two
         # concurrent deposits, we may have the transactions executed in the
         # following order
         #

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -660,7 +660,7 @@ class TokenNetwork:
         ).deposit
         return deposit > 0
 
-    def set_total_deposit(
+    def approve_and_set_total_deposit(
         self,
         given_block_identifier: BlockSpecification,
         channel_identifier: ChannelID,
@@ -675,12 +675,12 @@ class TokenNetwork:
         it simplifies the analysis of bad behavior and the handling code of
         out-dated balance proofs.
 
-        Races to `set_total_deposit` are handled by the smart contract, where
+        Races to `approve_and_set_total_deposit` are handled by the smart contract, where
         largest total deposit wins. The end balance of the funding accounts is
         undefined. E.g.
 
-        - Acc1 calls set_total_deposit with 10 tokens
-        - Acc2 calls set_total_deposit with 13 tokens
+        - Acc1 calls approve_and_set_total_deposit with 10 tokens
+        - Acc2 calls approve_and_set_total_deposit with 13 tokens
 
         - If Acc2's transaction is mined first, then Acc1 token supply is left intact.
         - If Acc1's transaction is mined first, then Acc2 will only move 3 tokens.
@@ -840,7 +840,7 @@ class TokenNetwork:
                 "given_block_identifier": format_block_id(given_block_identifier),
             }
 
-            self._set_total_deposit(
+            self._approve_and_set_total_deposit(
                 channel_identifier=channel_identifier,
                 total_deposit=total_deposit,
                 previous_total_deposit=our_details.deposit,
@@ -848,7 +848,7 @@ class TokenNetwork:
                 log_details=log_details,
             )
 
-    def _set_total_deposit(
+    def _approve_and_set_total_deposit(
         self,
         channel_identifier: ChannelID,
         total_deposit: TokenAmount,

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -236,7 +236,7 @@ class UserDeposit:
 
                 raise RaidenRecoverableError("Deposit failed of unknown reason")
 
-    def deposit(
+    def approve_and_deposit(
         self,
         beneficiary: Address,
         total_deposit: TokenAmount,
@@ -314,7 +314,7 @@ class UserDeposit:
                 "given_block_identifier": format_block_id(given_block_identifier),
                 "previous_total_deposit": previous_total_deposit,
             }
-            self._deposit(
+            self._approve_and_deposit(
                 beneficiary=beneficiary,
                 token=token,
                 total_deposit=total_deposit,
@@ -333,7 +333,7 @@ class UserDeposit:
 
         return balance
 
-    def _deposit(
+    def _approve_and_deposit(
         self,
         beneficiary: Address,
         token: Token,

--- a/raiden/tests/integration/api/test_restapi.py
+++ b/raiden/tests/integration/api/test_restapi.py
@@ -584,9 +584,9 @@ def test_api_open_and_deposit_race(
 ):
     """Tests that a race for the same deposit from the API is handled properly
 
-    The proxy's set_total_deposit is raising a RaidenRecoverableError in case of
-    races. That needs to be properly handled and not allowed to bubble out of
-    the greenlet.
+    The proxy's approve_and_set_total_deposit is raising a
+    RaidenRecoverableError in case of races. That needs to be properly handled
+    and not allowed to bubble out of the greenlet.
 
     Regression test for https://github.com/raiden-network/raiden/issues/4937
     """

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -185,7 +185,7 @@ def transfer_user_deposit_tokens(
     user_deposit_deploy_result: Callable[[], UserDeposit], transfer_to: Address
 ) -> None:
     user_deposit_proxy = user_deposit_deploy_result()
-    user_deposit_proxy.deposit(
+    user_deposit_proxy.approve_and_deposit(
         beneficiary=transfer_to, total_deposit=MONITORING_REWARD, given_block_identifier="latest"
     )
 

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -82,7 +82,9 @@ def test_payment_channel_proxy_basics(
     token_proxy.transfer(rpc_client.address, TokenAmount(initial_token_balance))
     assert token_proxy.balance_of(rpc_client.address) == initial_token_balance
     assert token_proxy.balance_of(partner) == 0
-    channel_proxy_1.set_total_deposit(total_deposit=TokenAmount(10), block_identifier="latest")
+    channel_proxy_1.approve_and_set_total_deposit(
+        total_deposit=TokenAmount(10), block_identifier="latest"
+    )
 
     # ChannelOpened, ChannelNewDeposit
     channel_events = get_all_netting_channel_events(
@@ -205,5 +207,7 @@ def test_payment_channel_proxy_basics(
         "This call should never have been attempted."
     )
     with pytest.raises(BrokenPreconditionError):
-        channel_proxy_1.set_total_deposit(total_deposit=TokenAmount(20), block_identifier="latest")
+        channel_proxy_1.approve_and_set_total_deposit(
+            total_deposit=TokenAmount(20), block_identifier="latest"
+        )
         pytest.fail(msg)

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -71,14 +71,14 @@ def test_token_network_deposit_race(
     )
     assert channel_identifier is not None
 
-    c1_token_network_proxy.set_total_deposit(
+    c1_token_network_proxy.approve_and_set_total_deposit(
         given_block_identifier="latest",
         channel_identifier=channel_identifier,
         total_deposit=2,
         partner=c2_client.address,
     )
     with pytest.raises(BrokenPreconditionError):
-        c1_token_network_proxy.set_total_deposit(
+        c1_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,
             total_deposit=1,
@@ -223,7 +223,7 @@ def test_token_network_proxy(
 
     msg = "Trying a deposit to an inexisting channel must fail."
     with pytest.raises(BrokenPreconditionError):
-        c1_token_network_proxy.set_total_deposit(
+        c1_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=100,
             total_deposit=1,
@@ -294,9 +294,9 @@ def test_token_network_proxy(
         is True
     )
 
-    msg = "set_total_deposit must fail if the amount exceed the account's balance"
+    msg = "approve_and_set_total_deposit must fail if the amount exceed the account's balance"
     with pytest.raises(BrokenPreconditionError):
-        c1_token_network_proxy.set_total_deposit(
+        c1_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,
             total_deposit=initial_token_balance + 1,
@@ -304,9 +304,9 @@ def test_token_network_proxy(
         )
         pytest.fail(msg)
 
-    msg = "set_total_deposit must fail with a negative amount"
+    msg = "approve_and_set_total_deposit must fail with a negative amount"
     with pytest.raises(BrokenPreconditionError):
-        c1_token_network_proxy.set_total_deposit(
+        c1_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,
             total_deposit=-1,
@@ -314,9 +314,9 @@ def test_token_network_proxy(
         )
         pytest.fail(msg)
 
-    msg = "set_total_deposit must fail with a zero amount"
+    msg = "approve_and_set_total_deposit must fail with a zero amount"
     with pytest.raises(BrokenPreconditionError):
-        c1_token_network_proxy.set_total_deposit(
+        c1_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,
             total_deposit=0,
@@ -324,7 +324,7 @@ def test_token_network_proxy(
         )
         pytest.fail(msg)
 
-    c1_token_network_proxy.set_total_deposit(
+    c1_token_network_proxy.approve_and_set_total_deposit(
         given_block_identifier="latest",
         channel_identifier=channel_identifier,
         total_deposit=10,
@@ -442,7 +442,7 @@ def test_token_network_proxy(
     msg = "depositing to a closed channel must fail"
     match = "closed"
     with pytest.raises(RaidenRecoverableError, match=match):
-        c2_token_network_proxy.set_total_deposit(
+        c2_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier=blocknumber_prior_to_close,
             channel_identifier=channel_identifier,
             total_deposit=20,
@@ -494,7 +494,7 @@ def test_token_network_proxy(
 
     msg = "depositing to a settled channel must fail"
     with pytest.raises(BrokenPreconditionError):
-        c1_token_network_proxy.set_total_deposit(
+        c1_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,
             total_deposit=10,
@@ -546,13 +546,13 @@ def test_token_network_proxy_update_transfer(
     assert initial_balance_c1 == initial_balance
     initial_balance_c2 = token_proxy.balance_of(c2_client.address)
     assert initial_balance_c2 == initial_balance
-    c1_token_network_proxy.set_total_deposit(
+    c1_token_network_proxy.approve_and_set_total_deposit(
         given_block_identifier="latest",
         channel_identifier=channel_identifier,
         total_deposit=10,
         partner=c2_client.address,
     )
-    c2_token_network_proxy.set_total_deposit(
+    c2_token_network_proxy.approve_and_set_total_deposit(
         given_block_identifier="latest",
         channel_identifier=channel_identifier,
         total_deposit=10,
@@ -714,7 +714,7 @@ def test_token_network_proxy_update_transfer(
 
     # Already settled
     with pytest.raises(BrokenPreconditionError) as exc:
-        c2_token_network_proxy.set_total_deposit(
+        c2_token_network_proxy.approve_and_set_total_deposit(
             given_block_identifier="latest",
             channel_identifier=channel_identifier,
             total_deposit=20,
@@ -814,7 +814,7 @@ def test_token_network_actions_at_pruned_blocks(
     c1_client.wait_until_block(target_block_number=pruned_number + STATE_PRUNING_AFTER_BLOCKS)
 
     # deposit with given block being pruned
-    c1_token_network_proxy.set_total_deposit(
+    c1_token_network_proxy.approve_and_set_total_deposit(
         given_block_identifier=pruned_number,
         channel_identifier=channel_identifier,
         total_deposit=2,
@@ -965,7 +965,7 @@ def test_concurrent_set_total_deposit(token_network_proxy: TokenNetwork) -> None
             total_deposit = i + 1
 
             g = gevent.spawn(
-                token_network_proxy.set_total_deposit,
+                token_network_proxy.approve_and_set_total_deposit,
                 given_block_identifier,
                 channel_identifier,
                 total_deposit,

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -185,7 +185,7 @@ def payment_channel_open_and_deposit(
 
             # the payment channel proxy will call approve
             # token.approve(token_network_proxy.address, deposit)
-            payment_channel_proxy.set_total_deposit(
+            payment_channel_proxy.approve_and_set_total_deposit(
                 total_deposit=deposit, block_identifier="latest"
             )
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -642,7 +642,7 @@ def run(ctx: Context, **kwargs: Any) -> None:
         name_or_id = ID_TO_NETWORKNAME.get(kwargs["network_id"], kwargs["network_id"])
         click.secho(
             f"FATAL: Another Raiden instance already running for account "
-            f"{address} on network id {name_or_id}",
+            f"{to_checksum_address(kwargs['address'])} on network id {name_or_id}",
             fg="red",
         )
         sys.exit(ReturnCode.CONFIGURATION_ERROR)


### PR DESCRIPTION
- renamed `deposit` to `approve_and_deposit`
- renamed `set_total_deposit` to `approve_and_set_total_deposit`.
- added a plain `deposit` to `UserDeposit`
- reduced the critical section of the `approve_and_deposit` in the `UserDeposit`, allows for more concurrent `approve` transactions.