### PR TITLE
Stress test fixes

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -37,6 +37,7 @@ enable=
     gevent-joinall-raise-error,
     gevent-disable-wait,
     gevent-group-join,
+    gevent-input-forbidden,
     import-self,
     inconsistent-return-statements,
     no-member,

--- a/pylintrc
+++ b/pylintrc
@@ -38,6 +38,7 @@ enable=
     gevent-disable-wait,
     gevent-group-join,
     gevent-input-forbidden,
+    gevent-sys-stdfds-forbidden,
     import-self,
     inconsistent-return-statements,
     no-member,

--- a/raiden/ui/sync.py
+++ b/raiden/ui/sync.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from itertools import count
 from json import JSONDecodeError
 from typing import Mapping
@@ -57,7 +56,6 @@ def wait_for_sync_blockcypher(
     print(syncing_str.format(local_block, blockcypher_block), end="")
 
     for i in count():
-        sys.stdout.flush()
         gevent.sleep(sleep)
         local_block = rpc_client.block_number()
 
@@ -66,13 +64,13 @@ def wait_for_sync_blockcypher(
             blockcypher_block = blockcypher_query_with_retries(sleep)
 
             if blockcypher_block is None:
-                print(error_str)
+                print(error_str, flush=True)
                 return
 
             if local_block >= blockcypher_block - tolerance:
                 return
 
-        print(syncing_str.format(local_block, blockcypher_block), end="")
+        print(syncing_str.format(local_block, blockcypher_block), end="", flush=True)
 
     # add a newline so that the next print will start have it's own line
     print("")
@@ -106,8 +104,7 @@ def wait_for_sync_rpc_api(
         if i % 3 == 0:
             print("\r", end="")
 
-        print(".", end="")
-        sys.stdout.flush()
+        print(".", end="", flush=True)
 
         gevent.sleep(sleep)
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -19,7 +19,7 @@ This script does not take into account fees, therefore it must use the no-fee PF
 Before using the stress test for the first time, you need to prepare the three nodes given in the config file:
 1. Create three accounts (e.g. with `geth account new`) and transfer some ETH to pay for the on-chain transactions.
 2. Adapt `tools/debugging/stress_test_transfers_config.ini` and `tools/debugging/channels_with_minimum_balance_config.json` to your node configuration.
-3. Uncomment the `input()` line in `stress_test_transfers.py` and start the script with the config file. Now the three nodes are running and you can use other scripts to interact with them.
+3. Run `stress_test_transfers.py` with the flag `--wait-after-first-sync`, this will start the nodes and notify you once they are initialized and available to be interacted with.
 4. Use `mint.sh` to mint tokens for the nodes (see section below).
 5. Use `channel_with_minimum_balance.py` to create the channels and deposit tokens into the channels (see section below).
 6. Now you can press enter to proceed past the `input` and start the stress test (or remove the `input()` line and start the script, again).

--- a/tools/pip-compile-wrapper.py
+++ b/tools/pip-compile-wrapper.py
@@ -329,7 +329,7 @@ def main() -> None:
     elif parsed.command == "upgrade":
         packages = set(parsed.packages)
         if not packages:
-            # This is a standalong script which is not using gevent
+            # This is a standalone script which is not using gevent
             resp = input(  # pylint: disable=gevent-input-forbidden
                 "Are you sure you want to upgrade ALL packages? [y/N] "
             )

--- a/tools/pip-compile-wrapper.py
+++ b/tools/pip-compile-wrapper.py
@@ -135,8 +135,7 @@ def _run_pip_compile(
         str(target_path),
         str(source_path.relative_to(working_path)),
     ]
-    print(f"Compiling {source_path.name}...", end="")
-    sys.stdout.flush()
+    print(f"Compiling {source_path.name}...", end="", flush=True)
     if verbose:
         print(f"\nRunning command: {' '.join(shlex.quote(c) for c in command)}")
     env = os.environ.copy()
@@ -238,8 +237,7 @@ def _ensure_pip_tools() -> None:
         )
         if not pip_tools_req:
             raise RuntimeError(f"Package 'pip-tools' not found in {REQUIREMENTS_SOURCE_DEV}")
-        print(f"Installing {pip_tools_req}...", end="")
-        sys.stdout.flush()
+        print(f"Installing {pip_tools_req}...", end="", flush=True)
         process = subprocess.run(
             [sys.executable, "-m", "pip", "install", pip_tools_req],
             stdout=subprocess.PIPE,
@@ -331,7 +329,10 @@ def main() -> None:
     elif parsed.command == "upgrade":
         packages = set(parsed.packages)
         if not packages:
-            resp = input("Are you sure you want to upgrade ALL packages? [y/N] ")
+            # This is a standalong script which is not using gevent
+            resp = input(  # pylint: disable=gevent-input-forbidden
+                "Are you sure you want to upgrade ALL packages? [y/N] "
+            )
             if resp.lower() != "y":
                 print("Aborting")
                 sys.exit(1)


### PR DESCRIPTION
- Add a lint forbidding usage of `sys.std(in|out|err)`
- Fix race conditions in the stress test script
- Fix stress test to use the status endpoint