### PR TITLE
Always print the exception to stderr

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -106,6 +106,7 @@ def write_stack_trace(ex: Exception) -> None:
     )
     with file as traceback_file:
         traceback.print_exc(file=traceback_file)
+        traceback.print_exc()
         click.secho(
             f"FATAL: An unexpected exception occurred. "
             f"A traceback has been written to {traceback_file.name}\n"
@@ -622,7 +623,6 @@ def run(ctx: Context, **kwargs: Any) -> None:
         click.secho(str(e), fg="red")
         sys.exit(ReturnCode.ETH_INTERFACE_ERROR)
     except RaidenUnrecoverableError as ex:
-        click.secho(f"FATAL: An un-recoverable error happen, Raiden is bailing {ex}", fg="red")
         write_stack_trace(ex)
         sys.exit(ReturnCode.FATAL)
     except APIServerPortInUseError as ex:


### PR DESCRIPTION
The previous approach redirectered the stacktrace to a file to avoid
showing it to a end users, however it makes it harder for our tooling to
make the stacktrace available for debugging, since the scenarios are
executed inside a docker container and the tmp folder is not mapped.
This changes the code to print the exception to the stderr to make it
available for debugging.