### PR TITLE
Remove pylint rule to enforce sets as first argument to `gevent.joinall()`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -33,7 +33,6 @@ enable=
     del-method-used,
     exception-in-del,
     expression-not-assigned,
-    gevent-joinall,
     gevent-joinall-raise-error,
     gevent-disable-wait,
     gevent-group-join,


### PR DESCRIPTION
## Description

In old versions of gevent passing the same greenlet multiple times to `joinall()` caused a deadlock.
Therefore we implemented a custom pylint checker to only allow sets as the first argument.
This bug is no longer present and therefore the checker has been removed.

Fixes: #6683
