### PR TITLE
Feature/client notifications 6838

### DIFF
--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -33,3 +33,11 @@ class PartnersPerToken:
     def __init__(self, partner_address: Address, channel: str) -> None:
         self.partner_address = partner_address
         self.channel = channel
+
+
+class Notification:
+    def __init__(self, notification_id: str, summary: str, body: str, urgency: str) -> None:
+        self.notification_id = notification_id
+        self.summary = summary
+        self.body = body
+        self.urgency = urgency

--- a/raiden/api/objects.py
+++ b/raiden/api/objects.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from raiden.utils.typing import List, TokenAddress
 
 
@@ -35,9 +36,9 @@ class PartnersPerToken:
         self.channel = channel
 
 
+@dataclass
 class Notification:
-    def __init__(self, notification_id: str, summary: str, body: str, urgency: str) -> None:
-        self.notification_id = notification_id
-        self.summary = summary
-        self.body = body
-        self.urgency = urgency
+    id: str
+    summary: str
+    body: str
+    urgency: str

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1,11 +1,9 @@
 import gevent
-from collections import defaultdict
 import structlog
 from eth_utils import is_binary_address
 
 from raiden import waiting
 from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
-from raiden.api.objects import Notification
 from raiden.constants import NULL_ADDRESS_BYTES, UINT64_MAX, UINT256_MAX
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
@@ -193,7 +191,7 @@ class RaidenAPI:  # pragma: no unittest
         return self.raiden.address
 
     @property
-    def notifications(self) -> List:
+    def notifications(self) -> Dict:
         return self.raiden.notifications
 
     @property
@@ -1324,13 +1322,10 @@ class RaidenAPI:  # pragma: no unittest
             amount=amount, given_block_identifier=confirmed_block_identifier
         )
 
-    def get_new_notifications(self):
-        notifications = self.raiden.notifications
-        self.raiden.notifications = defaultdict(lambda x: None)
-        return notifications.items()
-
-    def add_notification(self, notification: Notification) -> None:
-        self.raiden.notifications[notification["id"]] = notification
+    def get_new_notifications(self) -> List:
+        notifications = list(self.raiden.notifications.values())
+        self.raiden.notifications = {}
+        return notifications
 
     def shutdown(self) -> None:
         self.raiden.stop()

--- a/raiden/api/python.py
+++ b/raiden/api/python.py
@@ -1,9 +1,11 @@
 import gevent
+from collections import defaultdict
 import structlog
 from eth_utils import is_binary_address
 
 from raiden import waiting
 from raiden.api.exceptions import ChannelNotFound, NonexistingChannel
+from raiden.api.objects import Notification
 from raiden.constants import NULL_ADDRESS_BYTES, UINT64_MAX, UINT256_MAX
 from raiden.exceptions import (
     AlreadyRegisteredTokenAddress,
@@ -189,6 +191,10 @@ class RaidenAPI:  # pragma: no unittest
     @property
     def address(self) -> Address:
         return self.raiden.address
+
+    @property
+    def notifications(self) -> List:
+        return self.raiden.notifications
 
     @property
     def config(self) -> PythonApiConfig:
@@ -1317,6 +1323,14 @@ class RaidenAPI:  # pragma: no unittest
         return user_deposit.withdraw(
             amount=amount, given_block_identifier=confirmed_block_identifier
         )
+
+    def get_new_notifications(self):
+        notifications = self.raiden.notifications
+        self.raiden.notifications = defaultdict(lambda x: None)
+        return notifications.items()
+
+    def add_notification(self, notification: Notification) -> None:
+        self.raiden.notifications[notification["id"]] = notification
 
     def shutdown(self) -> None:
         self.raiden.stop()

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -31,9 +31,9 @@ from raiden.api.v1.encoding import (
     EventPaymentSentSuccessSchema,
     HexAddressConverter,
     InvalidEndpoint,
+    NotificationSchema,
     PartnersPerTokenListSchema,
     PaymentSchema,
-    NotificationSchema,
 )
 from raiden.api.v1.resources import (
     AddressResource,

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -33,6 +33,7 @@ from raiden.api.v1.encoding import (
     InvalidEndpoint,
     PartnersPerTokenListSchema,
     PaymentSchema,
+    NotificationSchema,
 )
 from raiden.api.v1.resources import (
     AddressResource,
@@ -44,6 +45,7 @@ from raiden.api.v1.resources import (
     ContractsResource,
     MintTokenResource,
     NodeSettingsResource,
+    NotificationsResource,
     PartnersResourceByTokenAddress,
     PaymentEventsResource,
     PaymentResource,
@@ -147,6 +149,7 @@ URLS_V1 = [
     ),
     ("/connections/<hexaddress:token_address>", ConnectionsResource),
     ("/connections", ConnectionsInfoResource),
+    ("/notifications", NotificationsResource),
     ("/payments", PaymentEventsResource, "paymentresource"),
     ("/payments/<hexaddress:token_address>", PaymentEventsResource, "token_paymentresource"),
     (
@@ -456,6 +459,7 @@ class RestAPI:  # pragma: no unittest
         self.sent_success_payment_schema = EventPaymentSentSuccessSchema()
         self.received_success_payment_schema = EventPaymentReceivedSuccessSchema()
         self.failed_payment_schema = EventPaymentSentFailedSchema()
+        self.notification_schema = NotificationSchema()
 
     @property
     def rpc_client(self) -> JSONRPCClient:
@@ -1000,6 +1004,13 @@ class RestAPI:  # pragma: no unittest
             "secret_hash": sha256(result.secret).digest(),
         }
         result = self.payment_schema.dump(payment)
+        return api_response(result=result)
+
+    def get_new_notifications(self) -> Response:
+        log.debug("Requesting new notifications")
+
+        notifications = self.raiden_api.get_new_notifications()
+        result = self.notification_schema.dump(notifications, many=True)
         return api_response(result=result)
 
     def _updated_channel_state_from_addresses(

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -376,7 +376,7 @@ class UserDepositPostSchema(BaseSchema):
 
 
 class NotificationSchema(BaseSchema):
-    notification_id = fields.String()
+    id = fields.String()
     summary = fields.String()
     body = fields.String()
     urgency = fields.String(

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -373,3 +373,12 @@ class UserDepositPostSchema(BaseSchema):
     total_deposit = IntegerToStringField(default=None, missing=None)
     planned_withdraw_amount = IntegerToStringField(default=None, missing=None)
     withdraw_amount = IntegerToStringField(default=None, missing=None)
+
+
+class Notification(BaseSchema):
+    notification_id = fields.String()
+    summary = fields.String()
+    body = fields.String()
+    urgency = fields.String(
+        default=None, missing=None, validate=validate.OneOf(["normal", "low", "critical"])
+    )

--- a/raiden/api/v1/encoding.py
+++ b/raiden/api/v1/encoding.py
@@ -375,7 +375,7 @@ class UserDepositPostSchema(BaseSchema):
     withdraw_amount = IntegerToStringField(default=None, missing=None)
 
 
-class Notification(BaseSchema):
+class NotificationSchema(BaseSchema):
     notification_id = fields.String()
     summary = fields.String()
     body = fields.String()

--- a/raiden/api/v1/resources.py
+++ b/raiden/api/v1/resources.py
@@ -276,3 +276,9 @@ class ShutdownResource(BaseResource):
     @if_api_available
     def post(self) -> Response:
         return self.rest_api.shutdown()
+
+
+class NotificationsResource(BaseResource):
+    @if_api_available
+    def get(self) -> Response:
+        return self.rest_api.get_new_notifications()

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -359,6 +359,9 @@ class RaidenService(Runnable):
         self.default_msc_address = monitoring_service_address
         self.routing_mode = routing_mode
         self.config = config
+        self.notifications = defaultdict(
+            lambda x: None
+        )  # notifications are unique (and indexed) by id.
 
         self.signer: Signer = LocalSigner(self.rpc_client.privkey)
         self.address = self.signer.address

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -317,20 +317,16 @@ class RaidenService(Runnable):
             BLOCK_ID_LATEST
         )
         invalid_settle_timeout = (
-            config.settle_timeout < settlement_timeout_min
-            or config.settle_timeout > settlement_timeout_max
+            settlement_timeout_max > config.settle_timeout < settlement_timeout_min
             or config.settle_timeout < config.reveal_timeout * 2
         )
         if invalid_settle_timeout:
+            contract = to_checksum_address(raiden_bundle.token_network_registry.address)
             raise InvalidSettleTimeout(
                 (
-                    "Settlement timeout for Registry contract {} must "
-                    "be in range [{}, {}], is {}"
-                ).format(
-                    to_checksum_address(raiden_bundle.token_network_registry.address),
-                    settlement_timeout_min,
-                    settlement_timeout_max,
-                    config.settle_timeout,
+                    f"Settlement timeout for Registry contract {contract} must "
+                    f"be in range [{settlement_timeout_min}, {settlement_timeout_max}], "
+                    f"is {config.settle_timeout}"
                 )
             )
 

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 
 from raiden.api.rest import APIServer
 from raiden.raiden_service import RaidenService
@@ -13,10 +12,6 @@ from raiden.utils.typing import List
 #       been invoked.
 @pytest.fixture
 def api_server_test_instance(raiden_network: List[RaidenService]) -> APIServer:
-    print("-" * 200)
-    print("testing")
-    print("-" * 200)
-
     api_server = prepare_api_server(raiden_network[0])
 
     yield api_server
@@ -24,9 +19,5 @@ def api_server_test_instance(raiden_network: List[RaidenService]) -> APIServer:
 
 @pytest.fixture
 def client(api_server_test_instance):
-    with api_server_test_instance.test_client() as client:
-        with api_server_test_instance.app_context():
-            api_server_test_instance.init_db()
+    with api_server_test_instance.flask_app.test_client() as client:
         yield client
-
-    os.unlink(api_server_test_instance.config["DATABASE"])

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from raiden.api.rest import APIServer
 from raiden.raiden_service import RaidenService
@@ -12,6 +13,20 @@ from raiden.utils.typing import List
 #       been invoked.
 @pytest.fixture
 def api_server_test_instance(raiden_network: List[RaidenService]) -> APIServer:
+    print("-" * 200)
+    print("testing")
+    print("-" * 200)
+
     api_server = prepare_api_server(raiden_network[0])
 
-    return api_server
+    yield api_server
+
+
+@pytest.fixture
+def client(api_server_test_instance):
+    with api_server_test_instance.test_client() as client:
+        with api_server_test_instance.app_context():
+            api_server_test_instance.init_db()
+        yield client
+
+    os.unlink(api_server_test_instance.config["DATABASE"])

--- a/raiden/tests/integration/api/fixtures.py
+++ b/raiden/tests/integration/api/fixtures.py
@@ -1,6 +1,7 @@
+from collections.abc import Generator
+
 import pytest
 
-from raiden.api.rest import APIServer
 from raiden.raiden_service import RaidenService
 from raiden.tests.integration.api.utils import prepare_api_server
 from raiden.utils.typing import List
@@ -11,7 +12,7 @@ from raiden.utils.typing import List
 #       the server is no longer running even though the teardown has not
 #       been invoked.
 @pytest.fixture
-def api_server_test_instance(raiden_network: List[RaidenService]) -> APIServer:
+def api_server_test_instance(raiden_network: List[RaidenService]) -> Generator:
     api_server = prepare_api_server(raiden_network[0])
 
     yield api_server

--- a/raiden/tests/integration/api/rest/test_notifications_endpoint.py
+++ b/raiden/tests/integration/api/rest/test_notifications_endpoint.py
@@ -1,0 +1,7 @@
+from raiden.tests.utils.detect_failure import raise_on_failure
+
+
+@raise_on_failure
+def test_get_empty_notifications(client):
+    response = client.get("/notifications")
+    assert response.get_json() == []

--- a/raiden/tests/integration/api/rest/test_notifications_endpoint.py
+++ b/raiden/tests/integration/api/rest/test_notifications_endpoint.py
@@ -60,7 +60,9 @@ def test_get_notifications_empty_queue(client, api_server_test_instance):
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_notifications_with_same_id_are_overwritten(client, api_server_test_instance):
     for i in range(3):
-        create_notification(api_server_test_instance, id="same_id", summary=f"summary_{i}")
+        create_notification(
+            api_server_test_instance, notification_id="same_id", summary=f"summary_{i}"
+        )
 
     response = client.get(notifications_endpoint)
     response = response.get_json()
@@ -68,9 +70,9 @@ def test_notifications_with_same_id_are_overwritten(client, api_server_test_inst
     assert response[0]["summary"] == "summary_2"
 
 
-def create_notification(api_server, id=None, summary=None, body=None, urgency=None):
+def create_notification(api_server, notification_id=None, summary=None, body=None, urgency=None):
     notification_opts = {
-        "id": id or fake.bs(),
+        "id": notification_id or fake.bs(),
         "summary": summary or fake.text(max_nb_chars=20),
         "body": body or fake.sentence(nb_words=7),
         "urgency": urgency or random.choice(["low", "normal", "critical"]),

--- a/raiden/tests/integration/api/rest/test_notifications_endpoint.py
+++ b/raiden/tests/integration/api/rest/test_notifications_endpoint.py
@@ -1,7 +1,11 @@
+import pytest
 from raiden.tests.utils.detect_failure import raise_on_failure
 
 
 @raise_on_failure
-def test_get_empty_notifications(client):
-    response = client.get("/notifications")
+@pytest.mark.parametrize("number_of_nodes", [1])
+@pytest.mark.parametrize("channels_per_node", [0])
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_get_empty_notifications(client, api_server_test_instance):
+    response = client.get("/api/v1/notifications")
     assert response.get_json() == []

--- a/raiden/tests/integration/api/rest/test_notifications_endpoint.py
+++ b/raiden/tests/integration/api/rest/test_notifications_endpoint.py
@@ -1,11 +1,80 @@
+import random
+
 import pytest
+from faker import Faker
+
+from raiden.api.objects import Notification
 from raiden.tests.utils.detect_failure import raise_on_failure
+
+fake = Faker()
+notifications_endpoint = "/api/v1/notifications"
 
 
 @raise_on_failure
-@pytest.mark.parametrize("number_of_nodes", [1])
-@pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_get_empty_notifications(client, api_server_test_instance):
-    response = client.get("/api/v1/notifications")
+    assert api_server_test_instance
+    response = client.get(notifications_endpoint)
     assert response.get_json() == []
+
+
+@raise_on_failure
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_get_notification(client, api_server_test_instance):
+    notification = create_notification(api_server_test_instance)
+    response = client.get(notifications_endpoint)
+    assert response.get_json() == [
+        {
+            "id": notification.id,
+            "summary": notification.summary,
+            "body": notification.body,
+            "urgency": notification.urgency,
+        }
+    ]
+
+
+@raise_on_failure
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_get_many_notifications(client, api_server_test_instance):
+    total_notifications = 3
+    for _ in range(total_notifications):
+        create_notification(api_server_test_instance)
+
+    response = client.get(notifications_endpoint)
+    assert len(response.get_json()) == total_notifications
+
+
+@raise_on_failure
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_get_notifications_empty_queue(client, api_server_test_instance):
+    create_notification(api_server_test_instance)
+
+    response = client.get(notifications_endpoint)
+    assert response.get_json() != []
+
+    response = client.get(notifications_endpoint)
+    assert response.get_json() == []
+
+
+@raise_on_failure
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_notifications_with_same_id_are_overwritten(client, api_server_test_instance):
+    for i in range(3):
+        create_notification(api_server_test_instance, id="same_id", summary=f"summary_{i}")
+
+    response = client.get(notifications_endpoint)
+    response = response.get_json()
+    assert len(response) == 1
+    assert response[0]["summary"] == "summary_2"
+
+
+def create_notification(api_server, id=None, summary=None, body=None, urgency=None):
+    notification_opts = {
+        "id": id or fake.bs(),
+        "summary": summary or fake.text(max_nb_chars=20),
+        "body": body or fake.sentence(nb_words=7),
+        "urgency": urgency or random.choice(["low", "normal", "critical"]),
+    }
+    notification = Notification(**notification_opts)
+    api_server.rest_api.raiden_api.raiden.add_notification(notification)
+    return notification

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -378,7 +378,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements-dev.txt
-matrix-synapse==1.29.0
+matrix-synapse==1.27.0
     # via -r requirements-dev.txt
 mccabe==0.6.1
     # via

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -30,6 +30,10 @@ appdirs==1.4.3
     # via
     #   -r requirements-dev.txt
     #   black
+appnope==0.1.2
+    # via
+    #   -r requirements-dev.txt
+    #   ipython
 asn1crypto==1.3.0
     # via
     #   -r requirements-dev.txt
@@ -223,6 +227,8 @@ execnet==1.6.0
     # via
     #   -r requirements-dev.txt
     #   pytest-xdist
+faker==6.6.0
+    # via -r requirements-dev.txt
 fancycompleter==0.8
     # via
     #   -r requirements-dev.txt
@@ -351,7 +357,9 @@ lru-dict==1.1.6
     #   -r requirements-dev.txt
     #   web3
 macholib==1.14
-    # via -r requirements-ci.in
+    # via
+    #   -r requirements-ci.in
+    #   pyinstaller
 markupsafe==1.1.1
     # via
     #   -r requirements-dev.txt
@@ -370,7 +378,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements-dev.txt
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
     # via -r requirements-dev.txt
 mccabe==0.6.1
     # via
@@ -580,8 +588,11 @@ pytest==6.2.2
     #   pytest-random
     #   pytest-select
     #   pytest-xdist
-python-dateutil==2.8.0
-    # via s3cmd
+python-dateutil==2.8.1
+    # via
+    #   -r requirements-dev.txt
+    #   faker
+    #   s3cmd
 python-magic==0.4.15
     # via s3cmd
 pytz==2019.1
@@ -732,6 +743,10 @@ sphinxcontrib-serializinghtml==1.1.4
     #   sphinx
 structlog==21.1.0
     # via -r requirements-dev.txt
+text-unidecode==1.3
+    # via
+    #   -r requirements-dev.txt
+    #   faker
 toml==0.10.2
     # via
     #   -r requirements-dev.txt

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -47,5 +47,5 @@ coverage
 bump2version
 
 # Test support
-matrix-synapse==1.29.0
+matrix-synapse==1.27.0
 six>=1.13.0  # work around bad deps declaration in treq, see https://github.com/twisted/treq/commit/934e127a2b915bf02be86d23f2cf8a65bcdb2533#r42782781

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -31,6 +31,7 @@ hypothesis
 raiden-api-client
 responses
 flaky
+Faker
 
 # Debugging
 ipython
@@ -46,5 +47,5 @@ coverage
 bump2version
 
 # Test support
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
 six>=1.13.0  # work around bad deps declaration in treq, see https://github.com/twisted/treq/commit/934e127a2b915bf02be86d23f2cf8a65bcdb2533#r42782781

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -336,7 +336,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements.txt
-matrix-synapse==1.29.0
+matrix-synapse==1.27.0
     # via -r requirements-dev.in
 mccabe==0.6.1
     # via

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -22,6 +22,8 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.3
     # via black
+appnope==0.1.2
+    # via ipython
 asn1crypto==1.3.0
     # via
     #   -r requirements.txt
@@ -200,6 +202,8 @@ eth-utils==1.10.0
     #   web3
 execnet==1.6.0
     # via pytest-xdist
+faker==6.6.0
+    # via -r requirements-dev.in
 fancycompleter==0.8
     # via pdbpp
 filelock==3.0.12
@@ -332,7 +336,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements.txt
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
     # via -r requirements-dev.in
 mccabe==0.6.1
     # via
@@ -501,6 +505,8 @@ pytest==6.2.2
     #   pytest-random
     #   pytest-select
     #   pytest-xdist
+python-dateutil==2.8.1
+    # via faker
 pytz==2019.1
     # via
     #   -r requirements-docs.txt
@@ -584,6 +590,7 @@ six==1.15.0
     #   pynacl
     #   pyopenssl
     #   pyrsistent
+    #   python-dateutil
     #   readme-renderer
     #   responses
     #   sphinxcontrib-httpdomain
@@ -641,6 +648,8 @@ sphinxcontrib-serializinghtml==1.1.4
     #   sphinx
 structlog==21.1.0
     # via -r requirements.txt
+text-unidecode==1.3
+    # via faker
 toml==0.10.2
     # via
     #   -r requirements.txt


### PR DESCRIPTION
## Implement a basic notification service 

Fixes: #6838 

WIP

This PR introduces the `Notification` as a new object, creates a dictionary on `RaidenServices` to store notifications indexing by the id, they can be accessed by the rest api. Getting the notifications clear the queue on RaidenServices.