### PR TITLE
Include synapse update in changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`6608` Compatibility with synapse 1.19 and [MSC2432](https://github.com/matrix-org/matrix-doc/pull/2432)
 * :bug:`6444` Fix a race condition when processing blockchain events.
 
 * :release:`1.1.1 <2020-07-20>`


### PR DESCRIPTION
The changelog item was not included in
https://github.com/raiden-network/raiden/pull/6608.

[skip tests]