### PR TITLE
Query address-metadata from PFS endpoint before direct transfer

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -37,6 +37,7 @@ from raiden.utils.system import get_system_spec
 from raiden.utils.transfers import to_rdn
 from raiden.utils.typing import (
     Address,
+    AddressMetadata,
     Any,
     BlockExpiration,
     BlockIdentifier,
@@ -541,14 +542,14 @@ def post_pfs_paths(
         )
 
 
-def query_user(
+def query_address_metadata(
     pfs_config: PFSConfig,
     user_address: Union[Address, TargetAddress],
-) -> str:
+) -> AddressMetadata:
     """ Get the matrix user_id for the given address from the PFS """
     try:
         response = session.get(
-            f"{pfs_config.info.url}/api/v1/user/{to_checksum_address(user_address)}",
+            f"{pfs_config.info.url}/api/v1/address/{to_checksum_address(user_address)}/metadata",
         )
     except RequestException as e:
         raise ServiceRequestFailed(
@@ -567,7 +568,7 @@ def query_user(
     if response.status_code != 200:
         raise PFSReturnedError.from_response(response_json)
 
-    return response_json["user_id"]
+    return response_json
 
 
 def query_paths(

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -91,6 +91,7 @@ from raiden.utils.typing import (
     MessageID,
     NamedTuple,
     Optional,
+    PeerCapabilities,
     RoomID,
     Set,
     Tuple,
@@ -516,9 +517,17 @@ class MatrixTransport(Runnable):
         return self._raiden_service.address if self._raiden_service else None
 
     @property
-    def user_id(self) -> Optional[str]:
+    def user_id(self) -> Optional[UserID]:
         address = self._node_address
         return make_user_id(address, self._server_name) if address is not None else None
+
+    @property
+    def address_metadata(self) -> Optional[AddressMetadata]:
+        own_caps = PeerCapabilities(capconfig_to_dict(self._config.capabilities_config))
+        own_user_id = self.user_id
+        if own_user_id is None:
+            return None
+        return dict(user_id=own_user_id, capabilities=own_caps)
 
     def start(  # type: ignore
         self,

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -200,8 +200,12 @@ def initiator_init(
     )
 
     error_msg = None
-
     if route_states is None:
+        our_address_metadata = raiden.transport.address_metadata
+
+        msg = "Transport is not initialized with raiden-service"
+        assert our_address_metadata is not None, msg
+
         error_msg, route_states, feedback_token = routing.get_best_routes(
             chain_state=views.state_from_raiden(raiden),
             token_network_address=token_network_address,
@@ -212,6 +216,7 @@ def initiator_init(
             previous_address=None,
             pfs_config=raiden.config.pfs_config,
             privkey=raiden.privkey,
+            our_address_metadata=our_address_metadata,
         )
 
         # Only prepare feedback when token is available

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -4,7 +4,6 @@ import structlog
 from eth_utils import to_canonical_address
 
 from raiden.exceptions import ServiceRequestFailed
-from raiden.messages.metadata import RouteMetadata
 from raiden.network.pathfinding import PFSConfig, query_address_metadata, query_paths
 from raiden.transfer import channel, views
 from raiden.transfer.state import ChainState, ChannelState, RouteState

--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -42,6 +42,10 @@ def get_best_routes(
     token_network = views.get_token_network_by_address(chain_state, token_network_address)
     assert token_network, "The token network must be validated and exist."
 
+    if pfs_config is None or one_to_n_address is None:
+        log.warning("Pathfinding Service could not be used.")
+        return "Pathfinding Service could not be used.", list(), None
+
     # Always use a direct channel if available:
     # - There are no race conditions and the capacity is guaranteed to be
     #   available.
@@ -67,10 +71,6 @@ def get_best_routes(
                     estimated_fee=FeeAmount(0),
                 )
                 return None, [direct_route], None
-
-    if pfs_config is None or one_to_n_address is None:
-        log.warning("Pathfinding Service could not be used.")
-        return "Pathfinding Service could not be used.", list(), None
 
     # Does any channel have sufficient capacity for the payment?
     channels = [

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -22,6 +22,14 @@ def synapse_config_generator():
         yield generator
 
 
+@pytest.fixture(autouse=True)
+def query_user_mock(local_matrix_servers, monkeypatch):
+    def query_user(_pfs_config, user_address):
+        return f"@0x{user_address.hex()}:{local_matrix_servers[0]}"
+
+    monkeypatch.setattr("raiden.routing.query_user", query_user)
+
+
 @pytest.fixture
 def matrix_server_count() -> int:
     return 1

--- a/raiden/tests/integration/fixtures/transport.py
+++ b/raiden/tests/integration/fixtures/transport.py
@@ -12,8 +12,16 @@ from raiden.settings import (
 )
 from raiden.tests.fixtures.variables import TransportProtocol
 from raiden.tests.utils.transport import ParsedURL, generate_synapse_config, matrix_server_starter
+from raiden.utils.capabilities import capconfig_to_dict
 from raiden.utils.http import HTTPExecutor
-from raiden.utils.typing import Iterable, Optional, Tuple
+from raiden.utils.typing import (
+    AddressMetadata,
+    Iterable,
+    Optional,
+    PeerCapabilities,
+    Tuple,
+    UserID,
+)
 
 
 @pytest.fixture(scope="session")
@@ -23,11 +31,17 @@ def synapse_config_generator():
 
 
 @pytest.fixture(autouse=True)
-def query_user_mock(local_matrix_servers, monkeypatch):
-    def query_user(_pfs_config, user_address):
-        return f"@0x{user_address.hex()}:{local_matrix_servers[0]}"
+def query_address_metadata_mock(local_matrix_servers, capabilities, monkeypatch):
+    def query_address_metadata(_pfs_config, user_address):
+        server_name = local_matrix_servers[0]
+        return AddressMetadata(
+            dict(
+                user_id=UserID(f"@0x{user_address.hex()}:{server_name}"),
+                capabilities=PeerCapabilities(capconfig_to_dict(capabilities)),
+            )
+        )
 
-    monkeypatch.setattr("raiden.routing.query_user", query_user)
+    monkeypatch.setattr("raiden.routing.query_address_metadata", query_address_metadata)
 
 
 @pytest.fixture

--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -549,6 +549,7 @@ def test_clear_closed_queue(raiden_network: List[RaidenService], token_addresses
         target=TargetAddress(target),
         identifier=payment_identifier,
         secret=secret,
+        route_states=[create_route_state_for_route([app0, app1], token_address)],
     )
 
     app1.transport.stop()

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -24,6 +24,7 @@ from raiden.tests.utils.protocol import HoldRaidenEventHandler, WaitForMessage
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
     block_offset_timeout,
+    create_route_state_for_route,
     get_channelstate,
     transfer,
 )
@@ -505,6 +506,7 @@ def test_channel_withdraw(
         target=target,
         identifier=identifier,
         secret=secret,
+        route_states=[create_route_state_for_route([alice_app, bob_app], token_address)],
     )
     wait_for_unlock = bob_app.message_handler.wait_for_message(
         Unlock, {"payment_identifier": identifier}
@@ -687,6 +689,7 @@ def test_settled_lock(
         target=target,
         identifier=identifier,
         secret=secret,
+        route_states=[create_route_state_for_route([app0, app1], token_address)],
     )
 
     secret_available.wait()  # wait for the messages to be exchanged

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -16,6 +16,7 @@ from raiden.tests.utils.protocol import HoldRaidenEventHandler
 from raiden.tests.utils.transfer import (
     assert_synced_channel_state,
     block_offset_timeout,
+    create_route_state_for_route,
     watch_for_unlock_failures,
 )
 from raiden.transfer import views
@@ -81,6 +82,7 @@ def test_send_queued_messages_after_restart(  # pylint: disable=unused-argument
             target=TargetAddress(app1.address),
             identifier=identifier,
             secret=secret,
+            route_states=[create_route_state_for_route([app0, app1], token_address)],
         )
 
     app0.stop()

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -659,9 +659,11 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
     address1, _, _, _ = addresses
 
     # with the transfer of 50 the direct channel should be returned,
-    # so there must be not a pfs call
-    with patch("raiden.routing.get_best_routes_pfs") as pfs_request:
-        pfs_request.return_value = None, [], "feedback_token"
+    # so there must be not a route request to the pfs
+    with patch("raiden.routing.get_best_routes_pfs") as pfs_route_request, patch(
+        "raiden.routing.query_user"
+    ) as pfs_user_request:
+        pfs_route_request.return_value = None, [], "feedback_token"
         _, routes, _ = get_best_routes(
             chain_state=chain_state,
             token_network_address=token_network_state.address,
@@ -674,7 +676,8 @@ def test_routing_in_direct_channel(happy_path_fixture, our_address, one_to_n_add
             privkey=PRIVKEY,
         )
         assert routes[0].next_hop_address == address1
-        assert not pfs_request.called
+        assert not pfs_route_request.called
+        assert pfs_user_request.called
 
     # with the transfer of 51 the direct channel should not be returned,
     # so there must be a pfs call

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -315,6 +315,7 @@ def _transfer_expired(
         identifier=identifier,
         secret=secret,
         secrethash=secrethash,
+        route_states=[create_route_state_for_route([initiator_app, target_app], token_address)],
     )
 
     with Timeout(seconds=timeout):
@@ -360,6 +361,7 @@ def _transfer_secret_not_requested(
         identifier=identifier,
         secret=secret,
         secrethash=secrethash,
+        route_states=[create_route_state_for_route([initiator_app, target_app], token_address)],
     )
 
     with Timeout(seconds=timeout):

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -185,7 +185,7 @@ def transfer(
     """Nice to read shortcut to make successful mediated transfer.
 
     Note:
-        Only the initiator and target are synched.
+        Only the initiator and target are synced.
     """
 
     if transfer_state is TransferState.UNLOCKED:
@@ -315,7 +315,6 @@ def _transfer_expired(
         identifier=identifier,
         secret=secret,
         secrethash=secrethash,
-        route_states=[create_route_state_for_route([initiator_app, target_app], token_address)],
     )
 
     with Timeout(seconds=timeout):
@@ -361,7 +360,6 @@ def _transfer_secret_not_requested(
         identifier=identifier,
         secret=secret,
         secrethash=secrethash,
-        route_states=[create_route_state_for_route([initiator_app, target_app], token_address)],
     )
 
     with Timeout(seconds=timeout):

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -376,7 +376,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements-dev.txt
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
     # via -r requirements-dev.txt
 mccabe==0.6.1
     # via

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -46,5 +46,5 @@ coverage
 bump2version
 
 # Test support
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
 six>=1.13.0  # work around bad deps declaration in treq, see https://github.com/twisted/treq/commit/934e127a2b915bf02be86d23f2cf8a65bcdb2533#r42782781

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -336,7 +336,7 @@ marshmallow==3.10.0
     #   marshmallow-polyfield
 matrix-client==0.3.2
     # via -r requirements.txt
-matrix-synapse==1.27.0
+matrix-synapse==1.29.0
     # via -r requirements-dev.in
 mccabe==0.6.1
     # via


### PR DESCRIPTION
## Description
For a direct transfer, the node is not querying the PFS for a path. Since the main source of information for 
address-metadata is the Path-resource from the PFS, a direct transfer needs another means to retrieve the 
information. In this PR, the address-metadata endpoint of the PFS is accessed in order to 
get the address-metadata of the receiving node of a direct transfer.
Additionally, the sending nodes' address-metadata is injected in order for the receiver to 
interact with the sender easier.

Fixes: #6841
