### PR TITLE
Benchmarks

### DIFF
--- a/raiden/tests/benchmark/_codespeed.py
+++ b/raiden/tests/benchmark/_codespeed.py
@@ -1,0 +1,30 @@
+import json
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def post_result(codespeed_url, commit_id, branch, bench_name, value):
+    hostname = socket.gethostname()
+    data = [
+        {
+            "commitid": commit_id,
+            "project": "raiden",
+            "branch": branch,
+            "executable": "raiden",
+            "benchmark": bench_name,
+            "environment": hostname,
+            "result_value": value,
+        }
+    ]
+
+    data_ = {"json": json.dumps(data)}
+    request_data = urllib.parse.urlencode(data_).encode("utf-8")
+    url = codespeed_url + "/result/add/json/"
+    try:
+        with urllib.request.urlopen(url, request_data):
+            pass
+    except urllib.error.HTTPError as e:
+        print(str(e))
+        print(e.read())

--- a/raiden/tests/benchmark/conftest.py
+++ b/raiden/tests/benchmark/conftest.py
@@ -1,0 +1,79 @@
+import contextlib
+import shlex
+import subprocess
+import time
+
+import pytest
+
+from raiden.tests.integration.fixtures.blockchain import *  # noqa: F401,F403
+from raiden.tests.integration.fixtures.raiden_network import *  # noqa: F401,F403
+from raiden.tests.integration.fixtures.smartcontracts import *  # noqa: F401,F403
+from raiden.tests.integration.fixtures.transport import *  # noqa: F401,F403
+
+from . import _codespeed
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--codespeed-url",
+        action="store",
+        default=None,
+        help="the URL of a running Codespeed instance, " "e.g. http://127.0.0.1:8000",
+    )
+    parser.addoption(
+        "--output-benchmark-results",
+        action="store",
+        default=None,
+        help="the path to write benchmark results to",
+    )
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        item.add_marker(pytest.mark.asyncio)
+
+
+_TIMES = {}
+
+
+_COMMIT_ID = (
+    subprocess.check_output(shlex.split("git describe --tags --abbrev=8")).decode().strip()
+)
+
+
+# "git branch --show-current" would be simpler, but CI git version is too old for that.
+_BRANCH = subprocess.check_output(shlex.split("git rev-parse --abbrev-ref HEAD")).decode().strip()
+
+
+@pytest.fixture
+def bench(request):
+    node_name = request.node.name
+
+    @contextlib.contextmanager
+    def wrapper(s=None):
+        t1 = time.perf_counter()
+        yield
+        t2 = time.perf_counter()
+        dt = t2 - t1
+        bench_name = "%s[%s]" % (node_name, s) if s is not None else node_name
+        print(f"{bench_name}: {dt}")
+        _TIMES[bench_name] = dt
+
+        url = request.config.getoption("--codespeed-url")
+        if url is not None:
+            _codespeed.post_result(url, _COMMIT_ID, _BRANCH, bench_name, dt)
+
+        path = request.config.getoption("--output-benchmark-results")
+        if path is not None:
+            with open(path, "a") as f:
+                f.write(f"{bench_name}, {dt}\n")
+
+    return wrapper
+
+
+def pytest_terminal_summary(
+    terminalreporter, exitstatus, config
+):  # pylint: disable=unused-argument
+    terminalreporter.section("benchmark report")
+    for bench_name, time_ in _TIMES.items():
+        terminalreporter.write_line(f"{bench_name}: {time_}")

--- a/raiden/tests/benchmark/test_mediated_transfer.py
+++ b/raiden/tests/benchmark/test_mediated_transfer.py
@@ -1,0 +1,63 @@
+from typing import List
+
+import pytest
+
+from raiden.raiden_service import RaidenService
+from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.tests.utils.network import CHAIN
+from raiden.tests.utils.transfer import (
+    assert_succeeding_transfer_invariants,
+    block_timeout_for_transfer_by_secrethash,
+    transfer,
+    wait_assert,
+)
+from raiden.transfer import views
+from raiden.utils.typing import PaymentAmount, PaymentID
+
+
+@raise_on_failure
+@pytest.mark.parametrize("channels_per_node", [CHAIN])
+@pytest.mark.parametrize("number_of_nodes", [3, 4, 5])
+def test_mediated_transfer(
+    raiden_network: List[RaidenService],
+    number_of_nodes,
+    deposit,
+    token_addresses,
+    network_wait,
+    bench,
+):
+    apps = raiden_network
+    token_address = token_addresses[0]
+    chain_state = views.state_from_raiden(apps[0])
+    token_network_registry_address = apps[0].default_registry.address
+    token_network_address = views.get_token_network_address_by_token_address(
+        chain_state, token_network_registry_address, token_address
+    )
+
+    with bench():
+        amount = PaymentAmount(10)
+        with bench("transfer"):
+            secrethash = transfer(
+                initiator_app=apps[0],
+                target_app=apps[-1],
+                token_address=token_address,
+                amount=amount,
+                identifier=PaymentID(1),
+                timeout=network_wait * number_of_nodes,
+                routes=[apps],
+            )
+
+        while len(apps) > 1:
+            app1 = apps.pop(0)
+            app2 = apps[0]
+            with block_timeout_for_transfer_by_secrethash(app2, secrethash):
+                wait_assert(
+                    assert_succeeding_transfer_invariants,
+                    token_network_address,
+                    app1,
+                    deposit - amount,
+                    [],
+                    app2,
+                    deposit + amount,
+                    [],
+                )

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -897,7 +897,7 @@ def wait_assert(func: Callable, *args, **kwargs) -> None:
             func(*args, **kwargs)
         except AssertionError as e:
             try:
-                gevent.sleep(0.5)
+                gevent.sleep(0.001)
             except gevent.Timeout:
                 raise e
         else:


### PR DESCRIPTION
This sets up a simple benchmark infrastructure, including posting results to a [Codespeed](https://github.com/tobami/codespeed) instance. See #6962.