### PR TITLE
[Raiddit] Allow multiple feedback tokens for the same route

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -877,7 +877,9 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
     def handle_routefailed(
         raiden: "RaidenService", route_failed_event: EventRouteFailed
     ) -> None:  # pragma: no unittest
-        feedback_token = raiden.route_to_feedback_token.get(tuple(route_failed_event.route))
+        feedback_token = raiden.route_to_feedback_token.get(
+            tuple(route_failed_event.route), [None]
+        ).pop()
         pfs_config = raiden.config.pfs_config
 
         if feedback_token and pfs_config:
@@ -901,8 +903,8 @@ class PFSFeedbackEventHandler(RaidenEventHandler):
         raiden: "RaidenService", payment_sent_success_event: EventPaymentSentSuccess
     ) -> None:  # pragma: no unittest
         feedback_token = raiden.route_to_feedback_token.get(
-            tuple(payment_sent_success_event.route)
-        )
+            tuple(payment_sent_success_event.route), [None]
+        ).pop()
         pfs_config = raiden.config.pfs_config
 
         if feedback_token and pfs_config:

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -230,11 +230,7 @@ def initiator_init(
     if feedback_token is not None:
         for route_state in routes:
             key = tuple(route_state.route)
-            if key in raiden.route_to_feedback_token:
-                raiden.route_to_feedback_token[key].append(feedback_token)
-            else:
-                raiden.route_to_feedback_token[key] = [feedback_token]
-
+            raiden.route_to_feedback_token.setdefault(key, []).append(feedback_token)
     return error_msg, ActionInitInitiator(transfer_state, routes)
 
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -229,7 +229,11 @@ def initiator_init(
     # Only prepare feedback when token is available
     if feedback_token is not None:
         for route_state in routes:
-            raiden.route_to_feedback_token[tuple(route_state.route)] = feedback_token
+            key = tuple(route_state.route)
+            if key in raiden.route_to_feedback_token:
+                raiden.route_to_feedback_token[key].append(feedback_token)
+            else:
+                raiden.route_to_feedback_token[key] = [feedback_token]
 
     return error_msg, ActionInitInitiator(transfer_state, routes)
 
@@ -396,7 +400,7 @@ class RaidenService(Runnable):
         self.payment_identifier_lock = gevent.lock.Semaphore()
 
         # A list is not hashable, so use tuple as key here
-        self.route_to_feedback_token: Dict[Tuple[Address, ...], UUID] = dict()
+        self.route_to_feedback_token: Dict[Tuple[Address, ...], List[Optional[UUID]]] = dict()
 
         # Flag used to skip the processing of all Raiden events during the
         # startup.


### PR DESCRIPTION
We want to see feedback for all successful routes, even if the same route is used multiple times.