### PR TITLE
Add Python 3.8 CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,25 +743,13 @@ workflows:
             - shellcheck
 
       - test:
-          name: test-integration-matrix-geth-3.7
-          py-version: "3.7"
+          matrix:
+            alias: test-integration
+            parameters:
+              py-version: ["3.7"]
+              blockchain-type: ["geth", "parity"]
           resource: "medium+"
           test-type: "integration"
-          blockchain-type: "geth"
-          transport-layer: "matrix"
-          parallelism: 25
-          requires:
-            - smoketest
-            - test
-            - test-fuzz
-            - shellcheck
-
-      - test:
-          name: test-integration-matrix-parity-3.7
-          py-version: "3.7"
-          resource: "medium+"
-          test-type: "integration"
-          blockchain-type: "parity"
           transport-layer: "matrix"
           parallelism: 25
           requires:
@@ -773,8 +761,7 @@ workflows:
       - finalize:
           requires:
             - scenario-player-integration-test
-            - test-integration-matrix-geth-3.7
-            - test-integration-matrix-parity-3.7
+            - test-integration
 
   deploy-release:
     jobs:
@@ -950,25 +937,13 @@ workflows:
             - shellcheck
 
       - test:
-          name: test-integration-matrix-geth-3.7
-          py-version: "3.7"
+          matrix:
+            alias: test-integration
+            parameters:
+              py-version: ["3.7"]
+              blockchain-type: ["geth", "parity"]
           resource: "medium+"
           test-type: "integration"
-          blockchain-type: "geth"
-          transport-layer: "matrix"
-          parallelism: 25
-          requires:
-            - smoketest
-            - test
-            - test-fuzz
-            - shellcheck
-
-      - test:
-          name: test-integration-matrix-parity-3.7
-          py-version: "3.7"
-          resource: "medium+"
-          test-type: "integration"
-          blockchain-type: "parity"
           transport-layer: "matrix"
           parallelism: 25
           requires:
@@ -980,8 +955,7 @@ workflows:
       - finalize:
           requires:
           - scenario-player-integration-test
-          - test-integration-matrix-geth-3.7
-          - test-integration-matrix-parity-3.7
+          - test-integration
 
       - build-binary-linux:
           name: build-binary-linux-x86

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,22 +715,19 @@ workflows:
             - lint
 
       - test:
-          name: test-unit-3.7
-          py-version: "3.7"
-          test-type: "unit"
+          matrix:
+            alias: test
+            parameters:
+              py-version: ["3.7", "3.8"]
+              test-type: ["unit", "mocked"]
           requires:
             - lint
 
       - test:
-          name: test-mocked-3.7
-          py-version: "3.7"
-          test-type: "mocked"
-          requires:
-            - lint
-
-      - test:
-          name: test-fuzz-3.7
-          py-version: "3.7"
+          matrix:
+            alias: test-fuzz
+            parameters:
+              py-version: ["3.7", "3.8"]
           test-type: "fuzz"
           additional-args: "--hypothesis-show-statistics"
           requires:
@@ -741,9 +738,8 @@ workflows:
           py-version: "3.7"
           requires:
             - smoketest
-            - test-unit-3.7
-            - test-fuzz-3.7
-            - test-mocked-3.7
+            - test
+            - test-fuzz
             - shellcheck
 
       - test:
@@ -756,9 +752,8 @@ workflows:
           parallelism: 25
           requires:
             - smoketest
-            - test-unit-3.7
-            - test-fuzz-3.7
-            - test-mocked-3.7
+            - test
+            - test-fuzz
             - shellcheck
 
       - test:
@@ -771,9 +766,8 @@ workflows:
           parallelism: 25
           requires:
             - smoketest
-            - test-unit-3.7
-            - test-fuzz-3.7
-            - test-mocked-3.7
+            - test
+            - test-fuzz
             - shellcheck
 
       - finalize:
@@ -928,22 +922,19 @@ workflows:
             - lint
 
       - test:
-          name: test-unit-3.7
-          py-version: "3.7"
-          test-type: "unit"
+          matrix:
+            alias: test
+            parameters:
+              py-version: ["3.7", "3.8"]
+              test-type: ["unit", "mocked"]
           requires:
             - lint
 
       - test:
-          name: test-mocked-3.7
-          py-version: "3.7"
-          test-type: "mocked"
-          requires:
-            - lint
-
-      - test:
-          name: test-fuzz-3.7
-          py-version: "3.7"
+          matrix:
+            alias: test-fuzz
+            parameters:
+              py-version: ["3.7", "3.8"]
           test-type: "fuzz"
           additional-args: "--hypothesis-show-statistics"
           requires:
@@ -954,9 +945,8 @@ workflows:
           py-version: "3.7"
           requires:
             - smoketest
-            - test-unit-3.7
-            - test-fuzz-3.7
-            - test-mocked-3.7
+            - test
+            - test-fuzz
             - shellcheck
 
       - test:
@@ -969,9 +959,8 @@ workflows:
           parallelism: 25
           requires:
             - smoketest
-            - test-unit-3.7
-            - test-fuzz-3.7
-            - test-mocked-3.7
+            - test
+            - test-fuzz
             - shellcheck
 
       - test:
@@ -984,9 +973,8 @@ workflows:
           parallelism: 25
           requires:
             - smoketest
-            - test-unit-3.7
-            - test-fuzz-3.7
-            - test-mocked-3.7
+            - test
+            - test-fuzz
             - shellcheck
 
       - finalize:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -705,38 +705,12 @@ workflows:
             - prepare-python-linux
 
       - smoketest:
-          name: smoketest-matrix-production-geth-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "production"
-          blockchain-type: "geth"
-          requires:
-            - lint
-
-      - smoketest:
-          name: smoketest-matrix-production-parity-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "production"
-          blockchain-type: "parity"
-          requires:
-            - lint
-
-      - smoketest:
-          name: smoketest-matrix-development-geth-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "development"
-          blockchain-type: "geth"
-          requires:
-            - lint
-
-      - smoketest:
-          name: smoketest-matrix-development-parity-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "development"
-          blockchain-type: "parity"
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
+              transport-layer: ["matrix"]
+              environment-type: ["production", "development"]
+              blockchain-type: ["geth", "parity"]
           requires:
             - lint
 
@@ -766,10 +740,7 @@ workflows:
           name: scenario-player-integration-test
           py-version: "3.7"
           requires:
-            - smoketest-matrix-production-geth-3.7
-            - smoketest-matrix-production-parity-3.7
-            - smoketest-matrix-development-geth-3.7
-            - smoketest-matrix-development-parity-3.7
+            - smoketest
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -784,10 +755,7 @@ workflows:
           transport-layer: "matrix"
           parallelism: 25
           requires:
-            - smoketest-matrix-production-geth-3.7
-            - smoketest-matrix-production-parity-3.7
-            - smoketest-matrix-development-geth-3.7
-            - smoketest-matrix-development-parity-3.7
+            - smoketest
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -802,10 +770,7 @@ workflows:
           transport-layer: "matrix"
           parallelism: 25
           requires:
-            - smoketest-matrix-production-geth-3.7
-            - smoketest-matrix-production-parity-3.7
-            - smoketest-matrix-development-geth-3.7
-            - smoketest-matrix-development-parity-3.7
+            - smoketest
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -953,38 +918,12 @@ workflows:
             - prepare-python-linux
 
       - smoketest:
-          name: smoketest-matrix-production-geth-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "production"
-          blockchain-type: "geth"
-          requires:
-            - lint
-
-      - smoketest:
-          name: smoketest-matrix-production-parity-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "production"
-          blockchain-type: "parity"
-          requires:
-            - lint
-
-      - smoketest:
-          name: smoketest-matrix-development-geth-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "development"
-          blockchain-type: "geth"
-          requires:
-            - lint
-
-      - smoketest:
-          name: smoketest-matrix-development-parity-3.7
-          py-version: "3.7"
-          transport-layer: "matrix"
-          environment-type: "development"
-          blockchain-type: "parity"
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
+              transport-layer: ["matrix"]
+              environment-type: ["production", "development"]
+              blockchain-type: ["geth", "parity"]
           requires:
             - lint
 
@@ -1014,10 +953,7 @@ workflows:
           name: scenario-player-integration-test
           py-version: "3.7"
           requires:
-            - smoketest-matrix-production-geth-3.7
-            - smoketest-matrix-production-parity-3.7
-            - smoketest-matrix-development-geth-3.7
-            - smoketest-matrix-development-parity-3.7
+            - smoketest
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -1032,10 +968,7 @@ workflows:
           transport-layer: "matrix"
           parallelism: 25
           requires:
-            - smoketest-matrix-production-geth-3.7
-            - smoketest-matrix-production-parity-3.7
-            - smoketest-matrix-development-geth-3.7
-            - smoketest-matrix-development-parity-3.7
+            - smoketest
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7
@@ -1050,10 +983,7 @@ workflows:
           transport-layer: "matrix"
           parallelism: 25
           requires:
-            - smoketest-matrix-production-geth-3.7
-            - smoketest-matrix-production-parity-3.7
-            - smoketest-matrix-development-geth-3.7
-            - smoketest-matrix-development-parity-3.7
+            - smoketest
             - test-unit-3.7
             - test-fuzz-3.7
             - test-mocked-3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -728,7 +728,7 @@ workflows:
             alias: test-fuzz
             parameters:
               py-version: ["3.7", "3.8"]
-          test-type: "fuzz"
+              test-type: ["fuzz"]
           additional-args: "--hypothesis-show-statistics"
           requires:
             - lint
@@ -747,9 +747,9 @@ workflows:
             alias: test-integration
             parameters:
               py-version: ["3.7"]
+              test-type: ["integration"]
               blockchain-type: ["geth", "parity"]
           resource: "medium+"
-          test-type: "integration"
           transport-layer: "matrix"
           parallelism: 25
           requires:
@@ -922,7 +922,7 @@ workflows:
             alias: test-fuzz
             parameters:
               py-version: ["3.7", "3.8"]
-          test-type: "fuzz"
+              test-type: ["fuzz"]
           additional-args: "--hypothesis-show-statistics"
           requires:
             - lint
@@ -941,9 +941,9 @@ workflows:
             alias: test-integration
             parameters:
               py-version: ["3.7"]
+              test-type: ["integration"]
               blockchain-type: ["geth", "parity"]
           resource: "medium+"
-          test-type: "integration"
           transport-layer: "matrix"
           parallelism: 25
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,8 +679,9 @@ workflows:
             - checkout
 
       - prepare-python-linux:
-          name: prepare-python-linux-3.7
-          py-version: '3.7'
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
           requires:
             - prepare-system-linux
 
@@ -690,16 +691,18 @@ workflows:
             - prepare-system-linux
 
       - lint:
-          name: lint-3.7
-          py-version: "3.7"
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
           requires:
-            - prepare-python-linux-3.7
+            - prepare-python-linux
 
       - build-docs:
-          name: build-docs-3.7
-          py-version: "3.7"
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
           requires:
-            - prepare-python-linux-3.7
+            - prepare-python-linux
 
       - smoketest:
           name: smoketest-matrix-production-geth-3.7
@@ -708,7 +711,7 @@ workflows:
           environment-type: "production"
           blockchain-type: "geth"
           requires:
-            - lint-3.7
+            - lint
 
       - smoketest:
           name: smoketest-matrix-production-parity-3.7
@@ -717,7 +720,7 @@ workflows:
           environment-type: "production"
           blockchain-type: "parity"
           requires:
-            - lint-3.7
+            - lint
 
       - smoketest:
           name: smoketest-matrix-development-geth-3.7
@@ -726,7 +729,7 @@ workflows:
           environment-type: "development"
           blockchain-type: "geth"
           requires:
-            - lint-3.7
+            - lint
 
       - smoketest:
           name: smoketest-matrix-development-parity-3.7
@@ -735,21 +738,21 @@ workflows:
           environment-type: "development"
           blockchain-type: "parity"
           requires:
-            - lint-3.7
+            - lint
 
       - test:
           name: test-unit-3.7
           py-version: "3.7"
           test-type: "unit"
           requires:
-            - lint-3.7
+            - lint
 
       - test:
           name: test-mocked-3.7
           py-version: "3.7"
           test-type: "mocked"
           requires:
-            - lint-3.7
+            - lint
 
       - test:
           name: test-fuzz-3.7
@@ -757,7 +760,7 @@ workflows:
           test-type: "fuzz"
           additional-args: "--hypothesis-show-statistics"
           requires:
-            - lint-3.7
+            - lint
 
       - scenario-player-integration-test:
           name: scenario-player-integration-test
@@ -924,8 +927,9 @@ workflows:
             - checkout
 
       - prepare-python-linux:
-          name: prepare-python-linux-3.7
-          py-version: '3.7'
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
           requires:
           - prepare-system-linux
 
@@ -935,16 +939,18 @@ workflows:
             - prepare-system-linux
 
       - lint:
-          name: lint-3.7
-          py-version: "3.7"
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
           requires:
-          - prepare-python-linux-3.7
+          - prepare-python-linux
 
       - build-docs:
-          name: build-docs-3.7
-          py-version: "3.7"
+          matrix:
+            parameters:
+              py-version: ["3.7", "3.8"]
           requires:
-            - prepare-python-linux-3.7
+            - prepare-python-linux
 
       - smoketest:
           name: smoketest-matrix-production-geth-3.7
@@ -953,7 +959,7 @@ workflows:
           environment-type: "production"
           blockchain-type: "geth"
           requires:
-            - lint-3.7
+            - lint
 
       - smoketest:
           name: smoketest-matrix-production-parity-3.7
@@ -962,7 +968,7 @@ workflows:
           environment-type: "production"
           blockchain-type: "parity"
           requires:
-            - lint-3.7
+            - lint
 
       - smoketest:
           name: smoketest-matrix-development-geth-3.7
@@ -971,7 +977,7 @@ workflows:
           environment-type: "development"
           blockchain-type: "geth"
           requires:
-            - lint-3.7
+            - lint
 
       - smoketest:
           name: smoketest-matrix-development-parity-3.7
@@ -980,21 +986,21 @@ workflows:
           environment-type: "development"
           blockchain-type: "parity"
           requires:
-            - lint-3.7
+            - lint
 
       - test:
           name: test-unit-3.7
           py-version: "3.7"
           test-type: "unit"
           requires:
-            - lint-3.7
+            - lint
 
       - test:
           name: test-mocked-3.7
           py-version: "3.7"
           test-type: "mocked"
           requires:
-            - lint-3.7
+            - lint
 
       - test:
           name: test-fuzz-3.7
@@ -1002,7 +1008,7 @@ workflows:
           test-type: "fuzz"
           additional-args: "--hypothesis-show-statistics"
           requires:
-            - lint-3.7
+            - lint
 
       - scenario-player-integration-test:
           name: scenario-player-integration-test

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     cmdclass={"test": PyTest, "egg_info": EggInfo},
     use_scm_version=True,


### PR DESCRIPTION
## Description

Add CI jobs for Python 3.8

This makes use of the new matrix syntax in CIrcleCI and uses that to also simplify the current job setup.

The integration tests are currently not run on python 3.8.


Part of https://github.com/raiden-network/raiden/issues/6166
