### PR TITLE
Always fetch list of available Matrix servers

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -414,9 +414,10 @@ class MatrixTransport(Runnable):
         self._raiden_service: Optional["RaidenService"] = None
 
         if config.server == MATRIX_AUTO_SELECT_SERVER:
-            our_homeserver_candidates = config.available_servers
+            homeserver_candidates = config.available_servers
         elif urlparse(config.server).scheme in {"http", "https"}:
-            our_homeserver_candidates = [config.server]
+            # When an explicit server is given we don't need to do the RTT check on all others
+            homeserver_candidates = [config.server]
         else:
             raise TransportError(
                 f"Invalid matrix server specified (valid values: "
@@ -434,7 +435,7 @@ class MatrixTransport(Runnable):
         self._client: GMatrixClient = make_client(
             self._handle_sync_messages,
             self._handle_member_join,
-            our_homeserver_candidates,
+            homeserver_candidates,
             http_pool_maxsize=4,
             http_retry_timeout=40,
             http_retry_delay=_http_retry_delay,

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -16,7 +16,6 @@ from raiden.constants import (
     CHAIN_TO_MIN_REVEAL_TIMEOUT,
     DOC_URL,
     GENESIS_BLOCK_NUMBER,
-    MATRIX_AUTO_SELECT_SERVER,
     RAIDEN_DB_VERSION,
     Environment,
     EthereumForks,
@@ -369,10 +368,9 @@ def run_raiden_service(
     else:
         deployed_addresses = load_deployment_addresses_from_contracts(contracts=contracts)
 
-    # Load the available matrix servers when no matrix server is given
-    # The list is used in a PFS check
-    if config.transport.server == MATRIX_AUTO_SELECT_SERVER:
-        fetch_available_matrix_servers(config.transport, config.environment_type)
+    # Always fetch all available matrix servers. It's necessary to know the complete list in order
+    # to be able to construct user-ids on other homeservers
+    fetch_available_matrix_servers(config.transport, config.environment_type)
 
     raiden_bundle = raiden_bundle_from_contracts_deployment(
         proxy_manager=proxy_manager,


### PR DESCRIPTION
## Description

This is necessary since we're currently use this list to construct user-ids on other homeservers in the to-device fallback communication method.
