### PR TITLE
Refactor CLI-parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ commands:
           name: Configuring PATH
           command: |
             echo 'export PATH=~/venv-${PYTHON_VERSION_SHORT}/bin:~/.local/bin:${PATH}' >> ${BASH_ENV}
-            echo 'export RAIDEN_VERSION=$(python3 setup.py --version)' >> ${BASH_ENV}
+            echo 'export CI_RAIDEN_VERSION=$(python3 setup.py --version)' >> ${BASH_ENV}
 
   checkout-and-persist:
     steps:
@@ -687,8 +687,8 @@ jobs:
                 command: |
                   rm dist/archive/*.txt
                   echo "TAG: ${CIRCLE_TAG}"
-                  RAIDEN_VERSION=${CIRCLE_TAG}
-                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${RAIDEN_VERSION} dist/archive/
+                  CI_RAIDEN_VERSION=${CIRCLE_TAG}
+                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${CI_RAIDEN_VERSION} dist/archive/
 
   deploy-pypi:
     parameters:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: check-vcs-permalinks
       - id: check-yaml
       - id: debug-statements
-        exclude: '^raiden/ui/cli.py$'
+        exclude: '^(raiden/ui/cli.py)|(raiden/tests/conftest.py)$'
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: .bumpversion_client.cfg

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -25,6 +25,7 @@ from raiden.utils.ethereum_clients import VersionSupport
 
 # Execute these before the raiden imports because rewrites can't work after the
 # module has been imported.
+pytest.register_assert_rewrite("raiden.tests.utils.cli")
 pytest.register_assert_rewrite("raiden.tests.utils.eth_node")
 pytest.register_assert_rewrite("raiden.tests.utils.factories")
 pytest.register_assert_rewrite("raiden.tests.utils.messages")

--- a/raiden/tests/integration/cli/conftest.py
+++ b/raiden/tests/integration/cli/conftest.py
@@ -61,9 +61,6 @@ def raiden_testchain(
         )
 
         args = result.args
-        # The setup of the testchain returns a TextIOWrapper but
-        # for the tests we need a filename
-        args["password_file"] = args["password_file"].name
         print("setup_raiden took", time.monotonic() - start_time)
         yield args
 

--- a/raiden/tests/unit/test_cli.py
+++ b/raiden/tests/unit/test_cli.py
@@ -194,18 +194,31 @@ def test_raiden_disable_on_no_rpc(cli_runner):
     assert rest_config.web_ui_enabled is False
 
 
-def test_no_monitoring_mainnet_warning(cli_runner):
-
-    cli_command = "raiden --accept-disclaimer"
-
-    expected_invoke_kwargs = {
-        "enable_monitoring": (ParameterSource.DEFAULT, False),
-        "chain_id": (ParameterSource.DEFAULT, 1),
-        "accept_disclaimer": (ParameterSource.COMMANDLINE, True),
-    }
+@pytest.mark.parametrize(
+    ("cli_command", "expected_kwargs"),
+    [
+        (
+            "raiden --accept-disclaimer",
+            {
+                "enable_monitoring": (ParameterSource.DEFAULT, False),
+                "chain_id": (ParameterSource.DEFAULT, 1),
+                "accept_disclaimer": (ParameterSource.COMMANDLINE, True),
+            },
+        ),
+        (
+            "raiden --no-enable-monitoring --network-id 1 --accept-disclaimer",
+            {
+                "enable_monitoring": (ParameterSource.COMMANDLINE, False),
+                "chain_id": (ParameterSource.COMMANDLINE, 1),
+                "accept_disclaimer": (ParameterSource.COMMANDLINE, True),
+            },
+        ),
+    ],
+)
+def test_no_monitoring_mainnet_warning(cli_runner, cli_command, expected_kwargs):
 
     _, kwargs = get_invoked_kwargs(cli_command, cli_runner, "raiden.ui.cli._run")
-    assert_invoked_kwargs(kwargs, expected_invoke_kwargs)
+    assert_invoked_kwargs(kwargs, expected_kwargs)
 
     result = get_cli_result(cli_command, cli_runner, "raiden.ui.cli.run_services")
 

--- a/raiden/tests/utils/cli.py
+++ b/raiden/tests/utils/cli.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, Tuple
+from unittest import mock
+
+from click.core import ParameterSource  # type: ignore
+
+from raiden.ui import cli
+
+
+def get_invoked_kwargs(cli_input, cli_runner, capture_function):
+
+    cli_args = cli_input.split()
+    command = cli_args[0]
+    assert command == "raiden"
+    call_args = cli_args[1:] or None
+
+    with mock.patch(capture_function, autospec=True) as mock_run:
+        result = cli_runner.invoke(cli.run, call_args)
+        assert result.exit_code == 0
+        assert not result.exception
+        assert mock_run.called
+        args, kwargs = mock_run.call_args
+
+    return args, kwargs
+
+
+def get_cli_result(cli_input, cli_runner, capture_function):
+
+    cli_args = cli_input.split()
+    command = cli_args[0]
+    assert command == "raiden"
+    call_args = cli_args[1:] or None
+
+    with mock.patch(capture_function, autospec=True):
+        result = cli_runner.invoke(cli.run, call_args)
+        return result
+
+
+def assert_invoked_kwargs(
+    kwargs: Dict[str, Any], expected_args: Dict[str, Tuple[ParameterSource, Any]]
+):
+    ctx = kwargs["ctx"]
+
+    dic = dict()
+    for k, v in kwargs.items():
+        if k in expected_args:
+            dic[k] = (ctx.get_parameter_source(k), v)
+
+    assert dic == expected_args

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -409,7 +409,7 @@ def setup_raiden(
         "keystore_path": keystore,
         "matrix_server": matrix_server,
         "chain_id": str(CHAINNAME_TO_ID["smoketest"]),
-        "password_file": click.File()(os.path.join(base_datadir, "pw")),
+        "password_file": os.path.join(base_datadir, "pw"),
         "user_deposit_contract_address": user_deposit_contract_address,
         "sync_check": False,
         "environment_type": Environment.DEVELOPMENT,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -13,7 +13,6 @@ from typing import Any, AnyStr, Callable, List, Optional
 import click
 import filelock
 import structlog
-from click.core import ParameterSource  # type: ignore
 from requests.exceptions import ConnectionError as RequestsConnectionError, ConnectTimeout
 from urllib3.exceptions import ReadTimeoutError
 
@@ -656,10 +655,9 @@ def _run(ctx: Context, **kwargs: Any) -> None:
         kwargs["config"] = raiden_config
         enable_monitoring = kwargs["enable_monitoring"]
         if enable_monitoring is False:
-            moni_source = ctx.get_parameter_source("enable_monitoring")  # type: ignore
             is_mainnet = kwargs["chain_id"] == ChainID(1)
 
-            if moni_source is ParameterSource.DEFAULT and is_mainnet:
+            if is_mainnet:
                 msg = (
                     "WARNING: You did not enable monitoring (`--enable-monitoring`) while "
                     "connecting to the Ethereum mainnet.\n"

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -123,7 +123,28 @@ def write_stack_trace(ex: Exception) -> None:
         )
 
 
+def get_version(short: bool) -> str:
+    if short:
+        return get_system_spec()["raiden"]
+    else:
+        return json.dumps(get_system_spec(), indent=2)
+
+
+def handle_version_option(ctx: Context, _param: Any, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(get_version(short=True))
+    ctx.exit()
+
+
 OPTIONS = [
+    option(
+        "--version",
+        is_flag=True,
+        callback=handle_version_option,
+        expose_value=False,
+        is_eager=True,
+    ),
     option(
         "--datadir",
         help="Directory for storing raiden data.",
@@ -594,7 +615,7 @@ def run(ctx: Context, **kwargs: Any) -> None:
         raiden_config = setup_raiden_config(**kwargs)
         kwargs["config"] = raiden_config
 
-        raiden_version = get_system_spec()["raiden"]
+        raiden_version = get_version(short=True)
         click.secho(f"Welcome to Raiden, version {raiden_version}!", fg="green")
 
         click.secho(
@@ -734,12 +755,11 @@ KNOWN_OPTIONS = {param.name.replace("_", "-") for param in run.params}.union(FLA
 
 @run.command()
 @option("--short", is_flag=True, help="Only display Raiden version")
-def version(short: bool) -> None:
+@click.pass_context
+def version(ctx: Context, short: bool) -> None:
     """Print version information and exit. """
-    if short:
-        print(get_system_spec()["raiden"])
-    else:
-        print(json.dumps(get_system_spec(), indent=2))
+    click.echo(get_version(short=short))
+    ctx.exit(0)
 
 
 @run.command()

--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -217,7 +217,7 @@ class GroupableOptionCommandGroup(click.Group):
                                 self._process_parse_result(
                                     ctx, param_name, source, value, parsed_value
                                 )
-                    except ParsingException:
+                    except SkipParsing:
                         ctx.params[parser.name] = None
                         ctx.set_parameter_source(parser.name, ParameterSource.DEFAULT_MAP)
 
@@ -412,7 +412,7 @@ class PathRelativePath(click.Path):
         return HypenTemplate(default).substitute(params)
 
 
-class ParsingException(Exception):
+class SkipParsing(Exception):
     pass
 
 
@@ -506,7 +506,8 @@ class ConfigParser(Parser):
             # the option wasn't explicitly supplied on the command line
             default_config_missing = ex.errno == errno.ENOENT and source == ParameterSource.DEFAULT
             if default_config_missing:
-                return dict()
+                msg = f"Default configuration file {value} not found. Skipping parsing."
+                raise SkipParsing(msg)
             else:
                 raise ConfigurationError(f"Error opening config file: {ex}")
 

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -119,7 +119,7 @@ chardet==3.0.4
     # via
     #   -r requirements-dev.txt
     #   requests
-click==7.1.2
+click==8.0.0a1
     # via
     #   -r requirements-dev.txt
     #   black

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -101,7 +101,7 @@ chardet==3.0.4
     #   -r requirements-docs.txt
     #   -r requirements.txt
     #   requests
-click==7.1.2
+click==8.0.0a1
     # via
     #   -r requirements.txt
     #   black

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,6 @@
 aiortc
 cachetools
-click
+click>=8.0.0a1
 coincurve
 colorama
 eth-keyfile

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -32,7 +32,7 @@ cffi==1.12.3
     #   pylibsrtp
 chardet==3.0.4
     # via requests
-click==7.1.2
+click==8.0.0a1
     # via
     #   -r requirements.in
     #   flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = B011, C814, E203, E402, E731, W503, W504, W391, C401, C408
+ignore = B011, C814, E203, E402, E731, W503, W504, W391, C401, C408, T100, T101
 max-line-length = 99
 exclude = build,dist,.git,.venv,tools/ansible/contrib
 


### PR DESCRIPTION
## Description
Refactor the config-file option parsing, since before it was not re-usable and very fine-grained, replicating `click` library's internal behaviour.

What this Refactoring does in detail:

- Now CLI options can additionally have a `Parser`-classes concrete implementation-class attached, which can alter all other parsed command line options (for e.g. config-file parsing based on a config-file CLI option, for injecting/overwriting options based on a provided policy-option, etc.)
- Priorities can be provided to the additional parsers to determine option overwrite-precedence
- The parser-wrapped command functions (e.g. `run` / `smoketest`) have now better introspection into what source 
set a specific option, via the `Context.get_parameter_source( option_name )`, which returns a `click.core.ParameterSource` enum.

The ParameterSource contains the following values:
```
ParameterSource.COMMANDLINE - the option was specifically set by the command line by the user
ParameterSource.DEFAULT - the option was set by the default value, as specified in the `option( )` decorator
ParameterSource.DEFAULT_MAP - *an extra Parser set the option*, or the option's default was overwritten by click's `default_map`
ParameterSource.ENVIRONMENT - the option was set by an environment variable
ParameterSource.PROMPT - the option was set by a user prompt
```
(Read more about the `default_map` [here](https://click.palletsprojects.com/en/7.x/commands/#overriding-defaults))

This is easily possible, since click will add quite some convenience functionality in version 8.
Unfortunately this means using a release candidate for now.

- Introduce `click>=8.0.0a1` RC for its improved functionality
- Change modified `click` classes to comply to version `8.0.0a1` RC

Fixes #6669 
Fixes #6779