### PR TITLE
Remove the usage of canonical alias

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -53,7 +53,6 @@ class Room(MatrixRoom):
     def __init__(self, client: "GMatrixClient", room_id: str) -> None:
         super().__init__(client, room_id)
         self._members: Dict[str, User] = {}
-        self.canonical_alias: str
         self.aliases: List[str]
 
     def get_joined_members(self, force_resync: bool = False) -> List[User]:
@@ -82,8 +81,6 @@ class Room(MatrixRoom):
         self._members.pop(user_id, None)
 
     def __repr__(self) -> str:
-        if self.canonical_alias:
-            return f"<Room id={self.room_id!r} alias={self.canonical_alias!r}>"
         return f"<Room id={self.room_id!r} aliases={self.aliases!r}>"
 
     def update_local_aliases(self) -> bool:
@@ -116,12 +113,6 @@ class Room(MatrixRoom):
             if self.aliases != response["aliases"]:
                 self.aliases = response["aliases"]
                 changed = True
-        if "alias" in response:
-            if self.canonical_alias != response["alias"]:
-                self.canonical_alias = response["alias"]
-                changed = True
-        if changed and self.aliases and not self.canonical_alias:
-            self.canonical_alias = self.aliases[0]
         return changed
 
 
@@ -536,7 +527,7 @@ class GMatrixClient(MatrixClient):
         if room_id not in self.rooms:
             self.rooms[room_id] = Room(self, room_id)
         room = self.rooms[room_id]
-        if not room.canonical_alias:
+        if not room.aliases:
             room.update_local_aliases()
         return room
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1326,9 +1326,6 @@ class MatrixTransport(Runnable):
             return room
 
     def _is_broadcast_room(self, room: Room) -> bool:
-        room_aliases = set(room.aliases)
-        if room.canonical_alias:
-            room_aliases.add(room.canonical_alias)
         return any(
             suffix in room_alias
             for suffix in self._config.broadcast_rooms

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -169,7 +169,7 @@ toml==0.10.0              # via -r requirements-dev.txt, black
 toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
-twisted[tls]==19.2.1      # via -r requirements-dev.txt, matrix-synapse, treq
+twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
 typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, mypy
 typing-extensions==3.7.4.1  # via -r requirements-dev.txt, matrix-synapse, mypy, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -163,7 +163,7 @@ toml==0.10.0              # via black
 toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via -r requirements.txt, ipython
 treq==18.6.0              # via matrix-synapse
-twisted[tls]==19.2.1      # via matrix-synapse, treq
+twisted[tls]==20.3.0      # via matrix-synapse, treq
 typed-ast==1.4.0          # via astroid, mypy
 typing-extensions==3.7.4.1  # via -r requirements.txt, matrix-synapse, mypy, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass


### PR DESCRIPTION
## Description

We never use or update canonical alias. The alias we use is stored in `room.aliases`. Therefore we can remove the usage of canonical alias until Matrix restructures its alias system (planned)