### PR TITLE
Registry services addresses

### DIFF
--- a/raiden/blockchain/events.py
+++ b/raiden/blockchain/events.py
@@ -44,6 +44,7 @@ from raiden.utils.typing import (
 )
 from raiden_contracts.constants import (
     CONTRACT_TOKEN_NETWORK,
+    EVENT_REGISTERED_SERVICE,
     EVENT_TOKEN_NETWORK_CREATED,
     ChannelEvent,
 )
@@ -209,6 +210,10 @@ def decode_raiden_event_to_internal(
     elif event == ChannelEvent.UNLOCKED:
         args["receiver"] = to_canonical_address(args["receiver"])
         args["sender"] = to_canonical_address(args["sender"])
+
+    elif event == EVENT_REGISTERED_SERVICE:
+        args["service_address"] = to_canonical_address(args.pop("service"))
+        assert "valid_till" in args, f"{EVENT_REGISTERED_SERVICE} without 'valid_till'"
 
     return DecodedEvent(
         chain_id=chain_id,

--- a/raiden/network/transport/__init__.py
+++ b/raiden/network/transport/__init__.py
@@ -1,1 +1,2 @@
 from raiden.network.transport.matrix import MatrixTransport  # NOQA
+from raiden.network.transport.matrix.transport import populate_services_addresses  # NOQA

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -51,6 +51,7 @@ from raiden.transfer.events import (
     SendWithdrawConfirmation,
     SendWithdrawExpired,
     SendWithdrawRequest,
+    UpdateServicesAddresses,
 )
 from raiden.transfer.identifiers import CanonicalIdentifier, QueueIdentifier
 from raiden.transfer.mediated_transfer.events import (
@@ -220,6 +221,9 @@ class RaidenEventHandler(EventHandler):
             elif type(event) == ContractSendChannelWithdraw:
                 assert isinstance(event, ContractSendChannelWithdraw), MYPY_ANNOTATION
                 self.handle_contract_send_channelwithdraw(raiden, event)
+            elif type(event) == UpdateServicesAddresses:
+                assert isinstance(event, UpdateServicesAddresses), MYPY_ANNOTATION
+                self.handle_update_services_addresses(raiden, event)
             elif type(event) in UNEVENTFUL_EVENTS:
                 pass
             else:
@@ -822,6 +826,14 @@ class RaidenEventHandler(EventHandler):
             )
         except InsufficientEth as e:
             raise RaidenUnrecoverableError(str(e)) from e
+
+    @staticmethod
+    def handle_update_services_addresses(
+        raiden: "RaidenService", update_services_addresses: UpdateServicesAddresses
+    ) -> None:  # pragma: no unittest
+        raiden.transport.update_services_addresses(
+            {update_services_addresses.service_address: update_services_addresses.validity}
+        )
 
 
 class PFSFeedbackEventHandler(RaidenEventHandler):

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -49,6 +49,7 @@ from raiden.network.proxies.proxy_manager import ProxyManager
 from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.proxies.user_deposit import UserDeposit
 from raiden.network.rpc.client import JSONRPCClient
+from raiden.network.transport import populate_services_addresses
 from raiden.network.transport.matrix.transport import MatrixTransport, MessagesQueue
 from raiden.raiden_event_handler import EventHandler
 from raiden.services import send_pfs_update, update_monitoring_service_from_balance_proof
@@ -575,7 +576,10 @@ class RaidenService(Runnable):
             neighbour_nodes=[to_checksum_address(address) for address in health_check_list],
             node=to_checksum_address(self.address),
         )
-
+        if self.default_service_registry is not None:
+            populate_services_addresses(
+                self.transport, self.default_service_registry, BLOCK_ID_LATEST
+            )
         self.transport.start(
             raiden_service=self, prev_auth_data=None, health_check_list=health_check_list
         )

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -915,6 +915,11 @@ class RaidenService(Runnable):
                     pfs_fee_updates.add(canonical_identifier)
                 else:
                     pfs_capacity_updates.add(canonical_identifier)
+            if isinstance(state_change, Block):
+                self.transport.expire_services_addresses(
+                    self.rpc_client.get_block(state_change.block_hash)["timestamp"],
+                    state_change.block_number,
+                )
 
         for event in events:
             if isinstance(event, PFS_UPDATE_FEE_EVENTS):

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -224,6 +224,7 @@ def initiator_init(
 def smart_contract_filters_from_node_state(
     chain_state: ChainState,
     secret_registry_address: SecretRegistryAddress,
+    service_registry: Optional[ServiceRegistry],
 ) -> RaidenContractFilter:
     token_network_registries = chain_state.identifiers_to_tokennetworkregistries.values()
     token_networks = [tn for tnr in token_network_registries for tn in tnr.token_network_list]
@@ -239,6 +240,7 @@ def smart_contract_filters_from_node_state(
         token_network_addresses={tn.address for tn in token_networks},
         channels_of_token_network=channels_of_token_network,
         ignore_secret_registry_until_channel_found=not channels_of_token_network,
+        service_registry=service_registry,
     )
 
 
@@ -751,7 +753,9 @@ class RaidenService(Runnable):
         event_filter = smart_contract_filters_from_node_state(
             chain_state,
             self.default_secret_registry.address,
+            self.default_service_registry,
         )
+
         log.debug("initial filter", event_filter=event_filter, node=self.address)
         blockchain_events = BlockchainEvents(
             web3=self.rpc_client.web3,

--- a/raiden/tests/integration/network/proxies/test_service_registry.py
+++ b/raiden/tests/integration/network/proxies/test_service_registry.py
@@ -3,13 +3,19 @@ from unittest.mock import Mock, patch
 import pytest
 from eth_utils import to_canonical_address
 
+from raiden.blockchain.decode import update_service_addresses_from_event
+from raiden.blockchain.events import decode_raiden_event_to_internal
+from raiden.blockchain.filters import RaidenContractFilter
 from raiden.constants import BLOCK_ID_LATEST
 from raiden.exceptions import BrokenPreconditionError
 from raiden.network.pathfinding import get_random_pfs, get_valid_pfs_url
+from raiden.settings import RAIDEN_CONTRACT_VERSION
 from raiden.tests.utils.factories import HOP1
 from raiden.tests.utils.smartcontracts import deploy_service_registry_and_set_urls
+from raiden.transfer.events import UpdateServicesAddresses
 from raiden.utils.keys import privatekey_to_address
 from raiden.utils.typing import FeeAmount, TokenNetworkRegistryAddress
+from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 
 token_network_registry_address_test_default = TokenNetworkRegistryAddress(
     to_canonical_address("0xB9633dd9a9a71F22C933bF121d7a22008f66B908")
@@ -76,3 +82,40 @@ def test_service_registry_random_pfs(
             get_random_pfs(c1_service_proxy, BLOCK_ID_LATEST, pathfinding_max_fee=FeeAmount(100))
             in urls
         )
+
+
+def test_service_registry_events(service_registry_address, private_keys, web3, contract_manager):
+    """
+    - Test that `RaidenContractFilter` successfully matches on `RegisteredService`.
+    - Test that blockchain-event, state_change and raiden-event decoding methods work.
+    """
+    c1_service_proxy, _ = deploy_service_registry_and_set_urls(
+        private_keys=private_keys,
+        web3=web3,
+        contract_manager=contract_manager,
+        service_registry_address=service_registry_address,
+    )
+    assert c1_service_proxy.ever_made_deposits_len(BLOCK_ID_LATEST) == 3
+
+    # register filter
+    event_filter = RaidenContractFilter(service_registry=c1_service_proxy)
+
+    manager = ContractManager(contracts_precompiled_path(RAIDEN_CONTRACT_VERSION))
+    flt = event_filter.to_web3_filters(
+        contract_manager=manager,
+        from_block=0,
+        to_block="latest",
+        node_address="0x6666666666666666666666666666666666666666",
+    )
+    web3 = c1_service_proxy.client.web3
+    flt[0].pop("_name")
+    events = web3.eth.getLogs(flt[0])
+    assert len(events) == 3
+
+    ABI = c1_service_proxy.proxy.abi
+    decoded_events = [decode_raiden_event_to_internal(ABI, 0, ev) for ev in events]
+    assert len(decoded_events) == 3
+    state_changes = [update_service_addresses_from_event(ev) for ev in decoded_events]
+    assert len(state_changes) == 3
+    raiden_events = [UpdateServicesAddresses.from_state_change(sc) for sc in state_changes]
+    assert len(raiden_events) == 3

--- a/raiden/transfer/events.py
+++ b/raiden/transfer/events.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from eth_utils import to_hex
 
@@ -32,6 +33,9 @@ from raiden.utils.typing import (
     TokenNetworkRegistryAddress,
     WithdrawAmount,
 )
+
+if TYPE_CHECKING:
+    from raiden.transfer.state_change import UpdateServicesAddressesStateChange
 
 # pylint: disable=too-many-arguments,too-few-public-methods
 
@@ -205,6 +209,23 @@ class ContractSendSecretReveal(ContractSendExpirableEvent):
         secrethash = sha256_secrethash(self.secret)
         return "ContractSendSecretReveal(secrethash={} triggered_by_block_hash={})".format(
             to_hex(secrethash), to_hex(self.triggered_by_block_hash)
+        )
+
+
+@dataclass(frozen=True)
+class UpdateServicesAddresses(Event):
+    """Transition used when adding a new service address."""
+
+    service_address: Address
+    validity: int
+
+    @staticmethod
+    def from_state_change(
+        state_change: "UpdateServicesAddressesStateChange",
+    ) -> "UpdateServicesAddresses":
+        return UpdateServicesAddresses(
+            service_address=state_change.service,
+            validity=state_change.valid_till,
         )
 
 

--- a/raiden/transfer/node.py
+++ b/raiden/transfer/node.py
@@ -15,6 +15,7 @@ from raiden.transfer.events import (
     ContractSendChannelWithdraw,
     ContractSendSecretReveal,
     SendWithdrawRequest,
+    UpdateServicesAddresses,
 )
 from raiden.transfer.identifiers import (
     CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
@@ -62,6 +63,7 @@ from raiden.transfer.state_change import (
     ReceiveWithdrawConfirmation,
     ReceiveWithdrawExpired,
     ReceiveWithdrawRequest,
+    UpdateServicesAddressesStateChange,
 )
 from raiden.utils.copy import deepcopy
 from raiden.utils.typing import (
@@ -729,6 +731,13 @@ def handle_receive_processed(
     return TransitionResult(chain_state, events)
 
 
+def handle_update_services_addresses_state_change(
+    chain_state: ChainState, state_change: UpdateServicesAddressesStateChange
+) -> TransitionResult[ChainState]:
+
+    return TransitionResult(chain_state, [UpdateServicesAddresses.from_state_change(state_change)])
+
+
 def handle_receive_unlock(
     chain_state: ChainState, state_change: ReceiveUnlock
 ) -> TransitionResult[ChainState]:
@@ -838,6 +847,9 @@ def handle_state_change(
     elif type(state_change) == ReceiveWithdrawExpired:
         assert isinstance(state_change, ReceiveWithdrawExpired), MYPY_ANNOTATION
         iteration = handle_receive_withdraw_expired(chain_state, state_change)
+    elif type(state_change) == UpdateServicesAddressesStateChange:
+        assert isinstance(state_change, UpdateServicesAddressesStateChange), MYPY_ANNOTATION
+        iteration = handle_update_services_addresses_state_change(chain_state, state_change)
     else:
         iteration = TransitionResult(chain_state, [])
 

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -415,3 +415,11 @@ class ReceiveWithdrawExpired(AuthenticatedSenderStateChange):
     @property
     def token_network_address(self) -> TokenNetworkAddress:
         return self.canonical_identifier.token_network_address
+
+
+@dataclass(frozen=True)
+class UpdateServicesAddressesStateChange(StateChange):
+    """ A `RegisteredService` contract event was received. """
+
+    service: Address
+    valid_till: int

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -8,6 +8,7 @@ import structlog
 from eth_typing import URI
 from eth_utils import is_address, to_canonical_address
 from web3 import HTTPProvider, Web3
+from web3.types import BlockIdentifier
 
 from raiden.accounts import AccountManager
 from raiden.api.rest import APIServer, RestAPI
@@ -33,8 +34,9 @@ from raiden.exceptions import ConfigurationError, RaidenError
 from raiden.message_handler import MessageHandler
 from raiden.network.pathfinding import check_pfs_transport_configuration
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
+from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.network.transport import MatrixTransport
+from raiden.network.transport import MatrixTransport, populate_services_addresses
 from raiden.network.transport.matrix import make_room_alias
 from raiden.raiden_event_handler import EventHandler, PFSFeedbackEventHandler, RaidenEventHandler
 from raiden.raiden_service import RaidenService
@@ -112,6 +114,8 @@ def setup_matrix(
     services_config: ServiceConfig,
     environment_type: Environment,
     routing_mode: RoutingMode,
+    service_registry: Optional[ServiceRegistry],
+    block_identifier: BlockIdentifier,
 ) -> MatrixTransport:
     # Add PFS broadcast room when not in private mode
     if routing_mode != RoutingMode.PRIVATE:
@@ -122,7 +126,11 @@ def setup_matrix(
     if services_config.monitoring_enabled is True:
         transport_config.broadcast_rooms.append(MONITORING_BROADCASTING_ROOM)
 
-    return MatrixTransport(config=transport_config, environment=environment_type)
+    transport = MatrixTransport(config=transport_config, environment=environment_type)
+    if service_registry is not None:
+        populate_services_addresses(transport, service_registry, block_identifier)
+
+    return transport
 
 
 def get_account_and_private_key(
@@ -435,7 +443,12 @@ def run_raiden_service(
     )
 
     matrix_transport = setup_matrix(
-        config.transport, config.services, config.environment_type, routing_mode
+        config.transport,
+        config.services,
+        config.environment_type,
+        routing_mode,
+        services_bundle.service_registry,
+        BLOCK_ID_LATEST,
     )
 
     event_handler: EventHandler = RaidenEventHandler()

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -8,7 +8,6 @@ import structlog
 from eth_typing import URI
 from eth_utils import is_address, to_canonical_address
 from web3 import HTTPProvider, Web3
-from web3.types import BlockIdentifier
 
 from raiden.accounts import AccountManager
 from raiden.api.rest import APIServer, RestAPI
@@ -34,9 +33,8 @@ from raiden.exceptions import ConfigurationError, RaidenError
 from raiden.message_handler import MessageHandler
 from raiden.network.pathfinding import check_pfs_transport_configuration
 from raiden.network.proxies.proxy_manager import ProxyManager, ProxyManagerMetadata
-from raiden.network.proxies.service_registry import ServiceRegistry
 from raiden.network.rpc.client import JSONRPCClient
-from raiden.network.transport import MatrixTransport, populate_services_addresses
+from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix import make_room_alias
 from raiden.raiden_event_handler import EventHandler, PFSFeedbackEventHandler, RaidenEventHandler
 from raiden.raiden_service import RaidenService
@@ -114,8 +112,6 @@ def setup_matrix(
     services_config: ServiceConfig,
     environment_type: Environment,
     routing_mode: RoutingMode,
-    service_registry: Optional[ServiceRegistry],
-    block_identifier: BlockIdentifier,
 ) -> MatrixTransport:
     # Add PFS broadcast room when not in private mode
     if routing_mode != RoutingMode.PRIVATE:
@@ -126,11 +122,7 @@ def setup_matrix(
     if services_config.monitoring_enabled is True:
         transport_config.broadcast_rooms.append(MONITORING_BROADCASTING_ROOM)
 
-    transport = MatrixTransport(config=transport_config, environment=environment_type)
-    if service_registry is not None:
-        populate_services_addresses(transport, service_registry, block_identifier)
-
-    return transport
+    return MatrixTransport(config=transport_config, environment=environment_type)
 
 
 def get_account_and_private_key(
@@ -447,8 +439,6 @@ def run_raiden_service(
         config.services,
         config.environment_type,
         routing_mode,
-        services_bundle.service_registry,
-        BLOCK_ID_LATEST,
     )
 
     event_handler: EventHandler = RaidenEventHandler()


### PR DESCRIPTION
## Description

Fixes: #6813 

This adds
- a mapping for `service_address => validity_timestamp` to `MatrixTransport`
- methods for populating and modifying the mapping
- actions on new `Block` to prune services with expired validity
- a blockchain event filter to listen for new `ServiceRegistry.sol::RegisteredService` events
- an almost effect-less ("phony") state change on such blockchain events (does not change state, but yields a raiden event, see below)
- a raiden event to update the service addresses in the transport

This should give us the necessary data structure in `MatrixTransport` to send `toDevice` messages to the services.
