### PR TITLE
Fix balance check for sending MR

### DIFF
--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -855,7 +855,6 @@ class RaidenService(Runnable):
             ],
         )
 
-        old_state = views.state_from_raiden(self)
         raiden_events = []
 
         with self.wal.process_state_change_atomically() as dispatcher:
@@ -864,7 +863,6 @@ class RaidenService(Runnable):
                 raiden_events.extend(events)
 
         return self._trigger_state_change_effects(
-            old_state=old_state,
             new_state=views.state_from_raiden(self),
             state_changes=state_changes,
             events=raiden_events,
@@ -872,7 +870,6 @@ class RaidenService(Runnable):
 
     def _trigger_state_change_effects(
         self,
-        old_state: ChainState,
         new_state: ChainState,
         state_changes: List[StateChange],
         events: List[Event],
@@ -1126,7 +1123,6 @@ class RaidenService(Runnable):
         )
         assert self.blockchain_events, msg
 
-        old_state = views.state_from_raiden(self)
         state_changes = []
         raiden_events = []
 
@@ -1213,7 +1209,6 @@ class RaidenService(Runnable):
         )
 
         event_greenlets = self._trigger_state_change_effects(
-            old_state=old_state,
             new_state=views.state_from_raiden(self),
             state_changes=state_changes,
             events=raiden_events,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -924,7 +924,7 @@ class RaidenService(Runnable):
         for monitoring_update in monitoring_updates.values():
             update_monitoring_service_from_balance_proof(
                 raiden=self,
-                chain_state=old_state,
+                chain_state=new_state,
                 new_balance_proof=monitoring_update.balance_proof,
                 non_closing_participant=self.address,
             )

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -93,7 +93,7 @@ MIN_REI_THRESHOLD = TokenAmount(55 * 10 ** 17)  # about 1.1$
 MONITORING_REWARD = TokenAmount(5 * 10 ** 18)  # about 1$
 
 MIN_MONITORING_AMOUNT_DAI = TokenAmount(1 * 10 ** 18)  # naive approach about 1$
-MIN_MONITORING_AMOUNT_WETH = TokenAmount(4 * 10 ** 15)  # naive approach about 1$
+MIN_MONITORING_AMOUNT_WETH = TokenAmount(900 * 10 ** 12)  # naive approach about 1$
 
 MIN_REVEAL_TIMEOUT = BlockTimeout(20)
 

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -38,14 +38,14 @@ nodes:
 scenario:
   serial:
     tasks:
-      - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
-      - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
+      - open_channel: {from: 0, to: 1, total_deposit: 2_000_000_000_000_000_000}
+      - transfer: {from: 0, to: 1, amount: 1_000_000_000_000_000_000, expected_http_status: 200}
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}
       ## Wait for channel to be closed
       - wait_blocks: 1
-      - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 500_000_000_000_000_000, state: "closed"}
+      - assert: {from: 0, to: 1, total_deposit: 2_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000, state: "closed"}
       - assert_events:
           contract_name: "TokenNetwork"
           event_name: "ChannelClosed"


### PR DESCRIPTION
Running MS1 failed on mainnet, since this check identified the balance as too for being worthy of monitoring. This was caused by two problems (each of them would fail the scenario by itself on mainnet):

* The checked balance was outdated
* The values were below our monitoring threshold

Closes #6736