### PR TITLE
Storing Claims in NettingChannelEndState

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -49,7 +49,6 @@ from raiden.transfer.state_change import (
     ContractReceiveUpdateTransfer,
 )
 from raiden.utils.typing import (
-    Balance,
     BlockNumber,
     BlockTimeout,
     Dict,
@@ -141,8 +140,8 @@ def contractreceivechannelnew_from_event(
     identifier = args["channel_identifier"]
     token_network_address = TokenNetworkAddress(event.originating_contract)
 
-    our_state = NettingChannelEndState(new_channel_details.our_address, Balance(0))
-    partner_state = NettingChannelEndState(new_channel_details.partner_address, Balance(0))
+    our_state = NettingChannelEndState(new_channel_details.our_address)
+    partner_state = NettingChannelEndState(new_channel_details.partner_address)
 
     open_transaction = SuccessfulTransactionState(block_number, None)
 

--- a/raiden/claim.py
+++ b/raiden/claim.py
@@ -24,7 +24,6 @@ from raiden.transfer.state_change import (
 )
 from raiden.utils.typing import (
     Address,
-    Balance,
     BlockHash,
     BlockNumber,
     BlockTimeout,
@@ -85,10 +84,10 @@ def get_state_changes_for_claims(
         # If node is channel participant, create NettingChannelState
         if node_address == claim.owner or node_address == claim.partner:
             our_state = NettingChannelEndState(
-                claim.owner if claim.owner == node_address else claim.partner, Balance(0)
+                claim.owner if claim.owner == node_address else claim.partner
             )
             partner_state = NettingChannelEndState(
-                claim.partner if claim.owner == node_address else claim.owner, Balance(0)
+                claim.partner if claim.owner == node_address else claim.owner
             )
 
             channel_state = NettingChannelState(

--- a/raiden/claim.py
+++ b/raiden/claim.py
@@ -43,14 +43,15 @@ DEFAULT_REVEAL_TIMEOUT = BlockTimeout(50)
 
 _DUMMY_ADDRESS = to_canonical_address("0x" + "0" * 40)
 
-EmptyClaim = Claim(
+
+EMPTY_CLAIM = Claim(
     chain_id=ChainID(2 ** 256 - 1),
     token_network_address=TokenNetworkAddress(_DUMMY_ADDRESS),
     owner=Address(_DUMMY_ADDRESS),
     partner=Address(_DUMMY_ADDRESS),
     total_amount=TokenAmount(0),
 )
-EmptyClaim.signature = Signature(b"")
+EMPTY_CLAIM.signature = Signature(b"")
 
 
 def parse_claims_file() -> List[Claim]:
@@ -127,6 +128,7 @@ def get_state_changes_for_claims(
                         participant_address=claim.owner,
                         contract_balance=claim.total_amount,
                         deposit_block_number=BlockNumber(1),
+                        claim=claim,
                     ),
                     transaction_hash=TransactionHash(b""),
                     block_number=BlockNumber(1),

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -247,7 +247,7 @@ class MessageHandler:
         balance_proof = balanceproof_from_envelope(message)
         lock_expired = ReceiveLockExpired(
             sender=balance_proof.sender,
-            balance_proof=balance_proof,
+            balance_proof=balance_proof,  # type: ignore
             secrethash=message.secrethash,
             message_identifier=message.message_identifier,
         )
@@ -273,7 +273,7 @@ class MessageHandler:
             state_changes.append(
                 ReceiveTransferCancelRoute(
                     transfer=from_transfer,
-                    balance_proof=from_transfer.balance_proof,
+                    balance_proof=from_transfer.balance_proof,  # type: ignore
                     sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
                 )
             )
@@ -287,7 +287,7 @@ class MessageHandler:
                 state_changes.append(
                     ActionTransferReroute(
                         transfer=from_transfer,
-                        balance_proof=from_transfer.balance_proof,  # pylint: disable=no-member
+                        balance_proof=from_transfer.balance_proof,  # type: ignore
                         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
                         secret=random_secret(),
                     )
@@ -296,7 +296,7 @@ class MessageHandler:
             state_changes.append(
                 ReceiveTransferRefund(
                     transfer=from_transfer,
-                    balance_proof=from_transfer.balance_proof,
+                    balance_proof=from_transfer.balance_proof,  # type: ignore
                     sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
                 )
             )
@@ -341,7 +341,7 @@ class MessageHandler:
             init_target_statechange = ActionInitTarget(
                 from_hop=from_hop,
                 transfer=from_transfer,
-                balance_proof=from_transfer.balance_proof,
+                balance_proof=from_transfer.balance_proof,  # type: ignore
                 sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
             )
             return [init_target_statechange]
@@ -363,7 +363,7 @@ class MessageHandler:
                 from_hop=from_hop,
                 route_states=route_states,
                 from_transfer=from_transfer,
-                balance_proof=from_transfer.balance_proof,
+                balance_proof=from_transfer.balance_proof,  # type: ignore
                 sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
             )
             return [init_mediator_statechange]

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -247,7 +247,7 @@ class MessageHandler:
         balance_proof = balanceproof_from_envelope(message)
         lock_expired = ReceiveLockExpired(
             sender=balance_proof.sender,
-            balance_proof=balance_proof,  # type: ignore
+            balance_proof=balance_proof,
             secrethash=message.secrethash,
             message_identifier=message.message_identifier,
         )
@@ -273,7 +273,7 @@ class MessageHandler:
             state_changes.append(
                 ReceiveTransferCancelRoute(
                     transfer=from_transfer,
-                    balance_proof=from_transfer.balance_proof,  # type: ignore
+                    balance_proof=from_transfer.balance_proof,
                     sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
                 )
             )
@@ -287,7 +287,7 @@ class MessageHandler:
                 state_changes.append(
                     ActionTransferReroute(
                         transfer=from_transfer,
-                        balance_proof=from_transfer.balance_proof,  # type: ignore
+                        balance_proof=from_transfer.balance_proof,
                         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
                         secret=random_secret(),
                     )
@@ -296,7 +296,7 @@ class MessageHandler:
             state_changes.append(
                 ReceiveTransferRefund(
                     transfer=from_transfer,
-                    balance_proof=from_transfer.balance_proof,  # type: ignore
+                    balance_proof=from_transfer.balance_proof,
                     sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
                 )
             )
@@ -341,7 +341,7 @@ class MessageHandler:
             init_target_statechange = ActionInitTarget(
                 from_hop=from_hop,
                 transfer=from_transfer,
-                balance_proof=from_transfer.balance_proof,  # type: ignore
+                balance_proof=from_transfer.balance_proof,
                 sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
             )
             return [init_target_statechange]
@@ -363,7 +363,7 @@ class MessageHandler:
                 from_hop=from_hop,
                 route_states=route_states,
                 from_transfer=from_transfer,
-                balance_proof=from_transfer.balance_proof,  # type: ignore
+                balance_proof=from_transfer.balance_proof,
                 sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
             )
             return [init_mediator_statechange]

--- a/raiden/messages/abstract.py
+++ b/raiden/messages/abstract.py
@@ -2,36 +2,9 @@ from dataclasses import dataclass
 
 from raiden.exceptions import InvalidSignature
 from raiden.messages.cmdid import CmdId
+from raiden.utils.datastructures import cached_property
 from raiden.utils.signer import Signer, recover
-from raiden.utils.typing import Address, Any, Callable, ClassVar, MessageID, Optional, Signature
-
-
-class cached_property:
-    """ Same as functools.cached_property in python 3.8
-
-    See https://docs.python.org/3/library/functools.html#functools.cached_property.
-    Remove after upgrading to python3.8
-    """
-
-    def __init__(self, func: Callable) -> None:
-        self.func = func
-        self.__doc__ = func.__doc__
-
-    def __get__(self, instance: Any, cls: Any = None) -> Any:
-        if instance is None:
-            return self
-        attrname = self.func.__name__
-        try:
-            cache = instance.__dict__
-        except AttributeError:  # objects with __slots__ have no __dict__
-            msg = (
-                f"No '__dict__' attribute on {type(instance).__name__!r} "
-                f"instance to cache {attrname!r} property."
-            )
-            raise TypeError(msg) from None
-        if attrname not in cache:
-            cache[attrname] = self.func(instance)
-        return cache[attrname]
+from raiden.utils.typing import Address, Any, ClassVar, MessageID, Optional, Signature
 
 
 @dataclass(repr=False, eq=False)

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import rlp
 from eth_utils import keccak
 
-from raiden.messages.abstract import cached_property
+from raiden.utils.datastructures import cached_property
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, List
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -6,6 +6,7 @@ from eth_utils import encode_hex, is_binary_address, to_canonical_address, to_he
 from gevent.lock import RLock
 from web3.exceptions import BadFunctionCallOutput
 
+from raiden.claim import Claim
 from raiden.constants import (
     BLOCK_ID_LATEST,
     EMPTY_BALANCE_HASH,
@@ -36,7 +37,7 @@ from raiden.network.rpc.client import (
 )
 from raiden.transfer.channel import compute_locksroot
 from raiden.transfer.identifiers import CanonicalIdentifier
-from raiden.transfer.state import Claim, PendingLocksState
+from raiden.transfer.state import PendingLocksState
 from raiden.transfer.utils import hash_balance_data
 from raiden.utils.formatting import format_block_id, to_checksum_address
 from raiden.utils.packing import pack_balance_proof, pack_signed_balance_proof, pack_withdraw

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -71,7 +71,7 @@ from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import (
     get_channelstate_by_canonical_identifier,
     get_channelstate_by_token_network_and_partner,
-    get_current_claim_by_token_network_and_partner,
+    get_current_claims_by_token_network_and_partner,
     state_from_raiden,
 )
 from raiden.utils.formatting import to_checksum_address
@@ -722,17 +722,10 @@ class RaidenEventHandler(EventHandler):
 
         our_details = participants_details.our_details
         partner_details = participants_details.partner_details
-        our_claim = get_current_claim_by_token_network_and_partner(
+        our_claim, partner_claim = get_current_claims_by_token_network_and_partner(
             chain_state=chain_state,
             token_network_address=canonical_identifier.token_network_address,
-            participant1=payment_channel.participant1,
-            participant2=payment_channel.participant2,
-        )
-        partner_claim = get_current_claim_by_token_network_and_partner(
-            chain_state=chain_state,
-            token_network_address=canonical_identifier.token_network_address,
-            participant1=payment_channel.participant2,
-            participant2=payment_channel.participant1,
+            partner=partner_details.address,
         )
 
         log_details = {

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -699,27 +699,9 @@ class RaidenService(Runnable):
         if not claims:
             return
 
-        processable_claims = []
-        unprocessable_claims = []
-
         chain_state = views.state_from_raiden(self)
 
         # TODO: check claim signature
-        for claim in claims:
-            token_network_state = views.get_token_network_by_address(
-                chain_state=chain_state, token_network_address=claim.token_network_address
-            )
-
-            if token_network_state is None:
-                # Token network not yet known, save for later
-                unprocessable_claims.append(claim)
-            else:
-                # Token network is known, process directly
-                processable_claims.append(claim)
-
-        # TODO: is this safe or do we need a special state change?
-        chain_state.unresolved_claims.extend(unprocessable_claims)
-
         # Create and process state changes
         state_changes = get_state_changes_for_claims(
             chain_state=chain_state,

--- a/raiden/tests/fuzz/utils.py
+++ b/raiden/tests/fuzz/utils.py
@@ -81,7 +81,7 @@ def action_init_initiator_to_action_init_target(
     from_hop = HopState(node_address=address, channel_identifier=channel.identifier)
     return ActionInitTarget(
         from_hop=from_hop, transfer=transfer, sender=address, balance_proof=transfer.balance_proof
-    )
+    )  # type: ignore
 
 
 @dataclass(frozen=True)
@@ -140,7 +140,7 @@ def locked_transfer_to_action_init_target(locked_transfer: LockedTransfer) -> Ac
     init_target_statechange = ActionInitTarget(
         from_hop=from_hop,
         transfer=from_transfer,
-        balance_proof=from_transfer.balance_proof,
+        balance_proof=from_transfer.balance_proof,  # type: ignore
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
     )
 

--- a/raiden/tests/fuzz/utils.py
+++ b/raiden/tests/fuzz/utils.py
@@ -81,7 +81,7 @@ def action_init_initiator_to_action_init_target(
     from_hop = HopState(node_address=address, channel_identifier=channel.identifier)
     return ActionInitTarget(
         from_hop=from_hop, transfer=transfer, sender=address, balance_proof=transfer.balance_proof
-    )  # type: ignore
+    )
 
 
 @dataclass(frozen=True)
@@ -140,7 +140,7 @@ def locked_transfer_to_action_init_target(locked_transfer: LockedTransfer) -> Ac
     init_target_statechange = ActionInitTarget(
         from_hop=from_hop,
         transfer=from_transfer,
-        balance_proof=from_transfer.balance_proof,  # type: ignore
+        balance_proof=from_transfer.balance_proof,
         sender=from_transfer.balance_proof.sender,  # pylint: disable=no-member
     )
 

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -346,6 +346,7 @@ def raiden_network(
 
     # Here we make sure, all apps know all the routes
     all_claims = claim_generator.claims()
+
     for app in raiden_apps:
         app.raiden.process_claims(all_claims)
 

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -2,7 +2,7 @@ import pytest
 from web3 import Web3
 
 from raiden.blockchain.events import get_all_netting_channel_events
-from raiden.claim import EmptyClaim
+from raiden.claim import EMPTY_CLAIM
 from raiden.constants import (
     BLOCK_ID_LATEST,
     EMPTY_BALANCE_HASH,
@@ -171,11 +171,11 @@ def test_payment_channel_proxy_basics(
         transferred_amount=TokenAmount(0),
         locked_amount=LockedAmount(0),
         locksroot=LOCKSROOT_OF_NO_LOCKS,
-        claim=EmptyClaim,
+        claim=EMPTY_CLAIM,
         partner_transferred_amount=TokenAmount(0),
         partner_locked_amount=LockedAmount(0),
         partner_locksroot=LOCKSROOT_OF_NO_LOCKS,
-        partner_claim=EmptyClaim,
+        partner_claim=EMPTY_CLAIM,
         block_identifier=BLOCK_ID_LATEST,
     )
     assert channel_proxy_1.settled(BLOCK_ID_LATEST) is True

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -31,7 +31,6 @@ from raiden.transfer.state import (
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
-    Balance,
     BlockNumber,
     BlockTimeout,
     ChainID,
@@ -91,10 +90,8 @@ def test_payment_channel_proxy_basics(
         reveal_timeout=reveal_timeout,
         settle_timeout=BlockTimeout(TEST_SETTLE_TIMEOUT_MIN),
         fee_schedule=FeeScheduleState(),
-        our_state=NettingChannelEndState(
-            address=token_network_proxy.client.address, contract_balance=Balance(0)
-        ),
-        partner_state=NettingChannelEndState(address=partner, contract_balance=Balance(0)),
+        our_state=NettingChannelEndState(address=token_network_proxy.client.address),
+        partner_state=NettingChannelEndState(address=partner),
         open_transaction=SuccessfulTransactionState(finished_block_number=BlockNumber(0)),
     )
     channel_proxy_1 = proxy_manager.payment_channel(
@@ -208,10 +205,8 @@ def test_payment_channel_proxy_basics(
         reveal_timeout=reveal_timeout,
         settle_timeout=BlockTimeout(TEST_SETTLE_TIMEOUT_MIN),
         fee_schedule=FeeScheduleState(),
-        our_state=NettingChannelEndState(
-            address=token_network_proxy.client.address, contract_balance=Balance(0)
-        ),
-        partner_state=NettingChannelEndState(address=partner, contract_balance=Balance(0)),
+        our_state=NettingChannelEndState(address=token_network_proxy.client.address),
+        partner_state=NettingChannelEndState(address=partner),
         open_transaction=SuccessfulTransactionState(finished_block_number=BlockNumber(0)),
     )
     channel_proxy_2 = proxy_manager.payment_channel(

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -2,7 +2,6 @@ import pytest
 from web3 import Web3
 
 from raiden.blockchain.events import get_all_netting_channel_events
-from raiden.claim import EMPTY_CLAIM
 from raiden.constants import (
     BLOCK_ID_LATEST,
     EMPTY_BALANCE_HASH,
@@ -21,6 +20,7 @@ from raiden.network.proxies.token import Token
 from raiden.network.proxies.token_network import TokenNetwork
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.tests.integration.network.proxies import BalanceProof
+from raiden.tests.utils.factories import make_claim
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.state import (
@@ -168,11 +168,11 @@ def test_payment_channel_proxy_basics(
         transferred_amount=TokenAmount(0),
         locked_amount=LockedAmount(0),
         locksroot=LOCKSROOT_OF_NO_LOCKS,
-        claim=EMPTY_CLAIM,
+        claim=make_claim(),
         partner_transferred_amount=TokenAmount(0),
         partner_locked_amount=LockedAmount(0),
         partner_locksroot=LOCKSROOT_OF_NO_LOCKS,
-        partner_claim=EMPTY_CLAIM,
+        partner_claim=make_claim(),
         block_identifier=BLOCK_ID_LATEST,
     )
     assert channel_proxy_1.settled(BLOCK_ID_LATEST) is True

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -227,7 +227,7 @@ def test_endstate_update_contract_balance():
     balance1 = 101
     node_address = make_address()
 
-    end_state = NettingChannelEndState(node_address,)
+    end_state = NettingChannelEndState(node_address)
     assert end_state.contract_balance == balance1
 
     claim = deepcopy(end_state.claim)

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -230,10 +230,14 @@ def test_endstate_update_contract_balance():
     end_state = NettingChannelEndState(node_address, balance1)
     assert end_state.contract_balance == balance1
 
-    channel.update_contract_balance(end_state, balance1 - 10)
+    claim = deepcopy(end_state.claim)
+    claim.total_amount = balance1 - 10
+
+    channel.update_contract_balance(end_state, balance1 - 10, claim)
     assert end_state.contract_balance == balance1
 
-    channel.update_contract_balance(end_state, balance1 + 10)
+    claim.total_amount = balance1 + 10
+    channel.update_contract_balance(end_state, balance1 + 10, claim)
     assert end_state.contract_balance == balance1 + 10
 
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -227,17 +227,17 @@ def test_endstate_update_contract_balance():
     balance1 = 101
     node_address = make_address()
 
-    end_state = NettingChannelEndState(node_address, balance1)
+    end_state = NettingChannelEndState(node_address,)
     assert end_state.contract_balance == balance1
 
     claim = deepcopy(end_state.claim)
     claim.total_amount = balance1 - 10
 
-    channel.update_contract_balance(end_state, balance1 - 10, claim)
+    channel.update_contract_balance(end_state, claim)
     assert end_state.contract_balance == balance1
 
     claim.total_amount = balance1 + 10
-    channel.update_contract_balance(end_state, balance1 + 10, claim)
+    channel.update_contract_balance(end_state, claim)
     assert end_state.contract_balance == balance1 + 10
 
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -7,7 +7,6 @@ from itertools import cycle
 import pytest
 from eth_utils import keccak
 
-from raiden.claim import EMPTY_CLAIM
 from raiden.constants import EMPTY_SIGNATURE, LOCKSROOT_OF_NO_LOCKS, UINT64_MAX
 from raiden.messages.decode import balanceproof_from_envelope
 from raiden.messages.transfers import Lock, Unlock
@@ -28,6 +27,7 @@ from raiden.tests.utils.factories import (
     make_address,
     make_block_hash,
     make_canonical_identifier,
+    make_claim,
     make_lock,
     make_privkey_address,
     make_secret,
@@ -226,20 +226,19 @@ def test_new_end_state():
 def test_endstate_update_contract_balance():
     """The balance must be monotonic."""
     balance1 = 101
-    claim = deepcopy(EMPTY_CLAIM)
+    claim = make_claim(balance1)
     claim.total_amount = balance1
     node_address = make_address()
 
     end_state = NettingChannelEndState(node_address, claim=claim)
     assert end_state.contract_balance == balance1
 
-    claim = deepcopy(end_state.claim)
-    claim.total_amount = balance1 - 10
+    claim = make_claim(balance1 - 10)
 
     channel.update_contract_balance(end_state, claim)
     assert end_state.contract_balance == balance1
 
-    claim.total_amount = balance1 + 10
+    claim = make_claim(balance1 + 10)
     channel.update_contract_balance(end_state, claim)
     assert end_state.contract_balance == balance1 + 10
 
@@ -260,7 +259,7 @@ def test_channelstate_update_contract_balance():
     balance1_new = our_model1.balance + deposit_amount
 
     deposit_transaction = TransactionChannelDeposit(
-        our_model1.participant_address, balance1_new, deposit_block_number,
+        our_model1.participant_address, balance1_new, deposit_block_number
     )
     state_change = ContractReceiveChannelDeposit(
         transaction_hash=make_transaction_hash(),

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -7,6 +7,7 @@ from itertools import cycle
 import pytest
 from eth_utils import keccak
 
+from raiden.claim import EMPTY_CLAIM
 from raiden.constants import EMPTY_SIGNATURE, LOCKSROOT_OF_NO_LOCKS, UINT64_MAX
 from raiden.messages.decode import balanceproof_from_envelope
 from raiden.messages.transfers import Lock, Unlock
@@ -225,9 +226,11 @@ def test_new_end_state():
 def test_endstate_update_contract_balance():
     """The balance must be monotonic."""
     balance1 = 101
+    claim = deepcopy(EMPTY_CLAIM)
+    claim.total_amount = balance1
     node_address = make_address()
 
-    end_state = NettingChannelEndState(node_address)
+    end_state = NettingChannelEndState(node_address, claim=claim)
     assert end_state.contract_balance == balance1
 
     claim = deepcopy(end_state.claim)
@@ -257,7 +260,7 @@ def test_channelstate_update_contract_balance():
     balance1_new = our_model1.balance + deposit_amount
 
     deposit_transaction = TransactionChannelDeposit(
-        our_model1.participant_address, balance1_new, deposit_block_number
+        our_model1.participant_address, balance1_new, deposit_block_number,
     )
     state_change = ContractReceiveChannelDeposit(
         transaction_hash=make_transaction_hash(),
@@ -1495,7 +1498,7 @@ def test_update_transfer():
 
 
 def test_get_amount_locked():
-    state = NettingChannelEndState(address=make_address(), contract_balance=0)
+    state = NettingChannelEndState(address=make_address())
 
     assert channel.get_amount_locked(state) == 0
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -28,6 +28,7 @@ from raiden.transfer.state import (
     BalanceProofSignedState,
     BalanceProofUnsignedState,
     ChainState,
+    Claim,
     HopState,
     NettingChannelEndState,
     NettingChannelState,
@@ -511,7 +512,17 @@ NettingChannelEndStateProperties.OUR_STATE = NettingChannelEndStateProperties(
 @create.register(NettingChannelEndStateProperties)  # noqa: F811
 def _(properties, defaults=None) -> NettingChannelEndState:
     args = _properties_to_kwargs(properties, defaults or NettingChannelEndStateProperties.DEFAULTS)
-    state = NettingChannelEndState(args["address"] or make_address(), args["balance"])
+
+    claim = Claim(
+        chain_id=UNIT_CHAIN_ID,
+        token_network_address=make_token_network_address(),
+        owner=args["address"] or make_address(),
+        partner=make_address(),
+        total_amount=args["balance"],
+        signature=make_signature(),
+    )
+
+    state = NettingChannelEndState(args["address"] or make_address(), claim=claim)
 
     pending_locks = args["pending_locks"] or None
     if pending_locks:

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -5,7 +5,7 @@ from functools import singledispatch
 from hashlib import sha256
 from operator import itemgetter
 
-from eth_utils import keccak
+from eth_utils import keccak, to_canonical_address
 
 from raiden.constants import EMPTY_SIGNATURE, LOCKSROOT_OF_NO_LOCKS, UINT64_MAX, UINT256_MAX
 from raiden.messages.decode import balanceproof_from_envelope
@@ -346,6 +346,19 @@ def make_hop_from_channel(channel_state: NettingChannelState = EMPTY) -> HopStat
 def make_hop_to_channel(channel_state: NettingChannelState = EMPTY) -> HopState:
     channel_state = if_empty(channel_state, create(NettingChannelStateProperties()))
     return HopState(channel_state.our_state.address, channel_state.identifier)
+
+
+def make_claim(balance: int = 0) -> Claim:
+    _DUMMY_ADDRESS = to_canonical_address("0x" + "0" * 40)
+    dummy_claim = Claim(
+        chain_id=ChainID(2 ** 256 - 1),
+        token_network_address=TokenNetworkAddress(_DUMMY_ADDRESS),
+        owner=Address(_DUMMY_ADDRESS),
+        partner=Address(_DUMMY_ADDRESS),
+        total_amount=TokenAmount(balance),
+    )
+    dummy_claim.signature = Signature(b"")
+    return dummy_claim
 
 
 # CONSTANTS

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -148,7 +148,7 @@ def payment_channel_open_and_deposit(
             channel_state = get_channelstate_by_canonical_identifier(
                 chain_state=chain_state, canonical_identifier=canonical_identifier
             )
-            assert channel_state, "nodes dont share a channel"
+            assert channel_state, "nodes do not share a channel"
 
         check_channel(app0, app1, token_network_address)
 

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -443,6 +443,7 @@ def run_smoketest(print_step: Callable, setup: RaidenTestSetup) -> None:
             chain_id=app.raiden.rpc_client.chain_id,
             channels=[(app.raiden.address, ConnectionManager.BOOTSTRAP_ADDR, TEST_DEPOSIT_AMOUNT)],
         )
+
         app.raiden.process_claims(claims)
 
         token_addresses = [to_checksum_address(setup.token.address)]  # type: ignore

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -152,7 +152,7 @@ def transfer(
     """ Nice to read shortcut to make successful mediated transfer.
 
     Note:
-        Only the initiator and target are synched.
+        Only the initiator and target are synced.
     """
     if transfer_state is TransferState.UNLOCKED:
         return _transfer_unlocked(

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from eth_utils import encode_hex, keccak, to_hex
 
-from raiden.claim import EMPTY_CLAIM
 from raiden.constants import LOCKSROOT_OF_NO_LOCKS, MAXIMUM_PENDING_TRANSFERS, UINT256_MAX
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, MediationFeeConfig
 from raiden.transfer.architecture import Event, StateChange, SuccessOrError, TransitionResult
@@ -1354,8 +1353,13 @@ def set_settled(channel_state: NettingChannelState, block_number: BlockNumber) -
 
 
 def update_contract_balance(
-    end_state: NettingChannelEndState, contract_balance: Balance, claim: Claim = EMPTY_CLAIM
+    end_state: NettingChannelEndState, contract_balance: Balance, claim: Claim = None
 ) -> None:
+    if claim is None:
+        from raiden.claim import EMPTY_CLAIM
+
+        claim = EMPTY_CLAIM
+
     if (
         contract_balance > end_state.contract_balance
         and claim.total_amount > end_state.claim.total_amount

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1352,19 +1352,13 @@ def set_settled(channel_state: NettingChannelState, block_number: BlockNumber) -
         channel_state.settle_transaction.result = TransactionExecutionStatus.SUCCESS
 
 
-def update_contract_balance(
-    end_state: NettingChannelEndState, contract_balance: Balance, claim: Claim = None
-) -> None:
+def update_contract_balance(end_state: NettingChannelEndState, claim: Claim = None) -> None:
     if claim is None:
         from raiden.claim import EMPTY_CLAIM
 
         claim = EMPTY_CLAIM
 
-    if (
-        contract_balance > end_state.contract_balance
-        and claim.total_amount > end_state.claim.total_amount
-    ):
-        end_state.contract_balance = contract_balance
+    if claim.total_amount > end_state.claim.total_amount:
         end_state.claim = claim
 
 
@@ -2409,13 +2403,12 @@ def handle_channel_deposit(
     channel_state: NettingChannelState, state_change: ContractReceiveChannelDeposit
 ) -> TransitionResult[NettingChannelState]:
     participant_address = state_change.deposit_transaction.participant_address
-    contract_balance = Balance(state_change.deposit_transaction.contract_balance)
     claim = state_change.deposit_transaction.claim
 
     if participant_address == channel_state.our_state.address:
-        update_contract_balance(channel_state.our_state, contract_balance, claim)
+        update_contract_balance(channel_state.our_state, claim)
     elif participant_address == channel_state.partner_state.address:
-        update_contract_balance(channel_state.partner_state, contract_balance, claim)
+        update_contract_balance(channel_state.partner_state, claim)
 
     # A deposit changes the total capacity of the channel and as such the fees need to change
     update_fee_schedule_after_balance_change(channel_state, state_change.fee_config)

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -4,13 +4,13 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
 from random import Random
+from typing import cast
 
 import networkx
 from eth_abi import encode_single
 from eth_utils import keccak, to_hex
 from web3 import Web3
 
-from raiden.claim import EMPTY_CLAIM
 from raiden.constants import (
     EMPTY_SECRETHASH,
     LOCKSROOT_OF_NO_LOCKS,
@@ -360,12 +360,17 @@ class TransactionChannelDeposit(State):
     participant_address: Address
     contract_balance: TokenAmount
     deposit_block_number: BlockNumber
-    claim: Claim = field(default=EMPTY_CLAIM)
+    claim: Claim = field(default=cast(Claim, None))
 
     def __post_init__(self) -> None:
         typecheck(self.participant_address, T_Address)
         typecheck(self.contract_balance, T_TokenAmount)
         typecheck(self.deposit_block_number, T_BlockNumber)
+
+        if self.claim is None:
+            from raiden.claim import EMPTY_CLAIM  # type: ignore
+
+            self.claim = EMPTY_CLAIM
 
 
 @dataclass
@@ -417,7 +422,7 @@ class NettingChannelEndState(State):
     )
     onchain_locksroot: Locksroot = LOCKSROOT_OF_NO_LOCKS
     nonce: Nonce = field(default=Nonce(0))
-    claim: Claim = field(default=EMPTY_CLAIM)
+    claim: Claim = field(default=cast(Claim, None))
 
     def __post_init__(self) -> None:
         typecheck(self.address, T_Address)
@@ -428,6 +433,11 @@ class NettingChannelEndState(State):
 
         if self.contract_balance < 0:
             raise ValueError("contract_balance cannot be negative.")
+
+        if self.claim is None:
+            from raiden.claim import EMPTY_CLAIM  # type: ignore
+
+            self.claim = EMPTY_CLAIM
 
     @property
     def offchain_total_withdraw(self) -> WithdrawAmount:

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -392,7 +392,6 @@ class NettingChannelEndState(State):
     """ The state of one of the nodes in a two party netting channel. """
 
     address: Address
-    contract_balance: Balance
     onchain_total_withdraw: WithdrawAmount = field(default=WithdrawAmount(0))
     withdraws_pending: Dict[WithdrawAmount, PendingWithdrawState] = field(
         repr=False, default_factory=dict
@@ -438,6 +437,10 @@ class NettingChannelEndState(State):
             from raiden.claim import EMPTY_CLAIM  # type: ignore
 
             self.claim = EMPTY_CLAIM
+
+    @property
+    def contract_balance(self) -> Balance:
+        return Balance(self.claim.total_amount)
 
     @property
     def offchain_total_withdraw(self) -> WithdrawAmount:

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -3,7 +3,6 @@ import random
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
-from functools import cached_property
 from random import Random
 
 import networkx
@@ -30,6 +29,7 @@ from raiden.transfer.architecture import (
 )
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
+from raiden.utils.datastructures import cached_property
 from raiden.utils.formatting import lpex, to_checksum_address, to_hex_address
 from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import (

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -424,6 +424,12 @@ class NettingChannelEndState(State):
     claim: Claim = field(default=cast(Claim, None))
 
     def __post_init__(self) -> None:
+
+        if self.claim is None:
+            from raiden.claim import EMPTY_CLAIM  # type: ignore
+
+            self.claim = EMPTY_CLAIM
+
         typecheck(self.address, T_Address)
         typecheck(self.contract_balance, T_TokenAmount)
 
@@ -432,11 +438,6 @@ class NettingChannelEndState(State):
 
         if self.contract_balance < 0:
             raise ValueError("contract_balance cannot be negative.")
-
-        if self.claim is None:
-            from raiden.claim import EMPTY_CLAIM  # type: ignore
-
-            self.claim = EMPTY_CLAIM
 
     @property
     def contract_balance(self) -> Balance:

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -371,6 +371,7 @@ class TransactionChannelDeposit(State):
             from raiden.claim import EMPTY_CLAIM  # type: ignore
 
             self.claim = EMPTY_CLAIM
+            self.claim.total_amount = Balance(self.contract_balance)
 
 
 @dataclass

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -340,7 +340,7 @@ class Claim(State):
         return ChannelID(int.from_bytes(bytes=hashed_id, byteorder="big"))
 
     @cached_property
-    def sender(self) -> Optional[Address]:
+    def signer(self) -> Optional[Address]:
         if not self.signature:
             return None
         data_that_was_signed = self.pack()

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -1,4 +1,3 @@
-from raiden.claim import EmptyClaim
 from raiden.transfer import channel
 from raiden.transfer.architecture import ContractSendEvent, TransferTask
 from raiden.transfer.identifiers import CanonicalIdentifier
@@ -13,6 +12,7 @@ from raiden.transfer.state import (
     TokenNetworkRegistryState,
     TokenNetworkState,
 )
+from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
     TYPE_CHECKING,
@@ -38,22 +38,6 @@ if TYPE_CHECKING:
 
 # TODO: Either enforce immutability or make a copy of the values returned by
 #     the view functions
-
-
-def get_current_claim_by_token_network_and_partner(
-    chain_state: ChainState,
-    token_network_address: TokenNetworkAddress,
-    participant1: Address,
-    participant2: Address,
-) -> Claim:
-    """ Allows bi-directional lookup for claims in a given TokenNetwork. """
-    msg = "FIXME"
-    assert chain_state, msg
-    assert token_network_address, msg
-    assert participant1, msg
-    assert participant2, msg
-    # FIXME: needs implementation
-    return EmptyClaim
 
 
 def all_neighbour_nodes(chain_state: ChainState) -> Set[Address]:
@@ -309,6 +293,21 @@ def get_channelstate_by_token_network_and_partner(
             channel_state = states[-1]
 
     return channel_state
+
+
+def get_current_claims_by_token_network_and_partner(
+    chain_state: ChainState, token_network_address: TokenNetworkAddress, partner: Address
+) -> Tuple[Claim, Claim]:
+    """ Allows bi-directional lookup for claims in a given TokenNetwork. """
+
+    channel_state = get_channelstate_by_token_network_and_partner(
+        chain_state, token_network_address, partner
+    )
+
+    msg = f"Channel with partner {to_checksum_address(partner)} not found in chain_state"
+    assert channel_state, msg
+
+    return channel_state.our_state.claim, channel_state.partner_state.claim
 
 
 def get_channelstate_by_canonical_identifier(

--- a/raiden/utils/datastructures.py
+++ b/raiden/utils/datastructures.py
@@ -1,6 +1,6 @@
 import collections
 from itertools import zip_longest
-from typing import Iterable, Tuple
+from typing import Any, Callable, Iterable, Tuple
 
 
 def merge_dict(to_update: dict, other_dict: dict) -> None:
@@ -25,3 +25,31 @@ def split_in_pairs(arg: Iterable) -> Iterable[Tuple]:
     # from the iterator each time and produces the desired result.
     iterator = iter(arg)
     return zip_longest(iterator, iterator)
+
+
+class cached_property:
+    """ Same as functools.cached_property in python 3.8
+
+    See https://docs.python.org/3/library/functools.html#functools.cached_property.
+    Remove after upgrading to python3.8
+    """
+
+    def __init__(self, func: Callable) -> None:
+        self.func = func
+        self.__doc__ = func.__doc__
+
+    def __get__(self, instance: Any, cls: Any = None) -> Any:
+        if instance is None:
+            return self
+        attrname = self.func.__name__
+        try:
+            cache = instance.__dict__
+        except AttributeError:  # objects with __slots__ have no __dict__
+            msg = (
+                f"No '__dict__' attribute on {type(instance).__name__!r} "
+                f"instance to cache {attrname!r} property."
+            )
+            raise TypeError(msg) from None
+        if attrname not in cache:
+            cache[attrname] = self.func(instance)
+        return cache[attrname]


### PR DESCRIPTION
## Description
Claims need to be stored somewhere to be available upon settlement.

Claims are stored in `NettingChannelEndState`.

`views.py` provides a function to receive the claims for a given channel with a partner. 
