### PR TITLE
Change eth client version check

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -65,7 +65,7 @@ from raiden.exceptions import (
     ReplacementTransactionUnderpriced,
 )
 from raiden.network.rpc.middleware import block_hash_cache_middleware
-from raiden.utils.ethereum_clients import is_supported_client
+from raiden.utils.ethereum_clients import VersionSupport, is_supported_client
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.smart_contracts import safe_gas_limit
@@ -1039,9 +1039,9 @@ class JSONRPCClient:
         version = web3.clientVersion
         supported, eth_node, _ = is_supported_client(version)
 
-        if eth_node is None:
+        if eth_node is None or supported is VersionSupport.UNSUPPORTED:
             raise EthNodeInterfaceError(f'Unsupported Ethereum client "{version}"')
-        if not supported:
+        if supported is VersionSupport.WARN:
             log.warn(f'Unsupported Ethereum client version "{version}"')
 
         address = privatekey_to_address(privkey)

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -1039,8 +1039,10 @@ class JSONRPCClient:
         version = web3.clientVersion
         supported, eth_node, _ = is_supported_client(version)
 
-        if not supported or eth_node is None:
-            raise EthNodeInterfaceError(f"Unsupported Ethereum client {version}")
+        if eth_node is None:
+            raise EthNodeInterfaceError(f'Unsupported Ethereum client "{version}"')
+        if not supported:
+            log.warn(f'Unsupported Ethereum client version "{version}"')
 
         address = privatekey_to_address(privkey)
         available_nonce = discover_next_available_nonce(web3, eth_node, address)

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -15,6 +15,8 @@ import gevent
 import pytest
 import structlog
 
+from raiden.utils.ethereum_clients import VersionSupport
+
 # Execute these before the raiden imports because rewrites can't work after the
 # module has been imported.
 pytest.register_assert_rewrite("raiden.tests.utils.eth_node")
@@ -126,7 +128,7 @@ def check_geth_version_for_tests(blockchain_type):
         ["geth", "version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     ).communicate()
     supported, _, our_version = is_supported_client(geth_version_string.decode())
-    if not supported:
+    if supported is VersionSupport.UNSUPPORTED:
         pytest.exit(
             f"You are trying to run tests with an unsupported GETH version. "
             f"Your Version: {our_version} "
@@ -144,7 +146,7 @@ def check_parity_version_for_tests(blockchain_type):
         ["openethereum", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     ).communicate()
     supported, _, our_version = is_supported_client(parity_version_string.decode())
-    if not supported:
+    if supported is VersionSupport.UNSUPPORTED:
         pytest.exit(
             f"You are trying to run tests with an unsupported PARITY version. "
             f"Your Version: {our_version} "

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -87,12 +87,10 @@ def run_test_check_json_rpc_geth():
     g4, _, v4 = is_supported_client("Geth/v2.0.3-unstable-e9295163/linux-amd64/go1.9.1")
     g5, _, v5 = is_supported_client("Geth/v11.55.86-unstable-e9295163/linux-amd64/go1.9.1")
     g6, _, v6 = is_supported_client("Geth/v999.999.999-unstable-e9295163/linux-amd64/go1.9.1")
-    # Test that patch version upgrades are not triggering the non-supported check
-    g7, _, v7 = is_supported_client("Geth/v1.9.3-unstable-e9295163/linux-amd64/go1.9.1")
     g8, _, v8 = is_supported_client("Geth/v1.9.0-stable-52f24617/linux-amd64/go1.12.7")
     g9, _, v9 = is_supported_client("Geth/v1.9.0-unstable-3d3e83ec-20190611/linux-amd64/go1.12.5")
     assert client is EthClient.GETH
-    assert all([g1, g2, g3, g7, g8, g9])
+    assert all([g1, g2, g3, g8, g9])
     assert not any([g4, g5, g6])
     assert v1 == "1.7.3"
     assert v2 == "1.7.2"
@@ -100,7 +98,6 @@ def run_test_check_json_rpc_geth():
     assert v4 == "2.0.3"
     assert v5 == "11.55.86"
     assert v6 == "999.999.999"
-    assert v7 == "1.9.3"
     assert v8 == "1.9.0"
     assert v9 == "1.9.0"
 
@@ -147,15 +144,11 @@ def run_test_check_json_rpc_parity():
     g6, _, v6 = is_supported_client(
         "Parity//v99.994.975-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
-    # Test that patch version upgrades are not triggering the non-supported check
-    g7, _, v7 = is_supported_client(
-        "Parity//v2.5.8-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
-    )
     g8, _, v8 = is_supported_client(
         "Parity//v2.5.0-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     assert client is EthClient.PARITY
-    assert all([g1, g2, g3, g7, g8])
+    assert all([g1, g2, g3, g8])
     assert not any([g4, g5, g6])
     assert v1 == "1.7.6"
     assert v2 == "1.7.7"
@@ -163,7 +156,6 @@ def run_test_check_json_rpc_parity():
     assert v4 == "2.9.7"
     assert v5 == "23.94.75"
     assert v6 == "99.994.975"
-    assert v7 == "2.5.8"
     assert v8 == "2.5.0"
 
     b1, client, v1 = is_supported_client(

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -18,7 +18,7 @@ from raiden.exceptions import (
 )
 from raiden.ui import cli
 from raiden.ui.cli import ReturnCode
-from raiden.utils.ethereum_clients import is_supported_client
+from raiden.utils.ethereum_clients import VersionSupport, is_supported_client
 
 
 @pytest.fixture
@@ -75,7 +75,7 @@ def test_run_error_reporting(cli_runner, monkeypatch):
 
 def test_check_is_supported_unknown_client():
     supported, client, version = is_supported_client("Aleth//v1.2.1")
-    assert not supported
+    assert supported is VersionSupport.UNSUPPORTED
     assert not client
     assert not version
 
@@ -90,8 +90,8 @@ def run_test_check_json_rpc_geth():
     g8, _, v8 = is_supported_client("Geth/v1.9.0-stable-52f24617/linux-amd64/go1.12.7")
     g9, _, v9 = is_supported_client("Geth/v1.9.0-unstable-3d3e83ec-20190611/linux-amd64/go1.12.5")
     assert client is EthClient.GETH
-    assert all([g1, g2, g3, g8, g9])
-    assert not any([g4, g5, g6])
+    assert {g1, g2, g3, g8, g9} == {VersionSupport.SUPPORTED}
+    assert {g4, g5, g6} == {VersionSupport.WARN}
     assert v1 == "1.7.3"
     assert v2 == "1.7.2"
     assert v3 == "1.8.2"
@@ -106,13 +106,13 @@ def run_test_check_json_rpc_geth():
     b3, _, v3 = is_supported_client("Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1")
     b4, _, _ = is_supported_client("Geth/v0.0.0-unstable-e9295163/linux-amd64/go1.9.1")
     assert client is EthClient.GETH
-    assert not any([b1, b2, b3, b4])
+    assert {b1, b2, b3, b4} == {VersionSupport.UNSUPPORTED}
     assert v1 == "1.7.1"
     assert v2 == "0.7.1"
     assert v3 == "0.0.0"
 
     supported, client, version = is_supported_client("Geth/faultyversion")
-    assert not supported
+    assert supported is VersionSupport.UNSUPPORTED
     assert not client
     assert not version
 
@@ -148,8 +148,8 @@ def run_test_check_json_rpc_parity():
         "Parity//v2.5.0-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     assert client is EthClient.PARITY
-    assert all([g1, g2, g3, g8])
-    assert not any([g4, g5, g6])
+    assert {g1, g2, g3, g8} == {VersionSupport.SUPPORTED}
+    assert {g4, g5, g6} == {VersionSupport.WARN}
     assert v1 == "1.7.6"
     assert v2 == "1.7.7"
     assert v3 == "1.8.7"
@@ -174,7 +174,7 @@ def run_test_check_json_rpc_parity():
         "Parity//v0.0.0-stable-19535333c-20171013/x86_64-linux-gnu/rustc1.20.0"
     )
     assert client is EthClient.PARITY
-    assert not any([b1, b2, b3, b4, b5])
+    assert {b1, b2, b3, b4, b5} == {VersionSupport.UNSUPPORTED}
     assert v1 == "1.7.5"
     assert v2 == "1.5.1"
     assert v3 == "0.7.1"
@@ -182,7 +182,7 @@ def run_test_check_json_rpc_parity():
     assert v5 == "0.0.0"
 
     supported, client, version = is_supported_client("Parity//faultyversion")
-    assert not supported
+    assert supported is VersionSupport.UNSUPPORTED
     assert not client
     assert not version
 

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -45,7 +45,6 @@ from raiden.settings import (
     ServiceConfig,
 )
 from raiden.ui.checks import (
-    check_ethereum_client_is_supported,
     check_ethereum_confirmed_block_is_not_pruned,
     check_ethereum_has_accounts,
     check_ethereum_network_id,
@@ -238,7 +237,6 @@ def run_raiden_service(
 
     check_sql_version()
     check_ethereum_has_accounts(account_manager)
-    check_ethereum_client_is_supported(web3)
     check_ethereum_network_id(network_id, web3)
 
     address, privatekey = get_account_and_private_key(account_manager, address, password_file)

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -4,22 +4,13 @@ import structlog
 from web3 import Web3
 
 from raiden.accounts import AccountManager
-from raiden.constants import (
-    EMPTY_SECRETHASH,
-    HIGHEST_SUPPORTED_GETH_VERSION,
-    HIGHEST_SUPPORTED_PARITY_VERSION,
-    LOWEST_SUPPORTED_GETH_VERSION,
-    LOWEST_SUPPORTED_PARITY_VERSION,
-    SQLITE_MIN_REQUIRED_VERSION,
-    Environment,
-)
-from raiden.exceptions import EthNodeInterfaceError, RaidenError
+from raiden.constants import EMPTY_SECRETHASH, SQLITE_MIN_REQUIRED_VERSION, Environment
+from raiden.exceptions import RaidenError
 from raiden.network.proxies.secret_registry import SecretRegistry
 from raiden.network.rpc.client import JSONRPCClient
 from raiden.settings import ORACLE_BLOCKNUMBER_DRIFT_TOLERANCE
 from raiden.storage.sqlite import assert_sqlite_version
 from raiden.ui.sync import wait_for_sync
-from raiden.utils.ethereum_clients import is_supported_client
 from raiden.utils.typing import (
     Address,
     BlockNumber,
@@ -52,26 +43,6 @@ def check_sql_version() -> None:
     if not assert_sqlite_version():
         version = "{}.{}.{}".format(*SQLITE_MIN_REQUIRED_VERSION)
         raise RaidenError(f"SQLite3 should be at least version {version}")
-
-
-def check_ethereum_client_is_supported(web3: Web3) -> None:
-    try:
-        node_version = web3.clientVersion
-    except ValueError:
-        raise EthNodeInterfaceError(
-            "The underlying ethereum node does not have the web3 rpc interface "
-            "enabled. Please run it with '--http.api eth,net,web3' for geth "
-            "and '--jsonrpc-apis=eth,net,web3,parity' for parity."
-        )
-
-    supported, our_client, our_version = is_supported_client(node_version)
-    if not supported:
-        raise RaidenError(
-            f"You need a Byzantium enabled ethereum node. Parity >= "
-            f"{LOWEST_SUPPORTED_PARITY_VERSION} <= {HIGHEST_SUPPORTED_PARITY_VERSION}"
-            f" or Geth >= {LOWEST_SUPPORTED_GETH_VERSION} <= {HIGHEST_SUPPORTED_GETH_VERSION}"
-            f" but you have {our_version} {our_client}"
-        )
 
 
 def check_ethereum_has_accounts(account_manager: AccountManager) -> None:

--- a/raiden/utils/ethereum_clients.py
+++ b/raiden/utils/ethereum_clients.py
@@ -30,21 +30,15 @@ def support_check(
     highest_supported_version_string: str,
     lowest_supported_version_string: str,
 ) -> bool:
+    """ Check if the eth client version is in the supported range
 
-    # TODO: Is there any better way to get major/minor/patch version from a Version object?
-    # Currently we use this private member which is not ideal. release is a tuple.
-    # Example: (1, 9, 0)
-    our_minor_num = our_version._version.release[1]
-
-    highest_supported_version: Version = parse_version(highest_supported_version_string)
-    highest_supported_min_num = highest_supported_version._version.release[1]
+    If every client strictly adhered to semver, we would only compare major
+    version numbers, here. Unfortunately, we had patch-level changes break
+    Raiden. So we actually check all version components, now.
+    """
     if our_version < parse_version(lowest_supported_version_string):
         return False
-
-    if our_version > highest_supported_version:
-        if our_minor_num == highest_supported_min_num:
-            return True
-        # else
+    if our_version > parse_version(highest_supported_version_string):
         return False
 
     return True

--- a/tools/generate_snapshot.py
+++ b/tools/generate_snapshot.py
@@ -16,7 +16,7 @@ from raiden.ui.app import rpc_normalized_endpoint
 from raiden.ui.checks import check_ethereum_network_id, check_synced
 from raiden.ui.cli import ETH_NETWORKID_OPTION, ETH_RPC_CONFIG_OPTION
 from raiden.utils.cli import NetworkChoiceType, group, option
-from raiden.utils.ethereum_clients import is_supported_client
+from raiden.utils.ethereum_clients import VersionSupport, is_supported_client
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     BlockNumber,
@@ -126,7 +126,7 @@ def main(output_directory, network_id, eth_rpc_endpoint, contracts_version):
 
     try:
         supported, _, _ = is_supported_client(web3.clientVersion)
-        assert supported, "Unsupported eth client"
+        assert supported is VersionSupport.SUPPORTED, "Unsupported eth client"
     except ConnectionError:
         click.secho(
             f"Couldn't connect to the ethereum node, double check it is running "

--- a/tools/generate_snapshot.py
+++ b/tools/generate_snapshot.py
@@ -13,13 +13,10 @@ from raiden.network.rpc.client import JSONRPCClient
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS, RAIDEN_CONTRACT_VERSION
 from raiden.tests.utils import factories
 from raiden.ui.app import rpc_normalized_endpoint
-from raiden.ui.checks import (
-    check_ethereum_client_is_supported,
-    check_ethereum_network_id,
-    check_synced,
-)
+from raiden.ui.checks import check_ethereum_network_id, check_synced
 from raiden.ui.cli import ETH_NETWORKID_OPTION, ETH_RPC_CONFIG_OPTION
 from raiden.utils.cli import NetworkChoiceType, group, option
+from raiden.utils.ethereum_clients import is_supported_client
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     BlockNumber,
@@ -128,7 +125,8 @@ def main(output_directory, network_id, eth_rpc_endpoint, contracts_version):
     web3 = Web3(HTTPProvider(rpc_normalized_endpoint(eth_rpc_endpoint)))
 
     try:
-        check_ethereum_client_is_supported(web3)
+        supported, _, _ = is_supported_client(web3.clientVersion)
+        assert supported, "Unsupported eth client"
     except ConnectionError:
         click.secho(
             f"Couldn't connect to the ethereum node, double check it is running "


### PR DESCRIPTION
The old check caused two kinds of problems:
* It prevented users from running on recently release eth clients
* It did not catch compatibility problems for changes in minor and patch level versions (which unfortunately do happen)

New behavior:
* Reduce version check error to a warning
* Warn for any version outside of the known range, event if it only changes in the patch level

This is not great, but it looks like an improvement to me.

Closes https://github.com/raiden-network/raiden/issues/6423

The SP integration test failure will be fixed by https://github.com/raiden-network/raiden/pull/6426/commits/40a50392f50f4c63b9e2971add687542aaabcb72 when https://github.com/raiden-network/raiden/pull/6426 is merged.