### PR TITLE
Check PFS matrix server

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -68,6 +68,7 @@ class PFSInfo:
     operator: str
     version: str
     confirmed_block_number: BlockNumber
+    matrix_server: str
 
 
 @dataclass
@@ -140,6 +141,7 @@ def get_pfs_info(url: str) -> PFSInfo:
             operator=infos["operator"],
             version=infos["version"],
             confirmed_block_number=infos["network_info"]["confirmed_block"]["number"],
+            matrix_server=infos["matrix_server"],
         )
     except requests.exceptions.RequestException as e:
         msg = "Selected Pathfinding Service did not respond"
@@ -224,6 +226,7 @@ def configure_pfs_or_exit(
     node_network_id: ChainID,
     token_network_registry_address: TokenNetworkRegistryAddress,
     pathfinding_max_fee: TokenAmount,
+    matrix_servers: List[str],
 ) -> PFSInfo:
     """
     Take in the given pfs_address argument, the service registry and find out a
@@ -289,6 +292,14 @@ def configure_pfs_or_exit(
             f" as your node ({to_checksum_address(token_network_registry_address)}).\n"
             f"Raiden will shut down. Please choose a different Pathfinding Service."
         )
+
+    if pathfinding_service_info.matrix_server not in matrix_servers:
+        raise RaidenError(
+            f"The Pathfinding Service {pfs_url} is not connected to the same matrix federation. "
+            f"Please check your settings for PFS and matrix server, if manually chosen. "
+            f"Otherwise, check your environment-type."
+        )
+
     click.secho(
         f"You have chosen the Pathfinding Service at {pfs_url}.\n"
         f"Operator: {pathfinding_service_info.operator}, "

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -371,6 +371,7 @@ def test_mediated_transfer_calls_pfs(raiden_chain: List[App], token_addresses: L
                 operator="",
                 version="",
                 price=TokenAmount(0),
+                matrix_server="http://matrix.example.com",
             ),
             maximum_fee=TokenAmount(100),
             iou_timeout=BlockTimeout(100),

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -114,6 +114,7 @@ PFS_CONFIG = PFSConfig(
         operator="",
         version="",
         confirmed_block_number=BlockNumber(10),
+        matrix_server="http://matrix.example.com",
     ),
     maximum_fee=TokenAmount(100),
     iou_timeout=BlockTimeout(100),
@@ -150,6 +151,7 @@ def get_best_routes_with_iou_request_mocked(
                     "operator": "John Doe",
                     "message": "This is your favorite pathfinding service",
                     "payment_address": to_checksum_address(factories.make_address()),
+                    "matrix_server": "http://matrix.example.com",
                 }
             )
         else:
@@ -899,6 +901,7 @@ def test_no_iou_when_pfs_price_0(query_paths_args):
             message="",
             operator="",
             version="",
+            matrix_server="http://matrix.example.com",
         ),
         maximum_fee=TokenAmount(100),
         iou_timeout=BlockNumber(100),

--- a/raiden/tests/unit/test_pfs_integration_refactored.py
+++ b/raiden/tests/unit/test_pfs_integration_refactored.py
@@ -32,6 +32,7 @@ def test_get_pfs_info_success():
         "operator": "John Doe",
         "message": "This is your favorite pathfinding service",
         "payment_address": pfs_test_default_payment_address,
+        "matrix_server": "http://matrix.example.com",
     }
 
     response = Mock()

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -332,6 +332,7 @@ def services_bundle_from_contracts_deployment(
                 token_network_registry_address
             ),
             pathfinding_max_fee=config.services.pathfinding_max_fee,
+            matrix_servers=config.transport.available_servers,
         )
         msg = "Eth address of selected pathfinding service is unknown."
         assert pfs_info.payment_address is not None, msg


### PR DESCRIPTION
The Raiden client and the PFS must be in the same matrix federation,
otherwise the PFS will not see the node as online. To verify this, check
that the PFS uses on of the `available_servers`, which should contain
all servers in the matrix federation.

The typical symptom of the error we avoid is `PFS: Source not online.
Approximate block at the time of the request ... (PFS error code:
2201)`. We had this error twice due to a matrix mismatch, so it's worth
the additional code for the check.