### PR TITLE
Cleanup state handling

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -6,7 +6,6 @@ itself, an utility should be added to `raiden.blockchain.state`, and then
 called by `blockchainevent_to_statechange`.
 """
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import structlog
 
@@ -21,11 +20,13 @@ from raiden.blockchain.state import (
     get_contractreceiveupdatetransfer_data_from_event,
 )
 from raiden.constants import EMPTY_LOCKSROOT, LOCKSROOT_OF_NO_LOCKS
-from raiden.settings import MediationFeeConfig
-from raiden.transfer import views
+from raiden.network.proxies.proxy_manager import ProxyManager
+from raiden.settings import MediationFeeConfig, RaidenConfig
+from raiden.storage.sqlite import SerializedSQLiteStorage
 from raiden.transfer.architecture import StateChange
 from raiden.transfer.identifiers import CanonicalIdentifier
 from raiden.transfer.state import (
+    ChainState,
     FeeScheduleState,
     NettingChannelEndState,
     NettingChannelState,
@@ -66,9 +67,6 @@ from raiden_contracts.constants import (
     EVENT_TOKEN_NETWORK_CREATED,
     ChannelEvent,
 )
-
-if TYPE_CHECKING:
-    from raiden.raiden_service import RaidenService
 
 log = structlog.get_logger(__name__)
 
@@ -338,20 +336,17 @@ def contractreceivechannelbatchunlock_from_event(
 
 
 def blockchainevent_to_statechange(
-    raiden: "RaidenService",
+    raiden_config: RaidenConfig,
+    proxy_manager: ProxyManager,
+    raiden_storage: SerializedSQLiteStorage,
+    chain_state: ChainState,
     event: DecodedEvent,
     current_confirmed_head: BlockNumber,
     pendingtokenregistration: Dict[
         TokenNetworkAddress, Tuple[TokenNetworkRegistryAddress, TokenAddress]
     ],
 ) -> List[StateChange]:  # pragma: no unittest
-    msg = "The state of the node has to be primed before blockchain events can be processed."
-    assert raiden.wal, msg
-
     event_name = event.event_data["event"]
-    chain_state = views.state_from_raiden(raiden)
-    proxy_manager = raiden.proxy_manager
-
     state_changes: List[StateChange] = []
 
     if event_name == EVENT_TOKEN_NETWORK_CREATED:
@@ -365,9 +360,9 @@ def blockchainevent_to_statechange(
         )
 
         if new_channel_details is not None:
-            fee_config: MediationFeeConfig = raiden.config.mediation_fees
+            fee_config = raiden_config.mediation_fees
             channel_config = ChannelConfig(
-                reveal_timeout=raiden.config.reveal_timeout,
+                reveal_timeout=raiden_config.reveal_timeout,
                 fee_schedule=FeeScheduleState(
                     cap_fees=fee_config.cap_meditation_fees,
                     flat=fee_config.get_flat_fee(new_channel_details.token_address),
@@ -383,11 +378,11 @@ def blockchainevent_to_statechange(
             state_changes.append(contractreceiveroutenew_from_event(event))
 
     elif event_name == ChannelEvent.DEPOSIT:
-        deposit = contractreceivechanneldeposit_from_event(event, raiden.config.mediation_fees)
+        deposit = contractreceivechanneldeposit_from_event(event, raiden_config.mediation_fees)
         state_changes.append(deposit)
 
     elif event_name == ChannelEvent.WITHDRAW:
-        withdraw = contractreceivechannelwithdraw_from_event(event, raiden.config.mediation_fees)
+        withdraw = contractreceivechannelwithdraw_from_event(event, raiden_config.mediation_fees)
         state_changes.append(withdraw)
 
     elif event_name == ChannelEvent.BALANCE_PROOF_UPDATED:
@@ -425,7 +420,7 @@ def blockchainevent_to_statechange(
 
     elif event_name == ChannelEvent.UNLOCKED:
         canonical_identifier = get_contractreceivechannelbatchunlock_data_from_event(
-            chain_state, raiden.wal.storage, event
+            chain_state, raiden_storage, event
         )
 
         if canonical_identifier is not None:

--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -137,7 +137,7 @@ class MessageHandler:
                         balance_proof.nonce,
                     )
 
-                return (0, 0)
+                return 0, 0
 
             all_state_changes.sort(key=by_canonical_identifier)
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -98,9 +98,8 @@ from raiden.transfer.mediated_transfer.state_change import (
     ReceiveTransferRefund,
 )
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask
-from raiden.transfer.state import ChainState, NetworkState, TokenNetworkRegistryState
+from raiden.transfer.state import ChainState, TokenNetworkRegistryState
 from raiden.transfer.state_change import (
-    ActionChangeNodeNetworkState,
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
     ActionInitChain,
@@ -1018,10 +1017,6 @@ class RaidenService(Runnable):
                 log.error(str(e))
             else:
                 raise
-
-    def set_node_network_state(self, node_address: Address, network_state: NetworkState) -> None:
-        state_change = ActionChangeNodeNetworkState(node_address, network_state)
-        self.handle_and_track_state_changes([state_change])
 
     def async_start_health_check_for(self, node_address: Address) -> None:
         """Start health checking `node_address`.

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1122,6 +1122,8 @@ class RaidenService(Runnable):
             ] = dict()
 
             state_changes: List[StateChange] = list()
+            chain_state = views.state_from_raiden(self)
+            assert self.wal, "raiden.wal not set"
             for event in poll_result.events:
                 # Important: `blockchainevent_to_statechange` has to be called
                 # with the block of the current confirmed head! An unconfirmed
@@ -1131,7 +1133,13 @@ class RaidenService(Runnable):
                 # the `current_confirmed_head` stays valid.
                 state_changes.extend(
                     blockchainevent_to_statechange(
-                        self, event, current_confirmed_head, pendingtokenregistration
+                        raiden_config=self.config,
+                        proxy_manager=self.proxy_manager,
+                        raiden_storage=self.wal.storage,
+                        chain_state=chain_state,
+                        event=event,
+                        current_confirmed_head=current_confirmed_head,
+                        pendingtokenregistration=pendingtokenregistration,
                     )
                 )
 


### PR DESCRIPTION
## Description

Some cleanup taken out of https://github.com/raiden-network/raiden/pull/6449 in order to make the PR smaller.

- Pass more detailed parameters to `blockchainevent_to_statechange`
- Remove unused `RaidenService.set_node_network_state`