### PR TITLE
Fix capabilities serialization in login()

### DIFF
--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -302,8 +302,7 @@ def first_login(
         current_capabilities = ""
 
     # Only set the capabilities if necessary.
-    cap_str = capabilities_schema.load(capabilities.get("capabilities", {}))
-    cap_str = cap_str["capabilities"]
+    cap_str = capabilities.get("capabilities", "mxc://")
     if current_capabilities != cap_str:
         user.set_avatar_url(cap_str)
 
@@ -312,6 +311,7 @@ def first_login(
         node=to_checksum_address(username),
         homeserver=server_name,
         server_url=server_url,
+        capabilities=capabilities,
     )
     return user
 
@@ -389,7 +389,7 @@ def login(
             )
 
     try:
-        cap: Dict = capabilities_schema.dump(capabilities)
+        cap: Dict = capabilities_schema.dump({"capabilities": capabilities})
     except ValueError:
         raise Exception("error serializing")
     return first_login(client, signer, username, cap, device_id)

--- a/raiden/tests/unit/test_matrix_transport.py
+++ b/raiden/tests/unit/test_matrix_transport.py
@@ -35,7 +35,7 @@ from raiden.utils.signer import recover
 from raiden.utils.typing import MessageID
 
 
-def test_login_for_the_first_time_must_set_the_display_name():
+def test_login_for_the_first_time_must_set_display_name_and_avatar_url():
     ownserver = "https://ownserver.com"
     api = Mock()
     api.base_url = ownserver
@@ -59,7 +59,12 @@ def test_login_for_the_first_time_must_set_the_display_name():
 
     signer = make_signer()
 
-    user = login(client=client, signer=signer, device_id=DeviceIDs.RAIDEN)
+    user = login(
+        client=client, signer=signer, device_id=DeviceIDs.RAIDEN, capabilities={"test": 1}
+    )
+
+    # avatar_url must have been set
+    user.set_avatar_url.assert_called_once_with("mxc://raiden.network/cap?test=1")
 
     # client.user_id will be set by login
     assert client.user_id.startswith(f"@{to_normalized_address(signer.address)}")


### PR DESCRIPTION
Due to the broken serialization, the python client did not set the
`avatar_url` for the capabilities server-side.

Fixes: #7047