### PR TITLE
Add extra details to exception messages

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -505,9 +505,10 @@ def post_pfs_paths(
     try:
         response_json = get_response_json(response)
         return response_json["result"], UUID(response_json["feedback_token"])
-    except KeyError:
+    except KeyError as e:
+        missing_field = e.args[0]
         raise ServiceRequestFailed(
-            "Answer from Pathfinding Service not understood ('result' field missing)",
+            f"Answer from Pathfinding Service not understood ('{missing_field}' field missing)",
             dict(response=get_response_json(response)),
         )
     except ValueError:


### PR DESCRIPTION
    Including error of the wrapped exception

    This is not ideal, since at moment exception messages can be used to show
    errors to the user, which will lead to parsing errors being printed to
    the screen. However at the moment the underlying error message is
    important to determine the cause of the failure for debugging. Ideally
    we should have specific exceptions for different failure modes with two
    set of messages, one to show to the end user and another with enough
    details to debug an issue.

    For now, to limit the amount of changes, including the extra details
    should be sufficient.