### PR TITLE
Only use ipython in dev requirements

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -1,4 +1,5 @@
 import datetime
+import importlib
 import json
 import os
 import sys
@@ -179,7 +180,6 @@ def options(func: Callable) -> Callable:
             help="hex encoded address of the User Deposit contract.",
             type=ADDRESS_TYPE,
         ),
-        option("--console", help="Start the interactive raiden console", is_flag=True),
         option(
             ETH_NETWORKID_OPTION,
             help=(
@@ -504,6 +504,11 @@ def options(func: Callable) -> Callable:
             ),
         ),
     ]
+
+    if importlib.util.find_spec("IPython"):
+        options_.append(
+            option("--console", help="Start the interactive raiden console", is_flag=True)
+        )
 
     for option_ in reversed(options_):
         func = option_(func)

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -68,7 +68,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==5.21.0        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.6.1  # via -r requirements-dev.txt, pluggy
+importlib-metadata==1.7.0  # via -r requirements-dev.txt, flake8, flake8-comprehensions, jsonschema, pluggy, pytest
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 iniconfig==1.0.1          # via -r requirements-dev.txt, pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements-dev.txt, web3
@@ -179,8 +179,8 @@ toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
 twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
-typed-ast==1.4.0          # via -r requirements-dev.txt, black, mypy
-typing-extensions==3.7.4.2  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, black, mypy
+typing-extensions==3.7.4.2  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via -r requirements-dev.txt, matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-dev.txt, requests

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -32,6 +32,7 @@ responses
 flaky
 
 # Debugging
+ipython
 pdbpp
 colour
 py-spy

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -14,7 +14,7 @@ astunparse==1.6.2         # via -r requirements-docs.txt, sphinxcontrib-httpexam
 attrs==19.3.0             # via -r requirements.txt, automat, black, flake8-bugbear, hypothesis, jsonschema, matrix-synapse, pytest, service-identity, treq, twisted
 automat==0.7.0            # via twisted
 babel==2.7.0              # via -r requirements-docs.txt, sphinx
-backcall==0.1.0           # via -r requirements.txt, ipython
+backcall==0.1.0           # via ipython
 base58==2.0.0             # via -r requirements.txt, multiaddr
 bcrypt==3.1.6             # via matrix-synapse
 bitarray==1.2.1           # via -r requirements.txt, eth-account
@@ -67,15 +67,15 @@ hyperlink==19.0.0         # via twisted
 hypothesis==5.21.0        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.6.1  # via pluggy
+importlib-metadata==1.7.0  # via -r requirements.txt, flake8, flake8-comprehensions, jsonschema, pluggy, pytest
 incremental==17.5.0       # via treq, twisted
 iniconfig==1.0.1          # via pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements.txt, web3
-ipython-genutils==0.2.0   # via -r requirements.txt, traitlets
-ipython==7.17.0           # via -r requirements.txt
+ipython-genutils==0.2.0   # via traitlets
+ipython==7.17.0           # via -r requirements-dev.in
 isort==4.3.21             # via -r requirements-dev.in, pylint
 itsdangerous==1.1.0       # via -r requirements.txt, flask
-jedi==0.17.0              # via -r requirements.txt, ipython
+jedi==0.17.0              # via ipython
 jinja2==2.10.1            # via -r requirements-docs.txt, -r requirements.txt, flask, matrix-synapse, sphinx
 jsonschema==3.2.0         # via -r requirements.txt, matrix-synapse, web3
 lazy-object-proxy==1.4.1  # via astroid
@@ -100,20 +100,20 @@ networkx==2.4             # via -r requirements.txt
 objgraph==3.4.1           # via -r requirements.txt
 packaging==19.0           # via -r requirements-docs.txt, pytest, sphinx
 parsimonious==0.8.1       # via -r requirements.txt, eth-abi
-parso==0.7.0              # via -r requirements.txt, jedi
+parso==0.7.0              # via jedi
 pathspec==0.8.0           # via black
 pdbpp==0.10.2             # via -r requirements-dev.in
-pexpect==4.8.0            # via -r requirements-dev.in, -r requirements.txt, ipython
+pexpect==4.8.0            # via -r requirements-dev.in, ipython
 phonenumbers==8.10.13     # via matrix-synapse
-pickleshare==0.7.5        # via -r requirements.txt, ipython
+pickleshare==0.7.5        # via ipython
 pillow==6.2.0             # via matrix-synapse
 pip-tools==5.3.1          # via -r requirements-dev.in
 pluggy==0.12.0            # via pytest
 prometheus-client==0.3.1  # via matrix-synapse
-prompt-toolkit==3.0.5     # via -r requirements.txt, ipython
+prompt-toolkit==3.0.5     # via ipython
 protobuf==3.11.3          # via -r requirements.txt, web3
 psutil==5.7.2             # via -r requirements.txt, mirakuru
-ptyprocess==0.6.0         # via -r requirements.txt, pexpect
+ptyprocess==0.6.0         # via pexpect
 py-ecc==1.4.7             # via -r requirements.txt, raiden-contracts
 py-solc==3.2.0            # via -r requirements.txt, raiden-contracts
 py-spy==0.3.3             # via -r requirements-dev.in
@@ -124,7 +124,7 @@ pycodestyle==2.6.0        # via flake8
 pycparser==2.19           # via -r requirements.txt, cffi
 pycryptodome==3.8.2       # via -r requirements.txt, eth-hash, eth-keyfile
 pyflakes==2.2.0           # via flake8
-pygments==2.6.1           # via -r requirements-docs.txt, -r requirements.txt, ipython, pdbpp, readme-renderer, sphinx
+pygments==2.6.1           # via -r requirements-docs.txt, ipython, pdbpp, readme-renderer, sphinx
 pyhamcrest==1.9.0         # via twisted
 pylint==2.6.0             # via -r requirements-dev.in
 pymacaroons==0.13.0       # via matrix-synapse
@@ -170,16 +170,16 @@ sphinxcontrib-serializinghtml==1.1.4  # via -r requirements-docs.txt, sphinx
 structlog==20.1.0         # via -r requirements.txt
 toml==0.10.1              # via -r requirements.txt, black, pylint, pytest
 toolz==0.9.0              # via -r requirements.txt, cytoolz
-traitlets==4.3.2          # via -r requirements.txt, ipython
+traitlets==4.3.2          # via ipython
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==20.3.0      # via matrix-synapse, treq
-typed-ast==1.4.0          # via black, mypy
-typing-extensions==3.7.4.2  # via -r requirements.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via astroid, black, mypy
+typing-extensions==3.7.4.2  # via -r requirements.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, requests
 varint==1.0.2             # via -r requirements.txt, multiaddr
-wcwidth==0.1.9            # via -r requirements.txt, prompt-toolkit
+wcwidth==0.1.9            # via prompt-toolkit
 web3==5.12.0              # via -r requirements.txt, raiden-contracts
 webencodings==0.5.1       # via bleach
 websockets==8.1           # via -r requirements.txt, web3
@@ -187,7 +187,7 @@ werkzeug==1.0.1           # via -r requirements.txt, flask
 wheel==0.33.4             # via -r requirements-docs.txt, astunparse
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via -r requirements.txt, importlib-metadata
 zope.event==4.4           # via -r requirements.txt, gevent
 zope.interface==5.1.0     # via -r requirements.txt, gevent, twisted
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -10,7 +10,6 @@ Flask-Cors
 Flask-RESTful
 gevent>=1.5a3
 guppy3
-ipython
 marshmallow-dataclass==6.0.0
 marshmallow-polyfield
 marshmallow

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,6 @@
 aniso8601==7.0.0          # via flask-restful
 asn1crypto==1.3.0         # via coincurve
 attrs==19.3.0             # via jsonschema
-backcall==0.1.0           # via ipython
 base58==2.0.0             # via multiaddr
 bitarray==1.2.1           # via eth-account
 cachetools==4.1.1         # via -r requirements.in
@@ -18,7 +17,7 @@ click==7.0                # via flask, raiden-contracts
 coincurve==13.0.0         # via -r requirements.in, raiden-contracts
 colorama==0.4.3           # via -r requirements.in
 cytoolz==0.10.1           # via eth-keyfile, eth-utils
-decorator==4.4.0          # via ipython, networkx, traitlets
+decorator==4.4.0          # via networkx
 eth-abi==2.1.0            # via eth-account, raiden-contracts, web3
 eth-account==0.5.2        # via web3
 eth-hash[pycryptodome]==0.2.0  # via eth-utils, web3
@@ -37,11 +36,9 @@ greenlet==0.4.16          # via gevent
 guppy3==3.0.10.post1      # via -r requirements.in
 hexbytes==0.2.0           # via eth-account, eth-rlp, web3
 idna==2.8                 # via requests
+importlib-metadata==1.7.0  # via jsonschema
 ipfshttpclient==0.6.0.post1  # via web3
-ipython-genutils==0.2.0   # via traitlets
-ipython==7.17.0           # via -r requirements.in
 itsdangerous==1.1.0       # via flask
-jedi==0.17.0              # via ipython
 jinja2==2.10.1            # via flask
 jsonschema==3.2.0         # via web3
 lru-dict==1.1.6           # via web3
@@ -59,18 +56,12 @@ netifaces==0.10.9         # via -r requirements.in
 networkx==2.4             # via -r requirements.in
 objgraph==3.4.1           # via -r requirements.in
 parsimonious==0.8.1       # via eth-abi
-parso==0.7.0              # via jedi
-pexpect==4.8.0            # via ipython
-pickleshare==0.7.5        # via ipython
-prompt-toolkit==3.0.5     # via ipython
 protobuf==3.11.3          # via web3
 psutil==5.7.2             # via -r requirements.in, mirakuru
-ptyprocess==0.6.0         # via pexpect
 py-ecc==1.4.7             # via raiden-contracts
 py-solc==3.2.0            # via raiden-contracts
 pycparser==2.19           # via cffi
 pycryptodome==3.8.2       # via eth-hash, eth-keyfile
-pygments==2.6.1           # via ipython
 pyrsistent==0.15.7        # via jsonschema
 pysha3==1.0.2             # via -r requirements.in
 pytz==2019.1              # via flask-restful
@@ -80,19 +71,18 @@ requests==2.24.0          # via -r requirements.in, ipfshttpclient, matrix-clien
 rlp==1.1.0                # via eth-account, eth-rlp, raiden-contracts
 semantic-version==2.6.0   # via py-solc
 semver==2.8.1             # via raiden-contracts
-six==1.12.0               # via flask-cors, flask-restful, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog, traitlets
+six==1.12.0               # via flask-cors, flask-restful, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog
 structlog==20.1.0         # via -r requirements.in
 toml==0.10.1              # via -r requirements.in
 toolz==0.9.0              # via cytoolz
-traitlets==4.3.2          # via ipython
-typing-extensions==3.7.4.2  # via -r requirements.in
+typing-extensions==3.7.4.2  # via -r requirements.in, web3
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
 varint==1.0.2             # via multiaddr
-wcwidth==0.1.9            # via prompt-toolkit
 web3==5.12.0              # via -r requirements.in, raiden-contracts
 websockets==8.1           # via web3
 werkzeug==1.0.1           # via flask
+zipp==3.1.0               # via importlib-metadata
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 


### PR DESCRIPTION
The `--console` option is only added to the cli when ipython is
installed. This allows removing ipython from the normal requirements,
which greatly cuts down on installed packages.

Lazily importing ipython improves the startup speed even when
ipython is installed.
