### PR TITLE
create notifications from system logs

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -99,6 +99,13 @@ class ServerListType(Enum):
     ALL_SERVERS = "all_servers"
 
 
+class NotificationIDs(Enum):
+    LOW_RDN = "low_rdn"
+    VERSION_OUTDATED = "version_outdated"
+    MISSING_GAS_RESERVE = "missing_gas_reserve"
+    VERSION_SECURITY_WARNING = "version_security_warning"
+
+
 # Set at 64 since parity's default is 64 and Geth's default is 128
 # TODO: Make this configurable. Since in parity this is also a configurable value
 STATE_PRUNING_AFTER_BLOCKS = 64

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Set, Tuple, cast
 from uuid import UUID
 
+import click
 import filelock
 import gevent
 import structlog
@@ -534,7 +535,18 @@ class RaidenService(Runnable):
 
         log.debug("Raiden Service stopped", node=to_checksum_address(self.address))
 
-    def add_notification(self, notification: Notification) -> None:
+    def add_notification(
+        self,
+        notification: Notification,
+        log_opts: Optional[Dict] = None,
+        click_opts: Optional[Dict] = None,
+    ) -> None:
+        log_opts = log_opts or {}
+        click_opts = click_opts or {}
+
+        log.info(notification.summary, **log_opts)
+        click.secho(notification.body, **click_opts)
+
         self.notifications[notification.id] = notification
 
     @property

--- a/raiden/tests/unit/test_version_check.py
+++ b/raiden/tests/unit/test_version_check.py
@@ -6,6 +6,9 @@ import requests
 from pkg_resources import parse_version
 
 from raiden.tasks import SECURITY_EXPRESSION, _do_check_version
+from raiden.tests.utils.mocks import MockRaidenService
+
+raiden_service = MockRaidenService()
 
 LATEST_RELEASE_RESPONSE = """{"url":
             "https://api.github.com/repos/raiden-network/raiden/releases/14541434",
@@ -171,7 +174,7 @@ def test_version_check_api_rate_limit_exceeded():
         return Response()
 
     with patch.object(requests, "get", side_effect=fake_request):
-        assert not _do_check_version(version)
+        assert not _do_check_version(version, raiden_service)
 
 
 def test_version_check():
@@ -186,5 +189,5 @@ def test_version_check():
         return Response()
 
     with patch.object(requests, "get", side_effect=fake_request):
-        assert not _do_check_version(version)
-        assert _do_check_version(parse_version("0.19.0"))
+        assert not _do_check_version(version, raiden_service)
+        assert _do_check_version(parse_version("0.19.0"), raiden_service)

--- a/raiden/tests/utils/mocks.py
+++ b/raiden/tests/utils/mocks.py
@@ -3,6 +3,9 @@ import random
 from collections import defaultdict
 from unittest.mock import Mock, PropertyMock
 
+import click
+
+from raiden.api.objects import Notification
 from raiden.constants import Environment, RoutingMode
 from raiden.settings import RaidenConfig
 from raiden.storage.serialization import JSONSerializer
@@ -192,6 +195,7 @@ class MockRaidenService:
 
         self.targets_to_identifiers_to_statuses: Dict[Address, dict] = defaultdict(dict)
         self.route_to_feedback_token: dict = {}
+        self.notifications: dict = {}
 
         if state_transition is None:
             state_transition = node.state_transition
@@ -212,6 +216,17 @@ class MockRaidenService:
 
         self.wal = wal
         self.transport = Mock()
+
+    def add_notification(
+        self,
+        notification: Notification,
+        click_opts: Optional[Dict] = None,
+    ) -> None:
+        click_opts = click_opts or {}
+
+        click.secho(notification.body, **click_opts)
+
+        self.notifications[notification.id] = notification
 
     def on_messages(self, messages):
         if self.message_handler:

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -27,7 +27,9 @@ def run_services(options: Dict[str, Any]) -> None:
 
         gevent_tasks.append(console)
 
-    gevent_tasks.append(spawn_named("check_version", check_version, get_system_spec()["raiden"]))
+    gevent_tasks.append(
+        spawn_named("check_version", check_version, get_system_spec()["raiden"], raiden_service)
+    )
     gevent_tasks.append(spawn_named("check_gas_reserve", check_gas_reserve, raiden_service))
     gevent_tasks.append(
         spawn_named(


### PR DESCRIPTION
## Connect the system log warnings with the notifications service

https://github.com/raiden-network/raiden/pull/6871 introduced the Notifications service. This PR is using the service, sending some logs to it, on top of still logging the messages as they were.