### PR TITLE
Enforce aiortc to send messages

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -225,6 +225,11 @@ IMBALANCE_MED_FEE_MIN = 0
 IMBALANCE_MED_FEE_MAX = 50_000
 
 
+class MatrixMessageType(Enum):
+    TEXT = "m.text"
+    NOTICE = "m.notice"
+
+
 # Web RTC constants
 class RTCMessageType(Enum):
     OFFER = "offer"
@@ -249,6 +254,14 @@ class RTCSignallingState(Enum):
     STABLE = "stable"
     HAVE_LOCAL_OFFER = "have-local-offer"
     HAVE_REMOTE_OFFER = "have-remote-offer"
+    CLOSED = "closed"
+
+
+class ICEConnectionState(Enum):
+    NEW = "new"
+    CHECKING = "checking"
+    COMPLETED = "completed"
+    FAILED = "failed"
     CLOSED = "closed"
 
 

--- a/raiden/network/transport/matrix/rtc/aiogevent.py
+++ b/raiden/network/transport/matrix/rtc/aiogevent.py
@@ -223,7 +223,16 @@ def yield_future(future, loop=None):
 
 
 def yield_aio_event(aio_event: AIOEvent) -> GEvent:
+    """
+    Converts an asyncio.Event into a gevent.event.Event
 
+    Will set the returned GEvent whenever the underlying
+    aio_event is set. Used to wait for an asyncio.Event
+    inside of a greenlet
+
+    params:
+        aio_event: Asyncio.Event to wait on
+    """
     task = asyncio.ensure_future(aio_event.wait())
     g_event = GEvent()
 

--- a/raiden/network/transport/matrix/rtc/utils.py
+++ b/raiden/network/transport/matrix/rtc/utils.py
@@ -51,7 +51,7 @@ def wait_for_future(future: Future, callback: Callable, **kwargs: Any) -> None:
 
 
 def create_task_callback(
-    callback: Callable[[Any, Any], None],
+    callback: Callable[..., None],
     *args: Any,
     **kwargs: Any,
 ) -> Callable:
@@ -71,6 +71,6 @@ def create_task_callback(
         return _greenlet_callback
 
 
-def wrap_callback(callback: Callable[[Any, Any], None], *args: Any, **kwargs: Any) -> None:
+def wrap_callback(callback: Callable[..., None], *args: Any, **kwargs: Any) -> None:
     callback_greenlet = gevent.Greenlet(callback, *args, **kwargs)
     callback_greenlet.start()

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -1,21 +1,23 @@
 import asyncio
 import time
-from asyncio import Task
+from asyncio import CancelledError, Event as AIOEvent, Task
+from dataclasses import dataclass, field
 from functools import partial
 
 import structlog
 from aiortc import InvalidStateError, RTCDataChannel, RTCPeerConnection, RTCSessionDescription
 from aiortc.sdp import candidate_from_sdp, candidate_to_sdp
-from gevent.event import Event
+from gevent.event import Event as GEvent
 
 from raiden.constants import (
     SDP_MID_DEFAULT,
     SDP_MLINE_INDEX_DEFAULT,
+    ICEConnectionState,
     RTCChannelState,
     RTCSignallingState,
     SDPTypes,
 )
-from raiden.network.transport.matrix.rtc.aiogevent import yield_future
+from raiden.network.transport.matrix.rtc.aiogevent import yield_aio_event, yield_future
 from raiden.network.transport.matrix.rtc.utils import create_task_callback, wrap_callback
 from raiden.network.transport.matrix.utils import my_place_or_yours
 from raiden.utils.formatting import to_checksum_address
@@ -44,21 +46,81 @@ class CoroutineHandler:
         self.coroutines.append(task)
         return task
 
-    async def wait_for_coroutines(self) -> None:
-        log.debug("Waiting for coroutines", coroutines=self.coroutines)
-        await asyncio.gather(*self.coroutines)
+    async def wait_for_coroutines(self, cancel: bool = True) -> None:
+
+        if cancel:
+            self.cancel_all_pending()
+
+        pending_coroutines = [
+            coroutine
+            for coroutine in self.coroutines
+            if not coroutine.done() and not coroutine.cancelled()
+        ]
+        log.debug("Waiting for coroutines", coroutines=pending_coroutines)
+
+        try:
+            await asyncio.gather(*pending_coroutines)
+        except CancelledError:
+            log.debug(
+                "Pending coroutines cancelled",
+                cancelled=[coroutine for coroutine in self.coroutines if coroutine.cancelled()],
+            )
 
     def join_all_coroutines(self) -> None:
         yield_future(self.wait_for_coroutines())
 
+    def cancel_all_pending(self) -> None:
+        for coroutine in self.coroutines:
+            if not coroutine.done() and not coroutine.cancelled():
+                coroutine.cancel()
+
 
 class RTCPartner(CoroutineHandler):
+    @dataclass
+    class SyncEvents:
+        aio_allow_init: AIOEvent = field(default_factory=AIOEvent)
+        aio_allow_candidates: AIOEvent = field(default_factory=AIOEvent)
+        aio_allow_hangup: AIOEvent = field(default_factory=AIOEvent)
+        reset_event: AIOEvent = field(default_factory=AIOEvent)
+
+        def __post_init__(self) -> None:
+            self.aio_allow_init.set()
+
+        @property
+        def g_allow_init(self) -> GEvent:
+            return yield_aio_event(self.aio_allow_init)
+
+        def reset(self) -> None:
+            self.reset_event.set()
+            self.set_all()
+            self.clear_all()
+            self.aio_allow_init.set()
+
+        def set_all(self) -> None:
+            self.aio_allow_init.set()
+            self.aio_allow_candidates.set()
+            self.aio_allow_hangup.set()
+
+        def clear_all(self) -> None:
+            self.aio_allow_init.clear()
+            self.aio_allow_candidates.clear()
+            self.aio_allow_hangup.clear()
+
+        async def wait_for_init(self) -> None:
+            await self.aio_allow_init.wait()
+
+        async def wait_for_candidates(self) -> None:
+            await self.aio_allow_candidates.wait()
+
+        async def wait_for_hangup(self) -> None:
+            await self.aio_allow_hangup.wait()
+
     def __init__(self, partner_address: Address, peer_connection: RTCPeerConnection) -> None:
         super().__init__()
         self.partner_address = partner_address
         self.peer_connection = peer_connection
         self.channel: Optional[RTCDataChannel] = None
-        self.partner_ready_event = Event()
+        self.sync_events = RTCPartner.SyncEvents()
 
     def _setup_channel(self, node_address: Address) -> None:
         lower_address = my_place_or_yours(node_address, self.partner_address)
@@ -68,7 +130,7 @@ class RTCPartner(CoroutineHandler):
         )
         self.channel = self.peer_connection.createDataChannel(channel_name)
 
-    def _set_channel_callbacks(
+    def set_channel_callbacks(
         self, node_address: Address, handle_message_callback: Callable[[str, Address], None]
     ) -> None:
         if self.channel is None:
@@ -85,7 +147,8 @@ class RTCPartner(CoroutineHandler):
             ),
         )
         # channel callback on close signal
-        self.channel.on("close", partial(on_channel_close, self))
+        self.channel.on("close", partial(on_channel_close, self, node_address))
+        self.channel.on("open", partial(on_channel_open, node_address, self.channel))
 
     def get_call_id(self, node_address: Address) -> str:
         lower_address = my_place_or_yours(node_address, self.partner_address)
@@ -93,11 +156,25 @@ class RTCPartner(CoroutineHandler):
         call_id = f"{to_checksum_address(lower_address)}|{to_checksum_address(higher_address)}"
         return call_id
 
-    async def _set_local_description(self, description: RTCSessionDescription) -> None:
+    async def _set_local_description(
+        self, description: RTCSessionDescription, node_address: Address
+    ) -> None:
         try:
+            log.debug(
+                "Set local description",
+                node_address=to_checksum_address(node_address),
+                partner_address=to_checksum_address(self.partner_address),
+                description=description,
+            )
             await self.peer_connection.setLocalDescription(description)
         except InvalidStateError:
             # this can happen if peer connection gets closed while awaiting in the try block
+            log.debug(
+                "Connection state in incompatible state",
+                partner_address=to_checksum_address(self.partner_address),
+                signaling_state=self.peer_connection.signalingState,
+                ice_connection_state=self.peer_connection.iceConnectionState,
+            )
             return None
 
     async def initialize_signalling(
@@ -107,17 +184,35 @@ class RTCPartner(CoroutineHandler):
     ) -> Optional[RTCSessionDescription]:
         """Coroutine to create channel. Setting up channel in aiortc"""
 
-        self._setup_channel(node_address)
-        offer = await self.peer_connection.createOffer()
-
-        self.schedule_task(self._set_local_description(offer))
-
-        if self.channel is None:
+        await self.sync_events.aio_allow_init.wait()
+        if self.sync_events.reset_event.is_set():
             return None
 
-        self._set_channel_callbacks(node_address, handle_message_callback)
-        log.debug("Created offer", offer=offer)
+        self._setup_channel(node_address)
+        try:
+            offer = await self.peer_connection.createOffer()
+        except InvalidStateError:
+            # this can happen if peer connection gets closed while awaiting in the try block
+            log.debug(
+                "Connection state in incompatible state",
+                node_address=to_checksum_address(node_address),
+                partner_address=to_checksum_address(self.partner_address),
+                signaling_state=self.peer_connection.signalingState,
+                ice_connection_state=self.peer_connection.iceConnectionState,
+            )
+            return None
 
+        self.schedule_task(self._set_local_description(offer, node_address))
+
+        self.set_channel_callbacks(node_address, handle_message_callback)
+        log.debug(
+            "Created offer",
+            offer=offer,
+            node_address=to_checksum_address(node_address),
+            partner_address=to_checksum_address(self.partner_address),
+        )
+
+        self.sync_events.aio_allow_hangup.set()
         return offer
 
     async def process_signalling(
@@ -127,17 +222,11 @@ class RTCPartner(CoroutineHandler):
         handle_message_callback: Callable[[str, Address], None],
     ) -> Optional[RTCSessionDescription]:
         """Coroutine to set remote description. Sets remote description in aiortc"""
-        log.debug(
-            "Received signalling message from partner",
-            node=to_checksum_address(node_address),
-            partner_address=to_checksum_address(self.partner_address),
-            type=description["type"],
-            description=description["sdp"],
-        )
 
-        if self.peer_connection.signalingState == RTCSignallingState.CLOSED:
+        await self.sync_events.aio_allow_init.wait()
+        if self.sync_events.reset_event.is_set():
             log.debug(
-                "Connection already closed",
+                "Reset called. Returning on coroutine",
                 node_address=to_checksum_address(node_address),
                 partner_address=to_checksum_address(self.partner_address),
             )
@@ -146,31 +235,101 @@ class RTCPartner(CoroutineHandler):
         remote_description = RTCSessionDescription(description["sdp"], description["type"])
         sdp_type = description["type"]
         # We need to wait for
-        log.debug("Wait for existing tasks", coroutines=self.coroutines)
-        await asyncio.gather(*self.coroutines)
-        log.debug("Set Remote Description", description=description)
-        await self.peer_connection.setRemoteDescription(remote_description)
-
-        @self.peer_connection.on("datachannel")
-        def on_datachannel(channel: RTCDataChannel) -> None:  # pylint: disable=unused-variable
-            self.channel = channel
+        log.debug(
+            "Wait for existing tasks before setting remote description",
+            coroutines=self.coroutines,
+            node_address=to_checksum_address(node_address),
+        )
+        await self.wait_for_coroutines(cancel=False)
+        if self.peer_connection.remoteDescription:
             log.debug(
-                f"Received rtc channel {channel.label}", node=to_checksum_address(node_address)
+                "Remote description already set",
+                node=to_checksum_address(node_address),
+                partner_address=to_checksum_address(self.partner_address),
             )
+            return None
 
-            self._set_channel_callbacks(node_address, handle_message_callback)
-
-        if sdp_type == SDPTypes.OFFER.value:
-            answer = await self.peer_connection.createAnswer()
-            self.schedule_task(
-                self._set_local_description(answer),
-                callback=None,
+        log.debug(
+            "Set Remote Description",
+            node_address=to_checksum_address(node_address),
+            partner_address=to_checksum_address(self.partner_address),
+            description=description,
+        )
+        try:
+            await self.peer_connection.setRemoteDescription(remote_description)
+        except InvalidStateError:
+            # this can happen if peer connection gets closed while awaiting in the try block
+            log.debug(
+                "Connection state in incompatible state",
+                node_address=to_checksum_address(node_address),
+                partner_address=to_checksum_address(self.partner_address),
+                signaling_state=self.peer_connection.signalingState,
+                ice_connection_state=self.peer_connection.iceConnectionState,
             )
-            return answer
+            return None
 
-        return None
+        finally:
+            self.sync_events.aio_allow_hangup.set()
+            self.sync_events.aio_allow_init.clear()
 
-    def send_message(self, message: str, node_address: Address) -> None:
+        if sdp_type == SDPTypes.ANSWER.value:
+            return None
+
+        self.peer_connection.on(
+            "datachannel", partial(on_datachannel, self, node_address, handle_message_callback)
+        )
+        answer = await self.peer_connection.createAnswer()
+        self.schedule_task(
+            self._set_local_description(answer, node_address),
+            callback=None,
+        )
+        return answer
+
+    async def set_candidates(self, content: Dict[str, Any], node_address: Address) -> None:
+
+        if self.peer_connection.sctp is None:
+            await self.sync_events.wait_for_candidates()
+            if self.sync_events.reset_event.is_set():
+                log.debug(
+                    "Reset called. Returning on coroutine",
+                    node_address=to_checksum_address(node_address),
+                    partner_address=to_checksum_address(self.partner_address),
+                )
+                return None
+
+        assert self.peer_connection.sctp, "SCTP should be set by now"
+
+        for candidate in content["candidates"]:
+
+            rtc_ice_candidate = candidate_from_sdp(candidate["candidate"])
+            rtc_ice_candidate.sdpMid = candidate["sdpMid"]
+            rtc_ice_candidate.sdpMLineIndex = candidate["sdpMLineIndex"]
+
+            if rtc_ice_candidate.sdpMid != self.peer_connection.sctp.mid:
+                log.debug(
+                    "Invalid candidate. Wrong sdpMid",
+                    node_address=to_checksum_address(node_address),
+                    candidate=candidate,
+                    sctp_sdp_mid=self.peer_connection.sctp.mid,
+                )
+                continue
+            log.debug(
+                "Adding ICE candidate",
+                node_address=to_checksum_address(node_address),
+                partner_address=to_checksum_address(self.partner_address),
+                candidate=candidate,
+            )
+            await self.peer_connection.addIceCandidate(rtc_ice_candidate)
+        candidates = self.peer_connection.sctp.transport.transport.getRemoteCandidates()
+        log.debug(
+            "Remote candidates",
+            candidates=[f"candidate:{candidate_to_sdp(candidate)}" for candidate in candidates],
+            node_address=to_checksum_address(node_address),
+            partner_address=to_checksum_address(self.partner_address),
+            sctp_sdp_mid=self.peer_connection.sctp.mid,
+        )
+
+    async def send_message(self, message: str, node_address: Address) -> None:
         """Sends message through aiortc. Not an async function. Output is written to buffer"""
 
         if self.channel is not None and self.channel.readyState == RTCChannelState.OPEN.value:
@@ -183,6 +342,27 @@ class RTCPartner(CoroutineHandler):
                 time=time.time(),
             )
             self.channel.send(message)
+            start_time = time.monotonic()
+            try:
+                while (
+                    self.peer_connection.sctp._data_channel_queue
+                    or self.peer_connection.sctp._outbound_queue
+                ):
+                    await self.peer_connection.sctp._data_channel_flush()
+                    while self.peer_connection.sctp._outbound_queue:
+                        await self.peer_connection.sctp._transmit()
+            except ConnectionError:
+                log.debug(
+                    "Connection error occurred while trying to send message",
+                    node_address=to_checksum_address(node_address),
+                    partner_address=to_checksum_address(self.partner_address),
+                )
+                await self.close(node_address)
+                return
+
+            end_time = time.monotonic()
+            log.debug("Channel Flush", duration=end_time - start_time)
+
         else:
             log.debug(
                 "Channel is not open but trying to send a message.",
@@ -193,12 +373,23 @@ class RTCPartner(CoroutineHandler):
                 else "No channel exists",
             )
 
-    def close(self) -> Task:
-        on_channel_close(self)
-        return self.schedule_task(
-            coroutine=self.peer_connection.close(),
-            callback=None,
+    async def close(self, node_address: Address) -> None:
+        log.debug(
+            "Closing peer connection",
+            node_address=to_checksum_address(node_address),
+            partner_address=to_checksum_address(self.partner_address),
         )
+
+        await self.peer_connection.close()
+        if self.channel:
+            self.channel.close()
+
+    async def reset(self) -> None:
+        self.sync_events.reset()
+        await self.wait_for_coroutines()
+        self.sync_events.reset_event.clear()
+        self.peer_connection = RTCPeerConnection()
+        self.channel = None
 
 
 class WebRTCManager(CoroutineHandler):
@@ -208,12 +399,14 @@ class WebRTCManager(CoroutineHandler):
         _handle_message_callback: Callable[[str, Address], None],
         _handle_sdp_callback: Callable[[Optional[RTCSessionDescription], Address], None],
         _handle_candidates_callback: Callable[[List[Dict[str, Union[int, str]]], Address], None],
+        _close_connection_callback: Callable[[Address], None],
     ) -> None:
         super().__init__()
         self.node_address = node_address
         self._handle_message_callback = _handle_message_callback
         self._handle_sdp_callback = _handle_sdp_callback
         self._handle_candidates_callback = _handle_candidates_callback
+        self._close_connection_callback = _close_connection_callback
         self.address_to_rtc_partners: Dict[Address, RTCPartner] = {}
 
     def get_rtc_partner(self, partner_address: Address) -> RTCPartner:
@@ -230,6 +423,24 @@ class WebRTCManager(CoroutineHandler):
                     rtc_partner=rtc_partner,
                     node_address=self.node_address,
                     candidates_callback=self._handle_candidates_callback,
+                ),
+            )
+            peer_connection.on(
+                "signalingstatechange",
+                partial(
+                    on_signalling_state_change,
+                    rtc_partner=rtc_partner,
+                    node_address=self.node_address,
+                ),
+            )
+
+            peer_connection.on(
+                "iceconnectionstatechange",
+                partial(
+                    on_ice_connection_state_change,
+                    rtc_partner=rtc_partner,
+                    node_address=self.node_address,
+                    closed_callback=self._close_connection_callback,
                 ),
             )
 
@@ -263,36 +474,7 @@ class WebRTCManager(CoroutineHandler):
     ) -> None:
         assert self.node_address, "Transport is not started yet but tried to set candidates"
         rtc_partner = self.get_rtc_partner(partner_address)
-
-        connection: RTCPeerConnection = rtc_partner.peer_connection
-
-        if rtc_partner.peer_connection.sctp is None:
-            # FIXME: we need to check if there are race conditions between
-            #  remote descriptions (offer) not being set yet but already
-            #  processing candidates which have been sent later
-            #  If so a return must be replaced by a wait on the set_remote_description coroutine
-            log.warning(
-                "Received candidates before answer",
-                node=to_checksum_address(self.node_address),
-                partner_address=to_checksum_address(partner_address),
-            )
-            return
-
-        for candidate in content["candidates"]:
-
-            rtc_ice_candidate = candidate_from_sdp(candidate["candidate"])
-            rtc_ice_candidate.sdpMid = candidate["sdpMid"]
-            rtc_ice_candidate.sdpMLineIndex = candidate["sdpMLineIndex"]
-
-            if rtc_ice_candidate.sdpMid != rtc_partner.peer_connection.sctp.mid:
-                log.debug(
-                    "Invalid candidate. Wrong sdpMid",
-                    node_address=to_checksum_address(self.node_address),
-                    candidate=candidate,
-                    sctp_sdp_mid=rtc_partner.peer_connection.sctp.mid,
-                )
-                continue
-            yield_future(connection.addIceCandidate(rtc_ice_candidate))
+        self.schedule_task(rtc_partner.set_candidates(content, self.node_address))
 
     def process_signalling_for_address(
         self, partner_address: Address, description: Dict[str, str]
@@ -318,46 +500,70 @@ class WebRTCManager(CoroutineHandler):
             partner_address=partner_address,
         )
 
-    def close_connection(self, partner_address: Address) -> Optional[Task]:
-        msg = "Transport not yet started"
-        assert self.node_address, msg
+    def send_message_for_address(self, partner_address: Address, message: str) -> None:
+        assert self.node_address, "Transport is not started yet but tried to send message"
+        rtc_partner = self.address_to_rtc_partners[partner_address]
+        self.schedule_task(rtc_partner.send_message(message, self.node_address))
 
-        log.debug(
-            "Closing web rtc connection",
-            node=to_checksum_address(self.node_address),
-            partner_address=to_checksum_address(partner_address),
-        )
+    def close_connection(self, partner_address: Address) -> Optional[Task]:
+        msg = "Transport not yet started but tried to close connection"
+        assert self.node_address, msg
 
         rtc_partner = self.address_to_rtc_partners.get(partner_address, None)
 
         if rtc_partner is not None:
-            self.address_to_rtc_partners.pop(rtc_partner.partner_address, None)
-            return rtc_partner.close()
+            rtc_partner.sync_events.clear_all()
+            return self.schedule_task(rtc_partner.close(self.node_address))
 
         return None
 
     def stop(self) -> None:
-        msg = "Transport not yet started"
+        msg = "Transport not yet started but tried to stop web rtc manager"
         assert self.node_address, msg
 
         log.debug("Closing rtc connections", node=to_checksum_address(self.node_address))
 
         for partner_address in list(self.address_to_rtc_partners.keys()):
-            rtc_partner = self.address_to_rtc_partners[partner_address]
-            self.close_connection(partner_address)
-            rtc_partner.join_all_coroutines()
+            if partner_address in self.address_to_rtc_partners:
+                rtc_partner = self.address_to_rtc_partners[partner_address]
+                self.close_connection(partner_address)
+                rtc_partner.join_all_coroutines()
 
         self.join_all_coroutines()
         self._reset_state()
 
 
-def on_channel_close(rtc_partner: RTCPartner) -> None:
+def on_datachannel(
+    rtc_partner: RTCPartner,
+    node_address: Address,
+    handle_message_callback: Callable[[str, Address], None],
+    channel: RTCDataChannel,
+) -> None:
+    rtc_partner.channel = channel
+    on_channel_open(node_address, channel)
+    rtc_partner.set_channel_callbacks(node_address, handle_message_callback)
+
+
+def on_channel_open(node_address: Address, channel: RTCDataChannel) -> None:
+    log.debug("Rtc datachannel open", node=to_checksum_address(node_address), label=channel.label)
+
+
+def on_channel_close(rtc_partner: RTCPartner, node_address: Address) -> None:
     """callback if channel is closed. It is part of a partial function"""
     if rtc_partner.channel is not None:
+        log.debug(
+            "Rtc datachannel closed",
+            node=to_checksum_address(node_address),
+            label=rtc_partner.channel.label,
+        )
         # remove all listeners on channel to not receive events anymore
         rtc_partner.channel.remove_all_listeners()
-        rtc_partner.channel.close()
         rtc_partner.channel = None
+        if rtc_partner.peer_connection.iceConnectionState in [
+            ICEConnectionState.COMPLETED,
+            ICEConnectionState.CHECKING,
+        ]:
+            rtc_partner.schedule_task(rtc_partner.close(node_address))
 
 
 def on_channel_message(
@@ -405,7 +611,7 @@ def on_ice_gathering_state_change(
 
         for candidate in rtc_ice_candidates:
             candidate = {
-                "candidate": candidate_to_sdp(candidate),
+                "candidate": f"candidate:{candidate_to_sdp(candidate)}",
                 "sdpMid": candidate.sdpMid if candidate.sdpMid is not None else SDP_MID_DEFAULT,
                 "sdpMLineIndex": candidate.sdpMLineIndex is not None
                 if candidate.sdpMLineIndex
@@ -418,3 +624,35 @@ def on_ice_gathering_state_change(
             candidates=candidates,
             partner_address=rtc_partner.partner_address,
         )
+
+
+def on_ice_connection_state_change(
+    rtc_partner: RTCPartner, node_address: Address, closed_callback: Callable[[Address], None]
+) -> None:
+    ice_connection_state = rtc_partner.peer_connection.iceConnectionState
+    log.debug(
+        "Ice connection state changed",
+        node=to_checksum_address(node_address),
+        partner_address=to_checksum_address(rtc_partner.partner_address),
+        signaling_state=ice_connection_state,
+    )
+    if ice_connection_state in [ICEConnectionState.CLOSED.value, ICEConnectionState.FAILED.value]:
+        asyncio.create_task(rtc_partner.reset())
+        wrap_callback(callback=closed_callback, partner_address=rtc_partner.partner_address)
+
+
+def on_signalling_state_change(rtc_partner: RTCPartner, node_address: Address) -> None:
+    signaling_state = rtc_partner.peer_connection.signalingState
+    log.debug(
+        "Signaling state changed",
+        node=to_checksum_address(node_address),
+        partner_address=to_checksum_address(rtc_partner.partner_address),
+        signaling_state=signaling_state,
+    )
+    # if signaling state is closed also set allow candidates otherwise
+    # coroutine will hang forever
+    if signaling_state in [
+        RTCSignallingState.HAVE_REMOTE_OFFER.value,
+        RTCSignallingState.CLOSED.value,
+    ]:
+        rtc_partner.sync_events.aio_allow_candidates.set()

--- a/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
+++ b/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
@@ -1,31 +1,44 @@
 import pytest
 
+from raiden.constants import ICEConnectionState
 from raiden.network.transport.matrix.rtc.aiogevent import yield_future
 from raiden.network.transport.matrix.rtc.web_rtc import WebRTCManager
 from raiden.tests.utils.factories import make_signer
-from raiden.tests.utils.transport import ignore_candidates, ignore_sdp, ignore_web_rtc_messages
+from raiden.tests.utils.transport import (
+    ignore_candidates,
+    ignore_close,
+    ignore_sdp,
+    ignore_web_rtc_messages,
+)
 
 pytestmark = pytest.mark.asyncio
 
 
 def test_rtc_partner_close():
 
-    web_rtc_manager = WebRTCManager(None, ignore_web_rtc_messages, ignore_sdp, ignore_candidates)
+    web_rtc_manager = WebRTCManager(
+        None, ignore_web_rtc_messages, ignore_sdp, ignore_candidates, ignore_close
+    )
 
     node_address = make_signer().address
     web_rtc_manager.node_address = node_address
     partner_address = make_signer().address
     rtc_partner = web_rtc_manager.get_rtc_partner(partner_address)
+    peer_connection_first = rtc_partner.peer_connection
 
     msg = "ICEConnectionState should be 'new'"
-    assert rtc_partner.peer_connection.iceConnectionState == "new", msg
+    assert peer_connection_first.iceConnectionState == "new", msg
 
     close_task = web_rtc_manager.close_connection(rtc_partner.partner_address)
     yield_future(close_task)
 
+    peer_connection_second = rtc_partner.peer_connection
+
+    msg = "peer connections should be different objects"
+    assert peer_connection_first != peer_connection_second, msg
+    msg = "New peer connection should be in state 'new'"
+    assert peer_connection_second.iceConnectionState == ICEConnectionState.NEW.value, msg
+    msg = "Old RTCPeerConnection state should be 'closed' after close()"
+    assert peer_connection_first.iceConnectionState == ICEConnectionState.CLOSED.value, msg
     msg = "Should not have ready channel after close()"
     assert not web_rtc_manager.has_ready_channel(partner_address), msg
-    msg = "Should not have rtc_partner in manager after close()"
-    assert partner_address not in web_rtc_manager.address_to_rtc_partners, msg
-    msg = "Old RTCPeerConnection state should be 'closed' after close()"
-    assert rtc_partner.peer_connection.iceConnectionState == "closed", msg

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -96,6 +96,10 @@ def ignore_candidates(
     pass
 
 
+def ignore_close(partner_address: Address) -> None:  # pylint: disable=unused-argument
+    pass
+
+
 def setup_broadcast_room(servers: List["ParsedURL"], broadcast_room_name: str) -> None:
     client = new_client(ignore_messages, ignore_member_join, servers[0])
     admin_power_level = {"users": {client.user_id: 100}}


### PR DESCRIPTION
## Description

This PR solves a couple of bugs and the until now unsolved reason why the python client was slower than the light client.

### Enforcing aiortc to send the message
`channel.send()` only appends the message into a queue
`peer_connection._data_channel_flush()` which is scheduled in `channel.send()` only takes the message from `data_channel_queue` and puts it into `_outbound_queue`. 
`peerconection.sctp.transmit()` transmits the data chunk in `_outbound_queue`.
`Pitfall: If there is still a data chunk in `_outbound_queue`, `peer_connection._data_channel_flush()` won't do anything`

### Properly close broken channels
Connections can be closed due to many reasons. The channel can simply be broken/expired. The user can go offline or close the connection on his side. As well as the channel could not get established in the beginning. A callback after closing a peer connection now handles this case and properly either do nothing or restart the initialzation process

### Ordering signalling messages
Signalling messages can arrive in the wrong order. The corresponding greenlets to process the messages need to be ordered. This is done by an event. Processing candidates must wait until the remote description is set.

### Introducing Sync Events for RTC Partners
RTCPartner objects have now sync_events which allow to coordinate between the coroutines. As described above, one example would be to wait for remote description being set before processing candidates. Also a connection close should not happen twice on the same connection. Another example is that a `hangup` should never be the first message received in a signaling cycle. All these conditions are handled by the syncevents being set or cleared. 

fixes: #6700 , #6480, #6476