### PR TITLE
Give synapse up to 30s to start up

### DIFF
--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -386,7 +386,7 @@ def matrix_server_starter(
 
             log.debug("Synapse command", command=synapse_cmd)
 
-            startup_timeout = 10
+            startup_timeout = 30
             sleep = 0.1
 
             executor = HTTPExecutor(


### PR DESCRIPTION
CI machines can be very slow occasionally and there's not harm in
increasing the timeout. This should avoid failures like
https://app.circleci.com/pipelines/github/raiden-network/raiden/9287/workflows/18a2c404-4f45-4a25-b615-d50bacdc7f3d/jobs/128639/test
