### PR TITLE
Read-only Metadata forwarding and hashing scheme

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -350,12 +350,14 @@ class MessageHandler:
         else:
             filtered_route_states = list()
             for route_state in from_transfer.route_states:
-                if len(route_state.route) < 2:
+                next_hop_address = route_state.hop_after(raiden.address)
+                if not next_hop_address:
+                    # Route is malformed or lacking forward information
                     continue
                 channel_state = views.get_channelstate_by_token_network_and_partner(
                     chain_state=views.state_from_raiden(raiden),
                     token_network_address=from_transfer.balance_proof.token_network_address,
-                    partner_address=route_state.route[1],
+                    partner_address=next_hop_address,
                 )
                 if channel_state is not None:
                     filtered_route_states.append(route_state)

--- a/raiden/messages/decode.py
+++ b/raiden/messages/decode.py
@@ -51,6 +51,7 @@ def lockedtransfersigned_from_message(message: LockedTransferBase) -> LockedTran
         initiator=message.initiator,
         target=message.target,
         route_states=route_states,
+        metadata=message.metadata.original_data,
     )
 
     return transfer_state

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -18,6 +18,12 @@ class RouteMetadata(MetadataValidation):
     address_metadata: Optional[Dict[Address, AddressMetadata]] = None
 
     class Meta:
+        """
+        Sets meta-options for the Schema as defined in
+        raiden.storage.serialization.schema.BaseSchemaOpts and the standard marshmallow options.
+
+        """
+
         unknown = EXCLUDE
         # Don't include optional fields that are None during dumping
         serialize_missing = False
@@ -51,15 +57,15 @@ class Metadata:
     for mediating nodes.
 
     For mediating / target nodes, the original datastructure as sent out by a previous node
-    is memorized in the original_data.
+    is memorized in original_data.
 
     All other attributes are attributes that our node can use internally.
     If an additional attribute is required (non-`Optional`) this means that our node requires
     this information from the previous node in order to successfully continue the payment.
-    Therefore a strategy for error recovery has to be implemented upon deserialisation, in the
-    case that this attributes are lacking.
+    Therefore a strategy for error recovery has to be implemented upon deserialization, in the
+    case that these attributes are lacking.
 
-    Note for serialisation:
+    Note for serialization:
     If there is `original_data` present in the object, as per the `_post_dump` other attributes
     on the object (e.g. `routes`) will not get dumped, and thus only the original_data will get
     persisted, e.g. upon dumping to the WAL!
@@ -75,6 +81,12 @@ class Metadata:
     original_data: Optional[Any] = None
 
     class Meta:
+        """
+        Sets meta-options for the Schema as defined in
+        raiden.storage.serialisation.schema.BaseSchemaOpts and the standard marshmallow options.
+
+        """
+
         unknown = EXCLUDE
 
     @cached_property

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -1,52 +1,39 @@
 from copy import deepcopy
 from dataclasses import dataclass
+from typing import Any
 
 import canonicaljson
-from eth_utils import keccak
+from eth_utils import keccak, to_checksum_address
+from marshmallow import EXCLUDE, post_dump, post_load
 
 from raiden.messages.abstract import cached_property
-from raiden.utils.formatting import to_checksum_address
-from raiden.utils.typing import MYPY_ANNOTATION, Address, AddressMetadata, Dict, List, Optional
+from raiden.storage.serialization import serializer
+from raiden.utils.typing import Address, AddressMetadata, Dict, List, Optional
 from raiden.utils.validation import MetadataValidation
 
 
 @dataclass
 class RouteMetadata(MetadataValidation):
     route: List[Address]
-    address_metadata: Optional[Dict[Address, AddressMetadata]]
+    address_metadata: Optional[Dict[Address, AddressMetadata]] = None
 
-    def __init__(
+    class Meta:
+        unknown = EXCLUDE
+        # Don't include optional fields that are None during dumping
+        serialize_missing = False
+
+    def __post_init__(
         self,
-        route: List[Address],
-        address_metadata: Optional[Dict[Address, AddressMetadata]] = None,
     ) -> None:
-
-        self.address_metadata = deepcopy(address_metadata) or {}
-        self.route = route
+        # don't use the original object, since this would result in mutated state
+        self.address_metadata = deepcopy(self.address_metadata)
         self._validate_address_metadata()
 
     def _validate_address_metadata(self) -> None:
-        assert self.address_metadata is not None, MYPY_ANNOTATION
         validation_errors = self.validate_address_metadata()
-        for address in validation_errors:
-            del self.address_metadata[address]
-
-    def _canonical_dict(self) -> dict:
-        """Return a dict that can be dumped as json
-
-        Used to build signatures.
-        """
-        route = [to_checksum_address(address) for address in self.route]
-        if not self.address_metadata:
-            # We add a default value of {} when validating. Normalize this to
-            # no key when signing.
-            return {"route": route}
-
-        address_metadata = {
-            to_checksum_address(address): metadata
-            for address, metadata in self.address_metadata.items()
-        }
-        return {"route": route, "address_metadata": address_metadata}
+        if self.address_metadata is not None:
+            for address in validation_errors:
+                del self.address_metadata[address]
 
     def get_metadata(self) -> Optional[Dict[Address, AddressMetadata]]:
         return self.address_metadata
@@ -57,16 +44,72 @@ class RouteMetadata(MetadataValidation):
 
 @dataclass(frozen=True)
 class Metadata:
+    """
+    Metadata is used by nodes to provide following hops in a transfer with additional information,
+    e.g. to make additonal optimizations possible.
+    It can contain arbitrary data and should be considered a read-only datastructure
+    for mediating nodes.
+
+    For mediating / target nodes, the original datastructure as sent out by a previous node
+    is memorized in the original_data.
+
+    All other attributes are attributes that our node can use internally.
+    If an additional attribute is required (non-`Optional`) this means that our node requires
+    this information from the previous node in order to successfully continue the payment.
+    Therefore a strategy for error recovery has to be implemented upon deserialisation, in the
+    case that this attributes are lacking.
+
+    Note for serialisation:
+    If there is `original_data` present in the object, as per the `_post_dump` other attributes
+    on the object (e.g. `routes`) will not get dumped, and thus only the original_data will get
+    persisted, e.g. upon dumping to the WAL!
+    """
+
+    # Providing routes is required for forwarding transfers and as a mediator we don't want to
+    # accept transfer where we would have to eventually pay the PFS for a path-request.
     routes: List[RouteMetadata]
+    # `original_data` is the JSON decoded Metadata as received from a node.
+    # The absence of this attribute is implying that we are the ones to
+    # inititally create the Metadata object as part of a message - this is the case when we are
+    # the initiator of a transfer.
+    original_data: Optional[Any] = None
+
+    class Meta:
+        unknown = EXCLUDE
 
     @cached_property
     def hash(self) -> bytes:
         return keccak(self._serialize_canonical())
 
+    @post_load(pass_original=True, pass_many=True)
+    def _post_load(  # pylint: disable=no-self-use,unused-argument
+        self, data: Dict[str, Any], original_data: Dict[str, Any], many: bool, **kwargs: Any
+    ) -> Dict[str, Any]:
+        data["original_data"] = original_data
+        return data
+
+    @post_dump(pass_many=True)
+    def _post_dump(  # pylint: disable=no-self-use,unused-argument
+        self, data: Dict[str, Any], many: bool
+    ) -> Dict[str, Any]:
+        original_data = data.pop("original_data", {})
+        if original_data:
+            # We received the metadata (Mediator/Target) and read in the data
+            # for internal processing,
+            # so once we pass them to the next node just dump the data exactly as we received them
+            return original_data
+        # We initially created the Metadata (Initiator),
+        # so dump the known fields as per the Schema
+        return data
+
     def __repr__(self) -> str:
         return f"Metadata: routes: {[repr(route) for route in self.routes]}"
 
+    def to_dict(self) -> Dict[str, Any]:
+        data = serializer.DictSerializer.serialize(self)
+        serializer.remove_type_inplace(data)
+        return data
+
     def _serialize_canonical(self) -> bytes:
-        return canonicaljson.encode_canonical_json(
-            {"routes": [route._canonical_dict() for route in self.routes]}
-        )
+        data = self.to_dict()
+        return canonicaljson.encode_canonical_json(data)

--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -375,6 +375,12 @@ class LockedTransferBase(EnvelopeMessage):
             secrethash=transfer.lock.secrethash,
         )
 
+        routes = [
+            RouteMetadata(route=r.route, address_metadata=r.address_to_metadata)
+            for r in transfer.route_states
+        ]
+        metadata = Metadata(routes=routes, original_data=transfer.metadata)
+
         # pylint: disable=unexpected-keyword-arg
         return cls(
             chain_id=balance_proof.chain_id,
@@ -392,12 +398,7 @@ class LockedTransferBase(EnvelopeMessage):
             target=transfer.target,
             initiator=transfer.initiator,
             signature=EMPTY_SIGNATURE,
-            metadata=Metadata(
-                routes=[
-                    RouteMetadata(route=r.route, address_metadata=r.address_to_metadata)
-                    for r in transfer.route_states
-                ]
-            ),
+            metadata=metadata,
         )
 
     def _packed_data(self) -> bytes:

--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -212,8 +212,21 @@ class CallablePolyField(PolyField):
 
 
 class BaseSchemaOpts(SchemaOpts):
+    """
+    This class defines additional, custom options for the `class Meta` options.
+    (https://marshmallow.readthedocs.io/en/stable/api_reference.html#marshmallow.Schema.Meta)
+    They can be set per Schema definition.
+
+
+    For more info, see:
+    https://marshmallow.readthedocs.io/en/stable/extending.html#custom-class-meta-options
+    """
+
     def __init__(self, meta, **kwargs):  # type: ignore
         SchemaOpts.__init__(self, meta, **kwargs)
+        # Setting this to False in a class Meta of a Schema will
+        # exclude all optional, not required fields that have value "None"
+        # from the dumped dictionary
         self.serialize_missing = getattr(meta, "serialize_missing", True)
 
 
@@ -223,9 +236,6 @@ class BaseSchema(marshmallow.Schema):
     # We want to ignore unknown fields
     class Meta:
         unknown = EXCLUDE
-        # Setting this to False in a class Meta of a Schema will
-        # exclude all optional, not required fields that have value "None"
-        # from the dumped dictionary
         serialize_missing = True
 
     TYPE_MAPPING = {

--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -197,14 +197,14 @@ class CallablePolyField(PolyField):
     @staticmethod
     def serialization_schema_selector(obj: Any, parent: Any) -> Schema:
         # pylint: disable=unused-argument
-        return SchemaCache.get_or_create_schema(obj.__class__)
+        return class_schema(obj.__class__, base_schema=BaseSchema)()
 
     def deserialization_schema_selector(
         self, deserializable_dict: Dict[str, Any], parent: Dict[str, Any]
     ) -> Schema:
         # pylint: disable=unused-argument
         type_ = deserializable_dict["_type"].split(".")[-1]
-        return SchemaCache.get_or_create_schema(self._class_of_classname[type_])
+        return class_schema(self._class_of_classname[type_], base_schema=BaseSchema)()
 
     def __call__(self, **metadata: Any) -> "CallablePolyField":
         self.metadata = metadata
@@ -340,15 +340,3 @@ class BaseSchema(marshmallow.Schema):
 
 def class_type(instance: Any) -> str:
     return f"{instance.__class__.__module__}.{instance.__class__.__name__}"
-
-
-class SchemaCache:
-    SCHEMA_CACHE: Dict[str, Schema] = {}
-
-    @classmethod
-    def get_or_create_schema(cls, clazz: type) -> Schema:
-        class_name = clazz.__name__
-        if class_name not in cls.SCHEMA_CACHE:
-            schema = class_schema(clazz, base_schema=BaseSchema)()
-            cls.SCHEMA_CACHE[class_name] = schema
-        return cls.SCHEMA_CACHE[class_name]

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -13,7 +13,7 @@ from typing import List, Mapping
 from marshmallow import ValidationError
 
 from raiden.exceptions import SerializationError
-from raiden.storage.serialization.schemas import SchemaCache
+from raiden.storage.serialization.schemas import BaseSchema, class_schema
 from raiden.utils.copy import deepcopy
 from raiden.utils.typing import Any, Dict
 
@@ -77,7 +77,7 @@ class DictSerializer(SerializationBase):
         data = obj
         if is_dataclass(obj):
             try:
-                schema = SchemaCache.get_or_create_schema(obj.__class__)
+                schema = class_schema(obj.__class__, base_schema=BaseSchema)()
                 data = schema.dump(obj)
             except (AttributeError, TypeError, ValidationError, ValueError) as ex:
                 raise SerializationError(f"Can't serialize: {data}") from ex
@@ -98,7 +98,7 @@ class DictSerializer(SerializationBase):
         if "_type" in data:
             try:
                 klass = _import_type(data["_type"])
-                schema = SchemaCache.get_or_create_schema(klass)
+                schema = class_schema(klass, base_schema=BaseSchema)()
                 return schema.load(deepcopy(data))
             except (ValueError, TypeError, ValidationError) as ex:
                 raise SerializationError(f"Can't deserialize: {data}") from ex

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -1,4 +1,3 @@
-import functools
 from typing import List, cast
 from unittest.mock import patch
 
@@ -13,7 +12,7 @@ from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
+from raiden.tests.utils.events import search_for_item
 from raiden.tests.utils.factories import make_secret
 from raiden.tests.utils.mediation_fees import get_amount_for_sending_before_and_after_fees
 from raiden.tests.utils.network import CHAIN
@@ -27,7 +26,7 @@ from raiden.tests.utils.transfer import (
     transfer_and_assert_path,
     wait_assert,
 )
-from raiden.transfer import channel, views
+from raiden.transfer import views
 from raiden.transfer.mediated_transfer.initiator import calculate_fee_margin
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
@@ -97,77 +96,6 @@ def test_mediated_transfer(
             deposit + amount,
             [],
         )
-
-
-@raise_on_failure
-@pytest.mark.parametrize("channels_per_node", [CHAIN])
-@pytest.mark.parametrize("number_of_nodes", [3])
-def test_mediated_transfer_unknown_metadata(
-    raiden_network: List[RaidenService],
-    number_of_nodes,
-    deposit,
-    token_addresses,
-    network_wait,
-):
-    app0, app1, app2 = raiden_network
-
-    token_address = token_addresses[0]
-    chain_state = views.state_from_raiden(app0)
-    token_network_registry_address = app0.default_registry.address
-    token_network_address = views.get_token_network_address_by_token_address(
-        chain_state, token_network_registry_address, token_address
-    )
-
-    amount = PaymentAmount(10)
-
-    unknown_metadata = {"extra_data": {"some": "data", "foo": 42}}
-    patched_send_lockedtransfer = functools.partial(
-        channel.send_lockedtransfer, additional_metadata=unknown_metadata
-    )
-    # Patch the (initiator's) send_lockedtransfer, so we don't have to create
-    # a cascade of modified message dataclasses just to inject some extra metadata
-    # This is ok for the other nodes, since this code path is only used by the initiator
-    with patch(
-        "raiden.transfer.mediated_transfer.initiator.channel.send_lockedtransfer"
-    ) as send_lockedtransfer:
-        send_lockedtransfer.side_effect = patched_send_lockedtransfer
-
-        secrethash = transfer(
-            initiator_app=app0,
-            target_app=app2,
-            token_address=token_address,
-            amount=amount,
-            identifier=PaymentID(1),
-            timeout=network_wait * number_of_nodes,
-            routes=[[app0, app1, app2]],
-        )
-
-        with block_timeout_for_transfer_by_secrethash(app1, secrethash):
-            wait_assert(
-                assert_succeeding_transfer_invariants,
-                token_network_address,
-                app0,
-                deposit - amount,
-                [],
-                app1,
-                deposit + amount,
-                [],
-            )
-        with block_timeout_for_transfer_by_secrethash(app1, secrethash):
-            wait_assert(
-                assert_succeeding_transfer_invariants,
-                token_network_address,
-                app1,
-                deposit - amount,
-                [],
-                app2,
-                deposit + amount,
-                [],
-            )
-
-        init_target = raiden_state_changes_search_for_item(app2, ActionInitTarget, {})
-        assert init_target
-        assert init_target.transfer.metadata == unknown_metadata
 
 
 @raise_on_failure

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -1,3 +1,4 @@
+import functools
 from typing import List, cast
 from unittest.mock import patch
 
@@ -12,7 +13,7 @@ from raiden.settings import DEFAULT_NUMBER_OF_BLOCK_CONFIRMATIONS
 from raiden.storage.sqlite import RANGE_ALL_STATE_CHANGES
 from raiden.tests.utils import factories
 from raiden.tests.utils.detect_failure import raise_on_failure
-from raiden.tests.utils.events import search_for_item
+from raiden.tests.utils.events import raiden_state_changes_search_for_item, search_for_item
 from raiden.tests.utils.factories import make_secret
 from raiden.tests.utils.mediation_fees import get_amount_for_sending_before_and_after_fees
 from raiden.tests.utils.network import CHAIN
@@ -26,7 +27,7 @@ from raiden.tests.utils.transfer import (
     transfer_and_assert_path,
     wait_assert,
 )
-from raiden.transfer import views
+from raiden.transfer import channel, views
 from raiden.transfer.mediated_transfer.initiator import calculate_fee_margin
 from raiden.transfer.mediated_transfer.mediation_fee import FeeScheduleState
 from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, ActionInitTarget
@@ -95,6 +96,77 @@ def test_mediated_transfer(
             deposit + amount,
             [],
         )
+
+
+@raise_on_failure
+@pytest.mark.parametrize("channels_per_node", [CHAIN])
+@pytest.mark.parametrize("number_of_nodes", [3])
+def test_mediated_transfer_unknown_metadata(
+    raiden_network: List[RaidenService],
+    number_of_nodes,
+    deposit,
+    token_addresses,
+    network_wait,
+):
+    app0, app1, app2 = raiden_network
+
+    token_address = token_addresses[0]
+    chain_state = views.state_from_raiden(app0)
+    token_network_registry_address = app0.default_registry.address
+    token_network_address = views.get_token_network_address_by_token_address(
+        chain_state, token_network_registry_address, token_address
+    )
+
+    amount = PaymentAmount(10)
+
+    unknown_metadata = {"extra_data": {"some": "data", "foo": 42}}
+    patched_send_lockedtransfer = functools.partial(
+        channel.send_lockedtransfer, additional_metadata=unknown_metadata
+    )
+    # Patch the (initiator's) send_lockedtransfer, so we don't have to create
+    # a cascade of modified message dataclasses just to inject some extra metadata
+    # This is ok for the other nodes, since this code path is only used by the initiator
+    with patch(
+        "raiden.transfer.mediated_transfer.initiator.channel.send_lockedtransfer"
+    ) as send_lockedtransfer:
+        send_lockedtransfer.side_effect = patched_send_lockedtransfer
+
+        secrethash = transfer(
+            initiator_app=app0,
+            target_app=app2,
+            token_address=token_address,
+            amount=amount,
+            identifier=PaymentID(1),
+            timeout=network_wait * number_of_nodes,
+            routes=[[app0, app1, app2]],
+        )
+
+        with block_timeout_for_transfer_by_secrethash(app1, secrethash):
+            wait_assert(
+                assert_succeeding_transfer_invariants,
+                token_network_address,
+                app0,
+                deposit - amount,
+                [],
+                app1,
+                deposit + amount,
+                [],
+            )
+        with block_timeout_for_transfer_by_secrethash(app1, secrethash):
+            wait_assert(
+                assert_succeeding_transfer_invariants,
+                token_network_address,
+                app1,
+                deposit - amount,
+                [],
+                app2,
+                deposit + amount,
+                [],
+            )
+
+        init_target = raiden_state_changes_search_for_item(app2, ActionInitTarget, {})
+        assert init_target
+        assert init_target.transfer.metadata == unknown_metadata
 
 
 @raise_on_failure

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -34,6 +34,7 @@ from raiden.transfer.mediated_transfer.state_change import ActionInitMediator, A
 from raiden.transfer.mediated_transfer.tasks import InitiatorTask
 from raiden.utils.secrethash import sha256_secrethash
 from raiden.utils.typing import (
+    Address,
     BlockExpiration,
     BlockNumber,
     BlockTimeout,
@@ -493,7 +494,7 @@ def test_mediated_transfer_calls_pfs(
                 amount=TokenAmount(5),
                 initiator=factories.HOP1,
                 target=TargetAddress(app2.address),
-                sender=factories.HOP1,
+                sender=Address(factories.HOP1),
                 pkey=factories.HOP1_KEY,
                 token=token_address,
                 canonical_identifier=factories.make_canonical_identifier(

--- a/raiden/tests/integration/transfer/test_refund_invalid.py
+++ b/raiden/tests/integration/transfer/test_refund_invalid.py
@@ -23,7 +23,6 @@ from raiden.utils.typing import (
     Nonce,
     PaymentAmount,
     PaymentID,
-    TargetAddress,
     TokenAmount,
 )
 
@@ -55,7 +54,7 @@ def test_receive_secrethashtransfer_unknown(raiden_network: List[RaidenService],
             token=token_address,
             canonical_identifier=canonical_identifier,
             transferred_amount=amount,
-            recipient=TargetAddress(app0.address),
+            recipient=app0.address,
             locksroot=locksroot,
             amount=amount,
             secret=UNIT_SECRET,

--- a/raiden/tests/unit/serialized_messages/LockedTransfer.json
+++ b/raiden/tests/unit/serialized_messages/LockedTransfer.json
@@ -13,7 +13,6 @@
     "metadata": {
         "routes": [
             {
-                "address_metadata": {},
                 "route": [
                     "0x77952ce83ca3cad9f7adcfabeda85bd2f1f52008",
                     "0x94622cc2a5b64a58c25a129d48a2beec4b65b779"
@@ -24,7 +23,7 @@
     "nonce": "1",
     "payment_identifier": "1",
     "recipient": "0x7461726765747461726765747461726765747461",
-    "signature": "0xa8c6aa0cbf6c6b8f8dab91d63c3860701693e1b4309550bace19a1ed6204622c5d84dddbe9aeeaaebd3acaf8ee9df765549f1ec109fdf78fa111dc1355ad79981b",
+    "signature": "0xcf304f3401934837830cff2086a29987eb7035bdfec12b1c73de8793625f982b4ec35504cc40db951ed8eebb44123a87679a615300177858babd950b2da3e4391b",
     "target": "0x7461726765747461726765747461726765747461",
     "token": "0x746f6b656e746f6b656e746f6b656e746f6b656e",
     "token_network_address": "0x6e6574776f726b6e6574776f726b6e6574776f72",

--- a/raiden/tests/unit/serialized_messages/RefundTransfer.json
+++ b/raiden/tests/unit/serialized_messages/RefundTransfer.json
@@ -13,7 +13,6 @@
     "metadata": {
         "routes": [
             {
-                "address_metadata": {},
                 "route": [
                     "0x77952ce83ca3cad9f7adcfabeda85bd2f1f52008",
                     "0x94622cc2a5b64a58c25a129d48a2beec4b65b779"

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -259,7 +259,7 @@ def test_routing_mocked_pfs_happy_path(happy_path_fixture, one_to_n_address, our
 
     assert_checksum_address_in_url(patched.call_args[0][0])
 
-    assert routes[0].next_hop_address == address2
+    assert routes[0].hop_after(our_signer.address) == address2
     assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
     # Check for iou arguments in request payload
@@ -303,7 +303,7 @@ def test_routing_mocked_pfs_happy_path_with_updated_iou(
 
     assert_checksum_address_in_url(patched.call_args[0][0])
 
-    assert routes[0].next_hop_address == address2
+    assert routes[0].hop_after(our_signer.address) == address2
     assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
     # Check for iou arguments in request payload
@@ -503,7 +503,7 @@ def test_routing_mocked_pfs_unavailable_peer(
         )
         # Node with address2 is not reachable, so even if the only route sent by the PFS
         # is over address2, the internal routing does not provide
-        assert routes[0].next_hop_address == address2
+        assert routes[0].hop_after(our_signer.address) == address2
         assert feedback_token == DEFAULT_FEEDBACK_TOKEN
 
 
@@ -710,7 +710,7 @@ def test_routing_in_direct_channel(happy_path_fixture, our_signer, one_to_n_addr
             privkey=PRIVKEY,
             our_address_metadata=make_address_metadata(our_signer),
         )
-        assert routes[0].next_hop_address == address1
+        assert routes[0].hop_after(our_signer.address) == address1
         assert not pfs_route_request.called
         assert pfs_user_request.called
 

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 import pytest
-from marshmallow_dataclass import class_schema
 
 from raiden.exceptions import SerializationError
 from raiden.messages.metadata import Metadata
@@ -16,7 +15,7 @@ from raiden.messages.synchronization import Delivered, Processed
 from raiden.messages.transfers import RevealSecret, SecretRequest
 from raiden.messages.withdraw import WithdrawConfirmation, WithdrawExpired, WithdrawRequest
 from raiden.storage.serialization import JSONSerializer
-from raiden.storage.serialization.schemas import BaseSchema
+from raiden.storage.serialization.schemas import BaseSchema, class_schema
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.tests.utils import factories
 from raiden.transfer import state

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -298,7 +298,7 @@ def test_metadata_pass_original_readonly():
 def test_locked_transfer_unknown_metadata():
     signer = LocalSigner(bytes(range(32)))
     additional_data = {
-        "arbitrary_data": {"new_key": "you didn't expect this, didn't you?"},
+        "arbitrary_data": {"new_key": "you didn't expect this, did you?"},
         # also check that an additional "unknown_data" does not cause an overwrite of
         # the "unknown_data" field on the dataclass used for temporary storage of the raw data
         "unknown_data": {"test": "123"},

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -1833,11 +1833,14 @@ def test_filter_reachable_routes():
         ),
     ]
 
+    our_address = channel1.our_state.address
     # Both nodes are online
     nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP1, HOP2])
 
     filtered_routes = routes.filter_reachable_routes(
-        route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
+        route_states=possible_routes,
+        nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
+        our_address=our_address,
     )
 
     assert possible_routes[0] in filtered_routes
@@ -1847,7 +1850,9 @@ def test_filter_reachable_routes():
     nodeaddresses_to_networkstates = factories.make_node_availability_map([HOP2])
 
     filtered_routes = routes.filter_reachable_routes(
-        route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
+        route_states=possible_routes,
+        nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
+        our_address=our_address,
     )
 
     assert possible_routes[0] not in filtered_routes
@@ -1857,7 +1862,9 @@ def test_filter_reachable_routes():
     nodeaddresses_to_networkstates = factories.make_node_availability_map([])
 
     filtered_routes = routes.filter_reachable_routes(
-        route_states=possible_routes, nodeaddresses_to_networkstates=nodeaddresses_to_networkstates
+        route_states=possible_routes,
+        nodeaddresses_to_networkstates=nodeaddresses_to_networkstates,
+        our_address=our_address,
     )
 
     assert possible_routes[0] not in filtered_routes

--- a/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_mediatorstate.py
@@ -235,13 +235,10 @@ def test_next_transfer_pair():
         ]
     )
 
-    route_state_table = channels.get_routes(1)
     pair, events = mediator.forward_transfer_pair(
         payer_transfer=payer_transfer,
         payer_channel=channels[0],
         payee_channel=channels[1],
-        route_state=route_state_table[0],
-        route_state_table=route_state_table,
         pseudo_random_generator=pseudo_random_generator,
         block_number=block_number,
     )
@@ -1996,8 +1993,6 @@ def _foward_transfer_pair(
         payer_transfer=payer_transfer,
         payer_channel=channels[0],
         payee_channel=channels[1],
-        route_state=channels.get_route(1),
-        route_state_table=channels.get_routes(),
         pseudo_random_generator=random.Random(),
         block_number=BlockNumber(2),
     )

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1414,8 +1414,7 @@ def create_sendlockedtransfer(
     recipient = channel_state.partner_state.address
     if recipient_metadata is None:
         # if no metadata was provided explicitly, try to find it in the
-        # route states. It should be there if this is a forward LockedTransfer
-        # and not a refund.
+        # route states.
         recipient_metadata = get_address_metadata(recipient, route_states)
     lockedtransfer = SendLockedTransfer(
         recipient=recipient,

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -87,6 +87,7 @@ from raiden.utils.typing import (
     MYPY_ANNOTATION,
     Address,
     AddressMetadata,
+    Any,
     Balance,
     BlockExpiration,
     BlockHash,
@@ -94,6 +95,7 @@ from raiden.utils.typing import (
     BlockTimeout,
     ChainID,
     ChannelID,
+    Dict,
     EncodedData,
     InitiatorAddress,
     List,
@@ -1355,6 +1357,7 @@ def create_sendlockedtransfer(
     secrethash: SecretHash,
     route_states: List[RouteState],
     recipient_metadata: AddressMetadata = None,
+    previous_metadata: Dict[str, Any] = None,
 ) -> Tuple[SendLockedTransfer, PendingLocksState]:
     our_state = channel_state.our_state
     partner_state = channel_state.partner_state
@@ -1405,6 +1408,7 @@ def create_sendlockedtransfer(
         initiator=initiator,
         target=target,
         route_states=route_states,
+        metadata=previous_metadata,
     )
 
     recipient = channel_state.partner_state.address
@@ -1504,6 +1508,7 @@ def send_lockedtransfer(
     secrethash: SecretHash,
     route_states: List[RouteState],
     recipient_metadata: AddressMetadata = None,
+    previous_metadata: Dict[str, Any] = None,
 ) -> SendLockedTransfer:
     send_locked_transfer_event, pending_locks = create_sendlockedtransfer(
         channel_state=channel_state,
@@ -1516,6 +1521,7 @@ def send_lockedtransfer(
         secrethash=secrethash,
         route_states=route_states,
         recipient_metadata=recipient_metadata,
+        previous_metadata=previous_metadata,
     )
 
     transfer = send_locked_transfer_event.transfer

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -358,6 +358,7 @@ def send_lockedtransfer(
             selected_route=route_state,
         ),
         recipient_metadata=recipient_metadata,
+        previous_metadata=None,
     )
     return lockedtransfer_event
 

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -9,7 +9,7 @@ from raiden.settings import (
     MAX_MEDIATION_FEE_PERC,
     PAYMENT_AMOUNT_BASED_FEE_MARGIN,
 )
-from raiden.transfer import channel, routes
+from raiden.transfer import channel
 from raiden.transfer.architecture import Event, TransitionResult
 from raiden.transfer.events import (
     EventInvalidSecretRequest,
@@ -363,11 +363,7 @@ def send_lockedtransfer(
         payment_identifier=transfer_description.payment_identifier,
         expiration=lock_expiration,
         secrethash=transfer_description.secrethash,
-        route_states=routes.prune_route_table(
-            route_states=route_states,
-            selected_route=route_state,
-            our_address=channel_state.our_state.address,
-        ),
+        route_states=route_states,
         recipient_metadata=recipient_metadata,
         previous_metadata=None,
     )

--- a/raiden/transfer/mediated_transfer/initiator_manager.py
+++ b/raiden/transfer/mediated_transfer/initiator_manager.py
@@ -295,6 +295,7 @@ def handle_transferreroute(
         blacklisted_channel_ids=payment_state.cancelled_channels,
         addresses_to_channel=addresses_to_channel,
         token_network_address=old_description.token_network_address,
+        our_address=channel_state.our_state.address,
     )
     transfer_description = TransferDescriptionWithSecretState(
         token_network_registry_address=old_description.token_network_registry_address,

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -427,6 +427,7 @@ def forward_transfer_pair(
         secrethash=payer_transfer.lock.secrethash,
         route_states=route_states,
         recipient_metadata=recipient_metadata,
+        previous_metadata=payer_transfer.metadata,
     )
     mediated_events: List[Event] = [lockedtransfer_event]
 

--- a/raiden/transfer/mediated_transfer/mediator.py
+++ b/raiden/transfer/mediated_transfer/mediator.py
@@ -1011,7 +1011,9 @@ def mediate_transfer(
         next_hop = route_state.hop_after(our_address)
         if not next_hop:
             continue
-        target_token_network = route_state.swaps.get(our_address, payer_channel.token_network_address)
+        target_token_network = route_state.swaps.get(
+            our_address, payer_channel.token_network_address
+        )
         payee_channel = addresses_to_channel.get((target_token_network, next_hop))
         if not payee_channel:
             continue

--- a/raiden/transfer/mediated_transfer/state.py
+++ b/raiden/transfer/mediated_transfer/state.py
@@ -16,6 +16,7 @@ from raiden.utils.typing import (
     TYPE_CHECKING,
     Address,
     AddressMetadata,
+    Any,
     BlockTimeout,
     ChannelID,
     Dict,
@@ -62,6 +63,7 @@ class LockedTransferUnsignedState(LockedTransferState):
 
     balance_proof: BalanceProofUnsignedState
     route_states: List[RouteState] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = field(repr=False, default=None)
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -88,6 +90,7 @@ class LockedTransferSignedState(LockedTransferState):
     message_identifier: MessageID
     route_states: List[RouteState]
     balance_proof: BalanceProofSignedState = field(repr=False)
+    metadata: Optional[Dict[str, Any]] = field(repr=False, default=None)
 
     def __post_init__(self) -> None:
         typecheck(self.lock, HashTimeLockState)

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -5,15 +5,21 @@ from raiden.utils.typing import Address, ChannelID, List, NodeNetworkStateMap, T
 
 
 def filter_reachable_routes(
-    route_states: List[RouteState], nodeaddresses_to_networkstates: NodeNetworkStateMap
+    route_states: List[RouteState],
+    nodeaddresses_to_networkstates: NodeNetworkStateMap,
+    our_address: Address,
 ) -> List[RouteState]:
     """This function makes sure we use reachable routes only."""
+    # TODO this function is not used anymore (only in tests), probably can be removed
 
-    return [
-        route
-        for route in route_states
-        if nodeaddresses_to_networkstates.get(route.next_hop_address) == NetworkState.REACHABLE
-    ]
+    filtered_routes = list()
+    for route in route_states:
+        next_hop = route.hop_after(our_address)
+        if not next_hop:
+            continue
+        if nodeaddresses_to_networkstates.get(next_hop) == NetworkState.REACHABLE:
+            filtered_routes.append(route)
+    return filtered_routes
 
 
 # TODO: change function for swaps
@@ -26,12 +32,16 @@ def filter_acceptable_routes(
     blacklisted_channel_ids: List[ChannelID],
     addresses_to_channel: Dict[Tuple[TokenNetworkAddress, Address], NettingChannelState],
     token_network_address: TokenNetworkAddress,
+    our_address: Address,
 ) -> List[RouteState]:
     """Keeps only routes whose forward_channel is not in the list of blacklisted channels"""
 
     acceptable_routes = list()
     for route in route_states:
-        channel = addresses_to_channel.get((token_network_address, route.next_hop_address))
+        next_hop = route.hop_after(our_address)
+        if not next_hop:
+            continue
+        channel = addresses_to_channel.get((token_network_address, next_hop))
         if channel is None:
             continue
         if channel.identifier not in blacklisted_channel_ids:
@@ -40,8 +50,7 @@ def filter_acceptable_routes(
 
 
 def prune_route_table(
-    route_states: List[RouteState],
-    selected_route: RouteState,
+    route_states: List[RouteState], selected_route: RouteState, our_address: Address
 ) -> List[RouteState]:
     """Given a selected route, returns a filtered route table that
     contains only routes using the same forward channel and removes our own
@@ -53,8 +62,20 @@ def prune_route_table(
     already been validated.
     """
 
-    return [
-        RouteState(route=rs.route[1:], address_to_metadata=rs.address_to_metadata)
-        for rs in route_states
-        if rs.next_hop == selected_route.next_hop
-    ]
+    pruned_route_states = list()
+    for rs in route_states:
+        next_hop = rs.hop_after(our_address)
+        if not next_hop:
+            continue
+        selected_next_hop = selected_route.hop_after(our_address)
+        if not selected_next_hop:
+            # This shouldn't happen, since we shouldn't select a route that has no next hop
+            continue
+        if next_hop == selected_next_hop:
+            idx = rs.route.index(our_address)
+            pruned_route = rs.route[idx + 1 :]
+            if pruned_route:
+                pruned_route_states.append(
+                    RouteState(route=pruned_route, address_to_metadata=rs.address_to_metadata)
+                )
+    return pruned_route_states

--- a/raiden/transfer/routes.py
+++ b/raiden/transfer/routes.py
@@ -47,35 +47,3 @@ def filter_acceptable_routes(
         if channel.identifier not in blacklisted_channel_ids:
             acceptable_routes.append(route)
     return acceptable_routes
-
-
-def prune_route_table(
-    route_states: List[RouteState], selected_route: RouteState, our_address: Address
-) -> List[RouteState]:
-    """Given a selected route, returns a filtered route table that
-    contains only routes using the same forward channel and removes our own
-    address in the process.
-    Note that address metadata are kept complete for the whole route.
-
-    Also note that we don't need to handle ``ValueError``s here since the new
-    ``RouteState``s are built from existing ones, which means the metadata have
-    already been validated.
-    """
-
-    pruned_route_states = list()
-    for rs in route_states:
-        next_hop = rs.hop_after(our_address)
-        if not next_hop:
-            continue
-        selected_next_hop = selected_route.hop_after(our_address)
-        if not selected_next_hop:
-            # This shouldn't happen, since we shouldn't select a route that has no next hop
-            continue
-        if next_hop == selected_next_hop:
-            idx = rs.route.index(our_address)
-            pruned_route = rs.route[idx + 1 :]
-            if pruned_route:
-                pruned_route_states.append(
-                    RouteState(route=pruned_route, address_to_metadata=rs.address_to_metadata)
-                )
-    return pruned_route_states

--- a/raiden/transfer/state.py
+++ b/raiden/transfer/state.py
@@ -158,21 +158,14 @@ class RouteState(MetadataValidation, State):
     def get_metadata(self) -> Optional[Dict[Address, AddressMetadata]]:
         return self.address_to_metadata
 
-    @property
-    def next_hop_address(self) -> Address:
-        assert len(self.route) >= 1, "Route has no next hop"
-        return self.route[1]
-
-    @property
-    def next_hop(self) -> Address:
-        """Identifies the next node
-
-        Use this to compare if two routes go to the same next node.
-
-        Planned change: Will return a token network in addition to the node address.
-        """
-        assert len(self.route) >= 1, "Route has no next hop"
-        return self.route[1]
+    def hop_after(self, address: Address) -> Optional[Address]:
+        try:
+            idx = self.route.index(address)
+            return self.route[idx + 1]
+        except (ValueError, IndexError):
+            # The queried address was not in the route
+            # or the queried address was the last hop
+            return None
 
     def __repr__(self) -> str:
         return "RouteState ({}), fee: {}".format(

--- a/tools/debugging/replay_wal.py
+++ b/tools/debugging/replay_wal.py
@@ -90,7 +90,6 @@ class Translator(dict):
             try:
                 return dict.__getitem__(self, alt)
             except KeyError:
-                # breakpoint()
                 raise e
 
     def __call__(self, match: re.Match) -> str:


### PR DESCRIPTION

## Read-only Metadata
- pass metadata from previous hop through the state-machine as-is and pass on to next hop
- canonicaljson hashing scheme for arbitrary data
Fixes: #7113

## Remove route-pruning and dependency on pruned routes
- no index based "next-hop" query - node searches itself and infers next hop from route
Fixes: #7090

## Fixes and refactoring
- changes to factory methods(mostly employed for  for state unit-testing)
- fix `test_resume_waiting_transfer`
- refactor unknown-metadata forwarding test and move from integration to unit-test
 