### PR TITLE
Handle `ServiceRequestFailed` errors in channel withdraw API

### DIFF
--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -1128,9 +1128,9 @@ class RestAPI:  # pragma: no unittest
                 channel_state.partner_state.address,
                 total_withdraw,
             )
-        except (NonexistingChannel, UnknownTokenAddress, ServiceRequestFailed) as e:
+        except (NonexistingChannel, UnknownTokenAddress) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
-        except (InsufficientFunds, WithdrawMismatch) as e:
+        except (InsufficientFunds, WithdrawMismatch, ServiceRequestFailed) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)
         # TODO handle InsufficientEth here
 

--- a/raiden/api/rest.py
+++ b/raiden/api/rest.py
@@ -88,6 +88,7 @@ from raiden.exceptions import (
     PaymentConflict,
     RaidenRecoverableError,
     SamePeerAddress,
+    ServiceRequestFailed,
     TokenNetworkDeprecated,
     TokenNotRegistered,
     UnexpectedChannelState,
@@ -1127,7 +1128,7 @@ class RestAPI:  # pragma: no unittest
                 channel_state.partner_state.address,
                 total_withdraw,
             )
-        except (NonexistingChannel, UnknownTokenAddress) as e:
+        except (NonexistingChannel, UnknownTokenAddress, ServiceRequestFailed) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.BAD_REQUEST)
         except (InsufficientFunds, WithdrawMismatch) as e:
             return api_error(errors=str(e), status_code=HTTPStatus.CONFLICT)

--- a/raiden/tests/integration/api/rest/test_channel.py
+++ b/raiden/tests/integration/api/rest/test_channel.py
@@ -782,7 +782,7 @@ def test_api_channel_withdraw_with_offline_partner(
         json=dict(total_withdraw="500"),
     )
     response = request.send().response
-    assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
+    assert_response_with_error(response, HTTPStatus.CONFLICT)
 
 
 @raise_on_failure

--- a/raiden/tests/integration/api/rest/test_channel.py
+++ b/raiden/tests/integration/api/rest/test_channel.py
@@ -757,6 +757,36 @@ def test_api_channel_withdraw(
 
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
+@pytest.mark.parametrize("deposit", [1000])
+@pytest.mark.parametrize("enable_rest_api", [True])
+def test_api_channel_withdraw_with_offline_partner(
+    api_server_test_instance: APIServer,
+    raiden_network: List[RaidenService],
+    token_addresses,
+    pfs_mock,
+):
+    app0, app1 = raiden_network
+    pfs_mock.add_apps([app0])
+
+    token_address = token_addresses[0]
+    partner_address = app1.address
+
+    # Withdraw when the partner node is offline
+    request = grequests.patch(
+        api_url_for(
+            api_server_test_instance,
+            "channelsresourcebytokenandpartneraddress",
+            token_address=token_address,
+            partner_address=partner_address,
+        ),
+        json=dict(total_withdraw="500"),
+    )
+    response = request.send().response
+    assert_response_with_error(response, HTTPStatus.BAD_REQUEST)
+
+
+@raise_on_failure
+@pytest.mark.parametrize("number_of_nodes", [2])
 @pytest.mark.parametrize("deposit", [0])
 @pytest.mark.parametrize("enable_rest_api", [True])
 def test_api_channel_set_reveal_timeout(


### PR DESCRIPTION
## Description

Fixes: #7093

The withdraw API wasn't handling the error which was thrown when the address metadata could not get fetched from the PFS. This happens for example if the partner node is offline.