### PR TITLE
Fix value error

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -341,8 +341,7 @@ class UserAddressManager:
     def query_capabilities_for_user_id(self, user_id: str) -> PeerCapabilities:
         """ This pulls the `avatar_url` for a given user/user_id and parses the capabilities.  """
         try:
-            user: User = self._client.get_user(user_id)
-            avatar_url = user.api.get_avatar_url(user.user_id)
+            avatar_url = self._client.api.get_avatar_url(user_id)
             if avatar_url is not None:
                 return PeerCapabilities(deserialize_capabilities(avatar_url))
         except MatrixRequestError:
@@ -671,7 +670,7 @@ def first_login(client: GMatrixClient, signer: Signer, username: str, cap_str: s
         user.set_display_name(signature_hex)
 
     try:
-        current_capabilities = user.api.get_avatar_url(user.user_id) or ""
+        current_capabilities = client.api.get_avatar_url(client.user_id) or ""
     except MatrixRequestError as ex:
         log.error(
             "Ignoring Matrix error in `get_avatar_url`",

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -671,7 +671,7 @@ def first_login(client: GMatrixClient, signer: Signer, username: str, cap_str: s
         user.set_display_name(signature_hex)
 
     try:
-        current_capabilities = user.get_avatar_url() or ""
+        current_capabilities = user.api.get_avatar_url(user.user_id) or ""
     except MatrixRequestError as ex:
         log.error(
             "Ignoring Matrix error in `get_avatar_url`",

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -342,7 +342,7 @@ class UserAddressManager:
         """ This pulls the `avatar_url` for a given user/user_id and parses the capabilities.  """
         try:
             user: User = self._client.get_user(user_id)
-            avatar_url = user.get_avatar_url()
+            avatar_url = user.api.get_avatar_url(user.user_id)
             if avatar_url is not None:
                 return PeerCapabilities(deserialize_capabilities(avatar_url))
         except MatrixRequestError:


### PR DESCRIPTION
## Fix clients breaking when querying invalid capability string 

Fixes: tbd.
Previously `matrix/utils.py` used the library provided `user.get_avatar_url()` call, which needed that capabilities have a `mxc://` protocol prefix. If the prefix was missing, `user.get_avatar_url()` would raise a `ValueError` when trying to generate the `download_url`.

Since this is external input, we need to make sure `avatar_url` can not break a client.

Therefore this PR 
- changes the `user.get_avatar_url` call to the raw matrix API call (`client.api.get_avatar_url(user_id)`) which does not perform `download_url` generation
- adds extra exception handling for `ValueError`