### PR TITLE
Make state machine state non-optional

### DIFF
--- a/raiden/network/resolver/client.py
+++ b/raiden/network/resolver/client.py
@@ -33,7 +33,7 @@ def reveal_secret_with_resolver(
     log.debug("Using resolver to fetch secret", resolver_endpoint=resolver_endpoint)
 
     assert isinstance(raiden.wal, WriteAheadLog), "RaidenService has not been started"
-    current_state = raiden.wal.state_manager.current_state
+    current_state = raiden.wal.get_current_state()
 
     if current_state is None:
         return False

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -449,7 +449,7 @@ class RaidenService(Runnable):
         # because of the node's queues.
         self.ready_to_process_events = False
 
-        # Counters use for state snapshotting
+        # Counters used for state snapshotting
         self.state_change_qty_snapshot = 0
         self.state_change_qty = 0
 

--- a/raiden/storage/sqlite.py
+++ b/raiden/storage/sqlite.py
@@ -363,15 +363,12 @@ class SQLiteStorage:
 
         return int(result[0][0])
 
-    def count_snapshots(self) -> int:
+    def has_snapshot(self) -> bool:
         cursor = self.conn.cursor()
-        query = cursor.execute("SELECT COUNT(1) FROM state_snapshot")
-        result = query.fetchall()
+        query = cursor.execute("SELECT EXISTS(SELECT 1 FROM state_snapshot)")
+        result = query.fetchone()
 
-        if len(result) == 0:
-            return 0
-
-        return int(result[0][0])
+        return bool(result[0])
 
     def write_state_changes(self, state_changes: List[str]) -> List[StateChangeID]:
         """Write `state_changes` to the database and returns the corresponding IDs."""
@@ -391,7 +388,7 @@ class SQLiteStorage:
         return state_change_ids
 
     def write_first_state_snapshot(self, snapshot: str) -> SnapshotID:
-        if self.count_snapshots() != 0:
+        if self.has_snapshot():
             raise RuntimeError(
                 "write_first_state_snapshot can only be used for an unitialized node."
             )

--- a/raiden/storage/utils.py
+++ b/raiden/storage/utils.py
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS state_changes (
 DB_CREATE_SNAPSHOT = """
 CREATE TABLE IF NOT EXISTS state_snapshot (
     identifier ULID PRIMARY KEY NOT NULL,
-    statechange_id ULID NOT NULL,
+    statechange_id ULID UNIQUE,
     statechange_qty INTEGER,
     data JSON,
     timestamp TIMESTAMP DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) NOT NULL,

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -253,7 +253,7 @@ class WriteAheadLog(Generic[ST]):
                 self.storage.write_state_snapshot(current_state, state_change_id, statechange_qty)
 
     def get_current_state(self) -> ST:
-        """Returns a copy of the current node state."""
+        """Returns the current node state."""
         return self._state_manager.current_state
 
     @property

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -324,9 +324,6 @@ def test_batch_unlock(
     hold_event_handler = bob_app.raiden_event_handler
     assert isinstance(hold_event_handler, HoldRaidenEventHandler)
 
-    # Take a snapshot early on
-    alice_app.snapshot()
-
     canonical_identifier = get_channelstate(
         alice_app, bob_app, token_network_address
     ).canonical_identifier
@@ -337,9 +334,6 @@ def test_batch_unlock(
     token_proxy = alice_app.proxy_manager.token(token_address, BLOCK_ID_LATEST)
     alice_initial_balance = token_proxy.balance_of(alice_app.address)
     bob_initial_balance = token_proxy.balance_of(bob_app.address)
-
-    # Take snapshot before transfer
-    alice_app.snapshot()
 
     alice_to_bob_amount = 10
     identifier = 1
@@ -372,7 +366,8 @@ def test_batch_unlock(
     )
 
     # Test WAL restore to return the latest channel state
-    alice_app.snapshot()
+    assert alice_app.wal, "WAL must be set."
+    alice_app.wal.snapshot(alice_app.state_change_qty)
     our_balance_proof = alice_bob_channel_state.our_state.balance_proof
     restored_channel_state = channel_state_until_state_change(
         raiden=alice_app,

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -351,7 +351,7 @@ def test_matrix_message_retry(
     queueid = QueueIdentifier(
         recipient=partner_address, canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE
     )
-    chain_state = raiden_service.wal.state_manager.current_state
+    chain_state = raiden_service.wal.get_current_state()
 
     retry_queue: _RetryQueue = transport._get_retrier(partner_address)
     assert bool(retry_queue), "retry_queue not running"

--- a/raiden/tests/unit/storage/test_serialization.py
+++ b/raiden/tests/unit/storage/test_serialization.py
@@ -1,4 +1,3 @@
-import random
 from pathlib import Path
 
 import marshmallow
@@ -21,9 +20,10 @@ from raiden.transfer.events import (
     SendWithdrawRequest,
 )
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
-from raiden.transfer.state_change import ActionInitChain
+from raiden.transfer.state_change import Block
 from raiden.utils.typing import (
     BlockExpiration,
+    BlockGasLimit,
     BlockNumber,
     ChainID,
     Nonce,
@@ -92,12 +92,10 @@ def test_events_loaded_from_storage_should_deserialize(tmp_path):
     # Satisfy the foreign-key constraint for state change ID
     ids = storage.write_state_changes(
         [
-            ActionInitChain(
-                pseudo_random_generator=random.Random(),
+            Block(
                 block_number=BlockNumber(1),
+                gas_limit=BlockGasLimit(1),
                 block_hash=factories.make_block_hash(),
-                our_address=factories.make_address(),
-                chain_id=ChainID(1),
             )
         ]
     )

--- a/raiden/tests/unit/test_raiden_event_handler.py
+++ b/raiden/tests/unit/test_raiden_event_handler.py
@@ -114,7 +114,7 @@ def test_handle_contract_send_channelunlock_already_unlocked():
 
     # This should not throw an unrecoverable error
     RaidenEventHandler().on_raiden_events(
-        raiden=raiden, chain_state=raiden.wal.state_manager.current_state, events=[event]
+        raiden=raiden, chain_state=raiden.wal.get_current_state(), events=[event]
     )
 
 
@@ -175,7 +175,7 @@ def test_pfs_handler_handle_routefailed_with_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_events(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             events=[route_failed_event],
         )
     assert pfs_feedback_handler.called
@@ -201,7 +201,7 @@ def test_pfs_handler_handle_routefailed_without_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_events(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             events=[route_failed_event],
         )
     assert not pfs_feedback_handler.called
@@ -235,7 +235,7 @@ def test_pfs_handler_handle_paymentsentsuccess_with_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_events(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             events=[route_failed_event],
         )
     assert pfs_feedback_handler.called
@@ -277,7 +277,7 @@ def test_pfs_handler_handle_paymentsentsuccess_without_feedback_token():
     with patch("raiden.raiden_event_handler.post_pfs_feedback") as pfs_feedback_handler:
         pfs_handler.on_raiden_events(
             raiden=raiden,
-            chain_state=cast(ChainState, raiden.wal.state_manager.current_state),  # type: ignore
+            chain_state=cast(ChainState, raiden.wal.get_current_state()),  # type: ignore
             events=[route_failed_event],
         )
     assert not pfs_feedback_handler.called

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -17,7 +17,7 @@ from raiden.messages.withdraw import WithdrawConfirmation, WithdrawExpired, With
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.tests.utils import factories
-from raiden.transfer import state, state_change
+from raiden.transfer import state
 from raiden.utils.signer import LocalSigner
 
 # Required for test_message_identical. It would be better to have a set of
@@ -208,8 +208,8 @@ def test_serialization_networkx_graph():
     assert instance.graph.edges == restored_instance.graph.edges
 
 
-def test_actioninitchain_restore():
-    """ ActionInitChain *must* restore the previous pseudo random generator
+def test_chainstate_restore():
+    """ ChainState *must* restore the previous pseudo random generator
     state.
 
     Message identifiers are used for confirmation messages, e.g. delivered and
@@ -225,25 +225,7 @@ def test_actioninitchain_restore():
     will not match the previous IDs and the message queues won't be properly
     cleared up.
     """
-    pseudo_random_generator = random.Random()
-    block_number = 577
-    our_address = factories.make_address()
-    chain_id = 777
 
-    original_obj = state_change.ActionInitChain(
-        pseudo_random_generator=pseudo_random_generator,
-        block_number=block_number,
-        block_hash=factories.make_block_hash(),
-        our_address=our_address,
-        chain_id=chain_id,
-    )
-
-    decoded_obj = JSONSerializer.deserialize(JSONSerializer.serialize(original_obj))
-
-    assert original_obj == decoded_obj
-
-
-def test_chainstate_restore():
     pseudo_random_generator = random.Random()
     block_number = 577
     our_address = factories.make_address()

--- a/raiden/tests/unit/test_upgrade.py
+++ b/raiden/tests/unit/test_upgrade.py
@@ -1,13 +1,15 @@
-import random
 from pathlib import Path
 from unittest.mock import ANY, Mock, patch
+
+from eth_typing import BlockNumber
 
 import raiden.utils.upgrades
 from raiden.storage.serialization import JSONSerializer
 from raiden.storage.sqlite import FilteredDBQuery, Operator, SQLiteStorage
 from raiden.tests.utils import factories
 from raiden.tests.utils.migrations import create_fake_web3_for_block_hash
-from raiden.transfer.state_change import ActionInitChain
+from raiden.transfer.state_change import Block
+from raiden.utils.typing import BlockGasLimit
 from raiden.utils.upgrades import VERSION_RE, UpgradeManager, UpgradeRecord, get_db_version
 
 
@@ -80,15 +82,13 @@ def test_upgrade_manager_restores_backup(tmp_path, monkeypatch):
     with patch("raiden.storage.sqlite.RAIDEN_DB_VERSION", new=16), SQLiteStorage(
         str(old_db_filename)
     ) as storage:
-        state_change = ActionInitChain(
-            chain_id=1,
-            our_address=factories.make_address(),
-            block_number=1,
+        state_change = Block(
+            block_number=BlockNumber(0),
+            gas_limit=BlockGasLimit(1000),
             block_hash=factories.make_block_hash(),
-            pseudo_random_generator=random.Random(),
         )
-        action_init_chain_data = JSONSerializer.serialize(state_change)
-        storage.write_state_changes(state_changes=[action_init_chain_data])
+        block_data = JSONSerializer.serialize(state_change)
+        storage.write_state_changes(state_changes=[block_data])
         storage.update_version()
 
     upgrade_functions = [UpgradeRecord(from_version=16, function=Mock())]
@@ -106,7 +106,7 @@ def test_upgrade_manager_restores_backup(tmp_path, monkeypatch):
     with SQLiteStorage(str(db_path)) as storage:
         state_change_record = storage.get_latest_state_change_by_data_field(
             FilteredDBQuery(
-                filters=[{"_type": "raiden.transfer.state_change.ActionInitChain"}],
+                filters=[{"_type": "raiden.transfer.state_change.Block"}],
                 main_operator=Operator.NONE,
                 inner_operator=Operator.NONE,
             )

--- a/raiden/tests/unit/test_wal.py
+++ b/raiden/tests/unit/test_wal.py
@@ -57,9 +57,12 @@ def new_wal(state_transition: Callable, state: State = None) -> WriteAheadLog:
 
     state_manager = StateManager(state_transition, state, [])
     storage = SerializedSQLiteStorage(":memory:", serializer)
+
+    assert not storage.database.has_snapshot()
     storage.write_first_state_snapshot(state)
-    wal = WriteAheadLog(state_manager, storage)
-    return wal
+    assert storage.database.has_snapshot()
+
+    return WriteAheadLog(state_manager, storage)
 
 
 def dispatch(wal: WriteAheadLog, state_changes: List[StateChange]):

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -12,8 +12,7 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
 from raiden.transfer import node
 from raiden.transfer.architecture import StateManager
-from raiden.transfer.state import NettingChannelState
-from raiden.transfer.state_change import ActionInitChain
+from raiden.transfer.state import ChainState, NettingChannelState
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.signer import LocalSigner
 from raiden.utils.typing import (
@@ -199,20 +198,19 @@ class MockRaidenService:
             state_transition = node.state_transition
 
         serializer = JSONSerializer()
-        state_manager = StateManager(state_transition, None)
-        storage = SerializedSQLiteStorage(":memory:", serializer)
-        self.wal = WriteAheadLog(state_manager, storage)
-
-        state_change = ActionInitChain(
+        initial_state = ChainState(
             pseudo_random_generator=random.Random(),
             block_number=BlockNumber(0),
             block_hash=factories.make_block_hash(),
             our_address=self.rpc_client.address,
             chain_id=self.rpc_client.chain_id,
         )
-        with self.wal.process_state_change_atomically() as dispatcher:
-            dispatcher.dispatch(state_change)
+        wal = WriteAheadLog(
+            StateManager(state_transition, initial_state, []),
+            SerializedSQLiteStorage(":memory:", serializer),
+        )
 
+        self.wal = wal
         self.transport = Mock()
 
     def on_messages(self, messages):
@@ -244,7 +242,7 @@ def make_raiden_service_mock(
     raiden_service = MockRaidenService()
     chain_state = MockChainState()
     wal = Mock()
-    wal.state_manager.current_state = chain_state
+    wal.get_current_state.return_value = chain_state
     raiden_service.wal = wal
 
     token_network = MockTokenNetwork()

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -45,7 +45,6 @@ from raiden.transfer.state_change import (
     ActionChannelClose,
     ActionChannelSetRevealTimeout,
     ActionChannelWithdraw,
-    ActionInitChain,
     Block,
     ContractReceiveChannelBatchUnlock,
     ContractReceiveChannelClosed,
@@ -499,21 +498,6 @@ def handle_block(chain_state: ChainState, state_change: Block) -> TransitionResu
     return TransitionResult(chain_state, events)
 
 
-def handle_action_init_chain(
-    chain_state: Optional[ChainState], state_change: ActionInitChain
-) -> TransitionResult[ChainState]:
-    if chain_state is None:
-        chain_state = ChainState(
-            pseudo_random_generator=state_change.pseudo_random_generator,
-            block_number=state_change.block_number,
-            block_hash=state_change.block_hash,
-            our_address=state_change.our_address,
-            chain_id=state_change.chain_id,
-        )
-    events: List[Event] = list()
-    return TransitionResult(chain_state, events)
-
-
 def handle_token_network_action(
     chain_state: ChainState, state_change: TokenNetworkStateChange
 ) -> TransitionResult[ChainState]:
@@ -763,122 +747,113 @@ def handle_receive_unlock(
 
 
 def handle_state_change(
-    chain_state: Optional[ChainState], state_change: StateChange
+    chain_state: ChainState, state_change: StateChange
 ) -> TransitionResult[ChainState]:  # pragma: no cover
 
-    if chain_state is None:
-        msg = "The first iteration must be ActionInitChain"
-        assert isinstance(state_change, ActionInitChain), msg
-        iteration = handle_action_init_chain(chain_state, state_change)
-    else:
-        if type(state_change) == Block:
-            assert isinstance(state_change, Block), MYPY_ANNOTATION
-            iteration = handle_block(chain_state, state_change)
-        elif type(state_change) == ActionChannelClose:
-            assert isinstance(state_change, ActionChannelClose), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ActionChannelWithdraw:
-            assert isinstance(state_change, ActionChannelWithdraw), MYPY_ANNOTATION
-            iteration = subdispatch_by_canonical_id(
-                chain_state=chain_state,
-                canonical_identifier=state_change.canonical_identifier,
-                state_change=state_change,
-            )
-        elif type(state_change) == ActionChannelSetRevealTimeout:
-            assert isinstance(state_change, ActionChannelSetRevealTimeout), MYPY_ANNOTATION
-            iteration = subdispatch_by_canonical_id(
-                chain_state=chain_state,
-                canonical_identifier=state_change.canonical_identifier,
-                state_change=state_change,
-            )
-        elif type(state_change) == ActionChangeNodeNetworkState:
-            assert isinstance(state_change, ActionChangeNodeNetworkState), MYPY_ANNOTATION
-            iteration = handle_action_change_node_network_state(chain_state, state_change)
-        elif type(state_change) == ActionInitInitiator:
-            assert isinstance(state_change, ActionInitInitiator), MYPY_ANNOTATION
-            iteration = handle_action_init_initiator(chain_state, state_change)
-        elif type(state_change) == ActionInitMediator:
-            assert isinstance(state_change, ActionInitMediator), MYPY_ANNOTATION
-            iteration = handle_action_init_mediator(chain_state, state_change)
-        elif type(state_change) == ActionInitTarget:
-            assert isinstance(state_change, ActionInitTarget), MYPY_ANNOTATION
-            iteration = handle_action_init_target(chain_state, state_change)
-        elif type(state_change) == ReceiveTransferCancelRoute:
-            assert isinstance(state_change, ReceiveTransferCancelRoute), MYPY_ANNOTATION
-            iteration = handle_receive_transfer_cancel_route(chain_state, state_change)
-        elif type(state_change) == ActionTransferReroute:
-            assert isinstance(state_change, ActionTransferReroute), MYPY_ANNOTATION
-            iteration = handle_action_transfer_reroute(chain_state, state_change)
-        elif type(state_change) == ContractReceiveNewTokenNetworkRegistry:
-            assert isinstance(
-                state_change, ContractReceiveNewTokenNetworkRegistry
-            ), MYPY_ANNOTATION
-            iteration = handle_contract_receive_new_token_network_registry(
-                chain_state, state_change
-            )
-        elif type(state_change) == ContractReceiveNewTokenNetwork:
-            assert isinstance(state_change, ContractReceiveNewTokenNetwork), MYPY_ANNOTATION
-            iteration = handle_contract_receive_new_token_network(chain_state, state_change)
-        elif type(state_change) == ContractReceiveChannelBatchUnlock:
-            assert isinstance(state_change, ContractReceiveChannelBatchUnlock), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveChannelNew:
-            assert isinstance(state_change, ContractReceiveChannelNew), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveChannelWithdraw:
-            assert isinstance(state_change, ContractReceiveChannelWithdraw), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveChannelClosed:
-            assert isinstance(state_change, ContractReceiveChannelClosed), MYPY_ANNOTATION
-            iteration = handle_contract_receive_channel_closed(chain_state, state_change)
-        elif type(state_change) == ContractReceiveChannelDeposit:
-            assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveChannelSettled:
-            assert isinstance(state_change, ContractReceiveChannelSettled), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveRouteNew:
-            assert isinstance(state_change, ContractReceiveRouteNew), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveRouteClosed:
-            assert isinstance(state_change, ContractReceiveRouteClosed), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ContractReceiveSecretReveal:
-            assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
-            iteration = handle_contract_receive_secret_reveal(chain_state, state_change)
-        elif type(state_change) == ContractReceiveUpdateTransfer:
-            assert isinstance(state_change, ContractReceiveUpdateTransfer), MYPY_ANNOTATION
-            iteration = handle_token_network_action(chain_state, state_change)
-        elif type(state_change) == ReceiveDelivered:
-            assert isinstance(state_change, ReceiveDelivered), MYPY_ANNOTATION
-            iteration = handle_receive_delivered(chain_state, state_change)
-        elif type(state_change) == ReceiveSecretReveal:
-            assert isinstance(state_change, ReceiveSecretReveal), MYPY_ANNOTATION
-            iteration = handle_receive_secret_reveal(chain_state, state_change)
-        elif type(state_change) == ReceiveTransferRefund:
-            assert isinstance(state_change, ReceiveTransferRefund), MYPY_ANNOTATION
-            iteration = handle_receive_transfer_refund(chain_state, state_change)
-        elif type(state_change) == ReceiveSecretRequest:
-            assert isinstance(state_change, ReceiveSecretRequest), MYPY_ANNOTATION
-            iteration = handle_receive_secret_request(chain_state, state_change)
-        elif type(state_change) == ReceiveProcessed:
-            assert isinstance(state_change, ReceiveProcessed), MYPY_ANNOTATION
-            iteration = handle_receive_processed(chain_state, state_change)
-        elif type(state_change) == ReceiveUnlock:
-            assert isinstance(state_change, ReceiveUnlock), MYPY_ANNOTATION
-            iteration = handle_receive_unlock(chain_state, state_change)
-        elif type(state_change) == ReceiveLockExpired:
-            assert isinstance(state_change, ReceiveLockExpired), MYPY_ANNOTATION
-            iteration = handle_receive_lock_expired(chain_state, state_change)
-        elif type(state_change) == ReceiveWithdrawRequest:
-            assert isinstance(state_change, ReceiveWithdrawRequest), MYPY_ANNOTATION
-            iteration = handle_receive_withdraw_request(chain_state, state_change)
-        elif type(state_change) == ReceiveWithdrawConfirmation:
-            assert isinstance(state_change, ReceiveWithdrawConfirmation), MYPY_ANNOTATION
-            iteration = handle_receive_withdraw_confirmation(chain_state, state_change)
-        elif type(state_change) == ReceiveWithdrawExpired:
-            assert isinstance(state_change, ReceiveWithdrawExpired), MYPY_ANNOTATION
-            iteration = handle_receive_withdraw_expired(chain_state, state_change)
+    if type(state_change) == Block:
+        assert isinstance(state_change, Block), MYPY_ANNOTATION
+        iteration = handle_block(chain_state, state_change)
+    elif type(state_change) == ActionChannelClose:
+        assert isinstance(state_change, ActionChannelClose), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ActionChannelWithdraw:
+        assert isinstance(state_change, ActionChannelWithdraw), MYPY_ANNOTATION
+        iteration = subdispatch_by_canonical_id(
+            chain_state=chain_state,
+            canonical_identifier=state_change.canonical_identifier,
+            state_change=state_change,
+        )
+    elif type(state_change) == ActionChannelSetRevealTimeout:
+        assert isinstance(state_change, ActionChannelSetRevealTimeout), MYPY_ANNOTATION
+        iteration = subdispatch_by_canonical_id(
+            chain_state=chain_state,
+            canonical_identifier=state_change.canonical_identifier,
+            state_change=state_change,
+        )
+    elif type(state_change) == ActionChangeNodeNetworkState:
+        assert isinstance(state_change, ActionChangeNodeNetworkState), MYPY_ANNOTATION
+        iteration = handle_action_change_node_network_state(chain_state, state_change)
+    elif type(state_change) == ActionInitInitiator:
+        assert isinstance(state_change, ActionInitInitiator), MYPY_ANNOTATION
+        iteration = handle_action_init_initiator(chain_state, state_change)
+    elif type(state_change) == ActionInitMediator:
+        assert isinstance(state_change, ActionInitMediator), MYPY_ANNOTATION
+        iteration = handle_action_init_mediator(chain_state, state_change)
+    elif type(state_change) == ActionInitTarget:
+        assert isinstance(state_change, ActionInitTarget), MYPY_ANNOTATION
+        iteration = handle_action_init_target(chain_state, state_change)
+    elif type(state_change) == ReceiveTransferCancelRoute:
+        assert isinstance(state_change, ReceiveTransferCancelRoute), MYPY_ANNOTATION
+        iteration = handle_receive_transfer_cancel_route(chain_state, state_change)
+    elif type(state_change) == ActionTransferReroute:
+        assert isinstance(state_change, ActionTransferReroute), MYPY_ANNOTATION
+        iteration = handle_action_transfer_reroute(chain_state, state_change)
+    elif type(state_change) == ContractReceiveNewTokenNetworkRegistry:
+        assert isinstance(state_change, ContractReceiveNewTokenNetworkRegistry), MYPY_ANNOTATION
+        iteration = handle_contract_receive_new_token_network_registry(chain_state, state_change)
+    elif type(state_change) == ContractReceiveNewTokenNetwork:
+        assert isinstance(state_change, ContractReceiveNewTokenNetwork), MYPY_ANNOTATION
+        iteration = handle_contract_receive_new_token_network(chain_state, state_change)
+    elif type(state_change) == ContractReceiveChannelBatchUnlock:
+        assert isinstance(state_change, ContractReceiveChannelBatchUnlock), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveChannelNew:
+        assert isinstance(state_change, ContractReceiveChannelNew), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveChannelWithdraw:
+        assert isinstance(state_change, ContractReceiveChannelWithdraw), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveChannelClosed:
+        assert isinstance(state_change, ContractReceiveChannelClosed), MYPY_ANNOTATION
+        iteration = handle_contract_receive_channel_closed(chain_state, state_change)
+    elif type(state_change) == ContractReceiveChannelDeposit:
+        assert isinstance(state_change, ContractReceiveChannelDeposit), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveChannelSettled:
+        assert isinstance(state_change, ContractReceiveChannelSettled), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveRouteNew:
+        assert isinstance(state_change, ContractReceiveRouteNew), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveRouteClosed:
+        assert isinstance(state_change, ContractReceiveRouteClosed), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ContractReceiveSecretReveal:
+        assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION
+        iteration = handle_contract_receive_secret_reveal(chain_state, state_change)
+    elif type(state_change) == ContractReceiveUpdateTransfer:
+        assert isinstance(state_change, ContractReceiveUpdateTransfer), MYPY_ANNOTATION
+        iteration = handle_token_network_action(chain_state, state_change)
+    elif type(state_change) == ReceiveDelivered:
+        assert isinstance(state_change, ReceiveDelivered), MYPY_ANNOTATION
+        iteration = handle_receive_delivered(chain_state, state_change)
+    elif type(state_change) == ReceiveSecretReveal:
+        assert isinstance(state_change, ReceiveSecretReveal), MYPY_ANNOTATION
+        iteration = handle_receive_secret_reveal(chain_state, state_change)
+    elif type(state_change) == ReceiveTransferRefund:
+        assert isinstance(state_change, ReceiveTransferRefund), MYPY_ANNOTATION
+        iteration = handle_receive_transfer_refund(chain_state, state_change)
+    elif type(state_change) == ReceiveSecretRequest:
+        assert isinstance(state_change, ReceiveSecretRequest), MYPY_ANNOTATION
+        iteration = handle_receive_secret_request(chain_state, state_change)
+    elif type(state_change) == ReceiveProcessed:
+        assert isinstance(state_change, ReceiveProcessed), MYPY_ANNOTATION
+        iteration = handle_receive_processed(chain_state, state_change)
+    elif type(state_change) == ReceiveUnlock:
+        assert isinstance(state_change, ReceiveUnlock), MYPY_ANNOTATION
+        iteration = handle_receive_unlock(chain_state, state_change)
+    elif type(state_change) == ReceiveLockExpired:
+        assert isinstance(state_change, ReceiveLockExpired), MYPY_ANNOTATION
+        iteration = handle_receive_lock_expired(chain_state, state_change)
+    elif type(state_change) == ReceiveWithdrawRequest:
+        assert isinstance(state_change, ReceiveWithdrawRequest), MYPY_ANNOTATION
+        iteration = handle_receive_withdraw_request(chain_state, state_change)
+    elif type(state_change) == ReceiveWithdrawConfirmation:
+        assert isinstance(state_change, ReceiveWithdrawConfirmation), MYPY_ANNOTATION
+        iteration = handle_receive_withdraw_confirmation(chain_state, state_change)
+    elif type(state_change) == ReceiveWithdrawExpired:
+        assert isinstance(state_change, ReceiveWithdrawExpired), MYPY_ANNOTATION
+        iteration = handle_receive_withdraw_expired(chain_state, state_change)
 
     chain_state = iteration.new_state
     assert chain_state is not None, "chain_state must be set"
@@ -1139,10 +1114,8 @@ def update_queues(iteration: TransitionResult[ChainState], state_change: StateCh
 
 
 def state_transition(
-    chain_state: Optional[ChainState], state_change: StateChange
+    chain_state: ChainState, state_change: StateChange
 ) -> TransitionResult[ChainState]:
-    # pylint: disable=too-many-branches,unidiomatic-typecheck
-
     iteration = handle_state_change(chain_state, state_change)
 
     update_queues(iteration, state_change)

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-few-public-methods,too-many-arguments,too-many-instance-attributes
 from dataclasses import dataclass, field
-from random import Random
 
 from raiden.constants import EMPTY_SECRETHASH
 from raiden.settings import MediationFeeConfig
@@ -37,7 +36,6 @@ from raiden.utils.typing import (
     SecretRegistryAddress,
     Signature,
     T_Address,
-    T_BlockHash,
     T_BlockNumber,
     T_Secret,
     T_SecretHash,
@@ -145,20 +143,6 @@ class ContractReceiveChannelClosed(ContractReceiveStateChange):
     @property
     def token_network_address(self) -> TokenNetworkAddress:
         return self.canonical_identifier.token_network_address
-
-
-@dataclass(frozen=True)
-class ActionInitChain(StateChange):
-    pseudo_random_generator: Random = field(compare=False)
-    block_number: BlockNumber
-    block_hash: BlockHash
-    our_address: Address
-    chain_id: ChainID
-
-    def __post_init__(self) -> None:
-        typecheck(self.block_number, T_BlockNumber)
-        typecheck(self.block_hash, T_BlockHash)
-        typecheck(self.chain_id, int)
 
 
 @dataclass(frozen=True)

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -77,8 +77,7 @@ def count_token_network_channels(
 
 def state_from_raiden(raiden: "RaidenService") -> ChainState:  # pragma: no unittest
     assert raiden.wal, "raiden.wal not set"
-    # TODO: current_state should not be optional
-    return raiden.wal.state_manager.current_state  # type: ignore
+    return raiden.wal.get_current_state()
 
 
 def get_pending_transactions(chain_state: ChainState) -> List[ContractSendEvent]:

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -3,7 +3,7 @@
 """
 This script is meant to be used as a template to step through a provided DB file
 for debugging a specific issue.
-It constructs the chain_state through the state_manager and uses the WAL
+It constructs the chain_state through the _state_manager and uses the WAL
 to replay all state changes through the state machines until all state changes are consumed.
 The parameters (token_network_address and partner_address) will help filter out all
 state changes until a channel is found with the provided token network address and partner.
@@ -214,9 +214,9 @@ def replay_wal(
 
     for _, state_change in enumerate(all_state_changes):
         # Dispatching the state changes one-by-one to easy debugging
-        _, events = wal.state_manager.dispatch(state_change)
+        _, events = wal._state_manager.dispatch(state_change)
 
-        chain_state = wal.state_manager.current_state
+        chain_state = wal.get_current_state()
         msg = "Chain state must never be cleared up."
         assert chain_state, msg
 

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -331,7 +331,7 @@ def transfer_and_assert_successful(
 
     assert response is not None, "request.post returned None"
     is_json = response.headers["Content-Type"] == "application/json"
-    assert is_json, response.headers["Content-Type"]
+    assert is_json, (response.headers["Content-Type"], response.text)
     assert response.status_code == HTTPStatus.OK, response.json()
 
     log.debug("Payment done", url=post_url, json=json, time=elapsed)


### PR DESCRIPTION
## Description

Resolves https://github.com/raiden-network/raiden/issues/4569
Based on https://github.com/raiden-network/raiden/pull/5525

Currently the state in the state machine is an optional type because the state might be uninitialized. This causes additional checks and branches which complicate the code.

This PR removes this optionality by initializing the state before the state machine is initialized.

