### PR TITLE
Validate address metadata in RouteStates

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -240,6 +240,9 @@ class MessageHandler:
         raiden: "RaidenService", message: RefundTransfer
     ) -> List[StateChange]:
         chain_state = views.state_from_raiden(raiden)
+        # XXX: Not sure about this one. What should we do if the LockedTransfer has no
+        #      route_states due to validation?
+        # AFAIK the routes in the received transfer aren't relevant for the refund anyway.
         from_transfer = lockedtransfersigned_from_message(message=message)
 
         role = views.get_transfer_role(

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -697,6 +697,7 @@ def test_routing_in_direct_channel(happy_path_fixture, our_signer, one_to_n_addr
         "raiden.routing.query_address_metadata"
     ) as pfs_user_request:
         pfs_route_request.return_value = None, [], "feedback_token"
+        pfs_user_request.return_value = None
         _, routes, _ = get_best_routes(
             chain_state=chain_state,
             token_network_address=token_network_state.address,

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -8,7 +8,7 @@ from raiden.messages.transfers import LockedTransfer, RefundTransfer
 from raiden.storage.serialization import DictSerializer
 from raiden.tests.utils import factories
 from raiden.tests.utils.events import search_for_item
-from raiden.tests.utils.factories import UNIT_TOKEN_NETWORK_ADDRESS, UNIT_TRANSFER_AMOUNT
+from raiden.tests.utils.factories import HOP1_KEY, UNIT_TOKEN_NETWORK_ADDRESS, UNIT_TRANSFER_AMOUNT
 from raiden.transfer import views
 from raiden.transfer.architecture import TransitionResult
 from raiden.transfer.events import EventPaymentSentFailed
@@ -86,7 +86,7 @@ def test_route_metadata_displayname_validation():
     properties = factories.RouteMetadataProperties()
     one_metadata = factories.create(properties)
     route = one_metadata.route
-    signer = factories.make_signer()
+    signer = LocalSigner(HOP1_KEY)
     server_name = urlparse("https://ownserver.com").netloc
     user_id = f"@{to_normalized_address(signer.address)}:{server_name}"
     displayname = encode_hex(signer.sign(user_id.encode()))

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -47,6 +47,10 @@ def prune_route_table(
     contains only routes using the same forward channel and removes our own
     address in the process.
     Note that address metadata are kept complete for the whole route.
+
+    Also note that we don't need to handle ``ValueError``s here since the new
+    ``RouteState``s are built from existing ones, which means the metadata have
+    already been validated.
     """
 
     return [

--- a/raiden/utils/validation.py
+++ b/raiden/utils/validation.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from enum import Flag, auto
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+from eth_typing import Address
+
+from raiden.utils.typing import AddressMetadata, UserID
+
+if TYPE_CHECKING:
+    from raiden.messages.metadata import RouteMetadata
+    from raiden.transfer.state import RouteState
+
+
+class MetadataValidationError(Flag):
+    USER_ID_MISSING = auto()
+    DISPLAY_NAME_MISSING = auto()
+    INVALID_SIGNATURE = auto()
+
+
+def validate_address_metadata(
+    instance: Union[RouteMetadata, RouteState]
+) -> Dict[Address, MetadataValidationError]:
+    """Validate address metadata
+
+    This function accepts both ``RouteMetadata`` and ``RouteState`` instances
+    and validates their ``address_metadata`` or ``address_to_metadata`` fields
+    respectively.
+
+    The rules are:
+
+      - Entirely missing metadata (``None`` or empty ``dict``) are ok
+      - If metadata are present both ``user_id`` and ``displayname`` need to be set
+      - ``displayname`` needs to be a valid signature for ``user_id``
+
+    Returns a dictionary of address to validation error flags.
+    """
+
+    # Yay, circular imports
+    from raiden.messages.metadata import RouteMetadata
+    from raiden.network.transport.matrix.utils import validate_user_id_signature
+    from raiden.transfer.state import RouteState
+
+    errors: Dict[Address, MetadataValidationError] = {}
+
+    if isinstance(instance, RouteMetadata):
+        metadata = instance.address_metadata
+    elif isinstance(instance, RouteState):
+        metadata = instance.address_to_metadata
+    else:
+        raise TypeError(f"Received unexpected instance of type {type(instance)}.")
+
+    if not metadata:
+        # Empty metadata are not a failure case
+        return errors
+
+    for address in instance.route:
+        # Special case for `Flag` instances. There's always a `0` value that represents the absence
+        # of a Flag
+        error = MetadataValidationError(0)
+
+        address_metadata: Optional[AddressMetadata] = metadata.get(address)
+        if not address_metadata:
+            # Missing or empty metadata is currently not a failure case
+            continue
+
+        user_id = address_metadata.get("user_id")
+        displayname = address_metadata.get("displayname")
+
+        if user_id is None:
+            error |= MetadataValidationError.USER_ID_MISSING
+        if displayname is None:
+            error |= MetadataValidationError.DISPLAY_NAME_MISSING
+
+        if not error:
+            verified_address = validate_user_id_signature(
+                UserID(user_id),  # type: ignore
+                displayname,
+            )
+            if verified_address != address:
+                error |= MetadataValidationError.INVALID_SIGNATURE
+
+        if error:
+            errors[address] = error
+
+    return errors

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ max-line-length = 99
 
 [isort]
 line_length=99
-known_future_library=future
 known_first_party=raiden,raiden_contracts,scenario_player
 default_section=THIRDPARTY
 combine_as_imports=1


### PR DESCRIPTION
## Description

Fixes: #7049

Until now `RouteState` had no validation on the `address_to_metadata` field (unlike `RouteMetadata` which is used in the transport).
In cases where invalid metadata were present this would lead to stuck transfers that would need to wait for lock expiration.

Adding the validation now allows either to select a route with valid metadata for all hops or immediate user feedback that the transfer can't be performed.

See #7049 for more details.
