### PR TITLE
Upgrade rlp to 2.0.1 to get rid of warning

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -296,10 +296,15 @@ imagesize==1.1.0
     # via
     #   -r requirements-dev.txt
     #   sphinx
-importlib-metadata==2.0.0
+importlib-metadata==3.4.0
     # via
     #   -r requirements-dev.txt
+    #   flake8
+    #   flake8-comprehensions
+    #   jsonschema
     #   pluggy
+    #   pyinstaller
+    #   pytest
 incremental==17.5.0
     # via
     #   -r requirements-dev.txt
@@ -351,7 +356,9 @@ lru-dict==1.1.6
     #   -r requirements-dev.txt
     #   web3
 macholib==1.14
-    # via -r requirements-ci.in
+    # via
+    #   -r requirements-ci.in
+    #   pyinstaller
 markupsafe==1.1.1
     # via
     #   -r requirements-dev.txt
@@ -621,7 +628,7 @@ requests==2.25.1
     #   web3
 responses==0.10.15
     # via -r requirements-dev.txt
-rlp==2.0.0
+rlp==2.0.1
     # via
     #   -r requirements-dev.txt
     #   eth-account
@@ -760,15 +767,18 @@ twisted[tls]==20.3.0
 typed-ast==1.4.0
     # via
     #   -r requirements-dev.txt
+    #   astroid
     #   black
     #   mypy
 typing-extensions==3.7.4.3
     # via
     #   -r requirements-dev.txt
     #   black
+    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
+    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements-dev.txt

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -269,8 +269,14 @@ imagesize==1.1.0
     # via
     #   -r requirements-docs.txt
     #   sphinx
-importlib-metadata==2.0.0
-    # via pluggy
+importlib-metadata==3.4.0
+    # via
+    #   -r requirements.txt
+    #   flake8
+    #   flake8-comprehensions
+    #   jsonschema
+    #   pluggy
+    #   pytest
 incremental==17.5.0
     # via
     #   treq
@@ -536,7 +542,7 @@ requests==2.25.1
     #   web3
 responses==0.10.15
     # via -r requirements-dev.in
-rlp==2.0.0
+rlp==2.0.1
     # via
     #   -r requirements.txt
     #   eth-account
@@ -663,15 +669,18 @@ twisted[tls]==20.3.0
     #   treq
 typed-ast==1.4.0
     # via
+    #   astroid
     #   black
     #   mypy
 typing-extensions==3.7.4.3
     # via
     #   -r requirements.txt
     #   black
+    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
+    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements.txt
@@ -716,7 +725,9 @@ wmctrl==0.3
 wrapt==1.11.1
     # via astroid
 zipp==3.4.0
-    # via importlib-metadata
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata
 zope.event==4.4
     # via
     #   -r requirements.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -121,6 +121,8 @@ hexbytes==0.2.0
     #   web3
 idna==2.8
     # via requests
+importlib-metadata==3.4.0
+    # via jsonschema
 ipfshttpclient==0.7.0a1
     # via web3
 itsdangerous==1.1.0
@@ -201,7 +203,7 @@ requests==2.25.1
     #   ipfshttpclient
     #   matrix-client
     #   web3
-rlp==2.0.0
+rlp==2.0.1
     # via
     #   eth-account
     #   eth-rlp
@@ -228,7 +230,10 @@ toml==0.10.2
 toolz==0.9.0
     # via cytoolz
 typing-extensions==3.7.4.3
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   importlib-metadata
+    #   web3
 typing-inspect==0.4.0
     # via marshmallow-dataclass
 ulid-py==1.1.0
@@ -245,6 +250,8 @@ websockets==8.1
     # via web3
 werkzeug==1.0.1
     # via flask
+zipp==3.4.0
+    # via importlib-metadata
 zope.event==4.4
     # via gevent
 zope.interface==5.1.0


### PR DESCRIPTION
## Description

rlp 2.0.0 used to unconditionally log a recommendation to install rusty-rlp.
This has been fixed in 2.0.1. See ethereum/pyrlp#129.
