### PR TITLE
Use local synapse server in cli tests

### DIFF
--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -5,12 +5,7 @@ from eth_typing import BlockNumber
 from eth_utils import denoms, to_hex
 
 import raiden_contracts.constants
-from raiden.constants import (
-    DISCOVERY_DEFAULT_ROOM,
-    MATRIX_AUTO_SELECT_SERVER,
-    PATH_FINDING_BROADCASTING_ROOM,
-    Environment,
-)
+from raiden.constants import DISCOVERY_DEFAULT_ROOM, MATRIX_AUTO_SELECT_SERVER, Environment
 from raiden.network.pathfinding import PFSConfig
 from raiden.utils.typing import (
     Address,
@@ -199,10 +194,7 @@ class RaidenConfig:
     transport: MatrixTransportConfig = MatrixTransportConfig(
         # None causes fetching from url in raiden.settings.py::DEFAULT_MATRIX_KNOWN_SERVERS
         available_servers=[],
-        # TODO: Remove `PATH_FINDING_BROADCASTING_ROOM` when implementing #3735
-        #       and fix the conditional in `raiden.ui.app:_setup_matrix`
-        #       as well as the tests
-        broadcast_rooms=[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM],
+        broadcast_rooms=[DISCOVERY_DEFAULT_ROOM],
         retries_before_backoff=DEFAULT_TRANSPORT_RETRIES_BEFORE_BACKOFF,
         retry_interval_initial=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL_INITIAL,
         retry_interval_max=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL_MAX,

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -11,6 +11,7 @@ from raiden.constants import MATRIX_AUTO_SELECT_SERVER, Environment, EthClient
 from raiden.settings import RAIDEN_CONTRACT_VERSION
 from raiden.tests.utils.ci import get_artifacts_storage
 from raiden.tests.utils.smoketest import setup_raiden, setup_testchain
+from raiden.tests.utils.transport import ParsedURL
 from raiden.utils.typing import Any, ContextManager, Dict, List, Optional
 
 
@@ -76,6 +77,7 @@ def changed_args() -> Optional[Dict[str, Any]]:
 def cli_args(
     logs_storage: str,
     raiden_testchain: Dict[str, Any],
+    local_matrix_servers: List[ParsedURL],
     removed_args: Optional[Dict[str, Any]],
     changed_args: Optional[Dict[str, Any]],
     environment_type: Environment,
@@ -102,7 +104,9 @@ def cli_args(
         "--no-sync-check",
         f"--debug-logfile-path={base_logfile}",
         "--routing-mode",
-        "local",
+        "private",
+        "--matrix-server",
+        local_matrix_servers[0],
     ]
 
     args += ["--environment-type", environment_type.value]

--- a/raiden/tests/integration/cli/test_cli_development.py
+++ b/raiden/tests/integration/cli/test_cli_development.py
@@ -13,6 +13,9 @@ pytestmark = [
         "cli_tests_contracts_version", [RAIDEN_CONTRACT_VERSION], scope="module"
     ),
     pytest.mark.parametrize("environment_type", [Environment.DEVELOPMENT], scope="module"),
+    # This is a bit awkward, the default `chain_id` for the `raiden_testchain` and
+    # `local_matrix_servers` fixtures don't align. Therefore we force it to "smoketest" here.
+    pytest.mark.parametrize("chain_id", ["smoketest"]),
 ]
 
 

--- a/raiden/tests/integration/cli/test_cli_production.py
+++ b/raiden/tests/integration/cli/test_cli_production.py
@@ -17,6 +17,9 @@ pytestmark = [
         "cli_tests_contracts_version", [RAIDEN_CONTRACT_VERSION], scope="module"
     ),
     pytest.mark.parametrize("environment_type", [EXPECTED_DEFAULT_ENVIRONMENT], scope="module"),
+    # This is a bit awkward, the default `chain_id` for the `raiden_testchain` and
+    # `local_matrix_servers` fixtures don't align. Therefore we force it to "smoketest" here.
+    pytest.mark.parametrize("chain_id", ["smoketest"]),
 ]
 
 

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -18,6 +18,7 @@ from eth_utils import encode_hex, to_normalized_address
 from gevent import subprocess
 from requests.packages import urllib3
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from structlog import get_logger
 from synapse.handlers.auth import AuthHandler
 from twisted.internet import defer
 
@@ -31,6 +32,8 @@ from raiden.transfer.identifiers import QueueIdentifier
 from raiden.utils.http import EXECUTOR_IO, HTTPExecutor
 from raiden.utils.signer import recover
 from raiden.utils.typing import Iterable, Port, Signature
+
+log = get_logger(__name__)
 
 _SYNAPSE_BASE_DIR_VAR_NAME = "RAIDEN_TESTS_SYNAPSE_BASE_DIR"
 _SYNAPSE_LOGS_PATH = os.environ.get("RAIDEN_TESTS_SYNAPSE_LOGS_DIR")
@@ -381,6 +384,8 @@ def matrix_server_starter(
 
                 synapse_io = DEVNULL, log_file, STDOUT
 
+            log.debug("Synapse command", command=synapse_cmd)
+
             startup_timeout = 10
             sleep = 0.1
 
@@ -415,6 +420,7 @@ def matrix_server_starter(
 
             servers.append((server_url, executor))
 
+        log.debug("Setting up broadcast rooms", aliases=broadcast_rooms_aliases)
         for broadcast_room_alias in broadcast_rooms_aliases:
             setup_broadcast_room([url for url, _ in servers], broadcast_room_alias)
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -104,7 +104,7 @@ def setup_matrix(
 
         transport_config.available_servers = available_servers
 
-    # Add PFS broadcast room when not in privat mode
+    # Add PFS broadcast room when not in private mode
     if routing_mode != RoutingMode.PRIVATE:
         if PATH_FINDING_BROADCASTING_ROOM not in transport_config.broadcast_rooms:
             transport_config.broadcast_rooms.append(PATH_FINDING_BROADCASTING_ROOM)


### PR DESCRIPTION
## Description

The CLI integration tests implicitly used the matrix servers defined in the RSB known servers list.
This caused the tests to be dependent on external services and therefore be flaky.

This now uses the existing infrastructure to run a local Synapse server thereby removing this dependency.

Fixes: #4642
