### PR TITLE
scenarios: Allow small balance deviations in mfee scenarios

### DIFF
--- a/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
+++ b/raiden/tests/scenarios/mfee3_only_imbalance_fees.yaml
@@ -66,8 +66,8 @@ scenario:
             # -2000 TKN fees are calculated, but the actual value is closer to zero because
             # 1. Due to the negative fee less tokens are transferred, resulting in a smaller negative fee
             # 2. A fee margin is applied
-            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 519_149_961_200_077_600, state: "opened"}
-            - assert: {from: 1, to: 0, total_deposit: 0, balance: 480_850_038_799_922_400, state: "opened"}
+            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 519_149_961_200_077_600, allow_balance_error: 5, state: "opened"}
+            - assert: {from: 1, to: 0, total_deposit: 0, balance: 480_850_038_799_922_400, allow_balance_error: 5, state: "opened"}
 
-            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 499_150_001_199_997_600, state: "opened"}
-            - assert: {from: 2, to: 1, total_deposit: 0, balance: 500_849_998_800_002_400, state: "opened"}
+            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 499_150_001_199_997_600, allow_balance_error: 5, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 0, balance: 500_849_998_800_002_400, allow_balance_error: 5, state: "opened"}

--- a/raiden/tests/scenarios/mfee4_combined_fees.yaml
+++ b/raiden/tests/scenarios/mfee4_combined_fees.yaml
@@ -75,11 +75,11 @@ scenario:
             # Total fees: 40e15 + 200 + 10e15 = 50e15
             # Margin: 50e15 * 3% + 500e15 * 0.05% = 1.5e15 + 0.25e15 = 1.525e15
             # Amount sent by initiator: 500e15 + 50e15 + 1.525e15 = 551e15
-            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 456_496_933_858_494_449, state: "opened"}
-            - assert: {from: 1, to: 0, total_deposit: 1_000_000_000_000_000_000, balance: 1_543_503_066_141_505_551, state: "opened"}
+            - assert: {from: 0, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 456_496_933_858_494_449, allow_balance_error: 10, state: "opened"}
+            - assert: {from: 1, to: 0, total_deposit: 1_000_000_000_000_000_000, balance: 1_543_503_066_141_505_551, allow_balance_error: 10, state: "opened"}
 
-            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 478_587_602_916_613_423, state: "opened"}
-            - assert: {from: 2, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_521_412_397_083_386_577, state: "opened"}
+            - assert: {from: 1, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 478_587_602_916_613_423, allow_balance_error: 10, state: "opened"}
+            - assert: {from: 2, to: 1, total_deposit: 1_000_000_000_000_000_000, balance: 1_521_412_397_083_386_577, allow_balance_error: 10, state: "opened"}
 
-            - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 498_743_132_371_418_303, state: "opened"}
-            - assert: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 1_501_256_867_628_581_697, state: "opened"}
+            - assert: {from: 2, to: 3, total_deposit: 1_000_000_000_000_000_000, balance: 498_743_132_371_418_303, allow_balance_error: 10, state: "opened"}
+            - assert: {from: 3, to: 2, total_deposit: 1_000_000_000_000_000_000, balance: 1_501_256_867_628_581_697, allow_balance_error: 10, state: "opened"}


### PR DESCRIPTION
## Description

Fixes: #7130

I don't think it's realistic to expect that every implementation handles fees exactly the same. Rounding differences and behavior of different big number libraries might differ in details and should not stop the scenarios from passing.

That said, I aimed for the minimal changes here. In my opinion it would be OK to allow a bigger error, but these changes should be enough to let the light client run those scenarios.
