### PR TITLE
Don't ignore gevent.monkey.MonkeyPatchWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,8 @@ norecursedirs = [
     "node_modules",
 ]
 # Ignore warnings:
-# - grequests monkeypatch
 # - urllib3 unverified TLS connection
 filterwarnings = [
-    "ignore::gevent.monkey.MonkeyPatchWarning",
     "ignore::urllib3.exceptions.InsecureRequestWarning",
 ]
 markers = [


### PR DESCRIPTION
It's actually important since it indicates that the monkey patching
occured too late and things may break, as has recently started happening
on our CI.