### PR TITLE
Return tx_hash for `mint_for` APIs in all layers

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -68,6 +68,7 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
+    TransactionHash,
     WithdrawAmount,
 )
 
@@ -482,18 +483,24 @@ class RaidenAPI:  # pragma: no unittest
 
         return channel_state.identifier
 
-    def mint_token_for(self, token_address: TokenAddress, to: Address, value: TokenAmount) -> None:
+    def mint_token_for(
+        self, token_address: TokenAddress, to: Address, value: TokenAmount
+    ) -> TransactionHash:
         """Try to mint `value` units of the token at `token_address` and
         assign them to `to`, using `mintFor`.
 
         Raises:
             MintFailed if the minting fails for any reason.
+
+        Returns:
+            TransactionHash of the successfully mined Ethereum transaction
+            associated with the token mint.
         """
         confirmed_block_identifier = self.raiden.get_block_number()
         token_proxy = self.raiden.proxy_manager.custom_token(
             token_address, block_identifier=confirmed_block_identifier
         )
-        token_proxy.mint_for(value, to)
+        return token_proxy.mint_for(value, to)
 
     def set_total_channel_withdraw(
         self,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -576,13 +576,17 @@ class RestAPI:  # pragma: no unittest
         )
 
         try:
-            self.raiden_api.mint_token_for(token_address=token_address, to=to, value=value)
+            transaction_hash = self.raiden_api.mint_token_for(
+                token_address=token_address, to=to, value=value
+            )
         except MintFailed as e:
             return api_error(f"Minting failed: {str(e)}", status_code=HTTPStatus.BAD_REQUEST)
         except InsufficientEth as e:
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
-        return api_response(status_code=HTTPStatus.OK, result={})
+        return api_response(
+            status_code=HTTPStatus.OK, result=dict(transaction_hash=transaction_hash.hex())
+        )
 
     def open(
         self,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -585,7 +585,7 @@ class RestAPI:  # pragma: no unittest
             return api_error(errors=str(e), status_code=HTTPStatus.PAYMENT_REQUIRED)
 
         return api_response(
-            status_code=HTTPStatus.OK, result=dict(transaction_hash=transaction_hash.hex())
+            status_code=HTTPStatus.OK, result=dict(transaction_hash=encode_hex(transaction_hash))
         )
 
     def open(

--- a/raiden/network/proxies/custom_token.py
+++ b/raiden/network/proxies/custom_token.py
@@ -5,7 +5,7 @@ import structlog
 from raiden.network.proxies.exceptions import MintFailed
 from raiden.network.proxies.token import Token
 from raiden.network.rpc.client import was_transaction_successfully_mined
-from raiden.utils.typing import ABI, Address, TokenAmount
+from raiden.utils.typing import ABI, Address, TokenAmount, TransactionHash
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN
 from raiden_contracts.contract_manager import ContractManager
 
@@ -42,11 +42,15 @@ class CustomToken(Token):
                 "Gas estimation failed. Make sure the token has a method mint(uint256)."
             )
 
-    def mint_for(self, amount: TokenAmount, address: Address) -> None:
+    def mint_for(self, amount: TokenAmount, address: Address) -> TransactionHash:
         """Try to mint tokens by calling `mintFor`.
 
         Raises:
             MintFailed if anything goes wrong.
+
+        Returns:
+            TransactionHash of the successfully mined Ethereum transaction
+            associated with the token mint.
         """
 
         extra_log_details: Dict[str, Any] = {}
@@ -60,6 +64,8 @@ class CustomToken(Token):
 
             if not was_transaction_successfully_mined(transaction_mined):
                 raise MintFailed("Call to contract method mintFor: Transaction failed.")
+            else:
+                return transaction_mined.transaction_hash
 
         else:
             raise MintFailed(

--- a/raiden/tests/integration/network/proxies/test_custom_token.py
+++ b/raiden/tests/integration/network/proxies/test_custom_token.py
@@ -1,0 +1,35 @@
+from raiden.constants import BLOCK_ID_LATEST
+from raiden.network.proxies.custom_token import CustomToken
+from raiden.network.proxies.service_registry import ServiceRegistry
+from raiden.network.rpc.client import JSONRPCClient
+from raiden.tests.utils.smartcontracts import is_tx_hash_bytes
+
+
+def test_custom_token(service_registry_address, private_keys, web3, contract_manager):
+    block_identifier = BLOCK_ID_LATEST
+    c1_client = JSONRPCClient(web3, private_keys[0])
+    c1_service_proxy = ServiceRegistry(
+        jsonrpc_client=c1_client,
+        service_registry_address=service_registry_address,
+        contract_manager=contract_manager,
+        block_identifier=block_identifier,
+    )
+    token_address = c1_service_proxy.token_address(block_identifier=block_identifier)
+    c1_token_proxy = CustomToken(
+        jsonrpc_client=c1_client,
+        token_address=token_address,
+        contract_manager=contract_manager,
+        block_identifier=block_identifier,
+    )
+
+    c2_client = JSONRPCClient(web3, private_keys[1])
+
+    mint_amount = 1000 * 10 ** 18
+    tx_hash = c1_token_proxy.mint_for(mint_amount, c2_client.address)
+    # check that we return a correctly formatted transaction_hash for a successful tx
+    assert is_tx_hash_bytes(tx_hash)
+    assert c1_token_proxy.balance_of(c2_client.address) == mint_amount
+    assert c1_token_proxy.balance_of(c1_client.address) == 0
+
+    c1_token_proxy.mint(mint_amount)
+    assert c1_token_proxy.balance_of(c1_client.address) == mint_amount

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from solc import compile_files
 from web3.contract import Contract
@@ -9,8 +10,18 @@ from raiden.network.pathfinding import get_random_pfs
 from raiden.network.proxies.custom_token import CustomToken
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.utils.typing import Any, Dict, List, TokenAmount, Tuple
+from raiden.utils.typing import Any, Dict, List, T_TransactionHash, TokenAmount, Tuple
 from raiden_contracts.contract_manager import ContractManager
+
+
+def is_tx_hash_bytes(bytes_: Any) -> bool:
+    """
+    Check wether the `bytes_` is a correctly encoded transaction hash,
+    but do not query any blockchain node to check for transaction validity.
+    """
+    if isinstance(bytes_, T_TransactionHash):
+        return bool(re.fullmatch("^0x([A-Fa-f0-9]{64})$", bytes_.hex()))
+    return False
 
 
 def deploy_token(

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 from solc import compile_files
 from web3.contract import Contract
@@ -16,11 +15,12 @@ from raiden_contracts.contract_manager import ContractManager
 
 def is_tx_hash_bytes(bytes_: Any) -> bool:
     """
-    Check wether the `bytes_` is a correctly encoded transaction hash,
+    Check wether the `bytes_` is a bytes object with the correct number of bytes
+    for a transaction,
     but do not query any blockchain node to check for transaction validity.
     """
     if isinstance(bytes_, T_TransactionHash):
-        return bool(re.fullmatch("^0x([A-Fa-f0-9]{64})$", bytes_.hex()))
+        return len(bytes_) == 32
     return False
 
 


### PR DESCRIPTION
## Description

The documentation of the public REST-API falsely claimed that the
transaction_hash will be returned in the response-body
for the endpoint at `POST /api/v1/_testing/tokens/<addr>/mint`.

Since no methods in the call stack of that endpoint returned
the transaction_hash, this behavior is implemented now -
the conversion from HexBytes to a HexString is done in the
most outer REST layer.
Fixes: #6649


