### PR TITLE
pass device_id as argument upon login

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -87,6 +87,12 @@ class Capabilities(Enum):
     TODEVICE = "toDevice"  # supports sending and receiving toDevice messages on Matrix
 
 
+class DeviceIDs(Enum):
+    RAIDEN = "RAIDEN"
+    PFS = "PATH_FINDING"
+    MS = "MONITORING"
+
+
 class ServerListType(Enum):
     ACTIVE_SERVERS = "active_servers"
     ALL_SERVERS = "all_servers"

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -27,6 +27,7 @@ from raiden.constants import (
     WEB_RTC_CHANNEL_TIMEOUT,
     Capabilities,
     CommunicationMedium,
+    DeviceIDs,
     Environment,
     MatrixMessageType,
     RTCMessageType,
@@ -484,6 +485,7 @@ class MatrixTransport(Runnable):
             login(
                 client=self._client,
                 signer=self._raiden_service.signer,
+                device_id=DeviceIDs.RAIDEN,
                 prev_auth_data=prev_auth_data,
                 capabilities=capabilities,
             )

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -9,6 +9,7 @@ import pytest
 from gevent import Timeout
 from matrix_client.errors import MatrixRequestError
 
+from raiden.constants import DeviceIDs
 from raiden.network.transport.matrix.client import GMatrixClient, Room, User
 from raiden.network.transport.matrix.transport import MatrixTransport
 from raiden.network.transport.matrix.utils import (
@@ -55,7 +56,7 @@ def create_logged_in_client(server: str) -> Tuple[GMatrixClient, Signer]:
     client = make_client(ignore_messages, ignore_member_join, [server])
     signer = factories.make_signer()
 
-    login(client, signer)
+    login(client, signer, DeviceIDs.RAIDEN)
 
     return client, signer
 

--- a/raiden/tests/unit/test_matrix_transport.py
+++ b/raiden/tests/unit/test_matrix_transport.py
@@ -14,7 +14,7 @@ from matrix_client.user import User
 
 import raiden.network.transport.matrix.client
 import raiden.network.transport.matrix.utils
-from raiden.constants import ServerListType
+from raiden.constants import DeviceIDs, ServerListType
 from raiden.exceptions import TransportError
 from raiden.messages.synchronization import Processed
 from raiden.messages.transfers import RevealSecret
@@ -59,7 +59,7 @@ def test_login_for_the_first_time_must_set_the_display_name():
 
     signer = make_signer()
 
-    user = login(client=client, signer=signer)
+    user = login(client=client, signer=signer, device_id=DeviceIDs.RAIDEN)
 
     # client.user_id will be set by login
     assert client.user_id.startswith(f"@{to_normalized_address(signer.address)}")

--- a/tools/debugging/matrix/generate_messages.py
+++ b/tools/debugging/matrix/generate_messages.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import gevent.monkey  # isort:skip # noqa
 
+from raiden.constants import DeviceIDs
+
 gevent.monkey.patch_all()  # isort:skip # noqa
 import argparse
 import json
@@ -176,7 +178,7 @@ def new_user(matrix_server_url: str) -> LoggedUser:
     signer = factories.make_signer()
 
     with logtime(USER) as details:
-        user = login(client, signer)
+        user = login(client, signer, DeviceIDs.RAIDEN)
         details["user_id"] = user.user_id
 
     return LoggedUser(client, signer, user)

--- a/tools/debugging/matrix/presence_report.py
+++ b/tools/debugging/matrix/presence_report.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import gevent.monkey
 
+from raiden.constants import DeviceIDs
+
 gevent.monkey.patch_all()  # isort:skip # noqa
 
 import json
@@ -65,7 +67,11 @@ def main(keystore_file: str, password: str, host: str, room_id: str, other_user_
     private_key = get_private_key(keystore_file, password)
     client = GMatrixClient(host)
 
-    user = login(client=client, signer=LocalSigner(private_key=decode_hex(private_key)))
+    user = login(
+        client=client,
+        signer=LocalSigner(private_key=decode_hex(private_key)),
+        device_id=DeviceIDs.RAIDEN,
+    )
 
     log.info("Logged in", user=user, server=host, room_id=room_id)
     # print("TKN: \n" + client.token)


### PR DESCRIPTION
## Description

In order to send to specific devices, `device_id` needs to be passed as an argument at `login()`. Since services uses them as well. Additionally, there is a new Enum class for consistent Device_ID setting.  

Fixes: #6812

Currently, also `RAIDEN` as a device ID is used in test. I did not see a reason to have a test device ID. 

