### PR TITLE
tar cf no longer compress the file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,8 +435,7 @@ jobs:
             done
 
             mkdir /tmp/artifacts
-            # For unknown reasons, this is not only tarred but also gzipped
-            tar cf /tmp/artifacts/test-logs-$CIRCLE_PR_NUMBER-$CIRCLE_NODE_INDEX.tar.gz "${files[@]}"
+            tar cfz /tmp/artifacts/test-logs-$CIRCLE_PR_NUMBER-$CIRCLE_NODE_INDEX.tar.gz "${files[@]}"
 
       - store_artifacts:
           path: /tmp/artifacts


### PR DESCRIPTION
it looks like `tar cf` no longer compresses the file by default.

~note: before merging we have to download the logs and check if it is gziped, and only once.~ done, all seem good