### PR TITLE
Prepare for python 3.8

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -112,7 +112,7 @@ def get_best_routes(
             )
 
             try:
-                route = networkx.shortest_path(
+                route = networkx.shortest_path(  # pylint: disable=E1121
                     token_network.network_graph.network, partner_address, to_address
                 )
             except (networkx.NetworkXNoPath, networkx.NodeNotFound):

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import *  # NOQA pylint:disable=wildcard-import,unused-wildcard-import
 from typing import TYPE_CHECKING, Any, Dict, NewType, Tuple, Type, Union
@@ -8,7 +9,6 @@ from eth_typing import (  # NOQA pylint:disable=unused-import
     Hash32,
     HexAddress,
 )
-from typing_extensions import Literal
 from web3.types import ABI, BlockIdentifier, Nonce  # NOQA pylint:disable=unused-import
 
 from raiden_contracts.contract_manager import CompiledContract  # NOQA pylint:disable=unused-import
@@ -18,6 +18,12 @@ from raiden_contracts.utils.type_aliases import (  # NOQA pylint:disable=unused-
 )
 
 from eth_typing import ChecksumAddress  # noqa: F401; pylint: disable=unused-import
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -10,7 +10,7 @@ aniso8601==7.0.0          # via -r requirements-dev.txt, flask-restful
 apipkg==1.5               # via -r requirements-dev.txt, execnet
 appdirs==1.4.3            # via -r requirements-dev.txt, black
 asn1crypto==1.3.0         # via -r requirements-dev.txt, coincurve
-astroid==2.2.5            # via -r requirements-dev.txt, pylint
+astroid==2.4.2            # via -r requirements-dev.txt, pylint
 astunparse==1.6.2         # via -r requirements-dev.txt, sphinxcontrib-httpexample
 attrs==19.3.0             # via -r requirements-dev.txt, automat, black, flake8-bugbear, hypothesis, jsonschema, matrix-synapse, pytest, service-identity, treq, twisted
 automat==0.7.0            # via -r requirements-dev.txt, twisted
@@ -68,7 +68,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==4.24.3        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.5.0  # via -r requirements-dev.txt, pluggy
+importlib-metadata==1.5.0  # via -r requirements-dev.txt, jsonschema, pluggy, pytest
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements-dev.txt, web3
 ipython-genutils==0.2.0   # via -r requirements-dev.txt, traitlets
@@ -80,7 +80,7 @@ jinja2==2.10.1            # via -r requirements-dev.txt, flask, matrix-synapse, 
 jsonschema==3.2.0         # via -r requirements-dev.txt, matrix-synapse, web3
 lazy-object-proxy==1.4.1  # via -r requirements-dev.txt, astroid
 lru-dict==1.1.6           # via -r requirements-dev.txt, web3
-macholib==1.14            # via -r requirements-ci.in
+macholib==1.14            # via -r requirements-ci.in, pyinstaller
 markupsafe==1.1.1         # via -r requirements-dev.txt, jinja2
 marshmallow-dataclass==6.0.0  # via -r requirements-dev.txt
 marshmallow-enum==1.5.1   # via -r requirements-dev.txt
@@ -128,7 +128,7 @@ pyflakes==2.1.1           # via -r requirements-dev.txt, flake8
 pygments==2.6.1           # via -r requirements-dev.txt, ipython, pdbpp, readme-renderer, sphinx
 pyhamcrest==1.9.0         # via -r requirements-dev.txt, twisted
 pyinstaller==3.6          # via -r requirements-ci.in
-pylint==2.3.1             # via -r requirements-dev.txt
+pylint==2.5.3             # via -r requirements-dev.txt
 pymacaroons==0.13.0       # via -r requirements-dev.txt, matrix-synapse
 pynacl==1.3.0             # via -r requirements-dev.txt, matrix-synapse, pymacaroons, signedjson
 pyopenssl==19.0.0         # via -r requirements-dev.txt, matrix-synapse, twisted
@@ -168,13 +168,13 @@ sphinxcontrib-httpexample==0.10.3  # via -r requirements-dev.txt
 sphinxcontrib-images==0.8.0  # via -r requirements-dev.txt
 sphinxcontrib-websupport==1.1.2  # via -r requirements-dev.txt, sphinx
 structlog==20.1.0         # via -r requirements-dev.txt
-toml==0.10.0              # via -r requirements-dev.txt, black
+toml==0.10.0              # via -r requirements-dev.txt, black, pylint
 toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
 twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
 typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, mypy
-typing-extensions==3.7.4.1  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson
+typing-extensions==3.7.4.1  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via -r requirements-dev.txt, matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-dev.txt, requests

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -9,6 +9,7 @@ altgraph==0.16.1          # via macholib, pyinstaller
 aniso8601==7.0.0          # via -r requirements-dev.txt, flask-restful
 apipkg==1.5               # via -r requirements-dev.txt, execnet
 appdirs==1.4.3            # via -r requirements-dev.txt, black
+appnope==0.1.0            # via -r requirements-dev.txt, ipython
 asn1crypto==1.3.0         # via -r requirements-dev.txt, coincurve
 astroid==2.4.2            # via -r requirements-dev.txt, pylint
 astunparse==1.6.2         # via -r requirements-dev.txt, sphinxcontrib-httpexample
@@ -68,7 +69,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==4.24.3        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.5.0  # via -r requirements-dev.txt, jsonschema, pluggy, pytest
+importlib-metadata==1.6.1  # via -r requirements-dev.txt, jsonschema, pluggy, pytest
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements-dev.txt, web3
 ipython-genutils==0.2.0   # via -r requirements-dev.txt, traitlets
@@ -184,7 +185,7 @@ web3==5.9.0               # via -r requirements-dev.txt, raiden-contracts
 webargs==5.3.1            # via -r requirements-dev.txt
 webencodings==0.5.1       # via -r requirements-dev.txt, bleach
 websockets==8.1           # via -r requirements-dev.txt, web3
-werkzeug==0.15.4          # via -r requirements-dev.txt, flask
+werkzeug==1.0.1           # via -r requirements-dev.txt, flask
 wheel==0.33.4             # via -r requirements-dev.txt, astunparse
 wmctrl==0.3               # via -r requirements-dev.txt, pdbpp
 wrapt==1.11.1             # via -r requirements-dev.txt, astroid

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -67,7 +67,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==4.24.3        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.5.0  # via jsonschema, pluggy, pytest
+importlib-metadata==1.6.1  # via -r requirements.txt, jsonschema, pluggy, pytest
 incremental==17.5.0       # via treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements.txt, web3
 ipython-genutils==0.2.0   # via -r requirements.txt, traitlets
@@ -178,11 +178,11 @@ web3==5.9.0               # via -r requirements.txt, raiden-contracts
 webargs==5.3.1            # via -r requirements.txt
 webencodings==0.5.1       # via bleach
 websockets==8.1           # via -r requirements.txt, web3
-werkzeug==0.15.4          # via -r requirements.txt, flask
+werkzeug==1.0.1           # via -r requirements.txt, flask
 wheel==0.33.4             # via -r requirements-docs.txt, astunparse
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via -r requirements.txt, importlib-metadata
 zope.interface==4.6.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,7 +9,7 @@ aniso8601==7.0.0          # via -r requirements.txt, flask-restful
 apipkg==1.5               # via execnet
 appdirs==1.4.3            # via black
 asn1crypto==1.3.0         # via -r requirements.txt, coincurve
-astroid==2.2.5            # via pylint
+astroid==2.4.2            # via pylint
 astunparse==1.6.2         # via -r requirements-docs.txt, sphinxcontrib-httpexample
 attrs==19.3.0             # via -r requirements.txt, automat, black, flake8-bugbear, hypothesis, jsonschema, matrix-synapse, pytest, service-identity, treq, twisted
 automat==0.7.0            # via twisted
@@ -67,7 +67,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==4.24.3        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.5.0  # via pluggy
+importlib-metadata==1.5.0  # via jsonschema, pluggy, pytest
 incremental==17.5.0       # via treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements.txt, web3
 ipython-genutils==0.2.0   # via -r requirements.txt, traitlets
@@ -125,7 +125,7 @@ pycryptodome==3.8.2       # via -r requirements.txt, eth-hash, eth-keyfile
 pyflakes==2.1.1           # via flake8
 pygments==2.6.1           # via -r requirements-docs.txt, -r requirements.txt, ipython, pdbpp, readme-renderer, sphinx
 pyhamcrest==1.9.0         # via twisted
-pylint==2.3.1             # via -r requirements-dev.in
+pylint==2.5.3             # via -r requirements-dev.in
 pymacaroons==0.13.0       # via matrix-synapse
 pynacl==1.3.0             # via matrix-synapse, pymacaroons, signedjson
 pyopenssl==19.0.0         # via matrix-synapse, twisted
@@ -162,13 +162,13 @@ sphinxcontrib-httpexample==0.10.3  # via -r requirements-docs.txt
 sphinxcontrib-images==0.8.0  # via -r requirements-docs.txt
 sphinxcontrib-websupport==1.1.2  # via -r requirements-docs.txt, sphinx
 structlog==20.1.0         # via -r requirements.txt
-toml==0.10.0              # via black
+toml==0.10.0              # via black, pylint
 toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via -r requirements.txt, ipython
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==20.3.0      # via matrix-synapse, treq
 typed-ast==1.4.0          # via astroid, mypy
-typing-extensions==3.7.4.1  # via -r requirements.txt, matrix-synapse, mypy, signedjson
+typing-extensions==3.7.4.1  # via -r requirements.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,6 +37,7 @@ greenlet==0.4.15          # via gevent
 guppy3==3.0.9             # via -r requirements.in
 hexbytes==0.2.0           # via eth-account, eth-rlp, web3
 idna==2.8                 # via requests
+importlib-metadata==1.6.1  # via jsonschema
 ipfshttpclient==0.4.12    # via web3
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.14.0           # via -r requirements.in
@@ -86,7 +87,7 @@ six==1.12.0               # via flask-cors, flask-restful, ipfshttpclient, jsons
 structlog==20.1.0         # via -r requirements.in
 toolz==0.9.0              # via cytoolz
 traitlets==4.3.2          # via ipython
-typing-extensions==3.7.4.1  # via -r requirements.in
+typing-extensions==3.7.4.1  # via -r requirements.in, web3
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
 varint==1.0.2             # via multiaddr
@@ -94,7 +95,8 @@ wcwidth==0.1.9            # via prompt-toolkit
 web3==5.9.0               # via -r requirements.in, raiden-contracts
 webargs==5.3.1            # via -r requirements.in
 websockets==8.1           # via web3
-werkzeug==0.15.4          # via flask
+werkzeug==1.0.1           # via flask
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
With these changes the tests run fine (but flakyness) on python 3.8. (see https://app.circleci.com/pipelines/github/raiden-network/raiden/9066/workflows/15513948-033e-4a7b-8938-b1953e591d5f)
I'll add CI jobs for 3.8 in a different PR.

Part of https://github.com/raiden-network/raiden/issues/6166
