### PR TITLE
Fix PyInstaller bundling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,6 +578,11 @@ jobs:
             source .circleci/get_archive_tag.sh
             make bundle-docker
             echo ${RELEASE_TYPE}/raiden-${ARCHIVE_TAG}-linux-<<parameters.architecture>>.tar.gz > dist/archive/_LATEST-${RELEASE_TYPE}-linux-<<parameters.architecture>>.txt
+      - run:
+          name: Test if Binary can be launched
+          command: |
+            tar -C /tmp -xf dist/archive/raiden-${ARCHIVE_TAG}-linux-<<parameters.architecture>>.tar.gz
+            /tmp/raiden-${ARCHIVE_TAG}-linux-<<parameters.architecture>> --help
       - persist_to_workspace:
           root: "~"
           paths:
@@ -610,6 +615,10 @@ jobs:
             pyinstaller --noconfirm --clean raiden.spec
             zip -9 --junk-paths dist/archive/raiden-${ARCHIVE_TAG}-macOS-x86_64.zip dist/raiden-${ARCHIVE_TAG}-macOS-x86_64
             echo ${RELEASE_TYPE}/raiden-${ARCHIVE_TAG}-macOS-x86_64.zip > dist/archive/_LATEST-${RELEASE_TYPE}-macOS-x86_64.txt
+      - run:
+          name: Test if Binary can be launched
+          command: |
+            dist/raiden-${ARCHIVE_TAG}-macOS-x86_64 --help
       - persist_to_workspace:
           root: "~"
           paths:

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ endif
 bundle-docker: ARCHITECTURE_TAG = $(shell docker run --rm python:3.7 uname -m)
 bundle-docker: ARCHIVE_TAG ?= v$(shell python setup.py --version)
 bundle-docker:
-	docker build -t pyinstallerbuilder --build-arg GETH_URL_LINUX=$(GETH_URL_LINUX) --build-arg SOLC_URL_LINUX=$(SOLC_URL_LINUX) --build-arg ARCHITECTURE_TAG=$(ARCHITECTURE_TAG) --build-arg ARCHIVE_TAG=$(ARCHIVE_TAG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .
+	docker build -t pyinstallerbuilder --build-arg ARCHITECTURE_TAG=$(ARCHITECTURE_TAG) --build-arg ARCHIVE_TAG=$(ARCHIVE_TAG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .
 	-(docker rm builder)
 	docker create --name builder pyinstallerbuilder
 	mkdir -p dist/archive

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,24 +1,11 @@
 FROM python:3.7-stretch
 
-# these are defined in .circleci/config.yml and passed here in the makefile
-ARG SOLC_URL_LINUX
-ARG GETH_URL_LINUX
-
 # install dependencies
 RUN apt-get update
 RUN apt-get install -y git-core wget xz-utils build-essential \
     automake pkg-config libtool libffi-dev python3-dev libgmp-dev \
     libavdevice-dev libavfilter-dev libopus-dev libvpx-dev pkg-config \
     libsrtp2-dev
-
-RUN wget -nv -O /usr/bin/solc ${SOLC_URL_LINUX} && \
-    chmod +x /usr/bin/solc
-RUN wget -nv -O /tmp/geth.tar.gz ${GETH_URL_LINUX} && \
-    cd /tmp && \
-    tar xf geth.tar.gz && \
-    mv geth-linux-amd64-*/geth /usr/bin/geth && \
-    rm geth.tar.gz
-
 
 RUN python3 -m venv /venv
 ENV PATH="/venv/bin:$PATH"

--- a/tools/pyinstaller_hooks/hook-av.py
+++ b/tools/pyinstaller_hooks/hook-av.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+
+hiddenimports = collect_submodules("av")

--- a/tools/pyinstaller_hooks/runtime_gevent_monkey.py
+++ b/tools/pyinstaller_hooks/runtime_gevent_monkey.py
@@ -1,7 +1,3 @@
-from gevent.monkey import patch_all  # isort:skip # noqa
+from gevent.monkey import patch_all
 
-patch_all()  # isort:skip # noqa
-
-from raiden.network.transport.matrix.rtc.utils import setup_asyncio_event_loop
-
-setup_asyncio_event_loop()
+patch_all()


### PR DESCRIPTION
## Description

Our bundled binaries seem to have been not working for some time (thanks @netcriptus for noticing).

We had two separate issues:
- The `av` dependency (via `aiortc`) wasn't being properly discovered by PyInstaller.
  This has been fixed with a hook.
- On Linux stripping of the libraries apparently causes some corruption
  See: https://github.com/pypa/manylinux/issues/119
  Therefore stripping is disabled for now.
- The gevent runtime hook would attempt to start the aio event loop. This caused a warning about an already running loop.

This also fixes:
- Don't include unnecessary av libraries in the bundle
- Remove no longer used GETH_URL and SOLC_URL build args from the `bundle-docker` make target.
- On CI: Invoke the built binaries with `--help` as a minimal functionality sanity check.

