### PR TITLE
Rerun tests that are too slow on setup_and_call

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -20,6 +20,8 @@ import structlog
 from _pytest.pathlib import LOCK_TIMEOUT, ensure_reset_dir, make_numbered_dir_with_cleanup
 from _pytest.tmpdir import get_user
 
+from raiden.tests.integration.exception import RetryTestError
+
 # Execute these before the raiden imports because rewrites can't work after the
 # module has been imported.
 pytest.register_assert_rewrite("raiden.tests.utils.eth_node")
@@ -477,7 +479,7 @@ def pytest_runtest_teardown(item):
 
     def report():
         gevent.util.print_run_info()
-        pytest.fail(
+        raise RetryTestError(
             f"Teardown timeout >{item.timeout_setup_and_call}s. This must not happen, when "
             f"the teardown times out not all finalizers got a chance to run. This "
             f"means not all fixtures are cleaned up, which can make subsequent "

--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -6,6 +6,18 @@ from raiden.tests.integration.fixtures.smartcontracts import *  # noqa: F401,F40
 from raiden.tests.integration.fixtures.transport import *  # noqa: F401,F403
 
 
+def pytest_collection_modifyitems(items):
+    """ Use ``flaky`` to rerun tests failing with ``RetryTestError``
+    """
+    # We don't want this in every test's namespace, so import locally
+    from raiden.tests.integration.exception import RetryTestError
+
+    for item in items:
+        item.add_marker(
+            pytest.mark.flaky(rerun_filter=lambda err, *args: issubclass(err[0], RetryTestError))
+        )
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "expect_failure")
 

--- a/raiden/tests/integration/exception.py
+++ b/raiden/tests/integration/exception.py
@@ -1,0 +1,2 @@
+class RetryTestError(Exception):
+    """ Use `flaky` to rerun a test failed due to this exception """

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -53,6 +53,7 @@ filelock==3.0.12          # via -r requirements-dev.txt
 flake8-bugbear==19.3.0    # via -r requirements-dev.txt
 flake8-tuple==0.4.1       # via -r requirements-dev.txt
 flake8==3.8.3             # via -r requirements-dev.txt, flake8-bugbear, flake8-tuple
+flaky==3.6.1              # via -r requirements-dev.txt
 flask-cors==3.0.8         # via -r requirements-dev.txt
 flask-restful==0.3.8      # via -r requirements-dev.txt
 flask==1.1.2              # via -r requirements-dev.txt, flask-cors, flask-restful
@@ -67,7 +68,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==5.16.1        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.6.1  # via -r requirements-dev.txt, pluggy
+importlib-metadata==1.6.1  # via -r requirements-dev.txt, flake8, jsonschema, pluggy, pytest
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements-dev.txt, web3
 ipython-genutils==0.2.0   # via -r requirements-dev.txt, traitlets
@@ -178,8 +179,8 @@ toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
 twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
-typed-ast==1.4.0          # via -r requirements-dev.txt, black, mypy
-typing-extensions==3.7.4.2  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, black, mypy
+typing-extensions==3.7.4.2  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via -r requirements-dev.txt, matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-dev.txt, requests

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -29,6 +29,7 @@ grequests
 pexpect
 hypothesis
 responses
+flaky
 
 # Debugging
 pdbpp

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -52,6 +52,7 @@ filelock==3.0.12          # via -r requirements.txt
 flake8-bugbear==19.3.0    # via -r requirements-dev.in
 flake8-tuple==0.4.1       # via -r requirements-dev.in
 flake8==3.8.3             # via -r requirements-dev.in, flake8-bugbear, flake8-tuple
+flaky==3.6.1              # via -r requirements-dev.in
 flask-cors==3.0.8         # via -r requirements.txt
 flask-restful==0.3.8      # via -r requirements.txt
 flask==1.1.2              # via -r requirements.txt, flask-cors, flask-restful
@@ -66,7 +67,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==5.16.1        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.6.1  # via pluggy
+importlib-metadata==1.6.1  # via -r requirements.txt, flake8, jsonschema, pluggy, pytest
 incremental==17.5.0       # via treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements.txt, web3
 ipython-genutils==0.2.0   # via -r requirements.txt, traitlets
@@ -172,8 +173,8 @@ toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via -r requirements.txt, ipython
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==20.3.0      # via matrix-synapse, treq
-typed-ast==1.4.0          # via black, mypy
-typing-extensions==3.7.4.2  # via -r requirements.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via astroid, black, mypy
+typing-extensions==3.7.4.2  # via -r requirements.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, requests
@@ -186,7 +187,7 @@ werkzeug==1.0.1           # via -r requirements.txt, flask
 wheel==0.33.4             # via -r requirements-docs.txt, astunparse
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via -r requirements.txt, importlib-metadata
 zope.event==4.4           # via -r requirements.txt, gevent
 zope.interface==5.1.0     # via -r requirements.txt, gevent, twisted
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,6 +37,7 @@ greenlet==0.4.16          # via gevent
 guppy3==3.0.10.post1      # via -r requirements.in
 hexbytes==0.2.0           # via eth-account, eth-rlp, web3
 idna==2.8                 # via requests
+importlib-metadata==1.6.1  # via jsonschema
 ipfshttpclient==0.4.12    # via web3
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.15.0           # via -r requirements.in
@@ -85,7 +86,7 @@ six==1.12.0               # via flask-cors, flask-restful, ipfshttpclient, jsons
 structlog==20.1.0         # via -r requirements.in
 toolz==0.9.0              # via cytoolz
 traitlets==4.3.2          # via ipython
-typing-extensions==3.7.4.2  # via -r requirements.in
+typing-extensions==3.7.4.2  # via -r requirements.in, web3
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
 varint==1.0.2             # via multiaddr
@@ -93,6 +94,7 @@ wcwidth==0.1.9            # via prompt-toolkit
 web3==5.11.0              # via -r requirements.in, raiden-contracts
 websockets==8.1           # via web3
 werkzeug==1.0.1           # via flask
+zipp==3.1.0               # via importlib-metadata
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 


### PR DESCRIPTION
This can be refined by raising the RetryTestError exception only in more
specific cases.

See https://github.com/raiden-network/raiden/issues/6101.