### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.2
+    rev: v3.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -26,6 +26,7 @@ repos:
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
+      - id: check-toml
       - id: check-vcs-permalinks
       - id: check-yaml
       - id: debug-statements
@@ -35,20 +36,19 @@ repos:
         exclude: .bumpversion_client.cfg
       - id: fix-encoding-pragma
         args: ['--remove']
-      - id: flake8
-        args: ["--config=setup.cfg"]
-        additional_dependencies: ["flake8-bugbear==18.8.0", "flake8-tuple", "readme-renderer",]
       - id: mixed-line-ending
       - id: no-commit-to-branch
         args: ['--branch', 'master', '--branch', 'develop']
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.1
+    rev: v1.8.0
     hooks:
       - id: python-no-eval
       - id: python-no-log-warn
       - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
 
   - repo: git://github.com/pre-commit/mirrors-isort
     rev: v5.8.0
@@ -61,6 +61,16 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://gitlab.com/PyCQA/flake8
+    rev: 3.9.1
+    hooks:
+      - id: flake8
+        args: ["--config=setup.cfg"]
+        additional_dependencies:
+          - "flake8-bugbear==21.4.3"
+          - "flake8-tuple==0.4.1"
+          - "readme-renderer==29.0"
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.812
     hooks:
@@ -68,7 +78,7 @@ repos:
         entry: tools/pre-commit/pre-commit-wrapper.py mypy
         additional_dependencies: ["pip-tools==6.1.0"]
 
-  - repo: https://github.com/pre-commit/mirrors-pylint
+  - repo: https://github.com/PyCQA/pylint
     rev: v2.8.2
     hooks:
       - id: pylint

--- a/tools/pre-commit/pre-commit-check-versions.py
+++ b/tools/pre-commit/pre-commit-check-versions.py
@@ -26,10 +26,11 @@ class ToolConfig:
 
 
 class Tool(Enum):
-    ISORT = ToolConfig(name="isort", url="git://github.com/pre-commit/mirrors-isort")
     BLACK = ToolConfig(name="black", url="https://github.com/python/black")
+    FLAKE8 = ToolConfig(name="flake8", url="https://gitlab.com/PyCQA/flake8")
+    ISORT = ToolConfig(name="isort", url="git://github.com/pre-commit/mirrors-isort")
     MYPY = ToolConfig(name="mypy", url="https://github.com/pre-commit/mirrors-mypy")
-    PYLINT = ToolConfig(name="pylint", url="https://github.com/pre-commit/mirrors-pylint")
+    PYLINT = ToolConfig(name="pylint", url="https://github.com/PyCQA/pylint")
 
 
 @dataclass
@@ -117,10 +118,10 @@ def check_pre_commit_tool_versions(
             )
         for additional_dep in tool_version.additional_deps:
             specifiers = list(additional_dep.specifier)
-            if len(specifiers) > 1 or specifiers[0].operator != "==":
+            if len(specifiers) != 1 or specifiers[0].operator != "==":
                 errors.append(
                     f"Can only process a single strict equality constraint for "
-                    f"'additional_dependencies' (in '{tool.name}', '{additional_dep}')"
+                    f"'additional_dependencies' (in '{tool.name}' -> '{additional_dep}')"
                 )
                 continue
             additional_dep_requirement = requirements.get(additional_dep.name)


### PR DESCRIPTION
## Description

- Update pre-commit/pre-commit-hooks to 3.4
  - This splits out flake8 into it's own repo which means it can now be checked by our version check helper as well.
  - Switch to using the official pylint repo instead of the deprecated mirror
- Update pre-commit/pygrep-hooks
  - Add some rst mistake checkers
