### PR TITLE
Update old channel state before deciding whether to unlock

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -66,7 +66,7 @@ from raiden.transfer.mediated_transfer.events import (
     SendSecretReveal,
     SendUnlock,
 )
-from raiden.transfer.state import ChainState, NettingChannelState
+from raiden.transfer.state import ChainState, NettingChannelEndState
 from raiden.transfer.views import (
     get_channelstate_by_canonical_identifier,
     get_channelstate_by_token_network_and_partner,
@@ -101,8 +101,8 @@ UNEVENTFUL_EVENTS = (
 
 
 def _update_lock_info(
-    state_to_update: NettingChannelState,
-    update_from_state: NettingChannelState,
+    old_state: NettingChannelEndState,
+    new_state: NettingChannelEndState,
     chain_state: ChainState,
 ) -> None:
     """Update old channel state with lock information from current state
@@ -110,46 +110,38 @@ def _update_lock_info(
     Call this after settlement, when you need to work on an older locksroot
     because the channel has been settled with an outdated balance proof.
     """
-    assert update_from_state.settle_transaction, "Channel must be settled"
-    for old_state, new_state in [
-        (state_to_update.our_state, update_from_state.our_state),
-        (state_to_update.partner_state, update_from_state.partner_state),
-    ]:
-        # After settlement, no unlocks can be processed. So all locks that are
-        # still present in the balance proof are locked, unless their secret is
-        # registered on-chain.
-        old_state.secrethashes_to_lockedlocks.update(
-            {
-                secret: unlock.lock
-                for secret, unlock in old_state.secrethashes_to_unlockedlocks.items()
-            }
-        )
-        old_state.secrethashes_to_unlockedlocks = {}
+    # After settlement, no unlocks can be processed. So all locks that are
+    # still present in the balance proof are locked, unless their secret is
+    # registered on-chain.
+    old_state.secrethashes_to_lockedlocks.update(
+        {secret: unlock.lock for secret, unlock in old_state.secrethashes_to_unlockedlocks.items()}
+    )
+    old_state.secrethashes_to_unlockedlocks = {}
 
-        # In the time between the states, some locks might have been unlocked
-        # on-chain. Update their state to "on-chain unlocked".
-        for secret, updated_unlock in new_state.secrethashes_to_onchain_unlockedlocks.items():
-            try:
-                del old_state.secrethashes_to_lockedlocks[secret]
-            except KeyError:
-                continue
-            old_state.secrethashes_to_onchain_unlockedlocks[secret] = updated_unlock
+    # In the time between the states, some locks might have been unlocked
+    # on-chain. Update their state to "on-chain unlocked".
+    for secret, updated_unlock in new_state.secrethashes_to_onchain_unlockedlocks.items():
+        try:
+            del old_state.secrethashes_to_lockedlocks[secret]
+        except KeyError:
+            continue
+        old_state.secrethashes_to_onchain_unlockedlocks[secret] = updated_unlock
 
-        # If we don't have a task for the secret, then that lock can't be
-        # relevant to us, anymore. Otherwise, we would not have deleted the
-        # payment task.
-        # One case where this is necessary: We are a mediator and didn't unlock
-        # the payee's BP, but the secret has been registered on-chain. We
-        # will receive an Unlock from the payer and delete our MediatorTask,
-        # since we got our tokens. After deleting the task, we won't listen for
-        # on-chain unlocks, so we wrongly consider the tokens in the outgoing
-        # channel to be ours and send an on-chain unlock although we won't
-        # unlock any tokens to our benefit.
-        old_state.secrethashes_to_lockedlocks = {
-            secret: lock
-            for secret, lock in old_state.secrethashes_to_lockedlocks.items()
-            if secret in chain_state.payment_mapping.secrethashes_to_task
-        }
+    # If we don't have a task for the secret, then that lock can't be
+    # relevant to us, anymore. Otherwise, we would not have deleted the
+    # payment task.
+    # One case where this is necessary: We are a mediator and didn't unlock
+    # the payee's BP, but the secret has been registered on-chain. We
+    # will receive an Unlock from the payer and delete our MediatorTask,
+    # since we got our tokens. After deleting the task, we won't listen for
+    # on-chain unlocks, so we wrongly consider the tokens in the outgoing
+    # channel to be ours and send an on-chain unlock although we won't
+    # unlock any tokens to our benefit.
+    old_state.secrethashes_to_lockedlocks = {
+        secret: lock
+        for secret, lock in old_state.secrethashes_to_lockedlocks.items()
+        if secret in chain_state.payment_mapping.secrethashes_to_task
+    }
 
 
 class EventHandler(ABC):
@@ -645,7 +637,9 @@ class RaidenEventHandler(EventHandler):
                 canonical_identifier=canonical_identifier,
                 state_change_identifier=state_change_identifier,
             )
-            _update_lock_info(restored_channel_state, channel_state, chain_state)
+            _update_lock_info(
+                restored_channel_state.partner_state, channel_state.partner_state, chain_state
+            )
 
             onchain_unlocked = (
                 restored_channel_state.partner_state.secrethashes_to_onchain_unlockedlocks.values()
@@ -686,7 +680,9 @@ class RaidenEventHandler(EventHandler):
                 canonical_identifier=canonical_identifier,
                 state_change_identifier=state_change_identifier,
             )
-            _update_lock_info(restored_channel_state, channel_state, chain_state)
+            _update_lock_info(
+                restored_channel_state.our_state, channel_state.our_state, chain_state
+            )
 
             unclaimed = restored_channel_state.our_state.secrethashes_to_lockedlocks.values()
             gain = sum(lock.amount for lock in unclaimed)

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -166,8 +166,8 @@ def _update_lock_info(
         # relevant to us, anymore. Otherwise, we would not have deleted the
         # payment task.
         # One case where this is necessary: We are a mediator and didn't unlock
-        # the receiver's BP, but the secret has been registered on-chain. We
-        # will receive an Unlock from our sender and delete our MediatorTask,
+        # the payee's BP, but the secret has been registered on-chain. We
+        # will receive an Unlock from the payer and delete our MediatorTask,
         # since we got our tokens. After deleting the task, we won't listen for
         # on-chain unlocks, so we wrongly consider the tokens in the outgoing
         # channel to be ours and send an on-chain unlock although we won't

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -646,8 +646,7 @@ class RaidenEventHandler(EventHandler):
             )
             gain = sum(unlock.lock.amount for unlock in onchain_unlocked)
 
-            skip_unlock = gain == 0
-            if not skip_unlock:
+            if gain > 0:
                 payment_channel.unlock(
                     sender=partner_address,
                     receiver=our_address,
@@ -687,8 +686,7 @@ class RaidenEventHandler(EventHandler):
             unclaimed = restored_channel_state.our_state.secrethashes_to_lockedlocks.values()
             gain = sum(lock.amount for lock in unclaimed)
 
-            skip_unlock = gain == 0
-            if not skip_unlock:
+            if gain > 0:
                 try:
                     payment_channel.unlock(
                         pending_locks=restored_channel_state.our_state.pending_locks,

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -27,7 +27,7 @@ from raiden.storage.restore import (
     get_state_change_with_balance_proof_by_locksroot,
 )
 from raiden.transfer.architecture import Event
-from raiden.transfer.channel import get_batch_unlock, get_batch_unlock_gain
+from raiden.transfer.channel import get_batch_unlock_gain
 from raiden.transfer.events import (
     ContractSendChannelBatchUnlock,
     ContractSendChannelClose,
@@ -116,13 +116,10 @@ def unlock(
     receiver: Address,
     given_block_identifier: BlockIdentifier,
 ) -> None:  # pragma: no unittest
-    pending_locks = get_batch_unlock(end_state)
-    assert pending_locks, "pending lock set is missing"
-
     payment_channel.unlock(
         sender=sender,
         receiver=receiver,
-        pending_locks=pending_locks,
+        pending_locks=end_state.pending_locks,
         given_block_identifier=given_block_identifier,
     )
 

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -499,7 +499,7 @@ def test_secret_revealed_on_chain(
             token_network_address, app0, deposit - amount, [], app1, deposit + amount, []
         )
 
-        with watch_for_unlock_failures(*raiden_chain), gevent.Timeout(20):
+        with watch_for_unlock_failures(*raiden_chain), gevent.Timeout(40):
             wait_for_state_change(
                 app1,
                 ContractReceiveChannelBatchUnlock,

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -693,8 +693,7 @@ def test_settled_lock(
 
     # Save the pending locks from the pending transfer, used to test the unlock
     channelstate_0_1 = get_channelstate(app0, app1, token_network_address)
-    batch_unlock = channel.get_batch_unlock(channelstate_0_1.our_state)
-    assert batch_unlock
+    pending_locks = channelstate_0_1.our_state.pending_locks
 
     hold_event_handler.release_secretrequest_for(app1, secrethash)
 
@@ -731,7 +730,7 @@ def test_settled_lock(
         netting_channel.unlock(
             sender=channelstate_0_1.our_state.address,
             receiver=channelstate_0_1.partner_state.address,
-            pending_locks=batch_unlock,
+            pending_locks=pending_locks,
             given_block_identifier=current_block,
         )
 

--- a/raiden/tests/unit/test_channelstate.py
+++ b/raiden/tests/unit/test_channelstate.py
@@ -1264,10 +1264,7 @@ def test_channelstate_get_unlock_proof():
     end_state.secrethashes_to_unlockedlocks = unlocked_locks
     end_state.pending_locks = pending_locks
 
-    unlock_proof = channel.get_batch_unlock(end_state)
-    assert len(unlock_proof.locks) == len(end_state.pending_locks.locks)
-    leaves_packed = b"".join(unlock_proof.locks)
-
+    leaves_packed = b"".join(end_state.pending_locks.locks)
     recomputed_pending_locks = pending_locks_from_packed_data(leaves_packed)
     assert len(recomputed_pending_locks.locks) == len(end_state.pending_locks.locks)
 

--- a/raiden/tests/unit/transfer/test_channel.py
+++ b/raiden/tests/unit/transfer/test_channel.py
@@ -19,7 +19,6 @@ from raiden.tests.utils.factories import (
 from raiden.transfer import channel
 from raiden.transfer.channel import (
     compute_locksroot,
-    get_batch_unlock_gain,
     get_secret,
     get_status,
     handle_block,
@@ -345,37 +344,6 @@ def make_unlock_partial_proof_state(amount):
     return UnlockPartialProofState(
         lock=make_hash_time_lock_state(amount), secret=factories.UNIT_SECRET
     )
-
-
-def test_get_batch_unlock_gain():
-    channel_state = factories.create(factories.NettingChannelStateProperties())
-    channel_state.our_state = replace(
-        channel_state.our_state,
-        secrethashes_to_lockedlocks={
-            factories.make_secret_hash(): make_hash_time_lock_state(1),
-            factories.make_secret_hash(): make_hash_time_lock_state(2),
-        },
-        secrethashes_to_unlockedlocks={
-            factories.make_secret_hash(): make_unlock_partial_proof_state(4)
-        },
-        secrethashes_to_onchain_unlockedlocks={
-            factories.make_secret_hash(): make_unlock_partial_proof_state(8)
-        },
-    )
-    channel_state.partner_state = replace(
-        channel_state.partner_state,
-        secrethashes_to_lockedlocks={factories.make_secret_hash(): make_hash_time_lock_state(16)},
-        secrethashes_to_unlockedlocks={
-            factories.make_secret_hash(): make_unlock_partial_proof_state(32)
-        },
-        secrethashes_to_onchain_unlockedlocks={
-            factories.make_secret_hash(): make_unlock_partial_proof_state(64),
-            factories.make_secret_hash(): make_unlock_partial_proof_state(128),
-        },
-    )
-    unlock_gain = get_batch_unlock_gain(channel_state)
-    assert unlock_gain.from_partner_locks == 192
-    assert unlock_gain.from_our_locks == 7
 
 
 def test_handle_block_closed_channel():

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1113,41 +1113,6 @@ def get_amount_locked(end_state: NettingChannelEndState) -> LockedAmount:
     return LockedAmount(result)
 
 
-def get_batch_unlock_gain(
-    channel_state: NettingChannelState,
-) -> UnlockGain:
-    """Collect amounts for unlocked/unclaimed locks and onchain unlocked locks.
-    Note: this function does not check expiry, so the values make only sense during settlement.
-
-    Returns:
-        gain_from_partner_locks: locks amount received and unlocked on-chain
-        gain_from_our_locks: locks amount which are unlocked or unclaimed
-    """
-    sum_from_partner_locks = sum(
-        unlock.lock.amount
-        for unlock in channel_state.partner_state.secrethashes_to_onchain_unlockedlocks.values()
-    )
-    gain_from_partner_locks = TokenAmount(sum_from_partner_locks)
-
-    """
-    The current participant will gain from unlocking its own locks when:
-    - The partner never managed to provide the secret to unlock the locked amount.
-    - The partner provided the secret to claim the locked amount but the current
-      participant node never sent out the unlocked balance proof and the partner
-      did not unlock the lock on-chain.
-    """
-    our_locked_locks_amount = sum(
-        lock.amount for lock in channel_state.our_state.secrethashes_to_lockedlocks.values()
-    )
-    our_unclaimed_locks_amount = sum(
-        lock.amount for lock in channel_state.our_state.secrethashes_to_unlockedlocks.values()
-    )
-    gain_from_our_locks = TokenAmount(our_locked_locks_amount + our_unclaimed_locks_amount)
-    return UnlockGain(
-        from_partner_locks=gain_from_partner_locks, from_our_locks=gain_from_our_locks
-    )
-
-
 def get_capacity(channel_state: NettingChannelState) -> TokenAmount:
     """Calculates the capacity of the given channel
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1225,20 +1225,6 @@ def get_distributable(
     return TokenAmount(min(overflow_limit, distributable))
 
 
-def get_batch_unlock(
-    end_state: NettingChannelEndState,
-) -> Optional[PendingLocksState]:
-    """Unlock proof for entire pending locks
-
-    The unlock proof contains all the locks, tightly packed, needed by the token
-    network contract to verify the secret expiry and calculate the token amounts to transfer.
-    """
-
-    if len(end_state.pending_locks.locks) == 0:  # pylint: disable=len-as-condition
-        return None
-    return end_state.pending_locks
-
-
 def get_lock(
     end_state: NettingChannelEndState, secrethash: SecretHash
 ) -> Optional[HashTimeLockState]:

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -168,7 +168,20 @@ class ContractSendChannelUpdateTransfer(ContractSendExpirableEvent):
 
 @dataclass(frozen=True)
 class ContractSendChannelBatchUnlock(ContractSendEvent):
-    """ Event emitted when the lock must be claimed on-chain. """
+    """Look for unlocks that we should do after settlement
+
+    This will only lead to an on-chain unlock if there are locks that can be
+    unlocked to our benefit.
+
+    Usually, we would check if this is the case in the state machine and skip
+    the creation of this event if no profitable locks are found. But if a
+    channel was closed with another BP than the latest one, we need to look in
+    the database for the locks that correspond to the on-chain data. Searching
+    the database is not possible in the state machine, so we create this event
+    in every case and do the check in the event handler.
+    Since locks for both receiving and sending transfers can potentially return
+    tokens to use, this event leads to 0-2 on-chain transactions.
+    """
 
     canonical_identifier: CanonicalIdentifier
     sender: Address  # sender of the lock


### PR DESCRIPTION
Using outdated channel information caused the wrong node to call unlock. See the commit messages for details.

Closes #6706.
Supersedes and thus closes https://github.com/raiden-network/raiden/pull/6708.