### PR TITLE
Add Recipient Metadata to SendMessageEvent

### DIFF
--- a/raiden/raiden_event_handler.py
+++ b/raiden/raiden_event_handler.py
@@ -158,6 +158,7 @@ class RaidenEventHandler(EventHandler):
     def on_raiden_events(
         self, raiden: "RaidenService", chain_state: ChainState, events: List[Event]
     ) -> None:  # pragma: no unittest
+
         message_queues: Dict[
             QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]
         ] = defaultdict(list)
@@ -250,7 +251,9 @@ class RaidenEventHandler(EventHandler):
     ) -> None:  # pragma: no unittest
         lock_expired_message = message_from_sendevent(send_lock_expired)
         raiden.sign(lock_expired_message)
-        message_queues[send_lock_expired.queue_identifier].append((lock_expired_message, None))
+        message_queues[send_lock_expired.queue_identifier].append(
+            (lock_expired_message, send_lock_expired.recipient_metadata)
+        )
 
     @staticmethod
     def handle_send_lockedtransfer(
@@ -261,7 +264,7 @@ class RaidenEventHandler(EventHandler):
         mediated_transfer_message = message_from_sendevent(send_locked_transfer)
         raiden.sign(mediated_transfer_message)
         message_queues[send_locked_transfer.queue_identifier].append(
-            (mediated_transfer_message, None)
+            (mediated_transfer_message, send_locked_transfer.recipient_metadata)
         )
 
     @staticmethod
@@ -272,7 +275,9 @@ class RaidenEventHandler(EventHandler):
     ) -> None:  # pragma: no unittest
         reveal_secret_message = message_from_sendevent(reveal_secret_event)
         raiden.sign(reveal_secret_message)
-        message_queues[reveal_secret_event.queue_identifier].append((reveal_secret_message, None))
+        message_queues[reveal_secret_event.queue_identifier].append(
+            (reveal_secret_message, reveal_secret_event.recipient_metadata)
+        )
 
     @staticmethod
     def handle_send_balanceproof(
@@ -282,7 +287,9 @@ class RaidenEventHandler(EventHandler):
     ) -> None:  # pragma: no unittest
         unlock_message = message_from_sendevent(balance_proof_event)
         raiden.sign(unlock_message)
-        message_queues[balance_proof_event.queue_identifier].append((unlock_message, None))
+        message_queues[balance_proof_event.queue_identifier].append(
+            (unlock_message, balance_proof_event.recipient_metadata)
+        )
 
     @staticmethod
     def handle_send_secretrequest(
@@ -297,7 +304,7 @@ class RaidenEventHandler(EventHandler):
         secret_request_message = message_from_sendevent(secret_request_event)
         raiden.sign(secret_request_message)
         message_queues[secret_request_event.queue_identifier].append(
-            (secret_request_message, None)
+            (secret_request_message, secret_request_event.recipient_metadata)
         )
 
     @staticmethod
@@ -305,11 +312,11 @@ class RaidenEventHandler(EventHandler):
         raiden: "RaidenService",
         refund_transfer_event: SendRefundTransfer,
         message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
-    ) -> None:  # pragma: no unittest
+    ) -> None:
         refund_transfer_message = message_from_sendevent(refund_transfer_event)
         raiden.sign(refund_transfer_message)
         message_queues[refund_transfer_event.queue_identifier].append(
-            (refund_transfer_message, None)
+            (refund_transfer_message, refund_transfer_event.recipient_metadata)
         )
 
     @staticmethod
@@ -321,7 +328,7 @@ class RaidenEventHandler(EventHandler):
         withdraw_request_message = message_from_sendevent(withdraw_request_event)
         raiden.sign(withdraw_request_message)
         message_queues[withdraw_request_event.queue_identifier].append(
-            (withdraw_request_message, None)
+            (withdraw_request_message, withdraw_request_event.recipient_metadata)
         )
 
     @staticmethod
@@ -329,10 +336,12 @@ class RaidenEventHandler(EventHandler):
         raiden: "RaidenService",
         withdraw_event: SendWithdrawConfirmation,
         message_queues: Dict[QueueIdentifier, List[Tuple[Message, Optional[AddressMetadata]]]],
-    ) -> None:
+    ) -> None:  # pragma: no unittest
         withdraw_message = message_from_sendevent(withdraw_event)
         raiden.sign(withdraw_message)
-        message_queues[withdraw_event.queue_identifier].append((withdraw_message, None))
+        message_queues[withdraw_event.queue_identifier].append(
+            (withdraw_message, withdraw_event.recipient_metadata)
+        )
 
     @staticmethod
     def handle_send_withdrawexpired(
@@ -343,7 +352,7 @@ class RaidenEventHandler(EventHandler):
         withdraw_expired_message = message_from_sendevent(withdraw_expired_event)
         raiden.sign(withdraw_expired_message)
         message_queues[withdraw_expired_event.queue_identifier].append(
-            (withdraw_expired_message, None)
+            (withdraw_expired_message, withdraw_expired_event.recipient_metadata)
         )
 
     @staticmethod
@@ -354,7 +363,9 @@ class RaidenEventHandler(EventHandler):
     ) -> None:  # pragma: no unittest
         processed_message = message_from_sendevent(processed_event)
         raiden.sign(processed_message)
-        message_queues[processed_event.queue_identifier].append((processed_message, None))
+        message_queues[processed_event.queue_identifier].append(
+            (processed_message, processed_event.recipient_metadata)
+        )
 
     @staticmethod
     def handle_paymentsentsuccess(

--- a/raiden/tests/unit/storage/test_serialization.py
+++ b/raiden/tests/unit/storage/test_serialization.py
@@ -105,6 +105,7 @@ def test_events_loaded_from_storage_should_deserialize(tmp_path):
     participant = factories.make_address()
     event = SendWithdrawRequest(
         recipient=recipient,
+        recipient_metadata=None,
         canonical_identifier=canonical_identifier,
         message_identifier=factories.make_message_identifier(),
         total_withdraw=WithdrawAmount(1),
@@ -130,6 +131,7 @@ def test_restore_queueids_to_queues(chain_state, netting_channel_state):
 
     msg_args = dict(
         recipient=recipient,
+        recipient_metadata=None,
         canonical_identifier=netting_channel_state.canonical_identifier,
         message_identifier=factories.make_message_identifier(),
         total_withdraw=WithdrawAmount(1),

--- a/raiden/tests/unit/test_node_queue.py
+++ b/raiden/tests/unit/test_node_queue.py
@@ -38,6 +38,7 @@ def test_delivered_message_must_clean_unordered_messages(chain_id):
     # element
     first_message = SendSecretReveal(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=message_identifier,
         secret=secret,
         canonical_identifier=canonical_identifier,
@@ -45,6 +46,7 @@ def test_delivered_message_must_clean_unordered_messages(chain_id):
 
     second_message = SendSecretReveal(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=random.randint(0, 2 ** 16),
         secret=secret,
         canonical_identifier=canonical_identifier,
@@ -88,6 +90,7 @@ def test_withdraw_request_message_cleanup(chain_id, token_network_state):
         total_withdraw=100,
         participant=our_address,
         recipient=recipient1,
+        recipient_metadata=None,
         nonce=1,
         expiration=10,
     )
@@ -147,12 +150,14 @@ def test_delivered_processed_message_cleanup():
 
     first_message = SendSecretReveal(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=random.randint(0, 2 ** 16),
         secret=secret,
         canonical_identifier=canonical_identifier,
     )
     second_message = SendSecretReveal(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=random.randint(0, 2 ** 16),
         secret=secret,
         canonical_identifier=canonical_identifier,

--- a/raiden/tests/unit/test_sqlite.py
+++ b/raiden/tests/unit/test_sqlite.py
@@ -292,6 +292,7 @@ def test_get_event_with_balance_proof():
     balance_proof = make_balance_proof_from_counter(counter)
     lock_expired = SendLockExpired(
         recipient=partner_address,
+        recipient_metadata=None,
         message_identifier=MessageID(next(counter)),
         balance_proof=balance_proof,
         secrethash=factories.make_secret_hash(next(counter)),
@@ -299,12 +300,14 @@ def test_get_event_with_balance_proof():
     )
     locked_transfer = SendLockedTransfer(
         recipient=partner_address,
+        recipient_metadata=None,
         message_identifier=MessageID(next(counter)),
         transfer=make_transfer_from_counter(counter),
         canonical_identifier=factories.make_canonical_identifier(),
     )
     send_balance_proof = SendUnlock(
         recipient=partner_address,
+        recipient_metadata=None,
         message_identifier=MessageID(next(counter)),
         payment_identifier=factories.make_payment_id(),
         token_address=factories.make_token_address(),
@@ -315,6 +318,7 @@ def test_get_event_with_balance_proof():
 
     refund_transfer = SendRefundTransfer(
         recipient=partner_address,
+        recipient_metadata=None,
         message_identifier=MessageID(next(counter)),
         transfer=make_transfer_from_counter(counter),
         canonical_identifier=factories.make_canonical_identifier(),

--- a/raiden/tests/unit/transfer/mediated_transfer/test_events.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_events.py
@@ -9,6 +9,7 @@ def test_send_refund_transfer_contains_balance_proof():
     message_identifier = 1
     event = SendRefundTransfer(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=message_identifier,
         transfer=transfer,
         canonical_identifier=factories.make_canonical_identifier(),

--- a/raiden/tests/unit/transfer/test_node.py
+++ b/raiden/tests/unit/transfer/test_node.py
@@ -407,6 +407,7 @@ def test_inplace_delete_message_queue(chain_state):
     chain_state.queueids_to_queues[global_identifier] = [
         SendMessageEvent(
             recipient=sender,
+            recipient_metadata=None,
             canonical_identifier=canonical_identifier,
             message_identifier=message_id,
         )
@@ -420,6 +421,7 @@ def test_inplace_delete_message_queue(chain_state):
     chain_state.queueids_to_queues[queue_identifier] = [
         SendMessageEvent(
             recipient=sender,
+            recipient_metadata=None,
             canonical_identifier=canonical_identifier,
             message_identifier=message_id,
         )

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -123,7 +123,8 @@ class Event:
       upper layer will use the events for.
     """
 
-    pass
+    def __post_init__(self) -> None:
+        pass
 
 
 class TransferRole(Enum):

--- a/raiden/transfer/architecture.py
+++ b/raiden/transfer/architecture.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-few-public-methods
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 import structlog
 from eth_utils import to_hex
@@ -13,6 +13,7 @@ from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import (
     AdditionalHash,
     Address,
+    AddressMetadata,
     Any,
     BalanceHash,
     BlockExpiration,
@@ -85,7 +86,7 @@ class State:
     pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class StateChange:
     """Declare the transition to be applied in a state object.
 
@@ -106,7 +107,7 @@ class StateChange:
     pass
 
 
-@dataclass
+@dataclass(frozen=True)
 class Event:
     """Events produced by the execution of a state change.
 
@@ -148,15 +149,15 @@ class SendMessageEvent(Event):
     """
 
     recipient: Address
+    recipient_metadata: Optional[AddressMetadata]
     canonical_identifier: CanonicalIdentifier
     message_identifier: MessageID
-    queue_identifier: QueueIdentifier = field(init=False)
 
-    def __post_init__(self) -> None:
-        queue_identifier = QueueIdentifier(
+    @property
+    def queue_identifier(self) -> QueueIdentifier:
+        return QueueIdentifier(
             recipient=self.recipient, canonical_identifier=self.canonical_identifier
         )
-        object.__setattr__(self, "queue_identifier", queue_identifier)
 
 
 @dataclass(frozen=True)

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1383,6 +1383,12 @@ def create_sendlockedtransfer(
 
     token = channel_state.token_address
     recipient = channel_state.partner_state.address
+    # TODO: uncomment when recipient metadata are set
+    # recipient_metadata = None
+    # for route_state in route_states:
+    #    recipient_metadata = route_state.address_metadata.get(recipient, None)
+    #    if recipient_metadata is not None:
+    #        break
     # the new lock is not registered yet
     locked_amount = LockedAmount(get_amount_locked(our_state) + amount)
 
@@ -1408,6 +1414,7 @@ def create_sendlockedtransfer(
 
     lockedtransfer = SendLockedTransfer(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=message_identifier,
         transfer=locked_transfer,
         canonical_identifier=channel_state.canonical_identifier,
@@ -1472,6 +1479,7 @@ def create_unlock(
 
     unlock_lock = SendUnlock(
         recipient=recipient,
+        recipient_metadata=None,
         message_identifier=message_identifier,
         payment_identifier=payment_identifier,
         token_address=token_address,
@@ -1634,6 +1642,7 @@ def send_withdraw_request(
             channel_identifier=channel_state.identifier,
         ),
         recipient=channel_state.partner_state.address,
+        recipient_metadata=None,
         message_identifier=message_identifier_from_prng(pseudo_random_generator),
         total_withdraw=withdraw_state.total_withdraw,
         participant=channel_state.our_state.address,
@@ -1687,6 +1696,7 @@ def create_sendexpiredlock(
 
     send_lock_expired = SendLockExpired(
         recipient=recipient,
+        recipient_metadata=None,
         canonical_identifier=balance_proof.canonical_identifier,
         message_identifier=message_identifier_from_prng(pseudo_random_generator),
         balance_proof=balance_proof,
@@ -1759,6 +1769,7 @@ def send_expired_withdraws(
         events.append(
             SendWithdrawExpired(
                 recipient=channel_state.partner_state.address,
+                recipient_metadata=None,
                 canonical_identifier=channel_state.canonical_identifier,
                 message_identifier=message_identifier_from_prng(pseudo_random_generator),
                 total_withdraw=withdraw_state.total_withdraw,
@@ -1944,6 +1955,7 @@ def handle_receive_withdraw_request(
         send_withdraw = SendWithdrawConfirmation(
             canonical_identifier=channel_state.canonical_identifier,
             recipient=channel_state.partner_state.address,
+            recipient_metadata=None,
             message_identifier=withdraw_request.message_identifier,
             total_withdraw=withdraw_request.total_withdraw,
             participant=channel_state.partner_state.address,
@@ -1979,6 +1991,7 @@ def handle_receive_withdraw_confirmation(
         events = [
             SendProcessed(
                 recipient=channel_state.partner_state.address,
+                recipient_metadata=None,
                 message_identifier=withdraw.message_identifier,
                 canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
             )
@@ -2045,6 +2058,7 @@ def handle_receive_withdraw_expired(
 
         send_processed = SendProcessed(
             recipient=channel_state.partner_state.address,
+            recipient_metadata=None,
             message_identifier=withdraw_expired.message_identifier,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
@@ -2084,6 +2098,7 @@ def handle_refundtransfer(
 
         send_processed = SendProcessed(
             recipient=refund.transfer.balance_proof.sender,
+            recipient_metadata=None,
             message_identifier=refund.transfer.message_identifier,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
@@ -2121,6 +2136,7 @@ def handle_receive_lock_expired(
 
         send_processed = SendProcessed(
             recipient=state_change.balance_proof.sender,
+            recipient_metadata=None,
             message_identifier=state_change.message_identifier,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
@@ -2161,6 +2177,7 @@ def handle_receive_lockedtransfer(
 
         send_processed = SendProcessed(
             recipient=mediated_transfer.balance_proof.sender,
+            recipient_metadata=None,
             message_identifier=mediated_transfer.message_identifier,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )
@@ -2192,6 +2209,7 @@ def handle_unlock(channel_state: NettingChannelState, unlock: ReceiveUnlock) -> 
 
         send_processed = SendProcessed(
             recipient=unlock.balance_proof.sender,
+            recipient_metadata=None,
             message_identifier=unlock.message_identifier,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -25,6 +25,7 @@ def refund_from_sendmediated(
 ) -> "SendRefundTransfer":
     return SendRefundTransfer(
         recipient=send_lockedtransfer_event.recipient,
+        recipient_metadata=None,
         message_identifier=send_lockedtransfer_event.message_identifier,
         transfer=send_lockedtransfer_event.transfer,
         canonical_identifier=send_lockedtransfer_event.queue_identifier.canonical_identifier,
@@ -44,7 +45,6 @@ class SendLockedTransfer(SendMessageEvent):
     transfer: LockedTransferUnsignedState
 
     def __post_init__(self) -> None:
-        super().__post_init__()
         typecheck(self.transfer, LockedTransferUnsignedState)
 
     @property
@@ -86,7 +86,6 @@ class SendSecretReveal(SendMessageEvent):
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
 
     def __post_init__(self) -> None:
-        super().__post_init__()
         object.__setattr__(self, "secrethash", sha256_secrethash(self.secret))
 
 
@@ -116,7 +115,6 @@ class SendUnlock(SendMessageEvent):
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
 
     def __post_init__(self) -> None:
-        super().__post_init__()
         object.__setattr__(self, "secrethash", sha256_secrethash(self.secret))
 
 

--- a/raiden/transfer/mediated_transfer/events.py
+++ b/raiden/transfer/mediated_transfer/events.py
@@ -45,6 +45,7 @@ class SendLockedTransfer(SendMessageEvent):
     transfer: LockedTransferUnsignedState
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         typecheck(self.transfer, LockedTransferUnsignedState)
 
     @property
@@ -86,6 +87,7 @@ class SendSecretReveal(SendMessageEvent):
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         object.__setattr__(self, "secrethash", sha256_secrethash(self.secret))
 
 
@@ -115,6 +117,7 @@ class SendUnlock(SendMessageEvent):
     secrethash: SecretHash = field(default=EMPTY_SECRETHASH)
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         object.__setattr__(self, "secrethash", sha256_secrethash(self.secret))
 
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -398,12 +398,16 @@ def handle_secretrequest(
         #
         message_identifier = message_identifier_from_prng(pseudo_random_generator)
         transfer_description = initiator_state.transfer_description
-        recipient = transfer_description.target
+        recipient = Address(transfer_description.target)
+        # TODO: uncomment when recipient metadata are set
+        # recipient_metadata = initiator_state.route.address_metadata.get(recipient, None)
+
         revealsecret = SendSecretReveal(
-            recipient=Address(recipient),
+            recipient=recipient,
+            recipient_metadata=None,
             message_identifier=message_identifier,
-            secret=transfer_description.secret,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
+            secret=transfer_description.secret,
         )
 
         initiator_state.transfer_state = "transfer_secret_revealed"

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -714,6 +714,7 @@ def events_for_secretreveal(
             payer_transfer = pair.payer_transfer
             revealsecret = SendSecretReveal(
                 recipient=payer_transfer.balance_proof.sender,
+                recipient_metadata=None,
                 message_identifier=message_identifier,
                 secret=secret,
                 canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
@@ -1395,6 +1396,7 @@ def handle_unlock(
 
                     send_processed = SendProcessed(
                         recipient=balance_proof_sender,
+                        recipient_metadata=None,
                         message_identifier=state_change.message_identifier,
                         canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
                     )

--- a/raiden/transfer/mediated_transfer/target.py
+++ b/raiden/transfer/mediated_transfer/target.py
@@ -126,6 +126,7 @@ def handle_inittarget(
             recipient = transfer.initiator
             secret_request = SendSecretRequest(
                 recipient=Address(recipient),
+                recipient_metadata=None,
                 message_identifier=message_identifier,
                 payment_identifier=transfer.payment_identifier,
                 amount=PaymentAmount(transfer.lock.amount),
@@ -179,12 +180,12 @@ def handle_offchain_secretreveal(
         target_state.state = TargetTransferState.OFFCHAIN_SECRET_REVEAL
         target_state.secret = state_change.secret
         recipient = route.node_address
-
         reveal = SendSecretReveal(
             recipient=recipient,
+            recipient_metadata=None,
             message_identifier=message_identifier,
-            secret=target_state.secret,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
+            secret=target_state.secret,
         )
 
         iteration = TransitionResult(target_state, [reveal])
@@ -247,6 +248,7 @@ def handle_unlock(
 
         send_processed = SendProcessed(
             recipient=balance_proof_sender,
+            recipient_metadata=None,
             message_identifier=state_change.message_identifier,
             canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
         )

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -77,9 +77,6 @@ AddressHex = HexAddress
 T_UserID = str
 UserID = NewType("UserID", T_UserID)
 
-T_AddressMetadata = Dict[str, Union[UserID, "PeerCapabilities"]]
-AddressMetadata = NewType("AddressMetadata", T_AddressMetadata)
-
 T_Balance = int
 Balance = NewType("Balance", T_Balance)
 
@@ -205,6 +202,8 @@ RoomID = NewType("RoomID", T_RoomID)
 
 T_PeerCapabilities = Dict[str, Union[str, bool]]
 PeerCapabilities = NewType("PeerCapabilities", T_PeerCapabilities)
+
+AddressMetadata = Dict[str, Union[UserID, PeerCapabilities]]
 
 AddressTypes = Union[
     Address,

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -356,7 +356,7 @@ markupsafe==1.1.1
     # via
     #   -r requirements-dev.txt
     #   jinja2
-marshmallow-dataclass==8.0.0
+marshmallow-dataclass[union]==8.0.0
     # via -r requirements-dev.txt
 marshmallow-enum==1.5.1
     # via -r requirements-dev.txt
@@ -761,6 +761,10 @@ typed-ast==1.4.0
     #   -r requirements-dev.txt
     #   black
     #   mypy
+typeguard==2.11.1
+    # via
+    #   -r requirements-dev.txt
+    #   marshmallow-dataclass
 typing-extensions==3.7.4.3
     # via
     #   -r requirements-dev.txt

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -318,7 +318,7 @@ markupsafe==1.1.1
     #   -r requirements-docs.txt
     #   -r requirements.txt
     #   jinja2
-marshmallow-dataclass==8.0.0
+marshmallow-dataclass[union]==8.0.0
     # via -r requirements.txt
 marshmallow-enum==1.5.1
     # via -r requirements.txt
@@ -664,6 +664,10 @@ typed-ast==1.4.0
     # via
     #   black
     #   mypy
+typeguard==2.11.1
+    # via
+    #   -r requirements.txt
+    #   marshmallow-dataclass
 typing-extensions==3.7.4.3
     # via
     #   -r requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,7 +12,7 @@ Flask-Cors
 Flask-RESTful
 gevent>=1.5a3
 guppy3
-marshmallow-dataclass
+marshmallow-dataclass[union]
 marshmallow-polyfield
 marshmallow
 marshmallow_enum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -133,7 +133,7 @@ lru-dict==1.1.6
     # via web3
 markupsafe==1.1.1
     # via jinja2
-marshmallow-dataclass==8.0.0
+marshmallow-dataclass[union]==8.0.0
     # via -r requirements.in
 marshmallow-enum==1.5.1
     # via -r requirements.in
@@ -226,6 +226,8 @@ toml==0.10.2
     # via -r requirements.in
 toolz==0.9.0
     # via cytoolz
+typeguard==2.11.1
+    # via marshmallow-dataclass
 typing-extensions==3.7.4.3
     # via -r requirements.in
 typing-inspect==0.4.0


### PR DESCRIPTION
## Description

With the new interface described in #6875 every message will ciom with optional AddressMetaData. This can also be None. As this is attached to the recipient of a message, this PR introduces a field `recipient_metadata` in order to pass it through the state machine. 

For now this is set to None but will be changed in the following PRs