### PR TITLE
Fix disabled console option

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -511,8 +511,11 @@ def options(func: Callable) -> Callable:
         )
     else:
 
-        def unsupported(*args: Any) -> None:
-            raise click.BadParameter("Console support is only available in development installs.")
+        def unsupported(_ctx: Any, _param: Any, value: bool) -> None:
+            if value:
+                raise click.BadParameter(
+                    "Console support is only available in development installs."
+                )
 
         options_.append(option("--console", is_flag=True, hidden=True, callback=unsupported))
 


### PR DESCRIPTION
I didn't properly test https://github.com/raiden-network/raiden/pull/6570, so I didn't notice
the always failing callback. Callbacks are called on flags, even when
the flag is false. So the exception raising callback needs to check the
parameter value.
