### PR TITLE
Fix MacOS nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
 version: 2.1
-parameters:
-  run_default_workflows:
-    default: true
-    type: boolean
 
 templates:
   filter-tag-templates: &only-tagged-version-filter
@@ -54,6 +50,8 @@ templates:
     PARITY_VERSION: 'v3.1.0'
     SOLC_URL_LINUX: 'https://github.com/ethereum/solidity/releases/download/v0.6.3/solc-static-linux'
     SOLC_VERSION: 'v0.6.3'
+    PYENV_PYTHON_VERSION_38: '3.8.6'
+    PYENV_PYTHON_VERSION_37: '3.7.9'
 
 
 orbs:
@@ -185,9 +183,9 @@ commands:
             if [[ ${OS_NAME} == "MACOS" ]]; then
               echo "export PYENV_ROOT=~/.local-MACOS/.pyenv" >> ${BASH_ENV}
               if [[ $PYTHON_VERSION_SHORT == 3.8 ]]; then
-                export PYENV_PYTHON_VERSION=3.8.6
+                export PYENV_PYTHON_VERSION=$PYENV_PYTHON_VERSION_38
               elif [[ $PYTHON_VERSION_SHORT == 3.7 ]]; then
-                export PYENV_PYTHON_VERSION=3.7.9
+                export PYENV_PYTHON_VERSION=$PYENV_PYTHON_VERSION_37
               else
                 exit 1
               fi
@@ -723,7 +721,6 @@ jobs:
 
 workflows:
   raiden-default:
-    when: << pipeline.parameters.run_default_workflows >>
     jobs:
       - checkout
 
@@ -817,7 +814,6 @@ workflows:
             - test-integration
 
   deploy-release:
-    when: << pipeline.parameters.run_default_workflows >>
     jobs:
       - checkout:
           filters:
@@ -893,7 +889,6 @@ workflows:
             <<: *only-tagged-version-filter
 
   nightly:
-    when: << pipeline.parameters.run_default_workflows >>
     jobs:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -856,26 +856,6 @@ workflows:
           filters:
             <<: *only-tagged-version-filter
 
-      - build-binary-linux:
-          name: build-binary-linux-armv7l
-          resource: "small"
-          remote-host: "armv7"
-          architecture: "armv7l"
-          requires:
-            - prepare-python-linux
-          filters:
-            <<: *only-tagged-version-filter
-
-      - build-binary-linux:
-          name: build-binary-linux-aarch64
-          resource: "small"
-          remote-host: "armv8"
-          architecture: "aarch64"
-          requires:
-            - prepare-python-linux
-          filters:
-            <<: *only-tagged-version-filter
-
       - build-binary-macos:
           requires:
             - prepare-python-macos
@@ -892,8 +872,6 @@ workflows:
           context: "Raiden Context"
           requires:
             - build-binary-linux-x86
-            - build-binary-linux-armv7l
-            - build-binary-linux-aarch64
             - build-binary-macos
           filters:
             <<: *only-tagged-version-filter
@@ -902,8 +880,6 @@ workflows:
           context: "Raiden Context"
           requires:
             - build-binary-linux-x86
-            - build-binary-linux-armv7l
-            - build-binary-linux-aarch64
             - build-binary-macos
           filters:
             <<: *only-tagged-version-filter
@@ -912,8 +888,6 @@ workflows:
           context: "Raiden Context"
           requires:
             - build-binary-linux-x86
-            - build-binary-linux-armv7l
-            - build-binary-linux-aarch64
             - build-binary-macos
           filters:
             <<: *only-tagged-version-filter
@@ -1017,22 +991,6 @@ workflows:
           requires:
             - finalize
 
-      - build-binary-linux:
-          name: build-binary-linux-armv7l
-          resource: "small"
-          remote-host: "armv7"
-          architecture: "armv7l"
-          requires:
-            - finalize
-
-      - build-binary-linux:
-          name: build-binary-linux-aarch64
-          resource: "small"
-          remote-host: "armv8"
-          architecture: "aarch64"
-          requires:
-            - finalize
-
       - prepare-system-macos:
           requires:
             - checkout
@@ -1052,8 +1010,6 @@ workflows:
           context: "Raiden Context"
           requires:
             - build-binary-linux-x86
-            - build-binary-linux-armv7l
-            - build-binary-linux-aarch64
             - build-binary-macos
 
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
-
+parameters:
+  run_default_workflows:
+    default: true
+    type: boolean
 
 templates:
   filter-tag-templates: &only-tagged-version-filter
@@ -103,7 +106,7 @@ commands:
           name: Configuring PATH
           command: |
             echo 'export PATH=~/venv-${PYTHON_VERSION_SHORT}/bin:~/.local/bin:${PATH}' >> ${BASH_ENV}
-            echo 'export RAIDEN_VERSION=$(python setup.py --version)' >> ${BASH_ENV}
+            echo 'export RAIDEN_VERSION=$(python3 setup.py --version)' >> ${BASH_ENV}
 
   checkout-and-persist:
     steps:
@@ -174,24 +177,65 @@ commands:
       py-version:
         <<: *py-version-template
     steps:
+      - run:
+          name: Preparing environment
+          command: |
+            export OS_NAME=$(uname -s | sed s/Darwin/macos/ | tr '[:lower:]' '[:upper:]')
+            echo "export OS_NAME=$OS_NAME" >> ${BASH_ENV}
+            if [[ ${OS_NAME} == "MACOS" ]]; then
+              echo "export PYENV_ROOT=~/.local-MACOS/.pyenv" >> ${BASH_ENV}
+              if [[ $PYTHON_VERSION_SHORT == 3.8 ]]; then
+                export PYENV_PYTHON_VERSION=3.8.6
+              elif [[ $PYTHON_VERSION_SHORT == 3.7 ]]; then
+                export PYENV_PYTHON_VERSION=3.7.9
+              else
+                exit 1
+              fi
+              echo "export PYENV_PYTHON_VERSION=$PYENV_PYTHON_VERSION" >> ${BASH_ENV}
+            fi
+            echo "SHA: ${CIRCLE_SHA1}"
+            echo "TAG: ${CIRCLE_TAG}"
       - attach-and-link:
           py-version: << parameters.py-version >>
-      - config-path
+      - restore_cache:
+          keys:
+          - system-deps-pyenv-v4-{{ arch }}-<< parameters.py-version >>
+      - run:
+          name: Installing Python on MacOS
+          command: |
+            if [[ ${OS_NAME} == "MACOS" ]]; then
+              if [[ ! -x $PYENV_ROOT ]]; then
+                git clone https://github.com/pyenv/pyenv.git $PYENV_ROOT
+              fi
+              export PATH=${PYENV_ROOT}/bin:${PATH}
+              env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $PYENV_PYTHON_VERSION -sv
+            fi
+      - save_cache:
+          key: system-deps-pyenv-v4-{{ arch }}-<< parameters.py-version >>
+          paths:
+          - "~/.local-MACOS/.pyenv"
       - restore_cache:
           key: pip-cache-{{ arch }}-<< parameters.py-version >>
       - restore_cache:
           keys:
-          - python-deps-v4-{{ arch }}-<< parameters.py-version >>-{{ checksum "requirements/requirements-ci.txt" }}
-          - python-deps-v4-{{ arch }}-<< parameters.py-version >>-
+          - python-deps-v7-{{ arch }}-<< parameters.py-version >>-{{ checksum "requirements/requirements-ci.txt" }}
+          - python-deps-v7-{{ arch }}-<< parameters.py-version >>-
       - run:
           name: Creating virtualenv
           command: |
-            export OS_NAME=$(uname -s | sed s/Darwin/macos/ | tr '[:lower:]' '[:upper:]')
+            if [[ ${OS_NAME} == "MACOS" ]]; then
+              export PATH=${PYENV_ROOT}/bin:${PATH}
+              eval "$(pyenv init -)"
+              pyenv local $PYENV_PYTHON_VERSION
+              echo "Detected MacOS: Using pyenv Python at $(pyenv which python<< parameters.py-version >>)"
+            fi
             if [ ! -x ~/venv-<< parameters.py-version >>/bin/python ]; then
+              echo "Virtual env not found. Creating virtual env using $(python<< parameters.py-version >> --version)."
               python<< parameters.py-version >> -m venv ~/venv-<< parameters.py-version >>-${OS_NAME}
             fi
             ln -nfs ~/venv-<< parameters.py-version >>-${OS_NAME} ~/venv-<< parameters.py-version >>
             echo 'export VENV_PATH="$HOME/venv-<< parameters.py-version >>"' >> ${BASH_ENV}
+      - config-path
       - run:
           name: Installing dependencies
           command: |
@@ -202,7 +246,7 @@ commands:
             pip-sync requirements-ci.txt _raiden-dev.txt
             popd
       - save_cache:
-          key: python-deps-v4-{{ arch }}-<< parameters.py-version >>-{{ checksum "requirements/requirements-ci.txt" }}
+          key: python-deps-v7-{{ arch }}-<< parameters.py-version >>-{{ checksum "requirements/requirements-ci.txt" }}
           paths:
           - "~/venv-<< parameters.py-version >>-LINUX"
           - "~/venv-<< parameters.py-version >>-MACOS"
@@ -214,6 +258,7 @@ commands:
           root: "~"
           paths:
           - venv-<< parameters.py-version >>-*
+          - .local-MACOS/.pyenv/versions/
 
 jobs:
   # This job exists to generate the `*.egg-info` metadata.
@@ -678,6 +723,7 @@ jobs:
 
 workflows:
   raiden-default:
+    when: << pipeline.parameters.run_default_workflows >>
     jobs:
       - checkout
 
@@ -771,6 +817,7 @@ workflows:
             - test-integration
 
   deploy-release:
+    when: << pipeline.parameters.run_default_workflows >>
     jobs:
       - checkout:
           filters:
@@ -872,6 +919,7 @@ workflows:
             <<: *only-tagged-version-filter
 
   nightly:
+    when: << pipeline.parameters.run_default_workflows >>
     jobs:
       - checkout
 

--- a/tools/pyinstaller_hooks/hook-coincurve.py
+++ b/tools/pyinstaller_hooks/hook-coincurve.py
@@ -1,6 +1,12 @@
 import os.path
+import sys
 
 from PyInstaller.utils.hooks import get_module_file_attribute
 
-coincurve_dir = os.path.dirname(get_module_file_attribute("coincurve"))
-binaries = [(os.path.join(coincurve_dir, "libsecp256k1.dll"), "coincurve")]
+from raiden.utils.typing import List, Tuple
+
+binaries: List[Tuple[str, str]] = []
+
+if sys.platform == "win32":
+    coincurve_dir = os.path.dirname(get_module_file_attribute("coincurve"))
+    binaries.append((os.path.join(coincurve_dir, "libsecp256k1.dll"), "coincurve"))


### PR DESCRIPTION
## Descriptions

Before this PR, the CI was using the system Python from the MacOS executors, which is fixed to version 
 `3.7.0`. This would cause that not all Raiden requirements were able to beinstalled for the MacOS builds, due to incompatibilities with Python `3.7.0`.

As of this commit, `pyenv` is used for all MacOS builds to install a custom version of Python.
If the CI's `py-version parameter` is set to `3.7`, this will use Python version `3.7.9`.

Additionally, it is now possible to use Python `3.8.6` for MacOS builds.

Future upgrades to other Python versions are now easier, since arbitrary versions can be passed to `pyenv install`.

The ARM builds will be removed for now, until #6178 is solved.

Fixes: #6705
