### PR TITLE
Fix GitHub and Homebrew autodeploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,7 +637,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "46:b3:a5:c3:d8:21:63:cd:de:6d:07:5d:0c:5d:ba:73"
+            - "a1:33:d7:62:77:54:79:76:32:4a:d3:5e:89:70:ce:31"
       - attach-and-link:
           py-version: << parameters.py-version >>
       - conditional-skip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -714,8 +714,7 @@ jobs:
                 command: |
                   rm dist/archive/*.txt
                   echo "TAG: ${CIRCLE_TAG}"
-                  CI_RAIDEN_VERSION=${CIRCLE_TAG}
-                  ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${CI_RAIDEN_VERSION} dist/archive/
+                  ghr -t ${GITHUB_TOKEN_RELEASES} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${CIRCLE_TAG} dist/archive/
 
   deploy-pypi:
     parameters:

--- a/.circleci/fetch_ssh_hostkey.sh
+++ b/.circleci/fetch_ssh_hostkey.sh
@@ -7,6 +7,9 @@ FINGERPRINT="$2"
 
 PUBKEY=$(mktemp)
 
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+
 ssh-keyscan -H "${HOST}" > "${PUBKEY}" 2>/dev/null
 
 if [[ $(ssh-keygen -l -f "${PUBKEY}" | cut -d ' ' -f 2) != "${FINGERPRINT}" ]]; then


### PR DESCRIPTION
## Description

As part of the Codecov leak related cleanup the GitHub token variable got renamed and therefore the deploy step had to be updated.

Also related to the Codecov related credentials invalidation we deleted the deploy key that had been used by the Homebrew auto-deploy.

Also the fetch hostkey script would previously crash if the `~/.ssh` folder was missing.