### PR TITLE
Enable to device for signaling

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -225,6 +225,12 @@ IMBALANCE_MED_FEE_MIN = 0
 IMBALANCE_MED_FEE_MAX = 50_000
 
 
+class CommunicationMedium(Enum):
+    WEB_RTC = "webRTC"
+    TO_DEVICE = "toDevice"
+    ROOM = "room"
+
+
 class MatrixMessageType(Enum):
     TEXT = "m.text"
     NOTICE = "m.notice"

--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -1,22 +1,9 @@
 import itertools
-import json
 import time
 from datetime import datetime
 from functools import wraps
 from itertools import repeat
-from typing import (
-    Any,
-    Callable,
-    Container,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Container, Dict, Iterable, Iterator, List, Optional, Tuple
 from urllib.parse import quote
 from uuid import UUID, uuid4
 
@@ -34,13 +21,13 @@ from matrix_client.user import User
 from requests import Response
 from requests.adapters import HTTPAdapter
 
-from raiden.constants import Environment, RTCMessageType
+from raiden.constants import Environment
 from raiden.exceptions import MatrixSyncMaxTimeoutReached, TransportError
 from raiden.network.transport.matrix.sync_progress import SyncProgress
 from raiden.utils.datastructures import merge_dict
 from raiden.utils.debugging import IDLE
 from raiden.utils.notifying_queue import NotifyingQueue
-from raiden.utils.typing import AddressHex, RoomID
+from raiden.utils.typing import AddressHex
 
 log = structlog.get_logger(__name__)
 
@@ -241,31 +228,6 @@ class GMatrixHttpApi(MatrixHttpApi):
 
     def get_presence(self, user_id: str) -> Dict[str, Any]:
         return self._send("GET", f"/presence/{quote(user_id)}/status")
-
-    def invite(self, room_id: RoomID, call_id: str, sdp_description: str) -> None:
-        message = {"type": RTCMessageType.OFFER.value, "sdp": sdp_description, "call_id": call_id}
-        self._send_signalling(room_id, message)
-
-    def answer(self, room_id: RoomID, call_id: str, sdp_description: str) -> None:
-        message = {"type": RTCMessageType.ANSWER.value, "sdp": sdp_description, "call_id": call_id}
-        self._send_signalling(room_id, message)
-
-    def hangup(self, room_id: RoomID, call_id: str) -> None:
-        message = {"type": RTCMessageType.HANGUP.value, "call_id": call_id}
-        self._send_signalling(room_id, message)
-
-    def candidates(
-        self, room_id: RoomID, call_id: str, candidates: List[Dict[str, Union[int, str]]]
-    ) -> None:
-        message = {"type": "candidates", "call_id": call_id, "candidates": candidates}
-        self._send_signalling(room_id, message)
-
-    def _send_signalling(
-        self,
-        room_id: RoomID,
-        message: Mapping[str, Any],
-    ) -> None:
-        self.send_message(room_id=room_id, text_content=json.dumps(message), msgtype="m.notice")
 
     def get_aliases(self, room_id: str) -> Dict[str, Any]:
         """

--- a/raiden/network/transport/matrix/rtc/utils.py
+++ b/raiden/network/transport/matrix/rtc/utils.py
@@ -31,7 +31,7 @@ def setup_asyncio_event_loop() -> Generator:
 
 def spawn_coroutine(
     coroutine: Union[Coroutine, Future],
-    callback: Optional[Callable[[Any, Any], None]],
+    callback: Optional[Callable[..., None]],
     **kwargs: Any,
 ) -> Greenlet:
     """Spawns a greenlet which runs a coroutine inside waiting for the result"""
@@ -43,7 +43,9 @@ def spawn_coroutine(
     return wrapped_coroutine
 
 
-def wait_for_future(future: Future, callback: Callable, **kwargs: Any) -> None:
+def wait_for_future(
+    future: Future, callback: Optional[Callable[..., None]], **kwargs: Any
+) -> None:
     """yield future and call callback with the result"""
     result = yield_future(future)
     if callback is not None:

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -210,6 +210,12 @@ class RTCPartner(CoroutineHandler):
                 signaling_state=self.peer_connection.signalingState,
                 ice_connection_state=self.peer_connection.iceConnectionState,
             )
+            asyncio.create_task(self.close())
+            return None
+
+        except AttributeError as ex:
+            self.log.error("Attribute error in coroutine", coroutine=coroutine, exception=ex)
+            asyncio.create_task(self.close())
             return None
 
     async def _set_local_description(self, description: RTCSessionDescription) -> None:
@@ -269,7 +275,7 @@ class RTCPartner(CoroutineHandler):
 
         self.peer_connection.on(
             "datachannel",
-            partial(on_datachannel, self, self.node_address, self._handle_message_callback),
+            partial(on_datachannel, self, self.node_address),
         )
         answer = await self._try_signaling(self.peer_connection.createAnswer())
         if answer is None:

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -189,9 +189,7 @@ class UserAddressManager:
         self,
         client: GMatrixClient,
         displayname_cache: DisplayNameCache,
-        address_reachability_changed_callback: Callable[
-            [Address, AddressReachability, PeerCapabilities], None
-        ],
+        address_reachability_changed_callback: Callable[[Address, AddressReachability], None],
         user_presence_changed_callback: Optional[Callable[[User, UserPresence], None]] = None,
         _log_context: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -405,10 +403,7 @@ class UserAddressManager:
             new_address_reachability, now
         )
         self._address_to_capabilities[address] = capabilities
-
-        self._address_reachability_changed_callback(
-            address, new_address_reachability, capabilities
-        )
+        self._address_reachability_changed_callback(address, new_address_reachability)
 
     def _presence_listener(self, event: Dict[str, Any], presence_update_id: int) -> None:
         """

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -134,7 +134,7 @@ class CapabilitiesConfig:
     mediate: bool = True
     delivery: bool = True
     web_rtc: bool = True
-    to_device: bool = False
+    to_device: bool = True
 
 
 @dataclass

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -525,7 +525,8 @@ def asyncio_loop(request):
             for task in tasks:
                 task.cancel()
             yield_future(asyncio.gather(*tasks, return_exceptions=True))
-        event_loop.stop()
+
+        event_loop.call_soon_threadsafe(event_loop.stop)
         with Timeout(ASYNCIO_LOOP_RUNNING_TIMEOUT, RuntimeError):
             while event_loop.is_running():
                 gevent.sleep(0.05)
@@ -533,6 +534,7 @@ def asyncio_loop(request):
         with Timeout(ASYNCIO_LOOP_RUNNING_TIMEOUT, RuntimeError):
             while not event_loop.is_closed():
                 gevent.sleep(0.05)
+
     else:
         log.debug("NO ASYNC IO MARKER FOUND")
         yield

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -1017,7 +1017,7 @@ def test_matrix_user_roaming(matrix_transports, roaming_peer):
     "roaming_peer",
     [pytest.param("high", id="roaming_high"), pytest.param("low", id="roaming_low")],
 )
-@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(to_device=False)])
+@pytest.mark.parametrize("capabilities", [CapabilitiesConfig(to_device=True)])
 def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     # 6 transports on 3 servers, where (0,3), (1,4), (2,5) are one the same server
     (
@@ -1047,9 +1047,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     transport_rs0_0.immediate_health_check_for(raiden_service1.address)
     transport_rs1_0.immediate_health_check_for(raiden_service0.address)
 
-    wait_for_room_with_address(transport_rs0_0, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_0, raiden_service0.address)
-
     assert ping_pong_message_success(transport_rs0_0, transport_rs1_0)
 
     # Node two switches to second server
@@ -1059,9 +1056,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     transport_rs1_1.start(raiden_service1, [], "")
     transport_rs1_1.immediate_health_check_for(raiden_service0.address)
 
-    wait_for_room_with_address(transport_rs0_0, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_1, raiden_service0.address)
-
     assert ping_pong_message_success(transport_rs0_0, transport_rs1_1)
 
     # Node two switches to third server
@@ -1070,9 +1064,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
 
     transport_rs1_2.start(raiden_service1, [], "")
     transport_rs1_2.immediate_health_check_for(raiden_service0.address)
-
-    wait_for_room_with_address(transport_rs0_0, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_2, raiden_service0.address)
 
     assert ping_pong_message_success(transport_rs0_0, transport_rs1_2)
     # Node one switches to second server, Node two back to first
@@ -1085,9 +1076,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     transport_rs0_1.immediate_health_check_for(raiden_service1.address)
     transport_rs1_0.immediate_health_check_for(raiden_service0.address)
 
-    wait_for_room_with_address(transport_rs0_1, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_0, raiden_service0.address)
-
     assert ping_pong_message_success(transport_rs0_1, transport_rs1_0)
 
     # Node two joins on second server again
@@ -1097,9 +1085,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     transport_rs1_1.start(raiden_service1, [], "")
     transport_rs1_1.immediate_health_check_for(raiden_service0.address)
 
-    wait_for_room_with_address(transport_rs0_1, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_1, raiden_service0.address)
-
     assert ping_pong_message_success(transport_rs0_1, transport_rs1_1)
 
     # Node two switches to third server
@@ -1108,9 +1093,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
 
     transport_rs1_2.start(raiden_service1, [], "")
     transport_rs1_2.immediate_health_check_for(raiden_service0.address)
-
-    wait_for_room_with_address(transport_rs0_1, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_2, raiden_service0.address)
 
     assert ping_pong_message_success(transport_rs0_1, transport_rs1_2)
 
@@ -1123,9 +1105,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     transport_rs1_0.start(raiden_service1, [], "")
     transport_rs1_0.immediate_health_check_for(raiden_service0.address)
 
-    wait_for_room_with_address(transport_rs0_2, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_0, raiden_service0.address)
-
     assert ping_pong_message_success(transport_rs0_2, transport_rs1_0)
 
     # Node two switches to second server
@@ -1135,9 +1114,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
     transport_rs1_1.start(raiden_service1, [], "")
     transport_rs1_1.immediate_health_check_for(raiden_service0.address)
 
-    wait_for_room_with_address(transport_rs0_2, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_1, raiden_service0.address)
-
     assert ping_pong_message_success(transport_rs0_2, transport_rs1_1)
 
     # Node two joins on third server
@@ -1146,9 +1122,6 @@ def test_matrix_multi_user_roaming(matrix_transports, roaming_peer):
 
     transport_rs1_2.start(raiden_service1, [], "")
     transport_rs1_2.immediate_health_check_for(raiden_service0.address)
-
-    wait_for_room_with_address(transport_rs0_2, raiden_service1.address)
-    wait_for_room_with_address(transport_rs1_2, raiden_service0.address)
 
     assert ping_pong_message_success(transport_rs0_2, transport_rs1_2)
 

--- a/raiden/tests/unit/test_matrix_presence.py
+++ b/raiden/tests/unit/test_matrix_presence.py
@@ -136,10 +136,9 @@ def user_presence_callback(user_presence):
 
 
 @pytest.fixture
-def address_reachability_callback(address_reachability, address_capability):
-    def _callback(address, reachability, capabilities):
+def address_reachability_callback(address_reachability):
+    def _callback(address, reachability):
         address_reachability[address] = reachability
-        address_capability[address] = capabilities
 
     return _callback
 


### PR DESCRIPTION
## Description
Signalling messages have been sent only via rooms and thus required the peers to have a room with each other. This makes the `toDevice` and the `webRTC` capability incompatible.

This PR modifies `MatrixTransport._send_raw()` such that it also can send signaling messages which are `msgType == "m.notice`.
It is then reused when sending signalling messages. 

fixes: #6701 

depends on: #6711 