### PR TITLE
Handles exeption insufficient funds at minting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`6323` Handling no ETH exception in the minting endpoint.
 * :release:`1.0.2-rc`
 * :feature:`-` Update WebUI to version 1.0.1 https://github.com/raiden-network/webui/releases/tag/v1.0.1
 * :bug:`6310` Fixed dependencies used in `setup.py`.

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -588,6 +588,8 @@ class RestAPI:  # pragma: no unittest
             self.raiden_api.mint_token_for(token_address=token_address, to=to, value=value)
         except MintFailed as e:
             return api_error(f"Minting failed: {str(e)}", status_code=HTTPStatus.BAD_REQUEST)
+        except InsufficientEth as e:
+            return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
         return api_response(status_code=HTTPStatus.OK, result={})
 

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -1332,7 +1332,6 @@ def test_api_testnet_token_mint(api_server_test_instance: APIServer, token_addre
     user_address = factories.make_checksum_address()
     token_address = token_addresses[0]
     url = api_url_for(api_server_test_instance, "tokensmintresource", token_address=token_address)
-
     request = grequests.post(url, json=dict(to=user_address, value=1))
     response = request.send().response
     assert_response_with_code(response, HTTPStatus.OK)
@@ -1351,6 +1350,12 @@ def test_api_testnet_token_mint(api_server_test_instance: APIServer, token_addre
     request = grequests.post(url, json=dict(to=user_address[:-2], value=10))
     response = request.send().response
     assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
+
+    # trying to mint with no ETH
+    burn_eth(api_server_test_instance.rest_api.raiden_api.raiden.rpc_client)
+    request = grequests.post(url, json=dict(to=user_address, value=1))
+    response = request.send().response
+    assert_response_with_code(response, HTTPStatus.PAYMENT_REQUIRED)
 
 
 @raise_on_failure


### PR DESCRIPTION
## Description

Fixes: #6323

The exception `InsufficientEth` was not handled the token minting endpoint