### PR TITLE
Minimize ContractSendChannelBatchUnlock events

### DIFF
--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -308,7 +308,7 @@ class NettingChannelEndState(State):
         repr=False, default_factory=dict
     )
     #: Locks for which the secret is known, the partner has not sent an
-    #: unlocked off chain yet, and the secret has been registered onchain
+    #: unlock off-chain yet, and the secret has been registered on-chain
     #: before the lock has expired.
     secrethashes_to_onchain_unlockedlocks: Dict[SecretHash, UnlockPartialProofState] = field(
         repr=False, default_factory=dict


### PR DESCRIPTION
Previously, we were creating these events whenever we might want to
unlock any lock. This had the following problems:
* `ContractSendChannelBatchUnlock` events were generated in many cases
where no transactions were actually sent. Confusing!
* `ContractSendChannelBatchUnlock.sender` was not always what was used
as sender on-chain, because the event handler decided which participant
to use as sender. Confusing!
* We easily got into cases where a node was calling unlock, although it
had no incentive to do so (#6706)

Previously, we were digging out old channel states. I could not find a
reason why that was needed, and it was causing wrong gains calculation,
since the secret registration was missing in those channel states.
Please double-check that this is ok during review!

Closes #6706.