### PR TITLE
pyproject.toml: remove py39 from black target version list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
The py39 version was added in 43ae6e32b15b10ca815a8be09370375337c660bf,
but our version of black doesn't support it.