### PR TITLE
Fix AssertionError during node startup

### DIFF
--- a/raiden/utils/notifying_queue.py
+++ b/raiden/utils/notifying_queue.py
@@ -46,4 +46,4 @@ class NotifyingQueue(Event, Generic[T]):
         return result
 
     def __repr__(self) -> str:
-        return f"NotifyingQueue(num_items={len(self.queue)})"
+        return f"NotifyingQueue(id={id(self)}, num_items={len(self.queue)})"


### PR DESCRIPTION
## Description

The healthcheck uses (via `NotifyingQueue`) an gevent `Event` to wait for items to be available in the Queue.
If a node already has open channels items will be put into thehealthcheck queue during startup leading to the internal event to already be set before the first run of the worker.

This triggers gevent/gevent#1540 leading to AssertionErrors to be printed on stderr.

For now switch the healthcheck worker to a busy loop until the gevent bug is fixed.
