### PR TITLE
Fix "bad secret request message from target" msg

### DIFF
--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -183,7 +183,7 @@ def handle_block(
             events.extend(expired_lock_events)
 
         if initiator_state.received_secret_request:
-            reason = "bad secret request message from target"
+            reason = "lock expired, despite receiving secret request"
         else:
             reason = "lock expired"
 


### PR DESCRIPTION
This message will also be returned when the secret request was valid,
but the payment timed out nevertheless. Using a less specific but
correct error message is preferable.

Closes https://github.com/raiden-network/raiden/issues/7044