### PR TITLE
Add missing parts of target role fuzz test

### DIFF
--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -600,7 +600,7 @@ class InitiatorMixin:
             node=initiator_address, private_key=private_key, event=result.events[0]
         )
 
-    @rule(source=send_secret_reveals_backward, wrong_secret=secret)
+    @rule(source=send_secret_reveals_backward, wrong_secret=secret())
     def process_secret_reveal_with_mismatched_secret_as_initiator(
         self, source: utils.SendSecretRevealInNode, wrong_secret: Secret
     ):
@@ -615,7 +615,7 @@ class InitiatorMixin:
         assert not result.events
         self.event("Secret reveal with wrong secret dropped in initiator node.")
 
-    @rule(source=send_secret_reveals_backward, wrong_secret=secret)
+    @rule(source=send_secret_reveals_backward, wrong_secret=secret())
     def process_secret_reveal_with_unknown_secrethash_as_initiator(
         self, source: utils.SendSecretRevealInNode, wrong_secret: Secret
     ):
@@ -631,7 +631,7 @@ class InitiatorMixin:
         assert not result.events
         self.event("Secret reveal with unknown secrethash dropped in initiator node.")
 
-    @rule(source=send_secret_reveals_backward, wrong_channel_id=integers)
+    @rule(source=send_secret_reveals_backward, wrong_channel_id=integers())
     def process_secret_reveal_with_wrong_channel_identifier_as_initiator(
         self, source: utils.SendSecretRevealInNode, wrong_channel_id
     ):
@@ -647,7 +647,9 @@ class InitiatorMixin:
         assert not result.events
         self.event("Secret reveal with unknown channel id dropped in initiator node.")
 
-    @rule(source=send_secret_reveals_backward, wrong_channel_id=integers, wrong_recipient=address)
+    @rule(
+        source=send_secret_reveals_backward, wrong_channel_id=integers(), wrong_recipient=address()
+    )
     def process_secret_reveal_with_wrong_queue_identifier_as_initiator(
         self, source: utils.SendSecretRevealInNode, wrong_channel_id, wrong_recipient
     ):

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -64,7 +64,7 @@ grequests==0.3.0          # via -r requirements-dev.in
 guppy3==3.0.9             # via -r requirements.txt
 hexbytes==0.2.0           # via -r requirements.txt, eth-account, eth-rlp, web3
 hyperlink==19.0.0         # via twisted
-hypothesis==4.24.3        # via -r requirements-dev.in
+hypothesis==5.16.0        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
 importlib-metadata==1.5.0  # via -r requirements.txt, jsonschema, pluggy, pytest


### PR DESCRIPTION
This PR completes the `TargetMixin` of the fuzz test. No problems with the state machine were found. The missing fuzz test coverage of mediator role and onchain events will be added in further PRs.

Closes #1157