### PR TITLE
cleanup validation class; improve circular import situation

### DIFF
--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -7,10 +7,10 @@ from eth_utils import keccak
 from raiden.messages.abstract import cached_property
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.typing import MYPY_ANNOTATION, Address, AddressMetadata, Dict, List, Optional
-from raiden.utils.validation import validate_address_metadata
+from raiden.utils.validation import MetadataValidation
 
 
-class RouteMetadata:
+class RouteMetadata(MetadataValidation):
     route: List[Address]
     address_metadata: Optional[Dict[Address, AddressMetadata]]
 
@@ -26,7 +26,7 @@ class RouteMetadata:
 
     def _validate_address_metadata(self) -> None:
         assert self.address_metadata is not None, MYPY_ANNOTATION
-        validation_errors = validate_address_metadata(self)
+        validation_errors = self.validate_address_metadata()
         for address in validation_errors:
             del self.address_metadata[address]
 
@@ -46,6 +46,9 @@ class RouteMetadata:
             for address, metadata in self.address_metadata.items()
         }
         return {"route": route, "address_metadata": address_metadata}
+
+    def get_metadata(self) -> Optional[Dict[Address, AddressMetadata]]:
+        return self.address_metadata
 
     def __repr__(self) -> str:
         return f"RouteMetadata: {' -> '.join([to_checksum_address(a) for a in self.route])}"

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -10,6 +10,7 @@ from raiden.utils.typing import MYPY_ANNOTATION, Address, AddressMetadata, Dict,
 from raiden.utils.validation import MetadataValidation
 
 
+@dataclass
 class RouteMetadata(MetadataValidation):
     route: List[Address]
     address_metadata: Optional[Dict[Address, AddressMetadata]]

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -65,7 +65,7 @@ from raiden.utils.typing import (
     WithdrawAmount,
     typecheck,
 )
-from raiden.utils.validation import validate_address_metadata
+from raiden.utils.validation import MetadataValidation
 
 
 QueueIdsToQueues = Dict[QueueIdentifier, List[SendMessageEvent]]
@@ -131,7 +131,7 @@ class HopState(State):
 
 
 @dataclass
-class RouteState(State):
+class RouteState(State, MetadataValidation):
     """A possible route for a payment to a given target."""
 
     # TODO: Add timestamp
@@ -148,13 +148,16 @@ class RouteState(State):
 
         In the future a more granular validation may be introduced.
         """
-        validation_errors = validate_address_metadata(self)
+        validation_errors = self.validate_address_metadata()
         if validation_errors:
             addresses_with_errors = ", ".join(
                 f"{to_checksum_address(address)}: {errors}"
                 for address, errors in validation_errors.items()
             )
             raise ValueError(f"Could not validate metadata {addresses_with_errors}.")
+
+    def get_metadata(self) -> Optional[Dict[Address, AddressMetadata]]:
+        return self.address_to_metadata
 
     @property
     def next_hop_address(self) -> Address:

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -131,7 +131,7 @@ class HopState(State):
 
 
 @dataclass
-class RouteState(State, MetadataValidation):
+class RouteState(MetadataValidation, State):
     """A possible route for a payment to a given target."""
 
     # TODO: Add timestamp

--- a/raiden/utils/validation.py
+++ b/raiden/utils/validation.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
 from enum import Flag, auto
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import Dict, List, Optional
 
 from eth_typing import Address
 
 from raiden.utils.typing import AddressMetadata, UserID
-
-if TYPE_CHECKING:
-    from raiden.messages.metadata import RouteMetadata
-    from raiden.transfer.state import RouteState
 
 
 class MetadataValidationError(Flag):
@@ -18,69 +14,62 @@ class MetadataValidationError(Flag):
     INVALID_SIGNATURE = auto()
 
 
-def validate_address_metadata(
-    instance: Union[RouteMetadata, RouteState]
-) -> Dict[Address, MetadataValidationError]:
-    """Validate address metadata
+class MetadataValidation:
+    route: List[Address]
 
-    This function accepts both ``RouteMetadata`` and ``RouteState`` instances
-    and validates their ``address_metadata`` or ``address_to_metadata`` fields
-    respectively.
+    def get_metadata(self) -> Optional[Dict[Address, AddressMetadata]]:
+        raise NotImplementedError()
 
-    The rules are:
+    def validate_address_metadata(self) -> Dict[Address, MetadataValidationError]:
+        """Validate address metadata
 
-      - Entirely missing metadata (``None`` or empty ``dict``) are ok
-      - If metadata are present both ``user_id`` and ``displayname`` need to be set
-      - ``displayname`` needs to be a valid signature for ``user_id``
+        The rules are:
 
-    Returns a dictionary of address to validation error flags.
-    """
+          - Entirely missing metadata (``None`` or empty ``dict``) are ok
+          - If metadata is present, both ``user_id`` and ``displayname`` need to be set
+          - ``displayname`` needs to be a valid signature for ``user_id``
 
-    # Yay, circular imports
-    from raiden.messages.metadata import RouteMetadata
-    from raiden.network.transport.matrix.utils import validate_user_id_signature
-    from raiden.transfer.state import RouteState
+        Returns a dictionary of address to validation error flags.
+        """
 
-    errors: Dict[Address, MetadataValidationError] = {}
+        # Circular imports
+        from raiden.network.transport.matrix.utils import validate_user_id_signature
 
-    if isinstance(instance, RouteMetadata):
-        metadata = instance.address_metadata
-    elif isinstance(instance, RouteState):
-        metadata = instance.address_to_metadata
-    else:
-        raise TypeError(f"Received unexpected instance of type {type(instance)}.")
+        errors: Dict[Address, MetadataValidationError] = {}
 
-    if not metadata:
-        # Empty metadata are not a failure case
+        metadata = self.get_metadata()
+
+        if not metadata:
+            # Empty metadata are not a failure case
+            return errors
+
+        for address in self.route:
+            # Special case for `Flag` instances.
+            # There's always a `0` value that represents the absence of a Flag
+            error = MetadataValidationError(0)
+
+            address_metadata: Optional[AddressMetadata] = metadata.get(address)
+            if not address_metadata:
+                # Missing or empty metadata is currently not a failure case
+                continue
+
+            user_id = address_metadata.get("user_id")
+            displayname = address_metadata.get("displayname")
+
+            if user_id is None:
+                error |= MetadataValidationError.USER_ID_MISSING
+            if displayname is None:
+                error |= MetadataValidationError.DISPLAY_NAME_MISSING
+
+            if not error:
+                verified_address = validate_user_id_signature(
+                    UserID(user_id),  # type: ignore
+                    displayname,
+                )
+                if verified_address != address:
+                    error |= MetadataValidationError.INVALID_SIGNATURE
+
+            if error:
+                errors[address] = error
+
         return errors
-
-    for address in instance.route:
-        # Special case for `Flag` instances. There's always a `0` value that represents the absence
-        # of a Flag
-        error = MetadataValidationError(0)
-
-        address_metadata: Optional[AddressMetadata] = metadata.get(address)
-        if not address_metadata:
-            # Missing or empty metadata is currently not a failure case
-            continue
-
-        user_id = address_metadata.get("user_id")
-        displayname = address_metadata.get("displayname")
-
-        if user_id is None:
-            error |= MetadataValidationError.USER_ID_MISSING
-        if displayname is None:
-            error |= MetadataValidationError.DISPLAY_NAME_MISSING
-
-        if not error:
-            verified_address = validate_user_id_signature(
-                UserID(user_id),  # type: ignore
-                displayname,
-            )
-            if verified_address != address:
-                error |= MetadataValidationError.INVALID_SIGNATURE
-
-        if error:
-            errors[address] = error
-
-    return errors

--- a/raiden/utils/validation.py
+++ b/raiden/utils/validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Flag, auto
 from typing import Dict, List, Optional
 
@@ -14,6 +15,7 @@ class MetadataValidationError(Flag):
     INVALID_SIGNATURE = auto()
 
 
+@dataclass
 class MetadataValidation:
     route: List[Address]
 


### PR DESCRIPTION
## Cleanup address metadata validation

Fixes: #7059 

- Clean up code validating address metadata, unify them in a base validation class.
- Circular import situation has been almost eliminated. One import still remains and will demand more investigation to eliminate.