### PR TITLE
Don't throw unrecoverable error when local state for unlock event is missing

### DIFF
--- a/raiden/blockchain/decode.py
+++ b/raiden/blockchain/decode.py
@@ -375,8 +375,6 @@ def blockchainevent_to_statechange(
 
         if canonical_identifier is not None:
             return contractreceivechannelbatchunlock_from_event(canonical_identifier, event)
-        else:
-            log.debug("Discarding unlock event, we're not part of it", raiden_event=event)
 
     else:
         log.error("Unknown event type", raiden_event=event)


### PR DESCRIPTION


## Description

Fixes: #6792 

There's no need to throw an `RaidenUnrecoverableError` here, but we should log the problem.

I'm not so happy about the added `str, bool` return value., If someone has a better idea let me know.
