### PR TITLE
toDevice message support

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -83,6 +83,7 @@ class Capabilities(Enum):
     MEDIATE = "Mediate"  # support for mediating transfers; mediating requires receiving
     DELIVERY = "Delivery"  # expects and sends Delivery messages
     WEBRTC = "webRTC"  # supports webRTC messaging
+    TODEVICE = "toDevice"  # supports sending and receiving toDevice messages on Matrix
 
 
 class ServerListType(Enum):

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -241,6 +241,12 @@ class GMatrixHttpApi(MatrixHttpApi):
         message = {"type": RTCMessageType.HANGUP.value, "call_id": call_id}
         self._send_signalling(room_id, message)
 
+    def send_to_device_message(self, user_ids: Iterable[str], text: str) -> None:
+        # TODO: send just to active user id
+        data = {user_id: {"*": text} for user_id in user_ids}
+
+        self.send_to_device(event_type="m.text", messages=data)
+
     def _send_signalling(self, room_id: RoomID, message: Dict[str, str]) -> None:
         self.send_message(room_id=room_id, text_content=json.dumps(message), msgtype="m.notice")
 

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -35,7 +35,8 @@ log = structlog.get_logger(__name__)
 SHUTDOWN_TIMEOUT = 35
 
 MatrixMessage = Dict[str, Any]
-MatrixRoomMessages = Tuple["Room", List[MatrixMessage]]
+# No room means it's a toDevice message
+MatrixRoomMessages = Tuple[Optional["Room"], List[MatrixMessage]]
 MatrixSyncMessages = List[MatrixRoomMessages]
 JSONResponse = Dict[str, Any]
 
@@ -783,6 +784,15 @@ class GMatrixClient(MatrixClient):
                 for listener in self.listeners[:]:
                     if listener["event_type"] == "to_device":
                         listener["callback"](to_device_message)
+
+            # Add toDevice messages to message queue
+            if response["to_device"]["events"]:
+                all_messages.append(
+                    (
+                        None,
+                        response["to_device"]["events"],
+                    )
+                )
 
             for room_id, invite_room in response["rooms"]["invite"].items():
                 for listener in self.invite_listeners[:]:

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -242,12 +242,6 @@ class GMatrixHttpApi(MatrixHttpApi):
         message = {"type": RTCMessageType.HANGUP.value, "call_id": call_id}
         self._send_signalling(room_id, message)
 
-    def send_to_device_message(self, user_ids: Iterable[str], text: str) -> None:
-        # TODO: send just to active user id
-        data = {user_id: {"*": text} for user_id in user_ids}
-
-        self.send_to_device(event_type="m.text", messages=data)
-
     def _send_signalling(self, room_id: RoomID, message: Dict[str, str]) -> None:
         self.send_message(room_id=room_id, text_content=json.dumps(message), msgtype="m.notice")
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -667,7 +667,7 @@ class MatrixTransport(Runnable):
             # This does not reduce latency for target<->initiator communication,
             # since the target may be the node with lower address, and therefore
             # the node that has to create the room.
-            self._maybe_create_room_for_address(node_address)
+            # self._maybe_create_room_for_address(node_address)
             # Ensure network state is updated in case we already know about the user presences
             # representing the target node
             user_ids = self.get_user_ids_for_address(node_address)
@@ -1692,10 +1692,10 @@ class MatrixTransport(Runnable):
             retrier = self._address_to_retrier.get(address)
             if retrier:
                 retrier.notify()
-            web_rtc_key = Capabilities.WEBRTC.value
-            if web_rtc_key in capabilities and capabilities[web_rtc_key]:
-                # if lower address spawn worker to create web rtc channel
-                self._maybe_create_web_rtc_channel(address)
+            # web_rtc_key = Capabilities.WEBRTC.value
+            # if web_rtc_key in capabilities and capabilities[web_rtc_key]:
+            #     # if lower address spawn worker to create web rtc channel
+            #     self._maybe_create_web_rtc_channel(address)
 
         elif reachability is AddressReachability.UNKNOWN:
             node_reachability = NetworkState.UNKNOWN

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1724,8 +1724,17 @@ class MatrixTransport(Runnable):
             )
             return
 
-        room = self._client.rooms[room_ids[0]]
+        capabilities = self._address_mgr.get_address_capabilities(peer_address)
+        to_device_key = Capabilities.TODEVICE.value
+        if to_device_key in capabilities and capabilities[to_device_key]:
+            self.log.debug(
+                "Both partner and we have `toDevice` capability, skipping room creation",
+                partner=to_checksum_address(peer_address),
+                parter_caps=capabilities,
+            )
+            return
 
+        room = self._client.rooms[room_ids[0]]
         if not room._members:
             room.get_joined_members(force_resync=True)
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1364,11 +1364,11 @@ class MatrixTransport(Runnable):
                 for user_id in self._address_mgr.get_userids_for_address(receiver_address)
                 if self._address_mgr.get_userid_presence(user_id) in USER_PRESENCE_REACHABLE_STATES
             }
-            body = {user_id: {"*": data} for user_id in online_userids}
+            body = {
+                user_id: {"*": {"msgtype": "m.text", "body": data}} for user_id in online_userids
+            }
 
-            self._client.api.send_to_device(
-                event_type="m.room.message", messages={"msgtype": "m.text", "body": body}
-            )
+            self._client.api.send_to_device(event_type="m.room.message", messages=body)
             return
 
         # Try sending using existing room

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1359,8 +1359,12 @@ class MatrixTransport(Runnable):
                 receiver=to_checksum_address(receiver_address),
                 data=data.replace("\n", "\\n"),
             )
-            user_ids = self._address_mgr.get_userids_for_address(receiver_address)
-            body = {user_id: {"*": data} for user_id in user_ids}
+            online_userids = {
+                user_id
+                for user_id in self._address_mgr.get_userids_for_address(receiver_address)
+                if self._address_mgr.get_userid_presence(user_id) in USER_PRESENCE_REACHABLE_STATES
+            }
+            body = {user_id: {"*": data} for user_id in online_userids}
 
             self._client.api.send_to_device(
                 event_type="m.room.message", messages={"msgtype": "m.text", "body": body}

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1366,6 +1366,10 @@ class MatrixTransport(Runnable):
                 for user_id in self._address_mgr.get_userids_for_address(receiver_address)
                 if self._address_mgr.get_userid_presence(user_id) in USER_PRESENCE_REACHABLE_STATES
             }
+            if not online_userids:
+                self.log.debug("No online user_ids", online_userids=online_userids)
+                return
+
             body = {
                 user_id: {"*": {"msgtype": "m.text", "body": data}} for user_id in online_userids
             }

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -133,6 +133,7 @@ class CapabilitiesConfig:
     mediate: bool = True
     delivery: bool = True
     web_rtc: bool = True
+    to_device: bool = True
 
 
 @dataclass

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -132,7 +132,7 @@ class CapabilitiesConfig:
     receive: bool = True
     mediate: bool = True
     delivery: bool = True
-    web_rtc: bool = True
+    web_rtc: bool = False
     to_device: bool = True
 
 

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -5,7 +5,11 @@ import pytest
 from raiden.constants import DISCOVERY_DEFAULT_ROOM, Environment
 from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix.utils import make_room_alias
-from raiden.settings import DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT, MatrixTransportConfig
+from raiden.settings import (
+    DEFAULT_TRANSPORT_MATRIX_SYNC_TIMEOUT,
+    CapabilitiesConfig,
+    MatrixTransportConfig,
+)
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.utils.transport import ParsedURL, generate_synapse_config, matrix_server_starter
 from raiden.utils.http import HTTPExecutor
@@ -78,6 +82,7 @@ def matrix_transports(
     number_of_transports: int,
     broadcast_rooms: List[str],
     matrix_sync_timeout: int,
+    capabilities: CapabilitiesConfig,
 ) -> Iterable[List[MatrixTransport]]:
     transports = []
     local_matrix_servers_str = [str(server) for server in local_matrix_servers]
@@ -94,6 +99,7 @@ def matrix_transports(
                     server=server,
                     available_servers=local_matrix_servers_str,
                     sync_timeout=matrix_sync_timeout,
+                    capabilities_config=capabilities,
                 ),
                 environment=Environment.DEVELOPMENT,
             )

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -798,6 +798,7 @@ def test_pfs_broadcast_messages(
 
 @pytest.mark.parametrize("number_of_transports", [2])
 @pytest.mark.parametrize("matrix_server_count", [2])
+@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(to_device=False)])
 def test_matrix_invite_private_room_happy_case(matrix_transports):
     """ Test that a room has been created between two communicating nodes."""
 
@@ -835,6 +836,7 @@ def test_matrix_invite_private_room_happy_case(matrix_transports):
 
 @pytest.mark.parametrize("matrix_server_count", [2])
 @pytest.mark.parametrize("number_of_transports", [2])
+@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(to_device=False)])
 def test_matrix_invite_retry_with_offline_invitee(
     matrix_transports: List[MatrixTransport],
 ) -> None:
@@ -903,6 +905,7 @@ def test_matrix_invite_retry_with_offline_invitee(
 
 @pytest.mark.parametrize("number_of_transports", [2])
 @pytest.mark.parametrize("matrix_server_count", [2])
+@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(to_device=False)])
 def test_matrix_invitee_receives_invite_on_restart(
     matrix_transports: List[MatrixTransport],
 ) -> None:

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -36,6 +36,7 @@ from raiden.services import send_pfs_update, update_monitoring_service_from_bala
 from raiden.settings import (
     MIN_MONITORING_AMOUNT_DAI,
     MONITORING_REWARD,
+    CapabilitiesConfig,
     MatrixTransportConfig,
     RaidenConfig,
     ServiceConfig,
@@ -1013,6 +1014,7 @@ def test_matrix_user_roaming(matrix_transports, roaming_peer):
     "roaming_peer",
     [pytest.param("high", id="roaming_high"), pytest.param("low", id="roaming_low")],
 )
+@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(to_device=False)])
 def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     # 6 transports on 3 servers, where (0,3), (1,4), (2,5) are one the same server
     (

--- a/raiden/tests/integration/network/transport/test_web_rtc.py
+++ b/raiden/tests/integration/network/transport/test_web_rtc.py
@@ -25,6 +25,7 @@ class MessageHandler:
         self.bag.update(messages)
 
 
+@pytest.mark.skip(reason="https://github.com/raiden-network/raiden/issues/6639")
 @pytest.mark.parametrize("matrix_server_count", [1])
 @pytest.mark.parametrize("number_of_transports", [2])
 @pytest.mark.parametrize("capabilities", [CapabilitiesConfig(web_rtc=True)])

--- a/raiden/tests/integration/network/transport/test_web_rtc.py
+++ b/raiden/tests/integration/network/transport/test_web_rtc.py
@@ -6,6 +6,7 @@ from raiden.constants import EMPTY_SIGNATURE
 from raiden.messages.synchronization import Processed
 from raiden.network.transport.matrix.transport import MessagesQueue
 from raiden.network.transport.matrix.utils import validate_and_parse_message
+from raiden.settings import CapabilitiesConfig
 from raiden.tests.utils import factories
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.transfer import views
@@ -26,6 +27,7 @@ class MessageHandler:
 
 @pytest.mark.parametrize("matrix_server_count", [1])
 @pytest.mark.parametrize("number_of_transports", [2])
+@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(web_rtc=True)])
 def test_web_rtc_message_sync(matrix_transports):
 
     transport0, transport1 = matrix_transports

--- a/raiden/utils/capabilities.py
+++ b/raiden/utils/capabilities.py
@@ -67,6 +67,7 @@ def capdict_to_config(capdict: Dict[str, Any]) -> CapabilitiesConfig:
         mediate=capdict.get(Capabilities.MEDIATE.value, True),
         delivery=capdict.get(Capabilities.DELIVERY.value, True),
         web_rtc=capdict.get(Capabilities.WEBRTC.value, False),
+        to_device=capdict.get(Capabilities.TODEVICE.value, False),
     )
     for key in capdict.keys():
         if key not in [_.value for _ in Capabilities]:
@@ -80,11 +81,12 @@ def capconfig_to_dict(config: CapabilitiesConfig) -> Dict[str, Any]:
         Capabilities.MEDIATE.value: config.mediate,
         Capabilities.DELIVERY.value: config.delivery,
         Capabilities.WEBRTC.value: config.web_rtc,
+        Capabilities.TODEVICE.value: config.to_device,
     }
     other_keys = [
         key
         for key in config.__dict__.keys()
-        if key not in ["receive", "mediate", "delivery", "web_rtc"]
+        if key not in ["receive", "mediate", "delivery", "web_rtc", "to_device"]
     ]
     for key in other_keys:
         if key not in [_.value for _ in Capabilities]:


### PR DESCRIPTION
## Description

Resolves #6627

This adds support for toDevice messages in Matrix.

- Adds a capability for `toDevice` messages
- Support receiving `toDevice` messages
- Support sending `toDevice` messages
- Don't open matrix rooms when `toDevice` capability is enabled.
- Disable webRTC for now