### PR TITLE
UDC deposit and withdraw API

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -899,6 +899,122 @@ Querying node state
    :statuscode 500: Internal Raiden error
 
 
+User Deposit for services
+===================
+
+For paying the :doc:`Raiden Services <raiden_services>` it is necessary to have RDN (Raiden Network Tokens) in the User Deposit Contract (UDC). 
+This endpoint can be used to deposit to and withdraw from the UDC.
+
+
+.. http:post:: /api/(version)/user_deposit
+
+   **Deposit**
+
+   Deposit RDN tokens to the UDC.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      POST /api/v1/user_deposit HTTP/1.1
+      Host: localhost:5001
+      Content-Type: application/json
+
+      {
+          "total_deposit": "200000"
+      }
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+         "transaction_hash": "0xc5988c93c07cf1579e73d39ee2a3d6e948d959d11015465a77817e5239165170"
+      }
+
+   :statuscode 200: Deposit was successful
+   :statuscode 400: The provided JSON is in some way malformed
+   :statuscode 402: Insufficient balance to do a deposit or insufficient ETH to pay for the gas of the on-chain transaction
+   :statuscode 404: No UDC is configured on the Raiden node
+   :statuscode 409: The provided ``total_deposit`` is not higher than the previous ``total_deposit`` or attempted to deposit more RDN than the UDC limit would allow
+   :statuscode 500: Internal Raiden node error
+   :statuscode 503: The API is currently unavailable, e. g. because the Raiden node is still in the initial sync or shutting down.
+
+   **Plan a withdraw**
+
+   Before RDN can be withdrawn from the UDC the withdraw must be planned.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      POST /api/v1/user_deposit HTTP/1.1
+      Host: localhost:5001
+      Content-Type: application/json
+
+      {
+          "planned_withdraw_amount": "1500"
+      }
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+         "planned_withdraw_block_number": 4269933,
+         "transaction_hash": "0xec6a0d010d740df20ca8b3b6456e9deaab8abf3787cb676ee244bef7d28aa4fc"
+      }
+
+   :statuscode 200: Withdraw plan was successful
+   :statuscode 400: The provided JSON is in some way malformed
+   :statuscode 402: Insufficient ETH to pay for the gas of the on-chain transaction
+   :statuscode 404: No UDC is configured on the Raiden node
+   :statuscode 409: The provided ``planned_withdraw_amount`` is higher than the balance in the UDC or not greater than zero
+   :statuscode 500: Internal Raiden node error
+   :statuscode 503: The API is currently unavailable, e. g. because the Raiden node is still in the initial sync or shutting down.
+
+   **Withdraw**
+
+   Withdraw RDN from the UDC. Can only be done after 100 blocks after the withdraw was planned.
+
+   **Example Request**:
+
+   .. http:example:: curl wget httpie python-requests
+
+      POST /api/v1/user_deposit HTTP/1.1
+      Host: localhost:5001
+      Content-Type: application/json
+
+      {
+          "withdraw_amount": "1500"
+      }
+
+   **Example Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+         "transaction_hash": "0xfc7edd195c6cc0c9391d84dd83b7aa9dbfffbcfc107e5c33a5ab912c0d92416c"
+      }
+
+   :statuscode 200: Withdraw was successful
+   :statuscode 400: The provided JSON is in some way malformed
+   :statuscode 402: Insufficient ETH to pay for the gas of the on-chain transaction
+   :statuscode 404: No UDC is configured on the Raiden node
+   :statuscode 409: The provided ``withdraw_amount`` is higher than the planned amount or not greater than zero or the withdraw is too early
+   :statuscode 500: Internal Raiden node error
+   :statuscode 503: The API is currently unavailable, e. g. because the Raiden node is still in the initial sync or shutting down.
+
+
 API endpoints for testing
 =========================
 

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -367,3 +367,9 @@ class EventPaymentReceivedSuccessSchema(EventPaymentSchema):
             "log_time",
             "token_address",
         )
+
+
+class UserDepositPostSchema(BaseSchema):
+    total_deposit = IntegerToStringField(default=None, missing=None)
+    planned_withdraw_amount = IntegerToStringField(default=None, missing=None)
+    withdraw_amount = IntegerToStringField(default=None, missing=None)

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -12,6 +12,7 @@ from raiden.api.v1.encoding import (
     MintTokenSchema,
     PaymentSchema,
     RaidenEventsRequestSchema,
+    UserDepositPostSchema,
 )
 from raiden.utils.typing import TYPE_CHECKING, Address, Any, TargetAddress, TokenAddress
 
@@ -253,6 +254,15 @@ class PendingTransfersResourceByTokenAndPartnerAddress(BaseResource):
     @if_api_available
     def get(self, token_address: TokenAddress, partner_address: Address) -> Response:
         return self.rest_api.get_pending_transfers(token_address, partner_address)
+
+
+class UserDepositResource(BaseResource):
+    post_schema = UserDepositPostSchema()
+
+    @if_api_available
+    def post(self) -> Response:
+        kwargs = validate_json(self.post_schema)
+        return self.rest_api.send_udc_transaction(**kwargs)
 
 
 class StatusResource(BaseResource):

--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -390,3 +390,9 @@ class MatrixSyncMaxTimeoutReached(RaidenRecoverableError):
 
 class ConfigurationError(RaidenError):
     """ Raised when there is something wrong with the provided Raiden Configuration/arguments """
+
+
+class UserDepositNotConfigured(RaidenRecoverableError):
+    """Raised when trying to perform operations on a user deposit contract but none has been
+    configured for the Raiden node.
+    """


### PR DESCRIPTION
## Description

Fixes: #5497 

This adds a `api/v1/user_deposit` endpoint as specified in the linked issue for interacting with the UDC.
It has three possibilities for POST requests depending on the body parameter:
- deposit: `{total_deposit: <amount>}`
- plan a withdraw: `{planned_withdraw_amount: <amount>}`
- withdraw: `{withdraw_amount: <amount>}`

This is needed for having a user-friendly interface to the UDC in the WebUI.
