### PR TITLE
Fix deposit in MS4

### DIFF
--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -10,7 +10,8 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: {{ ms_reward_with_margin }}
+        # There should be enough deposit to use the PFS, but not enough to be able to use the MS
+        balance_per_node: {{ pfs_fee * 10 }}
 
 token:
   address: "{{ transfer_token }}"


### PR DESCRIPTION
When adding templating to the scenarios this was changed to have a
proper deposit, which is not what the scenario requires.

https://github.com/raiden-network/raiden/commit/6999c650235c975639b5d4d1582a628da460ee34#diff-e7057410e2e4ef3cfbf88ae30193f1cc

Instead we change it to be 10x the PFS price, so that it works on both
testnet and mainnet.


Resolves https://github.com/raiden-network/raiden/issues/6130
