### PR TITLE
 Fix UDC deposit for PFS7 [skip tests]

### DIFF
--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -9,7 +9,7 @@ settings:
       enable: true
       token:
         deposit: true
-        balance_per_node: {{ ms_reward_with_margin }}
+        balance_per_node: {{ ms_reward_with_margin + 100 * pfs_fee}}
 
 token:
   address: "{{ transfer_token }}"


### PR DESCRIPTION
Part of #6158

After increasing the PFS cost, we need to adapt the UDC deposit as well.