### PR TITLE
Fix BF1 UDC desposit

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -9,7 +9,7 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: {{ ms_reward_with_margin }}
+        balance_per_node: {{ ms_reward_with_margin + 200 * pfs_fee}}
 
 token:
   address: "{{ transfer_token }}"


### PR DESCRIPTION
We need enough to pay for PFS routes in addition to paying the MS.

[skip tests]
