### PR TITLE
[WIP] Processing decode and dispatch per event not in batches

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -538,13 +538,13 @@ class BlockchainEvents:
         TNR    ####--*---
         TN           --*-
                      ^ ^
-                     | new channel openned
+                     | new channel opened
                      |
                      new token network registered
 
         For this example, the current batch is fetching the range `[4, 9]`. In
         this range a new token is registered at block 6, at block 8 a new
-        channel is openned in the new network.
+        channel is opened in the new network.
 
         If the events of the new TN are *not* queried, block 9 will be
         confirmed after processing the batch which adds the TN, and iff the
@@ -608,7 +608,7 @@ class BlockchainEvents:
                 ]
                 result.extend(decoded_events)
 
-                # Go throught he results and create the child filters, if
+                # Go through the results and create the child filters, if
                 # necessary.
                 #
                 # The generator result is converted to a list because we need

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -406,7 +406,7 @@ class RaidenEventHandler(EventHandler):
         )
 
         if channel_state is None:
-            raise RaidenUnrecoverableError("ContractSendChannelWithdraw for inexesting channel.")
+            raise RaidenUnrecoverableError("ContractSendChannelWithdraw for non-existing channel.")
 
         channel_proxy = raiden.proxy_manager.payment_channel(
             channel_state=channel_state, block_identifier=confirmed_block_identifier
@@ -462,7 +462,7 @@ class RaidenEventHandler(EventHandler):
         )
 
         if channel_state is None:
-            raise RaidenUnrecoverableError("ContractSendChannelClose for inexesting channel.")
+            raise RaidenUnrecoverableError("ContractSendChannelClose for non-existing channel.")
 
         channel_proxy = raiden.proxy_manager.payment_channel(
             channel_state=channel_state, block_identifier=confirmed_block_identifier
@@ -494,7 +494,7 @@ class RaidenEventHandler(EventHandler):
 
             if channel_state is None:
                 raise RaidenUnrecoverableError(
-                    "ContractSendChannelUpdateTransfer for inexesting channel."
+                    "ContractSendChannelUpdateTransfer for non-existing channel."
                 )
 
             channel = raiden.proxy_manager.payment_channel(
@@ -546,7 +546,7 @@ class RaidenEventHandler(EventHandler):
         )
         if channel_state is None:
             raise RaidenUnrecoverableError(
-                "ContractSendChannelBatchUnlock for inexesting channel."
+                "ContractSendChannelBatchUnlock for non-existing channel."
             )
 
         confirmed_block_identifier = state_from_raiden(raiden).block_hash
@@ -695,7 +695,7 @@ class RaidenEventHandler(EventHandler):
         )
 
         if channel_state is None:
-            raise RaidenUnrecoverableError("ContractSendChannelSettle for inexesting channel.")
+            raise RaidenUnrecoverableError("ContractSendChannelSettle for non-existing channel.")
 
         confirmed_block_identifier = chain_state.block_hash
         payment_channel: PaymentChannel = raiden.proxy_manager.payment_channel(

--- a/raiden/tests/integration/api/rest/test_channel.py
+++ b/raiden/tests/integration/api/rest/test_channel.py
@@ -429,7 +429,7 @@ def test_api_channel_open_close_and_settle(
     response = request.send().response
     assert_proper_response(response, HTTPStatus.CONFLICT)
 
-    # Try to create channel with the same partner again before previous channnel settles
+    # Try to create channel with the same partner again before previous channel settles
     request = grequests.put(
         api_url_for(api_server_test_instance, "channelsresource"), json=channel_data_obj
     )
@@ -668,8 +668,9 @@ def test_api_channel_state_change_errors(
     )
     response = request.send().response
     assert_proper_response(response)
-
+    breakpoint()
     # let's try to deposit to a settled channel
+    # TODO channel is not settled only closed
     request = grequests.patch(
         api_url_for(
             api_server_test_instance,


### PR DESCRIPTION
## Description

Fixes: #6444

The Raiden Clients decodes and dispatches all blockchain events in batches and not interleaved. That leads to bugs if in the same batch there are resulting state changes that depend on each other (like channel open and deposit).  

The goal is to decode and dispatch interleaved per item in a batch - instead of decoding every element and then dispatching every element.  

- [ ] Decode and process blockchain events interleaved
- [ ] Remove `pending_token_registrations`
- [ ] Proper DB tx handling
  - [ ] Maybe remove `maybe_commit`
- [ ] Investigate https://github.com/raiden-network/raiden/issues/6454


