### PR TITLE
Switch from pytoml (unmaintained) to toml

### DIFF
--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -6,14 +6,14 @@ from enum import EnumMeta
 from itertools import groupby
 from pathlib import Path
 from string import Template
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, MutableMapping, Union
 
 import click
 import requests
 from click import Choice, MissingParameter
 from click._compat import term_len
 from click.formatting import iter_rows, measure_table, wrap_text
-from pytoml import TomlError, load
+from toml import TomlDecodeError, load
 from web3.gas_strategies.time_based import fast_gas_price_strategy
 
 from raiden.exceptions import ConfigurationError, InvalidChecksummedAddress
@@ -365,7 +365,7 @@ def apply_config_file(
     }
 
     config_file_path = Path(cli_params[config_file_option_name])
-    config_file_values: Dict[str, Any] = dict()
+    config_file_values: MutableMapping[str, Any] = dict()
     try:
         with config_file_path.open() as config_file:
             config_file_values = load(config_file)
@@ -388,7 +388,7 @@ def apply_config_file(
         else:
             raise ConfigurationError(f"Error opening config file: {ex}")
 
-    except TomlError as ex:
+    except TomlDecodeError as ex:
         raise ConfigurationError(f"Error loading config file: {ex}")
 
     for config_name, config_value in config_file_values.items():

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -66,7 +66,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==5.16.1        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.6.1  # via -r requirements-dev.txt, pluggy
+importlib-metadata==1.6.1  # via -r requirements-dev.txt, flake8, jsonschema, pluggy, pytest
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements-dev.txt, web3
 ipython-genutils==0.2.0   # via -r requirements-dev.txt, traitlets
@@ -78,7 +78,7 @@ jinja2==2.10.1            # via -r requirements-dev.txt, flask, matrix-synapse, 
 jsonschema==3.2.0         # via -r requirements-dev.txt, matrix-synapse, web3
 lazy-object-proxy==1.4.1  # via -r requirements-dev.txt, astroid
 lru-dict==1.1.6           # via -r requirements-dev.txt, web3
-macholib==1.14            # via -r requirements-ci.in
+macholib==1.14            # via -r requirements-ci.in, pyinstaller
 markupsafe==1.1.1         # via -r requirements-dev.txt, jinja2
 marshmallow-dataclass==6.0.0  # via -r requirements-dev.txt
 marshmallow-enum==1.5.1   # via -r requirements-dev.txt
@@ -140,7 +140,6 @@ pytest-xdist==1.32.0      # via -r requirements-dev.txt
 pytest==5.4.3             # via -r requirements-dev.txt, pytest-forked, pytest-random, pytest-select, pytest-xdist
 python-dateutil==2.8.0    # via s3cmd
 python-magic==0.4.15      # via s3cmd
-pytoml==0.1.21            # via -r requirements-dev.txt
 pytz==2019.1              # via -r requirements-dev.txt, babel, flask-restful
 pyyaml==5.1.1             # via -r requirements-dev.txt, matrix-synapse
 raiden-contracts==0.37.1  # via -r requirements-dev.txt
@@ -172,13 +171,13 @@ sphinxcontrib-jsmath==1.0.1  # via -r requirements-dev.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -r requirements-dev.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via -r requirements-dev.txt, sphinx
 structlog==20.1.0         # via -r requirements-dev.txt
-toml==0.10.0              # via -r requirements-dev.txt, black, pylint
+toml==0.10.1              # via -r requirements-dev.txt, black, pylint
 toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
 twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
-typed-ast==1.4.0          # via -r requirements-dev.txt, black, mypy
-typing-extensions==3.7.4.2  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, black, mypy
+typing-extensions==3.7.4.2  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via -r requirements-dev.txt, matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-dev.txt, requests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -65,7 +65,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==5.16.1        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.6.1  # via pluggy
+importlib-metadata==1.6.1  # via -r requirements.txt, flake8, jsonschema, pluggy, pytest
 incremental==17.5.0       # via treq, twisted
 ipfshttpclient==0.4.12    # via -r requirements.txt, web3
 ipython-genutils==0.2.0   # via -r requirements.txt, traitlets
@@ -135,7 +135,6 @@ pytest-random==0.2        # via -r requirements-dev.in
 pytest-select==0.1.2      # via -r requirements-dev.in
 pytest-xdist==1.32.0      # via -r requirements-dev.in
 pytest==5.4.3             # via -r requirements-dev.in, pytest-forked, pytest-random, pytest-select, pytest-xdist
-pytoml==0.1.21            # via -r requirements.txt
 pytz==2019.1              # via -r requirements-docs.txt, -r requirements.txt, babel, flask-restful
 pyyaml==5.1.1             # via matrix-synapse
 raiden-contracts==0.37.1  # via -r requirements.txt
@@ -166,13 +165,13 @@ sphinxcontrib-jsmath==1.0.1  # via -r requirements-docs.txt, sphinx
 sphinxcontrib-qthelp==1.0.3  # via -r requirements-docs.txt, sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via -r requirements-docs.txt, sphinx
 structlog==20.1.0         # via -r requirements.txt
-toml==0.10.0              # via black, pylint
+toml==0.10.1              # via -r requirements.txt, black, pylint
 toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via -r requirements.txt, ipython
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==20.3.0      # via matrix-synapse, treq
-typed-ast==1.4.0          # via black, mypy
-typing-extensions==3.7.4.2  # via -r requirements.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via astroid, black, mypy
+typing-extensions==3.7.4.2  # via -r requirements.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, requests
@@ -185,7 +184,7 @@ werkzeug==1.0.1           # via -r requirements.txt, flask
 wheel==0.33.4             # via -r requirements-docs.txt, astunparse
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via -r requirements.txt, importlib-metadata
 zope.event==4.4           # via -r requirements.txt, gevent
 zope.interface==5.1.0     # via -r requirements.txt, gevent, twisted
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -21,7 +21,7 @@ netifaces
 networkx
 psutil
 pysha3
-pytoml
+toml
 raiden-contracts
 raiden-webui
 requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -74,7 +74,6 @@ pycryptodome==3.8.2       # via eth-hash, eth-keyfile
 pygments==2.6.1           # via ipython
 pyrsistent==0.15.7        # via jsonschema
 pysha3==1.0.2             # via -r requirements.in
-pytoml==0.1.21            # via -r requirements.in
 pytz==2019.1              # via flask-restful
 raiden-contracts==0.37.1  # via -r requirements.in
 raiden-webui==1.0.0       # via -r requirements.in
@@ -84,6 +83,7 @@ semantic-version==2.6.0   # via py-solc
 semver==2.8.1             # via raiden-contracts
 six==1.12.0               # via flask-cors, flask-restful, ipfshttpclient, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog, traitlets
 structlog==20.1.0         # via -r requirements.in
+toml==0.10.1              # via -r requirements.in
 toolz==0.9.0              # via cytoolz
 traitlets==4.3.2          # via ipython
 typing-extensions==3.7.4.2  # via -r requirements.in, web3


### PR DESCRIPTION
## Description

Fixes: #6243 

Remove the unmaintained `pytoml` package and use `toml` instead, which is already used by other dependencies.
