### PR TITLE
Remove internal routing

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -31,7 +31,6 @@ from raiden.transfer.state import (
     NettingChannelEndState,
     NettingChannelState,
     SuccessfulTransactionState,
-    TokenNetworkGraphState,
     TokenNetworkState,
     TransactionChannelDeposit,
     TransactionExecutionStatus,
@@ -44,7 +43,6 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelSettled,
     ContractReceiveChannelWithdraw,
     ContractReceiveNewTokenNetwork,
-    ContractReceiveRouteClosed,
     ContractReceiveRouteNew,
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
@@ -89,9 +87,7 @@ def contractreceivenewtokennetwork_from_event(
     return ContractReceiveNewTokenNetwork(
         token_network_registry_address=token_network_registry_address,
         token_network=TokenNetworkState(
-            address=token_network_address,
-            token_address=token_address,
-            network_graph=TokenNetworkGraphState(token_network_address),
+            address=token_network_address, token_address=token_address,
         ),
         transaction_hash=event.transaction_hash,
         block_number=event.block_number,
@@ -229,23 +225,6 @@ def contractreceivechannelclosed_from_event(
     )
 
 
-def contractreceiverouteclosed_from_event(event: DecodedEvent) -> ContractReceiveRouteClosed:
-    data = event.event_data
-    args = data["args"]
-    channel_identifier = args["channel_identifier"]
-
-    return ContractReceiveRouteClosed(
-        canonical_identifier=CanonicalIdentifier(
-            chain_identifier=event.chain_id,
-            token_network_address=TokenNetworkAddress(event.originating_contract),
-            channel_identifier=channel_identifier,
-        ),
-        transaction_hash=event.transaction_hash,
-        block_number=event.block_number,
-        block_hash=event.block_hash,
-    )
-
-
 def contractreceiveupdatetransfer_from_event(
     channel_state: NettingChannelState, event: DecodedEvent
 ) -> ContractReceiveUpdateTransfer:
@@ -371,8 +350,6 @@ def blockchainevent_to_statechange(
 
         if canonical_identifier is not None:
             return contractreceivechannelclosed_from_event(canonical_identifier, event)
-        else:
-            return contractreceiverouteclosed_from_event(event)
 
     elif event_name == ChannelEvent.SETTLED:
         channel_settle_state = get_contractreceivechannelsettled_data_from_event(

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -154,7 +154,6 @@ class RoutingMode(Enum):
     """Routing mode configuration that can be chosen on the command line"""
 
     PFS = "pfs"
-    LOCAL = "local"
     PRIVATE = "private"
 
 

--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -1,9 +1,7 @@
-import json
 from random import Random
 from typing import Dict, Iterable
 
 import marshmallow
-import networkx
 from eth_utils import to_bytes, to_canonical_address, to_hex
 from marshmallow import EXCLUDE, Schema, post_dump
 from marshmallow_dataclass import class_schema
@@ -213,25 +211,6 @@ class CallablePolyField(PolyField):
         return self
 
 
-class NetworkXGraphField(marshmallow.fields.Field):
-    """ Converts networkx.Graph objects to a string """
-
-    def _serialize(self, value: networkx.Graph, attr: Any, obj: Any, **kwargs: Any) -> str:
-        return json.dumps(
-            [(to_hex_address(edge[0]), to_hex_address(edge[1])) for edge in value.edges]
-        )
-
-    def _deserialize(self, value: str, attr: Any, data: Any, **kwargs: Any) -> networkx.Graph:
-        try:
-            raw_data = json.loads(value)
-            canonical_addresses = [
-                (to_canonical_address(edge[0]), to_canonical_address(edge[1])) for edge in raw_data
-            ]
-            return networkx.Graph(canonical_addresses)
-        except (TypeError, ValueError):
-            raise self.make_error("validator_failed", input=value)
-
-
 class BaseSchema(marshmallow.Schema):
     # We want to ignore unknown fields
     class Meta:
@@ -319,7 +298,6 @@ class BaseSchema(marshmallow.Schema):
         # QueueIdentifier (Special case)
         QueueIdentifier: QueueIdentifierField,
         # Other
-        networkx.Graph: NetworkXGraphField,
         Random: PRNGField,
     }
 

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -53,7 +53,6 @@ from raiden.transfer.state import (
     HashTimeLockState,
     NettingChannelState,
     NetworkState,
-    TokenNetworkGraphState,
     TokenNetworkRegistryState,
     TokenNetworkState,
     make_empty_pending_locks_state,
@@ -352,7 +351,6 @@ class ChainStateStateMachine(RuleBasedStateMachine):
         self.token_network_state = TokenNetworkState(
             address=self.token_network_address,
             token_address=self.token_id,
-            network_graph=TokenNetworkGraphState(self.token_network_address),
         )
 
         self.token_network_registry_address = factories.make_token_network_registry_address()

--- a/raiden/tests/fuzz/test_state_changes.py
+++ b/raiden/tests/fuzz/test_state_changes.py
@@ -349,8 +349,7 @@ class ChainStateStateMachine(RuleBasedStateMachine):
         self.token_network_address = factories.UNIT_TOKEN_NETWORK_ADDRESS
         self.token_id = factories.UNIT_TOKEN_ADDRESS
         self.token_network_state = TokenNetworkState(
-            address=self.token_network_address,
-            token_address=self.token_id,
+            address=self.token_network_address, token_address=self.token_id,
         )
 
         self.token_network_registry_address = factories.make_token_network_registry_address()

--- a/raiden/tests/integration/long_running/test_token_networks.py
+++ b/raiden/tests/integration/long_running/test_token_networks.py
@@ -242,6 +242,7 @@ def test_participant_selection(raiden_network: List[RaidenService], token_addres
         )
 
 
+@pytest.mark.skip(reason="Connection manager knowingly broken by removal of internal routing")
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [4])
 @pytest.mark.parametrize("channels_per_node", [0])
@@ -354,6 +355,7 @@ def test_connect_does_not_open_channels_with_offline_nodes(
         )
 
 
+@pytest.mark.skip(reason="Connection manager knowingly broken by removal of internal routing")
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [3])
 @pytest.mark.parametrize("channels_per_node", [0])

--- a/raiden/tests/integration/network/test_pathfinding.py
+++ b/raiden/tests/integration/network/test_pathfinding.py
@@ -59,17 +59,6 @@ def test_configure_pfs(service_registry_address, private_keys, web3, contract_ma
 
     response = mocked_json_response(response_data=json_data)
 
-    # With local routing configure_pfs should raise assertion
-    with pytest.raises(AssertionError):
-        _ = configure_pfs_or_exit(
-            pfs_url="",
-            routing_mode=RoutingMode.LOCAL,
-            service_registry=service_registry,
-            node_network_id=chain_id,
-            token_network_registry_address=token_network_registry_address_test_default,
-            pathfinding_max_fee=DEFAULT_PATHFINDING_MAX_FEE,
-        )
-
     # With private routing configure_pfs should raise assertion
     with pytest.raises(AssertionError):
         _ = configure_pfs_or_exit(

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -731,7 +731,6 @@ def test_pfs_broadcast_messages(
     retries_before_backoff,
     monkeypatch,
     broadcast_rooms,
-    route_mode,
 ):
     """
     Test that RaidenService broadcasts PFSCapacityUpdate messages to

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -720,7 +720,6 @@ def test_monitoring_broadcast_messages_in_production_if_bigger_than_threshold(
 
 
 @pytest.mark.parametrize("matrix_server_count", [1])
-@pytest.mark.parametrize("route_mode", [RoutingMode.LOCAL, RoutingMode.PFS])
 @pytest.mark.parametrize(
     "broadcast_rooms", [[DISCOVERY_DEFAULT_ROOM, PATH_FINDING_BROADCASTING_ROOM]]
 )
@@ -751,7 +750,7 @@ def test_pfs_broadcast_messages(
     transport._send_raw = MagicMock()
     raiden_service = MockRaidenService(None)
     raiden_service.config.services.monitoring_enabled = True
-    raiden_service.routing_mode = route_mode
+    raiden_service.routing_mode = RoutingMode.PFS
 
     transport.start(raiden_service, [], None)
 

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -36,7 +36,6 @@ from raiden.transfer.state_change import (
     Block,
     ContractReceiveChannelClosed,
     ContractReceiveChannelNew,
-    ContractReceiveRouteClosed,
 )
 from raiden.ui.startup import RaidenBundle
 from raiden.utils.copy import deepcopy
@@ -405,7 +404,4 @@ def test_blockchain_event_processed_interleaved(
 
     assert search_for_item(
         app1_state_changes, ContractReceiveChannelClosed, {"channel_identifier": channel_id}
-    )
-    assert not search_for_item(
-        app1_state_changes, ContractReceiveRouteClosed, {"channel_identifier": channel_id}
     )

--- a/raiden/tests/unit/fixtures.py
+++ b/raiden/tests/unit/fixtures.py
@@ -5,12 +5,7 @@ import responses
 
 from raiden.tests.utils import factories
 from raiden.tests.utils.factories import UNIT_CHAIN_ID
-from raiden.transfer.state import (
-    ChainState,
-    TokenNetworkGraphState,
-    TokenNetworkRegistryState,
-    TokenNetworkState,
-)
+from raiden.transfer.state import ChainState, TokenNetworkRegistryState, TokenNetworkState
 from raiden.utils.typing import BlockNumber, TokenAmount
 
 # pylint: disable=redefined-outer-name
@@ -71,12 +66,7 @@ def token_network_state(
     token_network_address,
     token_id,
 ):
-    token_network_graph_state = TokenNetworkGraphState(token_network_address)
-    token_network = TokenNetworkState(
-        address=token_network_address,
-        token_address=token_id,
-        network_graph=token_network_graph_state,
-    )
+    token_network = TokenNetworkState(address=token_network_address, token_address=token_id,)
     token_network_registry_state.tokennetworkaddresses_to_tokennetworks[
         token_network_address
     ] = token_network

--- a/raiden/tests/unit/test_data/db_statechanges.json
+++ b/raiden/tests/unit/test_data/db_statechanges.json
@@ -673,13 +673,6 @@
             "token_network": {
                 "address": "0x6F4C596f2F848dE7298DcDc218974D6b81889270",
                 "token_address": "0x89d06DB00Ba9A523A92fF9e1a13A8b4Fb788BA1b",
-                "network_graph": {
-                    "token_network_address": "0x6F4C596f2F848dE7298DcDc218974D6b81889270",
-                    "network": "[]",
-                    "channel_identifier_to_participants": {},
-                    "_type": "raiden.transfer.state.TokenNetworkGraphState",
-                    "_version": 0
-                },
                 "channelidentifiers_to_channels": {},
                 "partneraddresses_to_channelidentifiers": {},
                 "_type": "raiden.transfer.state.TokenNetworkState",

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime
 
 import pytest
-from eth_utils import to_canonical_address
-from networkx import Graph
 
 from raiden.exceptions import SerializationError
 from raiden.messages.monitoring_service import RequestMonitoring, SignedBlindedBalanceProof
@@ -139,11 +137,6 @@ messages.append(
 
 
 @dataclass
-class ClassWithGraphObject:
-    graph: Graph
-
-
-@dataclass
 class ClassWithInt:
     value: int
 
@@ -190,22 +183,6 @@ def test_serialize_missing_attribute():
 
     with pytest.raises(SerializationError):
         JSONSerializer.serialize(instance)
-
-
-def test_serialization_networkx_graph():
-    p1 = to_canonical_address("0x5522070585a1a275631ba69c444ac0451AA9Fe4C")
-    p2 = to_canonical_address("0x5522070585a1a275631ba69c444ac0451AA9Fe4D")
-    p3 = to_canonical_address("0x5522070585a1a275631ba69c444ac0451AA9Fe4E")
-    p4 = to_canonical_address("0x5522070585a1a275631ba69c444ac0451AA9Fe4F")
-
-    e = [(p1, p2), (p2, p3), (p3, p4)]
-    graph = Graph(e)
-    instance = ClassWithGraphObject(graph)
-
-    data = JSONSerializer.serialize(instance)
-    restored_instance = JSONSerializer.deserialize(data)
-
-    assert instance.graph.edges == restored_instance.graph.edges
 
 
 def test_chainstate_restore():

--- a/raiden/tests/unit/test_startup.py
+++ b/raiden/tests/unit/test_startup.py
@@ -168,7 +168,7 @@ def test_setup_proxies_raiden_addresses_are_given():
         config=config,
         proxy_manager=proxy_manager,
         deployed_addresses=deployed_addresses,
-        routing_mode=RoutingMode.LOCAL,
+        routing_mode=RoutingMode.PRIVATE,
         pathfinding_service_address=None,
         enable_monitoring=False,
     )
@@ -182,7 +182,7 @@ def test_setup_proxies_raiden_addresses_are_given():
 
 def test_setup_proxies_all_addresses_are_given():
     """
-    Test that startup for proxies works fine if all addresses are given and routing is local
+    Test that startup for proxies works fine if all addresses are given and routing is private
     """
     chain_id = ChainID(5)
     config = RaidenConfig(chain_id=chain_id, environment_type=Environment.DEVELOPMENT)
@@ -200,7 +200,7 @@ def test_setup_proxies_all_addresses_are_given():
             config=config,
             proxy_manager=proxy_manager,
             deployed_addresses=deployed_addresses,
-            routing_mode=RoutingMode.LOCAL,
+            routing_mode=RoutingMode.PRIVATE,
             pathfinding_service_address="my-pfs",
             enable_monitoring=True,
         )

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -51,7 +51,6 @@ from raiden.transfer.state import (
     NetworkState,
     PendingLocksState,
     RouteState,
-    TokenNetworkGraphState,
     TokenNetworkRegistryState,
     TokenNetworkState,
 )
@@ -225,11 +224,7 @@ def test_subdispatch_to_paymenttask_target(chain_state, netting_channel_state):
 def test_maybe_add_tokennetwork_unknown_token_network_registry(chain_state, token_network_address):
     token_network_registry_address = factories.make_address()
     token_address = factories.make_address()
-    token_network = TokenNetworkState(
-        address=token_network_address,
-        token_address=token_address,
-        network_graph=TokenNetworkGraphState(token_network_address=token_network_address),
-    )
+    token_network = TokenNetworkState(address=token_network_address, token_address=token_address,)
     msg = "test state invalid, token_network_registry already in chain_state"
     assert (
         token_network_registry_address not in chain_state.identifiers_to_tokennetworkregistries
@@ -248,11 +243,7 @@ def test_maybe_add_tokennetwork_unknown_token_network_registry(chain_state, toke
 
 def test_handle_new_token_network(chain_state, token_network_address):
     token_address = factories.make_address()
-    token_network = TokenNetworkState(
-        address=token_network_address,
-        token_address=token_address,
-        network_graph=TokenNetworkGraphState(token_network_address=token_network_address),
-    )
+    token_network = TokenNetworkState(address=token_network_address, token_address=token_address,)
     token_network_registry_address = factories.make_address()
     state_change = ContractReceiveNewTokenNetwork(
         token_network_registry_address=token_network_registry_address,
@@ -309,11 +300,7 @@ def test_subdispatch_by_canonical_id(chain_state):
     )
     canonical_identifier = channel_state.canonical_identifier
     token_network = TokenNetworkState(
-        address=canonical_identifier.token_network_address,
-        token_address=factories.make_address(),
-        network_graph=TokenNetworkGraphState(
-            token_network_address=channel_state.token_network_address
-        ),
+        address=canonical_identifier.token_network_address, token_address=factories.make_address(),
     )
     token_network.partneraddresses_to_channelidentifiers[
         partner_model.participant_address
@@ -405,11 +392,7 @@ def test_handle_node_change_network_state(chain_state, netting_channel_state, mo
 
 def test_handle_new_token_network_registry(chain_state, token_network_address):
     token_address = factories.make_address()
-    token_network = TokenNetworkState(
-        address=token_network_address,
-        token_address=token_address,
-        network_graph=TokenNetworkGraphState(token_network_address=token_network_address),
-    )
+    token_network = TokenNetworkState(address=token_network_address, token_address=token_address,)
     token_network_registry = TokenNetworkRegistryState(
         address=factories.make_address(), token_network_list=[token_network]
     )

--- a/raiden/tests/unit/transfer/test_views.py
+++ b/raiden/tests/unit/transfer/test_views.py
@@ -3,13 +3,11 @@ from raiden.transfer import views
 from raiden.transfer.mediated_transfer.state import InitiatorPaymentState
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.transfer.state import (
-    TokenNetworkGraphState,
     TokenNetworkRegistryState,
     TokenNetworkState,
     TransactionExecutionStatus,
 )
 from raiden.transfer.views import (
-    count_token_network_channels,
     filter_channels_by_partneraddress,
     filter_channels_by_status,
     get_networks,
@@ -53,17 +51,6 @@ def test_filter_channels_by_status_empty_excludes():
     assert (
         filter_channels_by_status(channel_states=channel_states, exclude_states=None)
         == channel_states
-    )
-
-
-def test_count_token_network_channels_no_token_network(chain_state):
-    assert (
-        count_token_network_channels(
-            chain_state=chain_state,
-            token_network_registry_address=factories.make_address(),
-            token_address=factories.make_address(),
-        )
-        == 0
     )
 
 
@@ -428,11 +415,7 @@ def test_get_networks(chain_state, token_network_address):
     ) == (token_network_registry_empty, None)
 
     chain_state = orig_chain_state
-    token_network = TokenNetworkState(
-        address=token_network_address,
-        token_address=token_address,
-        network_graph=TokenNetworkGraphState(token_network_address=token_network_address),
-    )
+    token_network = TokenNetworkState(address=token_network_address, token_address=token_address,)
     token_network_registry = TokenNetworkRegistryState(
         address=factories.make_address(), token_network_list=[token_network]
     )

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1406,9 +1406,7 @@ def make_chain_state(
     token_network_address = channel_set.channels[0].canonical_identifier.token_network_address
     token_address = make_address()
 
-    token_network = TokenNetworkState(
-        address=token_network_address, token_address=token_address
-    )
+    token_network = TokenNetworkState(address=token_network_address, token_address=token_address)
     for netting_channel in channel_set.channels:
         token_network.channelidentifiers_to_channels[
             netting_channel.canonical_identifier.channel_identifier

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -1407,7 +1407,7 @@ def make_chain_state(
     token_address = make_address()
 
     token_network = TokenNetworkState(
-        address=token_network_address, token_address=token_address, network_graph=None
+        address=token_network_address, token_address=token_address
     )
     for netting_channel in channel_set.channels:
         token_network.channelidentifiers_to_channels[
@@ -1498,7 +1498,7 @@ def create_network(
     state = token_network_state
     channels = list()
 
-    for count, route in enumerate(routes, 1):
+    for route in routes:
         if route.address1 == our_address:
             channel = route_properties_to_channel(route)
             state_change = ContractReceiveChannelNew(
@@ -1526,8 +1526,5 @@ def create_network(
             pseudo_random_generator=random.Random(),
         )
         state = iteration.new_state
-
-        assert len(state.network_graph.channel_identifier_to_participants) == count
-        assert len(state.network_graph.network.edges()) == count
 
     return state, channels

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -54,8 +54,6 @@ from raiden.transfer.state_change import (
     ContractReceiveChannelWithdraw,
     ContractReceiveNewTokenNetwork,
     ContractReceiveNewTokenNetworkRegistry,
-    ContractReceiveRouteClosed,
-    ContractReceiveRouteNew,
     ContractReceiveSecretReveal,
     ContractReceiveUpdateTransfer,
     ReceiveDelivered,
@@ -87,8 +85,6 @@ TokenNetworkStateChange = Union[
     ContractReceiveChannelNew,
     ContractReceiveChannelDeposit,
     ContractReceiveChannelSettled,
-    ContractReceiveRouteNew,
-    ContractReceiveRouteClosed,
     ContractReceiveUpdateTransfer,
     ContractReceiveChannelClosed,
     ContractReceiveChannelWithdraw,
@@ -816,12 +812,6 @@ def handle_state_change(
         iteration = handle_token_network_action(chain_state, state_change)
     elif type(state_change) == ContractReceiveChannelSettled:
         assert isinstance(state_change, ContractReceiveChannelSettled), MYPY_ANNOTATION
-        iteration = handle_token_network_action(chain_state, state_change)
-    elif type(state_change) == ContractReceiveRouteNew:
-        assert isinstance(state_change, ContractReceiveRouteNew), MYPY_ANNOTATION
-        iteration = handle_token_network_action(chain_state, state_change)
-    elif type(state_change) == ContractReceiveRouteClosed:
-        assert isinstance(state_change, ContractReceiveRouteClosed), MYPY_ANNOTATION
         iteration = handle_token_network_action(chain_state, state_change)
     elif type(state_change) == ContractReceiveSecretReveal:
         assert isinstance(state_change, ContractReceiveSecretReveal), MYPY_ANNOTATION

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -849,6 +849,8 @@ def handle_state_change(
     elif type(state_change) == ReceiveWithdrawExpired:
         assert isinstance(state_change, ReceiveWithdrawExpired), MYPY_ANNOTATION
         iteration = handle_receive_withdraw_expired(chain_state, state_change)
+    else:
+        iteration = TransitionResult(chain_state, [])
 
     chain_state = iteration.new_state
     assert chain_state is not None, "chain_state must be set"

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -315,6 +315,24 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
         return self.canonical_identifier.token_network_address
 
 
+# FIXME: remove on next breaking release
+# This needs to be kept, so that the state changes that are already in the DB
+# continue to be decodable.
+@dataclass(frozen=True)
+class ContractReceiveRouteClosed(ContractReceiveStateChange):
+    """ A channel was closed and this node is NOT a participant. """
+
+    canonical_identifier: CanonicalIdentifier
+
+    @property
+    def channel_identifier(self) -> ChannelID:
+        return self.canonical_identifier.channel_identifier
+
+    @property
+    def token_network_address(self) -> TokenNetworkAddress:
+        return self.canonical_identifier.token_network_address
+
+
 @dataclass(frozen=True)
 class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
     canonical_identifier: CanonicalIdentifier

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -316,21 +316,6 @@ class ContractReceiveRouteNew(ContractReceiveStateChange):
 
 
 @dataclass(frozen=True)
-class ContractReceiveRouteClosed(ContractReceiveStateChange):
-    """ A channel was closed and this node is NOT a participant. """
-
-    canonical_identifier: CanonicalIdentifier
-
-    @property
-    def channel_identifier(self) -> ChannelID:
-        return self.canonical_identifier.channel_identifier
-
-    @property
-    def token_network_address(self) -> TokenNetworkAddress:
-        return self.canonical_identifier.token_network_address
-
-
-@dataclass(frozen=True)
 class ContractReceiveUpdateTransfer(ContractReceiveStateChange):
     canonical_identifier: CanonicalIdentifier
     nonce: Nonce

--- a/raiden/transfer/views.py
+++ b/raiden/transfer/views.py
@@ -58,23 +58,6 @@ def block_number(chain_state: ChainState) -> BlockNumber:
     return chain_state.block_number
 
 
-def count_token_network_channels(
-    chain_state: ChainState,
-    token_network_registry_address: TokenNetworkRegistryAddress,
-    token_address: TokenAddress,
-) -> int:
-    token_network = get_token_network_by_token_address(
-        chain_state, token_network_registry_address, token_address
-    )
-
-    if token_network is not None:
-        count = len(token_network.network_graph.network)
-    else:
-        count = 0
-
-    return count
-
-
 def state_from_raiden(raiden: "RaidenService") -> ChainState:  # pragma: no unittest
     assert raiden.wal, "raiden.wal not set"
     return raiden.wal.get_current_state()
@@ -106,7 +89,10 @@ def get_participants_addresses(
     )
 
     if token_network is not None:
-        addresses = set(token_network.network_graph.network.nodes())
+        addresses = set()
+        for channel_state in token_network.channelidentifiers_to_channels.values():
+            addresses.add(channel_state.partner_state.address)
+            addresses.add(channel_state.our_state.address)
     else:
         addresses = set()
 

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -278,8 +278,7 @@ def options(func: Callable) -> Callable:
                 help=(
                     "Specify the routing mode to be used.\n"
                     '"pfs": use the path finding service\n'
-                    '"local": use local routing, but send updates to the PFS\n'
-                    '"private": use local routing and don\'t send updates to the PFS\n'
+                    '"private": only use direct channels and don\'t send updates to the PFS\n'
                 ),
                 type=EnumChoiceType(RoutingMode),
                 default=RoutingMode.PFS.value,
@@ -792,7 +791,7 @@ def smoketest(
 
                 # Matrix server
                 args["one_to_n_contract_address"] = "0x" + "1" * 40
-                args["routing_mode"] = RoutingMode.LOCAL
+                args["routing_mode"] = RoutingMode.PRIVATE
                 args["flat_fee"] = ()
                 args["proportional_fee"] = ()
                 args["proportional_imbalance_fee"] = ()

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -100,7 +100,6 @@ mypy-extensions==0.4.3    # via -r requirements-dev.txt, mypy, raiden-contracts,
 mypy==0.782               # via -r requirements-dev.txt
 netaddr==0.7.19           # via -r requirements-dev.txt, matrix-synapse, multiaddr
 netifaces==0.10.9         # via -r requirements-dev.txt, aioice
-networkx==2.5             # via -r requirements-dev.txt
 objgraph==3.4.1           # via -r requirements-dev.txt
 packaging==19.0           # via -r requirements-dev.txt, pytest, sphinx
 parsimonious==0.8.1       # via -r requirements-dev.txt, eth-abi

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -98,7 +98,6 @@ mypy-extensions==0.4.3    # via -r requirements.txt, mypy, raiden-contracts, typ
 mypy==0.782               # via -r requirements-dev.in
 netaddr==0.7.19           # via -r requirements.txt, matrix-synapse, multiaddr
 netifaces==0.10.9         # via -r requirements.txt, aioice
-networkx==2.5             # via -r requirements.txt
 objgraph==3.4.1           # via -r requirements.txt
 packaging==19.0           # via -r requirements-docs.txt, pytest, sphinx
 parsimonious==0.8.1       # via -r requirements.txt, eth-abi

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -18,7 +18,6 @@ marshmallow_enum
 matrix-client==0.3.2
 mirakuru==2.1.2
 netifaces
-networkx
 psutil
 pysha3
 toml

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -57,7 +57,6 @@ multiaddr==0.0.9          # via ipfshttpclient
 mypy-extensions==0.4.3    # via raiden-contracts, typing-inspect
 netaddr==0.7.19           # via multiaddr
 netifaces==0.10.9         # via -r requirements.in, aioice
-networkx==2.5             # via -r requirements.in
 objgraph==3.4.1           # via -r requirements.in
 parsimonious==0.8.1       # via eth-abi
 protobuf==3.11.3          # via web3


### PR DESCRIPTION
## Description

Fixes: https://github.com/raiden-network/raiden/issues/6496

Remove internal routing.

Note: This doesn't remove `ContractReceiveRouteNew` yet, as it is used by the connection manager.