### PR TITLE
Mark docs/adr/template.rst as orphan

### DIFF
--- a/docs/adr/template.rst
+++ b/docs/adr/template.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 [short title of solved problem and solution]
 ********************************************
 


### PR DESCRIPTION
template.rst is just a template and shouldn't be included in
the docs, but sphinx will complain:
```    
    raiden/docs/adr/template.rst: WARNING: document isn't included in any toctree
```    
So mark it as orphan to silence the warning.
