### PR TITLE
Introduce capabilites

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -82,6 +82,16 @@ class Networks(Enum):
     SMOKETEST = ChainID(627)
 
 
+class Capabilities(Enum):
+    """Capabilities allow for protocol handshake between nodes.
+    """
+
+    NO_RECEIVE = "noReceive"  # won't proceed with protocol for incoming transfers
+    NO_MEDIATE = "noMediate"  # can't mediate transfers; mediating requires receiving
+    NO_DELIVERY = "noDelivery"  # don't need Delivery messages
+    WEBRTC = "webRTC"
+
+
 # Set at 64 since parity's default is 64 and Geth's default is 128
 # TODO: Make this configurable. Since in parity this is also a configurable value
 STATE_PRUNING_AFTER_BLOCKS = 64

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -73,6 +73,7 @@ from raiden.utils.typing import (
     MessageID,
     NamedTuple,
     Optional,
+    PeerCapabilities,
     RoomID,
     Set,
     Tuple,
@@ -1379,7 +1380,7 @@ class MatrixTransport(Runnable):
         )
 
     def _address_reachability_changed(
-        self, address: Address, reachability: AddressReachability
+        self, address: Address, reachability: AddressReachability, capabilities: PeerCapabilities
     ) -> None:
         if reachability is AddressReachability.REACHABLE:
             node_reachability = NetworkState.REACHABLE
@@ -1395,6 +1396,7 @@ class MatrixTransport(Runnable):
             raise TypeError(f'Unexpected reachability state "{reachability}".')
 
         assert self._raiden_service is not None, "_raiden_service not set"
+        self._address_mgr._address_to_capabilities[address] = capabilities
         state_change = ActionChangeNodeNetworkState(address, node_reachability)
         self._raiden_service.handle_and_track_state_changes([state_change])
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -54,6 +54,7 @@ from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
 from raiden.transfer.state import NetworkState, QueueIdsToQueues
 from raiden.transfer.state_change import ActionChangeNodeNetworkState
+from raiden.utils.capabilities import capconfig_to_dict
 from raiden.utils.formatting import to_checksum_address, to_hex_address
 from raiden.utils.logging import redact_secret
 from raiden.utils.notifying_queue import NotifyingQueue
@@ -442,10 +443,12 @@ class MatrixTransport(Runnable):
         self._address_mgr.start()
 
         try:
+            capabilities = capconfig_to_dict(self._config.capabilities_config)
             login(
                 client=self._client,
                 signer=self._raiden_service.signer,
                 prev_auth_data=prev_auth_data,
+                capabilities=capabilities,
             )
         except ValueError:
             # `ValueError` may be raised if `get_user` provides invalid data to

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -128,6 +128,14 @@ class MediationFeeConfig:
 
 
 @dataclass
+class CapabilitiesConfig:
+    no_receive: bool = False
+    no_mediate: bool = False
+    no_delivery: bool = False
+    web_rtc: bool = False
+
+
+@dataclass
 class MatrixTransportConfig:
     retries_before_backoff: int
     retry_interval_initial: float
@@ -137,6 +145,7 @@ class MatrixTransportConfig:
     available_servers: List[str]
     sync_timeout: int = DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT
     sync_latency: int = DEFAULT_TRANSPORT_MATRIX_SYNC_LATENCY
+    capabilities_config: CapabilitiesConfig = CapabilitiesConfig()
 
 
 @dataclass
@@ -201,6 +210,7 @@ class RaidenConfig:
         retry_interval_max=DEFAULT_TRANSPORT_MATRIX_RETRY_INTERVAL_MAX,
         server=MATRIX_AUTO_SELECT_SERVER,
         sync_timeout=DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
+        capabilities_config=CapabilitiesConfig(),
     )
 
     rest_api: RestApiConfig = RestApiConfig()

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -8,6 +8,7 @@ from gevent.event import AsyncResult
 
 from raiden.constants import Environment, RoutingMode
 from raiden.raiden_service import RaidenService
+from raiden.settings import CapabilitiesConfig
 from raiden.tests.utils.network import (
     CHAIN,
     BlockchainServices,
@@ -82,6 +83,7 @@ def raiden_chain(
     resolver_ports: List[Optional[int]],
     enable_rest_api: bool,
     port_generator: Iterator[Port],
+    capabilities: CapabilitiesConfig,
 ) -> Iterable[List[RaidenService]]:
 
     if len(token_addresses) != 1:
@@ -122,6 +124,7 @@ def raiden_chain(
         resolver_ports=resolver_ports,
         enable_rest_api=enable_rest_api,
         port_generator=port_generator,
+        capabilities_config=capabilities,
     )
 
     confirmed_block = BlockNumber(raiden_apps[0].confirmation_blocks + 1)
@@ -188,6 +191,18 @@ def resolvers(resolver_ports):
 
 
 @pytest.fixture
+def adhoc_capability():
+    return False
+
+
+@pytest.fixture
+def capabilities(adhoc_capability) -> CapabilitiesConfig:
+    config = CapabilitiesConfig()
+    config.adhoc_capability = adhoc_capability  # type: ignore
+    return config
+
+
+@pytest.fixture
 def raiden_network(
     token_addresses: List[TokenAddress],
     token_network_registry_address: TokenNetworkRegistryAddress,
@@ -217,6 +232,7 @@ def raiden_network(
     resolver_ports: List[Optional[int]],
     enable_rest_api: bool,
     port_generator: Iterator[Port],
+    capabilities: CapabilitiesConfig,
 ) -> Iterable[List[RaidenService]]:
     service_registry_address = None
     if blockchain_services.service_registry:
@@ -249,6 +265,7 @@ def raiden_network(
         resolver_ports=resolver_ports,
         enable_rest_api=enable_rest_api,
         port_generator=port_generator,
+        capabilities_config=capabilities,
     )
 
     confirmed_block = BlockNumber(raiden_apps[0].confirmation_blocks + 1)

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -58,7 +58,7 @@ from raiden.transfer.state import NetworkState
 from raiden.transfer.state_change import ActionChannelClose
 from raiden.utils.capabilities import parse_capabilities
 from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import Address, Dict, List, TokenNetworkAddress, cast
+from raiden.utils.typing import Address, Dict, List, PeerCapabilities, TokenNetworkAddress, cast
 from raiden.waiting import wait_for_network_state
 
 HOP1_BALANCE_PROOF = factories.BalanceProofSignedStateProperties(pkey=factories.HOP1_KEY)
@@ -1352,3 +1352,7 @@ def test_transport_capabilities(raiden_network: List[RaidenService], retry_timeo
     assert "adhoc_capability" in app1_avatar_url, "avatar_url not set for app1"
     msg = "capabilities could not be parsed"
     assert parse_capabilities(app1_avatar_url) == dict(adhoc_capability=True), msg
+
+    msg = "capabilities were not collected in transport client"
+    collected_capabilities = app0.transport._address_mgr.get_address_capabilities(app1.address)
+    assert collected_capabilities == PeerCapabilities(dict(adhoc_capability=True)), msg

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -56,6 +56,7 @@ from raiden.transfer import views
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
 from raiden.transfer.state import NetworkState
 from raiden.transfer.state_change import ActionChannelClose
+from raiden.utils.capabilities import parse_capabilities
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import Address, Dict, List, TokenNetworkAddress, cast
 from raiden.waiting import wait_for_network_state
@@ -1322,3 +1323,32 @@ def test_transport_presence_updates(
     app2.transport.immediate_health_check_for(app1.address)
     wait_for_network_state(app0, app2.address, NetworkState.REACHABLE, retry_timeout)
     wait_for_network_state(app1, app2.address, NetworkState.REACHABLE, retry_timeout)
+
+
+@raise_on_failure
+@pytest.mark.parametrize("matrix_server_count", [1])
+@pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("adhoc_capability", [True])
+@pytest.mark.parametrize(
+    "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]]
+)
+def test_transport_capabilities(raiden_network: List[RaidenService], retry_timeout):
+    """
+    Test that raiden matrix users have the `avatar_url` set in a format understood
+    by the capabilities parser.
+    """
+    app0, app1 = raiden_network
+
+    app0.transport.immediate_health_check_for(app1.address)
+    app1.transport.immediate_health_check_for(app0.address)
+
+    wait_for_network_state(app0, app1.address, NetworkState.REACHABLE, retry_timeout)
+    wait_for_network_state(app1, app0.address, NetworkState.REACHABLE, retry_timeout)
+
+    app1_user_ids = app0.transport.get_user_ids_for_address(app1.address)
+    assert len(app1_user_ids) == 1, "app1 should have exactly one user_id"
+    app1_user = app0.transport._client.get_user(app1_user_ids.pop())
+    app1_avatar_url = app1_user.get_avatar_url()
+    assert "adhoc_capability" in app1_avatar_url, "avatar_url not set for app1"
+    msg = "capabilities could not be parsed"
+    assert parse_capabilities(app1_avatar_url) == dict(adhoc_capability=True), msg

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -45,7 +45,15 @@ class DummyMatrixClient:
     def search_user_directory(self, term: str) -> Iterator[User]:
         for user in self._user_directory_content:
             if term in user.user_id:
+                if user.api is None:
+                    user.api = self.api
                 yield user
+
+    def get_user(self, user_id: str) -> User:
+        all_users = list(self.search_user_directory(user_id))
+        if len(all_users):
+            return all_users[0]
+        raise MatrixRequestError(404, "Unknown user")
 
     def get_user_presence(self, user_id: str) -> str:
         presence = self._user_presence.get(user_id)
@@ -108,7 +116,7 @@ def user_presence():
 
 
 @pytest.fixture
-def user_capability():
+def address_capability():
     """Storage `user_capability` will update. Useful to assert over in tests."""
     return {}
 
@@ -128,10 +136,10 @@ def user_presence_callback(user_presence):
 
 
 @pytest.fixture
-def address_reachability_callback(address_reachability, user_capability):
+def address_reachability_callback(address_reachability, address_capability):
     def _callback(address, reachability, capabilities):
         address_reachability[address] = reachability
-        user_capability[address] = capabilities
+        address_capability[address] = capabilities
 
     return _callback
 

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -16,6 +16,12 @@ class DummyApi:
     def get_display_name(self, user_id):  # pylint: disable=no-self-use,unused-argument
         return "DUMMY_DISPLAYNAME"
 
+    def get_avatar_url(self, user_id):  # pylint: disable=no-self-use,unused-argument
+        return "DUMMY_CAPABILITY"
+
+    def get_download_url(self, value):  # pylint: disable=no-self-use
+        return value
+
 
 class DummyMatrixClient:
     def __init__(self, user_id: str, user_directory_content: Optional[List[User]] = None):
@@ -102,6 +108,12 @@ def user_presence():
 
 
 @pytest.fixture
+def user_capability():
+    """Storage `user_capability` will update. Useful to assert over in tests."""
+    return {}
+
+
+@pytest.fixture
 def address_reachability():
     """Storage `address_reachability_callback` will update. Useful to assert over in tests."""
     return {}
@@ -116,9 +128,10 @@ def user_presence_callback(user_presence):
 
 
 @pytest.fixture
-def address_reachability_callback(address_reachability):
-    def _callback(address, reachability):
+def address_reachability_callback(address_reachability, user_capability):
+    def _callback(address, reachability, capabilities):
         address_reachability[address] = reachability
+        user_capability[address] = capabilities
 
     return _callback
 

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -20,6 +20,7 @@ from raiden.settings import (
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
     DEFAULT_RETRY_TIMEOUT,
     BlockchainConfig,
+    CapabilitiesConfig,
     MatrixTransportConfig,
     MediationFeeConfig,
     RaidenConfig,
@@ -402,6 +403,7 @@ def create_apps(
     resolver_ports: List[Optional[int]],
     enable_rest_api: bool,
     port_generator: Iterator[Port],
+    capabilities_config: CapabilitiesConfig,
 ) -> List[RaidenService]:
     """ Create the apps."""
     # pylint: disable=too-many-locals
@@ -431,6 +433,7 @@ def create_apps(
             console=False,
             transport_type="matrix",
         )
+        config.transport.capabilities_config = capabilities_config
 
         if local_matrix_url is not None:
             config.transport = MatrixTransportConfig(
@@ -440,8 +443,10 @@ def create_apps(
                 retry_interval_max=retry_interval_max,
                 server=local_matrix_url,
                 available_servers=[],
+                capabilities_config=capabilities_config,
             )
 
+        assert config.transport.capabilities_config is not None
         if resolver_port is not None:
             config.resolver_endpoint = f"http://localhost:{resolver_port}"
 
@@ -481,6 +486,7 @@ def create_apps(
             )
 
         # Use `TestMatrixTransport` that saves sent messages for assertions in tests
+        assert config.transport.capabilities_config is not None
         transport = TestMatrixTransport(config=config.transport, environment=environment_type)
 
         raiden_event_handler = RaidenEventHandler()

--- a/raiden/utils/capabilities.py
+++ b/raiden/utils/capabilities.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, Optional
+
+from raiden.constants import Capabilities
+from raiden.settings import CapabilitiesConfig
+
+
+def parse_capabilities(capstring: str) -> Dict[str, Any]:
+    if capstring.startswith("mxc://"):
+        capstring = capstring[6:]
+    elif "/" in capstring:
+        capstring = capstring[capstring.rindex("/") + 1 :]
+    result: Dict[str, Any] = {}
+    if len(capstring) == 0:
+        return result
+    for token in capstring.split(","):
+        if "=" in token:
+            key, value = token.split("=")
+            value = value.strip('"')
+            result[key] = value
+        else:
+            result[token] = True
+    return result
+
+
+def serialize_capabilities(capdict: Optional[Dict[str, Any]]) -> str:
+    for key in (capdict or {}).keys():
+        if "/" in str(key):
+            raise ValueError(f"Key {key} is malformed, '/' not allowed")
+    if capdict is None:
+        return "mxc://"
+    entries = []
+    for key, value in capdict.items():
+        if isinstance(value, bool):
+            if value:
+                entries.append(key)
+        else:
+            entries.append(f'{key}="{value}"')
+    if len(entries):
+        return f"mxc://{','.join(entries)}"
+    return "mxc://"
+
+
+def capdict_to_config(capdict: Dict[str, Any]) -> CapabilitiesConfig:
+    config = CapabilitiesConfig(
+        no_receive=capdict.get(Capabilities.NO_RECEIVE.value, False),
+        no_mediate=capdict.get(Capabilities.NO_MEDIATE.value, False),
+        no_delivery=capdict.get(Capabilities.NO_DELIVERY.value, False),
+        web_rtc=capdict.get(Capabilities.WEBRTC.value, False),
+    )
+    for key in capdict.keys():
+        if key not in [_.value for _ in Capabilities]:
+            setattr(config, key, capdict[key])
+    return config
+
+
+def capconfig_to_dict(config: CapabilitiesConfig) -> Dict[str, Any]:
+    result = {}
+    result[Capabilities.NO_RECEIVE.value] = config.no_receive
+    result[Capabilities.NO_MEDIATE.value] = config.no_mediate
+    result[Capabilities.NO_DELIVERY.value] = config.no_delivery
+    result[Capabilities.WEBRTC.value] = config.web_rtc
+    for key in config.__dict__.keys():
+        if key not in [_.value for _ in Capabilities]:
+            result[key] = getattr(config, key)
+    return result

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -198,7 +198,7 @@ DatabasePath = Union[Path, Literal[":memory:"]]
 T_RoomID = str
 RoomID = NewType("RoomID", T_RoomID)
 
-T_PeerCapabilities = Dict[str, Any]
+T_PeerCapabilities = Dict[str, Union[str, bool]]
 PeerCapabilities = NewType("PeerCapabilities", T_PeerCapabilities)
 
 AddressTypes = Union[

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -198,6 +198,9 @@ DatabasePath = Union[Path, Literal[":memory:"]]
 T_RoomID = str
 RoomID = NewType("RoomID", T_RoomID)
 
+T_PeerCapabilities = Dict[str, Any]
+PeerCapabilities = NewType("PeerCapabilities", T_PeerCapabilities)
+
 AddressTypes = Union[
     Address,
     TokenAddress,


### PR DESCRIPTION
## Add protocol capabilities to the transport handshake

Fixes: #3283 

- sedes of capabilities are in a new module `utils/capability.py` https://github.com/raiden-network/raiden/pull/6482/files#diff-f02562dc4c1065f371e6994f4ba7c2c2
- this add manipulation of the matrix `avatar_url` with capability strings of the format defined in https://github.com/raiden-network/raiden/issues/3283#issuecomment-601270304
- the predefined capabilities are in `constants.py` https://github.com/raiden-network/raiden/pull/6482/files#diff-fc15643f6fbeaa49665008430fe239bbR85-R94
- the current client default settings are in `settings.py` https://github.com/raiden-network/raiden/pull/6482/files#diff-14a4915b775dfbab039e080a28553d78R130-R137
- on client startup the default settings are published during `login` of `matrix/utils.py` https://github.com/raiden-network/raiden/pull/6482/files#diff-b10b960f92576b8e90998119485c75ebR704
- on reachability changes, the `PeerCapabilities` are updated 