### PR TITLE
Return tx-hash for blockchain proxy methods

### DIFF
--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -257,7 +257,7 @@ class RaidenAPI:  # pragma: no unittest
             registry_address, block_identifier=chainstate.block_hash
         )
 
-        token_network_address = registry.add_token(
+        _, token_network_address = registry.add_token(
             token_address=token_address,
             channel_participant_deposit_limit=channel_participant_deposit_limit,
             token_network_deposit_limit=token_network_deposit_limit,

--- a/raiden/network/proxies/custom_token.py
+++ b/raiden/network/proxies/custom_token.py
@@ -18,7 +18,7 @@ class CustomToken(Token):
         """Overwrittable by subclasses to change the proxies ABI."""
         return contract_manager.get_contract_abi(CONTRACT_CUSTOM_TOKEN)
 
-    def mint(self, amount: TokenAmount) -> None:
+    def mint(self, amount: TokenAmount) -> TransactionHash:
         """Try to mint tokens by calling `mint`.
 
         Raises:
@@ -36,6 +36,8 @@ class CustomToken(Token):
 
             if not was_transaction_successfully_mined(transaction_mined):
                 raise MintFailed("Mint failed.")
+            else:
+                return transaction_mined.transaction_hash
 
         else:
             raise MintFailed(

--- a/raiden/network/proxies/payment_channel.py
+++ b/raiden/network/proxies/payment_channel.py
@@ -14,6 +14,7 @@ from raiden.utils.typing import (
     Signature,
     TokenAddress,
     TokenAmount,
+    TransactionHash,
     WithdrawAmount,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK, ChannelEvent
@@ -121,8 +122,8 @@ class PaymentChannel:
         partner_signature: Signature,
         expiration_block: BlockExpiration,
         block_identifier: BlockIdentifier,
-    ) -> None:
-        self.token_network.set_total_withdraw(
+    ) -> TransactionHash:
+        return self.token_network.set_total_withdraw(
             given_block_identifier=block_identifier,
             channel_identifier=self.channel_identifier,
             total_withdraw=total_withdraw,
@@ -181,8 +182,8 @@ class PaymentChannel:
         receiver: Address,
         pending_locks: PendingLocksState,
         given_block_identifier: BlockIdentifier,
-    ) -> None:
-        self.token_network.unlock(
+    ) -> TransactionHash:
+        return self.token_network.unlock(
             channel_identifier=self.channel_identifier,
             sender=sender,
             receiver=receiver,
@@ -199,9 +200,9 @@ class PaymentChannel:
         partner_locked_amount: LockedAmount,
         partner_locksroot: Locksroot,
         block_identifier: BlockIdentifier,
-    ) -> None:
+    ) -> TransactionHash:
         """ Settles the channel. """
-        self.token_network.settle(
+        return self.token_network.settle(
             channel_identifier=self.channel_identifier,
             transferred_amount=transferred_amount,
             locked_amount=locked_amount,

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -29,6 +29,7 @@ from raiden.utils.typing import (
     Secret,
     SecretHash,
     SecretRegistryAddress,
+    TransactionHash,
     Union,
 )
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY
@@ -81,12 +82,13 @@ class SecretRegistry:
     def register_secret(self, secret: Secret) -> None:
         self.register_secret_batch([secret])
 
-    def register_secret_batch(self, secrets: List[Secret]) -> None:
+    def register_secret_batch(self, secrets: List[Secret]) -> List[TransactionHash]:
         """Register a batch of secrets. Check if they are already registered at
         the given block identifier."""
         secrets_to_register = list()
         secrethashes_to_register = list()
         secrethashes_not_sent = list()
+        secrets_results = list()
         transaction_result = AsyncResult()
         wait_for = set()
 
@@ -128,10 +130,12 @@ class SecretRegistry:
                 if other_result is not None:
                     wait_for.add(other_result)
                     secrethashes_not_sent.append(secrethash_hex)
+                    secrets_results.append(other_result)
                 elif not self.is_secret_registered(secrethash, verification_block_hash):
                     secrets_to_register.append(secret)
                     secrethashes_to_register.append(secrethash_hex)
                     self.open_secret_transactions[secret] = transaction_result
+                    secrets_results.append(transaction_result)
 
         # From here on the lock is not required. Context-switches will happen
         # for the gas estimation and the transaction, however the
@@ -141,6 +145,7 @@ class SecretRegistry:
             self._register_secret_batch(secrets_to_register, transaction_result, log_details)
 
         gevent.joinall(wait_for, raise_error=True)
+        return [result.get() for result in secrets_results]
 
     def _register_secret_batch(
         self,

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -20,6 +20,7 @@ from raiden.utils.typing import (
     ServiceRegistryAddress,
     TokenAddress,
     TokenAmount,
+    TransactionHash,
 )
 from raiden_contracts.constants import CONTRACT_SERVICE_REGISTRY
 from raiden_contracts.contract_manager import ContractManager
@@ -111,7 +112,9 @@ class ServiceRegistry:
             )
         )
 
-    def deposit(self, block_identifier: BlockIdentifier, limit_amount: TokenAmount) -> None:
+    def deposit(
+        self, block_identifier: BlockIdentifier, limit_amount: TokenAmount
+    ) -> TransactionHash:
         """Makes a deposit to create or extend a registration"""
         extra_log_details = {"given_block_identifier": block_identifier}
         estimated_transaction = self.client.estimate_gas(
@@ -128,8 +131,10 @@ class ServiceRegistry:
         if not was_transaction_successfully_mined(transaction_mined):
             msg = "ServiceRegistry.deposit transaction failed"
             raise RaidenUnrecoverableError(msg)
+        else:
+            return transaction_mined.transaction_hash
 
-    def set_url(self, url: str) -> None:
+    def set_url(self, url: str) -> TransactionHash:
         """Sets the url needed to access the service via HTTP for the caller"""
         if not url.strip():
             msg = "Invalid empty URL"
@@ -154,3 +159,5 @@ class ServiceRegistry:
         if not was_transaction_successfully_mined(transaction_mined):
             msg = f"URL {url} is invalid"
             raise RaidenUnrecoverableError(msg)
+        else:
+            return transaction_mined.transaction_hash

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -21,6 +21,7 @@ from raiden.utils.typing import (
     Optional,
     TokenAddress,
     TokenAmount,
+    TransactionHash,
 )
 from raiden_contracts.constants import CONTRACT_HUMAN_STANDARD_TOKEN
 from raiden_contracts.contract_manager import ContractManager
@@ -73,7 +74,7 @@ class Token:
             self.proxy.functions.allowance(owner, spender).call(block_identifier=block_identifier)
         )
 
-    def approve(self, allowed_address: Address, allowance: TokenAmount) -> None:
+    def approve(self, allowed_address: Address, allowance: TokenAmount) -> TransactionHash:
         """Approve `allowed_address` to transfer up to `deposit` amount of token.
 
         Note:
@@ -125,6 +126,8 @@ class Token:
                         f"the requested allowance and enough eth to pay the gas. There may "
                         f"be a problem with the token contract."
                     )
+                else:
+                    return transaction_mined.transaction_hash
 
             else:
                 failed_at = self.client.get_block(BLOCK_ID_LATEST)
@@ -181,7 +184,7 @@ class Token:
 
         return None
 
-    def transfer(self, to_address: Address, amount: TokenAmount) -> None:
+    def transfer(self, to_address: Address, amount: TokenAmount) -> TransactionHash:
         """Transfer `amount` tokens to `to_address`.
 
         Note:
@@ -230,7 +233,7 @@ class Token:
                 transaction_mined = self.client.poll_transaction(transaction_sent)
 
                 if was_transaction_successfully_mined(transaction_mined):
-                    return
+                    return transaction_mined.transaction_hash
 
                 failed_at_block_number = BlockNumber(transaction_mined.receipt["blockNumber"])
                 check_for_insufficient_token_balance(failed_at_block_number)

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -39,6 +39,8 @@ from raiden.utils.typing import (
     TokenAmount,
     TokenNetworkAddress,
     TokenNetworkRegistryAddress,
+    TransactionHash,
+    Tuple,
     typecheck,
 )
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY, CONTRACT_TOKEN_NETWORK_REGISTRY
@@ -104,7 +106,7 @@ class TokenNetworkRegistry:
         channel_participant_deposit_limit: TokenAmount,
         token_network_deposit_limit: TokenAmount,
         given_block_identifier: BlockIdentifier,
-    ) -> TokenNetworkAddress:
+    ) -> Tuple[TransactionHash, TokenNetworkAddress]:
         """
         Register token of `token_address` with the token network.
         The limits apply for version 0.13.0 and above of raiden-contracts,
@@ -231,7 +233,7 @@ class TokenNetworkRegistry:
         channel_participant_deposit_limit: TokenAmount,
         token_network_deposit_limit: TokenAmount,
         log_details: Dict[Any, Any],
-    ) -> TokenNetworkAddress:
+    ) -> Tuple[TransactionHash, TokenNetworkAddress]:
         token_network_address = None
 
         kwargs = {
@@ -509,7 +511,10 @@ class TokenNetworkRegistry:
                 f"reason. Reference block {failed_at_blockhash} "
                 f"{failed_at_blocknumber}."
             )
-        return token_network_address
+        return (
+            TransactionHash(transaction_mined.transaction_hash),
+            TokenNetworkAddress(token_network_address),
+        )
 
     def filter_token_added_events(self) -> List[Dict[str, Any]]:
         filter_ = self.proxy.events.TokenNetworkCreated.createFilter(

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -418,8 +418,6 @@ class UserDeposit:
                 transaction_sent=transaction_sent, amount_to_plan_withdraw=amount
             )
 
-        assert transaction_mined is not None, "_plan_withdraw_check_result returned None"
-
         return (
             transaction_mined.transaction_hash,
             BlockNumber(transaction_mined.receipt["blockNumber"] + self.get_withdraw_delay()),
@@ -748,7 +746,7 @@ class UserDeposit:
 
     def _plan_withdraw_check_result(
         self, transaction_sent: Optional[TransactionSent], amount_to_plan_withdraw: TokenAmount
-    ) -> Optional[TransactionMined]:
+    ) -> TransactionMined:
         if transaction_sent is None:
             failed_at = self.client.get_block(BLOCK_ID_LATEST)
             failed_at_blocknumber = failed_at["number"]

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -132,6 +132,9 @@ class UserDeposit:
     def get_total_deposit(
         self, address: Address, block_identifier: BlockIdentifier
     ) -> TokenAmount:
+        return self.proxy.functions.total_deposit(address).call(block_identifier=block_identifier)
+
+    def get_balance(self, address: Address, block_identifier: BlockIdentifier) -> TokenAmount:
         return self.proxy.functions.balances(address).call(block_identifier=block_identifier)
 
     def whole_balance(self, block_identifier: BlockIdentifier) -> TokenAmount:
@@ -681,7 +684,7 @@ class UserDeposit:
             raise BrokenPreconditionError("Planned withdraw amount must be greater than zero.")
 
         try:
-            current_balance = self.get_total_deposit(
+            current_balance = self.get_balance(
                 address=self.node_address, block_identifier=given_block_identifier
             )
         except ValueError:
@@ -757,7 +760,7 @@ class UserDeposit:
 
             failed_at_blocknumber = BlockNumber(transaction_mined.receipt["blockNumber"])
 
-            current_balance = self.get_total_deposit(
+            current_balance = self.get_balance(
                 address=self.node_address, block_identifier=failed_at_blocknumber
             )
 

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -129,12 +129,13 @@ def register_token(
     token_network_registry_proxy = token_network_registry_deploy_result()
     token_contract = token_deploy_result()
 
-    return token_network_registry_proxy.add_token(
+    _, token_network_address = token_network_registry_proxy.add_token(
         token_address=TokenAddress(to_canonical_address(token_contract.address)),
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
         given_block_identifier=token_contract.web3.eth.blockNumber,
     )
+    return token_network_address
 
 
 def deploy_service_registry(

--- a/raiden/tests/integration/network/proxies/test_custom_token.py
+++ b/raiden/tests/integration/network/proxies/test_custom_token.py
@@ -31,5 +31,6 @@ def test_custom_token(service_registry_address, private_keys, web3, contract_man
     assert c1_token_proxy.balance_of(c2_client.address) == mint_amount
     assert c1_token_proxy.balance_of(c1_client.address) == 0
 
-    c1_token_proxy.mint(mint_amount)
+    tx_hash = c1_token_proxy.mint(mint_amount)
+    assert is_tx_hash_bytes(tx_hash)
     assert c1_token_proxy.balance_of(c1_client.address) == mint_amount

--- a/raiden/tests/integration/network/proxies/test_secret_registry.py
+++ b/raiden/tests/integration/network/proxies/test_secret_registry.py
@@ -17,6 +17,7 @@ from raiden.network.rpc.client import (
 )
 from raiden.tests.utils.events import must_have_event
 from raiden.tests.utils.factories import make_secret
+from raiden.tests.utils.smartcontracts import is_tx_hash_bytes
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import Address, BlockNumber, Dict, List, PrivateKey, Secret
 from raiden_contracts.constants import CONTRACT_SECRET_REGISTRY
@@ -29,7 +30,9 @@ def secret_registry_batch_happy_path(
     secrets = [make_secret() for i in range(4)]
     secrethashes = [sha256_secrethash(secret) for secret in secrets]
 
-    secret_registry_proxy.register_secret_batch(secrets=secrets)
+    transaction_hashes = secret_registry_proxy.register_secret_batch(secrets=secrets)
+    for tx_hash in transaction_hashes:
+        assert is_tx_hash_bytes(tx_hash)
 
     logs = get_contract_events(
         proxy_manager=proxy_manager,

--- a/raiden/tests/integration/network/proxies/test_token.py
+++ b/raiden/tests/integration/network/proxies/test_token.py
@@ -3,6 +3,7 @@ from eth_utils import to_canonical_address
 from raiden.constants import BLOCK_ID_LATEST
 from raiden.network.proxies.token import Token
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.tests.utils.smartcontracts import is_tx_hash_bytes
 from raiden.utils.keys import privatekey_to_address
 
 
@@ -20,10 +21,13 @@ def test_token(deploy_client, token_proxy, private_keys, web3, contract_manager)
 
     # send some funds from deployer to generated address
     transfer_funds = 100
-    token_proxy.transfer(address, transfer_funds)
+    transaction_hash = token_proxy.transfer(address, transfer_funds)
+    assert is_tx_hash_bytes(transaction_hash)
     assert transfer_funds == token_proxy.balance_of(address)
     allow_funds = 100
-    token_proxy.approve(address, allow_funds)
+
+    transaction_hash = token_proxy.approve(address, allow_funds)
+    assert is_tx_hash_bytes(transaction_hash)
     assert allow_funds == token_proxy.proxy.functions.allowance(
         deploy_client.address, address
     ).call(block_identifier=BLOCK_ID_LATEST)

--- a/raiden/tests/integration/network/proxies/test_token_network_registry.py
+++ b/raiden/tests/integration/network/proxies/test_token_network_registry.py
@@ -94,7 +94,7 @@ def test_token_network_registry(
 
     # Register a valid token
     preblockhash = deploy_client.get_confirmed_blockhash()
-    token_network_address = token_network_registry_proxy.add_token(
+    _, token_network_address = token_network_registry_proxy.add_token(
         token_address=test_token_address,
         channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
         token_network_deposit_limit=TokenAmount(UINT256_MAX),

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -172,11 +172,12 @@ def payment_channel_open_and_deposit(
         token_network_address, block_identifier=BLOCK_ID_LATEST
     )
 
-    channel_identifier, _, _ = token_network_proxy.new_netting_channel(
+    channel_details = token_network_proxy.new_netting_channel(
         partner=app1.address,
         settle_timeout=settle_timeout,
         given_block_identifier=block_identifier,
     )
+    channel_identifier = channel_details.channel_identifier
     assert channel_identifier
 
     if deposit != 0:

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -106,8 +106,12 @@ def deploy_service_registry_and_set_urls(
     c2_token_proxy.mint_for(c2_price, c2_client.address)
     assert c2_token_proxy.balance_of(c2_client.address) > 0
     c2_token_proxy.approve(allowed_address=service_registry_address, allowance=c2_price)
-    c2_service_proxy.deposit(block_identifier=BLOCK_ID_LATEST, limit_amount=c2_price)
-    c2_service_proxy.set_url(urls[1])
+    transaction_hash = c2_service_proxy.deposit(
+        block_identifier=BLOCK_ID_LATEST, limit_amount=c2_price
+    )
+    assert is_tx_hash_bytes(transaction_hash)
+    transaction_hash = c2_service_proxy.set_url(urls[1])
+    assert is_tx_hash_bytes(transaction_hash)
 
     c3_price = c3_service_proxy.current_price(block_identifier=BLOCK_ID_LATEST)
     c3_token_proxy.mint_for(c3_price, c3_client.address)

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -48,7 +48,7 @@ from raiden.tests.utils.eth_node import (
     parity_keystore,
     run_private_blockchain,
 )
-from raiden.tests.utils.smartcontracts import deploy_token
+from raiden.tests.utils.smartcontracts import deploy_token, is_tx_hash_bytes
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.transfer import channel, views
 from raiden.transfer.state import ChannelState
@@ -215,11 +215,12 @@ def deploy_smoketest_contracts(
         proxy_manager=proxy_manager,
         block_identifier=BLOCK_ID_LATEST,
     )
-    user_deposit_proxy.init(
+    transaction_hash = user_deposit_proxy.init(
         monitoring_service_address=MonitoringServiceAddress(monitoring_service_address),
         one_to_n_address=OneToNAddress(one_to_n_address),
         given_block_identifier=BLOCK_ID_LATEST,
     )
+    assert is_tx_hash_bytes(transaction_hash)
 
     addresses = {
         CONTRACT_SECRET_REGISTRY: secret_registry_address,

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -194,7 +194,7 @@ class ConsoleTools:
             registry_address, BLOCK_ID_LATEST
         )
 
-        token_network_address = registry.add_token(
+        _, token_network_address = registry.add_token(
             token_address=token_address,
             channel_participant_deposit_limit=TokenAmount(UINT256_MAX),
             token_network_deposit_limit=TokenAmount(UINT256_MAX),


### PR DESCRIPTION
In order to keep the interface consistent, all blockchain proxy
methods that internally call `JSONRPCClient.poll_transaction( )`
somewhere in their call-stack will now also return
the transaction hash, a list of transaction hashes or
an optional transaction hash.

Fixes: #6688

