### PR TITLE
Fix serialization error

### DIFF
--- a/raiden/routing.py
+++ b/raiden/routing.py
@@ -212,10 +212,15 @@ def get_best_routes_pfs(
             )
             continue
 
+        canonical_address_metadata = {
+            to_canonical_address(address): metadata
+            for address, metadata in address_to_metadata.items()
+        }
+
         paths.append(
             RouteState(
                 route=canonical_path,
-                address_to_metadata=address_to_metadata,
+                address_to_metadata=canonical_address_metadata,
                 estimated_fee=estimated_fee,
             )
         )

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -17,7 +17,6 @@ from raiden.storage.serialization.schemas import SchemaCache
 from raiden.utils.copy import deepcopy
 from raiden.utils.typing import Any, Dict
 
-
 MESSAGE_NAME_TO_QUALIFIED_NAME = {
     "AuthenticatedMessage": "raiden.messages.abstract.AuthenticatedMessage",
     "Delivered": "raiden.messages.synchronization.Delivered",
@@ -80,7 +79,7 @@ class DictSerializer(SerializationBase):
             try:
                 schema = SchemaCache.get_or_create_schema(obj.__class__)
                 data = schema.dump(obj)
-            except (TypeError, ValidationError, ValueError) as ex:
+            except (AttributeError, TypeError, ValidationError, ValueError) as ex:
                 raise SerializationError(f"Can't serialize: {data}") from ex
         elif not isinstance(obj, Mapping):
             raise SerializationError(f"Can only serialize dataclasses or dict-like objects: {obj}")


### PR DESCRIPTION
## Description

Fixes: #6943

Address metadata from a PFS path request response contains hex serialized addresses. Per our sandwich encoding convention, these addresses need to be deserialized before we do any further processing.