### PR TITLE
remove removing dependencies

### DIFF
--- a/raiden.spec
+++ b/raiden.spec
@@ -4,6 +4,7 @@ from __future__ import print_function
 import pdb
 import platform
 import sys
+from PyInstaller.building.datastruct import unique_name
 
 from raiden.utils.system import get_system_spec
 
@@ -16,15 +17,7 @@ ONEFILE = int(os.environ.get("ONEFILE", True))
 
 # Hack: This is a list of prefixes to be removed from the `binaries`.
 #       We do this to prevent including unnecessary libraries (pyav audio / video dependencies)
-BINARIES_PREFIX_BLOCKLIST = [
-    "libav",
-    "libaom",
-    "libswscale",
-    "libswrescale",
-    "libvorbis",
-    "libx264",
-    "libx265",
-]
+BINARIES_PREFIX_BLOCKLIST = []
 
 
 def Entrypoint(
@@ -80,16 +73,18 @@ def Entrypoint(
         excludes=excludes,
         runtime_hooks=runtime_hooks,
         datas=datas,
-    )
+        )
     # `Analysis.binaries` behaves set-like and matches on the first tuple item (`name`).
     # Since library names include the version we first build a list of the concrete names
     # by prefix matching and then subtract that via the set-like behaviour.
-    binaries_to_remove = [
-        (name, None, None)
-        for name, *_ in analysis.binaries
+    for binary_to_remove in [
+        (name, path, typecode)
+        for name, path, typecode in analysis.binaries
         if any(name.startswith(blocklist_item) for blocklist_item in BINARIES_PREFIX_BLOCKLIST)
-    ]
-    analysis.binaries -= binaries_to_remove
+    ]:
+        analysis.binaries.remove(binary_to_remove)
+        analysis.binaries.filenames.remove(unique_name(binary_to_remove))
+
     return analysis
 
 

--- a/raiden.spec
+++ b/raiden.spec
@@ -76,7 +76,7 @@ def Entrypoint(
         )
     # `Analysis.binaries` behaves set-like and matches on the first tuple item (`name`).
     # Since library names include the version we first build a list of the concrete names
-    # by prefix matching and then subtract that via the set-like behaviour.
+    # by prefix matching and then remove it from the list.
     for binary_to_remove in [
         (name, path, typecode)
         for name, path, typecode in analysis.binaries


### PR DESCRIPTION
Pyinstaller used to remove libav binaries which we dont need but are a requirement for aiortc. As we remove aiortc for a short term we can remove the check. 

It also goes around a bug in pyinstaller own datastructe TOC by removing via list.remove and not the __sub__ operator