### PR TITLE
Fix inconsistent TokenNetworkRegistryState

### DIFF
--- a/raiden/tests/unit/fixtures.py
+++ b/raiden/tests/unit/fixtures.py
@@ -70,12 +70,7 @@ def token_network_state(
         address=token_network_address,
         token_address=token_id,
     )
-    token_network_registry_state.tokennetworkaddresses_to_tokennetworks[
-        token_network_address
-    ] = token_network
-    token_network_registry_state.tokenaddresses_to_tokennetworkaddresses[
-        token_id
-    ] = token_network_address
+    token_network_registry_state.add_token_network(token_network)
 
     mapping = chain_state.tokennetworkaddresses_to_tokennetworkregistryaddresses
     mapping[token_network_address] = token_network_registry_address

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -426,12 +426,7 @@ def maybe_add_tokennetwork(
         ids_to_payments[token_network_registry_address] = token_network_registry_state
 
     if token_network_state_previous is None:
-        ids_to_tokens = token_network_registry_state.tokennetworkaddresses_to_tokennetworks
-        addresses_to_ids = token_network_registry_state.tokenaddresses_to_tokennetworkaddresses
-
-        ids_to_tokens[token_network_address] = token_network_state
-        addresses_to_ids[token_address] = token_network_address
-        token_network_registry_state.token_network_list.append(token_network_state)
+        token_network_registry_state.add_token_network(token_network_state)
 
         mapping = chain_state.tokennetworkaddresses_to_tokennetworkregistryaddresses
         mapping[token_network_address] = token_network_registry_address


### PR DESCRIPTION
After deserialization, the TokenNetworkStates in `token_network_list`
and and `tokennetworkaddresses_to_tokennetworks` were equal but not
identical.  When one of them was mutated, the other stayed unchanged,
leading to inconsistent results for the same token network.

To avoid this problem, only the `token_network_list` attribute is
serialized and `tokennetworkaddresses_to_tokennetworks` is derived from
that after deserialization.

It is still possible to modify these two attributes separately, but by
adding and using the `add_token_network` method, this is made less
likely. I did not find a way to completely remove the possibility
inconsistencies without breaking our (de)serialization mechanism.