### PR TITLE
Always return None if validate_user_id fails

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -762,15 +762,14 @@ def validate_userid_signature(user: User) -> Optional[Address]:
     # display_name should be an address in the USERID_RE format
     match = USERID_RE.match(user.user_id)
     if not match:
+        log.warning("Invalid user id", user=user.user_id)
         return None
 
-    msg = (
-        "The User instance provided to validate_userid_signature must have the "
-        "displayname attribute set. Make sure to warm the value using the "
-        "DisplayNameCache."
-    )
     displayname = user.displayname
-    assert displayname is not None, msg
+
+    if displayname is None:
+        log.warning("Displayname not set", user=user.user_id)
+        return None
 
     encoded_address = match.group(1)
     address: Address = to_canonical_address(encoded_address)
@@ -779,9 +778,11 @@ def validate_userid_signature(user: User) -> Optional[Address]:
         if DISPLAY_NAME_HEX_RE.match(displayname):
             signature_bytes = decode_hex(displayname)
         else:
+            log.warning("Displayname invalid format", user=user.user_id, displayname=displayname)
             return None
         recovered = recover(data=user.user_id.encode(), signature=Signature(signature_bytes))
         if not (address and recovered and recovered == address):
+            log.warning("Unexpected signer of displayname", user=user.user_id)
             return None
     except (
         DecodeError,


### PR DESCRIPTION
## Description
as described in #6555 there is only one case for an assert, all other unexpected behavior returns None. This removes the assertion and also returns None if the displayname is not set.

Additionally, I added some warnings for better logging. 



Fixes: #6555 
