### PR TITLE
Give eth nodes 20s to start up

### DIFF
--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -422,7 +422,7 @@ def eth_run_nodes(
             log_path = eth_node_to_logpath(node_config, logdir)
             logfile = stack.enter_context(open(log_path, "w+"))
 
-            startup_timeout = 10
+            startup_timeout = 20
             sleep = 0.1
 
             executor = JSONRPCExecutor(


### PR DESCRIPTION
CI machines have a strongly varying level of performance, so it does not
sound unreasonable to allow up to 20s for starting up geth. Currently
~30% of our flakiness is due to geth not staring up within 10s.
Hopefully, this will mostly eliminate that category of flakiness.

See https://github.com/raiden-network/raiden/issues/6101.