### PR TITLE
Dynamically adjust block batch size

### DIFF
--- a/raiden/blockchain/exceptions.py
+++ b/raiden/blockchain/exceptions.py
@@ -23,3 +23,19 @@ class UnknownExternalEventType(RaidenRecoverableError):
     not controlled. If this was an unrecoverable it would open a surface for
     attacks.
     """
+
+
+class EthGetLogsTimeout(RaidenRecoverableError):
+    """ Raised when an eth.getLogs RPC call caused a ReadTimeout exception.
+
+    It is used to automatically tune the block batching size.
+    """
+
+
+class BlockBatchSizeTooSmall(RaidenUnrecoverableError):
+    """ Raised when the block batch size would have to be reduced below the minimum allowed value.
+
+    This is an unrecoverable error since it indicates that either the connected Eth-node or the
+    network connection is not capable of supporting minimum performance requirements for the
+    eth.getLogs call.
+    """

--- a/raiden/blockchain/utils.py
+++ b/raiden/blockchain/utils.py
@@ -1,0 +1,91 @@
+import math
+
+from eth_typing import BlockNumber
+from structlog import get_logger
+
+from raiden.blockchain.exceptions import BlockBatchSizeTooSmall
+from raiden.settings import BlockBatchSizeConfig
+
+log = get_logger(__name__)
+
+
+class BlockBatchSizeAdjuster:
+    """ Helper to dynamically adjust the block batch size.
+
+    Internally it uses an exponential function of base ``base`` onto which the block range given
+    in the config is mapped.
+
+    The default values for ``base`` and ``step_size`` fit well for ranges that span several orders
+    of magnitude. For very small ranges those values may need to be adjusted.
+    """
+
+    def __init__(
+        self,
+        block_batch_size_config: BlockBatchSizeConfig,
+        base: float = 2.0,
+        step_size: float = 1.0,
+    ) -> None:
+        self._block_batch_size_config = block_batch_size_config
+        self._base = base
+        self._step_size = step_size
+
+        self._scale_max = math.log(self._block_batch_size_config.max, self._base) + 1
+        self._scale_min = math.log(self._block_batch_size_config.min, self._base)
+        self._scale_current = math.log(self._block_batch_size_config.initial, self._base)
+
+    def _log(self, previous_batch_size: BlockNumber) -> None:
+        batch_size = self.batch_size
+        log.debug(
+            "Adjusting block batch size",
+            batch_size=batch_size,
+            previous_batch_size=previous_batch_size,
+        )
+        if batch_size <= self._block_batch_size_config.warn_threshold:
+            log.warning(
+                "Block batch size approaching minimum",
+                batch_size=batch_size,
+                previous_batch_size=previous_batch_size,
+                warning_threshold=self._block_batch_size_config.warn_threshold,
+                minimum_batch_size=self._block_batch_size_config.min,
+            )
+
+    def increase(self) -> None:
+        """ Increase the block batch size.
+
+        Does nothing if the value is already at the maximum.
+        """
+        previous_batch_size = self.batch_size
+        if previous_batch_size >= self._block_batch_size_config.max:
+            return
+        self._scale_current += self._step_size
+        self._log(previous_batch_size)
+
+    def decrease(self) -> None:
+        """ Decrease the batch size.
+
+        If the current value is already at the minimum raise ``BlockBatchSizeTooSmall``.
+        """
+        previous_batch_size = self.batch_size
+        if previous_batch_size <= self._block_batch_size_config.min:
+            raise BlockBatchSizeTooSmall(
+                f"The block batch size has fallen below the minimum allowed value of "
+                f"{self._block_batch_size_config.min}. This indicates that either your Ethereum "
+                f"node or the network connection to it is overloaded or it is running on "
+                f"insufficiently powerful hardware."
+            )
+        self._scale_current -= self._step_size
+        self._log(previous_batch_size)
+
+    @property
+    def batch_size(self) -> BlockNumber:
+        """ Return the current batch size.
+
+        Clamps the value to the range given in the config.
+        """
+        return max(
+            self._block_batch_size_config.min,
+            min(
+                self._block_batch_size_config.max,
+                BlockNumber(int(self._base ** self._scale_current)),
+            ),
+        )

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -175,6 +175,10 @@ EMPTY_ADDRESS = b"\0" * 20
 BLOCK_ID_LATEST: Literal["latest"] = "latest"
 BLOCK_ID_PENDING: Literal["pending"] = "pending"
 
+# Thresholds for the ``eth.getLogs`` call. Used to automatically adjust the block batch size.
+ETH_GET_LOGS_TIMEOUT = 10
+ETH_GET_LOGS_THRESHOLD_FAST = ETH_GET_LOGS_TIMEOUT // 4
+ETH_GET_LOGS_THRESHOLD_SLOW = ETH_GET_LOGS_TIMEOUT // 2
 
 # Keep in sync with .circleci/config.yaml
 HIGHEST_SUPPORTED_GETH_VERSION = "1.9.11"

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from eth_typing import BlockNumber
 from eth_utils import denoms, to_hex
 
 import raiden_contracts.constants
@@ -148,10 +149,19 @@ class ServiceConfig:
     monitoring_enabled: bool = False
 
 
+@dataclass(frozen=True)
+class BlockBatchSizeConfig:
+    min: BlockNumber = BlockNumber(5)
+    warn_threshold: BlockNumber = BlockNumber(50)
+    initial: BlockNumber = BlockNumber(1_000)
+    max: BlockNumber = BlockNumber(100_000)
+
+
 @dataclass
 class BlockchainConfig:
     confirmation_blocks: BlockTimeout = DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
     query_interval: float = DEFAULT_BLOCKCHAIN_QUERY_INTERVAL
+    block_batch_size_config: BlockBatchSizeConfig = BlockBatchSizeConfig()
 
 
 @dataclass

--- a/raiden/tests/unit/utils/test_dynamic_block_batch_size.py
+++ b/raiden/tests/unit/utils/test_dynamic_block_batch_size.py
@@ -1,0 +1,40 @@
+import pytest
+from eth_typing import BlockNumber
+
+from raiden.blockchain.exceptions import BlockBatchSizeTooSmall
+from raiden.blockchain.utils import BlockBatchSizeAdjuster
+from raiden.settings import BlockBatchSizeConfig
+
+
+def test_dynamic_block_batch_size_adjuster():
+    config = BlockBatchSizeConfig(
+        min=BlockNumber(5),
+        warn_threshold=BlockNumber(50),
+        initial=BlockNumber(1000),
+        max=BlockNumber(100_000),
+    )
+    adjuster = BlockBatchSizeAdjuster(config, base=2, step_size=1)
+
+    # Check initial value
+    assert adjuster.batch_size == 1000
+
+    adjuster.increase()
+    assert adjuster.batch_size == 2000
+
+    # Increase all the way to the max value
+    for _ in range(6):
+        adjuster.increase()
+    assert adjuster.batch_size == config.max
+
+    # Ensure we're clamped to the max value
+    adjuster.increase()
+    assert adjuster.batch_size == config.max
+
+    # Decrease back down to the minimum
+    for _ in range(15):
+        adjuster.decrease()
+    assert adjuster.batch_size == config.min
+
+    # Decreasing below the minimum must raise an exception
+    with pytest.raises(BlockBatchSizeTooSmall):
+        adjuster.decrease()


### PR DESCRIPTION
## Description

Fixes: #5538

The batch size used while syncing with the Blockchain in the `eth.getLogs()` calls is now dynamically adjusted based on the response time.

The currently chosen default values are:
- min batch size: 5
- max batch size: 100_000
- initial batch size: 1_000

Also adds tests and fixed the calculation of the block range and blocks / s values in `RaidenService._log_sync_progress`.