### PR TITLE
Work around flaky eth node startup in CI

### DIFF
--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -27,7 +27,7 @@ dormant_signal=SIGUSR1
 ./.circleci/kill_if_no_output.py \
     --dormant-timeout=${dormant_timeout} \
     --dormant-signal=${dormant_signal} \
-    --kill-timeout=15 \
+    --kill-timeout=20 \
     --kill-signal=SIGKILL \
     coverage \
     run \

--- a/raiden/tests/integration/conftest.py
+++ b/raiden/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import gevent
 import pytest
 
@@ -18,7 +19,9 @@ def pytest_collection_modifyitems(items):
 
     for item in items:
         item.add_marker(
-            pytest.mark.flaky(rerun_filter=lambda err, *args: issubclass(err[0], RetryTestError))
+            pytest.mark.flaky(
+                rerun_filter=lambda err, *args: issubclass(err[0], RetryTestError), max_runs=3
+            )
         )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ omit =
     */site-packages/*
 
 [tool:pytest]
-timeout_limit_for_setup_and_call = 540
+timeout_limit_for_setup_and_call = 240
 timeout_limit_teardown = 15
 norecursedirs = node_modules
 ; Ignore warnings:
@@ -115,4 +115,3 @@ check_untyped_defs = True
 # ... so do the network tests
 [mypy-raiden.tests.integration.network.*]
 check_untyped_defs = False
-


### PR DESCRIPTION
We always had problems with eth nodes that started without errors but
never reliably processed blocks. This is the reason why we allow test
retries when they fail during startup. The [recent forced upgrade](https://github.com/raiden-network/raiden/commit/d99a477c7102a700cc1d759e193fbe87e4a50bb8) to
openethereum made this problem more pronounced, so that a high
percentage of CI runs failed due to a hanging node startup.

The combination of the following changes in this PR seems to be
effective:
* Allow tests to run up to 20mins (we have a separate timeout for times
without output)
* Allow up to three runs for test that fail during startup
* Reduce the allowed time for startup to 4 minutes, so that we don't
wait unnecessarily long for hanging eth clients.