### PR TITLE
Remove wait from the scenarios

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -232,8 +232,6 @@ scenario:
           tasks:
             - stop_node: 4
             - close_channel: {from: 3, to: 4}
-            ## Wait for channel to be closed
-            - wait_blocks: 1
             - assert: {from: 3, to: 4, state: "closed"}
             - assert_events:
                 contract_name: "TokenNetwork"

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -49,10 +49,8 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 2
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 3, amount: 10_000, expected_http_status: 200}
-            - wait_blocks: 1  # Wait for balances being up to date
 
             ## Check that the path is indeed the expected one
             - assert_pfs_history:

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -50,10 +50,8 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 2
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 3, amount: 10_000, expected_http_status: 200}
-            - wait_blocks: 1  # Wait for balances being up to date
 
             ## Check that the path is indeed the expected one
             - assert_pfs_history:

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -50,10 +50,8 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 2
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 2, amount: 500_000_000_000_000_000, expected_http_status: 200}
-            - wait_blocks: 1  # Wait for balances being up to date
 
             ## Check that the path is indeed the expected one
             - assert_pfs_history:

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -53,10 +53,8 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 2
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 3, amount: 500_000_000_000_000_000, expected_http_status: 200}
-            - wait_blocks: 1  # Wait for balances being up to date
 
             ## Check that the path is indeed the expected one
             - assert_pfs_history:

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -40,13 +40,9 @@ scenario:
     tasks:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
-      ## Wait for Monitor Request to be sent
-      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
-      ## Wait for channel to be closed
-      - wait_blocks: 1
       - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 500_000_000_000_000_000, state: "closed"}
       - assert_events:
           contract_name: "TokenNetwork"

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -40,13 +40,9 @@ scenario:
     tasks:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
-      ## Wait for Monitor Request to be sent
-      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
-      ## Wait for channel to be closed
-      - wait_blocks: 10
       - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 500_000_000_000_000_000, state: "closed"}
       - assert_events:
           contract_name: "TokenNetwork"

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -41,13 +41,10 @@ scenario:
     tasks:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
-      ## Wait for Monitor Request to be sent
-      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
       ## Wait for channel to be closed
-      - wait_blocks: 1
       - assert: {from: 0 ,to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 500_000_000_000_000_000, state: "closed"}
       - assert_events:
           contract_name: "TokenNetwork"

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -54,7 +54,6 @@ scenario:
       - serial:
           name: "Make monitor request"
           tasks:
-            - wait_blocks: 1
             - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - serial:
           name: "Stop node1"
@@ -67,7 +66,6 @@ scenario:
       - serial:
           name: "Wait for channel close and assert that it is closed"
           tasks:
-            - wait_blocks: 1
             - assert: {from: 0 ,to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 500_000_000_000_000_000, state: "closed"}
             - assert_events:
                 contract_name: "TokenNetwork"

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -45,11 +45,9 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 1
             # Check that the PFS returns a path from 0 to 3
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
-            - wait_blocks: 1
             # Assert that correct amount was tranferred
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 1, to: 0, total_deposit: 0, balance: 1_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -49,9 +49,7 @@ scenario:
           name: "Test providing routes"
           tasks:
             # Check that the payment goes through from 0 to 3
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
-            - wait_blocks: 1
 
             # Assert that correct amount was tranferred
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -49,10 +49,8 @@ scenario:
       - serial:
           name: "Test providing routes"
           tasks:
-            - wait_blocks: 1
             # Check that the payment goes through from 0 to 3
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
-            - wait_blocks: 1
 
             # Assert that correct amount was transferred
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -51,11 +51,9 @@ scenario:
           name: "Test shortest path route"
           tasks:
             # Check that a payment is made with shortest path [0, 4, 3] from 0 to 3
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
-            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_500_000_000_000_000, balance: 500_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
@@ -76,17 +74,14 @@ scenario:
 
             # There is not enough capacity through node4, so path [0, 1, 2, 3]
             # should be used instead.
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
-            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_500_000_000_000_000, balance: 500_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
-              #
             # Check that the second IOU is created
             - assert_pfs_iou: {source: 0, amount: {{ 2 * pfs_fee }}}
 

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -53,8 +53,9 @@ scenario:
             # We expect the pfs not to send any route, but to charge for the information
             # but the node can check if the direct channel is usable so we need a deposit
             - deposit: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, expected_http_status: 200}
+
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 409}
-            - wait_blocks: 1
+
             - assert_pfs_history: {source: 3, target: 0, request_count: 1}
             - assert_pfs_iou: {source: 3, amount: {{ pfs_fee }}}
             - assert_pfs_iou: {source: 2, iou_exists: false}
@@ -79,9 +80,9 @@ scenario:
           tasks:
             # Now that there is a path with capacity the transfer should go through
             # and another IOU should exist
-            - wait_blocks: 1
+
             - transfer: {from: 3, to: 0, amount: 1_000_000_000_000_000, expected_http_status: 200}
-            - wait_blocks: 1
+
             - assert_pfs_history: {source: 3, target: 0, request_count: 2}
             - assert_pfs_iou: {source: 3, amount: {{ 2 * pfs_fee }}}
             - assert_pfs_iou: {source: 2, iou_exists: false}

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -74,11 +74,9 @@ scenario:
           name: "Make payment from 0 to 3"
           tasks:
             # Check that a payment is made with shortest path [0, 4, 3] from 0 to 3
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was transferred on the correct path
-            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
@@ -106,11 +104,9 @@ scenario:
           name: "Make payment from 0 to 3 after node4 is stopped"
           tasks:
             # Check that a payment is made with the only available path [0, 1, 2, 3] from 0 to 3
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 1_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was transferred on the correct path
-            - wait_blocks: 1
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 999_000_000_000_000_000}

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -75,11 +75,9 @@ scenario:
           name: "Make payment from 0 to 3"
           tasks:
             # Check that a payment is made with shortest path [0, 4, 3] from 0 to 3
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 300_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount was tranferred on the correct path
-            - wait_blocks: 1
             - assert: {from: 0, to: 4, total_deposit: 1_000_000_000_000_000_000, balance: 700_000_000_000_000_000}
             - assert: {from: 4, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 700_000_000_000_000_000}
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000}
@@ -115,11 +113,9 @@ scenario:
           name: "Make payment from 0 to 3 after node4 withdrew and does not have enough capacity"
           tasks:
             # Check that a payment is made with the only path [0, 1, 2, 3] with enough capacity from 0 to 3
-            - wait_blocks: 1
             - transfer: {from: 0, to: 3, amount: 300_000_000_000_000_000, expected_http_status: 200}
 
             # Assert that correct amount is updated after payment
-            - wait_blocks: 1
             - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 0, balance: 700_000_000_000_000_000, state: "opened"}
             - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 0, balance: 700_000_000_000_000_000, state: "opened"}
             - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, total_withdraw: 0, balance: 700_000_000_000_000_000, state: "opened"}


### PR DESCRIPTION
Adding a task to wait in the scenarios is time consuming and error
prone. Coordination is responsibility of the scenario player, this was
moved to that tool.

fixes #5654
~Merge after: https://github.com/raiden-network/scenario-player/pull/563~