### PR TITLE
Remove fallback send to-device to all possible UserIDs

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -125,7 +125,7 @@ class MessageHandler:
 
         sender_metadata: Optional[AddressMetadata] = None
         if raiden.config.pfs_config is not None:
-            # HACK querying the PFS for the address-metadata directly after receiving a message
+            # FIXME querying the PFS for the address-metadata directly after receiving a message
             #   should be optimized / factored out at a later point!
             sender_metadata = query_address_metadata(raiden.config.pfs_config, message.sender)
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -286,8 +286,8 @@ class _RetryQueue(Runnable):
                 for send_event in self.transport._queueids_to_queues[message_data.queue_identifier]
             )
 
-        message_texts: List[str] = list()
         for subqueue, address_metadata in self._batch_by_address_metadata():
+            message_texts: List[str] = list()
             for message_data in subqueue:
                 # Messages are sent on two conditions:
                 # - Non-retryable (e.g. Delivered)

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1335,6 +1335,13 @@ class RaidenService(Runnable):
             for event in event_queue:
                 message = message_from_sendevent(event)
                 self.sign(message)
+                # FIXME: this will load the recipient's metadata from the persisted
+                #  state. If the recipient roamed during the offline time of our node,
+                #  the message will never reach the recipient,
+                #  especially since we don't have a WebRTC connection with the recipient at
+                #  startup.
+                #  Depending on the time our node is offline, roaming of the recipient
+                #  can become more likely.
                 queue_messages.append((message, event.recipient_metadata))
 
             all_messages.append(MessagesQueue(queue_identifier, queue_messages))

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1335,7 +1335,7 @@ class RaidenService(Runnable):
             for event in event_queue:
                 message = message_from_sendevent(event)
                 self.sign(message)
-                queue_messages.append((message, None))
+                queue_messages.append((message, event.recipient_metadata))
 
             all_messages.append(MessagesQueue(queue_identifier, queue_messages))
 

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -1571,10 +1571,16 @@ class RaidenService(Runnable):
         return payment_status
 
     def withdraw(
-        self, canonical_identifier: CanonicalIdentifier, total_withdraw: WithdrawAmount
+        self,
+        canonical_identifier: CanonicalIdentifier,
+        total_withdraw: WithdrawAmount,
+        recipient_metadata: AddressMetadata = None,
     ) -> None:
+
         init_withdraw = ActionChannelWithdraw(
-            canonical_identifier=canonical_identifier, total_withdraw=total_withdraw
+            canonical_identifier=canonical_identifier,
+            total_withdraw=total_withdraw,
+            recipient_metadata=recipient_metadata,
         )
 
         self.handle_and_track_state_changes([init_withdraw])

--- a/raiden/tests/integration/api/rest/test_api_wrapper.py
+++ b/raiden/tests/integration/api/rest/test_api_wrapper.py
@@ -7,7 +7,6 @@ from raiden_api_client.exceptions import InvalidInput
 from raiden import waiting
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.transfer import patch_transfer_routes
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import BlockNumber
 
@@ -16,8 +15,10 @@ from raiden.utils.typing import BlockNumber
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("enable_rest_api", [True])
-def test_api_wrapper(raiden_network, unregistered_custom_token, retry_timeout):
+def test_api_wrapper(raiden_network, unregistered_custom_token, retry_timeout, pfs_mock):
     app0, app1 = raiden_network
+    pfs_mock.add_apps(raiden_network)
+
     address1 = to_checksum_address(app0.address)
     address2 = to_checksum_address(app1.address)
 
@@ -55,9 +56,8 @@ def test_api_wrapper(raiden_network, unregistered_custom_token, retry_timeout):
     assert resp.total_deposit == "4"
 
     # Test transfer
-    with patch_transfer_routes([[app0, app1]], token_address=unregistered_custom_token):
-        resp = wrapper.transfer(partner=address2, token=token, amount=1)
-        assert resp.amount == "1"
+    resp = wrapper.transfer(partner=address2, token=token, amount=1)
+    assert resp.amount == "1"
 
     # Test channel query
     resp = wrapper.get_channels()

--- a/raiden/tests/integration/api/rest/test_api_wrapper.py
+++ b/raiden/tests/integration/api/rest/test_api_wrapper.py
@@ -7,6 +7,7 @@ from raiden_api_client.exceptions import InvalidInput
 from raiden import waiting
 from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.tests.utils.detect_failure import raise_on_failure
+from raiden.tests.utils.transfer import patch_transfer_routes
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import BlockNumber
 
@@ -54,8 +55,9 @@ def test_api_wrapper(raiden_network, unregistered_custom_token, retry_timeout):
     assert resp.total_deposit == "4"
 
     # Test transfer
-    resp = wrapper.transfer(partner=address2, token=token, amount=1)
-    assert resp.amount == "1"
+    with patch_transfer_routes([[app0, app1]], token_address=unregistered_custom_token):
+        resp = wrapper.transfer(partner=address2, token=token, amount=1)
+        assert resp.amount == "1"
 
     # Test channel query
     resp = wrapper.get_channels()

--- a/raiden/tests/integration/api/rest/test_channel.py
+++ b/raiden/tests/integration/api/rest/test_channel.py
@@ -691,9 +691,14 @@ def test_api_channel_state_change_errors(
 @pytest.mark.parametrize("deposit", [1000])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_api_channel_withdraw(
-    api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
+    api_server_test_instance: APIServer,
+    raiden_network: List[RaidenService],
+    token_addresses,
+    pfs_mock,
 ):
     _, app1 = raiden_network
+    pfs_mock.add_apps(raiden_network)
+
     token_address = token_addresses[0]
     partner_address = app1.address
 

--- a/raiden/tests/integration/api/rest/test_channel.py
+++ b/raiden/tests/integration/api/rest/test_channel.py
@@ -343,7 +343,9 @@ def test_api_channel_open_and_deposit_race(
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_api_channel_open_close_and_settle(
-    api_server_test_instance: APIServer, token_addresses, reveal_timeout
+    api_server_test_instance: APIServer,
+    token_addresses,
+    reveal_timeout,
 ):
     # let's create a new channel
     partner_address = "0x61C808D82A3Ac53231750daDc13c777b59310bD9"

--- a/raiden/tests/integration/api/rest/test_payments.py
+++ b/raiden/tests/integration/api/rest/test_payments.py
@@ -18,7 +18,7 @@ from raiden.tests.integration.api.rest.utils import (
 )
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.transfer import watch_for_unlock_failures
+from raiden.tests.utils.transfer import patch_transfer_routes, watch_for_unlock_failures
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import List, Secret
 
@@ -32,24 +32,25 @@ DEFAULT_ID = "42"
 def test_api_payments_target_error(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ) -> None:
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
 
     # stop app1 to force an error
     app1.stop()
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID},
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID},
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
 
 
 @raise_on_failure
@@ -61,7 +62,7 @@ def test_api_payments(
     token_addresses,
     deposit,
 ) -> None:
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     amount = 100
     identifier = 42
     token_address = token_addresses[0]
@@ -77,53 +78,55 @@ def test_api_payments(
         "identifier": str(identifier),
     }
 
-    # Test a normal payment
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": str(amount), "identifier": str(identifier)},
-    )
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        # Test a normal payment
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": str(amount), "identifier": str(identifier)},
+        )
 
-    with watch_for_unlock_failures(*raiden_network):
+        with watch_for_unlock_failures(*raiden_network):
+            response = request.send().response
+        assert_proper_response(response)
+        json_response = get_json_response(response)
+        assert_payment_secret_and_hash(json_response, payment)
+
+        # Test a payment without providing an identifier
+        payment["amount"] = "1"
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": "1"},
+        )
+        with watch_for_unlock_failures(*raiden_network):
+            response = request.send().response
+        assert_proper_response(response)
+        json_response = get_json_response(response)
+        assert_payment_secret_and_hash(json_response, payment)
+
+        # Test that trying out a payment with an amount higher than what is available
+        # returns an error
+        payment["amount"] = str(deposit)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": str(deposit)},
+        )
         response = request.send().response
-    assert_proper_response(response)
-    json_response = get_json_response(response)
-    assert_payment_secret_and_hash(json_response, payment)
-
-    # Test a payment without providing an identifier
-    payment["amount"] = "1"
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": "1"},
-    )
-    with watch_for_unlock_failures(*raiden_network):
-        response = request.send().response
-    assert_proper_response(response)
-    json_response = get_json_response(response)
-    assert_payment_secret_and_hash(json_response, payment)
-
-    # Test that trying out a payment with an amount higher than what is available returns an error
-    payment["amount"] = str(deposit)
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": str(deposit)},
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
+        assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
 
     # Test that querying the internal events resource works
     limit = 5
@@ -145,7 +148,7 @@ def test_api_payments(
 def test_api_payments_secret_hash_errors(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
     secret = to_hex(factories.make_secret())
@@ -154,74 +157,79 @@ def test_api_payments_secret_hash_errors(
     short_secret = "0x123"
     short_secret_hash = "Short secret hash"
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret": short_secret},
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret": short_secret},
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret": bad_secret},
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret": bad_secret},
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "secret_hash": short_secret_hash,
-        },
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "secret_hash": short_secret_hash,
+            },
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret_hash": bad_secret_hash},
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "secret_hash": bad_secret_hash,
+            },
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.BAD_REQUEST)
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "secret": secret,
-            "secret_hash": secret,
-        },
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "secret": secret,
+                "secret_hash": secret,
+            },
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
 
 
 @raise_on_failure
@@ -230,7 +238,7 @@ def test_api_payments_secret_hash_errors(
 def test_api_payments_with_secret_no_hash(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
     secret = to_hex(factories.make_secret())
@@ -245,21 +253,23 @@ def test_api_payments_with_secret_no_hash(
         "identifier": DEFAULT_ID,
     }
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret": secret},
-    )
-    with watch_for_unlock_failures(*raiden_network):
-        response = request.send().response
-    assert_proper_response(response)
-    json_response = get_json_response(response)
-    assert_payment_secret_and_hash(json_response, payment)
-    assert secret == json_response["secret"]
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={"amount": DEFAULT_AMOUNT, "identifier": DEFAULT_ID, "secret": secret},
+        )
+        with watch_for_unlock_failures(*raiden_network):
+            response = request.send().response
+
+        assert_proper_response(response)
+        json_response = get_json_response(response)
+        assert_payment_secret_and_hash(json_response, payment)
+        assert secret == json_response["secret"]
 
 
 @raise_on_failure
@@ -268,26 +278,27 @@ def test_api_payments_with_secret_no_hash(
 def test_api_payments_with_hash_no_secret(
     api_server_test_instance, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
     secret_hash = factories.make_secret_hash()
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "secret_hash": to_hex(secret_hash),
-        },
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "secret_hash": to_hex(secret_hash),
+            },
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
 
 
 @raise_on_failure
@@ -327,65 +338,70 @@ def test_api_payments_with_resolver(
     resolvers,  # pylint: disable=unused-argument
 ):
 
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     amount = 100
     identifier = 42
     token_address = token_addresses[0]
     target_address = app1.address
     secret_hash = factories.make_secret_hash()
 
-    # payment with secret_hash when both resolver and initiator don't have the secret
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": str(amount),
-            "identifier": str(identifier),
-            "secret_hash": to_hex(secret_hash),
-        },
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
-
-    # payment with secret where the resolver doesn't have the secret. Should work.
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": str(amount), "identifier": str(identifier), "secret": to_hex(secret_hash)},
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
-
-    # payment with secret_hash where the resolver has the secret. Should work.
-    secret = Secret(
-        decode_hex("0x2ff886d47b156de00d4cad5d8c332706692b5b572adfe35e6d2f65e92906806e")
-    )
-    secret_hash = sha256_secrethash(secret)
-
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": str(amount),
-            "identifier": str(identifier),
-            "secret_hash": to_hex(secret_hash),
-        },
-    )
-    with watch_for_unlock_failures(*raiden_network):
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        # payment with secret_hash when both resolver and initiator don't have the secret
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": str(amount),
+                "identifier": str(identifier),
+                "secret_hash": to_hex(secret_hash),
+            },
+        )
         response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
+        assert_proper_response(response, status_code=HTTPStatus.CONFLICT)
+
+        # payment with secret where the resolver doesn't have the secret. Should work.
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": str(amount),
+                "identifier": str(identifier),
+                "secret": to_hex(secret_hash),
+            },
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.OK)
+
+        # payment with secret_hash where the resolver has the secret. Should work.
+        secret = Secret(
+            decode_hex("0x2ff886d47b156de00d4cad5d8c332706692b5b572adfe35e6d2f65e92906806e")
+        )
+        secret_hash = sha256_secrethash(secret)
+
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": str(amount),
+                "identifier": str(identifier),
+                "secret_hash": to_hex(secret_hash),
+            },
+        )
+        with watch_for_unlock_failures(*raiden_network):
+            response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.OK)
 
 
 @raise_on_failure
@@ -394,7 +410,7 @@ def test_api_payments_with_resolver(
 def test_api_payments_with_secret_and_hash(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
     secret, secret_hash = factories.make_secret_with_hash()
@@ -409,27 +425,28 @@ def test_api_payments_with_secret_and_hash(
         "identifier": DEFAULT_ID,
     }
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "secret": to_hex(secret),
-            "secret_hash": to_hex(secret_hash),
-        },
-    )
-    with watch_for_unlock_failures(*raiden_network):
-        response = request.send().response
-    assert_proper_response(response)
-    json_response = get_json_response(response)
-    assert_payment_secret_and_hash(json_response, payment)
-    assert to_hex(secret) == json_response["secret"]
-    assert to_hex(secret_hash) == json_response["secret_hash"]
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "secret": to_hex(secret),
+                "secret_hash": to_hex(secret_hash),
+            },
+        )
+        with watch_for_unlock_failures(*raiden_network):
+            response = request.send().response
+        assert_proper_response(response)
+        json_response = get_json_response(response)
+        assert_payment_secret_and_hash(json_response, payment)
+        assert to_hex(secret) == json_response["secret"]
+        assert to_hex(secret_hash) == json_response["secret_hash"]
 
 
 @raise_on_failure
@@ -438,35 +455,36 @@ def test_api_payments_with_secret_and_hash(
 def test_api_payments_conflicts(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
 
-    payment_url = api_url_for(
-        api_server_test_instance,
-        "token_target_paymentresource",
-        token_address=to_checksum_address(token_address),
-        target_address=to_checksum_address(target_address),
-    )
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        payment_url = api_url_for(
+            api_server_test_instance,
+            "token_target_paymentresource",
+            token_address=to_checksum_address(token_address),
+            target_address=to_checksum_address(target_address),
+        )
 
-    # two different transfers (different amounts) with same identifier at the same time:
-    # payment conflict
-    responses = grequests.map(
-        [
-            grequests.post(payment_url, json={"amount": "10", "identifier": "11"}),
-            grequests.post(payment_url, json={"amount": "11", "identifier": "11"}),
-        ]
-    )
-    assert_payment_conflict(responses)
+        # two different transfers (different amounts) with same identifier at the same time:
+        # payment conflict
+        responses = grequests.map(
+            [
+                grequests.post(payment_url, json={"amount": "10", "identifier": "11"}),
+                grequests.post(payment_url, json={"amount": "11", "identifier": "11"}),
+            ]
+        )
+        assert_payment_conflict(responses)
 
-    # same request sent twice, e. g. when it is retried: no conflict
-    responses = grequests.map(
-        [
-            grequests.post(payment_url, json={"amount": "10", "identifier": "73"}),
-            grequests.post(payment_url, json={"amount": "10", "identifier": "73"}),
-        ]
-    )
-    assert all(response.status_code == HTTPStatus.OK for response in responses)
+        # same request sent twice, e. g. when it is retried: no conflict
+        responses = grequests.map(
+            [
+                grequests.post(payment_url, json={"amount": "10", "identifier": "73"}),
+                grequests.post(payment_url, json={"amount": "10", "identifier": "73"}),
+            ]
+        )
+        assert all(response.status_code == HTTPStatus.OK for response in responses)
 
 
 @raise_on_failure
@@ -476,81 +494,82 @@ def test_api_payments_conflicts(
 def test_api_payments_with_lock_timeout(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
     number_of_nodes = 2
     reveal_timeout = number_of_nodes * 4 + DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
     settle_timeout = 39
 
-    # try lock_timeout = reveal_timeout - should not work
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "lock_timeout": str(reveal_timeout),
-        },
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
-
-    # try lock_timeout = reveal_timeout * 2  - should  work.
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "lock_timeout": str(2 * reveal_timeout),
-        },
-    )
-    with watch_for_unlock_failures(*raiden_network):
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        # try lock_timeout = reveal_timeout - should not work
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "lock_timeout": str(reveal_timeout),
+            },
+        )
         response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
+        assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
-    # try lock_timeout = settle_timeout - should work.
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "lock_timeout": str(settle_timeout),
-        },
-    )
-    response = request.send().response
-    assert_proper_response(response, status_code=HTTPStatus.OK)
+        # try lock_timeout = reveal_timeout * 2  - should  work.
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "lock_timeout": str(2 * reveal_timeout),
+            },
+        )
+        with watch_for_unlock_failures(*raiden_network):
+            response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.OK)
 
-    # try lock_timeout = settle_timeout+1 - should not work.
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": DEFAULT_ID,
-            "lock_timeout": settle_timeout + 1,
-        },
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
+        # try lock_timeout = settle_timeout - should work.
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "lock_timeout": str(settle_timeout),
+            },
+        )
+        response = request.send().response
+        assert_proper_response(response, status_code=HTTPStatus.OK)
+
+        # try lock_timeout = settle_timeout+1 - should not work.
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": DEFAULT_ID,
+                "lock_timeout": settle_timeout + 1,
+            },
+        )
+        response = request.send().response
+        assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
 
 @raise_on_failure
@@ -559,48 +578,57 @@ def test_api_payments_with_lock_timeout(
 def test_api_payments_with_invalid_input(
     api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
 ):
-    _, app1 = raiden_network
+    app0, app1 = raiden_network
     token_address = token_addresses[0]
     target_address = app1.address
     settle_timeout = 39
 
-    # Invalid identifier being 0 or negative
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": "0", "lock_timeout": str(settle_timeout)},
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
+    with patch_transfer_routes([[app0, app1]], token_address=token_address):
+        # Invalid identifier being 0 or negative
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": "0",
+                "lock_timeout": str(settle_timeout),
+            },
+        )
+        response = request.send().response
+        assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={"amount": DEFAULT_AMOUNT, "identifier": "-1", "lock_timeout": str(settle_timeout)},
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": "-1",
+                "lock_timeout": str(settle_timeout),
+            },
+        )
+        response = request.send().response
+        assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
 
-    request = grequests.post(
-        api_url_for(
-            api_server_test_instance,
-            "token_target_paymentresource",
-            token_address=to_checksum_address(token_address),
-            target_address=to_checksum_address(target_address),
-        ),
-        json={
-            "amount": DEFAULT_AMOUNT,
-            "identifier": str(UINT64_MAX + 1),
-            "lock_timeout": str(settle_timeout),
-        },
-    )
-    response = request.send().response
-    assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)
+        request = grequests.post(
+            api_url_for(
+                api_server_test_instance,
+                "token_target_paymentresource",
+                token_address=to_checksum_address(token_address),
+                target_address=to_checksum_address(target_address),
+            ),
+            json={
+                "amount": DEFAULT_AMOUNT,
+                "identifier": str(UINT64_MAX + 1),
+                "lock_timeout": str(settle_timeout),
+            },
+        )
+        response = request.send().response
+        assert_response_with_error(response, status_code=HTTPStatus.CONFLICT)

--- a/raiden/tests/integration/api/rest/test_rest.py
+++ b/raiden/tests/integration/api/rest/test_rest.py
@@ -399,13 +399,18 @@ def test_query_partners_by_token(
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_api_timestamp_format(
-    api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
+    api_server_test_instance: APIServer,
+    raiden_network: List[RaidenService],
+    token_addresses,
+    pfs_mock,
 ) -> None:
     _, app1 = raiden_network
     amount = 200
     identifier = 42
     token_address = token_addresses[0]
     target_address = app1.address
+
+    pfs_mock.add_apps(raiden_network)
 
     payment_url = api_url_for(
         api_server_test_instance,
@@ -542,12 +547,16 @@ def test_get_connections_info(
 @pytest.mark.parametrize("enable_rest_api", [True])
 @pytest.mark.parametrize("number_of_tokens", [2])
 def test_payment_events_endpoints(
-    api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
+    api_server_test_instance: APIServer,
+    raiden_network: List[RaidenService],
+    token_addresses,
+    pfs_mock,
 ):
     app0, app1, app2 = raiden_network
 
     token_address0 = token_addresses[0]
     token_address1 = token_addresses[1]
+    pfs_mock.add_apps(raiden_network)
 
     app0_server = api_server_test_instance
     app1_server = prepare_api_server(app1)
@@ -557,6 +566,7 @@ def test_payment_events_endpoints(
     identifier1 = PaymentID(10)
     amount1 = PaymentAmount(10)
     secret1, secrethash1 = factories.make_secret_with_hash()
+
     request = grequests.post(
         api_url_for(
             app0_server,
@@ -583,7 +593,7 @@ def test_payment_events_endpoints(
     )
     request.send()
 
-    # Payment 3: app0 is sending some tokens of token0 to app2
+    # Payment 3: app0 is sending some tokens of token0 to app1
     identifier3 = PaymentID(30)
     amount3 = PaymentAmount(17)
     secret3, secrethash3 = factories.make_secret_with_hash()
@@ -897,13 +907,18 @@ def test_payment_events_endpoints(
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_channel_events_raiden(
-    api_server_test_instance: APIServer, raiden_network: List[RaidenService], token_addresses
+    api_server_test_instance: APIServer,
+    raiden_network: List[RaidenService],
+    token_addresses,
+    pfs_mock,
 ):
     _, app1 = raiden_network
     amount = 100
     identifier = 42
     token_address = token_addresses[0]
     target_address = app1.address
+
+    pfs_mock.add_apps(raiden_network)
 
     request = grequests.post(
         api_url_for(

--- a/raiden/tests/integration/api/test_pythonapi_regression.py
+++ b/raiden/tests/integration/api/test_pythonapi_regression.py
@@ -6,23 +6,21 @@ from raiden.constants import BLOCK_ID_LATEST
 from raiden.raiden_service import RaidenService
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.transfer import (
-    block_offset_timeout,
-    patch_transfer_routes,
-    watch_for_unlock_failures,
-)
+from raiden.tests.utils.transfer import block_offset_timeout, watch_for_unlock_failures
 from raiden.utils.typing import List, PaymentAmount, PaymentID, TargetAddress
 
 
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("channels_per_node", [1])
-def test_close_regression(raiden_network: List[RaidenService], deposit, token_addresses):
+def test_close_regression(raiden_network: List[RaidenService], deposit, token_addresses, pfs_mock):
     """The python api was using the wrong balance proof to close the channel,
     thus the close was failing if a transfer was made.
     """
     app0, app1 = raiden_network
     token_address = token_addresses[0]
+
+    pfs_mock.add_apps(raiden_network)
 
     api1 = RaidenAPI(app0)
     api2 = RaidenAPI(app1)
@@ -41,25 +39,24 @@ def test_close_regression(raiden_network: List[RaidenService], deposit, token_ad
     secret, secrethash = factories.make_secret_with_hash()
     timeout = block_offset_timeout(app1, "Transfer timed out.")
     with watch_for_unlock_failures(*raiden_network), timeout:
-        with patch_transfer_routes([[app0, app1]], token_address=token_address):
-            assert api1.transfer_and_wait(
-                registry_address=registry_address,
-                token_address=token_address,
-                amount=amount,
-                target=TargetAddress(api2.address),
-                identifier=identifier,
-                secret=secret,
-            )
-            timeout.exception_to_throw = ValueError(
-                "Waiting for transfer received success in the WAL timed out."
-            )
-            result = waiting.wait_for_received_transfer_result(
-                raiden=app1,
-                payment_identifier=identifier,
-                amount=amount,
-                retry_timeout=app1.alarm.sleep_time,
-                secrethash=secrethash,
-            )
+        assert api1.transfer_and_wait(
+            registry_address=registry_address,
+            token_address=token_address,
+            amount=amount,
+            target=TargetAddress(api2.address),
+            identifier=identifier,
+            secret=secret,
+        )
+        timeout.exception_to_throw = ValueError(
+            "Waiting for transfer received success in the WAL timed out."
+        )
+        result = waiting.wait_for_received_transfer_result(
+            raiden=app1,
+            payment_identifier=identifier,
+            amount=amount,
+            retry_timeout=app1.alarm.sleep_time,
+            secrethash=secrethash,
+        )
 
     msg = f"Unexpected transfer result: {str(result)}"
     assert result == waiting.TransferWaitResult.UNLOCKED, msg

--- a/raiden/tests/integration/fixtures/raiden_network.py
+++ b/raiden/tests/integration/fixtures/raiden_network.py
@@ -241,6 +241,14 @@ def pfs_mock(
     # Methods used by initiator
     monkeypatch.setattr("raiden.routing.query_address_metadata", pfs_mock.query_address_metadata)
     monkeypatch.setattr("raiden.routing.get_best_routes_pfs", pfs_mock.get_best_routes_pfs)
+    # Method used by WithdrawRequest message handler
+    monkeypatch.setattr(
+        "raiden.message_handler.query_address_metadata", pfs_mock.query_address_metadata
+    )
+    # Method used by Withdraw in the API
+    monkeypatch.setattr(
+        "raiden.api.python.query_address_metadata", pfs_mock.query_address_metadata
+    )
     # PFS info endpoint
     monkeypatch.setattr("raiden.network.pathfinding", pfs_mock.get_pfs_info)
 

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -529,9 +529,12 @@ def test_channel_withdraw(
     total_withdraw = WithdrawAmount(deposit + alice_to_bob_amount)
 
     bob_alice_channel_state = get_channelstate(bob_app, alice_app, token_network_address)
+
+    alice_metadata = pfs_mock.query_address_metadata(bob_app.config.pfs_config, alice_app.address)
     bob_app.withdraw(
         canonical_identifier=bob_alice_channel_state.canonical_identifier,
         total_withdraw=total_withdraw,
+        recipient_metadata=alice_metadata,
     )
 
     waiting.wait_for_withdraw_complete(
@@ -612,9 +615,11 @@ def test_channel_withdraw_expired(
 
     bob_alice_channel_state = get_channelstate(bob_app, alice_app, token_network_address)
 
+    alice_metadata = pfs_mock.query_address_metadata(bob_app.config.pfs_config, alice_app.address)
     bob_app.withdraw(
         canonical_identifier=bob_alice_channel_state.canonical_identifier,
         total_withdraw=total_withdraw,
+        recipient_metadata=alice_metadata,
     )
 
     with block_offset_timeout(bob_app):

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -481,9 +481,13 @@ def test_channel_withdraw(
     token_addresses: List[TokenAddress],
     deposit: TokenAmount,
     retry_timeout: float,
+    pfs_mock,
 ) -> None:
     """Withdraw funds after a mediated transfer."""
     alice_app, bob_app = raiden_network
+
+    pfs_mock.add_apps(raiden_network)
+
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_raiden(alice_app),
@@ -550,9 +554,12 @@ def test_channel_withdraw_expired(
     token_addresses: List[TokenAddress],
     deposit: TokenAmount,
     retry_timeout: float,
+    pfs_mock,
 ) -> None:
     """Tests withdraw expiration."""
     alice_app, bob_app = raiden_network
+    pfs_mock.add_apps(raiden_network)
+
     token_address = token_addresses[0]
     token_network_address = views.get_token_network_address_by_token_address(
         views.state_from_raiden(alice_app),

--- a/raiden/tests/integration/network/transport/test_matrix_transport.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport.py
@@ -353,10 +353,10 @@ def test_matrix_message_retry(
 
 
 @pytest.mark.parametrize("matrix_server_count", [3])
-@pytest.mark.parametrize("number_of_transports", [3])
+@pytest.mark.parametrize("number_of_transports", [2])
 def test_matrix_transport_handles_metadata(matrix_transports):
 
-    transport0, transport1, transport2 = matrix_transports
+    transport0, transport1 = matrix_transports
 
     transport0_messages = set()
     transport1_messages = set()
@@ -366,13 +366,11 @@ def test_matrix_transport_handles_metadata(matrix_transports):
 
     raiden_service0 = MockRaidenService(transport0_message_handler)
     raiden_service1 = MockRaidenService(transport1_message_handler)
-    raiden_service2 = MockRaidenService()
 
     raiden_service1.handle_and_track_state_changes = MagicMock()
 
     transport0.start(raiden_service0, None)
     transport1.start(raiden_service1, None)
-    transport2.start(raiden_service2, None)
 
     queue_identifier = QueueIdentifier(
         recipient=transport1._raiden_service.address,
@@ -382,50 +380,46 @@ def test_matrix_transport_handles_metadata(matrix_transports):
     raiden0_queues = views.get_all_messagequeues(views.state_from_raiden(raiden_service0))
     raiden0_queues[queue_identifier] = []
 
-    correct_metadata = {"user_id": transport1.user_id}
-    # This is the wrong user for the chosen address (address is implicit by the queue_identifier)
-    incorrect_metadata = {"user_id": transport2.user_id}
-    # invalid metadata, will lead to the fallback user-id generation
-    invalid_metadata = {"user_id": "invalid"}
-    no_metadata = None
+    correct_metadata = {"user_id": transport1.user_id}  # should correctly arrive at receiver
+    invalid_metadata = {"user_id": "invalid"}  # shouldn't arrive at receiver
+    no_metadata = None  # shouldn't arrive at receiver
 
-    all_metadata = (correct_metadata, incorrect_metadata, invalid_metadata, no_metadata)
+    all_metadata = (correct_metadata, invalid_metadata, no_metadata)
     num_sends = 2
     message_id = 0
 
-    for _ in range(num_sends):
-        for metadata in all_metadata:
+    for metadata in all_metadata:
+        for _ in range(num_sends):
             message = Processed(message_identifier=message_id, signature=EMPTY_SIGNATURE)
             raiden0_queues[queue_identifier].append(message)
+
             transport0._raiden_service.sign(message)
             message_queues = [MessagesQueue(queue_identifier, [(message, metadata)])]
             transport0.send_async(message_queues)
             message_id += 1
 
-    num_expected_messages = 3 * num_sends
+    num_expected_messages = num_sends
     with Timeout(TIMEOUT_MESSAGE_RECEIVE):
+        # Delivered messages
         while len(transport0_messages) < num_expected_messages:
             gevent.sleep(0.1)
 
+        # Processed messages
         while len(transport1_messages) < num_expected_messages:
             gevent.sleep(0.1)
 
-    # TODO also track / assert the number of to-device messages
-    #  and account for fallback user-ids and wrong user-ids!!
-    #  Because we have multiple messages per user-id (num_sends),
-    #  the calls to-device should be reduced per user-id because of batching
-
     # transport1 receives the `Processed` messages sent by transport0
-    for i in range(num_expected_messages):
-        assert any(m.message_identifier == i for m in transport1_messages)
+    ids = [m.message_identifier for m in transport1_messages]
+    # transport0 receives the `Delivered` messages sent by transport1
+    delivered_ids = [m.delivered_message_identifier for m in transport0_messages]
 
-    # transport0 answers with a `Delivered` for each `Processed`
-    for i in range(num_expected_messages):
-        assert any(m.delivered_message_identifier == i for m in transport0_messages)
+    assert sorted(ids) == sorted(delivered_ids)
+    assert sorted(ids) == list(range(0, num_sends))
+    assert len(transport0_messages) == num_expected_messages
+    assert len(transport1_messages) == num_expected_messages
 
     transport0.stop()
     transport1.stop()
-    transport2.stop()
 
 
 @pytest.mark.parametrize("matrix_server_count", [2])

--- a/raiden/tests/integration/test_balance_proof_check.py
+++ b/raiden/tests/integration/test_balance_proof_check.py
@@ -67,6 +67,7 @@ def test_node_can_settle_if_close_didnt_use_any_balance_proof(
         amount=PaymentAmount(1),
         identifier=PaymentID(1),
         timeout=network_wait * number_of_nodes,
+        routes=[[app0, app1]],
     )
     # stop app1 - the test uses token_network_contract now
     app1.stop()
@@ -154,6 +155,7 @@ def test_node_can_settle_if_partner_does_not_call_update_transfer(
         amount=PaymentAmount(1),
         identifier=PaymentID(1),
         timeout=network_wait * number_of_nodes,
+        routes=[[app0, app1]],
     )
     # stop app1 - the test uses token_network_contract now
     app1.stop()

--- a/raiden/tests/integration/test_integration_pfs.py
+++ b/raiden/tests/integration/test_integration_pfs.py
@@ -67,7 +67,7 @@ def wait_all_apps(raiden_network: List[RaidenService]) -> None:
 @pytest.mark.parametrize("channels_per_node", [0])
 @pytest.mark.parametrize("routing_mode", [RoutingMode.PFS])
 def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
-    raiden_network: List[RaidenService], token_addresses: List[TokenAddress]
+    raiden_network: List[RaidenService], token_addresses: List[TokenAddress], pfs_mock
 ) -> None:
     """
     We need to test if PFSCapacityUpdates and PFSFeeUpdates are being
@@ -77,6 +77,8 @@ def test_pfs_send_capacity_updates_on_deposit_and_withdraw(
     withdraw it is checked that the correct messages are sent.
     """
     app0, app1, app2 = raiden_network
+    pfs_mock.add_apps(raiden_network)
+
     api0 = RaidenAPI(app0)
     api0.channel_open(
         token_address=token_addresses[0],

--- a/raiden/tests/integration/test_raidenservice.py
+++ b/raiden/tests/integration/test_raidenservice.py
@@ -103,6 +103,7 @@ def test_broadcast_messages_must_be_sent_before_protocol_messages_on_restarts(
         amount=amount,
         identifier=payment_id,
         timeout=network_wait * number_of_nodes,
+        routes=[[app1, app0]],
     )
 
     app0.stop()

--- a/raiden/tests/integration/test_recovery.py
+++ b/raiden/tests/integration/test_recovery.py
@@ -262,6 +262,7 @@ def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
     network_wait,
     number_of_nodes,
     retry_timeout,
+    pfs_mock,
 ):
     """A test case related to https://github.com/raiden-network/raiden/issues/4639
     where a node sends a withdraw transaction, is stopped before the transaction is completed.
@@ -272,6 +273,7 @@ def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
     the on-chain transaction fails.
     """
     app0, app1 = raiden_network
+    pfs_mock.add_apps(raiden_network)
     token_address = token_addresses[0]
 
     # Prevent the withdraw transaction from being sent on-chain. This
@@ -287,8 +289,11 @@ def test_node_clears_pending_withdraw_transaction_after_channel_is_closed(
     )
     assert channel_state, "Channel does not exist"
 
+    app1_metadata = pfs_mock.query_address_metadata(app0.config.pfs_config, app1.address)
     app0.withdraw(
-        canonical_identifier=channel_state.canonical_identifier, total_withdraw=WithdrawAmount(1)
+        canonical_identifier=channel_state.canonical_identifier,
+        total_withdraw=WithdrawAmount(1),
+        recipient_metadata=app1_metadata,
     )
 
     timeout = network_wait * number_of_nodes

--- a/raiden/tests/integration/test_regression_parity.py
+++ b/raiden/tests/integration/test_regression_parity.py
@@ -58,6 +58,7 @@ def test_locksroot_loading_during_channel_settle_handling(
         amount=PaymentAmount(10),
         identifier=PaymentID(1),
         transfer_state=TransferState.SECRET_NOT_REQUESTED,
+        routes=[[app0, app1]],
     )
     transfer(
         initiator_app=app1,
@@ -66,6 +67,7 @@ def test_locksroot_loading_during_channel_settle_handling(
         amount=PaymentAmount(7),
         identifier=PaymentID(2),
         transfer_state=TransferState.SECRET_NOT_REQUESTED,
+        routes=[[app1, app0]],
     )
 
     token_network_address = views.get_token_network_address_by_token_address(

--- a/raiden/tests/integration/test_send_queued_messages.py
+++ b/raiden/tests/integration/test_send_queued_messages.py
@@ -207,6 +207,7 @@ def test_payment_statuses_are_restored(
             target=target_address,
             identifier=PaymentID(identifier),
             secret=secret,
+            route_states=[create_route_state_for_route([app0, app1], token_address)],
         )
         assert payment_status.payment_identifier == identifier
 

--- a/raiden/tests/integration/transfer/test_refundtransfer.py
+++ b/raiden/tests/integration/transfer/test_refundtransfer.py
@@ -316,7 +316,6 @@ def test_refund_transfer(
         {"message_identifier": receive_lock_expired.message_identifier},
         retry_timeout,
     )
-
     # make sure app1 queue has cleared the SendLockExpired
     chain_state1 = views.state_from_raiden(app1)
     queues1 = views.get_all_messagequeues(chain_state=chain_state1)

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import List  # pylint: skip-file  # XXX-UAM remove after tests are fixed
 
 import gevent
@@ -7,9 +8,8 @@ from gevent import Timeout
 from matrix_client.errors import MatrixRequestError
 from matrix_client.user import User
 
-from raiden.constants import EMPTY_SIGNATURE, Environment, MatrixMessageType
+from raiden.constants import Environment, MatrixMessageType
 from raiden.exceptions import RaidenUnrecoverableError
-from raiden.messages.abstract import Message
 from raiden.messages.transfers import SecretRequest
 from raiden.network.transport import MatrixTransport
 from raiden.network.transport.matrix import AddressReachability
@@ -21,12 +21,22 @@ from raiden.tests.utils import factories
 from raiden.tests.utils.factories import make_message_identifier, make_signer
 from raiden.tests.utils.mocks import MockRaidenService
 from raiden.transfer.identifiers import CANONICAL_IDENTIFIER_UNORDERED_QUEUE, QueueIdentifier
+from raiden.transfer.mediated_transfer.events import SendSecretRequest
 from raiden.utils.formatting import to_hex_address
 from raiden.utils.signer import LocalSigner
-from raiden.utils.typing import Address, AddressMetadata, BlockExpiration, PaymentAmount, PaymentID
+from raiden.utils.typing import (
+    Address,
+    AddressMetadata,
+    Any,
+    BlockExpiration,
+    Optional,
+    PaymentAmount,
+    PaymentID,
+    UserID,
+)
 
-USERID0 = "@0x1234567890123456789012345678901234567890:RestaurantAtTheEndOfTheUniverse"
-USERID1 = f"@{to_hex_address(factories.HOP1)}:Wonderland"  # pylint: disable=no-member
+USERID0 = UserID("@0x1234567890123456789012345678901234567890:RestaurantAtTheEndOfTheUniverse")
+USERID1 = UserID(f"@{to_hex_address(factories.HOP1)}:Wonderland")  # pylint: disable=no-member
 
 
 @pytest.fixture()
@@ -327,15 +337,29 @@ def record_sent_messages(mock_matrix):
     del mock_matrix.sent_messages
 
 
-def make_message(sign: bool = True) -> Message:
-    message = SecretRequest(
+def make_message_event(
+    recipient: Address,
+    address_metadata: Any = None,
+    canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
+):
+    return SendSecretRequest(
+        recipient=recipient,
+        recipient_metadata=address_metadata,
+        canonical_identifier=canonical_identifier,
         message_identifier=make_message_identifier(),
         payment_identifier=PaymentID(1),
-        secrethash=factories.UNIT_SECRETHASH,
         amount=PaymentAmount(1),
         expiration=BlockExpiration(10),
-        signature=EMPTY_SIGNATURE,
+        secrethash=factories.UNIT_SECRETHASH,
     )
+
+
+def make_message(sign: bool = True, message_event: Optional[SendSecretRequest] = None):
+    if message_event is None:
+        # recipient etc. doesn't matter, since this will not be considered
+        # on converting to a message
+        message_event = make_message_event(Address(factories.HOP1))
+    message = SecretRequest.from_event(message_event)
     if sign:
         message.sign(LocalSigner(factories.HOP1_KEY))
     return message
@@ -413,6 +437,125 @@ def test_message_in_p2p_room_raises(  # pylint: disable=unused-argument
         mock_matrix._handle_sync_messages([(room, [event])])
 
 
+def test_retry_queue_batch_by_user_id(mock_matrix: MatrixTransport) -> None:
+    """
+    Make sure that the retry-queues batchess messages by the attached
+    AddressMetadata, and pass the message-data to the _send_raw method per batch.
+    """
+
+    original_send_raw = mock_matrix._send_raw
+    sent_messages_by_callcount = defaultdict(list)
+    sent_messages = list()
+    send_raw_call_count = 0
+
+    def send_raw(
+        receiver_address: Address,
+        data: str,
+        message_type: MatrixMessageType = MatrixMessageType.TEXT,
+        receiver_metadata: AddressMetadata = None,
+    ) -> None:
+        nonlocal send_raw_call_count
+        send_raw_call_count += 1
+        for message in data.split("\n"):
+            sent_messages.append(message)
+            sent_messages_by_callcount[send_raw_call_count].append((message, receiver_metadata))
+
+    mock_matrix._send_raw = send_raw  # type: ignore
+
+    # Pretend the Transport greenlet is running
+    mock_matrix.greenlet = True
+
+    receiver_address = Address(factories.HOP1)
+
+    # This is intentionally not using ``MatrixTransport._get_retrier()`` since we don't want the
+    # greenlet to run but instead manually call its `_check_and_send()` method.
+    retry_queue = _RetryQueue(transport=mock_matrix, receiver=receiver_address)
+
+    # enqueue first message with no address metadata
+    address_metadata1 = None
+    message_event1 = make_message_event(receiver_address, address_metadata=address_metadata1)
+    message1 = make_message(message_event=message_event1)
+    serialized_message1 = MessageSerializer.serialize(message1)
+    retry_queue.enqueue(message_event1.queue_identifier, [(message1, address_metadata1)])
+
+    # enqueue second message with no address metadata
+    # dict, but no "user_id" key - this will end up in the same batch as address_metadata=None
+    address_metadata2: AddressMetadata = {"no_user_id": UserID("@nothing:here")}
+
+    message_event2 = make_message_event(receiver_address, address_metadata=address_metadata2)
+    message2 = make_message(message_event=message_event2)
+    serialized_message2 = MessageSerializer.serialize(message2)
+    retry_queue.enqueue(message_event2.queue_identifier, [(message2, address_metadata2)])
+
+    # enqueue third message with correct address metadata
+    correct_address_metadata: AddressMetadata = {"user_id": USERID1}
+    message_event3 = make_message_event(
+        receiver_address, address_metadata=correct_address_metadata
+    )
+    message3 = make_message(message_event=message_event3)
+    serialized_message3 = MessageSerializer.serialize(message3)
+    retry_queue.enqueue(message_event3.queue_identifier, [(message3, correct_address_metadata)])
+
+    # enqueue another message with correct address metadata
+    message_event4 = make_message_event(
+        receiver_address, address_metadata=correct_address_metadata
+    )
+    message4 = make_message(message_event=message_event4)
+    serialized_message4 = MessageSerializer.serialize(message4)
+    retry_queue.enqueue(message_event4.queue_identifier, [(message4, correct_address_metadata)])
+
+    # enqueue second message with no address metadata
+    # has key user-id, but is not a "valid" user-id. This should still get passed to the
+    # send raw
+    address_metadata5: AddressMetadata = {"user_id": UserID("invalid")}
+    message_event5 = make_message_event(receiver_address, address_metadata=address_metadata5)
+    message5 = make_message(message_event=message_event5)
+    serialized_message5 = MessageSerializer.serialize(message5)
+    retry_queue.enqueue(message_event5.queue_identifier, [(message5, address_metadata5)])
+
+    # Pretend the Transport greenlet is running
+    mock_matrix.greenlet = True
+
+    mock_matrix._queueids_to_queues[message_event1.queue_identifier] = [
+        message_event1,
+        message_event2,
+        message_event3,
+        message_event4,
+        message_event5,
+    ]
+
+    # This will call the batching
+    with retry_queue._lock:
+        retry_queue._check_and_send()
+
+    assert len(sent_messages) == 5
+    # only 3 batches expected by "user_id" in AddressMetadata
+    # so transport._send_raw should also only be called 3 times
+    assert send_raw_call_count == 3
+
+    # for the first batch, _send_raw will be called with address_metadata=None, because for
+    # message2, the address-metadata dict didn't include a "user_id" key
+    batch1 = [(serialized_message1, None), (serialized_message2, None)]
+    batch2 = [
+        (serialized_message3, correct_address_metadata),
+        (serialized_message4, correct_address_metadata),
+    ]
+    batch3 = [(serialized_message5, address_metadata5)]
+
+    for sent_batch in sent_messages_by_callcount.values():
+        matches = False
+        for batch in [batch1, batch2, batch3]:
+            if all(elem in sent_batch for elem in batch):  # type: ignore
+                matches = True
+                break
+        msg = f"Sent batch not expected: {sent_batch}"
+        assert matches is True, msg
+
+    mock_matrix._queueids_to_queues[message_event1.queue_identifier].clear()
+
+    mock_matrix._send_raw = original_send_raw  # type: ignore
+
+
 @pytest.mark.parametrize("retry_interval_initial", [0.01])
 @pytest.mark.usefixtures("record_sent_messages", "all_peers_reachable")
 def test_retry_queue_does_not_resend_removed_messages(
@@ -434,16 +577,13 @@ def test_retry_queue_does_not_resend_removed_messages(
     # greenlet to run but instead manually call its `_check_and_send()` method.
     retry_queue = _RetryQueue(transport=mock_matrix, receiver=Address(factories.HOP1))
 
-    message = make_message()
+    message_event = make_message_event(recipient=Address(factories.HOP1))
+    message = make_message(message_event=message_event)
     serialized_message = MessageSerializer.serialize(message)
-    queue_identifier = QueueIdentifier(
-        recipient=Address(factories.HOP1),
-        canonical_identifier=CANONICAL_IDENTIFIER_UNORDERED_QUEUE,
-    )
-    retry_queue.enqueue(queue_identifier, [(message, None)])
 
-    # TODO: Fix the code below, the types are not matching.
-    mock_matrix._queueids_to_queues[queue_identifier] = [message]  # type: ignore
+    retry_queue.enqueue(message_event.queue_identifier, [(message, None)])
+
+    mock_matrix._queueids_to_queues[message_event.queue_identifier] = [message_event]
 
     with retry_queue._lock:
         retry_queue._check_and_send()
@@ -451,7 +591,7 @@ def test_retry_queue_does_not_resend_removed_messages(
     assert len(mock_matrix.sent_messages) == 1  # type: ignore
     assert (factories.HOP1, serialized_message) in mock_matrix.sent_messages  # type: ignore
 
-    mock_matrix._queueids_to_queues[queue_identifier].clear()
+    mock_matrix._queueids_to_queues[message_event.queue_identifier].clear()
 
     # Make sure the retry interval has elapsed
     gevent.sleep(retry_interval_initial * 5)

--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -439,7 +439,7 @@ def test_message_in_p2p_room_raises(  # pylint: disable=unused-argument
 
 def test_retry_queue_batch_by_user_id(mock_matrix: MatrixTransport) -> None:
     """
-    Make sure that the retry-queues batchess messages by the attached
+    Make sure that the retry-queues batches messages by the attached
     AddressMetadata, and pass the message-data to the _send_raw method per batch.
     """
 
@@ -478,8 +478,8 @@ def test_retry_queue_batch_by_user_id(mock_matrix: MatrixTransport) -> None:
     serialized_message1 = MessageSerializer.serialize(message1)
     retry_queue.enqueue(message_event1.queue_identifier, [(message1, address_metadata1)])
 
-    # enqueue second message with no address metadata
-    # dict, but no "user_id" key - this will end up in the same batch as address_metadata=None
+    # enqueue second message with address metadata dict,
+    # but no "user_id" key - this will end up in the same batch as address_metadata=None
     address_metadata2: AddressMetadata = {"no_user_id": UserID("@nothing:here")}
 
     message_event2 = make_message_event(receiver_address, address_metadata=address_metadata2)
@@ -504,8 +504,8 @@ def test_retry_queue_batch_by_user_id(mock_matrix: MatrixTransport) -> None:
     serialized_message4 = MessageSerializer.serialize(message4)
     retry_queue.enqueue(message_event4.queue_identifier, [(message4, correct_address_metadata)])
 
-    # enqueue second message with no address metadata
-    # has key user-id, but is not a "valid" user-id. This should still get passed to the
+    # enqueue a message with address metadata dict,
+    # that has key `user_id`, but is not a "valid" user-id. This should still get passed to the
     # send raw
     address_metadata5: AddressMetadata = {"user_id": UserID("invalid")}
     message_event5 = make_message_event(receiver_address, address_metadata=address_metadata5)

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -355,7 +355,7 @@ def test_events_for_refund():
     assert is_valid, msg
 
     transfer_pair, refund_events = mediator.backward_transfer_pair(
-        refund_channel, received_transfer, pseudo_random_generator, block_number
+        refund_channel, received_transfer, received_transfer, pseudo_random_generator, block_number
     )
 
     assert search_for_item(
@@ -2202,6 +2202,7 @@ def test_backward_transfer_pair_with_fees_deducted():
     transfer_pair, refund_events = mediator.backward_transfer_pair(
         backward_channel=refund_channel,
         payer_transfer=received_transfer,
+        original_transfer=received_transfer,
         pseudo_random_generator=random.Random(),
         block_number=BlockNumber(1),
     )

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -2202,7 +2202,7 @@ def test_backward_transfer_pair_with_fees_deducted():
     transfer_pair, refund_events = mediator.backward_transfer_pair(
         backward_channel=refund_channel,
         payer_transfer=received_transfer,
-        original_transfer=received_transfer,
+        initial_payer_transfer=received_transfer,
         pseudo_random_generator=random.Random(),
         block_number=BlockNumber(1),
     )

--- a/raiden/tests/utils/network.py
+++ b/raiden/tests/utils/network.py
@@ -656,11 +656,6 @@ def wait_for_channels(
     retry_timeout: float = DEFAULT_RETRY_TIMEOUT,
 ) -> None:
     """Wait until all channels are usable from both directions."""
-    # XXX this is used a lot in the api / regression tests,
-    # this seems to fail around 80! tests
-
-    # This is because it calls wait for healthy internally.
-    # Maybe it's ok to just remove that
 
     for app0, app1 in app_channels:
         for token_address in token_addresses:

--- a/raiden/tests/utils/transfer.py
+++ b/raiden/tests/utils/transfer.py
@@ -209,12 +209,12 @@ def transfer(
         Only the initiator and target are synced.
     """
 
+    route_states: Optional[List[RouteState]] = None
+    if routes:
+        route_states = list()
+        for route in routes:
+            route_states.append(create_route_state_for_route(route, token_address))
     if transfer_state is TransferState.UNLOCKED:
-        route_states: Optional[List[RouteState]] = None
-        if routes:
-            route_states = list()
-            for route in routes:
-                route_states.append(create_route_state_for_route(route, token_address))
         return _transfer_unlocked(
             initiator_app=initiator_app,
             target_app=target_app,
@@ -242,6 +242,7 @@ def transfer(
             amount=amount,
             identifier=identifier,
             timeout=timeout,
+            route_states=route_states,
         )
     else:
         raise RuntimeError("Type of transfer not implemented.")
@@ -356,6 +357,7 @@ def _transfer_secret_not_requested(
     amount: PaymentAmount,
     identifier: PaymentID,
     timeout: Optional[float] = None,
+    route_states: List[RouteState] = None,
 ) -> SecretHash:
     if timeout is None:
         timeout = 10
@@ -381,6 +383,7 @@ def _transfer_secret_not_requested(
         identifier=identifier,
         secret=secret,
         secrethash=secrethash,
+        route_states=route_states,
     )
 
     with Timeout(seconds=timeout):

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -444,6 +444,7 @@ def forward_transfer_pair(
 def backward_transfer_pair(
     backward_channel: NettingChannelState,
     payer_transfer: LockedTransferSignedState,
+    original_transfer: LockedTransferSignedState,
     pseudo_random_generator: random.Random,
     block_number: BlockNumber,
 ) -> Tuple[Optional[MediationPairState], List[Event]]:
@@ -459,6 +460,10 @@ def backward_transfer_pair(
             to this node.
         payer_transfer: The *latest* payer transfer which is backing the
             mediation.
+        original_transfer: The *initial* transfer for the corresponding payment that
+            caused our node to try to forward-mediate that payment.
+            It is the same as `payer_transfer` when our node has no valid forward-path to the
+            target on the first forward-mediation attempt.
         block_number: The current block number.
 
     Returns:
@@ -492,7 +497,7 @@ def backward_transfer_pair(
             expiration=lock.expiration,
             secrethash=lock.secrethash,
             route_state=backward_route_state,
-            recipient_metadata=payer_transfer.payer_address_metadata,
+            recipient_metadata=original_transfer.payer_address_metadata,
         )
 
         transfer_pair = MediationPairState(
@@ -936,55 +941,64 @@ def events_to_remove_expired_locks(
     """
     events: List[Event] = list()
 
-    for transfer_pair in mediator_state.transfers_pair:
-        # XXX check the correct balance proof / channel-state is retrieved
-        # FIXME the balance proof of the payer_transfer and the payee_transfer have
-        #   the same channel_identifier!
-        balance_proof = transfer_pair.payee_transfer.balance_proof
-        channel_identifier = balance_proof.channel_identifier
-        channel_state = channelidentifiers_to_channels.get(channel_identifier)
-        if not channel_state:
-            continue
+    if mediator_state.transfers_pair:
 
-        secrethash = mediator_state.secrethash
-        lock: Union[None, LockType] = None
-        if secrethash in channel_state.our_state.secrethashes_to_lockedlocks:
-            assert (
-                secrethash not in channel_state.our_state.secrethashes_to_unlockedlocks
-            ), "Locks for secrethash are already unlocked"
-            lock = channel_state.our_state.secrethashes_to_lockedlocks.get(secrethash)
-        elif secrethash in channel_state.our_state.secrethashes_to_unlockedlocks:
-            lock = channel_state.our_state.secrethashes_to_unlockedlocks.get(secrethash)
-        if lock:
-            lock_expiration_threshold = channel.get_sender_expiration_threshold(lock.expiration)
-            has_lock_expired = channel.is_lock_expired(
-                end_state=channel_state.our_state,
-                lock=lock,
-                block_number=block_number,
-                lock_expiration_threshold=lock_expiration_threshold,
-            )
+        # This is the initial transfer we received for this payment. Here all the relevant
+        # route and address-metadata is present
+        original_transfer: LockedTransferSignedState = mediator_state.transfers_pair[
+            0
+        ].payer_transfer
+        for transfer_pair in mediator_state.transfers_pair:
+            balance_proof = transfer_pair.payee_transfer.balance_proof
+            channel_identifier = balance_proof.channel_identifier
+            channel_state = channelidentifiers_to_channels.get(channel_identifier)
+            if not channel_state:
+                continue
 
-            is_channel_open = channel.get_status(channel_state) == ChannelState.STATE_OPENED
-
-            payee_address_metadata = get_address_metadata(
-                transfer_pair.payee_address, transfer_pair.payee_transfer.route_states
-            )
-            if has_lock_expired and is_channel_open:
-                transfer_pair.payee_state = "payee_expired"
-                expired_lock_events = channel.send_lock_expired(
-                    channel_state=channel_state,
-                    locked_lock=lock,
-                    pseudo_random_generator=pseudo_random_generator,
-                    recipient_metadata=payee_address_metadata,
+            secrethash = mediator_state.secrethash
+            lock: Union[None, LockType] = None
+            if secrethash in channel_state.our_state.secrethashes_to_lockedlocks:
+                assert (
+                    secrethash not in channel_state.our_state.secrethashes_to_unlockedlocks
+                ), "Locks for secrethash are already unlocked"
+                lock = channel_state.our_state.secrethashes_to_lockedlocks.get(secrethash)
+            elif secrethash in channel_state.our_state.secrethashes_to_unlockedlocks:
+                lock = channel_state.our_state.secrethashes_to_unlockedlocks.get(secrethash)
+            if lock:
+                lock_expiration_threshold = channel.get_sender_expiration_threshold(
+                    lock.expiration
                 )
-                events.extend(expired_lock_events)
-
-                unlock_failed = EventUnlockFailed(
-                    transfer_pair.payee_transfer.payment_identifier,
-                    transfer_pair.payee_transfer.lock.secrethash,
-                    "lock expired",
+                has_lock_expired = channel.is_lock_expired(
+                    end_state=channel_state.our_state,
+                    lock=lock,
+                    block_number=block_number,
+                    lock_expiration_threshold=lock_expiration_threshold,
                 )
-                events.append(unlock_failed)
+
+                is_channel_open = channel.get_status(channel_state) == ChannelState.STATE_OPENED
+
+                # The original_transfer is the initial transfer we received from a previous hop,
+                # so there we have all metadata that was passed on to other nodes already
+                # present
+                payee_address_metadata = get_address_metadata(
+                    transfer_pair.payee_address, original_transfer.route_states
+                )
+                if has_lock_expired and is_channel_open:
+                    transfer_pair.payee_state = "payee_expired"
+                    expired_lock_events = channel.send_lock_expired(
+                        channel_state=channel_state,
+                        locked_lock=lock,
+                        pseudo_random_generator=pseudo_random_generator,
+                        recipient_metadata=payee_address_metadata,
+                    )
+                    events.extend(expired_lock_events)
+
+                    unlock_failed = EventUnlockFailed(
+                        transfer_pair.payee_transfer.payment_identifier,
+                        transfer_pair.payee_transfer.lock.secrethash,
+                        "lock expired",
+                    )
+                    events.append(unlock_failed)
 
     return events
 
@@ -1095,6 +1109,7 @@ def mediate_transfer(
     # Could not mediate, try to refund
     if state.transfers_pair:
         original_pair = state.transfers_pair[0]
+        original_transfer = original_pair.payer_transfer
         original_channel = addresses_to_channel.get(
             (
                 original_pair.payer_transfer.balance_proof.token_network_address,
@@ -1103,11 +1118,13 @@ def mediate_transfer(
         )
     else:
         original_channel = payer_channel
+        original_transfer = payer_transfer
 
     if original_channel:
         refund_transfer_pair, refund_events = backward_transfer_pair(
             original_channel,
             payer_transfer,
+            original_transfer,
             pseudo_random_generator,
             block_number,
         )

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -280,6 +280,7 @@ class ExpiredWithdrawState:
     total_withdraw: WithdrawAmount
     expiration: BlockExpiration
     nonce: Nonce
+    recipient_metadata: Optional[AddressMetadata] = None
 
 
 @dataclass
@@ -287,6 +288,7 @@ class PendingWithdrawState:
     total_withdraw: WithdrawAmount
     expiration: BlockExpiration
     nonce: Nonce
+    recipient_metadata: Optional[AddressMetadata] = None
 
 
 @dataclass

--- a/raiden/transfer/state_change.py
+++ b/raiden/transfer/state_change.py
@@ -19,6 +19,7 @@ from raiden.transfer.state import (
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
     Address,
+    AddressMetadata,
     BlockExpiration,
     BlockGasLimit,
     BlockHash,
@@ -29,6 +30,7 @@ from raiden.utils.typing import (
     Locksroot,
     MessageID,
     Nonce,
+    Optional,
     PaymentID,
     Secret,
     SecretHash,
@@ -107,6 +109,7 @@ class ActionChannelWithdraw(StateChange):
 
     canonical_identifier: CanonicalIdentifier
     total_withdraw: WithdrawAmount
+    recipient_metadata: Optional[AddressMetadata] = None
 
     @property
     def channel_identifier(self) -> ChannelID:
@@ -354,6 +357,7 @@ class ReceiveWithdrawRequest(AuthenticatedSenderStateChange):
     expiration: BlockExpiration
     signature: Signature
     participant: Address
+    sender_metadata: Optional[AddressMetadata] = None
 
     @property
     def channel_identifier(self) -> ChannelID:

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -37,6 +37,7 @@ from raiden.settings import (
     DEFAULT_HTTP_SERVER_PORT,
     DEFAULT_MATRIX_KNOWN_SERVERS,
     DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS,
+    MATRIX_AUTO_SELECT_SERVER,
     MatrixTransportConfig,
     PythonApiConfig,
     RaidenConfig,
@@ -368,9 +369,10 @@ def run_raiden_service(
     else:
         deployed_addresses = load_deployment_addresses_from_contracts(contracts=contracts)
 
-    # Always fetch all available matrix servers. It's necessary to know the complete list in order
-    # to be able to construct user-ids on other homeservers
-    fetch_available_matrix_servers(config.transport, config.environment_type)
+    # Load the available matrix servers when no matrix server is given
+    # The list is used in a PFS check
+    if config.transport.server == MATRIX_AUTO_SELECT_SERVER:
+        fetch_available_matrix_servers(config.transport, config.environment_type)
 
     raiden_bundle = raiden_bundle_from_contracts_deployment(
         proxy_manager=proxy_manager,


### PR DESCRIPTION

For invalid or non-existent AddressMetadata in the `_send_raw`
method of the transport, a fallback was used where the message
was sent out to all possible user-ids on all known Matrix servers
in the federation. This was considered a possible security
vulnerability, since a malicious matrix server wouldn't have
to follow signature verification and could be eavesdropping.
The fallback feature is therefore removed, so that messages without
address-metadata will remain the retry-queue as long as there is no
WebRTC connection established.
Fixes: #6953

There are also 2 bugfixes included:
- fix the flaky `test_matrix_transport_handles_metadata`

Fixes: #6976


- Fix message-batching for differing UserIDs per receiver 

Fixes: #6993

