### PR TITLE
Fix invoking pytest without path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: check-vcs-permalinks
       - id: check-yaml
       - id: debug-statements
-        exclude: '^(raiden/ui/cli.py)|(raiden/tests/conftest.py)$'
+        exclude: '^(raiden/ui/cli.py)|(conftest.py)$'
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: .bumpversion_client.cfg

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ JOBS_ARG=
 ifdef CIRCLECI
 JOBS_ARG=--jobs=8
 endif
-LINT_PATHS = raiden/ tools/ setup.py
+LINT_PATHS = raiden/ tools/ setup.py conftest.py
 ISORT_PARAMS = --ignore-whitespace --settings-path ./ --skip-glob '*/node_modules/*' $(LINT_PATHS)
 
 lint: ISORT_CHECK_PARAMS := --diff --check-only

--- a/conftest.py
+++ b/conftest.py
@@ -1,27 +1,12 @@
 # pylint: disable=wrong-import-position,redefined-outer-name,unused-wildcard-import,wildcard-import
-import gevent  # isort:skip # noqa
-from gevent import monkey, Timeout  # isort:skip # noqa
+# type: ignore
+from gevent import monkey
 
-monkey.patch_all(subprocess=False, thread=False)  # isort:skip # noqa
+monkey.patch_all(subprocess=False, thread=False)
 
-import asyncio
-import contextlib
-import datetime
-import os
-import signal
-import subprocess
-import sys
-import time
+# isort:split
 
 import pytest
-import structlog
-
-from raiden.network.transport.matrix.rtc.aiogevent import yield_future
-from raiden.network.transport.matrix.rtc.utils import (
-    ASYNCIO_LOOP_RUNNING_TIMEOUT,
-    setup_asyncio_event_loop,
-)
-from raiden.utils.ethereum_clients import VersionSupport
 
 # Execute these before the raiden imports because rewrites can't work after the
 # module has been imported.
@@ -35,22 +20,41 @@ pytest.register_assert_rewrite("raiden.tests.utils.smartcontracts")
 pytest.register_assert_rewrite("raiden.tests.utils.smoketest")
 pytest.register_assert_rewrite("raiden.tests.utils.transfer")
 
-from raiden.constants import (  # isort:skip
+# isort:split
+
+import asyncio
+import contextlib
+import datetime
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import gevent
+import structlog
+from gevent import Timeout
+
+from raiden.constants import (
     HIGHEST_SUPPORTED_GETH_VERSION,
     HIGHEST_SUPPORTED_PARITY_VERSION,
     LOWEST_SUPPORTED_GETH_VERSION,
     LOWEST_SUPPORTED_PARITY_VERSION,
     EthClient,
 )
-from raiden.log_config import configure_logging  # isort:skip
-from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403  # isort:skip
-from raiden.tests.fixtures.variables import *  # noqa: F401,F403  # isort:skip
-from raiden.tests.integration.exception import RetryTestError  # isort:skip
-from raiden.tests.utils.transport import make_requests_insecure  # isort:skip
-from raiden.utils.cli import LogLevelConfigType  # isort:skip
-from raiden.utils.debugging import enable_gevent_monitoring_signal  # isort:skip
-from raiden.utils.ethereum_clients import is_supported_client  # isort:skip
-
+from raiden.log_config import configure_logging
+from raiden.network.transport.matrix.rtc.aiogevent import yield_future
+from raiden.network.transport.matrix.rtc.utils import (
+    ASYNCIO_LOOP_RUNNING_TIMEOUT,
+    setup_asyncio_event_loop,
+)
+from raiden.tests.fixtures.blockchain import *  # noqa: F401,F403
+from raiden.tests.fixtures.variables import *  # noqa: F401,F403
+from raiden.tests.integration.exception import RetryTestError
+from raiden.tests.utils.transport import make_requests_insecure
+from raiden.utils.cli import LogLevelConfigType
+from raiden.utils.debugging import enable_gevent_monitoring_signal
+from raiden.utils.ethereum_clients import VersionSupport, is_supported_client
 
 log = structlog.get_logger()
 
@@ -370,14 +374,20 @@ def set_item_timeouts(item):
     timeout_limit_setup_and_call = item.config.getini("timeout_limit_for_setup_and_call")
 
     if timeout_limit_setup_and_call == "":
-        raise Exception("timeout_limit_for_setup_and_call must be set in setup.cfg")
+        raise RuntimeError(
+            "timeout_limit_for_setup_and_call must be set in section "
+            "'tool.pytest.ini_options' in pyproject.toml"
+        )
 
     timeout_limit_setup_and_call = float(timeout_limit_setup_and_call)
 
     timeout_limit_teardown = item.config.getini("timeout_limit_teardown")
 
     if timeout_limit_teardown == "":
-        raise Exception("timeout_limit_teardown must be set in setup.cfg")
+        raise RuntimeError(
+            "timeout_limit_teardown must be set in section "
+            "'tool.pytest.ini_options' in pyproject.toml"
+        )
 
     timeout_limit_teardown = float(timeout_limit_teardown)
 
@@ -388,7 +398,7 @@ def set_item_timeouts(item):
     timeout_setup_and_call = timeout_from_marker(marker) or timeout_limit_setup_and_call
 
     if timeout_setup_and_call > timeout_limit_setup_and_call:
-        raise Exception(
+        raise RuntimeError(
             f"Invalid value for the timeout marker {timeout_setup_and_call}. This "
             f"value must be smaller than {timeout_limit_setup_and_call}. This is "
             f"necessary because the runtime of a test has to be synchronized with "
@@ -400,10 +410,10 @@ def set_item_timeouts(item):
         )
 
     if timeout_setup_and_call <= 0:
-        raise Exception("timeout must not be negative")
+        raise RuntimeError("timeout must not be negative")
 
     if timeout_teardown <= 0:
-        raise Exception("timeout_limit_teardown must not be negative")
+        raise RuntimeError("timeout_limit_teardown must not be negative")
 
     item.timeout_setup_and_call = timeout_setup_and_call
     item.timeout_teardown = timeout_teardown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py37']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -12,3 +12,25 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.pytest.ini_options]
+testpaths = [
+    "raiden/tests",
+]
+timeout_limit_for_setup_and_call = 240
+timeout_limit_teardown = 15
+norecursedirs = [
+    "node_modules",
+]
+# Ignore warnings:
+# - grequests monkeypatch
+# - urllib3 unverified TLS connection
+filterwarnings = [
+    "ignore::gevent.monkey.MonkeyPatchWarning",
+    "ignore::urllib3.exceptions.InsecureRequestWarning",
+]
+markers = [
+    "timeout",
+    "asyncio: tests that require an asyncio eventloop",
+]
+junit_family = "xunit1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,21 +37,6 @@ omit =
     */tests/*
     */site-packages/*
 
-[tool:pytest]
-timeout_limit_for_setup_and_call = 240
-timeout_limit_teardown = 15
-norecursedirs = node_modules
-; Ignore warnings:
-; - grequests monkeypatch
-; - urllib3 unverified TLS connection
-filterwarnings =
-    ignore::gevent.monkey.MonkeyPatchWarning
-    ignore::urllib3.exceptions.InsecureRequestWarning
-markers =
-    timeout
-    asyncio: tests that require an asyncio eventloop
-junit_family = xunit1
-
 [mypy]
 ignore_missing_imports = True
 check_untyped_defs = True


### PR DESCRIPTION
## Description

Until now pytest needed to be invoked with the path to the tests (`raiden/tests`) in order for the top level `conftest.py` file to be read early enough for our custom CLI options to be enabled.
Also certain other hooks (e.g. temp path shortening on macOS) are configured there and only take effect when this file is read early enough.

Having to specify the path has been a long standing irritation for both old and new contributors.

This moves the top level conftest file to the project root so that it's read early enough in all cases.
