### PR TITLE
Allow selection of unstable env/contracts

### DIFF
--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -23,7 +23,7 @@ from raiden.utils.typing import (
     TokenAddress,
     TokenAmount,
 )
-from raiden_contracts.contract_manager import contracts_precompiled_path
+from raiden_contracts.contract_manager import ContractDevEnvironment, contracts_precompiled_path
 
 CACHE_TTL = 60
 GAS_LIMIT = 10 * 10 ** 6
@@ -206,6 +206,7 @@ class RaidenConfig:
     blockchain: BlockchainConfig = BlockchainConfig()
     mediation_fees: MediationFeeConfig = MediationFeeConfig()
     services: ServiceConfig = ServiceConfig()
+    development_environment: ContractDevEnvironment = ContractDevEnvironment.DEMO
 
     transport_type: str = "matrix"
     transport: MatrixTransportConfig = MatrixTransportConfig(

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -81,7 +81,7 @@ from raiden.utils.typing import (
     UserDepositAddress,
 )
 from raiden_contracts.constants import CONTRACT_TOKEN_NETWORK_REGISTRY, ID_TO_CHAINNAME
-from raiden_contracts.contract_manager import ContractManager
+from raiden_contracts.contract_manager import ContractDevEnvironment, ContractManager
 
 log = structlog.get_logger(__name__)
 
@@ -187,6 +187,7 @@ def setup_raiden_config(
     matrix_server: str,
     chain_id: ChainID,
     environment_type: Environment,
+    development_environment: ContractDevEnvironment,
     unrecoverable_error_should_crash: bool,
     pathfinding_max_paths: int,
     enable_monitoring: bool,
@@ -257,6 +258,7 @@ def setup_raiden_config(
     config = RaidenConfig(
         chain_id=chain_id,
         environment_type=environment_type,
+        development_environment=development_environment,
         reveal_timeout=default_reveal_timeout,
         settle_timeout=default_settle_timeout,
         console=console,
@@ -305,7 +307,7 @@ def run_raiden_service(
 
     address, privatekey = get_account_and_private_key(account_manager, address, password_file)
 
-    contracts = load_deployed_contracts_data(config, chain_id)
+    contracts = load_deployed_contracts_data(config, chain_id, config.development_environment)
 
     rpc_client = JSONRPCClient(
         web3=web3,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -72,6 +72,7 @@ from raiden.utils.formatting import to_checksum_address
 from raiden.utils.system import get_system_spec
 from raiden.utils.typing import MYPY_ANNOTATION, ChainID
 from raiden_contracts.constants import ID_TO_CHAINNAME
+from raiden_contracts.contract_manager import ContractDevEnvironment
 
 log = structlog.get_logger(__name__)
 ETH_RPC_CONFIG_OPTION = "--eth-rpc-endpoint"
@@ -234,6 +235,15 @@ OPTIONS = [
         type=EnumChoiceType(Environment),
         default=Environment.PRODUCTION.value,
         show_default=True,
+    ),
+    option(
+        "--development-environment",
+        help=(
+            "Choose which set of services and transport servers should be used. "
+            "Change this only when you are developing Raiden itself."
+        ),
+        type=EnumChoiceType(ContractDevEnvironment),
+        default=ContractDevEnvironment.DEMO.value,
     ),
     option(
         "--accept-disclaimer",

--- a/raiden/ui/startup.py
+++ b/raiden/ui/startup.py
@@ -42,6 +42,7 @@ from raiden_contracts.constants import (
     ID_TO_CHAINNAME,
 )
 from raiden_contracts.contract_manager import (
+    ContractDevEnvironment,
     contracts_precompiled_path,
     get_contracts_deployment_info,
 )
@@ -134,7 +135,11 @@ class ServicesBundle:
             )
 
 
-def load_deployed_contracts_data(config: RaidenConfig, chain_id: ChainID) -> Dict[str, Any]:
+def load_deployed_contracts_data(
+    config: RaidenConfig,
+    chain_id: ChainID,
+    development_environment: ContractDevEnvironment = ContractDevEnvironment.DEMO,
+) -> Dict[str, Any]:
     """Sets the contract deployment data depending on the network id and environment type
 
     If an invalid combination of network id and environment type is provided, exits
@@ -149,7 +154,9 @@ def load_deployed_contracts_data(config: RaidenConfig, chain_id: ChainID) -> Dic
 
     if chain_id in ID_TO_CHAINNAME and ID_TO_CHAINNAME[chain_id] != "smoketest":
         deployment_data = get_contracts_deployment_info(
-            chain_id=chain_id, version=contracts_version
+            chain_id=chain_id,
+            version=contracts_version,
+            development_environment=development_environment,
         )
         if not deployment_data:
             return deployed_contracts_data


### PR DESCRIPTION
Allow switching between the two contract deployments on goerli and
default to the old/demo contracts. See
https://github.com/raiden-network/light-client/issues/2521 on why we
want to do this.

Closes https://github.com/raiden-network/raiden/issues/6862