### PR TITLE
Increase pytest timeout to 20min

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -18,7 +18,7 @@ mkdir -p "${test_report_dir}"
 #
 # This value should be larger than our tests timeout configuration, the default
 # is defined at setup.cfg under the section `[tool:pytest]`.
-dormant_timeout=570
+dormant_timeout=1230
 
 # This signal is installed in
 # raiden/tests/conftest.py::auto_enable_gevent_monitoring_signal

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ omit =
     */site-packages/*
 
 [tool:pytest]
-timeout_limit_for_setup_and_call = 540
+timeout_limit_for_setup_and_call = 1200
 timeout_limit_teardown = 15
 norecursedirs = node_modules
 ; Ignore warnings:


### PR DESCRIPTION
Since jobs on Circle CI have a hard limit of 5h there is no need to
stick to the previously Travis inspired 540s

Use 20min for now and see if we still get failures.