### PR TITLE
remove cache workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,10 +178,8 @@ commands:
           key: pip-cache-{{ arch }}-<< parameters.py-version >>
       - restore_cache:
           keys:
-          - python-deps-v3-{{ arch }}-<< parameters.py-version >>-{{ checksum "requirements/requirements-ci.txt" }}
-# hack: solving a inter-PR cache problem
-          - python-deps-v3-{{ arch }}-<< parameters.py-version >>-2uPiIM_pNv5neMjXtHsw_aV6BQGcFOekCBcy7TJEkhI=
-          - python-deps-v3-{{ arch }}-<< parameters.py-version >>-
+          - python-deps-v4-{{ arch }}-<< parameters.py-version >>-{{ checksum "requirements/requirements-ci.txt" }}
+          - python-deps-v4-{{ arch }}-<< parameters.py-version >>-
       - run:
           name: Creating virtualenv
           command: |


### PR DESCRIPTION
This was introduced by https://github.com/raiden-network/raiden/pull/4665 , an explanation for the error is available on https://github.com/raiden-network/scenario-player/issues/230 and the upgrade was done by https://github.com/raiden-network/raiden/pull/4665 .

I have upgraded the cache version just in case to avoid any stale state.