### PR TITLE
Enable mypy's renundant-casts check

### DIFF
--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -778,7 +778,6 @@ def events_for_balanceproof(
             # At this point we are sure that payee_channel exists due to the
             # payee_channel_open check above. So let mypy know about this
             assert payee_channel, MYPY_ANNOTATION
-            payee_channel = cast(NettingChannelState, payee_channel)
             pair.payee_state = "payee_balance_proof"
 
             message_identifier = message_identifier_from_prng(pseudo_random_generator)

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ disallow_untyped_defs = True
 warn_unused_configs = True
 warn_unused_ignores = True
 warn_unreachable = True
+warn_redundant_casts = True
 strict_equality = True
 
 # These parts of raiden are not fully typed, yet


### PR DESCRIPTION
## Description

Make mypy a bit stricter, no changes needed otherwise.
