### PR TITLE
Add api/v1/settings endpoint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`6582` Add ``/settings`` endpoint with information about the used pathfinding service.
 * :bug:`6444` Fix a race condition when processing blockchain events.
 
 * :release:`1.1.1 <2020-07-20>`

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -43,6 +43,7 @@ from raiden.api.v1.resources import (
     ConnectionsResource,
     ContractsResource,
     MintTokenResource,
+    NodeSettingsResource,
     PartnersResourceByTokenAddress,
     PaymentEventsResource,
     PaymentResource,
@@ -134,6 +135,7 @@ CHANNEL_NETWORK_STATE = "network_state"
 URLS_V1 = [
     ("/address", AddressResource),
     ("/version", VersionResource),
+    ("/settings", NodeSettingsResource),
     ("/contracts", ContractsResource),
     ("/channels", ChannelsResource),
     ("/channels/<hexaddress:token_address>", ChannelsResourceByTokenAddress),
@@ -480,6 +482,14 @@ class RestAPI:  # pragma: no unittest
     @classmethod
     def get_raiden_version(cls) -> Response:
         return api_response(result=dict(version=get_system_spec()["raiden"]))
+
+    def get_node_settings(self) -> Response:
+        settings = dict(pathfinding_service_address="")
+        pfs_config = self.raiden_api.raiden.config.pfs_config
+        if pfs_config is not None:
+            settings["pathfinding_service_address"] = pfs_config.info.url
+
+        return api_response(result=settings)
 
     def get_contract_versions(self) -> Response:
         raiden = self.raiden_api.raiden

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -484,38 +484,36 @@ class RestAPI:  # pragma: no unittest
         return api_response(result=dict(version=get_system_spec()["raiden"]))
 
     def get_node_settings(self) -> Response:
-        settings = dict(pathfinding_service_address="")
         pfs_config = self.raiden_api.raiden.config.pfs_config
-        if pfs_config is not None:
-            settings["pathfinding_service_address"] = pfs_config.info.url
+        settings = dict(
+            pathfinding_service_address=pfs_config and pfs_config.info.url
+        )
 
         return api_response(result=settings)
 
     def get_contract_versions(self) -> Response:
         raiden = self.raiden_api.raiden
+        service_registry_address = raiden.default_service_registry and to_checksum_address(
+            raiden.default_service_registry.address
+        )
+        user_deposit_address = raiden.default_user_deposit and to_checksum_address(
+            raiden.default_user_deposit.address
+        )
+        monitoring_service_address = raiden.default_msc_address and to_checksum_address(
+            raiden.default_msc_address
+        )
+        one_to_n_address = raiden.default_one_to_n_address and to_checksum_address(
+            raiden.default_one_to_n_address
+        )
         contracts = dict(
             contracts_version=raiden.proxy_manager.contract_manager.contracts_version,
             token_network_registry_address=to_checksum_address(raiden.default_registry.address),
             secret_registry_address=to_checksum_address(raiden.default_secret_registry.address),
-            service_registry_address="",
-            user_deposit_address="",
-            monitoring_service_address="",
-            one_to_n_address="",
+            service_registry_address=service_registry_address,
+            user_deposit_address=user_deposit_address,
+            monitoring_service_address=monitoring_service_address,
+            one_to_n_address=one_to_n_address,
         )
-        if raiden.default_service_registry is not None:
-            contracts["service_registry_address"] = to_checksum_address(
-                raiden.default_service_registry.address
-            )
-        if raiden.default_user_deposit is not None:
-            contracts["user_deposit_address"] = to_checksum_address(
-                raiden.default_user_deposit.address
-            )
-        if raiden.default_msc_address is not None:
-            contracts["monitoring_service_address"] = to_checksum_address(
-                raiden.default_msc_address
-            )
-        if raiden.default_one_to_n_address is not None:
-            contracts["one_to_n_address"] = to_checksum_address(raiden.default_one_to_n_address)
 
         return api_response(result=contracts)
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -485,9 +485,7 @@ class RestAPI:  # pragma: no unittest
 
     def get_node_settings(self) -> Response:
         pfs_config = self.raiden_api.raiden.config.pfs_config
-        settings = dict(
-            pathfinding_service_address=pfs_config and pfs_config.info.url
-        )
+        settings = dict(pathfinding_service_address=pfs_config and pfs_config.info.url)
 
         return api_response(result=settings)
 

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -62,6 +62,12 @@ class VersionResource(BaseResource):
         return self.rest_api.get_raiden_version()
 
 
+class NodeSettingsResource(BaseResource):
+    @if_api_available
+    def get(self) -> Response:
+        return self.rest_api.get_node_settings()
+
+
 class ContractsResource(BaseResource):
     @if_api_available
     def get(self) -> Response:

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -209,13 +209,9 @@ def test_api_get_node_settings(api_server_test_instance: APIServer):
     response = request.send().response
     assert_proper_response(response)
 
-    pathfinding_service_address = ""
     pfs_config = api_server_test_instance.rest_api.raiden_api.raiden.config.pfs_config
-    if pfs_config is not None:
-        pathfinding_service_address = pfs_config.info.url
-
     assert get_json_response(response) == {
-        "pathfinding_service_address": pathfinding_service_address
+        "pathfinding_service_address": pfs_config and pfs_config.info.url
     }
 
 
@@ -238,7 +234,7 @@ def test_api_get_contract_infos(api_server_test_instance: APIServer):
         "one_to_n_address",
     ]:
         address = json[contract_name]
-        if address != "":
+        if address is not None:
             assert is_checksum_address(address)
 
 

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -204,6 +204,23 @@ def test_api_get_raiden_version(api_server_test_instance: APIServer):
 
 @raise_on_failure
 @pytest.mark.parametrize("enable_rest_api", [True])
+def test_api_get_node_settings(api_server_test_instance: APIServer):
+    request = grequests.get(api_url_for(api_server_test_instance, "nodesettingsresource"))
+    response = request.send().response
+    assert_proper_response(response)
+
+    pathfinding_service_address = ""
+    pfs_config = api_server_test_instance.rest_api.raiden_api.raiden.config.pfs_config
+    if pfs_config is not None:
+        pathfinding_service_address = pfs_config.info.url
+
+    assert get_json_response(response) == {
+        "pathfinding_service_address": pathfinding_service_address
+    }
+
+
+@raise_on_failure
+@pytest.mark.parametrize("enable_rest_api", [True])
 def test_api_get_contract_infos(api_server_test_instance: APIServer):
     request = grequests.get(api_url_for(api_server_test_instance, "contractsresource"))
     response = request.send().response


### PR DESCRIPTION
## Description

Fixes: #6582

Adds a `/api/v1/settings` endpoint that only returns the URL of the used pathfinding service, because it is needed for the connection manager replacement in the webui. The endpoint should provide more settings in the future (#5011). 

The response from a `GET http://localhost:5001/api/v1/settings` looks like this at the moment: 

```
{
    "pathfinding_service_address": "https://pfs.demo001.env.raiden.network"
}
```

I will update the docs accordingly.