### PR TITLE
Don't crash on /payments when no target is given (#6217)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,9 @@
 Changelog
 =========
 
+* :bug:`6217` Don't crash at ``/payments`` when no target address is given.
 * :bug:`6323` Handling no ETH exception in the minting endpoint.
+
 * :release:`1.0.2-rc`
 * :feature:`-` Update WebUI to version 1.0.1 https://github.com/raiden-network/webui/releases/tag/v1.0.1
 * :bug:`6310` Fixed dependencies used in `setup.py`.

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -46,6 +46,7 @@ from raiden.api.v1.resources import (
     ConnectionsResource,
     MintTokenResource,
     PartnersResourceByTokenAddress,
+    PaymentEventsResource,
     PaymentResource,
     PendingTransfersResource,
     PendingTransfersResourceByTokenAddress,
@@ -144,8 +145,8 @@ URLS_V1 = [
     ),
     ("/connections/<hexaddress:token_address>", ConnectionsResource),
     ("/connections", ConnectionsInfoResource),
-    ("/payments", PaymentResource),
-    ("/payments/<hexaddress:token_address>", PaymentResource, "token_paymentresource"),
+    ("/payments", PaymentEventsResource, "paymentresource"),
+    ("/payments/<hexaddress:token_address>", PaymentEventsResource, "token_paymentresource"),
     (
         "/payments/<hexaddress:token_address>/<hexaddress:target_address>",
         PaymentResource,

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -258,15 +258,27 @@ class ConnectionsInfoResource(BaseResource):
         )
 
 
-class PaymentResource(BaseResource):
+class PaymentEventsResource(BaseResource):
+    get_schema = RaidenEventsRequestSchema()
 
+    @if_api_available
+    def get(self, token_address: TokenAddress = None) -> Response:
+        kwargs = validate_query_params(self.get_schema)
+        return self.rest_api.get_raiden_events_payment_history_with_timestamps(
+            registry_address=self.rest_api.raiden_api.raiden.default_registry.address,
+            token_address=token_address,
+            **kwargs,
+        )
+
+
+class PaymentResource(BaseResource):
     post_schema = PaymentSchema(
         only=("amount", "identifier", "secret", "secret_hash", "lock_timeout")
     )
     get_schema = RaidenEventsRequestSchema()
 
     @if_api_available
-    def get(self, token_address: TokenAddress = None, target_address: Address = None) -> Response:
+    def get(self, token_address: TokenAddress, target_address: Address) -> Response:
         kwargs = validate_query_params(self.get_schema)
         return self.rest_api.get_raiden_events_payment_history_with_timestamps(
             registry_address=self.rest_api.raiden_api.raiden.default_registry.address,

--- a/raiden/tests/integration/api/rest/test_payments.py
+++ b/raiden/tests/integration/api/rest/test_payments.py
@@ -279,16 +279,6 @@ def test_api_payments_with_hash_no_secret(
     secret = to_hex(factories.make_secret())
     secret_hash = to_hex(sha256(to_bytes(hexstr=secret)).digest())
 
-    our_address = api_server_test_instance.rest_api.raiden_api.address
-
-    payment = {
-        "initiator_address": to_checksum_address(our_address),
-        "target_address": to_checksum_address(target_address),
-        "token_address": to_checksum_address(token_address),
-        "amount": str(amount),
-        "identifier": str(identifier),
-    }
-
     request = grequests.post(
         api_url_for(
             api_server_test_instance,
@@ -300,7 +290,27 @@ def test_api_payments_with_hash_no_secret(
     )
     response = request.send().response
     assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
-    assert payment == payment
+
+
+@raise_on_failure
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_api_payments_post_without_required_params(api_server_test_instance, token_addresses):
+    token_address = token_addresses[0]
+
+    request = grequests.post(api_url_for(api_server_test_instance, "paymentresource",),)
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.METHOD_NOT_ALLOWED)
+
+    request = grequests.post(
+        api_url_for(
+            api_server_test_instance,
+            "token_paymentresource",
+            token_address=to_checksum_address(token_address),
+        ),
+    )
+    response = request.send().response
+    assert_proper_response(response, status_code=HTTPStatus.METHOD_NOT_ALLOWED)
 
 
 @raise_on_failure


### PR DESCRIPTION
## Description

Fixes: #6217 

`flask-restful` assumes that parameters for a given request are available. The only way to make parameters optional is to add the same resource with different URLs.

This led to problems with the `/payments` endpoint, where all parameters are non-optional for the `POST` method, but optional for the `GET` method. The solution is to split the resource for the different parameters.
