### PR TITLE
Disallow FIXME, HACK, XXX in flake8 linting; add NettingChannelState documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         args: ['--remove']
       - id: flake8
         args: ["--config=setup.cfg"]
-        additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer",]
+        additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer", "flake8-fixme"]
       - id: mixed-line-ending
       - id: no-commit-to-branch
         args: ['--branch', 'master', '--branch', 'develop']

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -16,6 +16,7 @@ flake8
 flake8-comprehensions
 flake8-bugbear
 flake8-tuple
+flake8-fixme
 isort
 readme-renderer
 pylint


### PR DESCRIPTION
## Description
This adds some clarifying comments to the `NettingChannelState` and `NettingChannelEndState` classes - since I had problems understanding them while diving in the core functionality.
Review of correctness of my assumptions is very much appreciated.

Also, @ulope suggested to add checks for `XXX`, `FIXME` and `HACK` flags in comments to the linting,
so that those markers will not pass the pre-commit-hooks on new commits.
This is also implemented.

