### PR TITLE
handle pruned blocks while checking address for code

### DIFF
--- a/raiden/network/proxies/one_to_n.py
+++ b/raiden/network/proxies/one_to_n.py
@@ -1,7 +1,7 @@
 import structlog
 from eth_utils import decode_hex, is_binary_address
 
-from raiden.network.rpc.client import JSONRPCClient, check_address_has_code
+from raiden.network.rpc.client import JSONRPCClient, check_address_has_code_handle_pruned_block
 from raiden.utils.typing import Address, BlockIdentifier, OneToNAddress
 from raiden_contracts.constants import CONTRACT_ONE_TO_N
 from raiden_contracts.contract_manager import ContractManager
@@ -21,7 +21,7 @@ class OneToN:
             raise ValueError("Expected binary address for monitoring service")
 
         self.contract_manager = contract_manager
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=jsonrpc_client,
             address=Address(one_to_n_address),
             contract_name=CONTRACT_ONE_TO_N,

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -14,7 +14,7 @@ from raiden.exceptions import (
 )
 from raiden.network.rpc.client import (
     JSONRPCClient,
-    check_address_has_code,
+    check_address_has_code_handle_pruned_block,
     was_transaction_successfully_mined,
 )
 from raiden.utils.secrethash import sha256_secrethash
@@ -49,7 +49,7 @@ class SecretRegistry:
             raise ValueError("Expected binary address format for secret registry")
 
         self.contract_manager = contract_manager
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=jsonrpc_client,
             address=Address(secret_registry_address),
             contract_name=CONTRACT_SECRET_REGISTRY,

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -8,7 +8,7 @@ from web3.exceptions import BadFunctionCallOutput
 from raiden.exceptions import BrokenPreconditionError, RaidenUnrecoverableError
 from raiden.network.rpc.client import (
     JSONRPCClient,
-    check_address_has_code,
+    check_address_has_code_handle_pruned_block,
     was_transaction_successfully_mined,
 )
 from raiden.utils.typing import (
@@ -39,7 +39,7 @@ class ServiceRegistry:
             raise ValueError("Expected binary address for service registry")
 
         self.contract_manager = contract_manager
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=jsonrpc_client,
             address=Address(service_registry_address),
             contract_name=CONTRACT_SERVICE_REGISTRY,

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -6,7 +6,7 @@ from raiden.constants import BLOCK_ID_LATEST, GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL
 from raiden.exceptions import RaidenRecoverableError
 from raiden.network.rpc.client import (
     JSONRPCClient,
-    check_address_has_code,
+    check_address_has_code_handle_pruned_block,
     check_transaction_failure,
     was_transaction_successfully_mined,
 )
@@ -46,7 +46,7 @@ class Token:
         if not is_binary_address(token_address):
             raise ValueError("token_address must be a valid address")
 
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             jsonrpc_client,
             Address(token_address),
             "Token",

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -33,7 +33,7 @@ from raiden.network.proxies.utils import (
 )
 from raiden.network.rpc.client import (
     JSONRPCClient,
-    check_address_has_code,
+    check_address_has_code_handle_pruned_block,
     check_transaction_failure,
     was_transaction_successfully_mined,
 )
@@ -146,7 +146,7 @@ class TokenNetwork:
         if not is_binary_address(metadata.address):
             raise ValueError("Expected binary address format for token nework")
 
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=jsonrpc_client,
             address=Address(metadata.address),
             contract_name=CONTRACT_TOKEN_NETWORK,

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -21,7 +21,7 @@ from raiden.network.proxies.token import Token
 from raiden.network.proxies.utils import raise_on_call_returned_empty
 from raiden.network.rpc.client import (
     JSONRPCClient,
-    check_address_has_code,
+    check_address_has_code_handle_pruned_block,
     check_transaction_failure,
     was_transaction_successfully_mined,
 )
@@ -60,7 +60,7 @@ class TokenNetworkRegistry:
         block_identifier: BlockIdentifier,
     ) -> None:
 
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=rpc_client,
             address=Address(metadata.address),
             contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
@@ -301,7 +301,7 @@ class TokenNetworkRegistry:
 
                 check_transaction_failure(transaction_mined, self.rpc_client)
 
-                check_address_has_code(
+                check_address_has_code_handle_pruned_block(
                     client=self.rpc_client,
                     address=Address(secret_registry_address),
                     contract_name=CONTRACT_SECRET_REGISTRY,
@@ -429,7 +429,7 @@ class TokenNetworkRegistry:
                     "anymore."
                 )
 
-            check_address_has_code(
+            check_address_has_code_handle_pruned_block(
                 client=self.rpc_client,
                 address=Address(secret_registry_address),
                 contract_name=CONTRACT_SECRET_REGISTRY,

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -13,7 +13,7 @@ from raiden.network.proxies.utils import raise_on_call_returned_empty
 from raiden.network.rpc.client import (
     JSONRPCClient,
     TransactionSent,
-    check_address_has_code,
+    check_address_has_code_handle_pruned_block,
     was_transaction_successfully_mined,
 )
 from raiden.utils.formatting import format_block_id, to_checksum_address
@@ -67,7 +67,7 @@ class UserDeposit:
         if not is_binary_address(user_deposit_address):
             raise ValueError("Expected binary address format for token nework")
 
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=jsonrpc_client,
             address=Address(user_deposit_address),
             contract_name=CONTRACT_USER_DEPOSIT,
@@ -138,7 +138,7 @@ class UserDeposit:
         given_block_identifier: BlockIdentifier,
     ) -> None:
         """ Initialize the UserDeposit contract with MS and OneToN addresses """
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=self.client,
             address=Address(monitoring_service_address),
             contract_name=CONTRACT_MONITORING_SERVICE,
@@ -147,7 +147,7 @@ class UserDeposit:
             ),
             given_block_identifier=given_block_identifier,
         )
-        check_address_has_code(
+        check_address_has_code_handle_pruned_block(
             client=self.client,
             address=Address(one_to_n_address),
             contract_name=CONTRACT_ONE_TO_N,

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -1,11 +1,13 @@
 import gevent
 import pytest
+from eth_utils import to_canonical_address
 from web3 import Web3
 
 from raiden.network.rpc.client import (
     EthTransfer,
     JSONRPCClient,
     TransactionMined,
+    check_address_has_code,
     gas_price_for_fast_transaction,
     geth_discover_next_available_nonce,
 )
@@ -51,6 +53,14 @@ def test_geth_request_pruned_data_raises_an_exception(
 
     with pytest.raises(ValueError):
         contract_proxy.functions.get(1).call(block_identifier=pruned_block_number)
+
+    with pytest.raises(ValueError):
+        check_address_has_code(
+            deploy_client,
+            to_canonical_address(contract_proxy.address),
+            "RpcWithStorageTest",
+            given_block_identifier=pruned_block_number,
+        )
 
 
 def test_geth_discover_next_available_nonce_concurrent_transactions(

--- a/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
@@ -1,6 +1,7 @@
 import pytest
+from eth_utils import to_canonical_address
 
-from raiden.network.rpc.client import JSONRPCClient, TransactionMined
+from raiden.network.rpc.client import JSONRPCClient, TransactionMined, check_address_has_code
 from raiden.tests.utils.smartcontracts import deploy_rpc_test_contract
 
 pytestmark = pytest.mark.usefixtures("skip_if_not_parity")
@@ -42,3 +43,11 @@ def test_parity_request_pruned_data_raises_an_exception(deploy_client: JSONRPCCl
 
     with pytest.raises(ValueError):
         contract_proxy.functions.get(1).call(block_identifier=pruned_block_number)
+
+    with pytest.raises(ValueError):
+        check_address_has_code(
+            deploy_client,
+            to_canonical_address(contract_proxy.address),
+            "RpcWithStorageTest",
+            given_block_identifier=pruned_block_number,
+        )

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -2,6 +2,7 @@ import os
 
 from solc import compile_files
 from web3.contract import Contract
+from web3.types import TxReceipt
 
 from raiden.constants import BLOCK_ID_LATEST
 from raiden.network.pathfinding import get_random_pfs
@@ -137,7 +138,9 @@ def compile_files_cwd(*args: Any, **kwargs: Any) -> Dict[str, Any]:
     return compiled_contracts
 
 
-def deploy_rpc_test_contract(deploy_client: JSONRPCClient, name: str):
+def deploy_rpc_test_contract(
+    deploy_client: JSONRPCClient, name: str
+) -> Tuple[Contract, TxReceipt]:
     contract_path = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "..", "smart_contracts", f"{name}.sol")
     )


### PR DESCRIPTION
`eth_getCode` can fail if the target block was pruned

fix #6083