### PR TITLE
fix test_transfer_after_connect_works

### DIFF
--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -10,6 +10,7 @@ from raiden.transfer import channel, views
 from raiden.transfer.events import EventPaymentSentSuccess
 from raiden.transfer.state import ChannelState
 from raiden.utils.typing import BlockTimeout as BlockOffset, PaymentAmount, TokenAmount
+from raiden.waiting import wait_for_block
 
 
 def wait_for_transaction(receiver, registry_address, token_address, sender_address):
@@ -359,6 +360,11 @@ def test_transfer_after_connect_works(raiden_network, token_addresses):
     # Open channel between node0 and node2 to not run into the bootstrapping
     # case when joining the token network
     api0.channel_open(registry_address, token_address, app2.raiden.address)
+    # Make sure that app1 processed the block where channel open
+    # happened. Otherwise the test becomes flaky because it does not see
+    # potential participants in the network
+    current_block = app0.raiden.get_block_number()
+    wait_for_block(app1.raiden, current_block, 1)
 
     api1.token_network_connect(
         registry_address=registry_address,


### PR DESCRIPTION
## Description

`test_transfer_after_connect_works` had a little race condition in synchronizing the block which led to the test being flaky. The cause was, that while `node_0` and `node_2` opened a channel to each other and were waiting for the block being processed, `node_1` might be "one block behind" and therefor cannot see the potential partner to join. 

In the next step the connection manager tries to connect to potential partners. If the block with the channel opening is not processed yet by `node_1` the network seems to be "empty". Therefor, the node will not connect to any potential partner.

# How I fixed it
I get the block number of `node_0` and wait until `node_1` has processed this block. This should ensure that the channel opened by `node_0` and `node_2` is already seen by `node_1` and will therefore connect to the nodes.


Fixes: #6020
