### PR TITLE
Fix yaml gas_price parsing

### DIFF
--- a/raiden/tests/scenarios/bf1_basic_functionality.yaml
+++ b/raiden/tests/scenarios/bf1_basic_functionality.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: "{{ pfs_with_fee }}"

--- a/raiden/tests/scenarios/bf2_long_running.yaml
+++ b/raiden/tests/scenarios/bf2_long_running.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
+++ b/raiden/tests/scenarios/bf3_multi_directional_payment.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
+++ b/raiden/tests/scenarios/bf4_multi_payments_same_node.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/bf6_stress_hub_node.yaml
+++ b/raiden/tests/scenarios/bf6_stress_hub_node.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/bf7_long_path.yaml
+++ b/raiden/tests/scenarios/bf7_long_path.yaml
@@ -2,7 +2,7 @@ version: 2
 
 settings:
   # Gas price to use, either `fast`, `medium` or an integer (in gwei)
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/mfee1_flat_fee.yaml
+++ b/raiden/tests/scenarios/mfee1_flat_fee.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/mfee2_proportional_fees.yaml
+++ b/raiden/tests/scenarios/mfee2_proportional_fees.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/ms1_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   # Adapt to chain used
   services:
     pfs:

--- a/raiden/tests/scenarios/ms1_simple_monitoring_snapshot.yaml
+++ b/raiden/tests/scenarios/ms1_simple_monitoring_snapshot.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   # Adapt to chain used
   services:
     pfs:

--- a/raiden/tests/scenarios/ms2_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms2_simple_monitoring.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   # Adapt to chain used
   services:
     pfs:

--- a/raiden/tests/scenarios/ms3_simple_monitoring.yaml
+++ b/raiden/tests/scenarios/ms3_simple_monitoring.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   # Adapt to chain used
   services:
     pfs:

--- a/raiden/tests/scenarios/ms4_udc_too_low.yaml
+++ b/raiden/tests/scenarios/ms4_udc_too_low.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   # Adapt to chain used
   services:
     pfs:

--- a/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
+++ b/raiden/tests/scenarios/pfs1_get_a_simple_path.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs2_simple_no_path.yaml
+++ b/raiden/tests/scenarios/pfs2_simple_no_path.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs3_multiple_paths.yaml
+++ b/raiden/tests/scenarios/pfs3_multiple_paths.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs4_use_best_path.yaml
+++ b/raiden/tests/scenarios/pfs4_use_best_path.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
+++ b/raiden/tests/scenarios/pfs5_too_low_capacity.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
+++ b/raiden/tests/scenarios/pfs6_simple_path_rewards.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs7_multiple_payments.yaml
+++ b/raiden/tests/scenarios/pfs7_multiple_payments.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
+++ b/raiden/tests/scenarios/pfs8_mediator_goes_offline.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}

--- a/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
+++ b/raiden/tests/scenarios/pfs9_partial_withdraw.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 settings:
-  gas_price: "{{ gas_price }}"
+  gas_price: {{ gas_price }}
   services:
     pfs:
       url: {{ pfs_with_fee }}


### PR DESCRIPTION
This should fix the failing scenario-runs with the Jinja gas_price parameter.
Before, the double-quotes lead to an int being parsed as an explicit string in the scenario-player, which failed verification.
