### PR TITLE
Don't spawn individual greenlets for every channel

### DIFF
--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -24,7 +24,9 @@ def after_new_route_join_network(
     connection_manager = raiden.connection_manager_for_token_network(
         channelnew.token_network_address
     )
-    connection_manager._new_channel_signal.set()
+    retry_greenlet = connection_manager.spawn_retry()
+    if retry_greenlet is not None:
+        raiden.add_pending_greenlet(retry_greenlet)
 
 
 def after_new_channel_start_healthcheck(

--- a/raiden/blockchain_events_handler.py
+++ b/raiden/blockchain_events_handler.py
@@ -24,8 +24,7 @@ def after_new_route_join_network(
     connection_manager = raiden.connection_manager_for_token_network(
         channelnew.token_network_address
     )
-    retry_connect = spawn_named("cm-retry_connect", connection_manager.retry_connect)
-    raiden.add_pending_greenlet(retry_connect)
+    connection_manager._new_channel_signal.set()
 
 
 def after_new_channel_start_healthcheck(


### PR DESCRIPTION
## Description

Fixes #5706

Instead of spawning a new ConnectionManager `retry_connect` greenlet on every new channel blockchain event, we have *one* long running greenlet, that listens for a signal (`gevent.event.Event`), which is set from the blockchain event.