### PR TITLE
Fix Python API min reveal-timeout check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,7 @@ jobs:
           name: Install dependencies
           command: |
             pip install git+https://github.com/raiden-network/scenario-player.git
+            pip install -Ue ~/raiden
       - run:
           name: Set Locale
           command: |

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -195,12 +195,13 @@ class RaidenAPI:  # pragma: no unittest
         self, settle_timeout: BlockTimeout, reveal_timeout: BlockTimeout
     ) -> None:
         min_reveal_timeout = self.config.minimum_reveal_timeout
-        if reveal_timeout <= min_reveal_timeout:
+        if reveal_timeout < min_reveal_timeout:
             if reveal_timeout <= 0:
                 raise InvalidRevealTimeout("reveal_timeout should be larger than zero.")
             else:
                 raise InvalidRevealTimeout(
-                    f"reveal_timeout is required to be larger than { min_reveal_timeout - 1}"
+                    "reveal_timeout is lower than the required minimum value of"
+                    f" { min_reveal_timeout }"
                 )
 
         if settle_timeout < reveal_timeout * 2:


### PR DESCRIPTION
## Description

Recent PR #6707 had a bug in the Python API checking for the minimum reveal timeout 
in `channel_open( )` and `set_reveal_timeout( )` methods.
This caused the smoketest to fail, when the default reveal timeout was the minimum reveal timeout.

Weirdly,  the PR itself did pass the CI.
