### PR TITLE
Ignore phony mypy error

### DIFF
--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -505,7 +505,7 @@ def options(func: Callable) -> Callable:
         ),
     ]
 
-    if importlib.util.find_spec("IPython"):
+    if importlib.util.find_spec("IPython"):  # type: ignore
         options_.append(
             option("--console", help="Start the interactive raiden console", is_flag=True)
         )


### PR DESCRIPTION
This line triggers an error in mypy, even though it should not.

```
mypy raiden/ui/cli.py
raiden/ui/cli.py:508: error: Module has no attribute "util"
Found 1 error in 1 file (checked 1 source file)
```