### PR TITLE
SP: cleanup MS scenarios

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -40,7 +40,6 @@ scenario:
     tasks:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
-      ## Wait for Monitor Request to be sent
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -40,8 +40,6 @@ scenario:
     tasks:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
-      ## Wait for Monitor Request to be sent
-      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -41,8 +41,6 @@ scenario:
     tasks:
       - open_channel: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000}
       - transfer: {from: 0, to: 1, amount: 500_000_000_000_000_000, expected_http_status: 200}
-      ## Wait for Monitor Request to be sent
-      - wait_blocks: 1
       - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - stop_node: 1
       - close_channel: {from: 0, to: 1}

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -51,11 +51,7 @@ scenario:
           repeat: 10
           tasks:
             - transfer: {from: 0, to: 1, amount: 50_000_000_000_000_000, expected_http_status: 200}
-      - serial:
-          name: "Make monitor request"
-          tasks:
-            - wait_blocks: 1
-            - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
+      - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
       - serial:
           name: "Stop node1"
           tasks:


### PR DESCRIPTION
## Description

This completes what has been started in https://github.com/raiden-network/raiden/commit/3e466b852d31d0e1807e3184ecf5cc7e31d4e867

When shutting down a node it should send outstanding MRs without the need of additional waits. This removes the waits from the remaining MS scenarios.

This has been fixed in https://github.com/raiden-network/raiden/pull/6763 and showed problems in the LC: https://github.com/raiden-network/light-client/pull/2505
