### PR TITLE
Enable flaky test but rerun on failure

### DIFF
--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -142,7 +142,7 @@ def test_register_token_insufficient_eth(
         )
 
 
-@pytest.mark.skip(reason="flaky, see https://github.com/raiden-network/raiden/issues/5744")
+@pytest.mark.flaky
 @raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("number_of_nodes", [2])


### PR DESCRIPTION
Since we can't reliably get the reason for an estimateGas error at the
moment, there is a small chance or raising an unrecoverable error in
this test. Rerun the test until the eth clients provide better APIs.

Closes https://github.com/raiden-network/raiden/issues/5744.