### PR TITLE
Raise exception when `user.displayname` cannot be read

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -138,7 +138,7 @@ class DisplayNameCache:
                     try:
                         user.get_display_name()
                     except MatrixRequestError:
-                        return
+                        raise TransportError("Could not get 'display_name' for user")
 
                 if user.displayname is not None:
                     self.userid_to_displayname[user.user_id] = user.displayname


### PR DESCRIPTION
## Description

Fixes: https://github.com/raiden-network/raiden-services/issues/733


This is the case when the servers disk is full.

The displayname is used and we cannot continue when it is not set.

## Open questions

- [x] Which exception to raise, `TransportError` or `RaidenUnrecoverableError`?
- [x] Are `TransportError`s catched somewhere?
