### PR TITLE
Preserve the error details sent by the PFS

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -312,9 +312,10 @@ class ServiceRequestFailed(RaidenError):
 class ServiceRequestIOURejected(ServiceRequestFailed):
     """ Raised when a service request fails due to a problem with the iou. """
 
-    def __init__(self, message: str, error_code: int) -> None:
+    def __init__(self, message: str, error_code: int, error_details: dict) -> None:
         super().__init__(f"{message} ({error_code})")
         self.error_code = error_code
+        self.error_details = error_details
 
 
 class UndefinedMediationFee(RaidenError):

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -533,7 +533,9 @@ def post_pfs_paths(
         error_code = info["error_code"] = response_json.get("error_code", 0)
 
         if PFSError.is_iou_rejected(error_code):
-            raise ServiceRequestIOURejected(error, error_code)
+            raise ServiceRequestIOURejected(
+                error, error_code, error_details=response_json.get("error_details")
+            )
 
         raise ServiceRequestFailed(error, info)
 
@@ -625,7 +627,9 @@ def query_paths(
                 )
             except ServiceRequestIOURejected as error:
                 code = error.error_code
-                log.debug("Pathfinding Service rejected IOU", error=error)
+                log.debug(
+                    "Pathfinding Service rejected IOU", error=error, details=error.error_details
+                )
 
                 if retries == 0 or code in (
                     PFSError.WRONG_IOU_RECIPIENT,


### PR DESCRIPTION
The PFS provides additional debugging information in most error cases.
There should not get lost when the error response is converted to an
exception.