### PR TITLE
Use placeholders in scenarios

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -25,7 +24,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
@@ -42,11 +40,11 @@ nodes:
     0:
       matrix-server: {{ matrix_servers[0] }}
     1:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     2:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     3:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
     4:
       matrix-server: {{ matrix_servers[0] }}
 

--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:
@@ -40,15 +40,15 @@ nodes:
     default-reveal-timeout: 20
   node_options:
     0:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     1:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     2:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     3:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
     4:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
 
 scenario:
   serial:

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -5,7 +5,7 @@ settings:
   chain: goerli
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: goerli
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -25,7 +24,6 @@ nodes:
   enable-monitoring: false
   default_options:
     gas-price: fast
-    environment-type: development
     default-settle-timeout: 40
     default-reveal-timeout: 20
     proportional-fee:

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -25,7 +24,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -23,7 +22,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -26,7 +25,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
@@ -44,11 +42,11 @@ nodes:
     0:
       matrix-server: {{ matrix_servers[0] }}
     1:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     2:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     3:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
 
 # This is the BF5 scenario. It sets up a simple topology of two nodes and then uses
 # `join_network` to add more nodes to the network. It tests that nodes can join the network

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:
@@ -42,13 +42,13 @@ nodes:
 
   node_options:
     0:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     1:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     2:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     3:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
 
 # This is the BF5 scenario. It sets up a simple topology of two nodes and then uses
 # `join_network` to add more nodes to the network. It tests that nodes can join the network

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:
@@ -39,25 +39,25 @@ nodes:
 
   node_options:
     0:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     1:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     2:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     3:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
     4:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     5:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     6:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     7:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
     8:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     9:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
 
 # This is the BF6 scenario. It sets up a tolopogy with 9 nodes connected to node0,
 # so that node0 is the single hub that all payments have to go through. First one

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -25,7 +24,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
@@ -41,23 +39,23 @@ nodes:
     0:
       matrix-server: {{ matrix_servers[0] }}
     1:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     2:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     3:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
     4:
       matrix-server: {{ matrix_servers[0] }}
     5:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     6:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     7:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
     8:
       matrix-server: {{ matrix_servers[0] }}
     9:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
 
 # This is the BF6 scenario. It sets up a tolopogy with 9 nodes connected to node0,
 # so that node0 is the single hub that all payments have to go through. First one

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -6,7 +6,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:
@@ -40,35 +40,35 @@ nodes:
 
   node_options:
     0:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     1:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     2:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     3:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
     4:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     5:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     6:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     7:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
     8:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     9:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     10:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
     11:
-      matrix-server: https://transport04.raiden.network
+      {{ matrix_servers[3] }}
     12:
-      matrix-server: https://transport01.raiden.network
+      matrix-server: {{ matrix_servers[0] }}
     13:
-      matrix-server: https://transport02.raiden.network
+      {{ matrix_servers[1] }}
     14:
-      matrix-server: https://transport03.raiden.network
+      {{ matrix_servers[2] }}
 
 # This is the bf7 scenario. It tests long paths. There are a total of 15 nodes in the scenario.
 # A topology with deposits in both directions are created as [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -3,7 +3,6 @@ version: 2
 settings:
   # Gas price to use, either `fast`, `medium` or an integer (in gwei)
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -27,7 +26,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-fee: 100
     enable-monitoring: true
@@ -42,33 +40,33 @@ nodes:
     0:
       matrix-server: {{ matrix_servers[0] }}
     1:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     2:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     3:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
     4:
       matrix-server: {{ matrix_servers[0] }}
     5:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     6:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     7:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
     8:
       matrix-server: {{ matrix_servers[0] }}
     9:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     10:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
     11:
-      {{ matrix_servers[3] }}
+      matrix-server: {{ matrix_servers[3] }}
     12:
       matrix-server: {{ matrix_servers[0] }}
     13:
-      {{ matrix_servers[1] }}
+      matrix-server: {{ matrix_servers[1] }}
     14:
-      {{ matrix_servers[2] }}
+      matrix-server: {{ matrix_servers[2] }}
 
 # This is the bf7 scenario. It tests long paths. There are a total of 15 nodes in the scenario.
 # A topology with deposits in both directions are created as [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -22,7 +21,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -22,7 +21,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -22,7 +21,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -6,7 +6,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli.services-dev.raiden.network
+      url: {{ pfs_without_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -3,7 +3,6 @@ version: 2
 settings:
   gas_price: "fast"
   # Adapt to chain used
-  chain: any
   services:
     pfs:
       url: {{ pfs_without_fee }}
@@ -26,7 +25,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     enable-monitoring: true
     proportional-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -6,7 +6,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli.services-dev.raiden.network
+      url: {{ pfs_without_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -3,7 +3,6 @@ version: 2
 settings:
   gas_price: "fast"
   # Adapt to chain used
-  chain: any
   services:
     pfs:
       url: {{ pfs_without_fee }}
@@ -26,7 +25,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     enable-monitoring: true
     proportional-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -6,7 +6,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli.services-dev.raiden.network
+      url: {{ pfs_without_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -3,7 +3,6 @@ version: 2
 settings:
   gas_price: "fast"
   # Adapt to chain used
-  chain: any
   services:
     pfs:
       url: {{ pfs_without_fee }}
@@ -26,7 +25,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     enable-monitoring: true
     proportional-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -6,7 +6,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli.services-dev.raiden.network
+      url: {{ pfs_without_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -3,7 +3,6 @@ version: 2
 settings:
   gas_price: "fast"
   # Adapt to chain used
-  chain: any
   services:
     pfs:
       url: {{ pfs_without_fee }}
@@ -26,7 +25,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     enable-monitoring: true
     proportional-fee:
       - "0x59105441977ecD9d805A4f5b060E34676F50F806"

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 1
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     # Make sure to only use the "best" path
     pathfinding-max-paths: 1

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -21,7 +20,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -23,7 +22,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -22,7 +21,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     # Only use one path per call to make sure the expected one is used
     pathfinding-max-paths: 1

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -2,7 +2,6 @@ version: 2
 
 settings:
   gas_price: "fast"
-  chain: any
   services:
     pfs:
       url: {{ pfs_with_fee }}
@@ -22,7 +21,6 @@ nodes:
 
   default_options:
     gas-price: fast
-    environment-type: development
     routing-mode: pfs
     # PFS only returns one path to make sure that the best one available is returned
     pathfinding-max-paths: 1

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -5,7 +5,7 @@ settings:
   chain: any
   services:
     pfs:
-      url: https://pfs-goerli-with-fee.services-dev.raiden.network
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:


### PR DESCRIPTION
Remove all environment dependent values from the scenarios. For those cases, where we want to set different values for different nodes or scenarios, use placeholders than can be filled in by the templating engine in https://github.com/raiden-network/scenario-player/pull/536.

Merge after https://github.com/raiden-network/scenario-player/pull/536.