### PR TITLE
Reduce max presence update frequency

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -525,7 +525,7 @@ class MatrixTransport(Runnable):
 
     def _set_presence(self, state: UserPresence) -> None:
 
-        waiting_period = randint(1, SET_PRESENCE_INTERVAL)
+        waiting_period = randint(SET_PRESENCE_INTERVAL // 4, SET_PRESENCE_INTERVAL)
         gevent.wait(  # pylint: disable=gevent-disable-wait
             {self._stop_event}, timeout=waiting_period
         )


### PR DESCRIPTION
Having nodes submit the presence up to once a second might degrade the
service quality for other users too easily. Let's set it to 15-60 seconds.