### PR TITLE
set presence to online after random interval

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -548,7 +548,9 @@ class GMatrixClient(MatrixClient):
 
     def set_presence_state(self, state: str) -> Dict:
         return self.api._send(
-            "PUT", f"/presence/{quote(self.user_id)}/status", {"presence": state}
+            "PUT",
+            f"/presence/{quote(self.user_id)}/status",
+            {"presence": state, "status_msg": str(time.time())},
         )
 
     def _mkroom(self, room_id: str) -> Room:


### PR DESCRIPTION
## Description

[Workaround](https://github.com/raiden-network/raiden/issues/6724#issuecomment-747755358) for the presence bug by @andrevmatos. In this implementation a random interval after `transport.start()` is used to set presence in a distributed non-deterministic manner. 