### PR TITLE
Fix address-metadata state mutation in message verification

### DIFF
--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import dataclass
 
 import canonicaljson
@@ -20,7 +21,7 @@ class RouteMetadata:
         address_metadata: Optional[Dict[Address, AddressMetadata]] = None,
     ) -> None:
 
-        self.address_metadata = address_metadata or {}
+        self.address_metadata = deepcopy(address_metadata) or {}
         self.route = route
         self._validate_address_metadata()
 


### PR DESCRIPTION
States should never be mutated when the mutation is not the cause
of a state-change.
The RouteState.address_to_metadata dictionary was passed to the
RouteMetadata message container, and the mutable object was altered
upon verification of the metadata signatures.

This could cause losing of invalid metadata in the senders state,
once the metadata was passed to other nodes.

Fixes #7061

