### PR TITLE
Make transactions replay proof

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,11 @@ templates:
       type: string
 
   default-environment: &default-environment
-    GETH_URL_LINUX: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.21-0287d548.tar.gz'
-    GETH_MD5_LINUX: '639e3b7bfd95a78fc47642c8b88488e7'
-    GETH_URL_MACOS: 'https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.9.21-0287d548.tar.gz'
-    GETH_MD5_MACOS: '3fe7db3a327948d99dc22a20d880fe7f'
-    GETH_VERSION: '1.9.21'
+    GETH_URL_LINUX: 'https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.1-c2d2f4ed.tar.gz'
+    GETH_MD5_LINUX: '5e18a027f9919ed9ba08abd15c169f61'
+    GETH_URL_MACOS: 'https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.10.1-c2d2f4ed.tar.gz'
+    GETH_MD5_MACOS: '50270c1205c0a27457d9a8b182670c83'
+    GETH_VERSION: '1.10.1'
     PARITY_URL_LINUX: 'https://github.com/openethereum/openethereum/releases/download/v3.1.0/openethereum-linux-v3.1.0.zip'
     PARITY_SHA256_LINUX: '8dd753058e5db77ffaede5a53418005f9c8133212448e11df9169a651cdac997'
     PARITY_URL_MACOS: 'https://github.com/openethereum/openethereum/releases/download/v3.1.0/openethereum-macos-v3.1.0.zip'

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -88,7 +88,7 @@ from raiden.utils.typing import (
     TransactionHash,
     typecheck,
 )
-from raiden_contracts.utils.type_aliases import ChainID
+from raiden_contracts.utils.type_aliases import ChainID, T_ChainID
 
 log = structlog.get_logger(__name__)
 
@@ -1004,6 +1004,7 @@ class TransactionSent(ABC):
     gas_price: int
     nonce: Nonce
     transaction_hash: TransactionHash
+    chain_id: ChainID
 
 
 @dataclass
@@ -1017,6 +1018,7 @@ class TransactionMined:
     nonce: Nonce
     transaction_hash: TransactionHash
     receipt: TxReceipt
+    chain_id: ChainID
 
 
 class JSONRPCClient:
@@ -1224,6 +1226,7 @@ class JSONRPCClient:
             gas_price: int
             nonce: Nonce
             transaction_hash: TransactionHash
+            chain_id: ChainID
 
             def __post_init__(self) -> None:
                 self.extra_log_details.setdefault("token", str(uuid4()))
@@ -1234,6 +1237,7 @@ class JSONRPCClient:
                 typecheck(self.gas_price, int)
                 typecheck(self.nonce, T_Nonce)
                 typecheck(self.transaction_hash, T_TransactionHash)
+                typecheck(self.chain_id, T_ChainID)
 
             def to_log_details(self) -> Dict[str, Any]:
                 log_details = self.data.to_log_details()
@@ -1247,6 +1251,7 @@ class JSONRPCClient:
                         "gas_price": self.gas_price,
                         "nonce": self.nonce,
                         "transaction_hash": encode_hex(self.transaction_hash),
+                        "chain_id": self.chain_id,
                     }
                 )
                 return log_details
@@ -1299,6 +1304,7 @@ class JSONRPCClient:
                         "value": slot.data.value,
                         "to": function_call.contract.address,
                         "gasPrice": slot.gas_price,
+                        "chainId": self.chain_id,
                     }
 
                     log.debug(
@@ -1311,6 +1317,7 @@ class JSONRPCClient:
                         "nonce": slot.nonce,
                         "value": slot.data.value,
                         "gasPrice": slot.gas_price,
+                        "chainId": self.chain_id,
                     }
 
                     log.debug("Transaction to transfer ether will be sent", **log_details)
@@ -1321,6 +1328,7 @@ class JSONRPCClient:
                         "nonce": slot.nonce,
                         "value": 0,
                         "gasPrice": slot.gas_price,
+                        "chainId": self.chain_id,
                     }
 
                     log.debug("Transaction to deploy smart contract will be sent", **log_details)
@@ -1391,6 +1399,7 @@ class JSONRPCClient:
             gas_price=slot.gas_price,
             nonce=slot.nonce,
             transaction_hash=TransactionHash(tx_hash),
+            chain_id=self.chain_id,
         )
         log.debug("Transaction sent", **transaction_sent.to_log_details())
         return transaction_sent
@@ -1536,6 +1545,7 @@ class JSONRPCClient:
                         nonce=transaction_sent.nonce,
                         transaction_hash=transaction_sent.transaction_hash,
                         receipt=tx_receipt,
+                        chain_id=transaction_sent.chain_id,
                     )
                     return transaction_mined
 

--- a/raiden/network/utils.py
+++ b/raiden/network/utils.py
@@ -51,7 +51,7 @@ if sys.platform == "darwin":  # pragma: no cover
                 # SO_REUSEADDR on it's sockets. Most 'server' applications do.
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 try:
-                    sock.bind((LOOPBACK, port_candidate))
+                    sock.bind(("", port_candidate))
                 except OSError as ex:
                     if ex.errno == errno.EADDRINUSE:
                         continue

--- a/raiden/tests/conftest.py
+++ b/raiden/tests/conftest.py
@@ -511,7 +511,7 @@ if sys.platform == "darwin":
 
     def pytest_configure(config) -> None:
         if config.option.basetemp is None:
-            config.option.basetemp = f"/tmp/pytest-of-{os.getlogin():.6s}"
+            config.option.basetemp = f"/tmp/pytest-of-{os.getlogin():.6s}-{os.getpid()}"
 
 
 @pytest.fixture(autouse=True)

--- a/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
+++ b/raiden/tests/integration/rpc/assumptions/test_rpc_transaction_assumptions.py
@@ -140,6 +140,7 @@ def test_discover_next_available_nonce(deploy_client: JSONRPCClient) -> None:
             "nonce": next_nonce,
             "value": 1,
             "gasPrice": gas_price,
+            "chainId": deploy_client.chain_id,
         }
         signed_txn = deploy_client.web3.eth.account.sign_transaction(
             transaction, deploy_client.privkey
@@ -163,6 +164,7 @@ def test_discover_next_available_nonce(deploy_client: JSONRPCClient) -> None:
             "nonce": skip_nonce,
             "value": 1,
             "gasPrice": gas_price,
+            "chainId": deploy_client.chain_id,
         }
         signed_txn = deploy_client.web3.eth.account.sign_transaction(
             transaction, deploy_client.privkey


### PR DESCRIPTION
## Description

Fixes: #6872

Fixes geth 1.10 incompatibility and ensures txs created by Raiden are replay protected (EIP-155).
(Also contains some fixes to the `tools/parallel_tests.sh` helper for macOS)
