### PR TITLE
Prepare scenarios for mainnet testing

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -26,7 +26,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"
@@ -121,9 +121,9 @@ scenario:
             # Add a wait until all ious are processed correctly
             - wait: 100
             - assert_pfs_history: {source: 3, target: 0, request_count: 10}
-            - assert_pfs_iou: {source: 3, amount: 1000}
+            - assert_pfs_iou: {source: 3, amount: {{ 10 * pfs_fee }} }
             - assert_pfs_history: {source: 1, target: 4, request_count: 10}
-            - assert_pfs_iou: {source: 1, amount: 1000}
+            - assert_pfs_iou: {source: 1, amount: {{ 10 * pfs_fee }} }
             # Make sure that a mediating node has not used the PFS
             - assert_pfs_iou: {source: 2, iou_exists: false}
       - serial:

--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -15,7 +15,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -29,10 +29,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -34,7 +34,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
   node_options:
     0:
@@ -229,7 +229,7 @@ scenario:
                 event_args: {closing_participant: 0}
             - assert: {from: 0, to: 4, state: "closed"}
             # Make sure that channel between 0 and 4 is also settled
-            - wait_blocks: 40
+            - wait_blocks: {{ settlement_timeout_min }}
       - serial:
           name: "Close channel between 3 and 4 while 4 is offline"
           tasks:
@@ -245,7 +245,7 @@ scenario:
                 event_args: {closing_participant: 3}
 
             ## The MS reacts within the settle_timeout
-            - wait_blocks: 40
+            - wait_blocks: {{ settlement_timeout_min }}
             - assert_events:
                 contract_name: "TokenNetwork"
                 event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -15,7 +15,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     default-settle-timeout: 40
     default-reveal-timeout: 20
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 # This is the bf2 long running scenario. This scenario mimics user behaviour for

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -24,7 +24,7 @@ nodes:
   enable-monitoring: false
   default_options:
     gas-price: fast
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
     proportional-fee:
       - "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -26,7 +26,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -15,7 +15,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -29,10 +29,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 # This is the bf3 scenario. It sets up a topology of [0, 1, 2, 3, 4] and deposits in both directions between all nodes.

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -24,7 +24,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -13,7 +13,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -32,7 +32,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
 
 # This is the bf4 scenario. It sets up a topology of [ [0, 1, 2], [0, 1, 3], [0, 4, 5] ]

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -30,10 +30,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -27,7 +27,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -35,7 +35,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
 
   node_options:

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -26,7 +26,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -15,7 +15,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -29,10 +29,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
   node_options:

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -17,7 +17,7 @@ settings:
 
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -30,10 +30,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
   node_options:

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -27,7 +27,7 @@ nodes:
   default_options:
     gas-price: fast
     routing-mode: pfs
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -23,7 +23,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     flat-fee:
       - "{{ transfer_token }}"
       - 100

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_min: 1_000_000
   balance_fund: 1_000_000
 
@@ -25,13 +25,13 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     flat-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the MFEE1 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and checks

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -22,7 +22,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     flat-fee:
       - "{{ transfer_token }}"
       - 0

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 1_000_000
 
 nodes:
@@ -24,14 +24,14 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     flat-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       # For every 1000 TKN transferred 10 TKN is paid as fee
       - 10_000
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the MFEE2 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and checks

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_min: 100_000_000_000_000_000_000
   balance_fund: 100_000_000_000_000_000_000
 
@@ -25,13 +25,13 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     flat-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 10_000  # 1% imbalance fee on channel balance
     no-cap-mediation-fees: true
 

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -23,7 +23,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     flat-fee:
       - "{{ transfer_token }}"
       - 0

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -23,7 +23,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     flat-fee:
       - "{{ transfer_token }}"
       - 100

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_min: 100_000_000_000_000_000_000
   balance_fund: 100_000_000_000_000_000_000
 
@@ -25,13 +25,13 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     flat-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 10_000  # 1% proportional fee
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 20_000  # 2% imbalance fee on channel balance
     no-cap-mediation-fees: true
 

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -32,7 +32,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
 
 # This is the MS1 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
@@ -58,7 +58,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 40
+      - wait_blocks: {{ settlement_timeout_min }}
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -5,7 +5,7 @@ settings:
   # Adapt to chain used
   services:
     pfs:
-      url: {{ pfs_without_fee }}
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -16,7 +16,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     gas-price: fast
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -32,7 +32,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
 
 # This is the MS2 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
@@ -58,7 +58,7 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## The MS reacts within the settle_timeout
-      - wait_blocks: 40
+      - wait_blocks: {{ settlement_timeout_min }}
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "NonClosingBalanceProofUpdated"

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -5,7 +5,7 @@ settings:
   # Adapt to chain used
   services:
     pfs:
-      url: {{ pfs_without_fee }}
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -16,7 +16,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     gas-price: fast
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -32,7 +32,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
 
 # This is the MS3 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
@@ -74,8 +74,8 @@ scenario:
           event_args: {closing_participant: 0}
 
       ## Monitored channel must be settled before the monitoring service can claim its reward
-      ## Settlement timeout is 40 blocks, but we already waited 22 blocks.
-      ## Add 10 blocks as safety margin: 18 + 10 = 28
-      - wait_blocks: 28
+      ## We already waited 22 blocks, so we can subtract that from the settlement_timeout_min.
+      ## Add 10 blocks as safety margin.
+      - wait_blocks: {{ settlement_timeout_min - 22 + 10 }}
       # will fail for now since channel was closed by node1.
       - assert_ms_claim: {channel_info_key: "MS Test Channel", must_claim: False}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -5,7 +5,7 @@ settings:
   # Adapt to chain used
   services:
     pfs:
-      url: {{ pfs_without_fee }}
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -16,7 +16,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     gas-price: fast
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -32,7 +32,7 @@ nodes:
     proportional-imbalance-fee:
       - "{{ transfer_token }}"
       - 0
-    default-settle-timeout: 40
+    default-settle-timeout: {{ settlement_timeout_min }}
     default-reveal-timeout: 20
 
 ## This scenario tests that the MS does not kick in, if the node requesting monitoring does
@@ -81,7 +81,7 @@ scenario:
           name: "Wait for MS to not react"
           tasks:
             # The MS reacts within the settle_timeout
-            - wait_blocks: 40
+            - wait_blocks: {{ settlement_timeout_min }}
             # Note that 0 events are expected
             - assert_events:
                 contract_name: "TokenNetwork"

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -16,7 +16,7 @@ settings:
         max_funding: 10000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     gas-price: fast
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     default-settle-timeout: 40
     default-reveal-timeout: 20

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -5,7 +5,7 @@ settings:
   # Adapt to chain used
   services:
     pfs:
-      url: {{ pfs_without_fee }}
+      url: {{ pfs_with_fee }}
     udc:
       enable: true
       token:

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -22,7 +22,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -24,10 +24,10 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS1 scenario. It creates a network with topology 0 <-> 1 <-> 2 <-> 3 and checks

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -22,7 +22,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0
@@ -56,7 +56,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
 
             # Check that IOU is created despite no available path
-            - assert_pfs_iou: {source: 3, amount: 100}
+            - assert_pfs_iou: {source: 3, amount: {{ pfs_fee }} }
 
             ## Check that no path was returned
             - assert_pfs_history:

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -24,10 +24,10 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS2 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and checks

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -24,10 +24,10 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS3 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and 0 -> 4 -> 3

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -22,7 +22,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0
@@ -61,7 +61,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 100}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }} }
 
             ## Check that the paths are indeed the expected ones
             - assert_pfs_history:

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -22,7 +22,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 1
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0
@@ -62,7 +62,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 100}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }} }
 
             ## Check that the paths are indeed the expected ones
             - assert_pfs_history:

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -24,10 +24,10 @@ nodes:
     pathfinding-max-paths: 1
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS4 scenario. It creates a network with topology 0 -> 1 -> 2 -> 3 and 0 -> 4 -> 3

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -23,7 +23,7 @@ nodes:
     routing-mode: pfs
     # Make sure to only use the "best" path
     pathfinding-max-paths: 1
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0
@@ -63,7 +63,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 100}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }}}
 
             # Check that the paths are indeed the expected ones
             - assert_pfs_history:
@@ -88,7 +88,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
               #
             # Check that the second IOU is created
-            - assert_pfs_iou: {source: 0, amount: 200}
+            - assert_pfs_iou: {source: 0, amount: {{ 2 * pfs_fee }}}
 
             # Check that the paths are indeed the expected ones
             - assert_pfs_history:

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -25,10 +25,10 @@ nodes:
     pathfinding-max-paths: 1
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 # This is the PFS5 scenario. It creates a network with topology 0 <-> 1 <-> 2 <-> 3 and 0 <-> 4 <-> 3

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -22,7 +22,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0
@@ -56,7 +56,7 @@ scenario:
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 409}
             - wait_blocks: 1
             - assert_pfs_history: {source: 3, target: 0, request_count: 1}
-            - assert_pfs_iou: {source: 3, amount: 100}
+            - assert_pfs_iou: {source: 3, amount: {{ pfs_fee }}}
             - assert_pfs_iou: {source: 2, iou_exists: false}
 
       - parallel:
@@ -83,7 +83,7 @@ scenario:
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
             - wait_blocks: 1
             - assert_pfs_history: {source: 3, target: 0, request_count: 2}
-            - assert_pfs_iou: {source: 3, amount: 200}
+            - assert_pfs_iou: {source: 3, amount: {{ 2 * pfs_fee }}}
             - assert_pfs_iou: {source: 2, iou_exists: false}
             - assert_pfs_iou: {source: 1, iou_exists: false}
             - assert_pfs_iou: {source: 0, iou_exists: false}
@@ -93,15 +93,15 @@ scenario:
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
             - wait: 10
             - assert_pfs_history: {source: 0, target: 3, request_count: 1}
-            - assert_pfs_iou: {source: 0, amount: 100}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }}}
             - assert_pfs_iou: {source: 1, iou_exists: false}
             - assert_pfs_iou: {source: 2, iou_exists: false}
-            - assert_pfs_iou: {source: 3, amount: 200}
+            - assert_pfs_iou: {source: 3, amount: {{ 2 * pfs_fee }}}
 
             - transfer: {from: 2, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
             - wait: 10
             - assert_pfs_history: {source: 2, target: 0, request_count: 1}
-            - assert_pfs_iou: {source: 2, amount: 100}
+            - assert_pfs_iou: {source: 2, amount: {{ pfs_fee }}}
 
       - serial:
           name: "Assert on all channel balances after transfers"

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -11,7 +11,7 @@ settings:
         deposit: true
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -24,10 +24,10 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS6 scenario. It creates a network with topology 0 <-> 1 <-> 2 <-> 3 and

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -13,7 +13,7 @@ settings:
         min_balance: 5_000_000_000_000_000_000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -26,10 +26,10 @@ nodes:
     pathfinding-max-paths: 5
     pathfinding-max-fee: 100
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This scenario sets up a topology of [0, 1, 2, 3] and [0, 4, 3] with deposits in both directions.

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -24,7 +24,7 @@ nodes:
     gas-price: fast
     routing-mode: pfs
     pathfinding-max-paths: 5
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     proportional-fee:
       - "{{ transfer_token }}"
       - 0
@@ -90,7 +90,7 @@ scenario:
           name: "Check that IOUs exist after the payments"
           tasks:
             # Add a wait until all ious are processed correctly
-            - assert_pfs_iou: {source: 0, amount: 10000}
+            - assert_pfs_iou: {source: 0, amount: {{ 100 * pfs_fee }}}
             - assert_pfs_history:
                 source: 0
                 target: 3

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -12,7 +12,7 @@ settings:
         balance_per_node: 5000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS8 scenario. It aims to make sure that the PFS reacts correctly if a node along

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -24,7 +24,7 @@ nodes:
     routing-mode: pfs
     # Only use one path per call to make sure the expected one is used
     pathfinding-max-paths: 1
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"
@@ -87,7 +87,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 100}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }}}
       - serial:
           name: "Check that shortest path was used"
           tasks:
@@ -117,7 +117,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 200}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }}}
       - serial:
           name: "Check that the [0, 1, 2, 3] path was used"
           tasks:

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -24,7 +24,7 @@ nodes:
     routing-mode: pfs
     # PFS only returns one path to make sure that the best one available is returned
     pathfinding-max-paths: 1
-    pathfinding-max-fee: 100
+    pathfinding-max-fee: {{ pfs_fee }}
     enable-monitoring: true
     proportional-fee:
       - "{{ transfer_token }}"
@@ -88,7 +88,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 100}
+            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }}}
       - serial:
           name: "Check that shortest path was used"
           tasks:
@@ -128,7 +128,7 @@ scenario:
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 500_000_000_000_000_000, balance: 200_000_000_000_000_000, state: "opened"}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: 200}
+            - assert_pfs_iou: {source: 0, amount: {{ 2 * pfs_fee }}}
       - serial:
           name: "Check that the [0, 1, 2, 3] path was used"
           tasks:

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -12,7 +12,7 @@ settings:
         balance_per_node: 5000
 
 token:
-  address: "0x59105441977ecD9d805A4f5b060E34676F50F806"
+  address: "{{ transfer_token }}"
   balance_fund: 10_000_000_000_000_000_000
 
 nodes:
@@ -27,10 +27,10 @@ nodes:
     pathfinding-max-fee: 100
     enable-monitoring: true
     proportional-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
     proportional-imbalance-fee:
-      - "0x59105441977ecD9d805A4f5b060E34676F50F806"
+      - "{{ transfer_token }}"
       - 0
 
 ## This is the PFS9 scenario. It aims to make sure that the PFS reacts correctly to balance updates


### PR DESCRIPTION
Our mainnet test setup needs different settings than our usual test setup. To avoid having to maintain two sets of scenarios, let's use the templating to make the same scenarios work across all environments.

Merge after https://github.com/raiden-network/scenario-player/pull/541, or nightlies will break.

This is the main part of https://github.com/raiden-network/raiden/issues/6061