### PR TITLE
Handle new errors raised by geth v1.9.15

### DIFF
--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -481,7 +481,11 @@ def inspect_client_error(
             if "insufficient funds" in error["message"]:
                 return ClientErrorInspectResult.INSUFFICIENT_FUNDS
 
-            if "always failing transaction" in error["message"]:
+            if (
+                "always failing transaction" in error["message"]
+                or "execution reverted" in error["message"]
+                or "invalid opcode: opcode 0xfe not defined" in error["message"]
+            ):
                 return ClientErrorInspectResult.ALWAYS_FAIL
 
             if "replacement transaction underpriced" in error["message"]:
@@ -543,6 +547,15 @@ def check_value_error_for_parity(value_error: ValueError, call_type: ParityCallT
         code_checks_out = error_data["code"] == -32016
         message_checks_out = "The execution failed due to an exception" in error_data["message"]
     elif call_type == ParityCallType.CALL:
+        # TODO: refactor
+        # TODO: rename
+        if (
+            error_data["code"] == -32000
+            and "invalid opcode: opcode 0xfe not defined" in error_data["message"]
+        ):
+            return True
+        if error_data["code"] == -32000 and "execution reverted" in error_data["message"]:
+            return True
         code_checks_out = error_data["code"] == -32015
         message_checks_out = "VM execution error" in error_data["message"]
     else:


### PR DESCRIPTION
[cherry picked from b9e06e1d07a33b884321bbde4a97fe3c7e0c8e3f on develop]

This is the minimal change to make the tests pass, again. The code is
cleaned up in the following commits.

See https://github.com/ethereum/go-ethereum/releases/tag/v1.9.15 for
more information about the changes in error handling.