### PR TITLE
Improve Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ The Raiden Network is getting created with a set of tools, which are maintained 
 
 - The Raiden Python client within the current repository is used to manage payment channels and to make token transfers.
 
-- A [configured matrix server](https://github.com/raiden-network/raiden-transport) joins a federation of Matrix servers which is used as the transport layer for the Raiden Network. 
+- A [configured matrix server](https://github.com/raiden-network/raiden-transport) joins a federation of Matrix servers which is used as the transport layer for the Raiden Network.
 
 - The [Service repository](https://github.com/raiden-network/raiden-services) contains the code for following services:
-    - The Monitoring Service watches open payment channels when the user is not on-line. 
+    - The Monitoring Service watches open payment channels when the user is not on-line.
     - The Pathfinding service supports users in finding the cheapest or shortest way to route a payment through the network.
-    
+
 - The [Light Client repository](https://github.com/raiden-network/light-client) contains the code for following applications:
     - The Raiden Light Client SDK is a Raiden Network compatible client written in JavaScript/Typescript.
     - The Raiden DApp is a reference implementation of the Raiden Light Client SDK.
@@ -106,8 +106,8 @@ Website: [Raiden Network](https://raiden.network/)
 
 Blog: [Medium](https://medium.com/@raiden_network)
 
-Mail: contact@raiden.network 
+Mail: contact@raiden.network
 
 *The Raiden project is led by brainbot labs Est.*
 
-> Disclaimer: Please note, that even though we do our best to ensure the quality and accuracy of the information provided, this publication may contain views and opinions, errors and omissions for which the content creator(s) and any represented organization cannot be held liable. The wording and concepts regarding financial terminology (e.g. “payments”, “checks”, “currency”, “transfer” [of value]) are exclusively used in an exemplary way to describe technological principles and do not necessarily conform to the real world or legal equivalents of these terms and concepts.
+> Disclaimer: Please note, that even though we do our best to ensure the quality and accuracy of the information provided, this publication may contain views and opinions, errors and omissions for which the content creator(s) and any represented organization cannot be held liable. The wording and concepts regarding financial terminology (e.g. "payments", "checks", "currency", "transfer" [of value]) are exclusively used in an exemplary way to describe technological principles and do not necessarily conform to the real world or legal equivalents of these terms and concepts.

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -149,6 +149,9 @@ def configure_debug_logfile_path(debug_log_file_path: Optional[str]) -> str:
 
     # From here and on determine default based on user's system
     time = datetime.datetime.utcnow().isoformat()
+    if os.name == "nt":
+        # Windows does not allow colons in file names
+        time = time.replace(":", "_")
     debug_log_file_name = f"raiden-debug_{time}.log"
 
     home = os.path.expanduser("~")

--- a/raiden/utils/debugging.py
+++ b/raiden/utils/debugging.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import time
 from dataclasses import dataclass, field
@@ -29,6 +30,10 @@ def enable_gevent_monitoring_signal() -> None:
 
     def on_signal(signalnum: Any, stack_frame: Any) -> None:  # pylint: disable=unused-argument
         gevent.util.print_run_info()
+
+    if os.name == "nt":
+        # SIGUSR1 not supported on Windows
+        return
 
     signal.signal(signal.SIGUSR1, on_signal)
 

--- a/tools/pyinstaller_hooks/hook-coincurve.py
+++ b/tools/pyinstaller_hooks/hook-coincurve.py
@@ -1,0 +1,6 @@
+import os.path
+
+from PyInstaller.utils.hooks import get_module_file_attribute
+
+coincurve_dir = os.path.dirname(get_module_file_attribute("coincurve"))
+binaries = [(os.path.join(coincurve_dir, "libsecp256k1.dll"), "coincurve")]


### PR DESCRIPTION
This fixes multiple issues when trying to build a self-contained Raiden executable for Windows that does not require WSL. This does not fix all issues, yet. E.g. the ffmpeg dependencies won't be bundled correctly, but https://github.com/raiden-network/raiden/issues/6672 might help with that.

See https://github.com/raiden-network/raiden/issues/2482