### PR TITLE
Changes wrong error msg

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -281,8 +281,7 @@ def configure_pfs_or_exit(
         )
         if maybe_pfs_url is None:
             raise RaidenError(
-                "The Service Registry has no registered Pathfinding Service "
-                "and basic routing is not used."
+                "No registered pathfinding service is running and basic routing is not used."
             )
         else:
             pfs_url = maybe_pfs_url

--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -281,7 +281,7 @@ def configure_pfs_or_exit(
         )
         if maybe_pfs_url is None:
             raise RaidenError(
-                "No registered pathfinding service is running and basic routing is not used."
+                "Can not find any registered pathfinding service and basic routing is not used."
             )
         else:
             pfs_url = maybe_pfs_url


### PR DESCRIPTION
## Description

The error message `The Service Registry has no registered Pathfinding Service and basic routing is not used.` was not correct if simply none of the registered pfs' were online, the user would see that above message. 
