### PR TITLE
Correct DAI contract address [skip tests]

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -193,7 +193,7 @@ WETH_TOKEN_ADDRESS = TokenAddress(
     to_canonical_address("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 )
 DAI_TOKEN_ADDRESS = TokenAddress(
-    to_canonical_address("0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359")
+    to_canonical_address("0x6B175474E89094C44Da98b954EedeAC495271d0F")
 )
 
 FLAT_MED_FEE_MIN = 0


### PR DESCRIPTION
DAI switched to a new contract, we need to adapt for that.

Part of #6188 

Address according to https://github.com/raiden-network/raiden-contracts/blob/master/raiden_contracts/data_0.37.0/deployment_mainnet.json#L43
