### PR TITLE
Change Capabilities format

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -79,7 +79,7 @@ class Networks(Enum):
 class Capabilities(Enum):
     """Capabilities allow for protocol handshake between nodes."""
 
-    RECEIVE = "Receive"  # proceed with protocol for incoming transfers
+    RECEIVE = "Receive"  # handle receiving transfers
     MEDIATE = "Mediate"  # support for mediating transfers; mediating requires receiving
     DELIVERY = "Delivery"  # expects and sends Delivery messages
     WEBRTC = "webRTC"  # supports webRTC messaging

--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -79,10 +79,10 @@ class Networks(Enum):
 class Capabilities(Enum):
     """Capabilities allow for protocol handshake between nodes."""
 
-    NO_RECEIVE = "noReceive"  # won't proceed with protocol for incoming transfers
-    NO_MEDIATE = "noMediate"  # can't mediate transfers; mediating requires receiving
-    NO_DELIVERY = "noDelivery"  # don't need Delivery messages
-    WEBRTC = "webRTC"
+    RECEIVE = "Receive"  # proceed with protocol for incoming transfers
+    MEDIATE = "Mediate"  # support for mediating transfers; mediating requires receiving
+    DELIVERY = "Delivery"  # expects and sends Delivery messages
+    WEBRTC = "webRTC"  # supports webRTC messaging
 
 
 class ServerListType(Enum):

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -56,7 +56,7 @@ from raiden.network.transport.matrix.client import (
 )
 from raiden.network.utils import get_average_http_response_time
 from raiden.storage.serialization.serializer import MessageSerializer
-from raiden.utils.capabilities import parse_capabilities, serialize_capabilities
+from raiden.utils.capabilities import deserialize_capabilities, serialize_capabilities
 from raiden.utils.gevent import spawn_named
 from raiden.utils.signer import Signer, recover
 from raiden.utils.typing import Address, ChainID, MessageID, PeerCapabilities, Signature
@@ -346,7 +346,7 @@ class UserAddressManager:
             return PeerCapabilities({})
         avatar_url = user.get_avatar_url()
         if avatar_url is not None:
-            return PeerCapabilities(parse_capabilities(avatar_url))
+            return PeerCapabilities(deserialize_capabilities(avatar_url))
         else:
             return PeerCapabilities({})
 

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -129,9 +129,9 @@ class MediationFeeConfig:
 
 @dataclass
 class CapabilitiesConfig:
-    no_receive: bool = False
-    no_mediate: bool = False
-    no_delivery: bool = False
+    receive: bool = True
+    mediate: bool = True
+    delivery: bool = True
     web_rtc: bool = True
 
 

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -198,7 +198,8 @@ def adhoc_capability():
 @pytest.fixture
 def capabilities(adhoc_capability) -> CapabilitiesConfig:
     config = CapabilitiesConfig()
-    config.adhoc_capability = adhoc_capability  # type: ignore
+    if adhoc_capability:
+        config.adhoc_capability = adhoc_capability  # type: ignore
     return config
 
 

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -11,7 +11,7 @@ from raiden.settings import CapabilitiesConfig
 from raiden.utils.capabilities import (
     capconfig_to_dict,
     capdict_to_config,
-    parse_capabilities,
+    deserialize_capabilities,
     serialize_capabilities,
 )
 from raiden.utils.keys import privatekey_to_publickey
@@ -97,26 +97,25 @@ def test_get_http_rtt_ignore_failing(requests_responses):
     assert get_average_http_response_time(url="http://url3", method="get") is None
 
 
-def test_parse_capabilities():
-    capstring = 'foo,toad,bar="max",form,agar'
-    parsed = parse_capabilities(capstring)
+def test_deserialize_capabilities():
+    capstring = "mxc://raiden.network/cap?foo=1&toad=1&bar=max&form=1&agar=1&nottrue=0&l=one&l=2"
+    parsed = deserialize_capabilities(capstring)
     assert parsed.get("foo") is True
     assert parsed.get("toad") is True
     assert parsed.get("bar") == "max"
-    assert parsed.get("form") is True
     assert parsed.get("agar") is True
+    assert parsed.get("nottrue") is False
+    assert parsed.get("l") == ["one", "2"]
     assert not parsed.get("nothing")
 
-    assert serialize_capabilities(parsed) == f"mxc://{capstring}"
+    assert serialize_capabilities(parsed) == f"{capstring}"
 
     parsed["false"] = False
 
-    assert serialize_capabilities(parsed) == f"mxc://{capstring}"
+    # Explicit new value changes the serialization format
+    assert serialize_capabilities(parsed) != f"mxc://{capstring}"
 
-    parsed["nothing"] = None
-    assert 'nothing="None"' in serialize_capabilities(parsed)
-
-    assert parse_capabilities("") == dict()
+    assert deserialize_capabilities("") == dict()
 
     assert serialize_capabilities({}) == "mxc://"
 

--- a/raiden/utils/capabilities.py
+++ b/raiden/utils/capabilities.py
@@ -32,16 +32,14 @@ def serialize_capabilities(capdict: Optional[Dict[str, Any]]) -> str:
 def _strip_capstring(capstring: str) -> str:
     if capstring.startswith("mxc://"):
         capstring = capstring[6:]
-    if "/" in capstring:
-        capstring = capstring[capstring.rindex("/") + 1 :]
-    if "?" in capstring:
-        capstring = capstring[capstring.rindex("?") + 1 :]
+    _, _, capstring = capstring.rpartition("/")
+    _, _, capstring = capstring.rpartition("?")
     return capstring
 
 
 def deserialize_capabilities(capstring: str) -> Dict[str, Any]:
     capstring = _strip_capstring(capstring)
-    capdict = url_decode(capstring.encode("utf-8"))
+    capdict = url_decode(capstring.encode())
     capabilities: Dict[str, Any] = dict()
     for key in capdict:
         value = capdict.getlist(key, type=int_bool)

--- a/raiden/utils/capabilities.py
+++ b/raiden/utils/capabilities.py
@@ -43,9 +43,9 @@ def serialize_capabilities(capdict: Optional[Dict[str, Any]]) -> str:
 
 def capdict_to_config(capdict: Dict[str, Any]) -> CapabilitiesConfig:
     config = CapabilitiesConfig(
-        no_receive=capdict.get(Capabilities.NO_RECEIVE.value, False),
-        no_mediate=capdict.get(Capabilities.NO_MEDIATE.value, False),
-        no_delivery=capdict.get(Capabilities.NO_DELIVERY.value, False),
+        receive=capdict.get(Capabilities.RECEIVE.value, True),
+        mediate=capdict.get(Capabilities.MEDIATE.value, True),
+        delivery=capdict.get(Capabilities.DELIVERY.value, True),
         web_rtc=capdict.get(Capabilities.WEBRTC.value, False),
     )
     for key in capdict.keys():
@@ -56,15 +56,15 @@ def capdict_to_config(capdict: Dict[str, Any]) -> CapabilitiesConfig:
 
 def capconfig_to_dict(config: CapabilitiesConfig) -> Dict[str, Any]:
     result = {
-        Capabilities.NO_RECEIVE.value: config.no_receive,
-        Capabilities.NO_MEDIATE.value: config.no_mediate,
-        Capabilities.NO_DELIVERY.value: config.no_delivery,
+        Capabilities.RECEIVE.value: config.receive,
+        Capabilities.MEDIATE.value: config.mediate,
+        Capabilities.DELIVERY.value: config.delivery,
         Capabilities.WEBRTC.value: config.web_rtc,
     }
     other_keys = [
         key
         for key in config.__dict__.keys()
-        if key not in ["no_receive", "no_mediate", "no_delivery", "web_rtc"]
+        if key not in ["receive", "mediate", "delivery", "web_rtc"]
     ]
     for key in other_keys:
         if key not in [_.value for _ in Capabilities]:


### PR DESCRIPTION
## Description

This changes the capabilities according to the proposed changes in https://github.com/raiden-network/raiden/issues/6503#issuecomment-700001383 and/or https://github.com/raiden-network/raiden/issues/6503#issuecomment-704310156 

Fixes: #6503 

copy and past from the issue:

### Encoding/Serialization for use in matrix `avatar_url`
```python
"mxc://raiden.network/cap?{capabilities_url_encoded}"
```
where `{capabilities_url_encoded}` is the url query parameter encoding of capabilities.

Rules for url encoding:
- `bool` values are encoded as `"0"` for `False` and `"1"` for `True`
- other values are encoded as strings
- lists of values are allowed

### Deserialization / Decoding
The final interpretation of capability values is up to the receiving client, or rather the specified capability.

### Implicit values / Handling of unknown values
- intentionally omitting (falsy or whatever) known default values is **discouraged**. Client implementations are asked to **explicitly** state all known capabilities.
- Client implementations have to deal with receiving new/unknown capabilities gracefully, i.e. they should expect the peer to act backwards compatible.
- Client implementations have to deal with not receiving known capabilities gracefully, i.e. assume the peer implementation is going to exert _legacy behavior_ and therefore act backwards compatible.

Previously discussed versioning is postponed until there is a need for truncation of capabilities.

### Example
```python
avatar_url = "mxc://raiden.network/cap?Delivered=0&Mediate=1&Receive=1&webRTC=1&list_capability=one&list_capability=two"
capabilities_decoded = {
 'Delivered': False,
 'Mediate': True,
 'Receive': True,
 'webRTC': True,
 'list_capability': ['one', 'two']
}
```
### Rationale for the decision
- proper url conform encoding is expected to avoid any sanitation issues when communicating with matrix servers
- `json`+`base64` encoding was dropped because it is harder to inspect by humans
- url query parameters can be (de-)serialized by existing tooling/libraries
- the `boolean` convention (`0,1`) was necessary because there is no native format for boolean values in url parameters