### PR TITLE
Use 'pull_request_target' instead of 'pull_request' action

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,7 +2,7 @@ name: Dependent Issues
 
 on:
   issues:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: '0 0 * * *' # schedule daily check
 


### PR DESCRIPTION
## Description

Actions on forked PRs usually only have read only access to the target repo.
With `pull_request_target` they are run in the context of the base repo / branch and therefore have read/write access.
See:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
