### PR TITLE
Fix mypy unexpected type error

### DIFF
--- a/tools/debugging/matrix/generate_messages.py
+++ b/tools/debugging/matrix/generate_messages.py
@@ -42,7 +42,7 @@ ROOM = "room"
 
 
 def configure_logging(log_path: str) -> None:
-    processors = [
+    processors = (
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
@@ -50,7 +50,7 @@ def configure_logging(log_path: str) -> None:
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ]
+    )
     structlog.reset_defaults()
     logging.config.dictConfig(
         {

--- a/tools/debugging/matrix/generate_messages.py
+++ b/tools/debugging/matrix/generate_messages.py
@@ -25,7 +25,7 @@ from raiden.settings import (
 )
 from raiden.tests.utils import factories
 from raiden.utils.signer import Signer
-from raiden.utils.typing import Any, Dict, Iterator, RoomID
+from raiden.utils.typing import Any, Callable, Dict, Iterator, List, RoomID
 
 setup_asyncio_event_loop()
 
@@ -42,7 +42,7 @@ ROOM = "room"
 
 
 def configure_logging(log_path: str) -> None:
-    processors = (
+    processors: List[Callable] = [
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
@@ -50,7 +50,7 @@ def configure_logging(log_path: str) -> None:
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    )
+    ]
     structlog.reset_defaults()
     logging.config.dictConfig(
         {

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -41,14 +41,14 @@ TransferPath = List["RunningNode"]
 INITIATOR = 0
 TARGET = -1
 
-processors = (
+processors: List[Callable] = [
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
     structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
     structlog.processors.StackInfoRenderer(),
     structlog.processors.format_exc_info,
-)
+]
 structlog.reset_defaults()
 logging.config.dictConfig(
     {
@@ -72,7 +72,7 @@ logging.config.dictConfig(
     }
 )
 structlog.configure(
-    processors=processors + (structlog.stdlib.ProcessorFormatter.wrap_for_formatter,),
+    processors=processors + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
     wrapper_class=structlog.stdlib.BoundLogger,
     logger_factory=structlog.stdlib.LoggerFactory(),
 )

--- a/tools/debugging/stress_test_transfers.py
+++ b/tools/debugging/stress_test_transfers.py
@@ -41,14 +41,14 @@ TransferPath = List["RunningNode"]
 INITIATOR = 0
 TARGET = -1
 
-processors = [
+processors = (
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
     structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
     structlog.processors.StackInfoRenderer(),
     structlog.processors.format_exc_info,
-]
+)
 structlog.reset_defaults()
 logging.config.dictConfig(
     {
@@ -72,7 +72,7 @@ logging.config.dictConfig(
     }
 )
 structlog.configure(
-    processors=processors + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+    processors=processors + (structlog.stdlib.ProcessorFormatter.wrap_for_formatter,),
     wrapper_class=structlog.stdlib.BoundLogger,
     logger_factory=structlog.stdlib.LoggerFactory(),
 )


### PR DESCRIPTION
## Fix type mismatch

Fixes: https://github.com/raiden-network/raiden/issues/6878

Upgrading mypy exposed this type incompatibility. This PR fixes the errors and returns the develop branch to a green state.