### PR TITLE
Fix gas costs for registerSecretBatch

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -1,4 +1,3 @@
-import math
 from enum import Enum
 
 from eth_utils import keccak, to_canonical_address
@@ -157,7 +156,10 @@ class RoutingMode(Enum):
     PRIVATE = "private"
 
 
-GAS_REQUIRED_PER_SECRET_IN_BATCH = math.ceil(UNLOCK_TX_GAS_LIMIT / MAXIMUM_PENDING_TRANSFERS)
+# See gas measurements in raiden contracts for these values, rounded up
+GAS_REQUIRED_REGISTER_SECRET_BATCH_BASE = 23000
+GAS_REQUIRED_PER_SECRET_IN_BATCH = 26000
+
 GAS_LIMIT_FOR_TOKEN_CONTRACT_CALL = 100_000
 
 CHECK_RDN_MIN_DEPOSIT_INTERVAL = 5 * 60


### PR DESCRIPTION
The previous calculation did not make any sense. That has been obscured
by taking the maximum of the calculation and the gas estimate. But the
gas estimate can be wrong when other nodes try to register the same
secret at the same time.

The new approach of calculating the gas cost could be better, but the
new assert should alert us when the values go out of sync with the
expectations of the contracts.

Closes https://github.com/raiden-network/raiden/issues/6725.