### PR TITLE
Update twisted to 20.3.0 due to vulnerability fix

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -169,7 +169,7 @@ toml==0.10.0              # via -r requirements-dev.txt, black
 toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
-twisted[tls]==19.2.1      # via -r requirements-dev.txt, matrix-synapse, treq
+twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
 typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, mypy
 typing-extensions==3.7.4.1  # via -r requirements-dev.txt, matrix-synapse, mypy, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -163,7 +163,7 @@ toml==0.10.0              # via black
 toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via -r requirements.txt, ipython
 treq==18.6.0              # via matrix-synapse
-twisted[tls]==19.2.1      # via matrix-synapse, treq
+twisted[tls]==20.3.0      # via matrix-synapse, treq
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4.1  # via -r requirements.txt, matrix-synapse, mypy, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass


### PR DESCRIPTION
Matrix had a [security advisory](https://github.com/matrix-org/synapse/blob/master/CHANGES.md#security-advisory) for a vulnerability issue related ro request-smuggling attacks. nice discovery @palango 

Should not be too much of an issue for our use case but they provided an easy fix. 