### PR TITLE
Update `pillow`

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -40,7 +40,7 @@ coverage==5.3             # via -r requirements-dev.txt
 crc32c==2.0               # via -r requirements-dev.txt, aiortc
 cryptography==2.9.2       # via -r requirements-dev.txt, aiortc, pyopenssl, service-identity
 cytoolz==0.10.1           # via -r requirements-dev.txt, eth-keyfile, eth-utils
-decorator==4.4.0          # via -r requirements-dev.txt, ipython, networkx, traitlets
+decorator==4.4.0          # via -r requirements-dev.txt, ipython, traitlets
 docutils==0.14            # via -r requirements-dev.txt, readme-renderer, sphinx, sphinxcontrib-httpexample
 eth-abi==2.1.0            # via -r requirements-dev.txt, eth-account, raiden-contracts, web3
 eth-account==0.5.3        # via -r requirements-dev.txt, web3
@@ -72,7 +72,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==5.35.2        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.7.0  # via -r requirements-dev.txt, flake8, flake8-comprehensions, jsonschema, pluggy, pytest
+importlib-metadata==1.7.0  # via -r requirements-dev.txt, pluggy
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 iniconfig==1.0.1          # via -r requirements-dev.txt, pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements-dev.txt, web3
@@ -112,7 +112,7 @@ pdbpp==0.10.2             # via -r requirements-dev.txt
 pexpect==4.8.0            # via -r requirements-dev.txt, ipython
 phonenumbers==8.10.13     # via -r requirements-dev.txt, matrix-synapse
 pickleshare==0.7.5        # via -r requirements-dev.txt, ipython
-pillow==6.2.0             # via -r requirements-dev.txt, matrix-synapse
+pillow==7.2.0             # via -r requirements-dev.txt, matrix-synapse
 pip-tools==5.3.1          # via -r requirements-dev.txt
 pluggy==0.12.0            # via -r requirements-dev.txt, pytest
 prometheus-client==0.3.1  # via -r requirements-dev.txt, matrix-synapse
@@ -186,8 +186,8 @@ toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
 twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
-typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, black, mypy
-typing-extensions==3.7.4.3  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson, web3
+typed-ast==1.4.0          # via -r requirements-dev.txt, black, mypy
+typing-extensions==3.7.4.3  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via -r requirements-dev.txt, matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-dev.txt, requests

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -17,7 +17,7 @@ attrs==19.3.0             # via -r requirements.txt, automat, black, flake8-bugb
 automat==0.7.0            # via twisted
 av==8.0.2                 # via -r requirements.txt, aiortc
 babel==2.7.0              # via -r requirements-docs.txt, sphinx
-backcall==0.1.0           # via -r requirements.txt, ipython
+backcall==0.1.0           # via ipython
 base58==2.0.0             # via -r requirements.txt, multiaddr
 bcrypt==3.1.6             # via matrix-synapse
 bitarray==1.2.1           # via -r requirements.txt, eth-account
@@ -38,7 +38,7 @@ coverage==5.3             # via -r requirements-dev.in
 crc32c==2.0               # via -r requirements.txt, aiortc
 cryptography==2.9.2       # via -r requirements.txt, aiortc, pyopenssl, service-identity
 cytoolz==0.10.1           # via -r requirements.txt, eth-keyfile, eth-utils
-decorator==4.4.0          # via -r requirements.txt, ipython, networkx, traitlets
+decorator==4.4.0          # via -r requirements.txt, ipython, traitlets
 docutils==0.14            # via -r requirements-docs.txt, readme-renderer, sphinx, sphinxcontrib-httpexample
 eth-abi==2.1.0            # via -r requirements.txt, eth-account, raiden-contracts, web3
 eth-account==0.5.3        # via -r requirements.txt, web3
@@ -70,7 +70,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==5.35.2        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.7.0  # via -r requirements.txt, flake8, flake8-comprehensions, jsonschema, pluggy, pytest
+importlib-metadata==1.7.0  # via -r requirements.txt, pluggy
 incremental==17.5.0       # via treq, twisted
 iniconfig==1.0.1          # via pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements.txt, web3
@@ -109,7 +109,7 @@ pdbpp==0.10.2             # via -r requirements-dev.in
 pexpect==4.8.0            # via -r requirements-dev.in, ipython
 phonenumbers==8.10.13     # via matrix-synapse
 pickleshare==0.7.5        # via ipython
-pillow==6.2.0             # via matrix-synapse
+pillow==7.2.0             # via matrix-synapse
 pip-tools==5.3.1          # via -r requirements-dev.in
 pluggy==0.12.0            # via pytest
 prometheus-client==0.3.1  # via matrix-synapse
@@ -128,7 +128,7 @@ pycparser==2.19           # via -r requirements.txt, cffi
 pycryptodome==3.8.2       # via -r requirements.txt, eth-hash, eth-keyfile
 pyee==7.0.2               # via -r requirements.txt, aiortc
 pyflakes==2.2.0           # via flake8
-pygments==2.6.1           # via -r requirements-docs.txt, -r requirements.txt, ipython, pdbpp, readme-renderer, sphinx
+pygments==2.6.1           # via -r requirements-docs.txt, ipython, pdbpp, readme-renderer, sphinx
 pyhamcrest==1.9.0         # via twisted
 pylibsrtp==0.6.6          # via -r requirements.txt, aiortc
 pylint==2.6.0             # via -r requirements-dev.in
@@ -178,8 +178,8 @@ toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via ipython
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==20.3.0      # via matrix-synapse, treq
-typed-ast==1.4.0          # via astroid, black, mypy
-typing-extensions==3.7.4.3  # via -r requirements.txt, matrix-synapse, mypy, signedjson, web3
+typed-ast==1.4.0          # via black, mypy
+typing-extensions==3.7.4.3  # via -r requirements.txt, matrix-synapse, mypy, signedjson
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, requests


### PR DESCRIPTION
GitHub showed warnings about potential CVEs. Those shouldn't be urgent though, as we only use `synapse` as a dev dependency.
