### PR TITLE
Matrix display name failsafe

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -421,17 +421,18 @@ class UserAddressManager:
         if user.displayname is None:
             new_state = UserPresence.SERVER_ERROR
             self._set_user_presence(user_id, new_state, presence_update_id)
-        else:
-            address = self._validate_userid_signature(user)
-            if not address:
-                return
+            return
 
-            self.add_userid_for_address(address, user_id)
+        address = self._validate_userid_signature(user)
+        if not address:
+            return
 
-            new_state = UserPresence(event["content"]["presence"])
+        self.add_userid_for_address(address, user_id)
 
-            self._set_user_presence(user_id, new_state, presence_update_id)
-            self._maybe_address_reachability_changed(address)
+        new_state = UserPresence(event["content"]["presence"])
+
+        self._set_user_presence(user_id, new_state, presence_update_id)
+        self._maybe_address_reachability_changed(address)
 
     def _reset_state(self) -> None:
         self._address_to_userids: Dict[Address, Set[str]] = defaultdict(set)

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -80,6 +80,7 @@ class UserPresence(Enum):
     UNAVAILABLE = "unavailable"
     OFFLINE = "offline"
     UNKNOWN = "unknown"
+    SERVER_ERROR = "server_error"
 
 
 class AddressReachability(Enum):
@@ -287,7 +288,7 @@ class UserAddressManager:
             )
 
     def track_address_presence(
-        self, address: Address, user_ids: Union[Set[str], FrozenSet[str]] = frozenset()
+        self, address: Address, user_ids: Union[Set[str], FrozenSet[str]] = None
     ) -> None:
         """
         Update synthesized address presence state.
@@ -295,6 +296,8 @@ class UserAddressManager:
         Triggers callback (if any) in case the state has changed.
         """
         # Is this address already tracked for all given user_ids?
+        if user_ids is None:
+            user_ids = frozenset()
         state_known = (
             self.get_address_reachability_state(address).reachability
             != AddressReachability.UNKNOWN

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -105,6 +105,7 @@ USER_PRESENCE_TO_ADDRESS_REACHABILITY = {
     UserPresence.UNAVAILABLE: AddressReachability.REACHABLE,
     UserPresence.OFFLINE: AddressReachability.UNREACHABLE,
     UserPresence.UNKNOWN: AddressReachability.UNKNOWN,
+    UserPresence.SERVER_ERROR: AddressReachability.UNKNOWN,
 }
 
 

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -14,7 +14,7 @@ from raiden.utils.typing import Address
 
 class DummyApi:
     def get_display_name(self, user_id):  # pylint: disable=no-self-use,unused-argument
-        return None
+        return "DUMMY_DISPLAYNAME"
 
 
 class DummyMatrixClient:


### PR DESCRIPTION
## Description

Fixes: raiden-network/raiden-services/issues/799

There seem to be situations, where matrix servers can not serve user profiles. Previously we raised a `TransportException` in these cases. For raiden-services, this could lead to a cascading error, where services started to aggressively re-query the affected user profiles and ultimately triggered the rate limiting, taking down the entire federation.

With the current layout of the matrix client code we need to fix it here. 