### PR TITLE
Remove API endpoints for blockchain events

### DIFF
--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -208,11 +208,6 @@ class BaseListSchema(Schema):
         return decoding_class(list_)
 
 
-class BlockchainEventsRequestSchema(BaseSchema):
-    from_block = IntegerToStringField(missing=None)
-    to_block = IntegerToStringField(missing=None)
-
-
 class RaidenEventsRequestSchema(BaseSchema):
     limit = IntegerToStringField(missing=None)
     offset = IntegerToStringField(missing=None)

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -6,7 +6,6 @@ from flask_restful import Resource
 
 from raiden.api.rest_utils import if_api_available
 from raiden.api.v1.encoding import (
-    BlockchainEventsRequestSchema,
     ChannelPatchSchema,
     ChannelPutSchema,
     ConnectionsConnectSchema,
@@ -14,15 +13,7 @@ from raiden.api.v1.encoding import (
     PaymentSchema,
     RaidenEventsRequestSchema,
 )
-from raiden.constants import BLOCK_ID_LATEST
-from raiden.utils.typing import (
-    TYPE_CHECKING,
-    Address,
-    Any,
-    BlockIdentifier,
-    TargetAddress,
-    TokenAddress,
-)
+from raiden.utils.typing import TYPE_CHECKING, Address, Any, TargetAddress, TokenAddress
 
 if TYPE_CHECKING:
     from raiden.api.rest import RestAPI
@@ -143,62 +134,6 @@ class PartnersResourceByTokenAddress(BaseResource):
     def get(self, token_address: TokenAddress) -> Response:
         return self.rest_api.get_partners_by_token(
             self.rest_api.raiden_api.raiden.default_registry.address, token_address
-        )
-
-
-class BlockchainEventsNetworkResource(BaseResource):
-
-    get_schema = BlockchainEventsRequestSchema()
-
-    @if_api_available
-    def get(self) -> Response:
-        params = validate_query_params(self.get_schema)
-        from_block = params["from_block"] or self.rest_api.raiden_api.raiden.query_start_block
-        to_block = params["to_block"] or BLOCK_ID_LATEST
-
-        return self.rest_api.get_blockchain_events_network(
-            registry_address=self.rest_api.raiden_api.raiden.default_registry.address,
-            from_block=from_block,
-            to_block=to_block,
-        )
-
-
-class BlockchainEventsTokenResource(BaseResource):
-
-    get_schema = BlockchainEventsRequestSchema()
-
-    @if_api_available
-    def get(self, token_address: TokenAddress) -> Response:
-        params = validate_query_params(self.get_schema)
-        from_block = params["from_block"] or self.rest_api.raiden_api.raiden.query_start_block
-        to_block = params["to_block"] or BLOCK_ID_LATEST
-
-        return self.rest_api.get_blockchain_events_token_network(
-            token_address=token_address, from_block=from_block, to_block=to_block
-        )
-
-
-class ChannelBlockchainEventsResource(BaseResource):
-
-    get_schema = BlockchainEventsRequestSchema()
-
-    @if_api_available
-    def get(
-        self,
-        token_address: TokenAddress,
-        partner_address: Address = None,
-        from_block: BlockIdentifier = None,
-        to_block: BlockIdentifier = None,
-    ) -> Response:
-        params = validate_query_params(self.get_schema)
-        from_block = params["from_block"] or self.rest_api.raiden_api.raiden.query_start_block
-        to_block = params["to_block"] or BLOCK_ID_LATEST
-
-        return self.rest_api.get_blockchain_events_channel(
-            token_address=token_address,
-            partner_address=partner_address,
-            from_block=from_block,
-            to_block=to_block,
         )
 
 

--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -112,9 +112,9 @@ def get_contract_events(
     proxy_manager: ProxyManager,
     abi: ABI,
     contract_address: Address,
-    topics: Optional[List[str]],
-    from_block: BlockIdentifier,
-    to_block: BlockIdentifier,
+    topics: Optional[List[str]] = ALL_EVENTS,
+    from_block: BlockIdentifier = GENESIS_BLOCK_NUMBER,
+    to_block: BlockIdentifier = BLOCK_ID_LATEST,
 ) -> List[Dict]:
     """ Query the blockchain for all events of the smart contract at
     `contract_address` that match the filters `topics`, `from_block`, and
@@ -134,45 +134,6 @@ def get_contract_events(
             del decoded_event["blockNumber"]
         result.append(decoded_event)
     return result
-
-
-def get_token_network_registry_events(
-    proxy_manager: ProxyManager,
-    token_network_registry_address: TokenNetworkRegistryAddress,
-    contract_manager: ContractManager,
-    events: Optional[List[str]] = ALL_EVENTS,
-    from_block: BlockIdentifier = GENESIS_BLOCK_NUMBER,
-    to_block: BlockIdentifier = BLOCK_ID_LATEST,
-) -> List[Dict]:  # pragma: no unittest
-    """ Helper to get all events of the Registry contract at `registry_address`. """
-    return get_contract_events(
-        proxy_manager=proxy_manager,
-        abi=contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
-        contract_address=Address(token_network_registry_address),
-        topics=events,
-        from_block=from_block,
-        to_block=to_block,
-    )
-
-
-def get_token_network_events(
-    proxy_manager: ProxyManager,
-    token_network_address: TokenNetworkAddress,
-    contract_manager: ContractManager,
-    events: Optional[List[str]] = ALL_EVENTS,
-    from_block: BlockIdentifier = GENESIS_BLOCK_NUMBER,
-    to_block: BlockIdentifier = BLOCK_ID_LATEST,
-) -> List[Dict]:  # pragma: no unittest
-    """ Helper to get all events of the ChannelManagerContract at `token_address`. """
-
-    return get_contract_events(
-        proxy_manager,
-        contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
-        Address(token_network_address),
-        events,
-        from_block,
-        to_block,
-    )
 
 
 def get_all_netting_channel_events(
@@ -198,26 +159,6 @@ def get_all_netting_channel_events(
         contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
         Address(token_network_address),
         filter_args["topics"],  # type: ignore
-        from_block,
-        to_block,
-    )
-
-
-def get_secret_registry_events(
-    proxy_manager: ProxyManager,
-    secret_registry_address: SecretRegistryAddress,
-    contract_manager: ContractManager,
-    events: Optional[List[str]] = ALL_EVENTS,
-    from_block: BlockIdentifier = GENESIS_BLOCK_NUMBER,
-    to_block: BlockIdentifier = BLOCK_ID_LATEST,
-) -> List[Dict]:  # pragma: no unittest
-    """ Helper to get all events of a SecretRegistry contract. """
-
-    return get_contract_events(
-        proxy_manager,
-        contract_manager.get_contract_abi(CONTRACT_SECRET_REGISTRY),
-        Address(secret_registry_address),
-        events,
         from_block,
         to_block,
     )

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -9,7 +9,7 @@ from eth_utils import is_checksum_address, to_checksum_address, to_hex
 from flask import url_for
 
 from raiden.api.rest import APIServer
-from raiden.constants import GENESIS_BLOCK_NUMBER, Environment
+from raiden.constants import Environment
 from raiden.messages.transfers import LockedTransfer, Unlock
 from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
@@ -555,138 +555,6 @@ def test_connect_insufficient_reserve(api_server_test_instance: APIServer, token
     assert_proper_response(response, HTTPStatus.PAYMENT_REQUIRED)
     json_response = get_json_response(response)
     assert "The account balance is below the estimated amount" in json_response["errors"]
-
-
-@raise_on_failure
-@pytest.mark.parametrize("number_of_nodes", [1])
-@pytest.mark.parametrize("channels_per_node", [0])
-@pytest.mark.parametrize("enable_rest_api", [True])
-def test_network_events(api_server_test_instance: APIServer, token_addresses):
-    # let's create a new channel
-    partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
-    token_address = token_addresses[0]
-    settle_timeout = 1650
-    channel_data_obj = {
-        "partner_address": partner_address,
-        "token_address": to_checksum_address(token_address),
-        "settle_timeout": str(settle_timeout),
-    }
-    request = grequests.put(
-        api_url_for(api_server_test_instance, "channelsresource"), json=channel_data_obj
-    )
-    response = request.send().response
-
-    assert_proper_response(response, status_code=HTTPStatus.CREATED)
-
-    request = grequests.get(
-        api_url_for(
-            api_server_test_instance,
-            "blockchaineventsnetworkresource",
-            from_block=GENESIS_BLOCK_NUMBER,
-        )
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-    assert len(get_json_response(response)) > 0
-
-
-@raise_on_failure
-@pytest.mark.parametrize("number_of_nodes", [1])
-@pytest.mark.parametrize("channels_per_node", [0])
-@pytest.mark.parametrize("enable_rest_api", [True])
-def test_token_events(api_server_test_instance: APIServer, token_addresses):
-    # let's create a new channel
-    partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
-    token_address = token_addresses[0]
-    settle_timeout = 1650
-    channel_data_obj = {
-        "partner_address": partner_address,
-        "token_address": to_checksum_address(token_address),
-        "settle_timeout": str(settle_timeout),
-    }
-    request = grequests.put(
-        api_url_for(api_server_test_instance, "channelsresource"), json=channel_data_obj
-    )
-    response = request.send().response
-
-    assert_proper_response(response, status_code=HTTPStatus.CREATED)
-
-    request = grequests.get(
-        api_url_for(
-            api_server_test_instance,
-            "blockchaineventstokenresource",
-            token_address=token_address,
-            from_block=GENESIS_BLOCK_NUMBER,
-        )
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-    assert len(get_json_response(response)) > 0
-
-
-@raise_on_failure
-@pytest.mark.parametrize("number_of_nodes", [1])
-@pytest.mark.parametrize("channels_per_node", [0])
-@pytest.mark.parametrize("enable_rest_api", [True])
-def test_channel_events(api_server_test_instance: APIServer, token_addresses):
-    # let's create a new channel
-    partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"
-    token_address = token_addresses[0]
-    settle_timeout = 1650
-    channel_data_obj = {
-        "partner_address": partner_address,
-        "token_address": to_checksum_address(token_address),
-        "settle_timeout": str(settle_timeout),
-    }
-    request = grequests.put(
-        api_url_for(api_server_test_instance, "channelsresource"), json=channel_data_obj
-    )
-    response = request.send().response
-
-    assert_proper_response(response, status_code=HTTPStatus.CREATED)
-
-    request = grequests.get(
-        api_url_for(
-            api_server_test_instance,
-            "tokenchanneleventsresourceblockchain",
-            token_address=token_address,
-            from_block=str(GENESIS_BLOCK_NUMBER),
-        )
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-    assert len(get_json_response(response)) > 0
-
-
-@raise_on_failure
-@pytest.mark.parametrize("number_of_nodes", [1])
-@pytest.mark.parametrize("channels_per_node", [0])
-@pytest.mark.parametrize("enable_rest_api", [True])
-def test_token_events_errors_for_unregistered_token(api_server_test_instance):
-    request = grequests.get(
-        api_url_for(
-            api_server_test_instance,
-            "tokenchanneleventsresourceblockchain",
-            token_address="0x61C808D82A3Ac53231750daDc13c777b59310bD9",
-            from_block="5",
-            to_block="20",
-        )
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.NOT_FOUND)
-
-    request = grequests.get(
-        api_url_for(
-            api_server_test_instance,
-            "channelblockchaineventsresource",
-            token_address="0x61C808D82A3Ac53231750daDc13c777b59310bD9",
-            partner_address="0x61C808D82A3Ac53231750daDc13c777b59313bD9",
-            from_block="5",
-            to_block="20",
-        )
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.NOT_FOUND)
 
 
 @raise_on_failure

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -6,13 +6,7 @@ from web3._utils.events import construct_event_topic_set
 from raiden import waiting
 from raiden.api.python import RaidenAPI
 from raiden.app import App
-from raiden.blockchain.events import (
-    ALL_EVENTS,
-    get_all_netting_channel_events,
-    get_contract_events,
-    get_token_network_events,
-    get_token_network_registry_events,
-)
+from raiden.blockchain.events import get_all_netting_channel_events, get_contract_events
 from raiden.constants import BLOCK_ID_LATEST, GENESIS_BLOCK_NUMBER
 from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
@@ -52,6 +46,7 @@ from raiden.utils.typing import (
 from raiden.waiting import wait_until
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
+    CONTRACT_TOKEN_NETWORK_REGISTRY,
     EVENT_TOKEN_NETWORK_CREATED,
     ChannelEvent,
 )
@@ -253,11 +248,10 @@ def test_query_events(
         views.state_from_app(app0), registry_address, token_address
     )
 
-    events = get_token_network_registry_events(
+    events = get_contract_events(
         proxy_manager=app0.raiden.proxy_manager,
-        token_network_registry_address=registry_address,
-        contract_manager=contract_manager,
-        events=ALL_EVENTS,
+        abi=contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
+        contract_address=registry_address,
     )
 
     assert must_have_event(
@@ -274,11 +268,10 @@ def test_query_events(
     if blockchain_type == "geth":
         # FIXME: This is apparently meant to verify that querying nonexisting blocks
         # returns an empty list, which is not true for parity.
-        events = get_token_network_registry_events(
+        events = get_contract_events(
             proxy_manager=app0.raiden.proxy_manager,
-            token_network_registry_address=app0.raiden.default_registry.address,
-            contract_manager=contract_manager,
-            events=ALL_EVENTS,
+            abi=contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
+            contract_address=app0.raiden.default_registry.address,
             from_block=BlockNumber(999999998),
             to_block=BlockNumber(999999999),
         )
@@ -288,11 +281,10 @@ def test_query_events(
 
     wait_both_channel_open(app0, app1, registry_address, token_address, retry_timeout)
 
-    events = get_token_network_events(
+    events = get_contract_events(
         proxy_manager=app0.raiden.proxy_manager,
-        token_network_address=manager0.address,
-        contract_manager=contract_manager,
-        events=ALL_EVENTS,
+        abi=contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+        contract_address=manager0.address,
     )
 
     _event = must_have_event(
@@ -311,11 +303,10 @@ def test_query_events(
 
     if blockchain_type == "geth":
         # see above
-        events = get_token_network_events(
+        events = get_contract_events(
             proxy_manager=app0.raiden.proxy_manager,
-            token_network_address=manager0.address,
-            contract_manager=contract_manager,
-            events=ALL_EVENTS,
+            abi=contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
+            contract_address=manager0.address,
             from_block=BlockNumber(999999998),
             to_block=BlockNumber(999999999),
         )

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -4,7 +4,7 @@ import gevent
 import pytest
 from web3 import Web3
 
-from raiden.blockchain.events import get_secret_registry_events
+from raiden.blockchain.events import get_contract_events
 from raiden.constants import BLOCK_ID_LATEST, GENESIS_BLOCK_NUMBER, STATE_PRUNING_AFTER_BLOCKS
 from raiden.exceptions import NoStateForBlockIdentifier
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
@@ -18,7 +18,8 @@ from raiden.network.rpc.client import (
 from raiden.tests.utils.events import must_have_event
 from raiden.tests.utils.factories import make_secret
 from raiden.utils.secrethash import sha256_secrethash
-from raiden.utils.typing import BlockNumber, Dict, List, PrivateKey, Secret
+from raiden.utils.typing import Address, BlockNumber, Dict, List, PrivateKey, Secret
+from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY
 from raiden_contracts.contract_manager import ContractManager
 
 
@@ -30,10 +31,10 @@ def secret_registry_batch_happy_path(
 
     secret_registry_proxy.register_secret_batch(secrets=secrets)
 
-    logs = get_secret_registry_events(
+    logs = get_contract_events(
         proxy_manager=proxy_manager,
-        secret_registry_address=secret_registry_proxy.address,
-        contract_manager=secret_registry_proxy.contract_manager,
+        abi=proxy_manager.contract_manager.get_contract_abi(CONTRACT_SECRET_REGISTRY),
+        contract_address=Address(secret_registry_proxy.address),
     )
 
     for secrethash in secrethashes:
@@ -87,10 +88,10 @@ def test_register_secret_happy_path(
             filters_start_at=GENESIS_BLOCK_NUMBER,
         ),
     )
-    logs = get_secret_registry_events(
+    logs = get_contract_events(
         proxy_manager=proxy_manager,
-        secret_registry_address=secret_registry_proxy.address,
-        contract_manager=secret_registry_proxy.contract_manager,
+        abi=proxy_manager.contract_manager.get_contract_abi(CONTRACT_SECRET_REGISTRY),
+        contract_address=Address(secret_registry_proxy.address),
     )
     secret_registered = must_have_event(
         logs, {"event": "SecretRevealed", "args": {"secrethash": secrethash}}


### PR DESCRIPTION
## Description

Removes `/api/_debug/blockchain_events/*`. Those used a full range RPC request which would most likely not work (on mainnet) and aren't actively used.
