### PR TITLE
Fix (de)serialization for ContractSendEvents

### DIFF
--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -13,7 +13,8 @@ from typing import Mapping
 from marshmallow import ValidationError
 
 from raiden.exceptions import SerializationError
-from raiden.storage.serialization.types import MESSAGE_NAME_TO_QUALIFIED_NAME, SchemaCache
+from raiden.storage.serialization.cache import SchemaCache
+from raiden.storage.serialization.types import MESSAGE_NAME_TO_QUALIFIED_NAME
 from raiden.utils.copy import deepcopy
 from raiden.utils.typing import Any, Dict
 

--- a/raiden/storage/serialization/types.py
+++ b/raiden/storage/serialization/types.py
@@ -98,9 +98,9 @@ MESSAGE_NAME_TO_QUALIFIED_NAME = {
 }
 
 
-def transfer_task_schema_serialization(task: TransferTask, parent: Any) -> Schema:
+def serialization_schema_selector(obj: Any, parent: Any) -> Schema:
     # pylint: disable=unused-argument
-    return SchemaCache.get_or_create_schema(task.__class__)
+    return SchemaCache.get_or_create_schema(obj.__class__)
 
 
 def transfer_task_schema_deserialization(
@@ -128,13 +128,6 @@ def transfer_task_schema_deserialization(
     return None
 
 
-def balance_proof_schema_serialization(
-    balance_proof: Union[BalanceProofSignedState, BalanceProofUnsignedState], parent: Any
-) -> Schema:
-    # pylint: disable=unused-argument
-    return SchemaCache.get_or_create_schema(balance_proof.__class__)
-
-
 def balance_proof_schema_deserialization(
     balance_proof_dict: Dict[str, Any], parent: Dict[str, Any]
 ) -> Optional[Schema]:
@@ -149,11 +142,6 @@ def balance_proof_schema_deserialization(
         return SchemaCache.get_or_create_schema(BalanceProofSignedState)
 
     return None
-
-
-def message_event_schema_serialization(message_event: SendMessageEvent, parent: Any) -> Schema:
-    # pylint: disable=unused-argument
-    return SchemaCache.get_or_create_schema(message_event.__class__)
 
 
 def message_event_schema_deserialization(
@@ -210,13 +198,6 @@ def message_event_schema_deserialization(
         return SchemaCache.get_or_create_schema(SendProcessed)
 
     return None
-
-
-def contract_send_event_serialization(
-    contract_send_event: ContractSendEvent, parent: Any
-) -> Schema:
-    # pylint: disable=unused-argument
-    return SchemaCache.get_or_create_schema(contract_send_event.__class__)
 
 
 class_of_contract_send_event_classname = {
@@ -287,25 +268,25 @@ _native_to_marshmallow.update(
         ChannelID: IntegerToStringField,
         # Polymorphic fields
         TransferTask: CallablePolyField(
-            serialization_schema_selector=transfer_task_schema_serialization,
+            serialization_schema_selector=serialization_schema_selector,
             deserialization_schema_selector=transfer_task_schema_deserialization,
         ),
         Union[BalanceProofUnsignedState, BalanceProofSignedState]: CallablePolyField(
-            serialization_schema_selector=balance_proof_schema_serialization,
+            serialization_schema_selector=serialization_schema_selector,
             deserialization_schema_selector=balance_proof_schema_deserialization,
         ),
         Optional[Union[BalanceProofUnsignedState, BalanceProofSignedState]]: CallablePolyField(
-            serialization_schema_selector=balance_proof_schema_serialization,
+            serialization_schema_selector=serialization_schema_selector,
             deserialization_schema_selector=balance_proof_schema_deserialization,
             allow_none=True,
         ),
         SendMessageEvent: CallablePolyField(
-            serialization_schema_selector=message_event_schema_serialization,
+            serialization_schema_selector=serialization_schema_selector,
             deserialization_schema_selector=message_event_schema_deserialization,
             allow_none=True,
         ),
         ContractSendEvent: CallablePolyField(
-            serialization_schema_selector=contract_send_event_serialization,
+            serialization_schema_selector=serialization_schema_selector,
             deserialization_schema_selector=contract_send_event_deserialization,
             allow_none=False,
         ),

--- a/raiden/storage/serialization/types.py
+++ b/raiden/storage/serialization/types.py
@@ -28,8 +28,21 @@ from raiden.transfer.events import (
     ContractSendChannelWithdraw,
     ContractSendSecretReveal,
     SendMessageEvent,
+    SendProcessed,
+    SendWithdrawConfirmation,
+    SendWithdrawExpired,
+    SendWithdrawRequest,
 )
 from raiden.transfer.identifiers import QueueIdentifier
+from raiden.transfer.mediated_transfer.events import (
+    SendLockedTransfer,
+    SendLockExpired,
+    SendRefundTransfer,
+    SendSecretRequest,
+    SendSecretReveal,
+    SendUnlock,
+)
+from raiden.transfer.mediated_transfer.tasks import InitiatorTask, MediatorTask, TargetTask
 from raiden.utils.typing import (
     AdditionalHash,
     Address,
@@ -107,22 +120,15 @@ def transfer_task_schema_deserialization(
     task_dict: Dict[str, Any], parent: Dict[str, Any]
 ) -> Optional[Schema]:
     # pylint: disable=unused-argument
-    # Avoid cyclic dependencies
     task_type = task_dict.get("_type")
     if task_type is None:
         return None
 
     if task_type.endswith("InitiatorTask"):
-        from raiden.transfer.mediated_transfer.tasks import InitiatorTask
-
         return SchemaCache.get_or_create_schema(InitiatorTask)
     if task_type.endswith("MediatorTask"):
-        from raiden.transfer.mediated_transfer.tasks import MediatorTask
-
         return SchemaCache.get_or_create_schema(MediatorTask)
     if task_type.endswith("TargetTask"):
-        from raiden.transfer.mediated_transfer.tasks import TargetTask
-
         return SchemaCache.get_or_create_schema(TargetTask)
 
     return None
@@ -153,48 +159,24 @@ def message_event_schema_deserialization(
         return None
 
     if message_type.endswith("SendLockExpired"):
-        from raiden.transfer.mediated_transfer.events import SendLockExpired
-
         return SchemaCache.get_or_create_schema(SendLockExpired)
     elif message_type.endswith("SendLockedTransfer"):
-        from raiden.transfer.mediated_transfer.events import SendLockedTransfer
-
         return SchemaCache.get_or_create_schema(SendLockedTransfer)
     elif message_type.endswith("SendSecretReveal"):
-        from raiden.transfer.mediated_transfer.events import SendSecretReveal
-
         return SchemaCache.get_or_create_schema(SendSecretReveal)
     elif message_type.endswith("SendUnlock"):
-        from raiden.transfer.mediated_transfer.events import SendUnlock
-
         return SchemaCache.get_or_create_schema(SendUnlock)
     elif message_type.endswith("SendSecretRequest"):
-        from raiden.transfer.mediated_transfer.events import SendSecretRequest
-
         return SchemaCache.get_or_create_schema(SendSecretRequest)
     elif message_type.endswith("SendRefundTransfer"):
-        from raiden.transfer.mediated_transfer.events import SendRefundTransfer
-
         return SchemaCache.get_or_create_schema(SendRefundTransfer)
-
     elif message_type.endswith("SendWithdrawRequest"):
-        from raiden.transfer.events import SendWithdrawRequest
-
         return SchemaCache.get_or_create_schema(SendWithdrawRequest)
-
     elif message_type.endswith("SendWithdrawConfirmation"):
-        from raiden.transfer.events import SendWithdrawConfirmation
-
         return SchemaCache.get_or_create_schema(SendWithdrawConfirmation)
-
     elif message_type.endswith("SendWithdrawExpired"):
-        from raiden.transfer.events import SendWithdrawExpired
-
         return SchemaCache.get_or_create_schema(SendWithdrawExpired)
-
     elif message_type.endswith("SendProcessed"):
-        from raiden.transfer.events import SendProcessed
-
         return SchemaCache.get_or_create_schema(SendProcessed)
 
     return None


### PR DESCRIPTION
Without the PolyField, all `ContractSendEvent` subclasses will just be restored as `ContractSendEvent` instances, losing their subclass information.

Only the first commit is necessary to fix the bug, the rest is just refactoring. If we want to minimize the amount of changes for the next RC, we could cherry pick only the first commit.

Closes https://github.com/raiden-network/raiden/issues/6075