### PR TITLE
Remove local routing from the docs

### DIFF
--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -312,15 +312,10 @@ There are further CLI arguments with which you can control, among other things
 
 A pathfinding service is a third party service helping your node with efficient transfer routing. It is usually paid in RDN tokens.
 
-Raiden can be configured to not use a pathfinding service and rely on its internal routing instead.
-This is discouraged since the node has less information about the network that it can use to find routes and compute fees.
-So transfers will be more likely to fail to route, and paid fees will often be unnecessarily high when internal routing is used.
-If you want to use internal routing anyway, you can do so with ``--routing-mode local``.
-
-.. note::
-    Although otherwise discouraged, ``--routing-mode local`` has to be used at the moment to try
-    out Raiden on the mainnet. The Raiden Service Bundle, with pathfinding service and registry,
-    will not be deployed on the mainnet until the Alderaan release.
+Direct channels to other nodes can be used without asking the PFS for a route.
+If you want to stop broadcasting information about your channel states to
+PFSes, use ``--routing-mode private``. As a result, PFSes won't create routes
+that include your node as a mediator.
 
 If you want to use a particular pathfinding service, e.g. one of the testnet pathfinding services given below, you can
 do so with ``--pathfinding-service-address <url>``. Otherwise Raiden will automatically pick one of the pathfinding

--- a/docs/private_net_tutorial.rst
+++ b/docs/private_net_tutorial.rst
@@ -198,7 +198,7 @@ From the output, we remember the address of the UserDeposit contract.
 
 .. code:: bash
 
- (env) $ export UserDeposit="0x50E5f50b98a78615163E89A65fD60D551933CaE2"    
+ (env) $ export UserDeposit="0x50E5f50b98a78615163E89A65fD60D551933CaE2"
 
 
 We deploy another Token contract that's going to be transferred on Raiden network.
@@ -244,4 +244,4 @@ And you can start the Raiden client:
 
 .. code:: bash
 
- (env) $ raiden --datadir exchange-a  --keystore-path   ./blkchain1/keystore/ --network-id 4321  --accept-disclaimer --address $DeployerAddress --rpc --api-address 0.0.0.0:5001 --web-ui  --environment-type development  --console --no-sync-check --accept-disclaimer --user-deposit-contract-address $UserDeposit --routing-mode local --password-file passwd_file
+ (env) $ raiden --datadir exchange-a  --keystore-path   ./blkchain1/keystore/ --network-id 4321  --accept-disclaimer --address $DeployerAddress --rpc --api-address 0.0.0.0:5001 --web-ui  --environment-type development  --console --no-sync-check --accept-disclaimer --user-deposit-contract-address $UserDeposit --routing-mode private --password-file passwd_file

--- a/docs/raiden_services.rst
+++ b/docs/raiden_services.rst
@@ -21,17 +21,6 @@ Pathfinding services have a global view on a token network can provide suitable 
 The service will keep its view on the token network updated by listening to blockchain events and a public matrix room where current capacities and fees (Capacity Updates) are being published. Nodes can publish their channel capacities and fees in order to advertise their channels and mediate payments.
 
 
-Using a Pathfinding Service
----------------------------
-
-Using a Pathfinding service increases the likelihood of successful payments, especially when multiple mediators are used. Therefore, using a Pathfinding service is enabled by default.
-
-.. note::
-  Direct token transfers (using no mediators) never need information from a PFS, so in that case no request for a PFS is done.
-
-To disable the usage of Pathfinding services use the ``--routing-mode`` command line flag. This option is set to ``pfs`` by default, but can also be set to ``local`` or ``private`` if you don't want to use a Pathfinding service. See below for further information about privacy implications.
-
-
 Choosing a Pathfinding Service
 ------------------------------
 


### PR DESCRIPTION
The option of local routing is not available, anymore. Therefore, it
should not be mentioned in the documentation.

[skip tests]