### PR TITLE
Upgrade structlog to 20.1.0 for py3.8 compat

### DIFF
--- a/raiden/tests/unit/test_logging.py
+++ b/raiden/tests/unit/test_logging.py
@@ -104,6 +104,7 @@ def test_basic_logging(capsys, module, level, logger, disabled_debug, tmpdir):
         {module: level},
         disable_debug_logfile=disabled_debug,
         debug_log_file_path=str(tmpdir / "raiden-debug.log"),
+        colorize=False,
     )
     log = structlog.get_logger(logger).bind(foo="bar")
     log.debug("test event", key="value")

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -78,7 +78,7 @@ jinja2==2.10.1            # via -r requirements-dev.txt, flask, matrix-synapse, 
 jsonschema==3.2.0         # via -r requirements-dev.txt, matrix-synapse, web3
 lazy-object-proxy==1.4.1  # via -r requirements-dev.txt, astroid
 lru-dict==1.1.6           # via -r requirements-dev.txt, web3
-macholib==1.14            # via -r requirements-ci.in, pyinstaller
+macholib==1.14            # via -r requirements-ci.in
 markupsafe==1.1.1         # via -r requirements-dev.txt, jinja2
 marshmallow-dataclass==6.0.0  # via -r requirements-dev.txt
 marshmallow-enum==1.5.1   # via -r requirements-dev.txt
@@ -164,7 +164,7 @@ sphinxcontrib-httpdomain==1.7.0  # via -r requirements-dev.txt, sphinxcontrib-ht
 sphinxcontrib-httpexample==0.10.3  # via -r requirements-dev.txt
 sphinxcontrib-images==0.8.0  # via -r requirements-dev.txt
 sphinxcontrib-websupport==1.1.2  # via -r requirements-dev.txt, sphinx
-structlog==19.1.0         # via -r requirements-dev.txt
+structlog==20.1.0         # via -r requirements-dev.txt
 toml==0.10.0              # via -r requirements-dev.txt, black
 toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -158,7 +158,7 @@ sphinxcontrib-httpdomain==1.7.0  # via -r requirements-docs.txt, sphinxcontrib-h
 sphinxcontrib-httpexample==0.10.3  # via -r requirements-docs.txt
 sphinxcontrib-images==0.8.0  # via -r requirements-docs.txt
 sphinxcontrib-websupport==1.1.2  # via -r requirements-docs.txt, sphinx
-structlog==19.1.0         # via -r requirements.txt
+structlog==20.1.0         # via -r requirements.txt
 toml==0.10.0              # via black
 toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via -r requirements.txt, ipython

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -80,7 +80,7 @@ semantic-version==2.6.0   # via py-geth, py-solc
 semver==2.8.1             # via raiden-contracts
 simplegeneric==0.8.1      # via ipython
 six==1.12.0               # via flask-cors, flask-restful, ipfshttpclient, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog, traitlets
-structlog==19.1.0         # via -r requirements.in
+structlog==20.1.0         # via -r requirements.in
 toolz==0.9.0              # via cytoolz
 traitlets==4.3.2          # via ipython
 typing-extensions==3.7.4.1  # via -r requirements.in, web3


### PR DESCRIPTION
Version 19.2.0 is the first version supporting python3.8 and we were one
version behind: https://www.structlog.org/en/stable/changelog.html#id10