### PR TITLE
Refactor get_token_network_by_address and fix typos

### DIFF
--- a/raiden/blockchain/state.py
+++ b/raiden/blockchain/state.py
@@ -6,7 +6,7 @@ otherwise the node will be susceptible to races due to reorgs. These races can
 crash the client in the best case, or be an attack vector in the worst case.
 Because of this, the event itself must already be confirmed.
 
-If possible, the confirmed data should be retrievied from the same block at
+If possible, the confirmed data should be retrieved from the same block at
 which the event was emitted. However, because of state pruning this is not
 always possible. If that block is pruned then the latest confirmed block must
 be used.

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -629,7 +629,7 @@ def is_valid_lock_expired(
     result: PendingLocksStateOrError = (False, None, None)
 
     if secret_registered_on_chain:
-        msg = "Invalid LockExpired mesage. Lock was unlocked on-chain."
+        msg = "Invalid LockExpired message. Lock was unlocked on-chain."
         result = (False, msg, None)
 
     elif lock is None:
@@ -1073,7 +1073,7 @@ def is_valid_withdraw_expired(
             f"WithdrawExpired for withdraw that has not yet expired {state_change.total_withdraw}."
         )
     elif channel_state.canonical_identifier != state_change.canonical_identifier:
-        return SuccessOrError("Invalid canonical identifier provided in WithdrawExpire")
+        return SuccessOrError("Invalid canonical identifier provided in WithdrawExpired")
     elif state_change.sender != channel_state.partner_state.address:
         return SuccessOrError("Expired withdraw not from partner.")
     elif state_change.total_withdraw != withdraw_state.total_withdraw:
@@ -1242,7 +1242,7 @@ def get_batch_unlock(
 def get_lock(
     end_state: NettingChannelEndState, secrethash: SecretHash
 ) -> Optional[HashTimeLockState]:
-    """Return the lock correspoding to `secrethash` or None if the lock is
+    """Return the lock corresponding to `secrethash` or None if the lock is
     unknown.
     """
     lock = end_state.secrethashes_to_lockedlocks.get(secrethash)
@@ -1790,7 +1790,7 @@ def send_expired_withdraws(
         )
 
         # Break on the first non-expired withdraw as the list
-        # of withdraws are ordered and only ealier withdraws
+        # of withdraws are ordered and only earlier withdraws
         # can expire.
         if not withdraw_expired:
             break

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -462,7 +462,7 @@ def backward_transfer_pair(
         block_number: The current block number.
 
     Returns:
-        The mediator pair and the correspoding refund event.
+        The mediator pair and the corresponding refund event.
     """
     transfer_pair = None
     events: List[Event] = list()
@@ -819,7 +819,7 @@ def events_for_onchain_secretreveal_if_dangerzone(
     # Only consider the transfers which have a pair. This means if we have a
     # waiting transfer and for some reason the node knows the secret, it will
     # not try to register it. Otherwise it would be possible for an attacker to
-    # reveal the secret late, just to force the node to send an unecessary
+    # reveal the secret late, just to force the node to send an unnecessary
     # transaction.
 
     for pair in get_pending_transfer_pairs(transfers_pair):
@@ -1240,7 +1240,7 @@ def handle_refundtransfer(
 ) -> TransitionResult[MediatorTransferState]:
     """Validate and handle a ReceiveTransferRefund mediator_state change.
     A node might participate in mediated transfer more than once because of
-    refund transfers, eg. A-B-C-B-D-T, B tried to mediate the transfer through
+    refund transfers, e.g. A-B-C-B-D-T, B tried to mediate the transfer through
     C, which didn't have an available route to proceed and refunds B, at this
     point B is part of the path again and will try a new partner to proceed
     with the mediation through D, D finally reaches the target T.

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -97,20 +97,14 @@ def get_token_network_by_address(
     tn_registry_address = chain_state.tokennetworkaddresses_to_tokennetworkregistryaddresses.get(
         token_network_address
     )
+    if not tn_registry_address:
+        return None
 
-    tn_registry_state = None
-    if tn_registry_address:
-        tn_registry_state = chain_state.identifiers_to_tokennetworkregistries.get(
-            tn_registry_address
-        )
+    tn_registry_state = chain_state.identifiers_to_tokennetworkregistries.get(tn_registry_address)
+    if not tn_registry_state:
+        return None
 
-    token_network_state = None
-    if tn_registry_state:
-        token_network_state = tn_registry_state.tokennetworkaddresses_to_tokennetworks.get(
-            token_network_address
-        )
-
-    return token_network_state
+    return tn_registry_state.tokennetworkaddresses_to_tokennetworks.get(token_network_address)
 
 
 def subdispatch_to_all_channels(

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -99,7 +99,7 @@ def message_identifier_from_prng(prng: Random) -> MessageID:
 class PaymentMappingState(State):
     """Global map from secrethash to a transfer task.
     This mapping is used to quickly dispatch state changes by secrethash, for
-    those that dont have a balance proof, e.g. SecretReveal.
+    those that don't have a balance proof, e.g. SecretReveal.
     This mapping forces one task per secrethash, assuming that secrethash collision
     is unlikely. Features like token swaps, that span multiple networks, must
     be encapsulated in a single task to work with this structure.
@@ -172,7 +172,7 @@ class HashTimeLockState(State):
         typecheck(self.expiration, T_BlockNumber)
         typecheck(self.secrethash, T_Secret)
 
-        from raiden.messages.transfers import Lock  # put here to avoid cyclic depenendcies
+        from raiden.messages.transfers import Lock  # put here to avoid cyclic dependencies
 
         lock = Lock(amount=self.amount, expiration=self.expiration, secrethash=self.secrethash)
         self.encoded = EncodedData(lock.as_bytes)


### PR DESCRIPTION
The "fail early" style is more compact and easier to read, since you
can quickly understand the failure cases without reading all the way to
the end of the function.
