### PR TITLE
remove fix me metadata

### DIFF
--- a/raiden/tests/integration/test_regression.py
+++ b/raiden/tests/integration/test_regression.py
@@ -176,7 +176,6 @@ def test_regression_multiple_revealsecret(
 
     nonce = Nonce(1)
     transferred_amount = TokenAmount(0)
-    # FIXME: Metadata
     mediated_transfer = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=make_message_identifier(),

--- a/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer_invalid.py
@@ -122,7 +122,6 @@ def test_receive_lockedtransfer_invalidnonce(
 
     repeated_nonce = Nonce(1)
     expiration = reveal_timeout * 2
-    # FIXME: Metadata
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=make_message_identifier(),
@@ -178,7 +177,6 @@ def test_receive_lockedtransfer_invalidsender(
     channel0 = get_channelstate(app0, app1, token_network_address)
     lock_amount = LockedAmount(10)
     expiration = reveal_timeout * 2
-    # FIXME: Metadata
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=make_message_identifier(),
@@ -225,7 +223,6 @@ def test_receive_lockedtransfer_invalidrecipient(
     invalid_recipient = make_address()
     lock_amount = LockedAmount(10)
     expiration = reveal_timeout * 2
-    # FIXME: Metadata
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=make_message_identifier(),
@@ -280,7 +277,6 @@ def test_received_lockedtransfer_closedchannel(
     lock_amount = LockedAmount(10)
     payment_identifier = PaymentID(1)
     expiration = reveal_timeout * 2
-    # FIXME: Metadata
     mediated_transfer_message = LockedTransfer(
         chain_id=UNIT_CHAIN_ID,
         message_identifier=make_message_identifier(),

--- a/raiden/tests/unit/api/test_api.py
+++ b/raiden/tests/unit/api/test_api.py
@@ -48,7 +48,6 @@ def test_initiator_task_view():
         secret=secret,
         secrethash=sha256_secrethash(secret),
     )
-    # FIXME: Metadata
     transfer_state = InitiatorTransferState(
         route=RouteState(route=[transfer.initiator, transfer.target], address_to_metadata={}),
         transfer_description=transfer_description,
@@ -87,7 +86,6 @@ def test_mediator_task_view():
         )
     )
     secrethash1 = payee_transfer.lock.secrethash
-    # FIXME: Metadata
     route_state = RouteState(route=[payee_transfer.target], address_to_metadata={})
 
     transfer_state1 = MediatorTransferState(secrethash=secrethash1, routes=[route_state])

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1218,7 +1218,6 @@ def test_do_not_claim_an_almost_expiring_lock_if_a_payment_didnt_occur():
     }
 
     init_state_change = ActionInitMediator(
-        # FIXME: Metadata
         candidate_route_states=[
             RouteState(
                 route=[our_state.address, attacked_channel.partner_state.address],
@@ -1869,7 +1868,6 @@ def test_filter_reachable_routes():
     partner1 = factories.NettingChannelEndStateProperties(address=Address(HOP1))
     partner2 = replace(partner1, address=HOP2)
     channel1 = factories.create(factories.NettingChannelStateProperties(partner_state=partner1))
-    # FIXME: Metadata
     possible_routes = [
         RouteState(
             # pylint: disable=E1101

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -58,6 +58,7 @@ from raiden.transfer.state import (
     make_empty_pending_locks_state,
 )
 from raiden.transfer.state_change import ContractReceiveChannelDeposit, ReceiveUnlock
+from raiden.utils.capabilities import capconfig_to_dict
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.signer import LocalSigner, Signer
 from raiden.utils.timeout import BlockTimeout
@@ -78,6 +79,7 @@ from raiden.utils.typing import (
     PaymentAmount,
     PaymentID,
     PaymentWithFeeAmount,
+    PeerCapabilities,
     SecretHash,
     TargetAddress,
     TokenAddress,
@@ -123,13 +125,15 @@ def create_route_state_for_route(
     assert len(apps) > 1, "Need at least two nodes for a route"
 
     route = list()
-    # FIXME: Metadata
     address_metadata = dict()
     for app in apps:
         route.append(app.address)
         user_id = UserID(app.transport.user_id)
+        capabilities = PeerCapabilities(
+            capconfig_to_dict(app.transport._config.capabilities_config)
+        )
         assert user_id is not None
-        address_metadata[app.address] = {"user_id": user_id}
+        address_metadata[app.address] = {"user_id": user_id, "capabilities": capabilities}
 
     token_network = views.get_token_network_by_token_address(
         views.state_from_raiden(apps[0]),


### PR DESCRIPTION
removes fix mes. Most of the time metadata are not needed to serve the test purpose. Address metadata are now created with capabilities in `create_route_state_for_route`