### PR TITLE
Small no code exception message fix [skip tests]

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -368,7 +368,7 @@ def check_address_has_code(
 
     if expected_code is not None and result != expected_code:
         raise ContractCodeMismatch(
-            f"[{contract_name}]Address {to_checksum_address(address)} has wrong code."
+            f"[{contract_name}] Address {to_checksum_address(address)} has wrong code"
         )
 
 


### PR DESCRIPTION
Removes the double period in this message
```
[TokenNetworkRegistry]Address 0x3DE1B1E10Ae71C3E3b793e545A047d1B4FAB587a has wrong code.. Please update your Raiden installation.
```

As seen in #6070