### PR TITLE
Relax ULID time_monotonic resolution

### DIFF
--- a/raiden/storage/ulid.py
+++ b/raiden/storage/ulid.py
@@ -63,11 +63,11 @@ class ULIDMonotonicFactory(Generic[ID]):
         resolution = clock_getres(CLOCK_MONOTONIC_RAW)
 
         msg = (
-            "The monotonic clock must have nanosecond resolution. This is "
+            "The monotonic clock must have microsecond resolution. This is "
             "necessary because multiple state changes can be written on the same "
             "millisecond."
         )
-        assert resolution <= 0.000_000_001, msg
+        assert resolution <= 1e-06, msg
 
         current_time = time_ns()
 
@@ -77,6 +77,11 @@ class ULIDMonotonicFactory(Generic[ID]):
         self._previous_timestamp = start
         self._previous_monotonic = clock_gettime_ns(CLOCK_MONOTONIC_RAW)
         self._lock = Semaphore()
+        msg = (
+            "Consecutive calls to `new()` must not return the same value. "
+            "Most likely the monotonic clock resolution on this system is too low."
+        )
+        assert self.new() != self.new(), msg
 
     def new(self) -> ID:
         timestamp: int

--- a/raiden/storage/ulid.py
+++ b/raiden/storage/ulid.py
@@ -78,10 +78,10 @@ class ULIDMonotonicFactory(Generic[ID]):
         self._previous_monotonic = clock_gettime_ns(CLOCK_MONOTONIC_RAW)
         self._lock = Semaphore()
         msg = (
-            "Consecutive calls to `new()` must not return the same value. "
+            "Consecutive calls to `new()` must not return the same timestamp. "
             "Most likely the monotonic clock resolution on this system is too low."
         )
-        assert self.new() != self.new(), msg
+        assert self.new().timestamp != self.new().timestamp, msg
 
     def new(self) -> ID:
         timestamp: int
@@ -91,8 +91,9 @@ class ULIDMonotonicFactory(Generic[ID]):
             # of Linux Kernels which allowed `CLOCK_MONOTONIC` to go backwards
             # (PR: #4156).
             #
-            # A monotonic clock with ns precision must not return the same
-            # value twice, looking up the time itself should take more then 1ns,
+            # A monotonic clock with microsecond (us), or better, precision must
+            # not return the same value twice, looking up the time itself should
+            # take more then 1us:
             # https://www.python.org/dev/peps/pep-0564/#annex-clocks-resolution-in-python
             new_monotonic = clock_gettime_ns(CLOCK_MONOTONIC_RAW)
 


### PR DESCRIPTION
This changes the `CLOCK_MONOTONIC_RAW` resolution requirement for the `ULID` generator to be only `microsecond` scale.

#### Details

On some systems (i.e. Linux Subsystem for Windows), the monotonic time
resolution is larger than nanoseconds.

The requirement for the monotonic clock resolution is, that it needs to
be finer than consecutive calls to `time.clock_gettime_ns`, which should
still be satisfied with a `microsecond` (`1e-06`) resolution.

See also 
- https://github.com/raiden-network/raiden/issues/6224#issuecomment-640582410
- https://www.python.org/dev/peps/pep-0564/#annex-clocks-resolution-in-python

#### Fixes

This fixes #6224