### PR TITLE
Multiple fixes for the stress test

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -676,7 +676,7 @@ class RestAPI:  # pragma: no unittest
             except (DepositOverLimit, DepositMismatch, UnexpectedChannelState) as e:
                 return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
-        result = self._updated_chanel_state_from_addresses(
+        result = self._updated_channel_state_from_addresses(
             registry_address, partner_address, token_address
         )
         return api_response(result=result, status_code=status_code)
@@ -726,7 +726,7 @@ class RestAPI:  # pragma: no unittest
 
         closed_channels_result = list()
         for channel_state in closed_channels:
-            result = self._updated_chanel_state(registry_address, channel_state)
+            result = self._updated_channel_state(registry_address, channel_state)
             closed_channels_result.append(result)
 
         return api_response(result=closed_channels_result)
@@ -800,7 +800,7 @@ class RestAPI:  # pragma: no unittest
 
         channels_result = list()
         for channel_state in raiden_service_result:
-            result = self._updated_chanel_state(registry_address, channel_state)
+            result = self._updated_channel_state(registry_address, channel_state)
             channels_result.append(result)
 
         return api_response(result=channels_result)
@@ -913,7 +913,7 @@ class RestAPI:  # pragma: no unittest
             partner_address=to_checksum_address(partner_address),
         )
         try:
-            result = self._updated_chanel_state_from_addresses(
+            result = self._updated_channel_state_from_addresses(
                 registry_address, partner_address, token_address
             )
             if result is None:
@@ -1036,7 +1036,7 @@ class RestAPI:  # pragma: no unittest
         result = self.payment_schema.dump(payment)
         return api_response(result=result)
 
-    def _updated_chanel_state_from_addresses(
+    def _updated_channel_state_from_addresses(
         self,
         registry_address: TokenNetworkRegistryAddress,
         partner_address: Address,
@@ -1060,7 +1060,7 @@ class RestAPI:  # pragma: no unittest
 
         return result
 
-    def _updated_chanel_state(
+    def _updated_channel_state(
         self, registry_address: TokenNetworkRegistryAddress, channel_state: NettingChannelState
     ) -> Optional[Dict]:
         chain_state = views.state_from_raiden(self.raiden_api.raiden)
@@ -1119,7 +1119,7 @@ class RestAPI:  # pragma: no unittest
         except UnexpectedChannelState as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
-        result = self._updated_chanel_state(registry_address, channel_state)
+        result = self._updated_channel_state(registry_address, channel_state)
         return api_response(result=result)
 
     def _withdraw(
@@ -1154,7 +1154,7 @@ class RestAPI:  # pragma: no unittest
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
         # TODO handle InsufficientEth here
 
-        result = self._updated_chanel_state(registry_address, channel_state)
+        result = self._updated_channel_state(registry_address, channel_state)
         return api_response(result=result)
 
     def _set_channel_reveal_timeout(
@@ -1188,7 +1188,7 @@ class RestAPI:  # pragma: no unittest
         except InvalidRevealTimeout as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
 
-        result = self._updated_chanel_state(registry_address, channel_state)
+        result = self._updated_channel_state(registry_address, channel_state)
         return api_response(result=result)
 
     def _close(
@@ -1214,7 +1214,7 @@ class RestAPI:  # pragma: no unittest
         except InsufficientEth as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
-        result = self._updated_chanel_state(registry_address, channel_state)
+        result = self._updated_channel_state(registry_address, channel_state)
         return api_response(result=result)
 
     def patch_channel(

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -916,6 +916,14 @@ class RestAPI:  # pragma: no unittest
             result = self._updated_chanel_state_from_addresses(
                 registry_address, partner_address, token_address
             )
+            if result is None:
+                msg = (
+                    f"Channel with partner '{to_checksum_address(partner_address)}' "
+                    f"for token '{to_checksum_address(token_address)}' could not be "
+                    f"found."
+                )
+                return api_error(errors=msg, status_code=HTTPStatus.NOT_FOUND)
+
             return api_response(result=result)
         except ChannelNotFound as e:
             return api_error(errors=str(e), status_code=HTTPStatus.NOT_FOUND)

--- a/raiden/utils/nursery.py
+++ b/raiden/utils/nursery.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, Optional, Set, Type
 
 import gevent
 import structlog
-from gevent import Greenlet
+from gevent import Greenlet, GreenletExit
 from gevent.event import AsyncResult
 from gevent.greenlet import SpawnedLink
 from gevent.lock import RLock
@@ -31,12 +31,17 @@ class Nursery(ABC):
 
 
 class Janitor:
-    """Tries to properly stop all subprocesses before quitting the script.
+    """ Janitor to properly cleanup after spawned subprocesses and greenlets.
 
-    - This watches for the status of the subprocess, if the processes exits
-      with a non-zero error code then the failure is propagated.
-    - If for any reason this process is dying, then all the spawned processes
-      have to be killed in order for a proper clean up to happen.
+    The goal of the janitor is to:
+
+    - Propagate errors, if any of the watched processes / greenlets fails.
+    - Keep track of spawned subprocesses and greenlets and make sure that
+      everything is cleanup once the Janitor is done.
+        - If the janitor is exiting because the monitored block is done (i.e.
+          the with block is done executing), then a "clean" shutdown is
+          performed.
+        - Otherwise an exception occurred and the greenlets are killed it.
     """
 
     def __init__(self, stop_timeout: float = 20) -> None:
@@ -109,6 +114,9 @@ class Janitor:
                                 exception = SystemExit(exit_code)
                                 janitor._stop.set_exception(exception)
                         except Exception as exception:
+                            log.exception(
+                                "Process erroed! Propagating error.", args=process.args,
+                            )
                             janitor._stop.set_exception(exception)
 
                 with janitor._processes_lock:
@@ -139,20 +147,29 @@ class Janitor:
             def spawn_under_watch(function: Callable, *args: Any, **kwargs: Any) -> Greenlet:
                 greenlet = gevent.spawn(function, *args, **kwargs)
 
-                def kill_grenlet(_result: AsyncResult) -> None:
-                    # gevent.GreenletExit must **not** be used here, since that
-                    # exception is considered a successful run and it is not
-                    # re-raised on calls to `get`
-                    exception = RuntimeError("Janitor is stopping")
-                    greenlet.throw(exception)
+                # The callback provided to `AsyncResult.rawlink` is executed
+                # inside the Hub thread, the callback is calling `throw` which
+                # has to be called from the Hub, so here there is no need to
+                # wrap the callback in a SpawnedLink.
+                #
+                # `throw` does not raise the exception if the greenlet has
+                # finished, which is exactly the semantics needed here.
+                def stop_greenlet_from_hub(result: AsyncResult) -> None:
+                    """ Stop the greenlet if the nursery is stopped. """
+                    try:
+                        result.get()
+                    except BaseException as e:
+                        greenlet.throw(e)
+                    else:
+                        greenlet.throw(GreenletExit())
 
-                # The Event.rawlink is executed inside the Hub thread, which
-                # does validation and *raises on blocking calls*, to go around
-                # this a new greenlet has to be spawned, that in turn will
-                # raise the exception.
-                callback = SpawnedLink(kill_grenlet)
+                def propagate_error(g: Greenlet) -> None:
+                    """ If the greenlet fails, stop the nursery. """
+                    janitor._stop.set_exception(g.exception)
 
-                janitor._stop.rawlink(callback)
+                greenlet.link_exception(propagate_error)
+                janitor._stop.rawlink(stop_greenlet_from_hub)
+
                 return greenlet
 
             @staticmethod

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from http import HTTPStatus
 from itertools import chain, count, product
 from time import time
-from typing import Callable, Dict, Iterable, Iterator, List, NewType, NoReturn, Optional
+from typing import Callable, Dict, Iterable, Iterator, List, NewType, Optional
 
 import gevent
 import gevent.os
@@ -200,8 +200,6 @@ def wait_for_status_ready(base_url: str, retry_timeout: int) -> None:
     """Keeps polling for the `/status` endpoint until the status is `ready`."""
     while not is_ready(base_url):
         gevent.sleep(retry_timeout)
-
-    raise RuntimeError("Stopping")
 
 
 def start_and_wait_for_server(

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -180,13 +180,18 @@ class Transfer:
 def is_ready(base_url: str) -> bool:
     try:
         result = requests.get(f"{base_url}/api/v1/status").json()
-        return result["status"] == "ready"
     except KeyError:
         log.info(f"Server {base_url} returned invalid json data.")
     except requests.ConnectionError:
         log.info(f"Waiting for the server {base_url} to start.")
     except requests.RequestException:
         log.exception(f"Request to server {base_url} failed.")
+    else:
+        if result["status"] == "ready":
+            log.info(f"Server {base_url} ready.")
+            return True
+
+        log.info(f"Waiting for server {base_url} to become ready, status={result['status']}.")
 
     return False
 

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -580,7 +580,7 @@ def run_stress_test(
                 pool_size=concurrency,
             )
 
-            wait_for_balance([path[INITIATOR] for path in plan.transfers])
+            wait_for_balance(running_nodes)
 
             # After each `do_transfers` the state of the system must be
             # reset, otherwise there is a bug in the planner or Raiden.

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -216,7 +216,9 @@ def wait_for_reachable(transfers: List[TransferPath], token_address: str) -> Non
             response = requests.get(url, headers={"Content-Type": "application/json"})
             data = response.json()
 
-            if data.get("network_state") == NetworkState.REACHABLE.value:
+            # The return data **may** be `None`, this looks like a race
+            # condition in the Raiden client REST API.
+            if data and data.get("network_state") == NetworkState.REACHABLE.value:
                 channels_not_reachable.remove(url)
 
 

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -198,7 +198,9 @@ def wait_for_status_ready(base_url: str, retry_timeout: int) -> None:
         gevent.sleep(retry_timeout)
 
 
-def wait_for_reachable(transfers: List[TransferPath], token_address: str) -> None:
+def wait_for_reachable(
+    transfers: List[TransferPath], token_address: str, retry_timeout: int
+) -> None:
     """ Wait until the nodes used for the transfers can see each other. """
 
     # Deduplicate the URLs for the channels which need reachability testing
@@ -220,6 +222,9 @@ def wait_for_reachable(transfers: List[TransferPath], token_address: str) -> Non
             # condition in the Raiden client REST API.
             if data and data.get("network_state") == NetworkState.REACHABLE.value:
                 channels_not_reachable.remove(url)
+
+        if channels_not_reachable:
+            gevent.sleep(retry_timeout)
 
 
 def start_and_wait_for_server(
@@ -570,7 +575,7 @@ def run_stress_test(
                     nursery, running_nodes, config.profiler_data_directory
                 )
 
-            wait_for_reachable(plan.transfers, config.token_address)
+            wait_for_reachable(plan.transfers, config.token_address, config.retry_timeout)
 
             # TODO: `do_transfers` should return the amount of tokens
             # transferred with each `(from, to)` pair, and the total amount


### PR DESCRIPTION
- Added more granular log lines to better understand what is going on.
- Fixed the usage of `kill` and `throw` by the nursery.
- Added waiting routine to check the reachability state of a partner node that is required by the transfer script.
- Simplified some of the function and structure types 