### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/requirements/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## Description

Enables dependabot automatic dependency updates.

This creates PRs like this one: https://github.com/palango/raiden/pull/24

I limit the amount of PRs to 2 for now, to see how it works without drowning in PRs.
