### PR TITLE
Move the SP integration test to the long tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -752,12 +752,6 @@ workflows:
           requires:
             - lint-3.7
 
-      - scenario-player-integration-test:
-          name: scenario-player-integration-test
-          py-version: "3.7"
-          requires:
-            - lint-3.7
-
       - test:
           name: test-unit-3.7
           py-version: "3.7"
@@ -780,6 +774,19 @@ workflows:
           requires:
             - lint-3.7
 
+      - scenario-player-integration-test:
+          name: scenario-player-integration-test
+          py-version: "3.7"
+          requires:
+            - smoketest-matrix-production-geth-3.7
+            - smoketest-matrix-production-parity-3.7
+            - smoketest-matrix-development-geth-3.7
+            - smoketest-matrix-development-parity-3.7
+            - test-unit-3.7
+            - test-fuzz-3.7
+            - test-mocked-3.7
+            - shellcheck
+
       - test:
           name: test-integration-matrix-geth-3.7
           py-version: "3.7"
@@ -793,7 +800,6 @@ workflows:
             - smoketest-matrix-production-parity-3.7
             - smoketest-matrix-development-geth-3.7
             - smoketest-matrix-development-parity-3.7
-            - scenario-player-integration-test
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -812,7 +818,6 @@ workflows:
             - smoketest-matrix-production-parity-3.7
             - smoketest-matrix-development-geth-3.7
             - smoketest-matrix-development-parity-3.7
-            - scenario-player-integration-test
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -820,6 +825,7 @@ workflows:
 
       - finalize:
           requires:
+            - scenario-player-integration-test
             - test-integration-matrix-geth-3.7
             - test-integration-matrix-parity-3.7
 
@@ -991,12 +997,6 @@ workflows:
           requires:
             - lint-3.7
 
-      - scenario-player-integration-test:
-          name: scenario-player-integration-test
-          py-version: "3.7"
-          requires:
-            - lint-3.7
-
       - test:
           name: test-unit-3.7
           py-version: "3.7"
@@ -1019,6 +1019,19 @@ workflows:
           requires:
             - lint-3.7
 
+      - scenario-player-integration-test:
+          name: scenario-player-integration-test
+          py-version: "3.7"
+          requires:
+            - smoketest-matrix-production-geth-3.7
+            - smoketest-matrix-production-parity-3.7
+            - smoketest-matrix-development-geth-3.7
+            - smoketest-matrix-development-parity-3.7
+            - test-unit-3.7
+            - test-fuzz-3.7
+            - test-mocked-3.7
+            - shellcheck
+
       - test:
           name: test-integration-matrix-geth-3.7
           py-version: "3.7"
@@ -1032,7 +1045,6 @@ workflows:
             - smoketest-matrix-production-parity-3.7
             - smoketest-matrix-development-geth-3.7
             - smoketest-matrix-development-parity-3.7
-            - scenario-player-integration-test
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -1051,7 +1063,6 @@ workflows:
             - smoketest-matrix-production-parity-3.7
             - smoketest-matrix-development-geth-3.7
             - smoketest-matrix-development-parity-3.7
-            - scenario-player-integration-test
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -1059,6 +1070,7 @@ workflows:
 
       - finalize:
           requires:
+          - scenario-player-integration-test
           - test-integration-matrix-geth-3.7
           - test-integration-matrix-parity-3.7
 


### PR DESCRIPTION
This let's the long running tests run in parallel, shaving a few minutes of CI