### PR TITLE
Added type for sent transactions

### DIFF
--- a/raiden/network/proxies/custom_token.py
+++ b/raiden/network/proxies/custom_token.py
@@ -4,7 +4,7 @@ import structlog
 
 from raiden.network.proxies.exceptions import MintFailed
 from raiden.network.proxies.token import Token
-from raiden.network.rpc.transactions import check_transaction_threw
+from raiden.network.rpc.transactions import was_transaction_successfully_mined
 from raiden.utils.typing import Address, TokenAmount
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN
 from raiden_contracts.contract_manager import ContractManager
@@ -31,12 +31,10 @@ class CustomToken(Token):
         )
 
         if estimated_transaction is not None:
-            transaction_hash = self.client.transact(estimated_transaction)
+            transaction_sent = self.client.transact(estimated_transaction)
+            transaction_mined = self.client.poll_transaction(transaction_sent)
 
-            receipt = self.client.poll_transaction(transaction_hash)
-            failed_receipt = check_transaction_threw(receipt=receipt)
-
-            if failed_receipt:
+            if not was_transaction_successfully_mined(transaction_mined):
                 raise MintFailed(f"Mint failed.")
 
         else:
@@ -57,12 +55,10 @@ class CustomToken(Token):
         )
 
         if estimated_transaction is not None:
-            transaction_hash = self.client.transact(estimated_transaction)
+            transaction_sent = self.client.transact(estimated_transaction)
+            transaction_mined = self.client.poll_transaction(transaction_sent)
 
-            receipt = self.client.poll_transaction(transaction_hash)
-            failed_receipt = check_transaction_threw(receipt=receipt)
-
-            if failed_receipt:
+            if not was_transaction_successfully_mined(transaction_mined):
                 raise MintFailed(f"Call to contract method mintFor: Transaction failed.")
 
         else:

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -7,7 +7,7 @@ from web3.exceptions import BadFunctionCallOutput
 
 from raiden.exceptions import BrokenPreconditionError, RaidenUnrecoverableError
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
-from raiden.network.rpc.transactions import check_transaction_threw
+from raiden.network.rpc.transactions import was_transaction_successfully_mined
 from raiden.utils.typing import (
     Address,
     Any,
@@ -119,10 +119,10 @@ class ServiceRegistry:
             msg = "ServiceRegistry.deposit transaction fails"
             raise RaidenUnrecoverableError(msg)
 
-        transaction_hash = self.client.transact(estimated_transaction)
-        receipt = self.client.poll_transaction(transaction_hash)
-        failed_receipt = check_transaction_threw(receipt=receipt)
-        if failed_receipt:
+        transaction_sent = self.client.transact(estimated_transaction)
+        transaction_mined = self.client.poll_transaction(transaction_sent)
+
+        if not was_transaction_successfully_mined(transaction_mined):
             msg = "ServiceRegistry.deposit transaction failed"
             raise RaidenUnrecoverableError(msg)
 
@@ -145,9 +145,9 @@ class ServiceRegistry:
             msg = f"URL {url} is invalid"
             raise RaidenUnrecoverableError(msg)
 
-        transaction_hash = self.client.transact(estimated_transaction)
-        receipt = self.client.poll_transaction(transaction_hash)
-        failed_receipt = check_transaction_threw(receipt=receipt)
-        if failed_receipt:
+        transaction_sent = self.client.transact(estimated_transaction)
+        transaction_mined = self.client.poll_transaction(transaction_sent)
+
+        if not was_transaction_successfully_mined(transaction_mined):
             msg = f"URL {url} is invalid"
             raise RaidenUnrecoverableError(msg)

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -4,6 +4,8 @@ from eth_utils import decode_hex
 
 from raiden.blockchain.filters import decode_event, get_filter_args_for_specific_event_from_channel
 from raiden.exceptions import RaidenUnrecoverableError
+from raiden.network.rpc.client import ByteCode, EthTransfer, SmartContractCall, TransactionMined
+from raiden.network.rpc.transactions import was_transaction_successfully_mined
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.formatting import format_block_id
 from raiden.utils.typing import (
@@ -122,3 +124,52 @@ def raise_on_call_returned_empty(given_block_identifier: BlockSpecification) -> 
         f"should never happened."
     )
     raise RaidenUnrecoverableError(msg)
+
+
+def check_transaction_gas_used(transaction: TransactionMined) -> None:
+    """ Raise an exception if the transaction consumed all the gas. """
+
+    if was_transaction_successfully_mined(transaction):
+        return
+
+    receipt = transaction.receipt
+    gas_used = receipt["gasUsed"]
+
+    if gas_used >= transaction.startgas:
+        if isinstance(transaction.data, SmartContractCall):
+            smart_contract_function = transaction.data.function
+
+            # This error happened multiple times, it deserves a refresher on
+            # frequent reasons why it may happen:
+            msg = (
+                f"`{smart_contract_function}` failed and all gas was used "
+                f"({gas_used}). This can happen for a few reasons: "
+                f"1. The smart contract code may have an assert inside an if "
+                f"statement, at the time of gas estimation the condition was false, "
+                f"but another transaction changed the state of the smart contrat "
+                f"making the condition true. 2. The call to "
+                f"`{smart_contract_function}` executes an opcode with variable gas, "
+                f"at the time of gas estimation the cost was low, but another "
+                f"transaction changed the environment so that the new cost is high. "
+                f"This is particularly problematic storage is set to `0`, since the "
+                f"cost of a `SSTORE` increases 4 times. 3. The cost of the function "
+                f"varies with external state, if the cost increases because of "
+                f"another transaction the transaction can fail."
+            )
+        elif isinstance(transaction.data, ByteCode):
+            contract_name = transaction.data.contract_name
+            msg = f"Deploying {contract_name} failed because all the gas was used!"
+        else:
+            assert isinstance(transaction.data, EthTransfer)
+            msg = f"EthTransfer  ailed!"
+
+        # Keeping this around just in case the wrong value from the receipt is
+        # used (Previously the `cumulativeGasUsed` was used, which was
+        # incorrect).
+        if gas_used > transaction.startgas:
+            msg = (
+                "The receipt `gasUsed` reported in the receipt is higher than the "
+                "transaction startgas!." + msg
+            )
+
+        raise RaidenUnrecoverableError(msg)

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -161,7 +161,7 @@ def check_transaction_gas_used(transaction: TransactionMined) -> None:
             msg = f"Deploying {contract_name} failed because all the gas was used!"
         else:
             assert isinstance(transaction.data, EthTransfer)
-            msg = f"EthTransfer  ailed!"
+            msg = f"EthTransfer failed!"
 
         # Keeping this around just in case the wrong value from the receipt is
         # used (Previously the `cumulativeGasUsed` was used, which was

--- a/raiden/network/rpc/transactions.py
+++ b/raiden/network/rpc/transactions.py
@@ -1,21 +1,15 @@
 from typing import Any, Dict, Optional
 
 from raiden.constants import RECEIPT_FAILURE_CODE
+from raiden.network.rpc.client import TransactionMined
 
 
-def check_transaction_threw(receipt: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Check if the transaction threw/reverted or if it executed properly by reading
-       the transaction receipt.
-       Returns None in case of success and the transaction receipt if the
-       transaction's status indicator is 0x0.
-    """
-    if "status" not in receipt:
+def was_transaction_successfully_mined(transaction: TransactionMined) -> Optional[Dict[str, Any]]:
+    """ `True` if the transaction was successfully mined, `False` otherwise. """
+    if "status" not in transaction.receipt:
         # This should never happen. Raiden checks ethereum client for compatibility at startup
         raise AssertionError(
             "Transaction receipt does not contain a status field. Upgrade your client"
         )
 
-    if receipt["status"] == RECEIPT_FAILURE_CODE:
-        return receipt
-
-    return None
+    return transaction.receipt["status"] != RECEIPT_FAILURE_CODE

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -9,11 +9,16 @@ from raiden.constants import GENESIS_BLOCK_NUMBER, STATE_PRUNING_AFTER_BLOCKS
 from raiden.exceptions import NoStateForBlockIdentifier
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
 from raiden.network.proxies.secret_registry import SecretRegistry
-from raiden.network.rpc.client import JSONRPCClient, SmartContractCall, TransactionEstimated
+from raiden.network.rpc.client import (
+    JSONRPCClient,
+    SmartContractCall,
+    TransactionEstimated,
+    TransactionSent,
+)
 from raiden.tests.utils.events import must_have_event
 from raiden.tests.utils.factories import make_secret
 from raiden.utils.secrethash import sha256_secrethash
-from raiden.utils.typing import BlockNumber, Dict, List, PrivateKey, Secret, TransactionHash
+from raiden.utils.typing import BlockNumber, Dict, List, PrivateKey, Secret
 from raiden_contracts.contract_manager import ContractManager
 
 
@@ -151,7 +156,7 @@ def test_concurrent_secret_registration(secret_registry_proxy: SecretRegistry, m
 
         def count_how_many_times_a_secret_is_sent(
             transaction: TransactionEstimated
-        ) -> TransactionHash:
+        ) -> TransactionSent:
             assert isinstance(transaction.data, SmartContractCall)
             assert isinstance(transaction.data.args, tuple)
 

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 import gevent
 import pytest
 from web3 import Web3
@@ -7,6 +5,7 @@ from web3 import Web3
 from raiden.network.rpc.client import (
     EthTransfer,
     JSONRPCClient,
+    TransactionMined,
     gas_price_for_fast_transaction,
     geth_discover_next_available_nonce,
 )
@@ -24,7 +23,7 @@ def test_geth_request_pruned_data_raises_an_exception(
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
     iterations = 1
 
-    def send_transaction() -> Dict[str, Any]:
+    def send_transaction() -> TransactionMined:
         estimated_transaction = deploy_client.estimate_gas(
             contract_proxy, "waste_storage", {}, iterations
         )
@@ -32,7 +31,7 @@ def test_geth_request_pruned_data_raises_an_exception(
         transaction_hash = deploy_client.transact(estimated_transaction)
         return deploy_client.poll_transaction(transaction_hash)
 
-    first_receipt = send_transaction()
+    first_receipt = send_transaction().receipt
     mined_block_number = first_receipt["blockNumber"]
 
     while mined_block_number + 127 > web3.eth.blockNumber:

--- a/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
@@ -1,8 +1,6 @@
-from typing import Any, Dict
-
 import pytest
 
-from raiden.network.rpc.client import JSONRPCClient
+from raiden.network.rpc.client import JSONRPCClient, TransactionMined
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 
 pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
@@ -25,7 +23,7 @@ def test_parity_request_pruned_data_raises_an_exception(deploy_client: JSONRPCCl
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcWithStorageTest")
     iterations = 1000
 
-    def send_transaction() -> Dict[str, Any]:
+    def send_transaction() -> TransactionMined:
         estimated_transaction = deploy_client.estimate_gas(
             contract_proxy, "waste_storage", {}, iterations
         )
@@ -33,7 +31,7 @@ def test_parity_request_pruned_data_raises_an_exception(deploy_client: JSONRPCCl
         transaction = deploy_client.transact(estimated_transaction)
         return deploy_client.poll_transaction(transaction)
 
-    first_receipt = send_transaction()
+    first_receipt = send_transaction().receipt
     pruned_block_number = first_receipt["blockNumber"]
 
     for _ in range(10):

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -76,8 +76,8 @@ def test_estimate_gas_defaults_to_pending(deploy_client: JSONRPCClient) -> None:
     assert estimated_second_transaction, "gas estimation should not have failed"
     second_tx = deploy_client.transact(estimated_second_transaction)
 
-    first_receipt = deploy_client.poll_transaction(first_tx)
-    second_receipt = deploy_client.poll_transaction(second_tx)
+    first_receipt = deploy_client.poll_transaction(first_tx).receipt
+    second_receipt = deploy_client.poll_transaction(second_tx).receipt
 
     assert second_receipt["gasLimit"] < deploy_client.get_block("latest")["gasLimit"]
     assert first_receipt["status"] != RECEIPT_FAILURE_CODE

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
@@ -153,7 +153,7 @@ def test_local_transaction_with_zero_gasprice_is_mined(deploy_client: JSONRPCCli
     assert estimated_transaction.gas_price == 0, "Test requires a gas_price of zero"
 
     zerogas_txhash = deploy_client.transact(estimated_transaction)
-    zerogas_receipt = deploy_client.poll_transaction(zerogas_txhash)
+    zerogas_receipt = deploy_client.poll_transaction(zerogas_txhash).receipt
     zerogas_tx = deploy_client.web3.eth.getTransaction(zerogas_txhash)
 
     msg = "Even thought the transaction had a zero gas price, it is not removed from the pool"

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -9,7 +9,7 @@ from raiden.network.rpc.client import (
     discover_next_available_nonce,
     gas_price_for_fast_transaction,
 )
-from raiden.network.rpc.transactions import check_transaction_threw
+from raiden.network.rpc.transactions import was_transaction_successfully_mined
 from raiden.tests.utils.client import burn_eth
 from raiden.tests.utils.factories import make_address
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
@@ -29,10 +29,9 @@ def test_transact_opcode(deploy_client: JSONRPCClient) -> None:
     assert estimated_transaction
     estimated_transaction.estimated_gas *= 2
 
-    transaction_hash = deploy_client.transact(estimated_transaction)
-    receipt = deploy_client.poll_transaction(transaction_hash)
-
-    assert check_transaction_threw(receipt=receipt) is None, "must be empty"
+    transaction_sent = deploy_client.transact(estimated_transaction)
+    transaction_mined = deploy_client.poll_transaction(transaction_sent)
+    assert was_transaction_successfully_mined(transaction_mined) is None, "must be empty"
 
 
 def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
@@ -58,10 +57,9 @@ def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
         gas_price=gas_price,
         approximate_block=(block["hash"], block["number"]),
     )
-    transaction_hash = deploy_client.transact(estimated_transaction_fail_assert)
-    receipt = deploy_client.poll_transaction(transaction_hash)
-
-    assert check_transaction_threw(receipt=receipt), "must not be empty"
+    transaction_fail_assert_sent = deploy_client.transact(estimated_transaction_fail_assert)
+    transaction_fail_assert_mined = deploy_client.poll_transaction(transaction_fail_assert_sent)
+    assert was_transaction_successfully_mined(transaction_fail_assert_mined), "must not be empty"
 
     estimated_transaction_fail_require = TransactionEstimated(
         from_address=address,
@@ -72,10 +70,9 @@ def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
         gas_price=gas_price,
         approximate_block=(block["hash"], block["number"]),
     )
-    transaction_hash = deploy_client.transact(estimated_transaction_fail_require)
-    receipt = deploy_client.poll_transaction(transaction_hash)
-
-    assert check_transaction_threw(receipt=receipt), "must not be empty"
+    transaction_fail_require_sent = deploy_client.transact(estimated_transaction_fail_require)
+    transaction_fail_require_mined = deploy_client.poll_transaction(transaction_fail_require_sent)
+    assert was_transaction_successfully_mined(transaction_fail_require_mined), "must not be empty"
 
 
 def test_transact_opcode_oog(deploy_client: JSONRPCClient) -> None:
@@ -90,10 +87,9 @@ def test_transact_opcode_oog(deploy_client: JSONRPCClient) -> None:
     assert estimated_transaction
     estimated_transaction.estimated_gas //= 2
 
-    transaction = deploy_client.transact(estimated_transaction)
-    receipt = deploy_client.poll_transaction(transaction)
-
-    assert check_transaction_threw(receipt=receipt), "must not be empty"
+    transaction_sent = deploy_client.transact(estimated_transaction)
+    transaction_mined = deploy_client.poll_transaction(transaction_sent)
+    assert was_transaction_successfully_mined(transaction_mined) is None, "must be empty"
 
 
 def test_transact_fails_if_the_account_does_not_have_enough_eth_to_pay_for_the_gas(

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -31,7 +31,7 @@ def test_transact_opcode(deploy_client: JSONRPCClient) -> None:
 
     transaction_sent = deploy_client.transact(estimated_transaction)
     transaction_mined = deploy_client.poll_transaction(transaction_sent)
-    assert was_transaction_successfully_mined(transaction_mined) is None, "must be empty"
+    assert was_transaction_successfully_mined(transaction_mined), "Transaction must be succesfull"
 
 
 def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
@@ -59,7 +59,8 @@ def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
     )
     transaction_fail_assert_sent = deploy_client.transact(estimated_transaction_fail_assert)
     transaction_fail_assert_mined = deploy_client.poll_transaction(transaction_fail_assert_sent)
-    assert was_transaction_successfully_mined(transaction_fail_assert_mined), "must not be empty"
+    msg = "Transaction must have failed"
+    assert not was_transaction_successfully_mined(transaction_fail_assert_mined), msg
 
     estimated_transaction_fail_require = TransactionEstimated(
         from_address=address,
@@ -72,7 +73,8 @@ def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
     )
     transaction_fail_require_sent = deploy_client.transact(estimated_transaction_fail_require)
     transaction_fail_require_mined = deploy_client.poll_transaction(transaction_fail_require_sent)
-    assert was_transaction_successfully_mined(transaction_fail_require_mined), "must not be empty"
+    msg = "Transaction must have failed"
+    assert not was_transaction_successfully_mined(transaction_fail_require_mined), msg
 
 
 def test_transact_opcode_oog(deploy_client: JSONRPCClient) -> None:
@@ -89,7 +91,8 @@ def test_transact_opcode_oog(deploy_client: JSONRPCClient) -> None:
 
     transaction_sent = deploy_client.transact(estimated_transaction)
     transaction_mined = deploy_client.poll_transaction(transaction_sent)
-    assert was_transaction_successfully_mined(transaction_mined) is None, "must be empty"
+    msg = "Transaction must be succesfull"
+    assert not was_transaction_successfully_mined(transaction_mined), msg
 
 
 def test_transact_fails_if_the_account_does_not_have_enough_eth_to_pay_for_the_gas(

--- a/raiden/tests/unit/test_rpc.py
+++ b/raiden/tests/unit/test_rpc.py
@@ -1,8 +1,5 @@
-import pytest
-
 from raiden.constants import EthClient
 from raiden.network.rpc.client import ClientErrorInspectResult, inspect_client_error
-from raiden.network.rpc.transactions import check_transaction_threw
 
 
 def test_inspect_client_error():
@@ -15,9 +12,3 @@ def test_inspect_client_error():
 
     result = inspect_client_error(exception, EthClient.PARITY)
     assert result == ClientErrorInspectResult.ALWAYS_FAIL
-
-
-def test_check_transaction_threw_old_status():
-    """Test that an assertion is thrown if transaction receipt is pre-Byzantium"""
-    with pytest.raises(AssertionError):
-        check_transaction_threw({"this": "is", "a": "receipt", "without": "status"})


### PR DESCRIPTION
```
- In some places the value `cumulativeGasUsed` from the receipt was
  used, which is not the correct value to check for problems with the
  gas estimation. The correct vaue is `gasUsed`. The cumulative value,
  *includes* the gas usage of the other transactions in the same block,
  while the `gasUsed` only contains the gas usage of the current
  transaction.
- The `TransactionSlot` is not exposed anymore. Since the slot object is
  not available outside the `transact` method anymore, we can guarantee
  the slot is used. There is no need for the `_sent_lock` and the slot
  state. The slot class was kept because it merges the
  `TransactionEstimated` and `EthTransfer` into a single concept, which
  makes the code simpler to read.
- Added the type `TransactionMined`, which allows for better type
  checking. Namely, `check_transaction_gas_used` receives a mined
  transaction as an argument, and not just a dictionary.
```

PR https://github.com/raiden-network/raiden/pull/5975 is failing for the same reason as https://github.com/raiden-network/raiden/pull/5883 was. The check for gas usage didn't caught it because it was using the wrong value from the `receipt`. This PR fixes that and improves the types used to represent transactions.