### PR TITLE
Fix 6167

### DIFF
--- a/raiden/network/resolver/client.py
+++ b/raiden/network/resolver/client.py
@@ -60,7 +60,10 @@ def reveal_secret_with_resolver(
             log.debug(
                 "Stopped using resolver, transfer expired", resolver_endpoint=resolver_endpoint
             )
-            return False
+            # The locked transfer is expired now, so it makes no sense to continue processing it.
+            # When returning `False`, the event handler would contiue processing the events, which
+            # is not what is wanted here, so we return `True` to cancel
+            return True
 
         response = None
 

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -15,7 +15,7 @@ from contextlib import closing
 from itertools import chain
 
 import click
-from eth_utils import encode_hex, is_checksum_address, to_canonical_address
+from eth_utils import encode_hex, is_address, to_canonical_address
 
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES, SerializedSQLiteStorage
@@ -232,7 +232,7 @@ def replay_wal(
 
         ###
         # Customize this to filter things further somewhere around here.
-        # An example would be to add `import pdb; pdb.set_trace()`
+        # An example would be to add `breakpoint()`
         # and inspect the state.
         ###
         print_state_change(state_change, translator=translator)
@@ -272,14 +272,14 @@ def main(db_file, token_network_address, partner_address, names_translator):
     else:
         translator = None
 
-    assert is_checksum_address(token_network_address), "token_network_address must be provided"
-    assert is_checksum_address(partner_address), "partner_address must be provided"
+    assert is_address(token_network_address), "token_network_address must be provided"
+    assert is_address(partner_address), "partner_address must be provided"
 
     with closing(SerializedSQLiteStorage(db_file, JSONSerializer())) as storage:
         replay_wal(
             storage=storage,
-            token_network_address=token_network_address,
-            partner_address=partner_address,
+            token_network_address=to_canonical_address(token_network_address),
+            partner_address=to_canonical_address(partner_address),
             translator=translator,
         )
 


### PR DESCRIPTION
## Description

Fixes: #6167

Don't let a hanging resolver impact Raiden to much.
- Run resolver requests in a own greenlet
- Don't continue failed secret requests when they timed out the transfer
