### PR TITLE
Reduce batch size of the event polling because.

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -656,7 +656,7 @@ class RaidenService(Runnable):
             contract_manager=self.contract_manager,
             last_fetched_block=last_block_number,
             event_filters=filters,
-            max_number_of_blocks_to_poll=BlockNumber(100_000),
+            max_number_of_blocks_to_poll=BlockNumber(1_000),
         )
 
         latest_block_num = self.rpc_client.block_number()

--- a/raiden/tests/integration/cli/test_cli_development.py
+++ b/raiden/tests/integration/cli/test_cli_development.py
@@ -16,13 +16,11 @@ pytestmark = [
 ]
 
 
-@pytest.mark.timeout(60)
 def test_cli_full_init_dev(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     expect_cli_normal_startup(child, Environment.DEVELOPMENT.value)
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.parametrize("removed_args", [["address"]])
 def test_cli_manual_account_selection(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)

--- a/raiden/tests/integration/cli/test_cli_production.py
+++ b/raiden/tests/integration/cli/test_cli_production.py
@@ -19,17 +19,13 @@ pytestmark = [
     pytest.mark.parametrize("environment_type", [EXPECTED_DEFAULT_ENVIRONMENT], scope="module"),
 ]
 
-TIMEOUT = 120
 
-
-@pytest.mark.timeout(TIMEOUT)
 def test_cli_full_init(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     # expect the default mode
     expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT.value)
 
 
-@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("changed_args", [{"keystore_path": "."}])
 def test_cli_wrong_keystore_path(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -37,7 +33,6 @@ def test_cli_wrong_keystore_path(cli_args, raiden_spawner):
     child.expect("No Ethereum accounts found in the provided keystore directory")
 
 
-@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("removed_args", [["password_file"]])
 def test_cli_missing_password_file_enter_password(raiden_testchain, cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -50,14 +45,12 @@ def test_cli_missing_password_file_enter_password(raiden_testchain, cli_args, ra
     expect_cli_successful_connected(child, EXPECTED_DEFAULT_ENVIRONMENT.value)
 
 
-@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("removed_args", [["data_dir"]])
 def test_cli_missing_data_dir(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
     expect_cli_normal_startup(child, EXPECTED_DEFAULT_ENVIRONMENT.value)
 
 
-@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("changed_args", [{"eth_rpc_endpoint": "http://8.8.8.8:2020"}])
 def test_cli_wrong_rpc_endpoint(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -66,7 +59,6 @@ def test_cli_wrong_rpc_endpoint(cli_args, raiden_spawner):
     child.expect(".*Communicating with an external service failed.")
 
 
-@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize("changed_args", [{"network_id": "42"}])
 def test_cli_wrong_network_id_try_kovan(cli_args, raiden_spawner):
     child = raiden_spawner(cli_args)
@@ -74,7 +66,6 @@ def test_cli_wrong_network_id_try_kovan(cli_args, raiden_spawner):
     child.expect("The configured network.*differs from the Ethereum client's network")
 
 
-@pytest.mark.timeout(TIMEOUT)
 @pytest.mark.parametrize(
     "changed_args",
     [


### PR DESCRIPTION
Geth performance for `eth_getLogs` doesn't degrade well with the total
number of events in the blockchain. The testnets response times are
acceptable because the Blockchain does not have that many events,
however, for the Mainnet the number of events is large enough to trigger
timeouts in the client.

Below are the measurements, all o results include time to decode the
response using web3.py (that is why the response time can be higher than
the read timeout):

Geth on Mainnet *without filtering* for Raiden smart contracts.

number of blocks | `eth_getLogs` timing | number of events
--- | --- | ---
0                | 4.715455055236816    | 165
100              | 7.663008451461792    | 14000
200              | 12.996556758880615   | 27559
300              | 15.118395805358887   | 41357
400              | 60.43288326263428    | 56439

Geth on Goerli *without filtering* for Raidne smart contracts:

number of blocks | `eth_getLogs` timing | number of events
--- | --- | ---
0                | 0.025388240814208984 | 2
100              | 0.1299889087677002   | 163
200              | 0.1843571662902832   | 382
300              | 0.22373104095458984  | 533
400              | 0.28818750381469727  | 670

Geth on Mainnet *only for the Raiden smart contracts*.

number of blocks | `eth_getLogs` timing | number of events
--- | --- | ---
0                | 0.051666975021362305 | 0
1000             | 0.9480726718902588   | 28
2000             | 3.340684652328491    | 30
3000             | 4.283600330352783    | 30
4000             | 8.70504117012024     | 30
5000             | 8.81442141532898     | 30
6000             | 8.52564287185669     | 30

The response time increases with the range of blocks in the request. The
reduced batch size required more requests to cover a large number of
blocks, which will lead to slower first sync times. This should be fixed
by #5538, which would result in better for Parity, since its filtering
is much faster.