### PR TITLE
Add MS1 scenario variant with snapshot

### DIFF
--- a/raiden/tests/scenarios/ms1_simple_monitoring_snapshot.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring_snapshot.yaml
@@ -1,0 +1,72 @@
+version: 2
+
+settings:
+  gas_price: "fast"
+  # Adapt to chain used
+  services:
+    pfs:
+      url: {{ pfs_with_fee }}
+    udc:
+      enable: true
+      token:
+        deposit: true
+        balance_per_node: {{ ms_reward_with_margin }}
+
+token:
+  address: "{{ transfer_token }}"
+  balance_fund: 10_000_000_000_000_000_000
+
+nodes:
+  reuse_accounts: true
+  restore_snapshot: true
+  count: 2
+  raiden_version: local
+
+  default_options:
+    gas-price: fast
+    enable-monitoring: true
+    proportional-fee:
+      - "{{ transfer_token }}"
+      - 0
+    proportional-imbalance-fee:
+      - "{{ transfer_token }}"
+      - 0
+    default-settle-timeout: {{ settlement_timeout_min }}
+    default-reveal-timeout: 20
+
+# This is the MS1 scenario. A channel between two nodes is opened, a transfer is made. Then, node1 goes offline
+# and node0 closes the channel. The last assert checks whether the monitoring service interferes and received its reward.
+
+scenario:
+  serial:
+    tasks:
+      - snapshot:
+          tasks:
+            - open_channel: {from: 0, to: 1, total_deposit: 2_000_000_000_000_000_000}
+      - transfer: {from: 0, to: 1, amount: 1_000_000_000_000_000_000, expected_http_status: 200}
+      ## Wait for Monitor Request to be sent
+      - wait_blocks: 1
+      - store_channel_info: {from: 0, to: 1, key: "MS Test Channel"}
+      - stop_node: 1
+      - close_channel: {from: 0, to: 1}
+      ## Wait for channel to be closed
+      - wait_blocks: 1
+      - assert: {from: 0, to: 1, total_deposit: 2_000_000_000_000_000_000, balance: 1_000_000_000_000_000_000, state: "closed"}
+      - assert_events:
+          contract_name: "TokenNetwork"
+          event_name: "ChannelClosed"
+          num_events: 1
+          event_args: {closing_participant: 0}
+
+      ## The MS reacts within the settle_timeout
+      - wait_blocks: {{ settlement_timeout_min }}
+      - assert_events:
+          contract_name: "TokenNetwork"
+          event_name: "NonClosingBalanceProofUpdated"
+          num_events: 1
+          event_args: {closing_participant: 0}
+
+      ## Monitored channel must be settled before the monitoring service can claim its reward
+      ## To make sure the transactions gets mined in time, 10 additional blocks are added
+      - wait_blocks: 10
+      - assert_ms_claim: {channel_info_key: "MS Test Channel"}


### PR DESCRIPTION
This has been useful when debugging multiple times. But digging it out
every time is cumbersome and others might want to use it, too. It is not
symlinked to the sp1/sp2 dirs, so it should not get picket up by the SP
CI.