### PR TITLE
Add support for --pre flag to pip-compile wrapper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,11 +65,11 @@ repos:
     hooks:
       - id: mypy
         entry: tools/pre-commit/pre-commit-wrapper.py mypy
-        additional_dependencies: ["pip-tools==4.2.0"]
+        additional_dependencies: ["pip-tools>=4.5.1"]
 
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.3.1
     hooks:
       - id: pylint
         entry: tools/pre-commit/pre-commit-wrapper.py pylint
-        additional_dependencies: ["pip-tools==4.2.0"]
+        additional_dependencies: ["pip-tools>=4.5.1"]


### PR DESCRIPTION
## Description

pip-compile supports a `--pre` flag to allow resolving packages to pre-release versions.
This adds the possibility of passing that flag via our `pip-compile-wrapper` utility.

This recently came up during the RC release process and the need to use an rc release of raiden-contracts.
