### PR TITLE
Fix macOS CI build issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,7 @@ commands:
             if [[ ${OS_NAME} == "MACOS" ]]; then
               export PATH=${PYENV_ROOT}/bin:${PATH}
               eval "$(pyenv init -)"
+              eval "$(pyenv init --path)"
               pyenv local $PYENV_PYTHON_VERSION
               echo "Detected MacOS: Using pyenv Python at $(pyenv which python<< parameters.py-version >>)"
             fi


### PR DESCRIPTION
## Description

`pyenv` changed the behaviour of `pyenv init -` to no longer set the PATH
This fixes it.

