### PR TITLE
Allow retry on setup and call (2nd try)

### DIFF
--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -296,7 +296,7 @@ def timeout_for_setup_and_call(item):
 
     def report():
         gevent.util.print_run_info()
-        pytest.fail(f"Setup and Call timeout >{item.timeout_setup_and_call}s")
+        raise RetryTestError(f"Setup and Call timeout >{item.timeout_setup_and_call}s")
 
     def handler(signum, frame):  # pylint: disable=unused-argument
         report()


### PR DESCRIPTION
I missed on `fail` in
https://github.com/raiden-network/raiden/pull/6312/files that should
have been turned into a `RetryTestError`, leading to a non-retried
failure in
https://app.circleci.com/pipelines/github/raiden-network/raiden/9309/workflows/8478b7fc-f513-449a-a9c6-7b1e33541239/jobs/129235/tests .