### PR TITLE
Add optional AddressMetadata processing to transport

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -723,7 +723,7 @@ class MatrixTransport(Runnable):
                 )
 
             # These are not protocol messages, but transport specific messages
-            for message in queue.messages:
+            for message, _ in queue.messages:
                 if isinstance(message, (Delivered, Ping, Pong)):
                     raise ValueError(
                         f"Do not use send_async for {message.__class__.__name__} messages"
@@ -741,7 +741,8 @@ class MatrixTransport(Runnable):
                 "Send async",
                 receiver_address=to_checksum_address(receiver_address),
                 messages=[
-                    redact_secret(DictSerializer.serialize(message)) for message in queue.messages
+                    redact_secret(DictSerializer.serialize(message))
+                    for message, _ in queue.messages
                 ],
                 queue_identifier=queue.queue_identifier,
             )

--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import Optional, Tuple
 
 import structlog
 from eth_utils import encode_hex, to_hex
@@ -75,7 +76,7 @@ from raiden.transfer.views import (
 )
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.packing import pack_signed_balance_proof, pack_withdraw
-from raiden.utils.typing import MYPY_ANNOTATION, TYPE_CHECKING, Dict, List, Nonce
+from raiden.utils.typing import MYPY_ANNOTATION, TYPE_CHECKING, AddressMetadata, Dict, List, Nonce
 from raiden_contracts.constants import MessageTypeId
 
 if TYPE_CHECKING:
@@ -157,7 +158,9 @@ class RaidenEventHandler(EventHandler):
     def on_raiden_events(
         self, raiden: "RaidenService", chain_state: ChainState, events: List[Event]
     ) -> None:  # pragma: no unittest
-        message_queues: Dict[QueueIdentifier, List[Message]] = defaultdict(list)
+        message_queues: Dict[
+            QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]
+        ] = defaultdict(list)
 
         for event in events:
             # pylint: disable=too-many-branches
@@ -243,105 +246,115 @@ class RaidenEventHandler(EventHandler):
     def handle_send_lockexpired(
         raiden: "RaidenService",
         send_lock_expired: SendLockExpired,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         lock_expired_message = message_from_sendevent(send_lock_expired)
         raiden.sign(lock_expired_message)
-        message_queues[send_lock_expired.queue_identifier].append(lock_expired_message)
+        message_queues[send_lock_expired.queue_identifier].append((lock_expired_message, None))
 
     @staticmethod
     def handle_send_lockedtransfer(
         raiden: "RaidenService",
         send_locked_transfer: SendLockedTransfer,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         mediated_transfer_message = message_from_sendevent(send_locked_transfer)
         raiden.sign(mediated_transfer_message)
-        message_queues[send_locked_transfer.queue_identifier].append(mediated_transfer_message)
+        message_queues[send_locked_transfer.queue_identifier].append(
+            (mediated_transfer_message, None)
+        )
 
     @staticmethod
     def handle_send_secretreveal(
         raiden: "RaidenService",
         reveal_secret_event: SendSecretReveal,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         reveal_secret_message = message_from_sendevent(reveal_secret_event)
         raiden.sign(reveal_secret_message)
-        message_queues[reveal_secret_event.queue_identifier].append(reveal_secret_message)
+        message_queues[reveal_secret_event.queue_identifier].append((reveal_secret_message, None))
 
     @staticmethod
     def handle_send_balanceproof(
         raiden: "RaidenService",
         balance_proof_event: SendUnlock,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)
-        message_queues[balance_proof_event.queue_identifier].append(unlock_message)
+        message_queues[balance_proof_event.queue_identifier].append((unlock_message, None))
 
     @staticmethod
     def handle_send_secretrequest(
         raiden: "RaidenService",
         chain_state: ChainState,
         secret_request_event: SendSecretRequest,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         if reveal_secret_with_resolver(raiden, chain_state, secret_request_event):
             return
 
         secret_request_message = message_from_sendevent(secret_request_event)
         raiden.sign(secret_request_message)
-        message_queues[secret_request_event.queue_identifier].append(secret_request_message)
+        message_queues[secret_request_event.queue_identifier].append(
+            (secret_request_message, None)
+        )
 
     @staticmethod
     def handle_send_refundtransfer(
         raiden: "RaidenService",
         refund_transfer_event: SendRefundTransfer,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         refund_transfer_message = message_from_sendevent(refund_transfer_event)
         raiden.sign(refund_transfer_message)
-        message_queues[refund_transfer_event.queue_identifier].append(refund_transfer_message)
+        message_queues[refund_transfer_event.queue_identifier].append(
+            (refund_transfer_message, None)
+        )
 
     @staticmethod
     def handle_send_withdrawrequest(
         raiden: "RaidenService",
         withdraw_request_event: SendWithdrawRequest,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:
         withdraw_request_message = message_from_sendevent(withdraw_request_event)
         raiden.sign(withdraw_request_message)
-        message_queues[withdraw_request_event.queue_identifier].append(withdraw_request_message)
+        message_queues[withdraw_request_event.queue_identifier].append(
+            (withdraw_request_message, None)
+        )
 
     @staticmethod
     def handle_send_withdraw(
         raiden: "RaidenService",
         withdraw_event: SendWithdrawConfirmation,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:
         withdraw_message = message_from_sendevent(withdraw_event)
         raiden.sign(withdraw_message)
-        message_queues[withdraw_event.queue_identifier].append(withdraw_message)
+        message_queues[withdraw_event.queue_identifier].append((withdraw_message, None))
 
     @staticmethod
     def handle_send_withdrawexpired(
         raiden: "RaidenService",
         withdraw_expired_event: SendWithdrawExpired,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:
         withdraw_expired_message = message_from_sendevent(withdraw_expired_event)
         raiden.sign(withdraw_expired_message)
-        message_queues[withdraw_expired_event.queue_identifier].append(withdraw_expired_message)
+        message_queues[withdraw_expired_event.queue_identifier].append(
+            (withdraw_expired_message, None)
+        )
 
     @staticmethod
     def handle_send_processed(
         raiden: "RaidenService",
         processed_event: SendProcessed,
-        message_queues: Dict[QueueIdentifier, List[Message]],
+        message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
     ) -> None:  # pragma: no unittest
         processed_message = message_from_sendevent(processed_event)
         raiden.sign(processed_message)
-        message_queues[processed_event.queue_identifier].append(processed_message)
+        message_queues[processed_event.queue_identifier].append((processed_message, None))
 
     @staticmethod
     def handle_paymentsentsuccess(

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -114,6 +114,7 @@ from raiden.utils.transfers import random_secret
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
     Address,
+    AddressMetadata,
     BlockNumber,
     BlockTimeout,
     InitiatorAddress,
@@ -1348,11 +1349,11 @@ class RaidenService(Runnable):
         all_messages: List[MessagesQueue] = list()
         for queue_identifier, event_queue in events_queues.items():
 
-            queue_messages = list()
+            queue_messages: List[Tuple[Message, Optional[AddressMetadata]]] = list()
             for event in event_queue:
                 message = message_from_sendevent(event)
                 self.sign(message)
-                queue_messages.append(message)
+                queue_messages.append((message, None))
 
             all_messages.append(MessagesQueue(queue_identifier, queue_messages))
 

--- a/raiden/tests/integration/network/transport/test_web_rtc.py
+++ b/raiden/tests/integration/network/transport/test_web_rtc.py
@@ -70,7 +70,7 @@ def test_web_rtc_message_sync(matrix_transports):
         message = Processed(message_identifier=MessageID(i), signature=EMPTY_SIGNATURE)
         raiden0_queues[queue_identifier].append(message)
         transport0._raiden_service.sign(message)
-        transport0.send_async([MessagesQueue(queue_identifier, [message])])
+        transport0.send_async([MessagesQueue(queue_identifier, [(message, None)])])
 
     with Timeout(TIMEOUT_MESSAGE_RECEIVE):
         while not len(transport1_messages) == 5:

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -437,7 +437,7 @@ def test_retry_queue_does_not_resend_removed_messages(
         recipient=Address(factories.HOP1),
         canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     )
-    retry_queue.enqueue(queue_identifier, [message])
+    retry_queue.enqueue(queue_identifier, [(message, None)])
 
     # TODO: Fix the code below, the types are not matching.
     mock_matrix._queueids_to_queues[queue_identifier] = [message]  # type: ignore
@@ -493,7 +493,7 @@ def test_retryqueue_not_idle_with_messages(
         recipient=Address(factories.HOP1),
         canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
     )
-    retry_queue.enqueue(queue_identifier, [make_message()])
+    retry_queue.enqueue(queue_identifier, [(make_message(), None)])
 
     # Without the `all_peers_reachable` fixture, the default reachability will be `UNREACHABLE`
     # therefore the message will remain in the internal queue indefinitely.

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -74,6 +74,12 @@ T_Address = bytes
 
 AddressHex = HexAddress
 
+T_UserID = str
+UserID = NewType("UserID", T_UserID)
+
+T_AddressMetadata = Dict[str, Union[UserID, "PeerCapabilities"]]
+AddressMetadata = NewType("AddressMetadata", T_AddressMetadata)
+
 T_Balance = int
 Balance = NewType("Balance", T_Balance)
 


### PR DESCRIPTION
This is defining the interface of how the transport will receive
additional address-metadata that can be bound to individual messages.
This information will be used to specify more specific information
about transport specific user-ids and capabilities - that can
be forwarded to the node's transport from other peer's forwarded
metadata or from the PFS.
The transport will be able to send messages without the metadata.

## TODO

We decided to first  add the interfaces and the transport internal processing of address-metadata,
and then step by step add passing that metadata from the different locations (PFS query, peer messages)
to the transport.

If there is no metadata provided, the transport will construct the user-ids from the transport based
on the known matrix servers, so that the messages will be sent out to all possible user-ids via to-device messages.
