### PR TITLE
Remove webargs

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -8,16 +8,14 @@ import gevent
 import gevent.pool
 import structlog
 from eth_utils import encode_hex
-from flask import Flask, Request, Response, request, send_from_directory, url_for
+from flask import Flask, Response, request, send_from_directory, url_for
 from flask.json import jsonify
 from flask_cors import CORS
-from flask_restful import Api, abort
+from flask_restful import Api
 from gevent.event import Event
 from gevent.pywsgi import WSGIServer
 from hexbytes import HexBytes
-from marshmallow import Schema
 from raiden_webui import RAIDEN_WEBUI_PATH
-from webargs.flaskparser import parser
 from werkzeug.exceptions import NotFound
 from werkzeug.routing import BaseConverter
 
@@ -186,15 +184,6 @@ URLS_V1 = [
     ("/_debug/raiden_events", RaidenInternalEventsResource),
     ("/_testing/tokens/<hexaddress:token_address>/mint", MintTokenResource, "tokensmintresource"),
 ]
-
-
-@parser.error_handler
-def handle_request_parsing_error(
-    err: Any, _req: Request, _schema: Schema, _err_status_code: int, _err_headers: Any
-) -> None:
-    """ This handles request parsing errors generated for example by schema
-    field validation failing."""
-    abort(HTTPStatus.BAD_REQUEST, errors=err.messages)
 
 
 def endpoint_not_found(e: Any) -> Response:

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -181,6 +181,8 @@ class BaseSchema(Schema):
         # this will depend on the Schema used, which has its object class in
         # the class Meta attributes
         decoding_class = self.opts.decoding_class  # type: ignore # pylint: disable=no-member
+        if decoding_class is None:
+            return data
         return decoding_class(**data)
 
 
@@ -210,27 +212,16 @@ class BlockchainEventsRequestSchema(BaseSchema):
     from_block = IntegerToStringField(missing=None)
     to_block = IntegerToStringField(missing=None)
 
-    class Meta:
-        strict = True
-        # decoding to a dict is required by the @use_kwargs decorator from webargs
-        decoding_class = dict
-
 
 class RaidenEventsRequestSchema(BaseSchema):
     limit = IntegerToStringField(missing=None)
     offset = IntegerToStringField(missing=None)
-
-    class Meta:
-        strict = True
-        # decoding to a dict is required by the @use_kwargs decorator from webargs
-        decoding_class = dict
 
 
 class AddressSchema(BaseSchema):
     address = AddressField()
 
     class Meta:
-        strict = True
         decoding_class = Address
 
 
@@ -238,7 +229,6 @@ class AddressListSchema(BaseListSchema):
     data = fields.List(AddressField())
 
     class Meta:
-        strict = True
         decoding_class = AddressList
 
 
@@ -247,7 +237,6 @@ class PartnersPerTokenSchema(BaseSchema):
     channel = fields.String()
 
     class Meta:
-        strict = True
         decoding_class = PartnersPerToken
 
 
@@ -255,17 +244,12 @@ class PartnersPerTokenListSchema(BaseListSchema):
     data = fields.Nested(PartnersPerTokenSchema, many=True)
 
     class Meta:
-        strict = True
         decoding_class = PartnersPerTokenList
 
 
 class MintTokenSchema(BaseSchema):
     to = AddressField(required=True)
     value = IntegerToStringField(required=True, validate=validate.Range(min=1, max=UINT256_MAX))
-
-    class Meta:
-        strict = True
-        decoding_class = dict
 
 
 class ChannelStateSchema(BaseSchema):
@@ -302,10 +286,6 @@ class ChannelStateSchema(BaseSchema):
         """Return our total withdraw from this channel"""
         return str(channel_state.our_total_withdraw)
 
-    class Meta:
-        strict = True
-        decoding_class = dict
-
 
 class ChannelPutSchema(BaseSchema):
     token_address = AddressField(required=True)
@@ -313,11 +293,6 @@ class ChannelPutSchema(BaseSchema):
     reveal_timeout = IntegerToStringField(missing=None)
     settle_timeout = IntegerToStringField(missing=None)
     total_deposit = IntegerToStringField(default=None, missing=None)
-
-    class Meta:
-        strict = True
-        # decoding to a dict is required by the @use_kwargs decorator from webargs:
-        decoding_class = dict
 
 
 class ChannelPatchSchema(BaseSchema):
@@ -336,11 +311,6 @@ class ChannelPatchSchema(BaseSchema):
         ),
     )
 
-    class Meta:
-        strict = True
-        # decoding to a dict is required by the @use_kwargs decorator from webargs:
-        decoding_class = dict
-
 
 class PaymentSchema(BaseSchema):
     initiator_address = AddressField(missing=None)
@@ -352,19 +322,11 @@ class PaymentSchema(BaseSchema):
     secret_hash = SecretHashField(missing=None)
     lock_timeout = IntegerToStringField(missing=None)
 
-    class Meta:
-        strict = True
-        decoding_class = dict
-
 
 class ConnectionsConnectSchema(BaseSchema):
     funds = IntegerToStringField(required=True)
     initial_channel_target = IntegerToStringField(missing=DEFAULT_INITIAL_CHANNEL_TARGET)
     joinable_funds_target = fields.Decimal(missing=DEFAULT_JOINABLE_FUNDS_TARGET)
-
-    class Meta:
-        strict = True
-        decoding_class = dict
 
 
 class EventPaymentSchema(BaseSchema):
@@ -391,8 +353,6 @@ class EventPaymentSentFailedSchema(EventPaymentSchema):
 
     class Meta:
         fields = ("block_number", "event", "reason", "target", "log_time", "token_address")
-        strict = True
-        decoding_class = dict
 
 
 class EventPaymentSentSuccessSchema(EventPaymentSchema):
@@ -410,8 +370,6 @@ class EventPaymentSentSuccessSchema(EventPaymentSchema):
             "log_time",
             "token_address",
         )
-        strict = True
-        decoding_class = dict
 
 
 class EventPaymentReceivedSuccessSchema(EventPaymentSchema):
@@ -429,5 +387,3 @@ class EventPaymentReceivedSuccessSchema(EventPaymentSchema):
             "log_time",
             "token_address",
         )
-        strict = True
-        decoding_class = dict

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -367,12 +367,6 @@ class ConnectionsConnectSchema(BaseSchema):
         decoding_class = dict
 
 
-class ConnectionsLeaveSchema(BaseSchema):
-    class Meta:
-        strict = True
-        decoding_class = dict
-
-
 class EventPaymentSchema(BaseSchema):
     block_number = IntegerToStringField()
     identifier = IntegerToStringField()

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -10,8 +10,7 @@ from eth_utils import (
     to_checksum_address,
     to_hex,
 )
-from marshmallow import Schema, SchemaOpts, fields, post_dump, post_load, pre_load
-from webargs import validate
+from marshmallow import Schema, SchemaOpts, fields, post_dump, post_load, pre_load, validate
 from werkzeug.exceptions import NotFound
 from werkzeug.routing import BaseConverter
 

--- a/raiden/tests/integration/api/rest/test_channel.py
+++ b/raiden/tests/integration/api/rest/test_channel.py
@@ -226,7 +226,6 @@ def test_api_channel_open_and_deposit(
         "token_address": to_checksum_address(token_address),
         "settle_timeout": str(settle_timeout),
         "reveal_timeout": str(reveal_timeout),
-        "balance": "1",
     }
     request = grequests.put(
         api_url_for(api_server_test_instance, "channelsresource"), json=channel_data_obj

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -626,7 +626,6 @@ def test_channel_events(api_server_test_instance: APIServer, token_addresses):
         api_url_for(
             api_server_test_instance,
             "tokenchanneleventsresourceblockchain",
-            partner_address=partner_address,
             token_address=token_address,
             from_block=str(GENESIS_BLOCK_NUMBER),
         )

--- a/raiden/tests/unit/api/test_encoding.py
+++ b/raiden/tests/unit/api/test_encoding.py
@@ -12,7 +12,6 @@ class SchemaTest(BaseSchema):
     class Meta:
         fields = ("timestamp",)
         strict = True
-        decoding_class = dict
 
 
 def test_timestamp_field():

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -84,7 +84,7 @@ markupsafe==1.1.1         # via -r requirements-dev.txt, jinja2
 marshmallow-dataclass==6.0.0  # via -r requirements-dev.txt
 marshmallow-enum==1.5.1   # via -r requirements-dev.txt
 marshmallow-polyfield==5.8  # via -r requirements-dev.txt
-marshmallow==3.6.1        # via -r requirements-dev.txt, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield, webargs
+marshmallow==3.6.1        # via -r requirements-dev.txt, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield
 matrix-client==0.3.2      # via -r requirements-dev.txt
 matrix-synapse==1.10.1    # via -r requirements-dev.txt
 mccabe==0.6.1             # via -r requirements-dev.txt, flake8, pylint
@@ -186,7 +186,6 @@ urllib3==1.25.3           # via -r requirements-dev.txt, requests
 varint==1.0.2             # via -r requirements-dev.txt, multiaddr
 wcwidth==0.1.9            # via -r requirements-dev.txt, prompt-toolkit, pytest
 web3==5.11.0              # via -r requirements-dev.txt, raiden-contracts
-webargs==5.3.1            # via -r requirements-dev.txt
 webencodings==0.5.1       # via -r requirements-dev.txt, bleach
 websockets==8.1           # via -r requirements-dev.txt, web3
 werkzeug==1.0.1           # via -r requirements-dev.txt, flask

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -82,7 +82,7 @@ markupsafe==1.1.1         # via -r requirements-docs.txt, -r requirements.txt, j
 marshmallow-dataclass==6.0.0  # via -r requirements.txt
 marshmallow-enum==1.5.1   # via -r requirements.txt
 marshmallow-polyfield==5.8  # via -r requirements.txt
-marshmallow==3.6.1        # via -r requirements.txt, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield, webargs
+marshmallow==3.6.1        # via -r requirements.txt, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield
 matrix-client==0.3.2      # via -r requirements.txt
 matrix-synapse==1.10.1    # via -r requirements-dev.in
 mccabe==0.6.1             # via flake8, pylint
@@ -180,7 +180,6 @@ urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, r
 varint==1.0.2             # via -r requirements.txt, multiaddr
 wcwidth==0.1.9            # via -r requirements.txt, prompt-toolkit, pytest
 web3==5.11.0              # via -r requirements.txt, raiden-contracts
-webargs==5.3.1            # via -r requirements.txt
 webencodings==0.5.1       # via bleach
 websockets==8.1           # via -r requirements.txt, web3
 werkzeug==1.0.1           # via -r requirements.txt, flask

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -27,6 +27,5 @@ raiden-webui
 requests
 structlog
 web3
-webargs
 typing_extensions
 objgraph

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -49,7 +49,7 @@ markupsafe==1.1.1         # via jinja2
 marshmallow-dataclass==6.0.0  # via -r requirements.in
 marshmallow-enum==1.5.1   # via -r requirements.in
 marshmallow-polyfield==5.8  # via -r requirements.in
-marshmallow==3.6.1        # via -r requirements.in, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield, webargs
+marshmallow==3.6.1        # via -r requirements.in, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield
 matrix-client==0.3.2      # via -r requirements.in
 mirakuru==2.1.2           # via -r requirements.in
 multiaddr==0.0.9          # via ipfshttpclient
@@ -91,7 +91,6 @@ urllib3==1.25.3           # via requests
 varint==1.0.2             # via multiaddr
 wcwidth==0.1.9            # via prompt-toolkit
 web3==5.11.0              # via -r requirements.in, raiden-contracts
-webargs==5.3.1            # via -r requirements.in
 websockets==8.1           # via web3
 werkzeug==1.0.1           # via flask
 zope.event==4.4           # via gevent


### PR DESCRIPTION
Updating to the latest webargs version breaks multiple things. Since we don't use much functionality from webargs, this is a good opportunity to reduce the number of dependencies.