### PR TITLE
Fix 6444

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`6444` Fix a race condition when processing blockchain events.
+
 * :release:`1.1.1 <2020-07-20>`
 * :feature:`-` Update WebUI to version 1.0.2 https://github.com/raiden-network/webui/releases/tag/v1.0.2
 * :feature:`5407` Add ``/contracts`` endpoint with information about the used contracts.

--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -39,13 +39,11 @@ from raiden.utils.typing import (
     Address,
     BlockNumber,
     ChainID,
-    Dict,
     Locksroot,
     Optional,
     TokenAddress,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
-    Tuple,
 )
 
 
@@ -223,11 +221,7 @@ def get_contractreceivechannelbatchunlock_data_from_event(
 
 
 def get_contractreceivechannelnew_data_from_event(
-    chain_state: ChainState,
-    event: DecodedEvent,
-    pendingtokenregistration: Dict[
-        TokenNetworkAddress, Tuple[TokenNetworkRegistryAddress, TokenAddress]
-    ],
+    chain_state: ChainState, event: DecodedEvent,
 ) -> Optional[NewChannelDetails]:
     token_network_address = TokenNetworkAddress(event.originating_contract)
     data = event.event_data
@@ -245,22 +239,17 @@ def get_contractreceivechannelnew_data_from_event(
         # Not a channel which this node is a participant
         return None
 
-    pending_addresses = pendingtokenregistration.get(token_network_address)
+    token_network_registry = views.get_token_network_registry_by_token_network_address(
+        chain_state, token_network_address
+    )
+    assert token_network_registry is not None, "Token network registry missing"
 
-    if pending_addresses:
-        token_network_registry_address, token_address = pending_addresses
-    else:
-        token_network_registry = views.get_token_network_registry_by_token_network_address(
-            chain_state, token_network_address
-        )
-        assert token_network_registry is not None, "Token network registry missing"
-
-        token_network = views.get_token_network_by_address(
-            chain_state=chain_state, token_network_address=token_network_address
-        )
-        assert token_network is not None, "Token network missing"
-        token_network_registry_address = token_network_registry.address
-        token_address = token_network.token_address
+    token_network = views.get_token_network_by_address(
+        chain_state=chain_state, token_network_address=token_network_address
+    )
+    assert token_network is not None, "Token network missing"
+    token_network_registry_address = token_network_registry.address
+    token_address = token_network.token_address
 
     return NewChannelDetails(
         chain_id=event.chain_id,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -133,7 +133,6 @@ from raiden.utils.typing import (
     SecretHash,
     SecretRegistryAddress,
     TargetAddress,
-    TokenAddress,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
     WithdrawAmount,
@@ -1118,10 +1117,6 @@ class RaidenService(Runnable):
                 # No blocks could be fetched (due to timeout), retry
                 continue
 
-            pendingtokenregistration: Dict[
-                TokenNetworkAddress, Tuple[TokenNetworkRegistryAddress, TokenAddress]
-            ] = dict()
-
             assert self.wal, "raiden.wal not set"
             for event in poll_result.events:
                 # Important: `blockchainevent_to_statechange` has to be called
@@ -1137,7 +1132,6 @@ class RaidenService(Runnable):
                     chain_state=views.state_from_raiden(self),
                     event=event,
                     current_confirmed_head=current_confirmed_head,
-                    pendingtokenregistration=pendingtokenregistration,
                 )
                 if maybe_state_change is not None:
                     self.handle_and_track_state_changes([maybe_state_change])

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1130,17 +1130,17 @@ class RaidenService(Runnable):
                 # of reorgs, and older blocks are not sufficient to fix
                 # problems with pruning, the `SyncTimeout` is used to ensure
                 # the `current_confirmed_head` stays valid.
-                self.handle_and_track_state_changes(
-                    blockchainevent_to_statechange(
-                        raiden_config=self.config,
-                        proxy_manager=self.proxy_manager,
-                        raiden_storage=self.wal.storage,
-                        chain_state=views.state_from_raiden(self),
-                        event=event,
-                        current_confirmed_head=current_confirmed_head,
-                        pendingtokenregistration=pendingtokenregistration,
-                    )
+                maybe_state_change = blockchainevent_to_statechange(
+                    raiden_config=self.config,
+                    proxy_manager=self.proxy_manager,
+                    raiden_storage=self.wal.storage,
+                    chain_state=views.state_from_raiden(self),
+                    event=event,
+                    current_confirmed_head=current_confirmed_head,
+                    pendingtokenregistration=pendingtokenregistration,
                 )
+                if maybe_state_change is not None:
+                    self.handle_and_track_state_changes([maybe_state_change])
 
             # On restarts the node has to pick up all events generated since the
             # last run. To do this the node will set the filters' from_block to

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -835,6 +835,12 @@ class RaidenService(Runnable):
         if len(state_changes) == 0:
             return
 
+        # It's important to /not/ block here, because this function can
+        # be called from the alarm task greenlet, which should not
+        # starve. This was a problem when the node decided to send a new
+        # transaction, since the proxies block until the transaction is
+        # mined and confirmed (e.g. the settle window is over and the
+        # node sends the settle transaction).
         for greenlet in self.handle_state_changes(state_changes):
             self.add_pending_greenlet(greenlet)
 
@@ -1116,8 +1122,6 @@ class RaidenService(Runnable):
                 TokenNetworkAddress, Tuple[TokenNetworkRegistryAddress, TokenAddress]
             ] = dict()
 
-            state_changes: List[StateChange] = list()
-            chain_state = views.state_from_raiden(self)
             assert self.wal, "raiden.wal not set"
             for event in poll_result.events:
                 # Important: `blockchainevent_to_statechange` has to be called
@@ -1126,12 +1130,12 @@ class RaidenService(Runnable):
                 # of reorgs, and older blocks are not sufficient to fix
                 # problems with pruning, the `SyncTimeout` is used to ensure
                 # the `current_confirmed_head` stays valid.
-                state_changes.extend(
+                self.handle_and_track_state_changes(
                     blockchainevent_to_statechange(
                         raiden_config=self.config,
                         proxy_manager=self.proxy_manager,
                         raiden_storage=self.wal.storage,
-                        chain_state=chain_state,
+                        chain_state=views.state_from_raiden(self),
                         event=event,
                         current_confirmed_head=current_confirmed_head,
                         pendingtokenregistration=pendingtokenregistration,
@@ -1175,15 +1179,7 @@ class RaidenService(Runnable):
                 gas_limit=poll_result.polled_block_gas_limit,
                 block_hash=poll_result.polled_block_hash,
             )
-            state_changes.append(block_state_change)
-
-            # It's important to /not/ block here, because this function can
-            # be called from the alarm task greenlet, which should not
-            # starve. This was a problem when the node decided to send a new
-            # transaction, since the proxies block until the transaction is
-            # mined and confirmed (e.g. the settle window is over and the
-            # node sends the settle transaction).
-            self.handle_and_track_state_changes(state_changes)
+            self.handle_and_track_state_changes([block_state_change])
 
             self._log_sync_progress(poll_result.polled_block_number, current_confirmed_head)
 

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -358,7 +358,6 @@ def test_fees_are_updated_during_startup(
     assert channel_state.fee_schedule.imbalance_penalty == full_imbalance_penalty
 
 
-@pytest.mark.xfail(reason="Pending fix")
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -24,13 +24,20 @@ from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
 )
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
+from raiden.tests.integration.fixtures.raiden_network import RestartNode
+from raiden.tests.integration.test_integration_pfs import wait_all_apps
 from raiden.tests.utils.detect_failure import expect_failure, raise_on_failure
 from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.network import CHAIN
 from raiden.tests.utils.transfer import transfer
 from raiden.transfer import views
 from raiden.transfer.state import NettingChannelState
-from raiden.transfer.state_change import Block
+from raiden.transfer.state_change import (
+    Block,
+    ContractReceiveChannelClosed,
+    ContractReceiveChannelNew,
+    ContractReceiveRouteClosed,
+)
 from raiden.ui.startup import RaidenBundle
 from raiden.utils.copy import deepcopy
 from raiden.utils.typing import (
@@ -40,6 +47,7 @@ from raiden.utils.typing import (
     PaymentAmount,
     PaymentID,
     ProportionalFeeAmount,
+    TokenAddress,
     Type,
 )
 
@@ -348,3 +356,57 @@ def test_fees_are_updated_during_startup(
     ]
 
     assert channel_state.fee_schedule.imbalance_penalty == full_imbalance_penalty
+
+
+@pytest.mark.xfail(reason="Pending fix")
+@raise_on_failure
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("channels_per_node", [0])
+@pytest.mark.parametrize("number_of_tokens", [1])
+def test_blockchain_event_processed_interleaved(
+    raiden_network: List[RaidenService],
+    token_addresses: List[TokenAddress],
+    restart_node: RestartNode,
+):
+    """ Blockchain events must be transformed into state changes and processed by
+    the state machine interleaved.
+
+    Otherwise problems arise when the creation of the state change is dependent
+    on the state of the state machine.
+
+    Regression test for: https://github.com/raiden-network/raiden/issues/6444
+    """
+    app0, app1 = raiden_network
+
+    app1.stop()
+
+    api0 = RaidenAPI(app0)
+    channel_id = api0.channel_open(
+        registry_address=app0.default_registry.address,
+        token_address=token_addresses[0],
+        partner_address=app1.address,
+    )
+    api0.channel_close(
+        registry_address=app0.default_registry.address,
+        token_address=token_addresses[0],
+        partner_address=app1.address,
+    )
+
+    # Restart node 1
+    restart_node(app1)
+    wait_all_apps(raiden_network)
+
+    # Check correct events
+    assert app1.wal, "app1.wal not set"
+    app1_state_changes = app1.wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
+
+    assert search_for_item(
+        app1_state_changes, ContractReceiveChannelNew, {"channel_identifier": channel_id}
+    )
+
+    assert search_for_item(
+        app1_state_changes, ContractReceiveChannelClosed, {"channel_identifier": channel_id}
+    )
+    assert not search_for_item(
+        app1_state_changes, ContractReceiveRouteClosed, {"channel_identifier": channel_id}
+    )


### PR DESCRIPTION
## Description

Fixes: #6444

When receiving events from the blockchain, those events are transformed into state changes which are processed by the state machine.

In the past we batched the transformation and the processing in order to speed up execution. As we found out in #6444, this doesn't work in general, as the transformation from blockchain event to state changes might require prior state to be available in the state machine.

An example for this is the `ChannelClosed` event, which creates different state changes depending on whether or not the channel is found in the state.

This bug is solved by interleaving creation and processing of the state changes.

This is the minimal change necessary to fix this bug, further improvements should be subsequently. I'll link issues here.

### Follow-ups
- #6454
- https://github.com/raiden-network/raiden/issues/6473
- https://github.com/raiden-network/raiden/issues/6474
