### PR TITLE
Fix a whole bunch of deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,9 @@ jobs:
       - config-path
 
       - run:
+          name: Install docs requirements
+          command: pip-sync requirements/requirements-docs.txt
+      - run:
           name: Build documentation
           command: make docs
 

--- a/raiden/tasks.py
+++ b/raiden/tasks.py
@@ -125,7 +125,7 @@ def check_rdn_deposits(
 def check_chain_id(chain_id: ChainID, web3: Web3) -> None:  # pragma: no unittest
     """ Check periodically if the underlying ethereum client's network id has changed"""
     while True:
-        current_id = web3.eth.chainId
+        current_id = web3.eth.chain_id
         if chain_id != current_id:
             raise RuntimeError(
                 f"Raiden was running on network with id {chain_id} and it detected "

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -75,7 +75,7 @@ def pytest_addoption(parser):
         "--base-port",
         action="store",
         default=8500,
-        type="int",
+        type=int,
         help="Base port number to use for tests.",
     )
 

--- a/raiden/tests/integration/api/rest/test_api_wrapper.py
+++ b/raiden/tests/integration/api/rest/test_api_wrapper.py
@@ -43,7 +43,7 @@ def test_api_wrapper(raiden_network, unregistered_custom_token, retry_timeout):
     resp = wrapper.register_token(token=token)
     # The token network address will be needed for a later test
     token_network_address = resp.token_network_address
-    assert app0.rpc_client.web3.eth.getCode(resp.token_network_address)
+    assert app0.rpc_client.web3.eth.get_code(resp.token_network_address)
 
     # Test channel opening
     resp = wrapper.open_channel(partner=address2, token=token, deposit=2)

--- a/raiden/tests/integration/api/test_pythonapi.py
+++ b/raiden/tests/integration/api/test_pythonapi.py
@@ -566,7 +566,7 @@ def test_token_addresses(raiden_network: List[RaidenService], token_addresses):
     last_number = app0.rpc_client.block_number()
 
     for block_number in range(last_number, 0, -1):
-        code = app0.rpc_client.web3.eth.getCode(
+        code = app0.rpc_client.web3.eth.get_code(
             account=Address(token_network_address), block_identifier=block_number
         )
         if code == b"":

--- a/raiden/tests/integration/fixtures/smartcontracts.py
+++ b/raiden/tests/integration/fixtures/smartcontracts.py
@@ -133,7 +133,7 @@ def register_token(
         token_address=TokenAddress(to_canonical_address(token_contract.address)),
         channel_participant_deposit_limit=RED_EYES_PER_CHANNEL_PARTICIPANT_LIMIT,
         token_network_deposit_limit=RED_EYES_PER_TOKEN_NETWORK_LIMIT,
-        given_block_identifier=token_contract.web3.eth.blockNumber,
+        given_block_identifier=token_contract.web3.eth.block_number,
     )
     return token_network_address
 

--- a/raiden/tests/integration/network/proxies/test_payment_channel.py
+++ b/raiden/tests/integration/network/proxies/test_payment_channel.py
@@ -71,7 +71,7 @@ def test_payment_channel_proxy_basics(
     token_network_proxy = proxy_manager.token_network(
         address=token_network_address, block_identifier=BLOCK_ID_LATEST
     )
-    start_block = web3.eth.blockNumber
+    start_block = web3.eth.block_number
 
     channel_details = token_network_proxy.new_netting_channel(
         partner=partner,
@@ -121,12 +121,12 @@ def test_payment_channel_proxy_basics(
         netting_channel_identifier=channel_proxy_1.channel_identifier,
         contract_manager=contract_manager,
         from_block=start_block,
-        to_block=web3.eth.blockNumber,
+        to_block=web3.eth.block_number,
     )
 
     assert len(channel_events) == 2
 
-    block_before_close = web3.eth.blockNumber
+    block_before_close = web3.eth.block_number
     empty_balance_proof = BalanceProof(
         channel_identifier=channel_proxy_1.channel_identifier,
         token_network_address=token_network_address,
@@ -154,7 +154,7 @@ def test_payment_channel_proxy_basics(
         netting_channel_identifier=channel_proxy_1.channel_identifier,
         contract_manager=contract_manager,
         from_block=start_block,
-        to_block=web3.eth.blockNumber,
+        to_block=web3.eth.block_number,
     )
     assert len(channel_events) == 3
 
@@ -186,7 +186,7 @@ def test_payment_channel_proxy_basics(
         netting_channel_identifier=channel_proxy_1.channel_identifier,
         contract_manager=contract_manager,
         from_block=start_block,
-        to_block=web3.eth.blockNumber,
+        to_block=web3.eth.block_number,
     )
     assert len(channel_events) == 4
 

--- a/raiden/tests/integration/network/proxies/test_token_network.py
+++ b/raiden/tests/integration/network/proxies/test_token_network.py
@@ -760,7 +760,7 @@ def test_query_pruned_state(token_network_proxy, private_keys, web3, contract_ma
         partner=c2_client.address, settle_timeout=10, given_block_identifier=BLOCK_ID_LATEST
     )
     channel_identifier = channel_details.channel_identifier
-    block = c1_client.web3.eth.getBlock(BLOCK_ID_LATEST)
+    block = c1_client.web3.eth.get_block(BLOCK_ID_LATEST)
     block_number = int(block["number"])
     block_hash = bytes(block["hash"])
     channel_id = c1_token_network_proxy.get_channel_identifier(

--- a/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_geth_rpc_assumptions.py
@@ -36,7 +36,7 @@ def test_geth_request_pruned_data_raises_an_exception(
     first_receipt = send_transaction().receipt
     mined_block_number = first_receipt["blockNumber"]
 
-    while mined_block_number + 127 > web3.eth.blockNumber:
+    while mined_block_number + 127 > web3.eth.block_number:
         gevent.sleep(0.5)
 
     # geth keeps the latest 128 blocks before pruning. Unfortunately, this can
@@ -86,7 +86,7 @@ def test_geth_request_block_data_does_not_raise_an_exception(
     first_receipt = send_transaction().receipt
     mined_block_number = first_receipt["blockNumber"]
 
-    while mined_block_number + 127 > web3.eth.blockNumber:
+    while mined_block_number + 127 > web3.eth.block_number:
         gevent.sleep(0.5)
 
     # geth keeps the latest 128 blocks before pruning. Unfortunately, this can
@@ -103,7 +103,7 @@ def test_geth_request_block_data_does_not_raise_an_exception(
     with pytest.raises(ValueError):
         contract_proxy.functions.const().call(block_identifier=pruned_block_number)
 
-    latest_confirmed_block = deploy_client.web3.eth.getBlock(pruned_block_number)
+    latest_confirmed_block = deploy_client.web3.eth.get_block(pruned_block_number)
 
     msg = (
         "getBlock did not return the expected metadata for a pruned block "

--- a/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_parity_rpc_assumptions.py
@@ -84,7 +84,7 @@ def test_parity_request_block_data_does_not_raise_an_exception(
     with pytest.raises(ValueError):
         contract_proxy.functions.const().call(block_identifier=pruned_block_number)
 
-    latest_confirmed_block = deploy_client.web3.eth.getBlock(pruned_block_number)
+    latest_confirmed_block = deploy_client.web3.eth.get_block(pruned_block_number)
 
     msg = (
         "getBlock did not return the expected metadata for a pruned block "

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_call_assumptions.py
@@ -12,7 +12,7 @@ def test_call_invalid_selector(deploy_client: JSONRPCClient) -> None:
     """
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     data = decode_hex(get_transaction_data(deploy_client.web3, contract_proxy.abi, "ret", None))
     next_byte = chr(data[0] + 1).encode()
@@ -27,7 +27,7 @@ def test_call_inexisting_address(deploy_client: JSONRPCClient) -> None:
 
     inexisting_address = b"\x01\x02\x03\x04\x05" * 4
 
-    assert len(deploy_client.web3.eth.getCode(inexisting_address)) == 0
+    assert len(deploy_client.web3.eth.get_code(inexisting_address)) == 0
     transaction = {
         "from": deploy_client.address,
         "to": inexisting_address,
@@ -84,7 +84,7 @@ def test_call_throws(deploy_client: JSONRPCClient) -> None:
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     call = contract_proxy.functions.fail_assert().call
     assert call() == []

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_events_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_events_assumptions.py
@@ -49,8 +49,8 @@ def test_events_can_happen_in_the_deployment_block(web3: Web3, deploy_key: bytes
         deploy_signed_txn = web3.eth.account.sign_transaction(deploy_transaction_data, deploy_key)
         call_signed_txn = web3.eth.account.sign_transaction(call_transaction_data, deploy_key)
 
-        deploy_tx_hash = web3.eth.sendRawTransaction(deploy_signed_txn.rawTransaction)
-        call_tx_hash = web3.eth.sendRawTransaction(call_signed_txn.rawTransaction)
+        deploy_tx_hash = web3.eth.send_raw_transaction(deploy_signed_txn.rawTransaction)
+        call_tx_hash = web3.eth.send_raw_transaction(call_signed_txn.rawTransaction)
 
         while True:
             try:

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_estimation_assumptions.py
@@ -12,7 +12,7 @@ def test_estimate_gas_fail(deploy_client: JSONRPCClient) -> None:
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     msg = "Estimate gas should return None if the transaction hit an assert"
     assert deploy_client.estimate_gas(contract_proxy, "fail_assert", {}) is None, msg

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_gas_price_assumptions.py
@@ -44,7 +44,7 @@ def test_resending_pending_transaction_raises(deploy_client: JSONRPCClient) -> N
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     # Create a new instance of the JSONRPCClient, this will store the current available nonce
     client_invalid_nonce = JSONRPCClient(web3=deploy_client.web3, privkey=deploy_client.privkey)
@@ -76,7 +76,7 @@ def test_resending_mined_transaction_raises(deploy_client: JSONRPCClient) -> Non
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     # Create a new instance of the JSONRPCClient, this will store the current available nonce
     client_invalid_nonce = JSONRPCClient(deploy_client.web3, deploy_client.privkey)
@@ -150,7 +150,7 @@ def test_local_transaction_with_zero_gasprice_is_mined(deploy_client: JSONRPCCli
     )
 
     address = normal_gas_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     estimated_transaction = deploy_client.estimate_gas(zero_gas_proxy, "ret", {})
     assert estimated_transaction, "Gas estimation should not fail here"
@@ -200,7 +200,7 @@ def test_remote_transaction_with_zero_gasprice_is_not_mined(
     )
 
     address = normal_gas_proxy.address
-    assert len(client.web3.eth.getCode(address)) > 0
+    assert len(client.web3.eth.get_code(address)) > 0
 
     estimated_transaction = client.estimate_gas(zero_gas_proxy, "ret", {})
     assert estimated_transaction, "Gas estimation should not fail here"
@@ -258,7 +258,7 @@ def test_resending_pending_transaction_with_lower_gas_raises(deploy_client: JSON
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     client_invalid_nonce = JSONRPCClient(web3=deploy_client.web3, privkey=deploy_client.privkey)
 
@@ -293,7 +293,7 @@ def test_reusing_nonce_with_lower_gas_raises(deploy_client: JSONRPCClient) -> No
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     client_invalid_nonce = JSONRPCClient(web3=deploy_client.web3, privkey=deploy_client.privkey)
 

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -24,7 +24,7 @@ def test_transact_opcode(deploy_client: JSONRPCClient) -> None:
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     estimated_transaction = deploy_client.estimate_gas(contract_proxy, "ret", {})
     assert estimated_transaction
@@ -40,7 +40,7 @@ def test_transact_throws_opcode(deploy_client: JSONRPCClient) -> None:
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = to_canonical_address(contract_proxy.address)
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     # the method always fails, so the gas estimation returns 0 here, using a
     # hardcoded a value to circumvent gas estimation.
@@ -83,7 +83,7 @@ def test_transact_opcode_oog(deploy_client: JSONRPCClient) -> None:
     contract_proxy, _ = deploy_rpc_test_contract(deploy_client, "RpcTest")
 
     address = contract_proxy.address
-    assert len(deploy_client.web3.eth.getCode(address)) > 0
+    assert len(deploy_client.web3.eth.get_code(address)) > 0
 
     # divide the estimate by 2 to run into out-of-gas
     estimated_transaction = deploy_client.estimate_gas(contract_proxy, "loop", {}, 1000)
@@ -124,7 +124,7 @@ def test_discover_next_available_nonce(deploy_client: JSONRPCClient) -> None:
     """
     web3 = deploy_client.web3
     random_address = make_address()
-    gas_price = web3.eth.gasPrice  # pylint: disable=no-member
+    gas_price = web3.eth.gas_price  # pylint: disable=no-member
     eth_node = deploy_client.eth_node
     next_nonce = discover_next_available_nonce(web3, eth_node, deploy_client.address)
 
@@ -144,7 +144,7 @@ def test_discover_next_available_nonce(deploy_client: JSONRPCClient) -> None:
         signed_txn = deploy_client.web3.eth.account.sign_transaction(
             transaction, deploy_client.privkey
         )
-        deploy_client.web3.eth.sendRawTransaction(signed_txn.rawTransaction)
+        deploy_client.web3.eth.send_raw_transaction(signed_txn.rawTransaction)
 
         next_nonce = Nonce(next_nonce + 1)
         msg = "The nonce must increment when a new transaction is sent."
@@ -167,7 +167,7 @@ def test_discover_next_available_nonce(deploy_client: JSONRPCClient) -> None:
         signed_txn = deploy_client.web3.eth.account.sign_transaction(
             transaction, deploy_client.privkey
         )
-        deploy_client.web3.eth.sendRawTransaction(signed_txn.rawTransaction)
+        deploy_client.web3.eth.send_raw_transaction(signed_txn.rawTransaction)
 
         available_nonce = discover_next_available_nonce(web3, eth_node, deploy_client.address)
 

--- a/raiden/tests/unit/test_web3_assumptions.py
+++ b/raiden/tests/unit/test_web3_assumptions.py
@@ -40,10 +40,10 @@ _FAKE_BLOCK_DATA = {
 def patched_web3():
     web3 = Web3(HTTPProvider(URI("http://domain/")))
     monkey_patch_web3(web3=web3, gas_price_strategy=rpc_gas_price_strategy)
-    original_get_block = web3.eth.getBlock
-    web3.eth.getBlock = make_patched_web3_get_block(web3.eth.getBlock)
+    original_get_block = web3.eth.get_block
+    web3.eth.get_block = make_patched_web3_get_block(web3.eth.get_block)
     yield web3
-    web3.eth.getBlock = original_get_block
+    web3.eth.get_block = original_get_block
 
 
 def _make_json_rpc_null_response(
@@ -77,7 +77,7 @@ def test_web3_retries_block_not_found(
         responses.POST, "http://domain/", callback=_make_json_rpc_null_response(succeed_at)
     )
 
-    result = patched_web3.eth.getBlock(BlockNumber(1))
+    result = patched_web3.eth.get_block(BlockNumber(1))
     assert result["number"] == 1
 
 
@@ -87,4 +87,4 @@ def test_web3_reraises_block_not_found_after_retries(patched_web3, requests_resp
     )
 
     with pytest.raises(BlockNotFound):
-        _ = patched_web3.eth.getBlock(1)
+        _ = patched_web3.eth.get_block(1)

--- a/raiden/tests/utils/client.py
+++ b/raiden/tests/utils/client.py
@@ -8,12 +8,12 @@ def burn_eth(rpc_client: JSONRPCClient, amount_to_leave: int = 0) -> None:
     """Burns all the ETH on the account of the given raiden service"""
     address = rpc_client.address
     web3 = rpc_client.web3
-    gas_price = web3.eth.gasPrice
+    gas_price = web3.eth.gas_price
 
     # Leave enough ETH to pay for the burn transaction.
     amount_to_leave = TRANSACTION_INTRINSIC_GAS + amount_to_leave
 
-    amount_to_burn = web3.eth.getBalance(address) - gas_price * amount_to_leave
+    amount_to_burn = web3.eth.get_balance(address) - gas_price * amount_to_leave
     burn_transfer = EthTransfer(
         to_address=Address(HOP1), value=amount_to_burn, gas_price=gas_price
     )

--- a/raiden/tests/utils/eth_node.py
+++ b/raiden/tests/utils/eth_node.py
@@ -293,7 +293,7 @@ def eth_check_balance(web3: Web3, accounts_addresses: List[Address], retries: in
     addresses = {to_checksum_address(account) for account in accounts_addresses}
     for _ in range(retries):
         for address in addresses.copy():
-            if web3.eth.getBalance(address, BLOCK_ID_LATEST) > 0:
+            if web3.eth.get_balance(address, BLOCK_ID_LATEST) > 0:
                 addresses.remove(address)
         gevent.sleep(1)
 

--- a/raiden/tests/utils/smartcontracts.py
+++ b/raiden/tests/utils/smartcontracts.py
@@ -1,6 +1,6 @@
 import os
 
-from solc import compile_files
+from solcx import compile_files
 from web3.contract import Contract
 from web3.types import TxReceipt
 
@@ -145,7 +145,7 @@ def compile_files_cwd(*args: Any, **kwargs: Any) -> Dict[str, Any]:
             # We need to specify output values here because py-solc by default
             # provides them all and does not know that "clone-bin" does not exist
             # in solidity >= v0.5.0
-            output_values=("abi", "asm", "ast", "bin", "bin-runtime"),
+            output_values=["abi", "asm", "ast", "bin", "bin-runtime"],
             **kwargs,
         )
     finally:

--- a/raiden/ui/checks.py
+++ b/raiden/ui/checks.py
@@ -105,7 +105,7 @@ def check_ethereum_chain_id(given_chain_id: ChainID, web3: Web3) -> None:
     If they don't match, exits the program with an error. If they do adds it
     to the configuration and then returns it and whether it is a known network
     """
-    node_chain_id = ChainID(web3.eth.chainId)
+    node_chain_id = ChainID(web3.eth.chain_id)
 
     if node_chain_id != given_chain_id:
         given_name = ID_TO_CHAINNAME.get(given_chain_id)

--- a/raiden/ui/console.py
+++ b/raiden/ui/console.py
@@ -250,7 +250,7 @@ class ConsoleTools:
             True if the contract got mined, false otherwise
         """
         start_time = time.time()
-        result = self._raiden.rpc_client.web3.eth.getCode(
+        result = self._raiden.rpc_client.web3.eth.get_code(
             to_canonical_address(contract_address_hex)
         )
 
@@ -259,7 +259,7 @@ class ConsoleTools:
             if timeout and start_time + timeout > current_time:
                 return False
 
-            result = self._raiden.rpc_client.web3.eth.getCode(
+            result = self._raiden.rpc_client.web3.eth.get_code(
                 to_canonical_address(contract_address_hex)
             )
             gevent.sleep(0.5)

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -10,10 +10,6 @@ aioice==0.7.5
     #   aiortc
 aiortc==1.2.0
     # via -r requirements-dev.txt
-alabaster==0.7.12
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
 altgraph==0.16.1
     # via
     #   macholib
@@ -38,10 +34,6 @@ astroid==2.5.1
     # via
     #   -r requirements-dev.txt
     #   pylint
-astunparse==1.6.2
-    # via
-    #   -r requirements-dev.txt
-    #   sphinxcontrib-httpexample
 attrdict==2.0.1
     # via
     #   -r requirements-dev.txt
@@ -58,7 +50,7 @@ attrs==19.3.0
     #   service-identity
     #   treq
     #   twisted
-automat==0.7.0
+automat==20.2.0
     # via
     #   -r requirements-dev.txt
     #   twisted
@@ -66,10 +58,6 @@ av==8.0.2
     # via
     #   -r requirements-dev.txt
     #   aiortc
-babel==2.7.0
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
 backcall==0.1.0
     # via
     #   -r requirements-dev.txt
@@ -164,12 +152,10 @@ dnspython==2.1.0
     # via
     #   -r requirements-dev.txt
     #   aioice
-docutils==0.14
+docutils==0.16
     # via
     #   -r requirements-dev.txt
     #   readme-renderer
-    #   sphinx
-    #   sphinxcontrib-httpexample
 eth-abi==2.1.0
     # via
     #   -r requirements-dev.txt
@@ -281,9 +267,10 @@ hexbytes==0.2.0
     #   eth-account
     #   eth-rlp
     #   web3
-hyperlink==19.0.0
+hyperlink==21.0.0
     # via
     #   -r requirements-dev.txt
+    #   treq
     #   twisted
 hypothesis==6.3.0
     # via -r requirements-dev.txt
@@ -294,14 +281,15 @@ idna==2.8
     #   matrix-synapse
     #   requests
     #   twisted
-imagesize==1.1.0
+importlib-metadata==3.7.3
     # via
     #   -r requirements-dev.txt
-    #   sphinx
-importlib-metadata==3.4.0
-    # via
-    #   -r requirements-dev.txt
+    #   flake8
+    #   flake8-comprehensions
+    #   jsonschema
     #   pluggy
+    #   pyinstaller
+    #   pytest
 incremental==17.5.0
     # via
     #   -r requirements-dev.txt
@@ -333,12 +321,11 @@ jedi==0.17.0
     # via
     #   -r requirements-dev.txt
     #   ipython
-jinja2==2.10.1
+jinja2==2.11.3
     # via
     #   -r requirements-dev.txt
     #   flask
     #   matrix-synapse
-    #   sphinx
 jsonschema==3.2.0
     # via
     #   -r requirements-dev.txt
@@ -353,7 +340,9 @@ lru-dict==1.1.6
     #   -r requirements-dev.txt
     #   web3
 macholib==1.14
-    # via -r requirements-ci.in
+    # via
+    #   -r requirements-ci.in
+    #   pyinstaller
 markupsafe==1.1.1
     # via
     #   -r requirements-dev.txt
@@ -416,7 +405,6 @@ packaging==19.0
     #   -r requirements-dev.txt
     #   bleach
     #   pytest
-    #   sphinx
 parsimonious==0.8.1
     # via
     #   -r requirements-dev.txt
@@ -473,11 +461,7 @@ ptyprocess==0.6.0
     # via
     #   -r requirements-dev.txt
     #   pexpect
-py-ecc==1.4.7
-    # via
-    #   -r requirements-dev.txt
-    #   raiden-contracts
-py-solc==3.2.0
+py-solc-x==1.1.0
     # via
     #   -r requirements-dev.txt
     #   raiden-contracts
@@ -525,11 +509,6 @@ pygments==2.6.1
     #   ipython
     #   pdbpp
     #   readme-renderer
-    #   sphinx
-pyhamcrest==1.9.0
-    # via
-    #   -r requirements-dev.txt
-    #   twisted
 pyinstaller-hooks-contrib==2020.7
     # via pyinstaller
 pyinstaller==4.2
@@ -592,7 +571,6 @@ python-magic==0.4.15
 pytz==2019.1
     # via
     #   -r requirements-dev.txt
-    #   babel
     #   flask-restful
 pyyaml==5.1.1
     # via
@@ -600,7 +578,7 @@ pyyaml==5.1.1
     #   matrix-synapse
 raiden-api-client==1.1.0
     # via -r requirements-dev.txt
-raiden-contracts==0.37.1
+raiden-contracts==0.37.3
     # via -r requirements-dev.txt
 raiden-webui==1.1.1
     # via -r requirements-dev.txt
@@ -610,18 +588,15 @@ regex==2020.6.8
     # via
     #   -r requirements-dev.txt
     #   black
-releases==1.6.3
-    # via -r requirements-dev.txt
 requests==2.25.1
     # via
     #   -r requirements-dev.txt
     #   grequests
     #   ipfshttpclient
     #   matrix-client
+    #   py-solc-x
     #   raiden-api-client
     #   responses
-    #   sphinx
-    #   sphinxcontrib-images
     #   treq
     #   web3
 responses==0.10.15
@@ -634,14 +609,10 @@ rlp==2.0.1
     #   raiden-contracts
 s3cmd==2.1.0
     # via -r requirements-ci.in
-semantic-version==2.6.0
+semantic-version==2.8.5
     # via
     #   -r requirements-dev.txt
-    #   py-solc
-    #   releases
-semver==2.8.1
-    # via
-    #   -r requirements-dev.txt
+    #   py-solc-x
     #   raiden-contracts
 service-identity==18.1.0
     # via
@@ -659,7 +630,6 @@ simplejson==3.16.0
 six==1.15.0
     # via
     #   -r requirements-dev.txt
-    #   astunparse
     #   attrdict
     #   automat
     #   bcrypt
@@ -673,7 +643,6 @@ six==1.15.0
     #   packaging
     #   parsimonious
     #   protobuf
-    #   pyhamcrest
     #   pymacaroons
     #   pynacl
     #   pyopenssl
@@ -681,60 +650,13 @@ six==1.15.0
     #   python-dateutil
     #   readme-renderer
     #   responses
-    #   sphinxcontrib-httpdomain
     #   traitlets
     #   treq
-snowballstemmer==1.2.1
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
 sortedcontainers==2.1.0
     # via
     #   -r requirements-dev.txt
     #   hypothesis
     #   matrix-synapse
-sphinx-rtd-theme==0.5.1
-    # via -r requirements-dev.txt
-sphinx==3.5.2
-    # via
-    #   -r requirements-dev.txt
-    #   releases
-    #   sphinx-rtd-theme
-    #   sphinxcontrib-httpdomain
-    #   sphinxcontrib-httpexample
-    #   sphinxcontrib-images
-sphinxcontrib-applehelp==1.0.2
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
-sphinxcontrib-devhelp==1.0.2
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
-sphinxcontrib-htmlhelp==1.0.3
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
-sphinxcontrib-httpdomain==1.7.0
-    # via
-    #   -r requirements-dev.txt
-    #   sphinxcontrib-httpexample
-sphinxcontrib-httpexample==0.10.3
-    # via -r requirements-dev.txt
-sphinxcontrib-images==0.9.2
-    # via -r requirements-dev.txt
-sphinxcontrib-jsmath==1.0.1
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
-sphinxcontrib-qthelp==1.0.3
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
-sphinxcontrib-serializinghtml==1.1.4
-    # via
-    #   -r requirements-dev.txt
-    #   sphinx
 structlog==21.1.0
     # via -r requirements-dev.txt
 text-unidecode==1.3
@@ -755,11 +677,11 @@ traitlets==4.3.2
     # via
     #   -r requirements-dev.txt
     #   ipython
-treq==18.6.0
+treq==21.1.0
     # via
     #   -r requirements-dev.txt
     #   matrix-synapse
-twisted[tls]==20.3.0
+twisted[tls]==21.2.0
     # via
     #   -r requirements-dev.txt
     #   matrix-synapse
@@ -767,15 +689,19 @@ twisted[tls]==20.3.0
 typed-ast==1.4.0
     # via
     #   -r requirements-dev.txt
+    #   astroid
     #   black
     #   mypy
 typing-extensions==3.7.4.3
     # via
     #   -r requirements-dev.txt
     #   black
+    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
+    #   structlog
+    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements-dev.txt
@@ -815,10 +741,6 @@ werkzeug==1.0.1
     # via
     #   -r requirements-dev.txt
     #   flask
-wheel==0.33.4
-    # via
-    #   -r requirements-dev.txt
-    #   astunparse
 wmctrl==0.3
     # via
     #   -r requirements-dev.txt
@@ -827,7 +749,7 @@ wrapt==1.11.1
     # via
     #   -r requirements-dev.txt
     #   astroid
-zipp==3.4.0
+zipp==3.4.1
     # via
     #   -r requirements-dev.txt
     #   importlib-metadata

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -4,7 +4,9 @@
 
 # split out to allow faster building of docs and to not require python 3.7
 # since they don't support it in RTD yet: https://github.com/rtfd/readthedocs.org/issues/4713
--r requirements-docs.txt
+# FIXME: Temporarily remove docs requirements from dev until releases removes the pin of
+# `semantic-version<2.7`. See: https://github.com/bitprophet/releases/pull/86
+# -r requirements-docs.txt
 
 # Dependencies
 pip-tools~=5.5.0  # this is used by 'deps.py'

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -10,10 +10,6 @@ aioice==0.7.5
     #   aiortc
 aiortc==1.2.0
     # via -r requirements.txt
-alabaster==0.7.12
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
 aniso8601==7.0.0
     # via
     #   -r requirements.txt
@@ -28,10 +24,6 @@ asn1crypto==1.3.0
     #   coincurve
 astroid==2.5.1
     # via pylint
-astunparse==1.6.2
-    # via
-    #   -r requirements-docs.txt
-    #   sphinxcontrib-httpexample
 attrdict==2.0.1
     # via raiden-api-client
 attrs==19.3.0
@@ -46,16 +38,12 @@ attrs==19.3.0
     #   service-identity
     #   treq
     #   twisted
-automat==0.7.0
+automat==20.2.0
     # via twisted
 av==8.0.2
     # via
     #   -r requirements.txt
     #   aiortc
-babel==2.7.0
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
 backcall==0.1.0
     # via ipython
 base58==2.0.0
@@ -84,7 +72,6 @@ canonicaljson==1.4.0
     #   signedjson
 certifi==2019.3.9
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   requests
 cffi==1.12.3
@@ -98,7 +85,6 @@ cffi==1.12.3
     #   pynacl
 chardet==3.0.4
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   requests
 click==8.0.0a1
@@ -143,12 +129,8 @@ dnspython==2.1.0
     # via
     #   -r requirements.txt
     #   aioice
-docutils==0.14
-    # via
-    #   -r requirements-docs.txt
-    #   readme-renderer
-    #   sphinx
-    #   sphinxcontrib-httpexample
+docutils==0.16
+    # via readme-renderer
 eth-abi==2.1.0
     # via
     #   -r requirements.txt
@@ -255,24 +237,27 @@ hexbytes==0.2.0
     #   eth-account
     #   eth-rlp
     #   web3
-hyperlink==19.0.0
-    # via twisted
+hyperlink==21.0.0
+    # via
+    #   treq
+    #   twisted
 hypothesis==6.3.0
     # via -r requirements-dev.in
 idna==2.8
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   hyperlink
     #   matrix-synapse
     #   requests
     #   twisted
-imagesize==1.1.0
+importlib-metadata==3.7.3
     # via
-    #   -r requirements-docs.txt
-    #   sphinx
-importlib-metadata==3.4.0
-    # via pluggy
+    #   -r requirements.txt
+    #   flake8
+    #   flake8-comprehensions
+    #   jsonschema
+    #   pluggy
+    #   pytest
 incremental==17.5.0
     # via
     #   treq
@@ -297,13 +282,11 @@ itsdangerous==1.1.0
     #   flask
 jedi==0.17.0
     # via ipython
-jinja2==2.10.1
+jinja2==2.11.3
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   flask
     #   matrix-synapse
-    #   sphinx
 jsonschema==3.2.0
     # via
     #   -r requirements.txt
@@ -317,7 +300,6 @@ lru-dict==1.1.6
     #   web3
 markupsafe==1.1.1
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   jinja2
 marshmallow-dataclass==8.0.0
@@ -372,10 +354,8 @@ objgraph==3.5.0
     # via -r requirements.txt
 packaging==19.0
     # via
-    #   -r requirements-docs.txt
     #   bleach
     #   pytest
-    #   sphinx
 parsimonious==0.8.1
     # via
     #   -r requirements.txt
@@ -414,11 +394,7 @@ psutil==5.8.0
     #   mirakuru
 ptyprocess==0.6.0
     # via pexpect
-py-ecc==1.4.7
-    # via
-    #   -r requirements.txt
-    #   raiden-contracts
-py-solc==3.2.0
+py-solc-x==1.1.0
     # via
     #   -r requirements.txt
     #   raiden-contracts
@@ -454,13 +430,9 @@ pyflakes==2.2.0
     # via flake8
 pygments==2.6.1
     # via
-    #   -r requirements-docs.txt
     #   ipython
     #   pdbpp
     #   readme-renderer
-    #   sphinx
-pyhamcrest==1.9.0
-    # via twisted
 pylibsrtp==0.6.6
     # via
     #   -r requirements.txt
@@ -479,9 +451,7 @@ pyopenssl==19.0.0
     #   matrix-synapse
     #   twisted
 pyparsing==2.4.0
-    # via
-    #   -r requirements-docs.txt
-    #   packaging
+    # via packaging
 pyrsistent==0.15.7
     # via
     #   -r requirements.txt
@@ -507,15 +477,13 @@ python-dateutil==2.8.1
     # via faker
 pytz==2019.1
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
-    #   babel
     #   flask-restful
 pyyaml==5.1.1
     # via matrix-synapse
 raiden-api-client==1.1.0
     # via -r requirements-dev.in
-raiden-contracts==0.37.1
+raiden-contracts==0.37.3
     # via -r requirements.txt
 raiden-webui==1.1.1
     # via -r requirements.txt
@@ -523,19 +491,15 @@ readme-renderer==28.0
     # via -r requirements-dev.in
 regex==2020.6.8
     # via black
-releases==1.6.3
-    # via -r requirements-docs.txt
 requests==2.25.1
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   grequests
     #   ipfshttpclient
     #   matrix-client
+    #   py-solc-x
     #   raiden-api-client
     #   responses
-    #   sphinx
-    #   sphinxcontrib-images
     #   treq
     #   web3
 responses==0.10.15
@@ -546,15 +510,10 @@ rlp==2.0.1
     #   eth-account
     #   eth-rlp
     #   raiden-contracts
-semantic-version==2.6.0
-    # via
-    #   -r requirements-docs.txt
-    #   -r requirements.txt
-    #   py-solc
-    #   releases
-semver==2.8.1
+semantic-version==2.8.5
     # via
     #   -r requirements.txt
+    #   py-solc-x
     #   raiden-contracts
 service-identity==18.1.0
     # via
@@ -567,9 +526,7 @@ simplejson==3.16.0
 six==1.15.0
     # via
     #   -r requirements-dev.in
-    #   -r requirements-docs.txt
     #   -r requirements.txt
-    #   astunparse
     #   attrdict
     #   automat
     #   bcrypt
@@ -583,7 +540,6 @@ six==1.15.0
     #   packaging
     #   parsimonious
     #   protobuf
-    #   pyhamcrest
     #   pymacaroons
     #   pynacl
     #   pyopenssl
@@ -591,59 +547,12 @@ six==1.15.0
     #   python-dateutil
     #   readme-renderer
     #   responses
-    #   sphinxcontrib-httpdomain
     #   traitlets
     #   treq
-snowballstemmer==1.2.1
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
 sortedcontainers==2.1.0
     # via
     #   hypothesis
     #   matrix-synapse
-sphinx-rtd-theme==0.5.1
-    # via -r requirements-docs.txt
-sphinx==3.5.2
-    # via
-    #   -r requirements-docs.txt
-    #   releases
-    #   sphinx-rtd-theme
-    #   sphinxcontrib-httpdomain
-    #   sphinxcontrib-httpexample
-    #   sphinxcontrib-images
-sphinxcontrib-applehelp==1.0.2
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
-sphinxcontrib-devhelp==1.0.2
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
-sphinxcontrib-htmlhelp==1.0.3
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
-sphinxcontrib-httpdomain==1.7.0
-    # via
-    #   -r requirements-docs.txt
-    #   sphinxcontrib-httpexample
-sphinxcontrib-httpexample==0.10.3
-    # via -r requirements-docs.txt
-sphinxcontrib-images==0.9.2
-    # via -r requirements-docs.txt
-sphinxcontrib-jsmath==1.0.1
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
-sphinxcontrib-qthelp==1.0.3
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
-sphinxcontrib-serializinghtml==1.1.4
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
 structlog==21.1.0
     # via -r requirements.txt
 text-unidecode==1.3
@@ -660,23 +569,27 @@ toolz==0.9.0
     #   cytoolz
 traitlets==4.3.2
     # via ipython
-treq==18.6.0
+treq==21.1.0
     # via matrix-synapse
-twisted[tls]==20.3.0
+twisted[tls]==21.2.0
     # via
     #   matrix-synapse
     #   treq
 typed-ast==1.4.0
     # via
+    #   astroid
     #   black
     #   mypy
 typing-extensions==3.7.4.3
     # via
     #   -r requirements.txt
     #   black
+    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
+    #   structlog
+    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements.txt
@@ -689,7 +602,6 @@ unpaddedbase64==1.1.0
     #   signedjson
 urllib3==1.25.3
     # via
-    #   -r requirements-docs.txt
     #   -r requirements.txt
     #   requests
 varint==1.0.2
@@ -712,16 +624,14 @@ werkzeug==1.0.1
     # via
     #   -r requirements.txt
     #   flask
-wheel==0.33.4
-    # via
-    #   -r requirements-docs.txt
-    #   astunparse
 wmctrl==0.3
     # via pdbpp
 wrapt==1.11.1
     # via astroid
-zipp==3.4.0
-    # via importlib-metadata
+zipp==3.4.1
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata
 zope.event==4.4
     # via
     #   -r requirements.txt

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -22,7 +22,7 @@ idna==2.8
     # via requests
 imagesize==1.1.0
     # via sphinx
-jinja2==2.10.1
+jinja2==2.11.3
     # via sphinx
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,6 +12,7 @@ Flask-Cors
 Flask-RESTful
 gevent>=1.5a3
 guppy3
+jinja2>=2.11
 marshmallow-dataclass
 marshmallow-polyfield
 marshmallow

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -121,12 +121,16 @@ hexbytes==0.2.0
     #   web3
 idna==2.8
     # via requests
+importlib-metadata==3.7.3
+    # via jsonschema
 ipfshttpclient==0.7.0a1
     # via web3
 itsdangerous==1.1.0
     # via flask
-jinja2==2.10.1
-    # via flask
+jinja2==2.11.3
+    # via
+    #   -r requirements.in
+    #   flask
 jsonschema==3.2.0
     # via web3
 lru-dict==1.1.6
@@ -171,9 +175,7 @@ psutil==5.8.0
     # via
     #   -r requirements.in
     #   mirakuru
-py-ecc==1.4.7
-    # via raiden-contracts
-py-solc==3.2.0
+py-solc-x==1.1.0
     # via raiden-contracts
 pycparser==2.19
     # via cffi
@@ -191,7 +193,7 @@ pysha3==1.0.2
     # via -r requirements.in
 pytz==2019.1
     # via flask-restful
-raiden-contracts==0.37.1
+raiden-contracts==0.37.3
     # via -r requirements.in
 raiden-webui==1.1.1
     # via -r requirements.in
@@ -200,16 +202,17 @@ requests==2.25.1
     #   -r requirements.in
     #   ipfshttpclient
     #   matrix-client
+    #   py-solc-x
     #   web3
 rlp==2.0.1
     # via
     #   eth-account
     #   eth-rlp
     #   raiden-contracts
-semantic-version==2.6.0
-    # via py-solc
-semver==2.8.1
-    # via raiden-contracts
+semantic-version==2.8.5
+    # via
+    #   py-solc-x
+    #   raiden-contracts
 six==1.15.0
     # via
     #   cryptography
@@ -227,7 +230,11 @@ toml==0.10.2
 toolz==0.9.0
     # via cytoolz
 typing-extensions==3.7.4.3
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   importlib-metadata
+    #   structlog
+    #   web3
 typing-inspect==0.4.0
     # via marshmallow-dataclass
 ulid-py==1.1.0
@@ -244,6 +251,8 @@ websockets==8.1
     # via web3
 werkzeug==1.0.1
     # via flask
+zipp==3.4.1
+    # via importlib-metadata
 zope.event==4.4
     # via gevent
 zope.interface==5.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ filterwarnings =
     ignore::urllib3.exceptions.InsecureRequestWarning
 markers =
     timeout
+    asyncio: tests that require an asyncio eventloop
 junit_family = xunit1
 
 [mypy]


### PR DESCRIPTION
## Description

We had accrued a big bunch of deprecation warnings (which usually showed up when running the tests) which would cause  reakage in future Python versions.

This upgrades packages as necessary and fixes most warnings.
The remaining ones are being tracked here:

- raiden-network/raiden-api-client#1
- matrix-org/synapse#9641
- matrix-org/synapse#9642
- slezica/python-frozendict#25

This also temporarily removes the docs requirements from the dev set since there's a conflict between `releases` and `py-solc-x` pinned versions of `semantic-version`. See: bitprophet/releases#94

This requires some fixes in raiden-contracts.
Requires raiden-network/raiden-contracts#1443
