### PR TITLE
update rlp, eth-account, eth-rlp

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -43,11 +43,11 @@ cytoolz==0.10.1           # via -r requirements-dev.txt, eth-keyfile, eth-utils
 decorator==4.4.2          # via -r requirements-dev.txt, ipython, traitlets
 docutils==0.14            # via -r requirements-dev.txt, readme-renderer, sphinx, sphinxcontrib-httpexample
 eth-abi==2.1.0            # via -r requirements-dev.txt, eth-account, raiden-contracts, web3
-eth-account==0.5.3        # via -r requirements-dev.txt, web3
+eth-account==0.5.4        # via -r requirements-dev.txt, web3
 eth-hash[pycryptodome]==0.2.0  # via -r requirements-dev.txt, eth-utils, web3
 eth-keyfile==0.5.1        # via -r requirements-dev.txt, eth-account
 eth-keys==0.3.3           # via -r requirements-dev.txt, eth-account, eth-keyfile
-eth-rlp==0.1.2            # via -r requirements-dev.txt, eth-account
+eth-rlp==0.2.1            # via -r requirements-dev.txt, eth-account
 eth-typing==2.2.1         # via -r requirements-dev.txt, eth-abi, eth-keys, eth-utils, raiden-contracts, web3
 eth-utils==1.9.5          # via -r requirements-dev.txt, eth-abi, eth-account, eth-keyfile, eth-keys, eth-rlp, hexbytes, raiden-contracts, rlp, web3
 execnet==1.6.0            # via -r requirements-dev.txt, pytest-xdist
@@ -159,7 +159,7 @@ regex==2020.6.8           # via -r requirements-dev.txt, black
 releases==1.6.3           # via -r requirements-dev.txt
 requests==2.25.0          # via -r requirements-dev.txt, grequests, ipfshttpclient, matrix-client, raiden-api-client, responses, sphinx, sphinxcontrib-images, treq, web3
 responses==0.10.15        # via -r requirements-dev.txt
-rlp==1.1.0                # via -r requirements-dev.txt, eth-account, eth-rlp, raiden-contracts
+rlp==2.0.0                # via -r requirements-dev.txt, eth-account, eth-rlp, raiden-contracts
 s3cmd==2.1.0              # via -r requirements-ci.in
 semantic-version==2.6.0   # via -r requirements-dev.txt, py-solc, releases
 semver==2.8.1             # via -r requirements-dev.txt, raiden-contracts

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -42,11 +42,11 @@ cytoolz==0.10.1           # via -r requirements.txt, eth-keyfile, eth-utils
 decorator==4.4.2          # via ipython, traitlets
 docutils==0.14            # via -r requirements-docs.txt, readme-renderer, sphinx, sphinxcontrib-httpexample
 eth-abi==2.1.0            # via -r requirements.txt, eth-account, raiden-contracts, web3
-eth-account==0.5.3        # via -r requirements.txt, web3
+eth-account==0.5.4        # via -r requirements.txt, web3
 eth-hash[pycryptodome]==0.2.0  # via -r requirements.txt, eth-utils, web3
 eth-keyfile==0.5.1        # via -r requirements.txt, eth-account
 eth-keys==0.3.3           # via -r requirements.txt, eth-account, eth-keyfile
-eth-rlp==0.1.2            # via -r requirements.txt, eth-account
+eth-rlp==0.2.1            # via -r requirements.txt, eth-account
 eth-typing==2.2.1         # via -r requirements.txt, eth-abi, eth-keys, eth-utils, raiden-contracts, web3
 eth-utils==1.9.5          # via -r requirements.txt, eth-abi, eth-account, eth-keyfile, eth-keys, eth-rlp, hexbytes, raiden-contracts, rlp, web3
 execnet==1.6.0            # via pytest-xdist
@@ -153,7 +153,7 @@ regex==2020.6.8           # via black
 releases==1.6.3           # via -r requirements-docs.txt
 requests==2.25.0          # via -r requirements-docs.txt, -r requirements.txt, grequests, ipfshttpclient, matrix-client, raiden-api-client, responses, sphinx, sphinxcontrib-images, treq, web3
 responses==0.10.15        # via -r requirements-dev.in
-rlp==1.1.0                # via -r requirements.txt, eth-account, eth-rlp, raiden-contracts
+rlp==2.0.0                # via -r requirements.txt, eth-account, eth-rlp, raiden-contracts
 semantic-version==2.6.0   # via -r requirements-docs.txt, -r requirements.txt, py-solc, releases
 semver==2.8.1             # via -r requirements.txt, raiden-contracts
 service-identity==18.1.0  # via matrix-synapse, twisted

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -23,11 +23,11 @@ crc32c==2.0               # via aiortc
 cryptography==3.2         # via aiortc
 cytoolz==0.10.1           # via eth-keyfile, eth-utils
 eth-abi==2.1.0            # via eth-account, raiden-contracts, web3
-eth-account==0.5.3        # via web3
+eth-account==0.5.4        # via web3
 eth-hash[pycryptodome]==0.2.0  # via eth-utils, web3
 eth-keyfile==0.5.1        # via -r requirements.in, eth-account
 eth-keys==0.3.3           # via -r requirements.in, eth-account, eth-keyfile
-eth-rlp==0.1.2            # via eth-account
+eth-rlp==0.2.1            # via eth-account
 eth-typing==2.2.1         # via eth-abi, eth-keys, eth-utils, raiden-contracts, web3
 eth-utils==1.9.5          # via -r requirements.in, eth-abi, eth-account, eth-keyfile, eth-keys, eth-rlp, hexbytes, raiden-contracts, rlp, web3
 filelock==3.0.12          # via -r requirements.in
@@ -72,7 +72,7 @@ pytz==2019.1              # via flask-restful
 raiden-contracts==0.37.1  # via -r requirements.in
 raiden-webui==1.1.1       # via -r requirements.in
 requests==2.25.0          # via -r requirements.in, ipfshttpclient, matrix-client, web3
-rlp==1.1.0                # via eth-account, eth-rlp, raiden-contracts
+rlp==2.0.0                # via eth-account, eth-rlp, raiden-contracts
 semantic-version==2.6.0   # via py-solc
 semver==2.8.1             # via raiden-contracts
 six==1.15.0               # via cryptography, flask-cors, flask-restful, jsonschema, multiaddr, parsimonious, protobuf, pyrsistent, structlog


### PR DESCRIPTION
There is a dependency conflict with py-evm used in eth-tester in the raiden-services repo. 