### PR TITLE
Unflake test_payment_statuses_are_restored

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -540,8 +540,11 @@ class MatrixTransport(Runnable):
         )
         self._address_to_retrier = {}
 
-        self._address_mgr.stop()
+        # We have to stop the client before the address manager. Otherwise the
+        # sync thread might call the address manager after the manager has been
+        # stopped.
         self._client.stop()  # stop sync_thread, wait on client's greenlets
+        self._address_mgr.stop()
 
         # wait on own greenlets. No need to get on them, exceptions are
         # re-raised because of the `link_exception`

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -1,3 +1,4 @@
+import gevent
 import pytest
 
 from raiden import waiting
@@ -238,15 +239,16 @@ def test_payment_statuses_are_restored(  # pylint: disable=unused-argument
     with watch_for_unlock_failures(*raiden_network):
         waiting.wait_for_healthy(app0_restart, app1.address, network_wait)
 
-        waiting.wait_for_payment_balance(
-            raiden=app1,
-            token_network_registry_address=token_network_registry_address,
-            token_address=token_address,
-            partner_address=app0_restart.address,
-            target_address=Address(target_address),
-            target_balance=spent_amount,
-            retry_timeout=network_wait,
-        )
+        with gevent.Timeout(60):
+            waiting.wait_for_payment_balance(
+                raiden=app1,
+                token_network_registry_address=token_network_registry_address,
+                token_address=token_address,
+                partner_address=app0_restart.address,
+                target_address=Address(target_address),
+                target_balance=spent_amount,
+                retry_timeout=network_wait,
+            )
 
     # Check that payments are completed after both nodes come online after restart
     for identifier in range(spent_amount):


### PR DESCRIPTION
This fixes the flakyness of `test_payment_statuses_are_restored`. What
happened before was the following:

* The address manager was stopped and reset it's state when stopping
* The client's sync thread was still running for a short time and wrote
to the address manager.
* After the node restart, the address manager's state was unclean, which
led to misbehaving health checks
* The Presence updates were not correctly handled, since the node was
not whitelisted
* Some messages get stuck in the queue because the other node seemed
offline

While this fixes the problem, I think it is unwise to have such state
reset code as we currently have in the address manager. Removing the
objects on stop and creating them again on restart is far safer and
probably even less code.