### PR TITLE
raiden: storage: add missing type ContractSendChannelBatchUnlock

### DIFF
--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -14,6 +14,7 @@ from raiden.transfer.architecture import (
     TransferTask,
 )
 from raiden.transfer.events import (
+    ContractSendChannelBatchUnlock,
     ContractSendChannelClose,
     ContractSendChannelSettle,
     ContractSendChannelUpdateTransfer,
@@ -291,6 +292,7 @@ class BaseSchema(marshmallow.Schema):
                 ContractSendChannelClose,
                 ContractSendChannelSettle,
                 ContractSendChannelUpdateTransfer,
+                ContractSendChannelBatchUnlock,
                 ContractSendSecretReveal,
             ],
             allow_none=False,


### PR DESCRIPTION
Fixes #7094.
