### PR TITLE
Add av replacement stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ bundle-docker:
 	docker cp builder:/raiden/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar.gz dist/archive/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar.gz
 	docker rm builder
 
-bundle: ONEFILE ?= $(ONEFILE)
 bundle:
 	pyinstaller --noconfirm --clean raiden.spec
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,14 @@ monkey.patch_all(subprocess=False, thread=False)
 
 # isort:split
 
+import aiortc_pyav_stub
+
+# Install the av replacement stub to make sure we catch possible version
+# upgrade breakages
+aiortc_pyav_stub.install_as_av()
+
+# isort: split
+
 import pytest
 
 # Execute these before the raiden imports because rewrites can't work after the

--- a/raiden.spec
+++ b/raiden.spec
@@ -4,7 +4,6 @@ from __future__ import print_function
 import pdb
 import platform
 import sys
-from PyInstaller.building.datastruct import unique_name
 
 from raiden.utils.system import get_system_spec
 
@@ -14,10 +13,6 @@ PyInstaller spec file to build single file or dir distributions
 
 # Set to false to produce an exploded single-dir
 ONEFILE = int(os.environ.get("ONEFILE", True))
-
-# Hack: This is a list of prefixes to be removed from the `binaries`.
-#       We do this to prevent including unnecessary libraries (pyav audio / video dependencies)
-BINARIES_PREFIX_BLOCKLIST = []
 
 
 def Entrypoint(
@@ -73,18 +68,7 @@ def Entrypoint(
         excludes=excludes,
         runtime_hooks=runtime_hooks,
         datas=datas,
-        )
-    # `Analysis.binaries` behaves set-like and matches on the first tuple item (`name`).
-    # Since library names include the version we first build a list of the concrete names
-    # by prefix matching and then remove it from the list.
-    for binary_to_remove in [
-        (name, path, typecode)
-        for name, path, typecode in analysis.binaries
-        if any(name.startswith(blocklist_item) for blocklist_item in BINARIES_PREFIX_BLOCKLIST)
-    ]:
-        analysis.binaries.remove(binary_to_remove)
-        analysis.binaries.filenames.remove(unique_name(binary_to_remove))
-
+    )
     return analysis
 
 
@@ -111,13 +95,17 @@ a = Entrypoint(
     hookspath=["tools/pyinstaller_hooks"],
     runtime_hooks=[
         "tools/pyinstaller_hooks/runtime_gevent_monkey.py",
+        "tools/pyinstaller_hooks/runtime_aiortc_pyav_stub.py",
         "tools/pyinstaller_hooks/runtime_encoding.py",
         "tools/pyinstaller_hooks/runtime_raiden_contracts.py",
     ],
-    hiddenimports=[],
+    hiddenimports=[
+        "aiortc_pyav_stub",
+    ],
     datas=[],
     excludes=[
         "_tkinter",
+        "av",
         "FixTk",
         "ipython",
         "jupyter",
@@ -152,7 +140,7 @@ else:
         a.scripts,
         exclude_binaries=True,
         name=executable_name,
-        debug=True,
+        debug="all",
         strip=False,
         upx=False,
         console=True,

--- a/raiden.spec
+++ b/raiden.spec
@@ -80,10 +80,11 @@ def Entrypoint(
     for binary_to_remove in [
         (name, path, typecode)
         for name, path, typecode in analysis.binaries
-        if any(name.startswith(blocklist_item) for blocklist_item in BINARIES_PREFIX_BLOCKLIST)]:
+        if any(name.startswith(blocklist_item) for blocklist_item in BINARIES_PREFIX_BLOCKLIST)
+    ]:
         analysis.binaries.remove(binary_to_remove)
         analysis.binaries.filenames.remove(unique_name(binary_to_remove))
-        
+
     return analysis
 
 
@@ -151,7 +152,7 @@ else:
         a.scripts,
         exclude_binaries=True,
         name=executable_name,
-        debug="all",
+        debug=True,
         strip=False,
         upx=False,
         console=True,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import gevent
-import pkg_resources
 import structlog
 from aiortc import RTCSessionDescription
 from eth_utils import encode_hex, is_binary_address, to_normalized_address
@@ -21,7 +20,6 @@ from gevent.queue import JoinableQueue
 from matrix_client.errors import MatrixError, MatrixHttpLibError
 from web3.types import BlockIdentifier
 
-import raiden
 from raiden.constants import (
     EMPTY_SIGNATURE,
     MATRIX_AUTO_SELECT_SERVER,
@@ -73,6 +71,7 @@ from raiden.utils.capabilities import capconfig_to_dict
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.logging import redact_secret
 from raiden.utils.runnable import Runnable
+from raiden.utils.system import get_system_spec
 from raiden.utils.typing import (
     MYPY_ANNOTATION,
     Address,
@@ -435,7 +434,7 @@ class MatrixTransport(Runnable):
                 self._config.retry_interval_max,
             )
 
-        version = pkg_resources.require(raiden.__name__)[0].version
+        version = get_system_spec()["raiden"]
         self._client: GMatrixClient = make_client(
             self._handle_sync_messages,
             homeserver_candidates,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import gevent
 import pkg_resources
 import structlog
+from aiortc import RTCSessionDescription
 from eth_utils import encode_hex, is_binary_address, to_normalized_address
 from gevent.event import Event
 from gevent.lock import Semaphore
@@ -43,6 +44,7 @@ from raiden.network.transport.matrix.client import (
     MatrixSyncMessages,
     Room,
 )
+from raiden.network.transport.matrix.rtc.web_rtc import WebRTCManager
 from raiden.network.transport.matrix.utils import (
     JOIN_RETRIES,
     AddressReachability,
@@ -91,21 +93,6 @@ from raiden.utils.typing import (
     Tuple,
     UserID,
 )
-
-HAVE_RTC = False
-try:
-    from aiortc import RTCSessionDescription
-    from raiden.network.transport.matrix.rtc.web_rtc import WebRTCManager
-
-    HAVE_RTC = True
-except ImportError:
-
-    class WebRTCManager:
-        pass
-
-    class RTCSessionDescription:
-        pass
-
 
 if TYPE_CHECKING:
     from raiden.raiden_service import RaidenService
@@ -459,16 +446,14 @@ class MatrixTransport(Runnable):
             user_agent=f"Raiden {version}",
         )
 
-        self._web_rtc_manager: Optional[WebRTCManager] = None
-        if HAVE_RTC:
-            # web RTC
-            self._web_rtc_manager = WebRTCManager(
-                node_address=None,
-                _handle_message_callback=self._handle_web_rtc_messages,
-                _handle_sdp_callback=self._handle_sdp_callback,
-                _handle_candidates_callback=self._handle_candidates_callback,
-                _close_connection_callback=self._handle_closed_connection,
-            )
+        # web RTC
+        self._web_rtc_manager = WebRTCManager(
+            node_address=None,
+            _handle_message_callback=self._handle_web_rtc_messages,
+            _handle_sdp_callback=self._handle_sdp_callback,
+            _handle_candidates_callback=self._handle_candidates_callback,
+            _close_connection_callback=self._handle_closed_connection,
+        )
 
         self.server_url = self._client.api.base_url
         self._server_name = urlparse(self.server_url).netloc
@@ -564,8 +549,7 @@ class MatrixTransport(Runnable):
         self._stop_event.clear()
         self._starting = True
         self._raiden_service = raiden_service
-        if HAVE_RTC:
-            self._web_rtc_manager.node_address = self._raiden_service.address
+        self._web_rtc_manager.node_address = self._raiden_service.address
 
         assert asyncio.get_event_loop().is_running(), "the loop must be running"
         self.log.debug("Asyncio loop is running", running=asyncio.get_event_loop().is_running())
@@ -654,19 +638,18 @@ class MatrixTransport(Runnable):
         self._broadcast_event.set()
 
         if self._raiden_service:
-            if HAVE_RTC:
-                self._web_rtc_manager.stop()
-                for (
-                    partner_address,
-                    rtc_partner,
-                ) in self._web_rtc_manager.address_to_rtc_partners.items():
-                    hang_up_message = {
-                        "type": RTCMessageType.HANGUP.value,
-                        "call_id": rtc_partner.call_id,
-                    }
-                    self._send_raw(
-                        partner_address, json.dumps(hang_up_message), MatrixMessageType.NOTICE
-                    )
+            self._web_rtc_manager.stop()
+            for (
+                partner_address,
+                rtc_partner,
+            ) in self._web_rtc_manager.address_to_rtc_partners.items():
+                hang_up_message = {
+                    "type": RTCMessageType.HANGUP.value,
+                    "call_id": rtc_partner.call_id,
+                }
+                self._send_raw(
+                    partner_address, json.dumps(hang_up_message), MatrixMessageType.NOTICE
+                )
 
         for retrier in self._address_to_retrier.values():
             if retrier:
@@ -1104,9 +1087,6 @@ class MatrixTransport(Runnable):
         """
         assert self._raiden_service is not None, "_raiden_service not set"
 
-        if not HAVE_RTC:
-            return
-
         for received_message in call_messages:
             call_message = received_message.message
             partner_address = received_message.sender
@@ -1206,7 +1186,7 @@ class MatrixTransport(Runnable):
         assert self._raiden_service is not None, "_raiden_service not set"
 
         user_ids: Set[UserID] = set()
-        if HAVE_RTC and self._web_rtc_manager.has_ready_channel(receiver_address):
+        if self._web_rtc_manager.has_ready_channel(receiver_address):
             communication_medium = CommunicationMedium.WEB_RTC
         else:
             user_id = get_user_id_from_metadata(receiver_address, receiver_metadata)
@@ -1253,9 +1233,6 @@ class MatrixTransport(Runnable):
             return
 
         assert self._raiden_service is not None, "_raiden_service not set"
-
-        if not HAVE_RTC:
-            return
 
         self._web_rtc_manager.get_rtc_partner(address).sync_events.aio_allow_init.set()
         lower_address = my_place_or_yours(self._raiden_service.address, address)
@@ -1340,9 +1317,6 @@ class MatrixTransport(Runnable):
         """
         assert self._raiden_service is not None, "_raiden_service not set"
 
-        if not HAVE_RTC:
-            return
-
         if self._stop_event.ready():
             return
 
@@ -1424,7 +1398,7 @@ class MatrixTransport(Runnable):
                 self._maybe_initialize_web_rtc(address)
 
         elif reachability is AddressReachability.UNREACHABLE:
-            if HAVE_RTC and address in self._web_rtc_manager.address_to_rtc_partners:
+            if address in self._web_rtc_manager.address_to_rtc_partners:
                 self._web_rtc_manager.close_connection(address)
         else:
             raise TypeError(f'Unexpected reachability state "{reachability}".')

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Tuple
 from urllib.parse import urljoin, urlsplit
 
 import requests
+from aiortc import RTCSessionDescription
 from eth_utils import encode_hex, to_normalized_address
 from gevent import subprocess
 from requests.packages import urllib3
@@ -25,7 +26,7 @@ from synapse.handlers.auth import AuthHandler
 from raiden.constants import DeviceIDs, Environment
 from raiden.messages.abstract import Message
 from raiden.network.transport.matrix.client import GMatrixClient, MatrixSyncMessages
-from raiden.network.transport.matrix.transport import HAVE_RTC, MatrixTransport, MessagesQueue
+from raiden.network.transport.matrix.transport import MatrixTransport, MessagesQueue
 from raiden.settings import MatrixTransportConfig
 from raiden.tests.utils.factories import make_signer
 from raiden.transfer.identifiers import QueueIdentifier
@@ -33,11 +34,6 @@ from raiden.utils.http import EXECUTOR_IO, HTTPExecutor
 from raiden.utils.signer import recover
 from raiden.utils.typing import Address, Iterable, Optional, Port, Union
 from raiden_contracts.utils.type_aliases import Signature
-
-if HAVE_RTC:
-    from aiortc import RTCSessionDescription
-else:
-    from raiden.network.transport.matrix.transport import RTCSessionDescription
 
 log = get_logger(__name__)
 

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -8,6 +8,8 @@ aioice==0.7.5
     # via
     #   -r requirements-dev.txt
     #   aiortc
+aiortc-pyav-stub==0.1.1
+    # via -r requirements-dev.txt
 aiortc==1.2.0
     # via -r requirements-dev.txt
 altgraph==0.16.1
@@ -282,10 +284,17 @@ idna==2.8
     #   matrix-synapse
     #   requests
     #   twisted
-importlib-metadata==3.7.3
+importlib-metadata==4.0.1
     # via
     #   -r requirements-dev.txt
+    #   click
+    #   flake8
+    #   flake8-comprehensions
+    #   jsonschema
+    #   pep517
     #   pluggy
+    #   pyinstaller
+    #   pytest
 incremental==17.5.0
     # via
     #   -r requirements-dev.txt
@@ -336,7 +345,9 @@ lru-dict==1.1.6
     #   -r requirements-dev.txt
     #   web3
 macholib==1.14
-    # via -r requirements-ci.in
+    # via
+    #   -r requirements-ci.in
+    #   pyinstaller
 markupsafe==1.1.1
     # via
     #   -r requirements-dev.txt
@@ -692,6 +703,8 @@ twisted[tls]==21.2.0
 typed-ast==1.4.3
     # via
     #   -r requirements-dev.txt
+    #   astroid
+    #   black
     #   mypy
 typeguard==2.11.1
     # via
@@ -700,9 +713,13 @@ typeguard==2.11.1
 typing-extensions==3.10.0.0
     # via
     #   -r requirements-dev.txt
+    #   black
+    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
+    #   structlog
+    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements-dev.txt
@@ -754,6 +771,7 @@ zipp==3.4.1
     # via
     #   -r requirements-dev.txt
     #   importlib-metadata
+    #   pep517
 zope.event==4.4
     # via
     #   -r requirements-dev.txt

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -4,6 +4,12 @@
 #
 #    'requirements/deps compile' (for details see requirements/README)
 #
+aioice==0.7.5
+    # via
+    #   -r requirements-dev.txt
+    #   aiortc
+aiortc==1.2.0
+    # via -r requirements-dev.txt
 altgraph==0.16.1
     # via
     #   macholib
@@ -20,10 +26,6 @@ appdirs==1.4.3
     # via
     #   -r requirements-dev.txt
     #   black
-appnope==0.1.2
-    # via
-    #   -r requirements-dev.txt
-    #   ipython
 asn1crypto==1.3.0
     # via
     #   -r requirements-dev.txt
@@ -52,6 +54,10 @@ automat==20.2.0
     # via
     #   -r requirements-dev.txt
     #   twisted
+av==8.0.3
+    # via
+    #   -r requirements-dev.txt
+    #   aiortc
 backcall==0.1.0
     # via
     #   -r requirements-dev.txt
@@ -91,6 +97,7 @@ certifi==2019.3.9
 cffi==1.12.3
     # via
     #   -r requirements-dev.txt
+    #   aiortc
     #   bcrypt
     #   coincurve
     #   cryptography
@@ -121,9 +128,14 @@ constantly==15.1.0
     #   twisted
 coverage==5.5
     # via -r requirements-dev.txt
+crc32c==2.2
+    # via
+    #   -r requirements-dev.txt
+    #   aiortc
 cryptography==3.4.7
     # via
     #   -r requirements-dev.txt
+    #   aiortc
     #   matrix-synapse
     #   pyopenssl
     #   service-identity
@@ -137,6 +149,10 @@ decorator==4.4.2
     #   -r requirements-dev.txt
     #   ipython
     #   traitlets
+dnspython==2.1.0
+    # via
+    #   -r requirements-dev.txt
+    #   aioice
 docutils==0.16
     # via
     #   -r requirements-dev.txt
@@ -266,16 +282,10 @@ idna==2.8
     #   matrix-synapse
     #   requests
     #   twisted
-importlib-metadata==4.0.1
+importlib-metadata==3.7.3
     # via
     #   -r requirements-dev.txt
-    #   flake8
-    #   flake8-comprehensions
-    #   jsonschema
-    #   pep517
     #   pluggy
-    #   pyinstaller
-    #   pytest
 incremental==17.5.0
     # via
     #   -r requirements-dev.txt
@@ -326,9 +336,7 @@ lru-dict==1.1.6
     #   -r requirements-dev.txt
     #   web3
 macholib==1.14
-    # via
-    #   -r requirements-ci.in
-    #   pyinstaller
+    # via -r requirements-ci.in
 markupsafe==1.1.1
     # via
     #   -r requirements-dev.txt
@@ -385,7 +393,9 @@ netaddr==0.7.19
     #   matrix-synapse
     #   multiaddr
 netifaces==0.10.9
-    # via -r requirements-dev.txt
+    # via
+    #   -r requirements-dev.txt
+    #   aioice
 objgraph==3.5.0
     # via -r requirements-dev.txt
 packaging==19.0
@@ -487,6 +497,10 @@ pycryptodome==3.8.2
     #   -r requirements-dev.txt
     #   eth-hash
     #   eth-keyfile
+pyee==7.0.2
+    # via
+    #   -r requirements-dev.txt
+    #   aiortc
 pyflakes==2.3.1
     # via
     #   -r requirements-dev.txt
@@ -502,7 +516,9 @@ pyinstaller-hooks-contrib==2020.7
 pyinstaller==4.3
     # via -r requirements-ci.in
 pylibsrtp==0.6.8
-    # via -r requirements-dev.txt
+    # via
+    #   -r requirements-dev.txt
+    #   aiortc
 pylint==2.8.2
     # via -r requirements-dev.txt
 pymacaroons==0.13.0
@@ -676,8 +692,6 @@ twisted[tls]==21.2.0
 typed-ast==1.4.3
     # via
     #   -r requirements-dev.txt
-    #   astroid
-    #   black
     #   mypy
 typeguard==2.11.1
     # via
@@ -686,13 +700,9 @@ typeguard==2.11.1
 typing-extensions==3.10.0.0
     # via
     #   -r requirements-dev.txt
-    #   black
-    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
-    #   structlog
-    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements-dev.txt
@@ -744,7 +754,6 @@ zipp==3.4.1
     # via
     #   -r requirements-dev.txt
     #   importlib-metadata
-    #   pep517
 zope.event==4.4
     # via
     #   -r requirements-dev.txt

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,6 +8,8 @@ aioice==0.7.5
     # via
     #   -r requirements.txt
     #   aiortc
+aiortc-pyav-stub==0.1.1
+    # via -r requirements.txt
 aiortc==1.2.0
     # via -r requirements.txt
 aniso8601==7.0.0
@@ -253,8 +255,16 @@ idna==2.8
     #   matrix-synapse
     #   requests
     #   twisted
-importlib-metadata==3.7.3
-    # via pluggy
+importlib-metadata==4.0.1
+    # via
+    #   -r requirements.txt
+    #   click
+    #   flake8
+    #   flake8-comprehensions
+    #   jsonschema
+    #   pep517
+    #   pluggy
+    #   pytest
 incremental==17.5.0
     # via
     #   treq
@@ -583,6 +593,8 @@ twisted[tls]==21.2.0
 typed-ast==1.4.3
     # via
     #   -r requirements-dev.in
+    #   astroid
+    #   black
     #   mypy
 typeguard==2.11.1
     # via
@@ -591,9 +603,13 @@ typeguard==2.11.1
 typing-extensions==3.10.0.0
     # via
     #   -r requirements.txt
+    #   black
+    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
+    #   structlog
+    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements.txt
@@ -633,7 +649,10 @@ wmctrl==0.3
 wrapt==1.11.1
     # via astroid
 zipp==3.4.1
-    # via importlib-metadata
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata
+    #   pep517
 zope.event==4.4
     # via
     #   -r requirements.txt

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,6 +4,12 @@
 #
 #    'requirements/deps compile' (for details see requirements/README)
 #
+aioice==0.7.5
+    # via
+    #   -r requirements.txt
+    #   aiortc
+aiortc==1.2.0
+    # via -r requirements.txt
 aniso8601==7.0.0
     # via
     #   -r requirements.txt
@@ -12,8 +18,6 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.3
     # via black
-appnope==0.1.2
-    # via ipython
 asn1crypto==1.3.0
     # via
     #   -r requirements.txt
@@ -36,6 +40,10 @@ attrs==19.3.0
     #   twisted
 automat==20.2.0
     # via twisted
+av==8.0.3
+    # via
+    #   -r requirements.txt
+    #   aiortc
 backcall==0.1.0
     # via ipython
 base58==2.0.0
@@ -70,6 +78,7 @@ certifi==2019.3.9
 cffi==1.12.3
     # via
     #   -r requirements.txt
+    #   aiortc
     #   bcrypt
     #   coincurve
     #   cryptography
@@ -98,8 +107,14 @@ constantly==15.1.0
     # via twisted
 coverage==5.5
     # via -r requirements-dev.in
+crc32c==2.2
+    # via
+    #   -r requirements.txt
+    #   aiortc
 cryptography==3.4.7
     # via
+    #   -r requirements.txt
+    #   aiortc
     #   matrix-synapse
     #   pyopenssl
     #   service-identity
@@ -112,6 +127,10 @@ decorator==4.4.2
     # via
     #   ipython
     #   traitlets
+dnspython==2.1.0
+    # via
+    #   -r requirements.txt
+    #   aioice
 docutils==0.16
     # via readme-renderer
 eth-abi==2.1.0
@@ -234,15 +253,8 @@ idna==2.8
     #   matrix-synapse
     #   requests
     #   twisted
-importlib-metadata==4.0.1
-    # via
-    #   -r requirements.txt
-    #   flake8
-    #   flake8-comprehensions
-    #   jsonschema
-    #   pep517
-    #   pluggy
-    #   pytest
+importlib-metadata==3.7.3
+    # via pluggy
 incremental==17.5.0
     # via
     #   treq
@@ -334,7 +346,9 @@ netaddr==0.7.19
     #   matrix-synapse
     #   multiaddr
 netifaces==0.10.9
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   aioice
 objgraph==3.5.0
     # via -r requirements.txt
 packaging==19.0
@@ -409,6 +423,10 @@ pycryptodome==3.8.2
     #   -r requirements.txt
     #   eth-hash
     #   eth-keyfile
+pyee==7.0.2
+    # via
+    #   -r requirements.txt
+    #   aiortc
 pyflakes==2.3.1
     # via flake8
 pygments==2.7.4
@@ -417,7 +435,9 @@ pygments==2.7.4
     #   pdbpp
     #   readme-renderer
 pylibsrtp==0.6.8
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   aiortc
 pylint==2.8.2
     # via -r requirements-dev.in
 pymacaroons==0.13.0
@@ -563,8 +583,6 @@ twisted[tls]==21.2.0
 typed-ast==1.4.3
     # via
     #   -r requirements-dev.in
-    #   astroid
-    #   black
     #   mypy
 typeguard==2.11.1
     # via
@@ -573,13 +591,9 @@ typeguard==2.11.1
 typing-extensions==3.10.0.0
     # via
     #   -r requirements.txt
-    #   black
-    #   importlib-metadata
     #   matrix-synapse
     #   mypy
     #   signedjson
-    #   structlog
-    #   web3
 typing-inspect==0.4.0
     # via
     #   -r requirements.txt
@@ -619,10 +633,7 @@ wmctrl==0.3
 wrapt==1.11.1
     # via astroid
 zipp==3.4.1
-    # via
-    #   -r requirements.txt
-    #   importlib-metadata
-    #   pep517
+    # via importlib-metadata
 zope.event==4.4
     # via
     #   -r requirements.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
-#aiortc
-#av>=8.0.3
+aiortc
+av>=8.0.3
 cachetools
 canonicaljson
 click>=8.0.0a1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,5 @@
 aiortc
+aiortc-pyav-stub>=0.1.1
 av>=8.0.3
 cachetools
 canonicaljson

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,12 +4,20 @@
 #
 #    'requirements/deps compile' (for details see requirements/README)
 #
+aioice==0.7.5
+    # via aiortc
+aiortc==1.2.0
+    # via -r requirements.in
 aniso8601==7.0.0
     # via flask-restful
 asn1crypto==1.3.0
     # via coincurve
 attrs==19.3.0
     # via jsonschema
+av==8.0.3
+    # via
+    #   -r requirements.in
+    #   aiortc
 base58==2.0.0
     # via multiaddr
 bitarray==1.2.1
@@ -22,7 +30,9 @@ certifi==2019.3.9
     # via requests
 cffi==1.12.3
     # via
+    #   aiortc
     #   coincurve
+    #   cryptography
     #   pylibsrtp
 chardet==3.0.4
     # via requests
@@ -37,10 +47,16 @@ coincurve==15.0.0
     #   raiden-contracts
 colorama==0.4.4
     # via -r requirements.in
+crc32c==2.2
+    # via aiortc
+cryptography==3.4.7
+    # via aiortc
 cytoolz==0.10.1
     # via
     #   eth-keyfile
     #   eth-utils
+dnspython==2.1.0
+    # via aioice
 eth-abi==2.1.0
     # via
     #   eth-account
@@ -111,8 +127,6 @@ hexbytes==0.2.0
     #   web3
 idna==2.8
     # via requests
-importlib-metadata==4.0.1
-    # via jsonschema
 ipfshttpclient==0.7.0a1
     # via web3
 itsdangerous==1.1.0
@@ -152,7 +166,9 @@ mypy-extensions==0.4.3
 netaddr==0.7.19
     # via multiaddr
 netifaces==0.10.9
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   aioice
 objgraph==3.5.0
     # via -r requirements.in
 parsimonious==0.8.1
@@ -171,8 +187,12 @@ pycryptodome==3.8.2
     # via
     #   eth-hash
     #   eth-keyfile
+pyee==7.0.2
+    # via aiortc
 pylibsrtp==0.6.8
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   aiortc
 pyrsistent==0.15.7
     # via jsonschema
 pysha3==1.0.2
@@ -219,11 +239,7 @@ toolz==0.9.0
 typeguard==2.11.1
     # via marshmallow-dataclass
 typing-extensions==3.10.0.0
-    # via
-    #   -r requirements.in
-    #   importlib-metadata
-    #   structlog
-    #   web3
+    # via -r requirements.in
 typing-inspect==0.4.0
     # via marshmallow-dataclass
 ulid-py==1.1.0
@@ -240,8 +256,6 @@ websockets==8.1
     # via web3
 werkzeug==1.0.1
     # via flask
-zipp==3.4.1
-    # via importlib-metadata
 zope.event==4.4
     # via gevent
 zope.interface==5.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,8 @@
 #
 aioice==0.7.5
     # via aiortc
+aiortc-pyav-stub==0.1.1
+    # via -r requirements.in
 aiortc==1.2.0
     # via -r requirements.in
 aniso8601==7.0.0
@@ -127,6 +129,10 @@ hexbytes==0.2.0
     #   web3
 idna==2.8
     # via requests
+importlib-metadata==4.0.1
+    # via
+    #   click
+    #   jsonschema
 ipfshttpclient==0.7.0a1
     # via web3
 itsdangerous==1.1.0
@@ -239,7 +245,11 @@ toolz==0.9.0
 typeguard==2.11.1
     # via marshmallow-dataclass
 typing-extensions==3.10.0.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   importlib-metadata
+    #   structlog
+    #   web3
 typing-inspect==0.4.0
     # via marshmallow-dataclass
 ulid-py==1.1.0
@@ -256,6 +266,8 @@ websockets==8.1
     # via web3
 werkzeug==1.0.1
     # via flask
+zipp==3.4.1
+    # via importlib-metadata
 zope.event==4.4
     # via gevent
 zope.interface==5.1.0

--- a/tools/pip-compile-wrapper.py
+++ b/tools/pip-compile-wrapper.py
@@ -128,7 +128,7 @@ def _run_pip_compile(
         "--verbose" if verbose else "--quiet",
         *dry_run_cmd,
         *pre_cmd,
-        "--no-emit-index-url",
+        "--no-index",
         *upgrade_packages_cmd,
         *upgrade_all_cmd,
         "--output-file",

--- a/tools/pip-compile-wrapper.py
+++ b/tools/pip-compile-wrapper.py
@@ -128,7 +128,7 @@ def _run_pip_compile(
         "--verbose" if verbose else "--quiet",
         *dry_run_cmd,
         *pre_cmd,
-        "--no-index",
+        "--no-emit-index-url",
         *upgrade_packages_cmd,
         *upgrade_all_cmd,
         "--output-file",

--- a/tools/pyinstaller_hooks/runtime_aiortc_pyav_stub.py
+++ b/tools/pyinstaller_hooks/runtime_aiortc_pyav_stub.py
@@ -1,0 +1,4 @@
+import aiortc_pyav_stub
+
+
+aiortc_pyav_stub.install_as_av()


### PR DESCRIPTION
## Description

Add `av` replacement stub

We're using `aiortc` as our base library to provide WebRTC support in Raiden.

Even though we're using only data transfer features it has a non-optional dependency on the `av` library which provides audio / video codec support etc.

This library is problematic case of building binary bundles since it causes a whole lot of (system) libraries to be unnecessarily included in the bundle.

Among others these libraries are FFMpeg (libav, libx264, libx265), Vorbis etc.

There are two problems caused by this:
- The bundle size grows from ~20MB to ~70MB
- Some of those libraries are licensed under the GPL and can therefore not be distributed in an MIT licensed bundle

To solve all these problems this PR adds a stub library [`aiortc-pyav-stub`](https://github.com/ulope/aiortc-pyav-stub) that
makes `aiortc` importable even without `av` present (as long as none of the audio / video features are bing used of course).

Additionally the PyInstaller config has been updated to exclude `av` from the bundling process and a runtime hook is added to install the stub module.

Also the tests are run with the stub module installed to allow us to catch any possible incompatibilities introduced by future `aiortc` updates.

(Also this reverts 21823fae1b857edc652d96cc3684b12d263d3c7b)