### PR TITLE
Remove get_channel_participants_from_open_event

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -711,8 +711,7 @@ class RaidenAPI:  # pragma: no unittest
             address=token_network_address, block_identifier=confirmed_block_identifier
         )
         channel_proxy = self.raiden.proxy_manager.payment_channel(
-            canonical_identifier=channel_state.canonical_identifier,
-            block_identifier=confirmed_block_identifier,
+            channel_state=channel_state, block_identifier=confirmed_block_identifier
         )
 
         blockhash = chain_state.block_hash

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -108,7 +108,7 @@ def get_contractreceivechannelsettled_data_from_event(
         # provided during settle.
         our_locksroot, partner_locksroot = get_onchain_locksroots(
             proxy_manager=proxy_manager,
-            canonical_identifier=channel_state.canonical_identifier,
+            channel_state=channel_state,
             participant1=channel_state.our_state.address,
             participant2=channel_state.partner_state.address,
             block_identifier=block_hash,
@@ -128,7 +128,7 @@ def get_contractreceivechannelsettled_data_from_event(
         # channel.
         our_locksroot, partner_locksroot = get_onchain_locksroots(
             proxy_manager=proxy_manager,
-            canonical_identifier=channel_state.canonical_identifier,
+            channel_state=channel_state,
             participant1=channel_state.our_state.address,
             participant2=channel_state.partner_state.address,
             block_identifier=current_confirmed_head,

--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -375,12 +375,12 @@ class LockedTransferBase(EnvelopeMessage):
 
     @overload  # noqa: F811
     @classmethod
-    def from_event(cls, event: SendRefundTransfer) -> "RefundTransfer":
+    def from_event(cls, event: SendRefundTransfer) -> "RefundTransfer":  # noqa: F811
         # pylint: disable=unused-argument
         ...
 
     @classmethod  # noqa: F811
-    def from_event(cls, event: Any) -> Any:
+    def from_event(cls, event: Any) -> Any:  # noqa: F811
         transfer = event.transfer
         balance_proof = transfer.balance_proof
         lock = Lock(

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -1,6 +1,6 @@
 from raiden.blockchain.filters import decode_event, get_filter_args_for_specific_event_from_channel
 from raiden.network.proxies.token_network import ChannelDetails, TokenNetwork
-from raiden.transfer.state import PendingLocksState, NettingChannelState
+from raiden.transfer.state import NettingChannelState, PendingLocksState
 from raiden.utils.typing import (
     AdditionalHash,
     Address,

--- a/raiden/network/proxies/proxy_manager.py
+++ b/raiden/network/proxies/proxy_manager.py
@@ -15,7 +15,7 @@ from raiden.network.proxies.token_network import TokenNetwork, TokenNetworkMetad
 from raiden.network.proxies.token_network_registry import TokenNetworkRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.transfer.identifiers import CanonicalIdentifier
+from raiden.transfer.state import NettingChannelState
 from raiden.utils.typing import (
     Address,
     BlockIdentifier,
@@ -240,11 +240,11 @@ class ProxyManager:
         return self.address_to_service_registry[address]
 
     def payment_channel(
-        self, canonical_identifier: CanonicalIdentifier, block_identifier: BlockIdentifier
+        self, channel_state: NettingChannelState, block_identifier: BlockIdentifier
     ) -> PaymentChannel:
 
-        token_network_address = canonical_identifier.token_network_address
-        channel_id = canonical_identifier.channel_identifier
+        token_network_address = channel_state.canonical_identifier.token_network_address
+        channel_id = channel_state.canonical_identifier.channel_identifier
 
         if not is_binary_address(token_network_address):
             raise ValueError("address must be a valid address")
@@ -260,7 +260,7 @@ class ProxyManager:
 
                 self.identifier_to_payment_channel[dict_key] = PaymentChannel(
                     token_network=token_network,
-                    channel_identifier=channel_id,
+                    channel_state=channel_state,
                     contract_manager=self.contract_manager,
                 )
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -27,10 +27,7 @@ from raiden.exceptions import (
     WithdrawMismatch,
 )
 from raiden.network.proxies.metadata import SmartContractMetadata
-from raiden.network.proxies.utils import (
-    get_channel_participants_from_open_event,
-    raise_on_call_returned_empty,
-)
+from raiden.network.proxies.utils import raise_on_call_returned_empty
 from raiden.network.rpc.client import (
     JSONRPCClient,
     check_address_has_code_handle_pruned_block,
@@ -2393,25 +2390,11 @@ class TokenNetwork:
                     locksroot=partner_locksroot,
                 )
 
-                participants = get_channel_participants_from_open_event(
-                    token_network=self,
-                    channel_identifier=channel_identifier,
-                    contract_manager=self.contract_manager,
-                    from_block=self.metadata.filters_start_at,
-                )
-                if not participants:
-                    msg = (
-                        f"The provided channel identifier {channel_identifier} "
-                        f"does not exist on-chain."
-                    )
-                    raise RaidenUnrecoverableError(msg)
-
-                if self.node_address not in participants:
-                    msg = (
-                        f"Settling a channel in which the current node is not a participant "
-                        f"of is not allowed."
-                    )
-                    raise RaidenUnrecoverableError(msg)
+                # The channel_identifier and the address of the participants
+                # can not be verified because querying for the open event would
+                # take prohibitly long (see #6106). Instead it is assumed that
+                # if there is a local ChannelState instance it is properly
+                # validated and the data is confirmed.
 
                 if channel_onchain_detail.state in (ChannelState.SETTLED, ChannelState.REMOVED):
                     raise RaidenRecoverableError("Channel is already settled")
@@ -2477,25 +2460,11 @@ class TokenNetwork:
                 locksroot=partner_locksroot,
             )
 
-            participants = get_channel_participants_from_open_event(
-                token_network=self,
-                channel_identifier=channel_identifier,
-                contract_manager=self.contract_manager,
-                from_block=self.metadata.filters_start_at,
-            )
-            if not participants:
-                msg = (
-                    f"The provided channel identifier {channel_identifier} "
-                    f"does not exist on-chain."
-                )
-                raise RaidenUnrecoverableError(msg)
-
-            if self.node_address not in participants:
-                msg = (
-                    f"Settling a channel in which the current node is not a participant "
-                    f"of is not allowed."
-                )
-                raise RaidenUnrecoverableError(msg)
+            # The channel_identifier and the address of the participants
+            # can not be verified because querying for the open event would
+            # take prohibitly long (see #6106). Instead it is assumed that
+            # if there is a local ChannelState instance it is properly
+            # validated and the data is confirmed.
 
             if channel_onchain_detail.state in (ChannelState.SETTLED, ChannelState.REMOVED):
                 raise RaidenRecoverableError("Channel is already settled")

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -2392,7 +2392,7 @@ class TokenNetwork:
 
                 # The channel_identifier and the address of the participants
                 # can not be verified because querying for the open event would
-                # take prohibitly long (see #6106). Instead it is assumed that
+                # take prohibitively long (see #6106). Instead it is assumed that
                 # if there is a local ChannelState instance it is properly
                 # validated and the data is confirmed.
 
@@ -2462,7 +2462,7 @@ class TokenNetwork:
 
             # The channel_identifier and the address of the participants
             # can not be verified because querying for the open event would
-            # take prohibitly long (see #6106). Instead it is assumed that
+            # take prohibitively long (see #6106). Instead it is assumed that
             # if there is a local ChannelState instance it is properly
             # validated and the data is confirmed.
 

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from raiden.exceptions import RaidenUnrecoverableError
-from raiden.transfer.identifiers import CanonicalIdentifier
+from raiden.transfer.state import NettingChannelState
 from raiden.utils.formatting import format_block_id
 from raiden.utils.typing import Address, BlockIdentifier, Locksroot, NoReturn, Tuple
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 def get_onchain_locksroots(
     proxy_manager: "ProxyManager",
-    canonical_identifier: CanonicalIdentifier,
+    channel_state: NettingChannelState,
     participant1: Address,
     participant2: Address,
     block_identifier: BlockIdentifier,
@@ -44,14 +44,14 @@ def get_onchain_locksroots(
       locksroot was used.
     """
     payment_channel = proxy_manager.payment_channel(
-        canonical_identifier=canonical_identifier, block_identifier=block_identifier
+        channel_state=channel_state, block_identifier=block_identifier
     )
     token_network = payment_channel.token_network
 
     participants_details = token_network.detail_participants(
         participant1=participant1,
         participant2=participant2,
-        channel_identifier=canonical_identifier.channel_identifier,
+        channel_identifier=channel_state.canonical_identifier.channel_identifier,
         block_identifier=block_identifier,
     )
 

--- a/raiden/network/proxies/utils.py
+++ b/raiden/network/proxies/utils.py
@@ -1,61 +1,13 @@
 from typing import TYPE_CHECKING
 
-from eth_utils import decode_hex
-
-from raiden.blockchain.filters import decode_event, get_filter_args_for_specific_event_from_channel
-from raiden.constants import BLOCK_ID_LATEST
 from raiden.exceptions import RaidenUnrecoverableError
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.utils.formatting import format_block_id
-from raiden.utils.typing import (
-    Address,
-    BlockIdentifier,
-    BlockNumber,
-    ChannelID,
-    Locksroot,
-    NoReturn,
-    Optional,
-    Tuple,
-)
-from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
-from raiden_contracts.contract_manager import ContractManager
+from raiden.utils.typing import Address, BlockIdentifier, Locksroot, NoReturn, Tuple
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
     from raiden.network.proxies.proxy_manager import ProxyManager
-    from raiden.network.proxies.token_network import TokenNetwork
-
-
-def get_channel_participants_from_open_event(
-    token_network: "TokenNetwork",
-    channel_identifier: ChannelID,
-    contract_manager: ContractManager,
-    from_block: BlockNumber,
-) -> Optional[Tuple[Address, Address]]:
-    # For this check it is perfectly fine to use a `latest` block number.
-    # Because the filter is looking just for the OPENED event.
-    to_block = BLOCK_ID_LATEST
-
-    filter_args = get_filter_args_for_specific_event_from_channel(
-        token_network_address=token_network.address,
-        channel_identifier=channel_identifier,
-        event_name=ChannelEvent.OPENED,
-        contract_manager=contract_manager,
-        from_block=from_block,
-        to_block=to_block,
-    )
-
-    events = token_network.proxy.web3.eth.getLogs(filter_args)
-
-    # There must be only one channel open event per channel identifier
-    if len(events) != 1:
-        return None
-
-    event = decode_event(contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK), events[0])
-    participant1 = Address(decode_hex(event["args"]["participant1"]))
-    participant2 = Address(decode_hex(event["args"]["participant2"]))
-
-    return participant1, participant2
 
 
 def get_onchain_locksroots(

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -69,9 +69,9 @@ from raiden.transfer.mediated_transfer.events import (
 )
 from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import (
+    get_channelstate_by_canonical_identifier,
     get_channelstate_by_token_network_and_partner,
     state_from_raiden,
-    get_channelstate_by_canonical_identifier,
 )
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.packing import pack_signed_balance_proof, pack_withdraw

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -12,7 +12,7 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
-from raiden.transfer.identifiers import CanonicalIdentifier
+from raiden.transfer.state import NettingChannelState
 from raiden.transfer.state_change import ActionInitChain
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.signer import LocalSigner
@@ -75,9 +75,11 @@ class MockProxyManager:
         self.mocked_addresses = mocked_addresses or dict()
 
     def payment_channel(
-        self, canonical_identifier: CanonicalIdentifier, block_identifier: BlockIdentifier
+        self, channel_state: NettingChannelState, block_identifier: BlockIdentifier
     ):  # pylint: disable=unused-argument
-        return MockPaymentChannel(self.token_network, canonical_identifier.channel_identifier)
+        return MockPaymentChannel(
+            self.token_network, channel_state.canonical_identifier.channel_identifier
+        )
 
     def token_network_registry(
         self, address: Address, block_identifier: BlockIdentifier
@@ -144,6 +146,7 @@ class MockChannelState:
     def __init__(self):
         self.settle_transaction = None
         self.close_transaction = None
+        self.canonical_identifier = factories.make_canonical_identifier()
         self.our_state = Mock()
         self.partner_state = Mock()
 


### PR DESCRIPTION
The function get_channel_participants_from_open_event relied on fetching
the channel open event from the ethereum node. This, however, is an
operation with linear complexity on both geth and parity, which requires
a lot of CPU from the node and leads to timeout issues. Since this API
can not be safely used in production/mainnet the interface is being
removed, instead the code is relying on the event polling code to be
correct, and assuming that if a NettingChannelState instance is only
created for valid events. This removes the performance drawback from
freshly fecthing the events from the blockchain while maintaining a
level of type safety.

fix #6106