### PR TITLE
Better error message for problematic smart contracts

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -250,11 +250,6 @@ class AddressWithoutCode(RaidenError):
     """Raised on attempt to execute contract on address without a code."""
 
 
-class AddressWrongContract(RaidenError):
-    """Raised on attempt to execute contract on address that has code but
-    is probably not the contract we wanted."""
-
-
 class DuplicatedChannelError(RaidenRecoverableError):
     """Raised if someone tries to create a channel that already exists."""
 

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -360,6 +360,8 @@ def check_address_has_code(
     result = client.web3.eth.getCode(address, given_block_identifier)
 
     if not result:
+        # The error message is printed to the user from ui/cli.py. Make sure it
+        # is readable.
         raise AddressWithoutCode(
             "[{}]Address {} does not contain code".format(
                 contract_name, to_checksum_address(address)
@@ -367,6 +369,8 @@ def check_address_has_code(
         )
 
     if expected_code is not None and result != expected_code:
+        # The error message is printed to the user from ui/cli.py. Make sure it
+        # is readable.
         raise ContractCodeMismatch(
             f"[{contract_name}] Address {to_checksum_address(address)} has wrong code"
         )

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -54,7 +54,7 @@ def mock_raises(exception):
 def test_run_error_reporting(cli_runner, monkeypatch):
     caught_exceptions = {
         APIServerPortInUseError(): ReturnCode.PORT_ALREADY_IN_USE,
-        ConfigurationError(): ReturnCode.CONFIGURATION_ERROR,
+        ConfigurationError(): ReturnCode.RAIDEN_CONFIGURATION_ERROR,
         ConnectTimeout(): ReturnCode.GENERIC_COMMUNICATION_ERROR,
         ConnectionError(): ReturnCode.GENERIC_COMMUNICATION_ERROR,
         EthereumNonceTooLow(): ReturnCode.ETH_ACCOUNT_ERROR,


### PR DESCRIPTION
This should make issues like https://github.com/raiden-network/raiden/issues/6070 easier for the user.

Output will look like:

```
Select one of them by index to continue: 0
Enter the password to unlock ...:
The Raiden API RPC server is now running at http://127.0.0.1:5001/.

 See the Raiden documentation for all available endpoints at
 http://raiden-network.readthedocs.io/en/stable/rest_api.html
Checking if the ethereum node is synchronized
[TokenNetworkRegistry]Address 0x3DE1B1E10Ae71C3E3b793e545A047d1B4FAB587a does not contain code. This may happen if an external ERC20 smart contract selfdestructed, or if the configured address is misconfigured, make sure the used address is not a normal account but a smart contract, and that it is deployed to ropsten.
ReturnCode.SMART_CONTRACTS_CONFIGURATION_ERROR
```