### PR TITLE
Fetch matrix server list before PFS check

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -298,7 +298,8 @@ def configure_pfs_or_exit(
     server_in_federation = any(
         pathfinding_service_info.matrix_server in matrix_server for matrix_server in matrix_servers
     )
-    if not server_in_federation:
+    # Only check if PFS is right federation when matrix server is not given explicitely
+    if len(matrix_servers) > 0 and not server_in_federation:
         raise RaidenError(
             f"The Pathfinding Service {pfs_url} is not connected to the same matrix federation. "
             f"Please check your settings for PFS and matrix server, if manually chosen. "


### PR DESCRIPTION
Fetch matrix server list before PFS check, otherwise the checks will always fail.

To allow usage of custom servers for testing this check is only done if the matrix server isn't given explicitly.
