### PR TITLE
Provide API endpoint to shutdown Raiden

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1332,3 +1332,6 @@ class RaidenAPI:  # pragma: no unittest
                 channel_id = partner_channel.identifier
 
         return transfer_tasks_view(transfer_tasks, token_address, channel_id)
+
+    def shutdown(self) -> None:
+        self.raiden.stop()

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -322,3 +322,9 @@ class PendingTransfersResourceByTokenAndPartnerAddress(BaseResource):
 class StatusResource(BaseResource):
     def get(self) -> Response:
         return self.rest_api.get_status()
+
+
+class ShutdownResource(BaseResource):
+    @if_api_available
+    def post(self) -> Response:
+        return self.rest_api.shutdown()

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -1244,3 +1244,19 @@ def test_api_testnet_token_mint(api_server_test_instance: APIServer, token_addre
     request = grequests.post(url, json=dict(to=user_address[:-2], value=10))
     response = request.send().response
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
+
+
+@raise_on_failure
+@pytest.mark.parametrize("number_of_nodes", [1])
+@pytest.mark.parametrize("channels_per_node", [0])
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_shutdown(api_server_test_instance: APIServer):
+    """ Node must stop after shutdown is called """
+    url = ("http://localhost:{port}/api/v1/shutdown").format(
+        port=api_server_test_instance.config.port
+    )
+    response = grequests.post(url).send().response
+
+    assert_response_with_code(response, HTTPStatus.OK)
+    finished = gevent.joinall({api_server_test_instance}, timeout=10, raise_error=True)
+    assert finished, "The Raiden node did not shut down!"


### PR DESCRIPTION
This can then be used in the WebUI.

Closes https://github.com/raiden-network/raiden/issues/6113.
