### PR TITLE
Let Nursery propagate process exit errors

### DIFF
--- a/raiden/tests/unit/utils/test_nursery.py
+++ b/raiden/tests/unit/utils/test_nursery.py
@@ -30,3 +30,9 @@ def test_nursery_dectect_exit_code_process():
         with Janitor() as nursery:
             p = nursery.exec_under_watch(die_os(timeout=2))
             gevent.joinall({p}, raise_error=True, count=1)
+
+
+def test_nursery_detects_failing_popen():
+    with pytest.raises(FileNotFoundError):
+        with Janitor() as nursery:
+            nursery.exec_under_watch(["nota_valid_program"])

--- a/raiden/tests/unit/utils/test_nursery.py
+++ b/raiden/tests/unit/utils/test_nursery.py
@@ -1,0 +1,32 @@
+import gevent
+import pytest
+
+from raiden.utils.nursery import Janitor
+
+
+class NurseryException(Exception):
+    def __init__(self, exit_code):
+        super().__init__(self, exit_code)
+
+
+def die(timeout: int = 0, exit_code: int = 42):
+    gevent.sleep(timeout)
+    raise NurseryException(exit_code)
+
+
+def die_os(timeout: int = 0, exit_code: int = 42):
+    return ["python", "-c", f"import time, sys; time.sleep({timeout}); sys.exit({exit_code})"]
+
+
+def test_nursery_detects_exit_code():
+    with pytest.raises(NurseryException):
+        with Janitor() as nursery:
+            p = nursery.spawn_under_watch(die, timeout=2)
+            gevent.joinall({p}, raise_error=True, count=1)
+
+
+def test_nursery_dectect_exit_code_process():
+    with pytest.raises(SystemExit):
+        with Janitor() as nursery:
+            p = nursery.exec_under_watch(die_os(timeout=2))
+            gevent.joinall({p}, raise_error=True, count=1)

--- a/raiden/utils/nursery.py
+++ b/raiden/utils/nursery.py
@@ -144,9 +144,7 @@ class Janitor:
         traceback: Optional[TracebackType],
     ) -> Optional[bool]:
         with self._processes_lock:
-            # Make sure to signal that we are exiting. This is a noop if the signal
-            # is set already (e.g. because a subprocess exited with a non-zero
-            # status code)
+            # Make sure to signal that we are exiting.
             if not self._stop.done():
                 self._stop.set()
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/raiden-network/scenario-player/issues/539

By changing `Janitor._stop` to be an `AsyncResult` it becomes possible to propagate `AsyncResult.exception`. 