### PR TITLE
.circleci: fix deployment to digitalocean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1048,7 +1048,7 @@ workflows:
             - prepare-python-macos-3.7
 
       - deploy-digitalocean:
-          context: "Raiden Context"
+          context: "raiden-py"
           requires:
             - build-binary-linux-x86
             - build-binary-macos


### PR DESCRIPTION
There's no "Raiden Context" anymore.

Fixes https://github.com/raiden-network/raiden/issues/7107