### PR TITLE
Bundle the synapse testing config template

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 include requirements.txt
 include requirements/requirements.txt
+include raiden/tests/utils/synapse_config.yaml.template

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     package_data={"raiden": ["py.typed"]},
     license="MIT",
     zip_safe=False,
+    include_package_data=True,
     long_description_content_type="text/markdown",
     keywords="raiden",
     classifiers=[


### PR DESCRIPTION
This is required for supporting the `scenario_player` smoketest.