### PR TITLE
Fix dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     cmdclass={"test": PyTest, "egg_info": EggInfo},
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    install_requires=[read_requirements("requirements.txt")],
+    install_requires=read_requirements("requirements/requirements.txt"),
     tests_require=test_requirements,
     python_requires=">=3.7",
     entry_points={"console_scripts": ["raiden = raiden.__main__:main"]},


### PR DESCRIPTION
## Description

Accidentally we used the `requirements.txt` file from the root directory, not `requirements/requirements.txt`. So no dependencies get installed via `pip install .`