### PR TITLE
Always try to create room on healthchcheck

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -617,19 +617,19 @@ class MatrixTransport(Runnable):
 
             self._address_mgr.add_address(node_address)
 
-            # Start the room creation early on. This reduces latency for channel
-            # partners, by removing the latency of creating the room on the first
-            # message.
-            #
-            # This does not reduce latency for target<->initiator communication,
-            # since the target may be the node with lower address, and therefore
-            # the node that has to create the room.
-            self._maybe_create_room_for_address(node_address)
+        # Start the room creation early on. This reduces latency for channel
+        # partners, by removing the latency of creating the room on the first
+        # message.
+        #
+        # This does not reduce latency for target<->initiator communication,
+        # since the target may be the node with lower address, and therefore
+        # the node that has to create the room.
+        self._maybe_create_room_for_address(node_address)
 
-            # Ensure network state is updated in case we already know about the user presences
-            # representing the target node
-            user_ids = self.get_user_ids_for_address(node_address)
-            self._address_mgr.track_address_presence(node_address, user_ids)
+        # Ensure network state is updated in case we already know about the user presences
+        # representing the target node
+        user_ids = self.get_user_ids_for_address(node_address)
+        self._address_mgr.track_address_presence(node_address, user_ids)
 
     def _health_check_worker(self) -> None:
         """ Worker to process healthcheck requests. """


### PR DESCRIPTION
## Description

Fixes: #5918 
⚠️ WIP

Besides some gas estimation this fixes the"lock expired" problem in BF5 for me. While this fixes the problem, I'm not sure if this is a proper solution.

The connection manager seems to create a different code path than "manually" opened channels. Somehow the reachability is already set when`immediate_health_check_for` is called for a peer.

https://github.com/raiden-network/raiden/blob/86dcbf6d3349bcb4508b77d1d98e186faf09533f/raiden/network/transport/matrix/transport.py#L600-L614

There `is_health_information_available` is unexpectedly `True`, which results in the room never being created.
