### PR TITLE
Clean up UDC balances in scenarios

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -8,11 +8,8 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -8,11 +8,8 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -8,11 +8,8 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -9,8 +9,7 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf5_join_and_leave.yaml
+++ b/raiden/tests/scenarios/bf5_join_and_leave.yaml
@@ -8,11 +8,8 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   # We need a new token to be able to predict the network topology

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -8,11 +8,8 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -9,11 +9,8 @@ settings:
     udc:
       enable: true
       token:
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
         deposit: true
-        balance_per_node: 100_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 
 token:

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -10,10 +10,7 @@ settings:
       enable: true
       token:
         deposit: true
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
-        balance_per_node: 7_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -10,10 +10,7 @@ settings:
       enable: true
       token:
         deposit: true
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
-        balance_per_node: 7_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -10,10 +10,7 @@ settings:
       enable: true
       token:
         deposit: true
-        # Make sure that enough is deposited to pay for an MR
-        # The cost of an MR is `5 * 10 ** 18`
-        balance_per_node: 7_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -10,10 +10,7 @@ settings:
       enable: true
       token:
         deposit: true
-        min_balance: 9000
-        balance_per_node: 10000
-        # MS reward is 5 * 10 ** 18 tokens, so less than that must be deposited
-        max_funding: 10000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -12,7 +12,7 @@ settings:
 
 token:
   address: "{{ transfer_token }}"
-  balance_fund: 10_000_000_000_000_000_000
+  balance_fund: 1_000_000_000_000_000_000
 
 nodes:
   count: 4

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -9,8 +9,7 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: 7_000_000_000_000_000_000
-        min_balance: 5_000_000_000_000_000_000
+        balance_per_node: {{ ms_reward_with_margin }}
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -9,7 +9,6 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: 5000
 
 token:
   address: "{{ transfer_token }}"

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -9,7 +9,6 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: 5000
 
 token:
   address: "{{ transfer_token }}"


### PR DESCRIPTION
There was quite a mix-up of different values with different purposes and
some outright wrong and useless entries. Currently, we really only have
three different cases which are solved as follows:

* No UDC required: omit `deposit: true`
* Need deposit for a few PFS payments: use `deposit: true` with defaults
* Need enough for the MS to trigger:
  set `balance_per_node: {{ ms_reward_with_margin }}`
