### PR TITLE
Fix broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ If you haven't used Raiden before, you can
 ### Use Raiden
 
 If you want to use Raiden:
-* Install Raiden easily with the [Raiden Wizard](https://docs.raiden.network/quick-start)
-* Read [all installation options](https://raiden-network.readthedocs.io/en/stable/overview_and_guide.html) for Raiden
-* Read the updated [WebUI tutorial](https://docs.raiden.network/the-raiden-web-interface) to quickly get started doing payments
-* Read the thorough guide to [get started with the Raiden API](https://raiden-network.readthedocs.io/en/stable/api_walkthrough.html)
+* Install Raiden easily with the [Raiden Wizard](https://raiden-network.readthedocs.io/en/stable/installation/quick-start)
+* Read [all installation options](https://raiden-network.readthedocs.io/en/stable/overview_and_guide.html#installation) for Raiden
+* Read the updated [WebUI tutorial](https://raiden-network.readthedocs.io/en/stable/the-raiden-web-interface/the-raiden-web-interface.html) to quickly get started doing payments
+* Read the thorough guide to [get started with the Raiden API](https://raiden-network.readthedocs.io/en/stable/raiden-api-1/api-tutorial)
 
 ## Specification
 Read the [tentative specification for the Raiden Network](https://raiden-network-specification.readthedocs.io/en/latest/index.html) to understand in detail how Raiden works. It is maintained within [this repository](https://github.com/raiden-network/spec).

--- a/docs/other/known-issues.rst
+++ b/docs/other/known-issues.rst
@@ -47,7 +47,7 @@ two options:
 
 - if there are no funds worth recovering, you can also simply start over with a new
   Ethereum keystore file and
-  `start over <https://raiden-network.readthedocs.io/en/latest/overview_and_guide.html#firing-it-up>`__.
+  :ref:`start over <running_raiden>`.
   This should be true for all usage on testnet and in cases where your channel balances
   are very low on mainnet. Don't hesitate to
   `ask for help <https://gitter.im/raiden-network/raiden>`__!

--- a/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
+++ b/raiden/tests/unit/transfer/mediated_transfer/test_initiatorstate.py
@@ -269,7 +269,7 @@ def test_init_with_fees_more_than_max_limit():
     reason_msg = (
         "none of the available routes could be used and at least one of them "
         "exceeded the maximum fee limit "
-        "(see https://docs.raiden.network/using-raiden/mediation-fees#frequently-asked-questions)"  # noqa
+        "(see https://raiden-network.readthedocs.io/en/stable/using-raiden-on-mainnet/overview.html#frequently-asked-questions)"  # noqa
     )
     assert transition.events[0].reason == reason_msg
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -1117,7 +1117,7 @@ def get_capacity(channel_state: NettingChannelState) -> TokenAmount:
     """Calculates the capacity of the given channel
 
     For the definition of capacity see
-    https://raiden-network.readthedocs.io/en/stable/glossary.html#term-channel-capacity
+    https://raiden-network.readthedocs.io/en/stable/glossary.html#term-Channel-capacity
     """
     return TokenAmount(
         channel_state.our_total_deposit
@@ -1131,7 +1131,7 @@ def get_balance(sender: NettingChannelEndState, receiver: NettingChannelEndState
     """Calculates the balance for a participant in a channel.
 
     For the definition of balance see
-    https://raiden-network.readthedocs.io/en/stable/glossary.html#term-balance
+    https://raiden-network.readthedocs.io/en/stable/glossary.html#term-Balance
     """
     sender_transferred_amount = 0
     receiver_transferred_amount = 0

--- a/raiden/transfer/mediated_transfer/initiator.py
+++ b/raiden/transfer/mediated_transfer/initiator.py
@@ -280,7 +280,7 @@ def try_new_route(
         if route_fee_exceeds_max:
             reason += (
                 " and at least one of them exceeded the maximum fee limit "
-                "(see https://docs.raiden.network/using-raiden/mediation-fees#frequently-asked-questions)"  # noqa
+                "(see https://raiden-network.readthedocs.io/en/stable/using-raiden-on-mainnet/overview.html#frequently-asked-questions)"  # noqa
             )
 
         transfer_failed = EventPaymentSentFailed(

--- a/raiden/ui/app.py
+++ b/raiden/ui/app.py
@@ -430,7 +430,7 @@ def run_raiden_service(
         click.secho(
             "Default fee settings are used. "
             "If you want use Raiden with mediation fees - flat, proportional and imbalance fees - "
-            "see https://raiden-network.readthedocs.io/en/latest/overview_and_guide.html#firing-it-up",  # noqa: E501
+            "see https://raiden-network.readthedocs.io/en/latest/overview_and_guide.html#run-it",  # noqa: E501
             fg="yellow",
         )
 


### PR DESCRIPTION
## Description

As our documentation was completely moved to readthedocs, this fixes all links to the documentation.