### PR TITLE
include token address in skip monitoring log

### DIFF
--- a/raiden/services.py
+++ b/raiden/services.py
@@ -113,7 +113,8 @@ def update_monitoring_service_from_balance_proof(
             "Skipping update to Monitoring service. "
             "Your channel balance {channel_balance} is less than "
             "the required minimum balance of {min_balance} "
-            "that you have set before sending the MonitorRequest"
+            "that you have set before sending the MonitorRequest,"
+            " token address {token_address}"
         )
 
         dai_token_network_address = views.get_token_network_address_by_token_address(
@@ -133,7 +134,9 @@ def update_monitoring_service_from_balance_proof(
             if channel_balance < MIN_MONITORING_AMOUNT_DAI:
                 log.warning(
                     message.format(
-                        channel_balance=channel_balance, min_balance=MIN_MONITORING_AMOUNT_DAI
+                        channel_balance=channel_balance,
+                        min_balance=MIN_MONITORING_AMOUNT_DAI,
+                        token_address=to_checksum_address(DAI_TOKEN_ADDRESS)
                     )
                 )
                 return
@@ -141,7 +144,9 @@ def update_monitoring_service_from_balance_proof(
             if channel_balance < MIN_MONITORING_AMOUNT_WETH:
                 log.warning(
                     message.format(
-                        channel_balance=channel_balance, min_balance=MIN_MONITORING_AMOUNT_WETH
+                        channel_balance=channel_balance,
+                        min_balance=MIN_MONITORING_AMOUNT_WETH,
+                        token_address=to_checksum_address(WETH_TOKEN_ADDRESS)
                     )
                 )
                 return

--- a/raiden/services.py
+++ b/raiden/services.py
@@ -113,8 +113,6 @@ def update_monitoring_service_from_balance_proof(
             "Skipping update to Monitoring service. "
             "Your channel balance {channel_balance} is less than "
             "the required minimum balance of {min_balance} "
-            "that you have set before sending the MonitorRequest,"
-            " token address {token_address}"
         )
 
         dai_token_network_address = views.get_token_network_address_by_token_address(
@@ -130,25 +128,26 @@ def update_monitoring_service_from_balance_proof(
         channel_balance = get_balance(
             sender=channel_state.our_state, receiver=channel_state.partner_state,
         )
+
         if channel_state.canonical_identifier.token_network_address == dai_token_network_address:
             if channel_balance < MIN_MONITORING_AMOUNT_DAI:
-                log.warning(
-                    message.format(
-                        channel_balance=channel_balance,
-                        min_balance=MIN_MONITORING_AMOUNT_DAI,
-                        token_address=to_checksum_address(DAI_TOKEN_ADDRESS)
-                    )
+                data = dict(
+                    channel_balance=channel_balance,
+                    min_balance=MIN_MONITORING_AMOUNT_DAI,
+                    channel_id=channel_state.canonical_identifier.channel_identifier,
+                    token_address=to_checksum_address(DAI_TOKEN_ADDRESS),
                 )
+                log.warning(message.format(**data), **data)
                 return
         if channel_state.canonical_identifier.token_network_address == weth_token_network_address:
             if channel_balance < MIN_MONITORING_AMOUNT_WETH:
-                log.warning(
-                    message.format(
-                        channel_balance=channel_balance,
-                        min_balance=MIN_MONITORING_AMOUNT_WETH,
-                        token_address=to_checksum_address(WETH_TOKEN_ADDRESS)
-                    )
+                data = dict(
+                    channel_balance=channel_balance,
+                    min_balance=MIN_MONITORING_AMOUNT_WETH,
+                    channel_id=channel_state.canonical_identifier.channel_identifier,
+                    token_address=to_checksum_address(WETH_TOKEN_ADDRESS),
                 )
+                log.warning(message.format(**data), **data)
                 return
 
     log.info(


### PR DESCRIPTION
## Description

Fixes:

Please, describe what this PR does in detail:
- The logs for skipping monitoring request dont specify for which token they are doing it. It could be helpful to know the token address.
