### PR TITLE
move docstring to correct place

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -909,13 +909,12 @@ class MatrixTransport(Runnable):
         )
         gevent.joinall(greenlets, raise_error=True)
 
-    """
-    returns list of address of room members.
-    If address can not be extracted due to false displayname
-    it will include None in the list
-    """
-
     def _extract_addresses(self, room: Room) -> List[Optional[Address]]:
+        """
+        returns list of address of room members.
+        If address can not be extracted due to false displayname
+        it will include None in the list
+        """
         assert self._raiden_service is not None, "_raiden_service not set"
         joined_addresses = set(
             validate_userid_signature(user) for user in room.get_joined_members()


### PR DESCRIPTION
## Description
In one of my last PRs a false docstring location got merged into develop. Here is the fix