### PR TITLE
Safe broadcast stop

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -567,6 +567,8 @@ class MatrixTransport(Runnable):
         if self._stop_event.ready():
             return
         self.log.debug("Matrix stopping")
+        # Ensure, we send all broadcast messages before shutting down
+        self._broadcast_queue.join()
         self._stop_event.set()
         self._broadcast_event.set()
 

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -41,7 +41,6 @@ scenario:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
       ## Wait for Monitor Request to be sent
-      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}


### PR DESCRIPTION
## Don't allow the transport to shut down, when broadcast queue has `unfinished_tasks`
Fixes: #6756 -- this should help generally with the problem of a node being stopped when there are still Monitoring Requests in flight. It does however not secure us against forced shutdowns.