### PR TITLE
JSONRPCClient requires a privatekey.

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -906,11 +906,11 @@ class JSONRPCClient:
     def __init__(
         self,
         web3: Web3,
-        privkey: Optional[PrivateKey],
+        privkey: PrivateKey,
         gas_price_strategy: Callable = rpc_gas_price_strategy,
         block_num_confirmations: int = 0,
     ) -> None:
-        if privkey is None or len(privkey) != 32:
+        if len(privkey) != 32:
             raise ValueError("Invalid private key")
 
         if block_num_confirmations < 0:


### PR DESCRIPTION
The signature allowed for `None` to be used, but that resulted in a
runtime error. Instead of having an error at runtime this enforces the
caller to provide a privatekey statically.

The privatekey is required because transactions are signed locally.