### PR TITLE
Implement `candidates` messages in WebRTC

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         args: ["--ignore-whitespace", "--settings-path", "./", "--recursive"]
 
   - repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
 

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -4,7 +4,20 @@ import time
 from datetime import datetime
 from functools import wraps
 from itertools import repeat
-from typing import Any, Callable, Container, Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import (
+    Any,
+    Callable,
+    Container,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 from urllib.parse import quote
 from uuid import UUID, uuid4
 
@@ -242,7 +255,13 @@ class GMatrixHttpApi(MatrixHttpApi):
         message = {"type": RTCMessageType.HANGUP.value, "call_id": call_id}
         self._send_signalling(room_id, message)
 
-    def _send_signalling(self, room_id: RoomID, message: Dict[str, str]) -> None:
+    def candidates(self, room_id: RoomID, call_id: str, candidates: List[str]) -> None:
+        message = {"type": "candidates", "call_id": call_id, "candidates": candidates}
+        self._send_signalling(room_id, message)
+
+    def _send_signalling(
+        self, room_id: RoomID, message: Mapping[str, Union[str, Sequence[str]]]
+    ) -> None:
         self.send_message(room_id=room_id, text_content=json.dumps(message), msgtype="m.notice")
 
     def get_aliases(self, room_id: str) -> Dict[str, Any]:
@@ -781,12 +800,7 @@ class GMatrixClient(MatrixClient):
 
             # Add toDevice messages to message queue
             if response["to_device"]["events"]:
-                all_messages.append(
-                    (
-                        None,
-                        response["to_device"]["events"],
-                    )
-                )
+                all_messages.append((None, response["to_device"]["events"],))
 
             for room_id, invite_room in response["rooms"]["invite"].items():
                 for listener in self.invite_listeners[:]:

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -800,7 +800,12 @@ class GMatrixClient(MatrixClient):
 
             # Add toDevice messages to message queue
             if response["to_device"]["events"]:
-                all_messages.append((None, response["to_device"]["events"],))
+                all_messages.append(
+                    (
+                        None,
+                        response["to_device"]["events"],
+                    )
+                )
 
             for room_id, invite_room in response["rooms"]["invite"].items():
                 for listener in self.invite_listeners[:]:

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -118,6 +118,7 @@ class WebRTCManager:
 
             candidate = candidate_from_sdp(candidate_str)
             if candidate is not None:
+                candidate.sdpMid = "0"
                 connection.addIceCandidate(candidate)
 
     def spawn_set_remote_description(

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -5,13 +5,24 @@ from functools import partial
 import gevent
 import structlog
 from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
+from aiortc.sdp import candidate_from_sdp
 from gevent.event import Event
 
 from raiden.constants import RTCChannelState, SDPTypes
 from raiden.network.transport.matrix.rtc.utils import spawn_coroutine
 from raiden.network.transport.matrix.utils import my_place_or_yours
 from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import Address, Any, Callable, Coroutine, Dict, Optional, Set
+from raiden.utils.typing import (
+    Address,
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -91,6 +102,23 @@ class WebRTCManager:
             rtc_partner, self.node_address, self._handle_message_callback
         )
         self._spawn_web_rtc_coroutine(coroutine, self._handle_sdp_callback, partner_address)
+
+    def set_candidates(
+        self, partner_address: Address, description: Dict[str, Union[str, Sequence[str]]]
+    ) -> None:
+        assert self.node_address, "Transport is not started yet but tried to set candidates"
+        rtc_partner = self.get_rtc_partner(partner_address)
+        msg = "Partner RTCPeerConnection is not set, but tried to set candidates"
+        assert rtc_partner.peer_connection is not None, msg
+        msg = "Partner remote description is not set, but tried to set candidates"
+        assert rtc_partner.peer_connection.remoteDescription is not None, msg
+
+        connection: RTCPeerConnection = rtc_partner.peer_connection
+        for candidate_str in description["candidates"]:
+
+            candidate = candidate_from_sdp(candidate_str)
+            if candidate is not None:
+                connection.addIceCandidate(candidate)
 
     def spawn_set_remote_description(
         self, partner_address: Address, description: Dict[str, str]

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -107,9 +107,10 @@ class WebRTCManager:
         self, partner_address: Address, description: Dict[str, Union[str, Sequence[str]]]
     ) -> None:
         assert self.node_address, "Transport is not started yet but tried to set candidates"
+        msg = "Tried to set candidates, but RTCPeerConnection does not exist"
+        assert partner_address in self.address_to_rtc_partners, msg
         rtc_partner = self.get_rtc_partner(partner_address)
-        msg = "Partner RTCPeerConnection is not set, but tried to set candidates"
-        assert rtc_partner.peer_connection is not None, msg
+        # TODO: check if remoteDescription is necessary precondition
         msg = "Partner remote description is not set, but tried to set candidates"
         assert rtc_partner.peer_connection.remoteDescription is not None, msg
 
@@ -117,9 +118,8 @@ class WebRTCManager:
         for candidate_str in description["candidates"]:
 
             candidate = candidate_from_sdp(candidate_str)
-            if candidate is not None:
-                candidate.sdpMid = "0"
-                connection.addIceCandidate(candidate)
+            candidate.sdpMid = "0"
+            connection.addIceCandidate(candidate)
 
     def spawn_set_remote_description(
         self, partner_address: Address, description: Dict[str, str]

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1310,7 +1310,13 @@ class MatrixTransport(Runnable):
                         )
                         self._web_rtc_manager.close(peer_address)
 
-                    # TODO: implement candidates handling
+                    elif rtc_message_type == RTCMessageType.CANDIDATES.value:
+                        self.log.debug(
+                            "Received 'candidates' message",
+                            partner_address=to_checksum_address(peer_address),
+                            content=content,
+                        )
+                        self._web_rtc_manager.set_candidates(peer_address, content)
                     else:
                         self.log.debug(
                             "Unknown rtc message type",
@@ -1564,8 +1570,7 @@ class MatrixTransport(Runnable):
 
         if lower_address == self._raiden_service.address:
             self.log.debug(
-                "Spawning create rtc channel worker",
-                partner_address=to_checksum_address(address),
+                "Spawning create rtc channel worker", partner_address=to_checksum_address(address),
             )
             # initiate web rtc handling
             self._schedule_new_greenlet(self._create_web_rtc_channel, address)
@@ -1658,8 +1663,7 @@ class MatrixTransport(Runnable):
             capabilities = self._address_mgr.get_address_capabilities(partner_address)
             if self._capability_usable(Capabilities.WEBRTC, capabilities):
                 self.log.debug(
-                    "Initiating web rtc",
-                    partner_address=to_checksum_address(partner_address),
+                    "Initiating web rtc", partner_address=to_checksum_address(partner_address),
                 )
                 self._web_rtc_manager.spawn_create_channel(partner_address)
             else:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1570,7 +1570,8 @@ class MatrixTransport(Runnable):
 
         if lower_address == self._raiden_service.address:
             self.log.debug(
-                "Spawning create rtc channel worker", partner_address=to_checksum_address(address),
+                "Spawning create rtc channel worker",
+                partner_address=to_checksum_address(address),
             )
             # initiate web rtc handling
             self._schedule_new_greenlet(self._create_web_rtc_channel, address)
@@ -1663,7 +1664,8 @@ class MatrixTransport(Runnable):
             capabilities = self._address_mgr.get_address_capabilities(partner_address)
             if self._capability_usable(Capabilities.WEBRTC, capabilities):
                 self.log.debug(
-                    "Initiating web rtc", partner_address=to_checksum_address(partner_address),
+                    "Initiating web rtc",
+                    partner_address=to_checksum_address(partner_address),
                 )
                 self._web_rtc_manager.spawn_create_channel(partner_address)
             else:


### PR DESCRIPTION
## Description

This adds handling of incoming SDP `candidates` messages and implements outgoing message sending.

Logic for triggering outgoing candidates messages is not yet added.

Related: https://github.com/raiden-network/raiden/issues/6475

Unrelated changes:
- `black` version in pre-commit configuration was old and broke linting