### PR TITLE
upgrade matrix-synapse

### DIFF
--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -378,7 +378,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements-dev.txt
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
     # via -r requirements-dev.txt
 mccabe==0.6.1
     # via

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -47,5 +47,5 @@ coverage
 bump2version
 
 # Test support
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
 six>=1.13.0  # work around bad deps declaration in treq, see https://github.com/twisted/treq/commit/934e127a2b915bf02be86d23f2cf8a65bcdb2533#r42782781

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -336,7 +336,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements.txt
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
     # via -r requirements-dev.in
 mccabe==0.6.1
     # via


### PR DESCRIPTION
## Upgrade matrix-synapse dependency

The matrix-synapse 1.27.0 lib has a known issue with some versions of postgresql: https://github.com/matrix-org/synapse/issues/8996

This has been fixed in version 1.28.0, and the latest version, 1.29.0, seems to work well for us.