### PR TITLE
Remove usage of deprecated geth flags

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -231,7 +231,7 @@ def geth_assert_rpc_interfaces(web3: Web3) -> None:
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying geth node does not have the web3 rpc interface "
-            "enabled. Please run it with --rpcapi eth,net,web3"
+            "enabled. Please run it with '--http.api eth,net,web3'"
         )
 
     try:
@@ -239,7 +239,7 @@ def geth_assert_rpc_interfaces(web3: Web3) -> None:
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying geth node does not have the eth rpc interface "
-            "enabled. Please run it with --rpcapi eth,net,web3"
+            "enabled. Please run it with '--http.api eth,net,web3'"
         )
 
     try:
@@ -247,7 +247,7 @@ def geth_assert_rpc_interfaces(web3: Web3) -> None:
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying geth node does not have the net rpc interface "
-            "enabled. Please run it with --rpcapi eth,net,web3"
+            "enabled. Please run it with '--http.api eth,net,web3'"
         )
 
 

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -85,22 +85,21 @@ def geth_to_cmd(node: Dict, datadir: str, chain_id: ChainID, verbosity: str) -> 
     Return:
         cmd-args list
     """
-    node_config = [
-        "nodekeyhex",
-        "port",
-        "rpcport",
-        "bootnodes",
-        "minerthreads",
-        "unlock",
-        "password",
-    ]
+    node_config = {
+        "nodekeyhex": "nodekeyhex",
+        "port": "port",
+        "rpcport": "http.port",
+        "bootnodes": "bootnodes",
+        "minerthreads": "minerthreads",
+        "unlock": "unlock",
+        "password": "password",
+    }
 
     cmd = ["geth"]
 
-    for config in node_config:
+    for config, option in node_config.items():
         if config in node:
-            value = node[config]
-            cmd.extend([f"--{config}", str(value)])
+            cmd.extend([f"--{option}", str(node[config])])
 
     # Add parameters that are only required in newer versions
     geth_version_string, _ = subprocess.Popen(
@@ -128,10 +127,10 @@ def geth_to_cmd(node: Dict, datadir: str, chain_id: ChainID, verbosity: str) -> 
     # configuration flag.
     cmd.extend(
         [
-            "--rpc",
-            "--rpcapi",
+            "--http",
+            "--http.api",
             "eth,net,web3,personal,debug",
-            "--rpcaddr",
+            "--http.addr",
             "127.0.0.1",
             "--networkid",
             str(chain_id),

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -60,8 +60,8 @@ def check_ethereum_client_is_supported(web3: Web3) -> None:
     except ValueError:
         raise EthNodeInterfaceError(
             "The underlying ethereum node does not have the web3 rpc interface "
-            "enabled. Please run it with --rpcapi eth,net,web3 for geth "
-            "and --jsonrpc-apis=eth,net,web3,parity for parity."
+            "enabled. Please run it with '--http.api eth,net,web3' for geth "
+            "and '--jsonrpc-apis=eth,net,web3,parity' for parity."
         )
 
     supported, our_client, our_version = is_supported_client(node_version)


### PR DESCRIPTION
## Description

Fixes usage of deprecated geth flags. In the geth logs this looked like:
```
WARN [07-16|15:40:07.821] The flag --rpc is deprecated and will be removed in the future, please use --http 
WARN [07-16|15:40:07.821] The flag --rpcaddr is deprecated and will be removed in the future, please use --http.addr 
WARN [07-16|15:40:07.821] The flag --rpcport is deprecated and will be removed in the future, please use --http.port 
WARN [07-16|15:40:07.821] The flag --rpcapi is deprecated and will be removed in the future, please use --http.api 
```
