### PR TITLE
Add wait after node start in BF2 [skip tests]

### DIFF
--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -198,6 +198,7 @@ scenario:
           name: "Restarting node1"
           tasks:
             - start_node: 1
+            - wait: 100
       - parallel:
           name: "Checking for the node3 <-> node2 channel state"
           tasks:


### PR DESCRIPTION
## Description

Should fix the BF2 failures last night
