### PR TITLE
Handled changed geth error message

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -481,7 +481,10 @@ def inspect_client_error(
             if "insufficient funds" in error["message"]:
                 return ClientErrorInspectResult.INSUFFICIENT_FUNDS
 
-            if "always failing transaction" in error["message"]:
+            if (
+                "always failing transaction" in error["message"]
+                or "execution reverted" in error["message"]
+            ):
                 return ClientErrorInspectResult.ALWAYS_FAIL
 
             if "replacement transaction underpriced" in error["message"]:


### PR DESCRIPTION
We look at error message strings to categorize errors more fine grained
than just by HTTP codes. geth changed one of the returned messages in
one of the latest releases, so we need to adapt our error handling.
Without this, we get `ValueError: {'code': -32000, 'message': 'execution
reverted'}` exceptions instead of `None` return values when using our
`TransactionPending.estimate_gas` function.

Closes https://github.com/raiden-network/raiden/issues/6653