### PR TITLE
Add `shellcheck` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,9 @@ repos:
       - id: pylint
         entry: tools/pre-commit/pre-commit-wrapper.py pylint
         additional_dependencies: ["pip-tools>=5.1.2"]
+
+  - repo: git://github.com/detailyang/pre-commit-shell
+    rev: v1.0.6
+    hooks:
+    - id: shell-lint
+      args: [--format=tty]

--- a/tools/test_and_report.sh
+++ b/tools/test_and_report.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 ######################################################
 ### Run coverage, generate and display html report ###
@@ -62,11 +62,11 @@ if [[ "$ONLY" = "*" ]];
 then
     SHOW=${SHOW:-index.html}
 else
-    SHOW=$(python -c "import sys; print(sys.argv[1].replace('/', '_').replace('.', '_') + '.html')" $ONLY)
+    SHOW=$(python -c "import sys; print(sys.argv[1].replace('/', '_').replace('.', '_') + '.html')" "$ONLY")
 fi
 
 # in case that out dir was configured, make sure, that it exists
-mkdir -p $OUT_DIR
+mkdir -p "$OUT_DIR"
 
 rm .coverage
-coverage run --branch $PYTEST -x $SUITE && coverage html -d $OUT_DIR --include=$ONLY && $OPEN $OUT_DIR/$SHOW
+coverage run --branch "$PYTEST" -x "$SUITE" && coverage html -d "$OUT_DIR" --include="$ONLY" && $OPEN "$OUT_DIR"/"$SHOW"


### PR DESCRIPTION
PR #6228 added `schellcheck` to CI. We should also be checking this  during `pre-commit`.

I tested the functionality by fixing `tools/test_and_report.sh`.