### PR TITLE
Avoid six version conflict in scenario player

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -39,7 +39,7 @@ coverage==5.3             # via -r requirements-dev.txt
 crc32c==2.0               # via -r requirements-dev.txt, aiortc
 cryptography==2.9.2       # via -r requirements-dev.txt, aiortc, pyopenssl, service-identity
 cytoolz==0.10.1           # via -r requirements-dev.txt, eth-keyfile, eth-utils
-decorator==4.4.0          # via -r requirements-dev.txt, ipython, networkx, traitlets
+decorator==4.4.2          # via -r requirements-dev.txt, ipython, networkx, traitlets
 docutils==0.14            # via -r requirements-dev.txt, readme-renderer, sphinx, sphinxcontrib-httpexample
 eth-abi==2.1.0            # via -r requirements-dev.txt, eth-account, raiden-contracts, web3
 eth-account==0.5.3        # via -r requirements-dev.txt, web3
@@ -71,7 +71,7 @@ hyperlink==19.0.0         # via -r requirements-dev.txt, twisted
 hypothesis==5.35.2        # via -r requirements-dev.txt
 idna==2.8                 # via -r requirements-dev.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-dev.txt, sphinx
-importlib-metadata==1.7.0  # via -r requirements-dev.txt, pluggy
+importlib-metadata==2.0.0  # via -r requirements-dev.txt, flake8, flake8-comprehensions, jsonschema, pluggy, pytest
 incremental==17.5.0       # via -r requirements-dev.txt, treq, twisted
 iniconfig==1.0.1          # via -r requirements-dev.txt, pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements-dev.txt, web3
@@ -164,7 +164,7 @@ semver==2.8.1             # via -r requirements-dev.txt, raiden-contracts
 service-identity==18.1.0  # via -r requirements-dev.txt, matrix-synapse, twisted
 signedjson==1.1           # via -r requirements-dev.txt, matrix-synapse
 simplejson==3.16.0        # via -r requirements-dev.txt, canonicaljson
-six==1.12.0               # via -r requirements-dev.txt, astroid, astunparse, automat, bcrypt, bleach, cryptography, flake8-tuple, flask-cors, flask-restful, jsonschema, multiaddr, packaging, parsimonious, pip-tools, protobuf, pyhamcrest, pymacaroons, pynacl, pyopenssl, pyrsistent, python-dateutil, readme-renderer, responses, sphinxcontrib-httpdomain, structlog, traitlets, treq
+six==1.15.0               # via -r requirements-dev.txt, astroid, astunparse, automat, bcrypt, bleach, cryptography, flake8-tuple, flask-cors, flask-restful, jsonschema, multiaddr, packaging, parsimonious, pip-tools, protobuf, pyhamcrest, pymacaroons, pynacl, pyopenssl, pyrsistent, python-dateutil, readme-renderer, responses, sphinxcontrib-httpdomain, structlog, traitlets, treq
 snowballstemmer==1.2.1    # via -r requirements-dev.txt, sphinx
 sortedcontainers==2.1.0   # via -r requirements-dev.txt, hypothesis, matrix-synapse
 sphinx-rtd-theme==0.5.0   # via -r requirements-dev.txt
@@ -184,8 +184,8 @@ toolz==0.9.0              # via -r requirements-dev.txt, cytoolz
 traitlets==4.3.2          # via -r requirements-dev.txt, ipython
 treq==18.6.0              # via -r requirements-dev.txt, matrix-synapse
 twisted[tls]==20.3.0      # via -r requirements-dev.txt, matrix-synapse, treq
-typed-ast==1.4.0          # via -r requirements-dev.txt, black, mypy
-typing-extensions==3.7.4.3  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via -r requirements-dev.txt, astroid, black, mypy
+typing-extensions==3.7.4.3  # via -r requirements-dev.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements-dev.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via -r requirements-dev.txt, matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-dev.txt, requests
@@ -198,7 +198,7 @@ werkzeug==1.0.1           # via -r requirements-dev.txt, flask
 wheel==0.33.4             # via -r requirements-dev.txt, astunparse
 wmctrl==0.3               # via -r requirements-dev.txt, pdbpp
 wrapt==1.11.1             # via -r requirements-dev.txt, astroid
-zipp==3.1.0               # via -r requirements-dev.txt, importlib-metadata
+zipp==3.2.0               # via -r requirements-dev.txt, importlib-metadata
 zope.event==4.4           # via -r requirements-dev.txt, gevent
 zope.interface==5.1.0     # via -r requirements-dev.txt, gevent, twisted
 

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -45,3 +45,4 @@ bump2version
 
 # Test support
 matrix-synapse==1.19.1
+six>=1.13.0  # work around bad deps declaration in treq, see https://github.com/twisted/treq/commit/934e127a2b915bf02be86d23f2cf8a65bcdb2533#r42782781

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -38,7 +38,7 @@ coverage==5.3             # via -r requirements-dev.in
 crc32c==2.0               # via -r requirements.txt, aiortc
 cryptography==2.9.2       # via -r requirements.txt, aiortc, pyopenssl, service-identity
 cytoolz==0.10.1           # via -r requirements.txt, eth-keyfile, eth-utils
-decorator==4.4.0          # via -r requirements.txt, ipython, networkx, traitlets
+decorator==4.4.2          # via -r requirements.txt, ipython, networkx, traitlets
 docutils==0.14            # via -r requirements-docs.txt, readme-renderer, sphinx, sphinxcontrib-httpexample
 eth-abi==2.1.0            # via -r requirements.txt, eth-account, raiden-contracts, web3
 eth-account==0.5.3        # via -r requirements.txt, web3
@@ -70,7 +70,7 @@ hyperlink==19.0.0         # via twisted
 hypothesis==5.35.2        # via -r requirements-dev.in
 idna==2.8                 # via -r requirements-docs.txt, -r requirements.txt, hyperlink, matrix-synapse, requests, twisted
 imagesize==1.1.0          # via -r requirements-docs.txt, sphinx
-importlib-metadata==1.7.0  # via pluggy
+importlib-metadata==2.0.0  # via -r requirements.txt, flake8, flake8-comprehensions, jsonschema, pluggy, pytest
 incremental==17.5.0       # via treq, twisted
 iniconfig==1.0.1          # via pytest
 ipfshttpclient==0.6.0.post1  # via -r requirements.txt, web3
@@ -157,7 +157,7 @@ semver==2.8.1             # via -r requirements.txt, raiden-contracts
 service-identity==18.1.0  # via matrix-synapse, twisted
 signedjson==1.1           # via matrix-synapse
 simplejson==3.16.0        # via canonicaljson
-six==1.12.0               # via -r requirements-docs.txt, -r requirements.txt, astroid, astunparse, automat, bcrypt, bleach, cryptography, flake8-tuple, flask-cors, flask-restful, jsonschema, multiaddr, packaging, parsimonious, pip-tools, protobuf, pyhamcrest, pymacaroons, pynacl, pyopenssl, pyrsistent, readme-renderer, responses, sphinxcontrib-httpdomain, structlog, traitlets, treq
+six==1.15.0               # via -r requirements-dev.in, -r requirements-docs.txt, -r requirements.txt, astroid, astunparse, automat, bcrypt, bleach, cryptography, flake8-tuple, flask-cors, flask-restful, jsonschema, multiaddr, packaging, parsimonious, pip-tools, protobuf, pyhamcrest, pymacaroons, pynacl, pyopenssl, pyrsistent, readme-renderer, responses, sphinxcontrib-httpdomain, structlog, traitlets, treq
 snowballstemmer==1.2.1    # via -r requirements-docs.txt, sphinx
 sortedcontainers==2.1.0   # via hypothesis, matrix-synapse
 sphinx-rtd-theme==0.5.0   # via -r requirements-docs.txt
@@ -177,8 +177,8 @@ toolz==0.9.0              # via -r requirements.txt, cytoolz
 traitlets==4.3.2          # via ipython
 treq==18.6.0              # via matrix-synapse
 twisted[tls]==20.3.0      # via matrix-synapse, treq
-typed-ast==1.4.0          # via black, mypy
-typing-extensions==3.7.4.3  # via -r requirements.txt, matrix-synapse, mypy, signedjson
+typed-ast==1.4.0          # via astroid, black, mypy
+typing-extensions==3.7.4.3  # via -r requirements.txt, matrix-synapse, mypy, signedjson, web3
 typing-inspect==0.4.0     # via -r requirements.txt, marshmallow-dataclass
 unpaddedbase64==1.1.0     # via matrix-synapse, signedjson
 urllib3==1.25.3           # via -r requirements-docs.txt, -r requirements.txt, requests
@@ -191,7 +191,7 @@ werkzeug==1.0.1           # via -r requirements.txt, flask
 wheel==0.33.4             # via -r requirements-docs.txt, astunparse
 wmctrl==0.3               # via pdbpp
 wrapt==1.11.1             # via astroid
-zipp==3.1.0               # via importlib-metadata
+zipp==3.2.0               # via -r requirements.txt, importlib-metadata
 zope.event==4.4           # via -r requirements.txt, gevent
 zope.interface==5.1.0     # via -r requirements.txt, gevent, twisted
 

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -21,7 +21,7 @@ pytz==2019.1              # via babel
 releases==1.6.3           # via -r requirements-docs.in
 requests==2.24.0          # via sphinx, sphinxcontrib-images
 semantic-version==2.6.0   # via releases
-six==1.12.0               # via astunparse, packaging, sphinxcontrib-httpdomain
+six==1.15.0               # via astunparse, packaging, sphinxcontrib-httpdomain
 snowballstemmer==1.2.1    # via sphinx
 sphinx-rtd-theme==0.5.0   # via -r requirements-docs.in
 sphinx==3.2.1             # via -r requirements-docs.in, releases, sphinx-rtd-theme, sphinxcontrib-httpdomain, sphinxcontrib-httpexample, sphinxcontrib-images

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,7 +22,7 @@ colorama==0.4.3           # via -r requirements.in
 crc32c==2.0               # via aiortc
 cryptography==2.9.2       # via aiortc
 cytoolz==0.10.1           # via eth-keyfile, eth-utils
-decorator==4.4.0          # via networkx
+decorator==4.4.2          # via networkx
 eth-abi==2.1.0            # via eth-account, raiden-contracts, web3
 eth-account==0.5.3        # via web3
 eth-hash[pycryptodome]==0.2.0  # via eth-utils, web3
@@ -41,6 +41,7 @@ greenlet==0.4.17          # via gevent
 guppy3==3.0.10.post1      # via -r requirements.in
 hexbytes==0.2.0           # via eth-account, eth-rlp, web3
 idna==2.8                 # via requests
+importlib-metadata==2.0.0  # via jsonschema
 ipfshttpclient==0.6.0.post1  # via web3
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
@@ -77,17 +78,18 @@ requests==2.24.0          # via -r requirements.in, ipfshttpclient, matrix-clien
 rlp==1.1.0                # via eth-account, eth-rlp, raiden-contracts
 semantic-version==2.6.0   # via py-solc
 semver==2.8.1             # via raiden-contracts
-six==1.12.0               # via cryptography, flask-cors, flask-restful, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog
+six==1.15.0               # via cryptography, flask-cors, flask-restful, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog
 structlog==20.1.0         # via -r requirements.in
 toml==0.10.1              # via -r requirements.in
 toolz==0.9.0              # via cytoolz
-typing-extensions==3.7.4.3  # via -r requirements.in
+typing-extensions==3.7.4.3  # via -r requirements.in, web3
 typing-inspect==0.4.0     # via marshmallow-dataclass
 urllib3==1.25.3           # via requests
 varint==1.0.2             # via multiaddr
 web3==5.12.1              # via -r requirements.in, raiden-contracts
 websockets==8.1           # via web3
 werkzeug==1.0.1           # via flask
+zipp==3.2.0               # via importlib-metadata
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 


### PR DESCRIPTION
Synapse uses treq, which uses six. Unfortunately, the recent treq
version requires six>=1.13.0 but does not declare that in the
dependencies. This works ok for the current Raiden setup, since the
versions of all dependencies are frozen and the treq version is old
enough to not require the recent six version.
However, this is not true for the SP, which only versions direct
dependencies. I added the workaround to this repo rather than in the SP
repo, so that we won't get the same breakage again when one of the
dependencies is updated here.

See also https://github.com/twisted/treq/commit/934e127a2b915bf02be86d23f2cf8a65bcdb2533#r42782781