### PR TITLE
Add disabled --console option when missing ipython

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -509,6 +509,12 @@ def options(func: Callable) -> Callable:
         options_.append(
             option("--console", help="Start the interactive raiden console", is_flag=True)
         )
+    else:
+
+        def unsupported(*args: Any) -> None:
+            raise click.BadParameter("Console support is only available in development installs.")
+
+        options_.append(option("--console", is_flag=True, hidden=True, callback=unsupported))
 
     for option_ in reversed(options_):
         func = option_(func)


### PR DESCRIPTION
If this option is missing in some cases, the list of options passed
around needs defaults for missing values. Otherwise you can get errors
like
```
Traceback (most recent call last):
  File "/home/karl/raiden/raiden/ui/cli.py", line 624, in run
      run_services(kwargs)
        File "/home/karl/raiden/raiden/ui/runners.py", line 25, in
        run_services
            if options["console"]:
            KeyError: 'console'
            ReturnCode.FATAL
```

Instead of adding a default, I chose to add a disabled hidden option, so
that you will get an informative error when trying to use the option.