### PR TITLE
Use configured default reveal timeout

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -717,6 +717,7 @@ class RaidenService(Runnable):
             node_address=self.address,
             token_network_registry_address=self.default_registry.address,
             settle_timeout=self.default_registry.settlement_timeout_min(BLOCK_ID_LATEST),
+            reveal_timeout=self.config.reveal_timeout,
             fee_config=self.config.mediation_fees,
             proxy_manager=self.proxy_manager,
             ignore_unrelated=ignore_unrelated,

--- a/raiden/tests/integration/test_raiddit.py
+++ b/raiden/tests/integration/test_raiddit.py
@@ -4,7 +4,6 @@ import gevent
 import pytest
 from eth_typing import BlockNumber
 
-import raiden.utils.claim
 from raiden.api.python import RaidenAPI
 from raiden.app import App
 from raiden.constants import BLOCK_ID_LATEST
@@ -58,9 +57,7 @@ def test_raiddit(
     ignore_unrelated_claims: bool,
     settle_timeout: BlockTimeout,
     retry_timeout,
-    monkeypatch,
 ):
-    monkeypatch.setattr(raiden.utils.claim, "DEFAULT_REVEAL_TIMEOUT", 6)
     app0, app1, app2 = raiden_network
     token_address = token_addresses[0]
     token_proxy: Token = app0.raiden.proxy_manager.token(

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -234,7 +234,7 @@ def options(func: Callable) -> Callable:
                 help="Sets the default reveal timeout to be used to newly created channels",
                 default=DEFAULT_REVEAL_TIMEOUT,
                 show_default=True,
-                type=click.IntRange(min=20),
+                type=click.IntRange(min=10),
             ),
             option(
                 "--default-settle-timeout",

--- a/raiden/utils/claim.py
+++ b/raiden/utils/claim.py
@@ -45,7 +45,6 @@ log = get_logger(__name__)
 
 
 DEFAULT_SETTLE_TIMEOUT = BlockTimeout(100)
-DEFAULT_REVEAL_TIMEOUT = BlockTimeout(50)
 DEFAULT_TOKEN_AMOUNT = TokenAmount(100)
 
 
@@ -92,6 +91,7 @@ def get_state_changes_for_claims(
     node_address: Address,
     token_network_registry_address: TokenNetworkRegistryAddress,
     settle_timeout: BlockTimeout,
+    reveal_timeout: BlockTimeout,
     fee_config: MediationFeeConfig,
     proxy_manager: Any,  # FIXME: remove import cycle
     ignore_unrelated: bool = True,
@@ -132,7 +132,7 @@ def get_state_changes_for_claims(
                 ),
                 token_address=token_network_state.token_address,
                 token_network_registry_address=token_network_registry_address,
-                reveal_timeout=DEFAULT_REVEAL_TIMEOUT,
+                reveal_timeout=reveal_timeout,
                 settle_timeout=settle_timeout,
                 fee_schedule=FeeScheduleState(
                     cap_fees=fee_config.cap_meditation_fees,


### PR DESCRIPTION
instead of a hard-coded one in `claims.py`.

Relates to raiden-network/raiddit#51.

