### PR TITLE
Side-effect free connection manager healthcheck

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -590,8 +590,7 @@ class MatrixTransport(Runnable):
     def force_check_address_reachability(self, address: Address) -> AddressReachability:
         """Force checks an address's reachability bypassing the whitelisting"""
         user_ids = self.get_user_ids_for_address(address)
-        self._address_mgr.track_address_presence(address, user_ids)
-        return self._address_mgr.get_address_reachability(address)
+        return self._address_mgr.get_reachability_from_matrix(user_ids)
 
     def async_start_health_check(self, node_address: Address) -> None:
         """

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -322,6 +322,19 @@ class UserAddressManager:
 
         self._maybe_address_reachability_changed(address)
 
+    def get_reachability_from_matrix(self, user_ids: Iterable[str]) -> AddressReachability:
+        """ Get the current reachability without any side effects
+
+        Since his does not even do any caching, don't use it for the normal
+        communication between participants in a channel.
+        """
+        for uid in user_ids:
+            presence = self._fetch_user_presence(uid)
+            if USER_PRESENCE_TO_ADDRESS_REACHABILITY[presence] == AddressReachability.REACHABLE:
+                return AddressReachability.REACHABLE
+
+        return AddressReachability.UNREACHABLE
+
     def _maybe_address_reachability_changed(self, address: Address) -> None:
         # A Raiden node may have multiple Matrix users, this happens when
         # Raiden roams from a Matrix server to another. This loop goes over all

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -339,7 +339,6 @@ def test_connect_does_not_open_channels_with_offline_nodes(raiden_network, token
         )
 
 
-@pytest.mark.xfail(reason="https://github.com/raiden-network/raiden/issues/5918")
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [0])


### PR DESCRIPTION
The healthcheck problems in the bf5 scenarios are caused by`force_check_address_reachability`, which is only used in the connection manager. When that is called, the address and its presence become known, which prevents the room from being created in `immediate_health_check_for`.
    
This PR removes all side-effects from `force_check_address_reachability`, thereby resolving this issue.

Closes https://github.com/raiden-network/raiden/issues/5918