### PR TITLE
Add AtomicStateChangeDispatcher and use it for blockchain events

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -860,8 +860,24 @@ class RaidenService(Runnable):
         )
 
         old_state = views.state_from_raiden(self)
-        new_state, raiden_event_list = self.wal.log_and_dispatch(state_changes)
+        new_state, events = self.wal.log_and_dispatch(state_changes)
 
+        return self._trigger_state_change_effects(
+            old_state=old_state, new_state=new_state, state_changes=state_changes, events=events,
+        )
+
+    def _trigger_state_change_effects(
+        self,
+        old_state: ChainState,
+        new_state: ChainState,
+        state_changes: List[StateChange],
+        events: List[Event],
+    ) -> List[Greenlet]:
+        """Trigger effects that are based on processed state changes.
+
+        Examples are MS/PFS updates, transport communication channel updates
+        and presence checks.
+        """
         # For safety of the mediation the monitoring service must be updated
         # before the balance proof is sent. Otherwise a timing attack would be
         # possible, where an attacker would mediate a transfer through a node,
@@ -874,7 +890,6 @@ class RaidenService(Runnable):
         # all state changes to produce and send only unique messages. Assumption is
         # that the latest related state_change defines the correct messages.
         # Goal is to reduce messages.
-
         monitoring_updates: Dict[CanonicalIdentifier, BalanceProofStateChange] = dict()
         pfs_fee_updates: Set[CanonicalIdentifier] = set()
         pfs_capacity_updates: Set[CanonicalIdentifier] = set()
@@ -896,7 +911,7 @@ class RaidenService(Runnable):
                 else:
                     pfs_capacity_updates.add(canonical_identifier)
 
-        for event in raiden_event_list:
+        for event in events:
             if isinstance(event, PFS_UPDATE_FEE_EVENTS):
                 pfs_fee_updates.add(event.canonical_identifier)
             elif isinstance(event, PFS_UPDATE_CAPACITY_EVENTS):
@@ -924,9 +939,7 @@ class RaidenService(Runnable):
         log.debug(
             "Raiden events",
             node=to_checksum_address(self.address),
-            raiden_events=[
-                redact_secret(DictSerializer.serialize(event)) for event in raiden_event_list
-            ],
+            raiden_events=[redact_secret(DictSerializer.serialize(event)) for event in events],
         )
 
         self.state_change_qty += len(state_changes)
@@ -935,7 +948,7 @@ class RaidenService(Runnable):
             self.snapshot()
 
         if self.ready_to_process_events:
-            return self.async_handle_events(chain_state=new_state, raiden_events=raiden_event_list)
+            return self.async_handle_events(chain_state=new_state, raiden_events=events)
         else:
             return list()
 
@@ -1110,6 +1123,10 @@ class RaidenService(Runnable):
         )
         assert self.blockchain_events, msg
 
+        old_state = views.state_from_raiden(self)
+        state_changes = []
+        raiden_events = []
+
         guard = SyncTimeout(current_confirmed_head, timeout)
         while guard.should_continue(self.blockchain_events.last_fetched_block):
             poll_result = self.blockchain_events.fetch_logs_in_batch(current_confirmed_head)
@@ -1118,64 +1135,88 @@ class RaidenService(Runnable):
                 continue
 
             assert self.wal, "raiden.wal not set"
-            for event in poll_result.events:
-                # Important: `blockchainevent_to_statechange` has to be called
-                # with the block of the current confirmed head! An unconfirmed
-                # block could lead to the wrong state being dispatched because
-                # of reorgs, and older blocks are not sufficient to fix
-                # problems with pruning, the `SyncTimeout` is used to ensure
-                # the `current_confirmed_head` stays valid.
-                maybe_state_change = blockchainevent_to_statechange(
-                    raiden_config=self.config,
-                    proxy_manager=self.proxy_manager,
-                    raiden_storage=self.wal.storage,
-                    chain_state=views.state_from_raiden(self),
-                    event=event,
-                    current_confirmed_head=current_confirmed_head,
-                )
-                if maybe_state_change is not None:
-                    self.handle_and_track_state_changes([maybe_state_change])
+            with self.wal.process_state_change_atomically() as dispatcher:
+                for event in poll_result.events:
+                    # Important: `blockchainevent_to_statechange` has to be called
+                    # with the block of the current confirmed head! An unconfirmed
+                    # block could lead to the wrong state being dispatched because
+                    # of reorgs, and older blocks are not sufficient to fix
+                    # problems with pruning, the `SyncTimeout` is used to ensure
+                    # the `current_confirmed_head` stays valid.
+                    maybe_state_change = blockchainevent_to_statechange(
+                        raiden_config=self.config,
+                        proxy_manager=self.proxy_manager,
+                        raiden_storage=self.wal.storage,  # FXIME: use more recent
+                        chain_state=dispatcher.latest_state(),
+                        event=event,
+                        current_confirmed_head=current_confirmed_head,
+                    )
+                    if maybe_state_change is not None:
+                        events = dispatcher.dispatch(maybe_state_change)
 
-            # On restarts the node has to pick up all events generated since the
-            # last run. To do this the node will set the filters' from_block to
-            # the value of the latest block number known to have *all* events
-            # processed.
-            #
-            # To guarantee the above the node must either:
-            #
-            # - Dispatch the state changes individually, leaving the Block
-            # state change last, so that it knows all the events for the
-            # given block have been processed. On restarts this can result in
-            # the same event being processed twice.
-            # - Dispatch all the smart contract events together with the Block
-            # state change in a single transaction, either all or nothing will
-            # be applied, and on a restart the node picks up from where it
-            # left.
-            #
-            # The approach used below is to dispatch the Block and the
-            # blockchain events in a single transaction. This is the preferred
-            # approach because it guarantees that no events will be missed and
-            # it fixes race conditions on the value of the block number value,
-            # that can lead to crashes.
-            #
-            # Example: The user creates a new channel with an initial deposit
-            # of X tokens. This is done with two operations, the first is to
-            # open the new channel, the second is to deposit the requested
-            # tokens in it. Once the node fetches the event for the new channel,
-            # it will immediately request the deposit, which leaves a window for
-            # a race condition. If the Block state change was not yet
-            # processed, the block hash used as the triggering block for the
-            # deposit will be off-by-one, and it will point to the block
-            # immediately before the channel existed. This breaks a proxy
-            # precondition which crashes the client.
-            block_state_change = Block(
-                block_number=poll_result.polled_block_number,
-                gas_limit=poll_result.polled_block_gas_limit,
-                block_hash=poll_result.polled_block_hash,
-            )
-            self.handle_and_track_state_changes([block_state_change])
+                        state_changes.append(maybe_state_change)
+                        raiden_events.extend(events)
+
+                # On restarts the node has to pick up all events generated since the
+                # last run. To do this the node will set the filters' from_block to
+                # the value of the latest block number known to have *all* events
+                # processed.
+                #
+                # To guarantee the above the node must either:
+                #
+                # - Dispatch the state changes individually, leaving the Block
+                # state change last, so that it knows all the events for the
+                # given block have been processed. On restarts this can result in
+                # the same event being processed twice.
+                # - Dispatch all the smart contract events together with the Block
+                # state change in a single transaction, either all or nothing will
+                # be applied, and on a restart the node picks up from where it
+                # left.
+                #
+                # The approach used below is to dispatch the Block and the
+                # blockchain events in a single transaction. This is the preferred
+                # approach because it guarantees that no events will be missed and
+                # it fixes race conditions on the value of the block number value,
+                # that can lead to crashes.
+                #
+                # Example: The user creates a new channel with an initial deposit
+                # of X tokens. This is done with two operations, the first is to
+                # open the new channel, the second is to deposit the requested
+                # tokens in it. Once the node fetches the event for the new channel,
+                # it will immediately request the deposit, which leaves a window for
+                # a race condition. If the Block state change was not yet
+                # processed, the block hash used as the triggering block for the
+                # deposit will be off-by-one, and it will point to the block
+                # immediately before the channel existed. This breaks a proxy
+                # precondition which crashes the client.
+                block_state_change = Block(
+                    block_number=poll_result.polled_block_number,
+                    gas_limit=poll_result.polled_block_gas_limit,
+                    block_hash=poll_result.polled_block_hash,
+                )
+                events = dispatcher.dispatch(block_state_change)
+                state_changes.append(block_state_change)
+                raiden_events.extend(events)
 
             self._log_sync_progress(poll_result.polled_block_number, current_confirmed_head)
+
+        log.debug(
+            "State changes",
+            node=to_checksum_address(self.address),
+            state_changes=[
+                redact_secret(DictSerializer.serialize(state_change))
+                for state_change in state_changes
+            ],
+        )
+
+        event_greenlets = self._trigger_state_change_effects(
+            old_state=old_state,
+            new_state=views.state_from_raiden(self),
+            state_changes=state_changes,
+            events=raiden_events,
+        )
+        for greenlet in event_greenlets:
+            self.add_pending_greenlet(greenlet)
 
         current_synched_block_number = self.get_block_number()
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -860,10 +860,18 @@ class RaidenService(Runnable):
         )
 
         old_state = views.state_from_raiden(self)
-        new_state, events = self.wal.log_and_dispatch(state_changes)
+        raiden_events = []
+
+        with self.wal.process_state_change_atomically() as dispatcher:
+            for state_change in state_changes:
+                events = dispatcher.dispatch(state_change)
+                raiden_events.extend(events)
 
         return self._trigger_state_change_effects(
-            old_state=old_state, new_state=new_state, state_changes=state_changes, events=events,
+            old_state=old_state,
+            new_state=views.state_from_raiden(self),
+            state_changes=state_changes,
+            events=raiden_events,
         )
 
     def _trigger_state_change_effects(

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -88,6 +88,7 @@ def restore_to_state_change(
 
 
 ST = TypeVar("ST", bound=State)
+ST2 = TypeVar("ST2", bound=State)
 
 
 @dataclass(frozen=True)
@@ -129,10 +130,9 @@ class WriteAheadLog(Generic[ST]):
     def process_state_change_atomically(
         self,
     ) -> Generator[AtomicStateChangeDispatcher, None, None]:
-        # FIXME: fix mypy annotation
-        class _AtomicStateChangeDispatcher(AtomicStateChangeDispatcher, Generic[ST]):  # type: ignore  # noqa
+        class _AtomicStateChangeDispatcher(AtomicStateChangeDispatcher, Generic[ST2]):
             def __init__(
-                self, state_manager: StateManager[ST], storage: SerializedSQLiteStorage
+                self, state_manager: StateManager[ST2], storage: SerializedSQLiteStorage
             ) -> None:
                 self.state_manager = state_manager
                 self.storage = storage

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -81,7 +81,8 @@ def restore_to_state_change(
             ],
             node=to_checksum_address(node_address),
         )
-        wal.state_manager.dispatch(unapplied_state_changes)
+        for state_change in unapplied_state_changes:
+            wal.state_manager.dispatch(state_change)
 
     return state_change_qty, len(unapplied_state_changes), wal
 
@@ -139,7 +140,7 @@ class WriteAheadLog(Generic[ST]):
                 self.last_state_change_id: Optional[StateChangeID] = None
 
             def dispatch(self, state_change: StateChange) -> List[Event]:
-                _, events = self.state_manager.dispatch2(state_change)
+                _, events = self.state_manager.dispatch(state_change)
                 state_change_id = self.write_state_change_and_events(state_change, events)
 
                 self.last_state_change_id = state_change_id

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -60,6 +60,12 @@ def new_wal(state_transition: Callable, state: State = None) -> WriteAheadLog:
     return wal
 
 
+def dispatch(wal: WriteAheadLog, state_changes: List[StateChange]):
+    with wal.process_state_change_atomically() as dispatcher:
+        for state_change in state_changes:
+            dispatcher.dispatch(state_change)
+
+
 def test_connect_to_corrupt_db(tmpdir):
     serializer = JSONSerializer
     dbpath = os.path.join(tmpdir, "log.db")
@@ -104,13 +110,13 @@ def test_write_read_log() -> None:
     state_changes1 = wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     count1 = len(state_changes1)
 
-    wal.log_and_dispatch([block])
+    dispatch(wal, [block])
 
     state_changes2 = wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     count2 = len(state_changes2)
     assert count1 + 1 == count2
 
-    wal.log_and_dispatch([contract_receive_unlock])
+    dispatch(wal, [contract_receive_unlock])
 
     state_changes3 = wal.storage.get_statechanges_by_range(RANGE_ALL_STATE_CHANGES)
     count3 = len(state_changes3)
@@ -173,13 +179,13 @@ def test_restore_without_snapshot():
     wal = new_wal(state_transition_noop)
 
     block1 = Block(block_number=5, gas_limit=1, block_hash=make_transaction_hash())
-    wal.log_and_dispatch([block1])
+    dispatch(wal, [block1])
 
     block2 = Block(block_number=7, gas_limit=1, block_hash=make_transaction_hash())
-    wal.log_and_dispatch([block2])
+    dispatch(wal, [block2])
 
     block3 = Block(block_number=8, gas_limit=1, block_hash=make_transaction_hash())
-    wal.log_and_dispatch([block3])
+    dispatch(wal, [block3])
 
     _, _, newwal = restore_to_state_change(
         transition_function=state_transtion_acc,
@@ -198,7 +204,7 @@ def test_restore_without_snapshot_in_batches():
     block1 = Block(block_number=5, gas_limit=1, block_hash=make_transaction_hash())
     block2 = Block(block_number=7, gas_limit=1, block_hash=make_transaction_hash())
     block3 = Block(block_number=8, gas_limit=1, block_hash=make_transaction_hash())
-    wal.log_and_dispatch([block1, block2, block3])
+    dispatch(wal, [block1, block2, block3])
 
     _, _, newwal = restore_to_state_change(
         transition_function=state_transtion_acc,
@@ -217,19 +223,19 @@ def test_get_snapshot_before_state_change() -> None:
     block1 = Block(
         block_number=BlockNumber(5), gas_limit=BlockGasLimit(1), block_hash=make_block_hash()
     )
-    wal.log_and_dispatch([block1])
+    dispatch(wal, [block1])
     wal.snapshot(1)
 
     block2 = Block(
         block_number=BlockNumber(7), gas_limit=BlockGasLimit(1), block_hash=make_block_hash()
     )
-    wal.log_and_dispatch([block2])
+    dispatch(wal, [block2])
     wal.snapshot(2)
 
     block3 = Block(
         block_number=BlockNumber(8), gas_limit=BlockGasLimit(1), block_hash=make_block_hash()
     )
-    wal.log_and_dispatch([block3])
+    dispatch(wal, [block3])
     wal.snapshot(3)
 
     snapshot = wal.storage.get_snapshot_before_state_change(HIGH_STATECHANGE_ULID)

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -210,8 +210,9 @@ class MockRaidenService:
             our_address=self.rpc_client.address,
             chain_id=self.rpc_client.chain_id,
         )
+        with self.wal.process_state_change_atomically() as dispatcher:
+            dispatcher.dispatch(state_change)
 
-        self.wal.log_and_dispatch([state_change])
         self.transport = Mock()
 
     def on_messages(self, messages):

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -251,7 +251,7 @@ class StateManager(Generic[ST]):
         log.debug("Copied state before applying state changes", duration=time.time() - before_copy)
         return StateManager(self.state_transition, copy_state)
 
-    def dispatch2(self, state_change: StateChange) -> Tuple[ST, List[Event]]:
+    def dispatch(self, state_change: StateChange) -> Tuple[ST, List[Event]]:
         # Update the current state by applying the state changes
         iteration = self.state_transition(self.current_state, state_change)
 
@@ -267,47 +267,6 @@ class StateManager(Generic[ST]):
         self.current_state = next_state
 
         return iteration.new_state, iteration.events
-
-    def dispatch(self, state_changes: List[StateChange]) -> Tuple[ST, List[List[Event]]]:
-        """ Apply the `state_change` in the current machine and return the
-        resulting events.
-
-        Args:
-            state_changes: An object representation of a state
-            change.
-
-        Return:
-            A list of events produced by the state transition.
-            It's the upper layer's responsibility to decided how to handle
-            these events.
-        """
-        if not state_changes:
-            raise ValueError("dispatch called with an empty state_changes list")
-
-        # The state objects must be treated as immutable, so make a copy of the
-        # current state and pass the copy to the state machine to be modified.
-        before_copy = time.time()
-        next_state = deepcopy(self.current_state)
-        log.debug("Copied state before applying state changes", duration=time.time() - before_copy)
-
-        # Update the current state by applying the state changes
-        events: List[List[Event]] = list()
-        for state_change in state_changes:
-            iteration = self.state_transition(next_state, state_change)
-
-            typecheck(iteration, TransitionResult)
-            for e in iteration.events:
-                typecheck(e, Event)
-            typecheck(iteration.new_state, State)
-
-            # Skipping the copy because this value is internal
-            events.append(iteration.events)
-            next_state = iteration.new_state
-
-        assert next_state is not None, "State transition did not yield new state"
-        self.current_state = next_state
-
-        return iteration.new_state, events
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -12,7 +12,6 @@ The ignored state changes will still be applied, but they will just not be print
 import json
 import re
 from contextlib import closing
-from itertools import chain
 
 import click
 from eth_utils import encode_hex, is_address, to_canonical_address
@@ -215,7 +214,7 @@ def replay_wal(
 
     for _, state_change in enumerate(all_state_changes):
         # Dispatching the state changes one-by-one to easy debugging
-        _, events = wal.state_manager.dispatch([state_change])
+        _, events = wal.state_manager.dispatch(state_change)
 
         chain_state = wal.state_manager.current_state
         msg = "Chain state must never be cleared up."
@@ -236,7 +235,7 @@ def replay_wal(
         # and inspect the state.
         ###
         print_state_change(state_change, translator=translator)
-        print_events(chain.from_iterable(events), translator=translator)
+        print_events(events, translator=translator)
 
         # Enable to print color coded presence state of channel partners
         # print_presence_view(chain_state, translator)


### PR DESCRIPTION
## Description

The fix #6470 brought some performance problems because the `ChainState` was copied for every state change (see performance measurements below).

This PR wraps the state change processing for blockchain events into an atomic state manager, so that the copy isn't necessary.

At the same time all database writes are put into a database transaction. This leaves the proxies with an up-to-date block number which results in better and more informative error messages.

Fixes https://github.com/raiden-network/raiden/issues/6474

### Performance:

This brings performance back after #6470 and makes it ~36% faster than current `develop`:
#### develop

```
num_state_changes=2 time_per_sc=0.011809587478637695
num_state_changes=1 time_per_sc=0.003674030303955078
num_state_changes=1 time_per_sc=0.004012107849121094
num_state_changes=437 time_per_sc=0.00027565661502375484
num_state_changes=425 time_per_sc=0.0003503737730138442
num_state_changes=1625 time_per_sc=0.00023894940889798678
num_state_changes=2468 time_per_sc=0.00025791702626010393
num_state_changes=3903 time_per_sc=0.000250094858707601
num_state_changes=4982 time_per_sc=0.000257042314766019
num_state_changes=2229 time_per_sc=0.00025390305825015685
num_state_changes=132 time_per_sc=0.00040177323601462626
num_state_changes=55 time_per_sc=0.0006727825511585583
```

#### After #6470

```
num_state_changes=2 time_per_sc=0.013517498970031738
num_state_changes=1 time_per_sc=0.005203962326049805
num_state_changes=1 time_per_sc=0.005265951156616211
num_state_changes=437 time_per_sc=0.0021587880306985887
num_state_changes=425 time_per_sc=0.0030157061184153838
num_state_changes=1625 time_per_sc=0.004215660241933969
num_state_changes=2468 time_per_sc=0.007394305794126983
num_state_changes=3903 time_per_sc=0.013630374590311483
num_state_changes=4982 time_per_sc=0.021643087357605666
num_state_changes=2229 time_per_sc=0.026860458105334578
num_state_changes=132 time_per_sc=0.028242356849439217
num_state_changes=55 time_per_sc=0.02827532941644842
```


#### This PR:

```
num_state_changes=2 time_per_sc=0.017097949981689453
num_state_changes=1 time_per_sc=0.0019299983978271484
num_state_changes=1 time_per_sc=0.001405954360961914
num_state_changes=437 time_per_sc=0.00020245720101712224
num_state_changes=425 time_per_sc=0.00018084301668054917
num_state_changes=1625 time_per_sc=0.00019198520366962138
num_state_changes=2468 time_per_sc=0.00016206560876806127
num_state_changes=3903 time_per_sc=0.00016300072891114157
num_state_changes=4982 time_per_sc=0.00018094644542680308
num_state_changes=2229 time_per_sc=0.00022145898527177045
num_state_changes=132 time_per_sc=0.0010577801502112186
num_state_changes=64 time_per_sc=0.000624779611825943
```