### PR TITLE
Incremental download of logs

### DIFF
--- a/tools/debugging/sp_download_scenario_logs.sh
+++ b/tools/debugging/sp_download_scenario_logs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cd /var/lib/scenario-player;
+source env.sh
+
+find_in_array() {
+    local word=$1
+    shift
+    for entry in "$@"; do [[ "$entry" == "$word" ]] && return 0; done
+    return 1
+}
+
+cd "${DATA_DIR}"/scenarios;
+for scenario_path in "$SCENARIOS_DIR"/ci/"$SP"/*.yaml; do
+    scenario_file=$(basename "$scenario_path")
+    scenario=${scenario_file//.yaml}
+
+    find_in_array $scenario "$@" || {
+        run=$(cat "${scenario}"/run_number.txt)
+
+        find "$scenario"/node_"$run"_*
+        ls "$scenario"/scenario-player-run* -1 -t | head -1
+    }
+done | tar zcf - -T -


### PR DESCRIPTION
- Added pv to show the current download speed for the scenario logs
- Changed the code to gradually download logs, start from the end of the
last run. Useful for unreliable connections, were the download can be
interrupted before finishing. Note: This won't fix partial downloads.
  - To do this, the list of local folder has to be removed from the
  remote scenarios. To implement this the script couldn't be provided
  inline, so a new file was introduced (the alternative would be to
  expand the script locally, at the cost of escaping a lot of special
  characters).