### PR TITLE
Fix error format

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -160,7 +160,7 @@ def get_best_routes(
             f"the requested transfer."
         )
         if error_direct is not None:
-            error_msg += "direct channel {error_direct}."
+            error_msg += f"direct channel {error_direct}."
 
         log.warning(
             "None of the existing channels could be used to complete the transfer",


### PR DESCRIPTION
The `f` was missing so the error was not being replaced in the string contents.