### PR TITLE
remove double "the" in the the whole codebase

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = True
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.1.1 <2020-07-20>`
 * :feature:`-` Update WebUI to version 1.0.2 https://github.com/raiden-network/webui/releases/tag/v1.0.2
 * :feature:`5407` Add ``/contracts`` endpoint with information about the used contracts.
 * :bug:`6217` Don't crash at ``/payments`` when no target address is given.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ master_doc = "index"
 project = "Raiden Network"
 author = "Raiden Project"
 
-version_string = "1.1.0"
+version_string = "1.1.1"
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -261,7 +261,7 @@ On the sender's side for the messages in the unordered queue:
 
 Receiving a ``Delivered`` is enough to `remove <https://github.com/raiden-network/raiden/blob/9790bfd76de3f63a8c2e8e2a99eeabdbcd6df867/raiden/transfer/node.py#L531>`_ them from the queue triggering the transport to stop retrying sending them.
 
-On the sender's side for the specific queues they’ll wait for the `Processed <https://github.com/raiden-network/raiden/blob/761bedfee2ee326401ad5ec95d55b1ab458a5213/raiden/messages.py#L328>`_ message, signaling not only that the message was delivered, but also that the processing of the respective state change occurred successfully, or else keep retrying. If a ``Processed`` is received the the specific queue is `cleared <https://github.com/raiden-network/raiden/blob/9790bfd76de3f63a8c2e8e2a99eeabdbcd6df867/raiden/transfer/node.py#L735>`_.
+On the sender's side for the specific queues they’ll wait for the `Processed <https://github.com/raiden-network/raiden/blob/761bedfee2ee326401ad5ec95d55b1ab458a5213/raiden/messages.py#L328>`_ message, signaling not only that the message was delivered, but also that the processing of the respective state change occurred successfully, or else keep retrying. If a ``Processed`` is received the specific queue is `cleared <https://github.com/raiden-network/raiden/blob/9790bfd76de3f63a8c2e8e2a99eeabdbcd6df867/raiden/transfer/node.py#L735>`_.
 
 So, for a specific queue message, e.g. a ``LockedTransfer`` in a specific channel:
 

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -740,7 +740,7 @@ class RaidenAPI:  # pragma: no unittest
         if total_deposit <= channel_state.our_state.contract_balance:
             raise DepositMismatch("Total deposit did not increase.")
 
-        # If this check succeeds it does not imply the the `deposit` will
+        # If this check succeeds it does not imply the `deposit` will
         # succeed, since the `deposit` transaction may race with another
         # transaction.
         if not (balance >= addendum):

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -239,7 +239,7 @@ class SecretRegistry:
             if estimated_transaction is not None:
                 assert msg, "Unexpected control flow, an exception should have been raised."
                 error = (
-                    f"Sending the the transaction for registerSecretBatch "
+                    f"Sending the transaction for registerSecretBatch "
                     f"failed with: `{msg}`.  This happens if the same ethereum "
                     f"account is being used by more than one program which is not "
                     f"supported."

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -809,7 +809,7 @@ def test_refund_transfer_no_more_routes():
     assert search_for_item(iteration.events, SendProcessed, {}) is not None
     assert iteration.new_state, "payment task should be there waiting for next block"
 
-    # process the the block after lock expiration
+    # process the block after lock expiration
     current_state = iteration.new_state
     state_change = Block(
         block_number=expiry_block + 1, gas_limit=1, block_hash=factories.make_transaction_hash()

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -578,7 +578,7 @@ def run(ctx: Context, **kwargs: Any) -> None:
             | assume all risk related thereto and hereby release, waive, discharge   |
             | and covenant not to hold liable Brainbot Labs Establishment or any of  |
             | its officers, employees or affiliates from and for any direct or       |
-            | indirect damage resulting from the the software or the use thereof.    |
+            | indirect damage resulting from the software or the use thereof.        |
             | Such to the extent as permissible by applicable laws and regulations.  |
             |                                                                        |
             | Privacy warning: Please be aware, that by using the Raiden Client,     |


### PR DESCRIPTION
## Description
https://github.com/raiden-network/raiden/search?q=%22the+the%22&unscoped_q=%22the+the%22
Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
