### PR TITLE
Fix IOU assertion in PFS8

### DIFF
--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -116,7 +116,7 @@ scenario:
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
 
             # Check that IOU is created
-            - assert_pfs_iou: {source: 0, amount: {{ pfs_fee }}}
+            - assert_pfs_iou: {source: 0, amount: {{ 2 * pfs_fee }}}
       - serial:
           name: "Check that the [0, 1, 2, 3] path was used"
           tasks:


### PR DESCRIPTION
This was converted to templates with a small error, this PR brings back
the missing factor of two.

See https://github.com/raiden-network/raiden/commit/657b21925408f026c19dc17a2eb5ddcf60498d2b#diff-418d7f34cecc7db3f39a553e5e3b909fR120

Resolves #6129