### PR TITLE
Fix pytest temp dir on macOS

### DIFF
--- a/raiden/tests/fixtures/blockchain.py
+++ b/raiden/tests/fixtures/blockchain.py
@@ -5,6 +5,8 @@ import pytest
 from raiden.settings import RAIDEN_CONTRACT_VERSION
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 
+__all__ = ("contracts_path", "contract_manager")
+
 
 @pytest.fixture
 def contracts_path() -> Path:

--- a/raiden/tests/fixtures/variables.py
+++ b/raiden/tests/fixtures/variables.py
@@ -23,6 +23,47 @@ from raiden_contracts.constants import TEST_SETTLE_TIMEOUT_MAX, TEST_SETTLE_TIME
 
 DUPLICATED_BRACKETS = str.maketrans({"{": "{{", "}": "}}"})
 
+__all__ = (
+    "account_genesis_eth_balance",
+    "blockchain_extra_config",
+    "blockchain_key_seed",
+    "blockchain_number_of_nodes",
+    "blockchain_query_interval",
+    "blockchain_type",
+    "chain_id",
+    "channels_per_node",
+    "deploy_key",
+    "deposit",
+    "enable_rest_api",
+    "environment_type",
+    "eth_nodes_configuration",
+    "logs_storage",
+    "network_wait",
+    "number_of_nodes",
+    "number_of_tokens",
+    "port_generator",
+    "private_keys",
+    "privatekey_seed",
+    "random_marker",
+    "register_tokens",
+    "retries_before_backoff",
+    "retry_interval_initial",
+    "retry_interval_max",
+    "retry_timeout",
+    "reveal_timeout",
+    "settle_timeout",
+    "settle_timeout_max",
+    "settle_timeout_min",
+    "skip_if_not_geth",
+    "skip_if_not_parity",
+    "skip_if_parity",
+    "start_raiden_apps",
+    "token_amount",
+    "transport",
+    "transport_protocol",
+    "unrecoverable_error_should_crash",
+)
+
 
 class TransportProtocol(Enum):
     MATRIX = "matrix"


### PR DESCRIPTION
## Description

We previously already had a complicated implementation intending to fix too long temp dir paths on macOS.

This simplifies it greatly by overriding the base temp directory to use the public `/tmp` instead of the default per-user private long one.

(Also fix some flake8 warnings)