### PR TITLE
Revert "Bump mirakuru from 2.1.2 to 2.3.0 in /requirements"

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -89,7 +89,7 @@ marshmallow==3.6.1        # via -r requirements-dev.txt, marshmallow-dataclass, 
 matrix-client==0.3.2      # via -r requirements-dev.txt
 matrix-synapse==1.10.1    # via -r requirements-dev.txt
 mccabe==0.6.1             # via -r requirements-dev.txt, flake8, pylint
-mirakuru==2.3.0           # via -r requirements-dev.txt
+mirakuru==2.1.2           # via -r requirements-dev.txt
 more-itertools==7.0.0     # via -r requirements-dev.txt, pytest
 msgpack==0.6.1            # via -r requirements-dev.txt, matrix-synapse
 multiaddr==0.0.9          # via -r requirements-dev.txt, ipfshttpclient

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -87,7 +87,7 @@ marshmallow==3.6.1        # via -r requirements.txt, marshmallow-dataclass, mars
 matrix-client==0.3.2      # via -r requirements.txt
 matrix-synapse==1.10.1    # via -r requirements-dev.in
 mccabe==0.6.1             # via flake8, pylint
-mirakuru==2.3.0           # via -r requirements.txt
+mirakuru==2.1.2           # via -r requirements.txt
 more-itertools==7.0.0     # via pytest
 msgpack==0.6.1            # via matrix-synapse
 multiaddr==0.0.9          # via -r requirements.txt, ipfshttpclient

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -16,7 +16,7 @@ marshmallow-polyfield
 marshmallow
 marshmallow_enum
 matrix-client==0.3.2
-mirakuru
+mirakuru==2.1.2
 netifaces
 networkx
 psutil

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -51,7 +51,7 @@ marshmallow-enum==1.5.1   # via -r requirements.in
 marshmallow-polyfield==5.8  # via -r requirements.in
 marshmallow==3.6.1        # via -r requirements.in, marshmallow-dataclass, marshmallow-enum, marshmallow-polyfield, webargs
 matrix-client==0.3.2      # via -r requirements.in
-mirakuru==2.3.0           # via -r requirements.in
+mirakuru==2.1.2           # via -r requirements.in
 multiaddr==0.0.9          # via ipfshttpclient
 mypy-extensions==0.4.3    # via raiden-contracts, typing-inspect
 netaddr==0.7.19           # via multiaddr


### PR DESCRIPTION
This reverts commit 2bd0f708339653e6130545336eeaa6456cf2b0b2.

Test if that update made stuff more flaky..


One idea is that many test now fail in teardown, with an error that looks like it was changed recently: https://github.com/ClearcodeHQ/mirakuru/commit/b25cb28b02fca2f77b8186568b6c44e03af356c1
