### PR TITLE
Refactorings web rtc

### DIFF
--- a/raiden/__main__.py
+++ b/raiden/__main__.py
@@ -6,11 +6,9 @@ def main() -> None:
 
     gevent.monkey.patch_all()
 
-    import asyncio  # isort:skip # noqa
-    import raiden.network.transport.matrix.rtc.aiogevent as aiogevent  # isort:skip # noqa
+    from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 
-    asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-    gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
+    setup_asyncio_event_loop()
 
     from raiden.ui.cli import run
 

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -209,3 +209,26 @@ PROPORTIONAL_MED_FEE_MIN = 0
 PROPORTIONAL_MED_FEE_MAX = 1_000_000
 IMBALANCE_MED_FEE_MIN = 0
 IMBALANCE_MED_FEE_MAX = 50_000
+
+
+# Web RTC constants
+class RTCMessageType(Enum):
+    OFFER = "offer"
+    ANSWER = "answer"
+    CANDIDATES = "candidates"
+    HANGUP = "hangup"
+
+
+class SDPTypes(Enum):
+    OFFER = "offer"
+    ANSWER = "answer"
+
+
+class RTCChannelState(Enum):
+    CONNECTING = "connecting"
+    OPEN = "open"
+    CLOSING = "closing"
+    CLOSED = "closed"
+
+
+WEB_RTC_CHANNEL_TIMEOUT = 10

--- a/raiden/network/transport/matrix/rtc/utils.py
+++ b/raiden/network/transport/matrix/rtc/utils.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from asyncio import Future
+
+import gevent
+from gevent import Greenlet
+
+from raiden.network.transport.matrix.rtc import aiogevent
+from raiden.network.transport.matrix.rtc.aiogevent import yield_future
+from raiden.utils.typing import Address, Any, Callable, Coroutine, Optional
+
+
+def setup_asyncio_event_loop() -> None:
+    asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())
+    gevent.spawn(asyncio.get_event_loop().run_forever)
+
+
+def spawn_coroutine(
+    coroutine: Coroutine,
+    callback: Optional[Callable[[Any, Address], None]],
+    partner_address: Address,
+) -> Greenlet:
+    """Spawns a greenlet which runs a coroutine inside waiting for the result"""
+
+    return gevent.spawn(
+        wait_for_future, asyncio.ensure_future(coroutine), callback, partner_address
+    )
+
+
+def wait_for_future(future: Future, callback: Callable, partner_address: Address) -> None:
+    """yield future and call callback with the result"""
+    result = yield_future(future)
+    if callback is not None:
+        callback(result, partner_address)

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -1,26 +1,19 @@
-import asyncio
 import time
-from asyncio import Future
 from dataclasses import dataclass, field
-from enum import Enum
+from functools import partial
 
 import gevent
 import structlog
 from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
-from gevent import Greenlet
 from gevent.event import Event
 
-from raiden.network.transport.matrix.rtc.aiogevent import yield_future
+from raiden.constants import RTCChannelState, SDPTypes
+from raiden.network.transport.matrix.rtc.utils import spawn_coroutine
 from raiden.network.transport.matrix.utils import my_place_or_yours
 from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import Address, Callable, Coroutine, Dict, List, Optional
+from raiden.utils.typing import Address, Any, Callable, Coroutine, Dict, Optional, Set
 
 log = structlog.get_logger(__name__)
-
-
-class SDPTypes(Enum):
-    OFFER = "offer"
-    ANSWER = "answer"
 
 
 @dataclass
@@ -38,20 +31,11 @@ class RTCPartner:
         )
         self.channel = self.peer_connection.createDataChannel(channel_name)
 
-
-def spawn_coroutine(
-    coroutine: Coroutine, callback: Callable, partner_address: Address
-) -> Greenlet:
-
-    return gevent.spawn(
-        wait_for_future, asyncio.ensure_future(coroutine), callback, partner_address
-    )
-
-
-def wait_for_future(future: Future, callback: Callable, partner_address: Address) -> None:
-    result = yield_future(future)
-    if callback is not None:
-        callback(result, partner_address)
+    def get_call_id(self, node_address: Address) -> str:
+        lower_address = my_place_or_yours(node_address, self.partner_address)
+        higher_address = self.partner_address if lower_address == node_address else node_address
+        call_id = f"{to_checksum_address(lower_address)}|{to_checksum_address(higher_address)}"
+        return call_id
 
 
 class WebRTCManager:
@@ -64,8 +48,8 @@ class WebRTCManager:
         self.node_address: Optional[Address] = node_address
         self._handle_message_callback = handle_message_callback
         self._handle_sdp_callback = handle_sdp_callback
-        self.address_to_rtc_partners: Dict[Address, RTCPartner] = dict()
-        self.coroutines: List[Coroutine] = list()
+        self.address_to_rtc_partners: Dict[Address, RTCPartner] = {}
+        self.wrapped_coroutines: Set[gevent.Greenlet] = set()
 
     def get_rtc_partner(self, partner_address: Address) -> RTCPartner:
         if partner_address not in self.address_to_rtc_partners:
@@ -80,137 +64,203 @@ class WebRTCManager:
         channel = self.address_to_rtc_partners[partner_address].channel
         if channel is None:
             return False
-        if channel.readyState == "open":
+        if channel.readyState == RTCChannelState.OPEN.value:
             return True
         return False
 
-    def async_create_channel(self, partner_address: Address) -> None:
-        assert self.node_address, "Transport is not started yet but tried to create rtc channel"
-        rtc_partner = self.get_rtc_partner(partner_address)
-        spawn_coroutine(
-            coroutine=create_channel(
-                rtc_partner, self.node_address, self._handle_message_callback
-            ),
-            callback=self._handle_sdp_callback,
-            partner_address=partner_address,
+    def _reset_state(self) -> None:
+        self.address_to_rtc_partners = {}
+        self.wrapped_coroutines = set()
+
+    def _spawn_web_rtc_coroutine(
+        self,
+        coroutine: Coroutine,
+        callback: Optional[Callable[[Any, Address], None]],
+        partner_address: Address,
+    ) -> None:
+        self.wrapped_coroutines.add(
+            spawn_coroutine(
+                coroutine=coroutine,
+                callback=callback,
+                partner_address=partner_address,
+            )
         )
 
-    def async_set_remote_description(
+    def spawn_create_channel(self, partner_address: Address) -> None:
+        assert self.node_address, "Transport is not started yet but tried to create rtc channel"
+        rtc_partner = self.get_rtc_partner(partner_address)
+        coroutine = create_channel_coroutine(
+            rtc_partner, self.node_address, self._handle_message_callback
+        )
+        self._spawn_web_rtc_coroutine(coroutine, self._handle_sdp_callback, partner_address)
+
+    def spawn_set_remote_description(
         self, partner_address: Address, description: Dict[str, str]
     ) -> None:
         assert self.node_address, "Transport is not started yet but tried to set candidates"
         rtc_partner = self.get_rtc_partner(partner_address)
-        spawn_coroutine(
-            coroutine=set_remote_description(
-                rtc_partner=rtc_partner,
-                node_address=self.node_address,
-                description=description,
-                handle_message_callback=self._handle_message_callback,
-            ),
-            callback=self._handle_sdp_callback,
-            partner_address=partner_address,
+
+        if rtc_partner.peer_connection.remoteDescription is not None:
+            log.debug(
+                "Remote description already set",
+                node=to_checksum_address(self.node_address),
+                partner_address=to_checksum_address(partner_address),
+            )
+            return
+        coroutine = set_remote_description_coroutine(
+            rtc_partner=rtc_partner,
+            node_address=self.node_address,
+            description=description,
+            handle_message_callback=self._handle_message_callback,
         )
+        self._spawn_web_rtc_coroutine(coroutine, self._handle_sdp_callback, partner_address)
+
+    def close(self, partner_address: Address) -> None:
+        rtc_partner = self.address_to_rtc_partners.pop(partner_address, None)
+
+        if rtc_partner is not None:
+            aiortc_channel_close_callback(rtc_partner)
+            rtc_partner.peer_connection.close()
 
     def stop(self) -> None:
         if self.node_address is None:
             return
 
-        log.debug("Gracefully closing rtc channels", node=to_checksum_address(self.node_address))
+        log.debug("Closing rtc channels", node=to_checksum_address(self.node_address))
 
         for rtc_partner in self.address_to_rtc_partners.values():
-            if rtc_partner.channel:
-                rtc_partner.channel.close()
+            aiortc_channel_close_callback(rtc_partner)
+
+        gevent.joinall(set(self.wrapped_coroutines), raise_error=True)
+        self._reset_state()
 
 
-async def create_channel(
-    rtc_partner: RTCPartner, node_address: Address, handle_message_callback: Callable
-) -> RTCSessionDescription:
+def aiortc_channel_close_callback(rtc_partner: RTCPartner) -> None:
+    """callback if channel is closed. It is part of a partial function"""
+    if rtc_partner.channel is not None:
+        # remove all listeners on channel to not receive events anymore
+        rtc_partner.channel.remove_all_listeners()
+        rtc_partner.channel.close()
+        rtc_partner.channel = None
+
+
+async def aiortc_channel_message_callback(
+    rtc_partner: RTCPartner,
+    node_address: Address,
+    handle_message_callback: Callable[[str, Address], None],
+    message: str,
+) -> None:
+    """callback if message is received. It is part of a partial function"""
+    assert rtc_partner.channel, "channel not set but received message"
+    log.debug(
+        "Received message in asyncio kingdom",
+        node=to_checksum_address(node_address),
+        partner_address=to_checksum_address(rtc_partner.partner_address),
+        channel=rtc_partner.channel.label,
+        message=message,
+        time=time.time(),
+    )
+    # callback to transport
+    handle_message_callback(message, rtc_partner.partner_address)
+
+
+async def create_channel_coroutine(
+    rtc_partner: RTCPartner,
+    node_address: Address,
+    handle_message_callback: Callable[[str, Address], None],
+) -> Optional[RTCSessionDescription]:
+    """Coroutine to create channel. Setting up channel in aiortc"""
 
     pc = rtc_partner.peer_connection
     rtc_partner.create_channel(node_address)
 
     offer = await pc.createOffer()
     await pc.setLocalDescription(offer)
+    if rtc_partner.channel is None:
+        return None
 
     log.debug("Created offer", offer=offer)
 
-    msg = "Channel must be created already"
-    assert rtc_partner.channel is not None, msg
-
-    @rtc_partner.channel.on("message")
-    async def on_message(message: Dict[str, bytes]) -> None:  # pylint: disable=unused-variable
-        log.debug(
-            "Received message in asyncio kingdom",
-            node=to_checksum_address(node_address),
-            message=message,
-            time=time.time(),
-        )
-        handle_message_callback(message, rtc_partner.partner_address)
-
-    @rtc_partner.channel.on("close")
-    def on_close() -> None:  # pylint: disable=unused-variable
-        rtc_partner.channel = None
+    # channel callback on message signal
+    rtc_partner.channel.on(
+        "message",
+        partial(
+            aiortc_channel_message_callback,
+            rtc_partner,
+            node_address,
+            handle_message_callback,
+        ),
+    )
+    # channel callback on close signal
+    rtc_partner.channel.on("close", partial(aiortc_channel_close_callback, rtc_partner))
 
     return pc.localDescription
 
 
-async def set_remote_description(
+async def set_remote_description_coroutine(
     rtc_partner: RTCPartner,
     node_address: Address,
     description: Dict[str, str],
-    handle_message_callback: Callable,
+    handle_message_callback: Callable[[str, Address], None],
 ) -> Optional[RTCSessionDescription]:
+    """Coroutine to set remote description. Sets remote description in aiortc"""
+    log.debug(
+        "Received signalling message from partner",
+        node=to_checksum_address(node_address),
+        partner=to_checksum_address(rtc_partner.partner_address),
+        type=description["type"],
+        description=description["sdp"],
+    )
 
     remote_description = RTCSessionDescription(description["sdp"], description["type"])
     sdp_type = description["type"]
     pc = rtc_partner.peer_connection
-    await pc.setRemoteDescription(remote_description)
+    try:
+        await pc.setRemoteDescription(remote_description)
+    except ValueError:
+        return None
 
     @rtc_partner.peer_connection.on("datachannel")
     def on_datachannel(channel: RTCDataChannel) -> None:  # pylint: disable=unused-variable
         rtc_partner.channel = channel
         log.debug(f"Received rtc channel {channel.label}", node=to_checksum_address(node_address))
 
-        @channel.on("close")
-        def channel_closed() -> None:  # pylint: disable=unused-variable
-            rtc_partner.channel = None
-
-        @channel.on("message")
-        async def on_message(message: Dict[str, bytes]) -> None:  # pylint:disable=unused-variable
-            log.debug(
-                "Received message in asyncio kingdom",
-                node=to_checksum_address(node_address),
-                message=message,
-                time=time.time(),
-            )
-            handle_message_callback(message, rtc_partner.partner_address)
-
-        @channel.on("close")
-        async def on_close() -> None:  # pylint: disable=unused-variable
-            rtc_partner.channel = None
+        rtc_partner.channel.on(
+            "message",
+            partial(
+                aiortc_channel_message_callback,
+                rtc_partner,
+                node_address,
+                handle_message_callback,
+            ),
+        )
+        rtc_partner.channel.on("close", partial(aiortc_channel_close_callback, rtc_partner))
 
     if sdp_type == SDPTypes.OFFER.value:
         # send answer
         answer = await pc.createAnswer()
         await pc.setLocalDescription(answer)
-
         return pc.localDescription
     return None
 
 
-def send_message(rtc_partner: RTCPartner, message: str, node_address: Address) -> None:
+def send_rtc_message(rtc_partner: RTCPartner, message: str, node_address: Address) -> None:
+    """Sends message through aiortc. Not an async function. Output is written to buffer"""
     channel = rtc_partner.channel
-    if channel is not None and channel.readyState == "open":
+    if channel is not None and channel.readyState == RTCChannelState.OPEN.value:
         log.debug(
             "Sending message in asyncio kingdom",
             node=to_checksum_address(node_address),
+            partner_address=to_checksum_address(rtc_partner.partner_address),
+            channel=channel.label,
             message=message,
             time=time.time(),
         )
         channel.send(message)
     else:
         log.debug(
-            "Channel is not open. ReadyState: "
-            f"{channel.readyState if channel is not None else 'No channel exists'}",
+            "Channel is not open but trying to send a message.",
             node=to_checksum_address(node_address),
+            partner_address=to_checksum_address(rtc_partner.partner_address),
+            ready_state=channel.readyState if channel is not None else "No channel exists",
         )

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -342,13 +342,12 @@ class UserAddressManager:
         """ This pulls the `avatar_url` for a given user/user_id and parses the capabilities.  """
         try:
             user: User = self._client.get_user(user_id)
+            avatar_url = user.get_avatar_url()
+            if avatar_url is not None:
+                return PeerCapabilities(deserialize_capabilities(avatar_url))
         except MatrixRequestError:
-            return PeerCapabilities({})
-        avatar_url = user.get_avatar_url()
-        if avatar_url is not None:
-            return PeerCapabilities(deserialize_capabilities(avatar_url))
-        else:
-            return PeerCapabilities({})
+            log.debug("Could not fetch capabilities", user_id=user_id)
+        return PeerCapabilities({})
 
     def get_reachability_from_matrix(self, user_ids: Iterable[str]) -> AddressReachability:
         """Get the current reachability without any side effects

--- a/raiden/tests/integration/network/transport/test_web_rtc.py
+++ b/raiden/tests/integration/network/transport/test_web_rtc.py
@@ -70,5 +70,4 @@ def test_web_rtc_message_sync(matrix_transports):
 
     with Timeout(TIMEOUT_MESSAGE_RECEIVE):
         while not len(transport1_messages) == 5:
-            print(len(transport1_messages))
             gevent.sleep(0.1)

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -5,6 +5,7 @@ import time
 
 import gevent
 import IPython
+import nest_asyncio
 from eth_utils import denoms, to_canonical_address
 
 from raiden import waiting
@@ -111,6 +112,7 @@ class Console(gevent.Greenlet):
         print("Entering Console" + OKGREEN)
         print("Tip:" + OKBLUE)
         print_usage()
+        nest_asyncio.apply()
         IPython.start_ipython(argv=[], user_ns=self.console_locals)
 
         sys.exit(0)

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -98,6 +98,7 @@ msgpack==0.6.1            # via -r requirements-dev.txt, matrix-synapse
 multiaddr==0.0.9          # via -r requirements-dev.txt, ipfshttpclient
 mypy-extensions==0.4.3    # via -r requirements-dev.txt, black, mypy, raiden-contracts, typing-inspect
 mypy==0.782               # via -r requirements-dev.txt
+nest-asyncio==1.4.1       # via -r requirements-dev.txt
 netaddr==0.7.19           # via -r requirements-dev.txt, matrix-synapse, multiaddr
 netifaces==0.10.9         # via -r requirements-dev.txt, aioice
 objgraph==3.4.1           # via -r requirements-dev.txt

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -36,6 +36,7 @@ ipython
 pdbpp
 colour
 py-spy
+nest-asyncio
 
 # Continuous Integration
 coverage

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -70,7 +70,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==5.35.2        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==2.0.0  # via -r requirements.txt, pluggy
+importlib-metadata==2.0.0  # via pluggy
 incremental==17.5.0       # via treq, twisted
 iniconfig==1.0.1          # via pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements.txt, web3
@@ -96,6 +96,7 @@ msgpack==0.6.1            # via matrix-synapse
 multiaddr==0.0.9          # via -r requirements.txt, ipfshttpclient
 mypy-extensions==0.4.3    # via -r requirements.txt, black, mypy, raiden-contracts, typing-inspect
 mypy==0.782               # via -r requirements-dev.in
+nest-asyncio==1.4.1       # via -r requirements-dev.in
 netaddr==0.7.19           # via -r requirements.txt, matrix-synapse, multiaddr
 netifaces==0.10.9         # via -r requirements.txt, aioice
 objgraph==3.4.1           # via -r requirements.txt
@@ -190,7 +191,7 @@ werkzeug==1.0.1           # via -r requirements.txt, flask
 wheel==0.33.4             # via -r requirements-docs.txt, astunparse
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==3.2.0               # via -r requirements.txt, importlib-metadata
+zipp==3.2.0               # via importlib-metadata
 zope.event==4.4           # via -r requirements.txt, gevent
 zope.interface==5.1.0     # via -r requirements.txt, gevent, twisted
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -40,7 +40,6 @@ greenlet==0.4.17          # via gevent
 guppy3==3.0.10.post1      # via -r requirements.in
 hexbytes==0.2.0           # via eth-account, eth-rlp, web3
 idna==2.8                 # via requests
-importlib-metadata==2.0.0  # via jsonschema
 ipfshttpclient==0.6.0.post1  # via web3
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
@@ -80,14 +79,13 @@ six==1.15.0               # via cryptography, flask-cors, flask-restful, jsonsch
 structlog==20.1.0         # via -r requirements.in
 toml==0.10.1              # via -r requirements.in
 toolz==0.9.0              # via cytoolz
-typing-extensions==3.7.4.3  # via -r requirements.in, web3
+typing-extensions==3.7.4.3  # via -r requirements.in
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
 varint==1.0.2             # via multiaddr
 web3==5.12.1              # via -r requirements.in, raiden-contracts
 websockets==8.1           # via web3
 werkzeug==1.0.1           # via flask
-zipp==3.2.0               # via importlib-metadata
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 

--- a/tools/debugging/channels_with_minimum_balance.py
+++ b/tools/debugging/channels_with_minimum_balance.py
@@ -15,13 +15,9 @@ import gevent
 import requests
 import structlog
 
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
-
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
-
+setup_asyncio_event_loop()
 
 NODE_SECTION_RE = re.compile("^node[0-9]+")
 API_VERSION = "v1"

--- a/tools/debugging/matrix/generate_messages.py
+++ b/tools/debugging/matrix/generate_messages.py
@@ -15,6 +15,7 @@ import structlog
 from gevent.pool import Pool
 
 from raiden.network.transport.matrix.client import GMatrixClient, MatrixSyncMessages, Room, User
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 from raiden.network.transport.matrix.utils import login
 from raiden.settings import (
     DEFAULT_TRANSPORT_MATRIX_SYNC_LATENCY,
@@ -24,12 +25,7 @@ from raiden.tests.utils import factories
 from raiden.utils.signer import Signer
 from raiden.utils.typing import Any, Dict, Iterator, RoomID
 
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
-
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
-
+setup_asyncio_event_loop()
 
 log = structlog.get_logger(__name__)
 

--- a/tools/debugging/matrix/load_with_generate_messages.py
+++ b/tools/debugging/matrix/load_with_generate_messages.py
@@ -8,17 +8,10 @@ import time
 from dataclasses import dataclass
 from typing import Iterator, List
 
-import gevent
-
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 from raiden.utils.nursery import Janitor, Nursery
 
-
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
-
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
-
+setup_asyncio_event_loop()
 
 CWD = os.path.dirname(os.path.abspath(__file__))
 GENERATE_MESSAGES_SCRIPT = os.path.join(CWD, "generate_messages.py")

--- a/tools/debugging/matrix/presence_report.py
+++ b/tools/debugging/matrix/presence_report.py
@@ -7,25 +7,20 @@ import json
 
 import click
 import gevent
-
 import structlog
 from eth_account import Account
 from eth_utils import decode_hex
 
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 from raiden.utils.signer import LocalSigner
 
-
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
-
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
-
+setup_asyncio_event_loop()
 
 log = structlog.get_logger(__name__)
 
 if True:
     import sys
+
     from raiden.network.transport.matrix.client import GMatrixClient
     from raiden.network.transport.matrix.utils import login
 

--- a/tools/debugging/matrix/presence_update.py
+++ b/tools/debugging/matrix/presence_update.py
@@ -3,11 +3,10 @@ import gevent.monkey  # isort:skip # noqa
 
 gevent.monkey.patch_all()  # isort:skip # noqa
 
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
+setup_asyncio_event_loop()
+
 if True:
     import sys
     from raiden.network.transport.matrix.client import GMatrixClient

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -25,18 +25,14 @@ from gevent.pool import Pool
 from gevent.subprocess import DEVNULL, STDOUT, Popen
 from greenlet import greenlet
 
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 from raiden.network.utils import get_free_port
 from raiden.transfer.state import NetworkState
 from raiden.utils.formatting import pex
 from raiden.utils.nursery import Janitor, Nursery
 from raiden.utils.typing import Address, Host, Port, TokenAmount
 
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
-
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
-
+setup_asyncio_event_loop()
 
 BaseURL = NewType("BaseURL", str)
 Amount = NewType("Amount", int)

--- a/tools/pyinstaller_hooks/runtime_gevent_monkey.py
+++ b/tools/pyinstaller_hooks/runtime_gevent_monkey.py
@@ -1,10 +1,7 @@
 from gevent.monkey import patch_all  # isort:skip # noqa
-import gevent
 
 patch_all()  # isort:skip # noqa
 
-import asyncio  # isort:skip # noqa
-from raiden.network.transport.matrix.rtc import aiogevent  # isort:skip # noqa
+from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
 
-asyncio.set_event_loop_policy(aiogevent.EventLoopPolicy())  # isort:skip # noqa
-gevent.spawn(asyncio.get_event_loop().run_forever)  # isort:skip # noqa
+setup_asyncio_event_loop()


### PR DESCRIPTION
## Description

a couple of issues to be fixed:

- [x] error handling for malformed signalling messages (DoS prevention)
- [x] `msgType`clarification
- [x] Race condition between Health Check and handling signalling messages
- [x] fixing #6568
- [x] ignoring messages from own address (before it only filtered messages from own user)
- [x] fixing multiple asyncio loops running (when starting the raiden with `--console` ipython starts another loop) by using nestasyncio
- [x] move rtc channel creation from healthcheck to reachability changed to online (the latter relies on the first)
- [x] fixing minor race conditions