### PR TITLE
Explicitly set test root dir in scenario player tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,11 +396,13 @@ jobs:
       - run:
           name: Checkout Scenario Player
           command: |
+            cd ~
             git clone https://github.com/raiden-network/scenario-player.git
       - run:
           name: Install dependencies
           command: |
-            pip install git+https://github.com/raiden-network/scenario-player.git
+            cd ~
+            pip install ~/scenario-player
             pip install -Ue ~/raiden
       - run:
           name: Set Locale
@@ -413,12 +415,12 @@ jobs:
       - run:
           name: Run Unit Tests
           command: |
-            cd scenario-player
-            pytest .
+            cd ~/scenario-player
+            pytest --rootdir . tests
       - run:
           name: Run Smoketest
           command: |
-            cd scenario-player
+            cd ~/scenario-player
             scenario_player smoketest
 
   test:


### PR DESCRIPTION
## Description

Since #6991 a `conftest.py` file exists in the Raiden project root.
This seems to cause the scenario player tests to pick that up as the test root dir (since the SP repo is cloned into the Raiden checkout) and use the Raiden conftest file.
This produces unexpected results (infinite recursion).

The scenario player checkout is now done next to the Raiden repo, not inside it.
