### PR TITLE
Use types from contracts

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -122,6 +122,7 @@ from raiden.utils.typing import (
     Optional,
     PaymentAmount,
     PaymentID,
+    PrivateKey,
     Secret,
     SecretHash,
     SecretRegistryAddress,
@@ -477,7 +478,7 @@ class RaidenService(Runnable):
         return self.config.blockchain.confirmation_blocks
 
     @property
-    def privkey(self) -> bytes:
+    def privkey(self) -> PrivateKey:
         return self.rpc_client.privkey
 
     def add_pending_greenlet(self, greenlet: Greenlet) -> None:

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -24,6 +24,7 @@ from raiden.utils.typing import (
     Optional,
     PaymentAmount,
     PaymentWithFeeAmount,
+    PrivateKey,
     TargetAddress,
     TokenNetworkAddress,
     Tuple,
@@ -41,7 +42,7 @@ def get_best_routes(
     amount: PaymentAmount,
     previous_address: Optional[Address],
     pfs_config: Optional[PFSConfig],
-    privkey: bytes,
+    privkey: PrivateKey,
 ) -> Tuple[Optional[str], List[RouteState], Optional[UUID]]:
 
     token_network = views.get_token_network_by_address(chain_state, token_network_address)
@@ -248,7 +249,7 @@ def get_best_routes_pfs(
     amount: PaymentAmount,
     previous_address: Optional[Address],
     pfs_config: PFSConfig,
-    privkey: bytes,
+    privkey: PrivateKey,
     pfs_wait_for_block: BlockNumber,
 ) -> Tuple[Optional[str], List[RouteState], Optional[UUID]]:
     try:

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -9,7 +9,7 @@ from raiden.tests.utils.transfer import block_offset_timeout, watch_for_unlock_f
 from raiden.transfer import channel, views
 from raiden.transfer.events import EventPaymentSentSuccess
 from raiden.transfer.state import ChannelState
-from raiden.utils.typing import BlockTimeout as BlockOffset, PaymentAmount, TokenAmount
+from raiden.utils.typing import BlockTimeout as BlockOffset, PaymentAmount, PrivateKey, TokenAmount
 from raiden.waiting import wait_for_block
 
 
@@ -155,7 +155,7 @@ def test_participant_selection(raiden_network, token_addresses):
                 amount=PaymentAmount(1),
                 previous_address=None,
                 pfs_config=None,
-                privkey=b"",  # not used if pfs is not configured
+                privkey=PrivateKey(b""),  # not used if pfs is not configured
             )
             assert routes is not None
 

--- a/raiden/utils/packing.py
+++ b/raiden/utils/packing.py
@@ -98,6 +98,6 @@ def pack_withdraw(
         chain_identifier=canonical_identifier.chain_identifier,
         channel_identifier=canonical_identifier.channel_identifier,
         participant=to_hex_address(participant),
-        amount_to_withdraw=total_withdraw,
+        amount_to_withdraw=TokenAmount(total_withdraw),
         expiration_block=expiration_block,
     )

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -13,8 +13,24 @@ from web3.types import ABI, BlockIdentifier, Nonce  # NOQA pylint:disable=unused
 
 from raiden_contracts.contract_manager import CompiledContract  # NOQA pylint:disable=unused-import
 from raiden_contracts.utils.type_aliases import (  # NOQA pylint:disable=unused-import
+    AdditionalHash,
+    BalanceHash,
+    BlockExpiration,
     ChainID,
+    ChannelID,
+    Locksroot,
+    PrivateKey,
+    Signature,
+    T_AdditionalHash,
+    T_BalanceHash,
+    T_BlockExpiration,
     T_ChainID,
+    T_ChannelID,
+    T_Locksroot,
+    T_PrivateKey,
+    T_Signature,
+    T_TokenAmount,
+    TokenAmount,
 )
 
 from eth_typing import ChecksumAddress  # noqa: F401; pylint: disable=unused-import
@@ -53,23 +69,15 @@ T_Address = bytes
 
 AddressHex = HexAddress
 
-# An absolute number of blocks
-T_BlockExpiration = int
-BlockExpiration = NewType("BlockExpiration", T_BlockExpiration)
-
 T_Balance = int
 Balance = NewType("Balance", T_Balance)
 
 T_GasPrice = int
 GasPrice = NewType("GasPrice", T_GasPrice)
 
-T_BalanceHash = bytes
-BalanceHash = NewType("BalanceHash", T_BalanceHash)
-
 T_BlockGasLimit = int
 BlockGasLimit = NewType("BlockGasLimit", T_BlockGasLimit)
 
-# TODO: remove alias
 T_BlockHash = bytes
 BlockHash = Hash32
 
@@ -79,25 +87,16 @@ T_BlockNumber = int
 T_BlockTimeout = int
 BlockTimeout = NewType("BlockTimeout", T_BlockTimeout)
 
-T_ChannelID = int
-ChannelID = NewType("ChannelID", T_ChannelID)
-
 T_ChannelState = int
 ChannelState = NewType("ChannelState", T_ChannelState)
 
 T_InitiatorAddress = bytes
 InitiatorAddress = NewType("InitiatorAddress", T_InitiatorAddress)
 
-T_Locksroot = bytes
-Locksroot = NewType("Locksroot", T_Locksroot)
-
 T_MessageID = int
 MessageID = NewType("MessageID", T_MessageID)
 
 T_Nonce = int
-
-T_AdditionalHash = bytes
-AdditionalHash = NewType("AdditionalHash", T_AdditionalHash)
 
 T_NetworkTimeout = float
 NetworkTimeout = NewType("NetworkTimeout", T_NetworkTimeout)
@@ -108,9 +107,6 @@ PaymentID = NewType("PaymentID", T_PaymentID)
 # PaymentAmount is for amounts of tokens paid end-to-end
 T_PaymentAmount = int
 PaymentAmount = NewType("PaymentAmount", T_PaymentAmount)
-
-T_PrivateKey = bytes
-PrivateKey = NewType("PrivateKey", T_PrivateKey)
 
 T_PublicKey = bytes
 PublicKey = NewType("PublicKey", T_PublicKey)
@@ -159,9 +155,6 @@ OneToNAddress = NewType("OneToNAddress", T_OneToNAddress)
 T_TokenNetworkAddress = bytes
 TokenNetworkAddress = NewType("TokenNetworkAddress", T_TokenNetworkAddress)
 
-T_TokenAmount = int
-TokenAmount = NewType("TokenAmount", T_TokenAmount)
-
 T_TransferID = bytes
 TransferID = NewType("TransferID", T_TransferID)
 
@@ -173,9 +166,6 @@ SecretHash = NewType("SecretHash", T_SecretHash)
 
 T_SecretRegistryAddress = bytes
 SecretRegistryAddress = NewType("SecretRegistryAddress", T_SecretRegistryAddress)
-
-T_Signature = bytes
-Signature = NewType("Signature", T_Signature)
 
 T_TransactionHash = bytes
 TransactionHash = NewType("TransactionHash", T_TransactionHash)

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -145,7 +145,7 @@ python-magic==0.4.15      # via s3cmd
 pytoml==0.1.21            # via -r requirements-dev.txt
 pytz==2019.1              # via -r requirements-dev.txt, babel, flask-restful
 pyyaml==5.1.1             # via -r requirements-dev.txt, matrix-synapse
-raiden-contracts==0.37.0  # via -r requirements-dev.txt
+git+git://github.com/raiden-network/raiden-contracts.git@bf405d3ebfaf8e2394b7981ed4a2843fbff48349  # via -r requirements-dev.txt
 raiden-webui==0.11.1      # via -r requirements-dev.txt
 readme-renderer==24.0     # via -r requirements-dev.txt
 releases==1.6.3           # via -r requirements-dev.txt

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -140,7 +140,7 @@ pytest==5.3.5             # via -r requirements-dev.in, pytest-forked, pytest-ra
 pytoml==0.1.21            # via -r requirements.txt
 pytz==2019.1              # via -r requirements-docs.txt, -r requirements.txt, babel, flask-restful
 pyyaml==5.1.1             # via matrix-synapse
-raiden-contracts==0.37.0  # via -r requirements.txt
+git+git://github.com/raiden-network/raiden-contracts.git@bf405d3ebfaf8e2394b7981ed4a2843fbff48349  # via -r requirements.txt
 raiden-webui==0.11.1      # via -r requirements.txt
 readme-renderer==24.0     # via -r requirements-dev.in
 releases==1.6.3           # via -r requirements-docs.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -24,7 +24,7 @@ py-geth
 py-solc
 pysha3
 pytoml
-raiden-contracts==0.37.0
+git+git://github.com/raiden-network/raiden-contracts.git@bf405d3ebfaf8e2394b7981ed4a2843fbff48349
 raiden-webui
 requests
 structlog

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -76,7 +76,7 @@ pyrsistent==0.15.7        # via jsonschema
 pysha3==1.0.2             # via -r requirements.in
 pytoml==0.1.21            # via -r requirements.in
 pytz==2019.1              # via flask-restful
-raiden-contracts==0.37.0  # via -r requirements.in
+git+git://github.com/raiden-network/raiden-contracts.git@bf405d3ebfaf8e2394b7981ed4a2843fbff48349  # via -r requirements.in
 raiden-webui==0.11.1      # via -r requirements.in
 requests==2.22.0          # via -r requirements.in, ipfshttpclient, matrix-client, web3
 rlp==1.1.0                # via eth-account, eth-rlp, raiden-contracts


### PR DESCRIPTION
These types are used in both packages, so they have to be in the
contracts repo, since the dependency is "raiden -> raiden-contracts".

See raiden-network/raiden-contracts#1394.

To make such changes work without releasing a new raiden-contracts package every time, I had to add an ugly workaround to allow git dependencies. See first commit.