### PR TITLE
Fix `/status` endpoint in docs

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -877,7 +877,7 @@ Querying node state
 
    .. http:example:: curl wget httpie python-requests
 
-      GET /api/v1/address HTTP/1.1
+      GET /api/v1/status HTTP/1.1
       Host: localhost:5001
 
    **Example Response**:


### PR DESCRIPTION
In the API documentation, there was an incorrect endpoint example for the `status` API.