### PR TITLE
Transport cleanup

### DIFF
--- a/raiden/network/transport/matrix/client.py
+++ b/raiden/network/transport/matrix/client.py
@@ -1,5 +1,6 @@
 import itertools
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
 from itertools import repeat
@@ -24,11 +25,12 @@ from requests.adapters import HTTPAdapter
 
 from raiden.constants import Environment
 from raiden.exceptions import MatrixSyncMaxTimeoutReached, TransportError
+from raiden.messages.abstract import Message
 from raiden.network.transport.matrix.sync_progress import SyncProgress
 from raiden.utils.datastructures import merge_dict
 from raiden.utils.debugging import IDLE
 from raiden.utils.notifying_queue import NotifyingQueue
-from raiden.utils.typing import AddressHex
+from raiden.utils.typing import Address, AddressHex, AddressMetadata
 
 log = structlog.get_logger(__name__)
 
@@ -39,6 +41,22 @@ MatrixMessage = Dict[str, Any]
 MatrixRoomMessages = Tuple[Optional["Room"], List[MatrixMessage]]
 MatrixSyncMessages = List[MatrixRoomMessages]
 JSONResponse = Dict[str, Any]
+
+
+@dataclass
+class _ReceivedMessageBase:
+    sender: Address
+
+
+@dataclass
+class ReceivedRaidenMessage(_ReceivedMessageBase):
+    message: Message
+    sender_metadata: Optional[AddressMetadata] = None
+
+
+@dataclass
+class ReceivedCallMessage(_ReceivedMessageBase):
+    message: MatrixMessage
 
 
 def node_address_from_userid(user_id: Optional[str]) -> Optional[AddressHex]:

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -26,7 +26,7 @@ from raiden.utils.typing import Address, Any, Callable, Coroutine, Dict, List, O
 log = structlog.get_logger(__name__)
 
 
-class CoroutineHandler:
+class _CoroutineHandler:
     def __init__(self) -> None:
         self.coroutines: List[Task] = list()
 
@@ -76,7 +76,7 @@ class CoroutineHandler:
                 coroutine.cancel()
 
 
-class _RTCPartner(CoroutineHandler):
+class _RTCPartner(_CoroutineHandler):
     @dataclass
     class SyncEvents:
         """
@@ -362,7 +362,7 @@ class _RTCPartner(CoroutineHandler):
 
 
 @dataclass
-class WebRTCManager(CoroutineHandler):
+class WebRTCManager(_CoroutineHandler):
     def __init__(
         self,
         node_address: Optional[Address],

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -173,7 +173,7 @@ class _RTCPartner(_CoroutineHandler):
         )
         self.peer_connection.on(
             "signalingstatechange",
-            partial(on_signalling_state_change, rtc_partner=self),
+            partial(_on_signalling_state_change, rtc_partner=self),
         )
 
         self.peer_connection.on(
@@ -563,7 +563,7 @@ def _on_ice_connection_state_change(
         wrap_callback(callback=closed_callback, partner_address=rtc_partner.partner_address)
 
 
-def on_signalling_state_change(rtc_partner: _RTCPartner) -> None:
+def _on_signalling_state_change(rtc_partner: _RTCPartner) -> None:
     signaling_state = rtc_partner.peer_connection.signalingState
     rtc_partner.log.debug("Signaling state changed", signaling_state=signaling_state)
     # if signaling state is closed also set allow candidates otherwise

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -278,7 +278,7 @@ class _RTCPartner(_CoroutineHandler):
 
         self.peer_connection.on(
             "datachannel",
-            partial(on_datachannel, self, self.node_address),
+            partial(_on_datachannel, self, self.node_address),
         )
         answer = await self._try_signaling(self.peer_connection.createAnswer())
         if answer is None:
@@ -469,7 +469,7 @@ class WebRTCManager(_CoroutineHandler):
         self._reset_state()
 
 
-def on_datachannel(
+def _on_datachannel(
     rtc_partner: _RTCPartner,
     node_address: Address,
     channel: RTCDataChannel,

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -166,7 +166,7 @@ class _RTCPartner(_CoroutineHandler):
         self.peer_connection.on(
             "icegatheringstatechange",
             partial(
-                on_ice_gathering_state_change,
+                _on_ice_gathering_state_change,
                 rtc_partner=self,
                 candidates_callback=self._handle_candidates_callback,
             ),
@@ -520,7 +520,7 @@ def on_channel_message(
     )
 
 
-def on_ice_gathering_state_change(
+def _on_ice_gathering_state_change(
     rtc_partner: _RTCPartner,
     candidates_callback: Callable[[List[Dict[str, Union[int, str]]], Address], None],
 ) -> None:

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -190,7 +190,7 @@ class _RTCPartner(_CoroutineHandler):
             return
 
         self.channel.on(
-            "message", partial(on_channel_message, self, self._handle_message_callback)
+            "message", partial(_on_channel_message, self, self._handle_message_callback)
         )
         self.channel.on("close", partial(on_channel_close, self, self.node_address))
         self.channel.on("open", partial(on_channel_open, self.node_address, self.channel))
@@ -501,7 +501,7 @@ def on_channel_close(rtc_partner: _RTCPartner, node_address: Address) -> None:
             rtc_partner.schedule_task(rtc_partner.close())
 
 
-def on_channel_message(
+def _on_channel_message(
     rtc_partner: _RTCPartner,
     handle_message_callback: Callable[[str, Address], None],
     message: str,

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -599,6 +599,17 @@ class WebRTCManager(_CoroutineHandler, Runnable):
 
         self.join_all_coroutines()
         self._reset_state()
+        self._send_hangup_messages()
+
+    def _send_hangup_messages(self) -> None:
+        for partner_address, rtc_partner in self.address_to_rtc_partners.items():
+            hang_up_message = {
+                "type": RTCMessageType.HANGUP.value,
+                "call_id": rtc_partner.call_id,
+            }
+            self._signaling_send(
+                partner_address, json.dumps(hang_up_message), MatrixMessageType.NOTICE
+            )
 
 
 def _on_datachannel(

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -179,7 +179,7 @@ class _RTCPartner(_CoroutineHandler):
         self.peer_connection.on(
             "iceconnectionstatechange",
             partial(
-                on_ice_connection_state_change,
+                _on_ice_connection_state_change,
                 rtc_partner=self,
                 closed_callback=self._close_connection_callback,
             ),
@@ -552,7 +552,7 @@ def on_ice_gathering_state_change(
         )
 
 
-def on_ice_connection_state_change(
+def _on_ice_connection_state_change(
     rtc_partner: _RTCPartner, closed_callback: Callable[[Address], None]
 ) -> None:
     ice_connection_state = rtc_partner.peer_connection.iceConnectionState

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -492,7 +492,7 @@ class WebRTCManager(_CoroutineHandler, Runnable):
             "Initiating web rtc",
             partner_address=to_checksum_address(partner_address),
         )
-        self.initialize_signalling_for_address(partner_address)
+        self._initialize_signalling_for_address(partner_address)
 
         # wait for WEB_RTC_CHANNEL_TIMEOUT seconds and check if connection was established
         if self._stop_event.wait(timeout=WEB_RTC_CHANNEL_TIMEOUT):
@@ -548,7 +548,7 @@ class WebRTCManager(_CoroutineHandler, Runnable):
     def _reset_state(self) -> None:
         self._address_to_rtc_partners = {}
 
-    def initialize_signalling_for_address(self, partner_address: Address) -> None:
+    def _initialize_signalling_for_address(self, partner_address: Address) -> None:
         rtc_partner = self.get_rtc_partner(partner_address)
         self.schedule_task(
             coroutine=rtc_partner.initialize_signalling(),
@@ -556,13 +556,13 @@ class WebRTCManager(_CoroutineHandler, Runnable):
             partner_address=partner_address,
         )
 
-    def set_candidates_for_address(
+    def _set_candidates_for_address(
         self, partner_address: Address, content: Dict[str, Any]
     ) -> None:
         rtc_partner = self.get_rtc_partner(partner_address)
         self.schedule_task(rtc_partner.set_candidates(content))
 
-    def process_signalling_for_address(
+    def _process_signalling_for_address(
         self, partner_address: Address, description: Dict[str, str]
     ) -> None:
         rtc_partner = self.get_rtc_partner(partner_address)
@@ -593,11 +593,11 @@ class WebRTCManager(_CoroutineHandler, Runnable):
             rtc_message_type in [RTCMessageType.OFFER.value, RTCMessageType.ANSWER.value]
             and "sdp" in content
         ):
-            self.process_signalling_for_address(partner_address, content)
+            self._process_signalling_for_address(partner_address, content)
         elif rtc_message_type == RTCMessageType.HANGUP.value:
             self.close_connection(partner_address)
         elif rtc_message_type == RTCMessageType.CANDIDATES.value:
-            self.set_candidates_for_address(partner_address, content)
+            self._set_candidates_for_address(partner_address, content)
         else:
             self.log.error(
                 "Unknown rtc message type",

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -192,7 +192,7 @@ class _RTCPartner(_CoroutineHandler):
         self.channel.on(
             "message", partial(_on_channel_message, self, self._handle_message_callback)
         )
-        self.channel.on("close", partial(on_channel_close, self, self.node_address))
+        self.channel.on("close", partial(_on_channel_close, self, self.node_address))
         self.channel.on("open", partial(on_channel_open, self.node_address, self.channel))
 
     @property
@@ -483,7 +483,7 @@ def on_channel_open(node_address: Address, channel: RTCDataChannel) -> None:
     log.debug("Rtc datachannel open", node=to_checksum_address(node_address), label=channel.label)
 
 
-def on_channel_close(rtc_partner: _RTCPartner, node_address: Address) -> None:
+def _on_channel_close(rtc_partner: _RTCPartner, node_address: Address) -> None:
     """callback if channel is closed. It is part of a partial function"""
     if rtc_partner.channel is not None:
         log.debug(

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -586,6 +586,25 @@ class WebRTCManager(_CoroutineHandler, Runnable):
 
         return None
 
+    def process_signalling_message(
+        self, partner_address: Address, rtc_message_type: str, content: Dict[str, str]
+    ) -> None:
+        if (
+            rtc_message_type in [RTCMessageType.OFFER.value, RTCMessageType.ANSWER.value]
+            and "sdp" in content
+        ):
+            self.process_signalling_for_address(partner_address, content)
+        elif rtc_message_type == RTCMessageType.HANGUP.value:
+            self.close_connection(partner_address)
+        elif rtc_message_type == RTCMessageType.CANDIDATES.value:
+            self.set_candidates_for_address(partner_address, content)
+        else:
+            self.log.error(
+                "Unknown rtc message type",
+                partner_address=to_checksum_address(partner_address),
+                type=rtc_message_type,
+            )
+
     def stop(self) -> None:
         self.log.debug("Closing rtc connections")
 

--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -193,7 +193,7 @@ class _RTCPartner(_CoroutineHandler):
             "message", partial(_on_channel_message, self, self._handle_message_callback)
         )
         self.channel.on("close", partial(_on_channel_close, self, self.node_address))
-        self.channel.on("open", partial(on_channel_open, self.node_address, self.channel))
+        self.channel.on("open", partial(_on_channel_open, self.node_address, self.channel))
 
     @property
     def call_id(self) -> str:
@@ -475,11 +475,11 @@ def on_datachannel(
     channel: RTCDataChannel,
 ) -> None:
     rtc_partner.channel = channel
-    on_channel_open(node_address, channel)
+    _on_channel_open(node_address, channel)
     rtc_partner.set_channel_callbacks()
 
 
-def on_channel_open(node_address: Address, channel: RTCDataChannel) -> None:
+def _on_channel_open(node_address: Address, channel: RTCDataChannel) -> None:
     log.debug("Rtc datachannel open", node=to_checksum_address(node_address), label=channel.label)
 
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -111,7 +111,7 @@ class MessagesQueue:
     messages: List[Tuple[Message, Optional[AddressMetadata]]]
 
 
-def metadata_key_func(message_data: "_RetryQueue._MessageData") -> str:
+def _metadata_key_func(message_data: "_RetryQueue._MessageData") -> str:
     address_metadata = message_data.address_metadata
     if address_metadata is None:
         return ""
@@ -261,8 +261,8 @@ class _RetryQueue(Runnable):
             )
 
         # batch by user_id, so that we can potentially combine data for send-to-device calls
-        queue_by_user_id = sorted(self._message_queue[:], key=metadata_key_func)
-        for user_id, batch in itertools.groupby(queue_by_user_id, metadata_key_func):
+        queue_by_user_id = sorted(self._message_queue[:], key=_metadata_key_func)
+        for user_id, batch in itertools.groupby(queue_by_user_id, _metadata_key_func):
             message_data_batch = list(batch)
             if user_id == "":
                 address_metadata = None

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -594,17 +594,6 @@ class MatrixTransport(Runnable):
 
         if self._raiden_service:
             self._web_rtc_manager.stop()
-            for (
-                partner_address,
-                rtc_partner,
-            ) in self._web_rtc_manager.address_to_rtc_partners.items():
-                hang_up_message = {
-                    "type": RTCMessageType.HANGUP.value,
-                    "call_id": rtc_partner.call_id,
-                }
-                self._send_raw(
-                    partner_address, json.dumps(hang_up_message), MatrixMessageType.NOTICE
-                )
 
         for retrier in self._address_to_retrier.values():
             if retrier:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -857,7 +857,7 @@ class MatrixTransport(Runnable):
 
         self.log.debug("Rejecting invite", room_id=room_id, sender=sender)
 
-        self.retry_api_call(
+        self._retry_api_call(
             self._client.api.send_state_event,
             room_id=room_id,
             event_type="m.room.member",
@@ -1122,7 +1122,7 @@ class MatrixTransport(Runnable):
             )
             return
 
-    def retry_api_call(
+    def _retry_api_call(
         self,
         method_with_api_request: Callable,
         verify_response: Callable[[Any], bool] = lambda x: True,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -887,18 +887,6 @@ class MatrixTransport(Runnable):
 
         return [address for address in joined_addresses if address != self._raiden_service.address]
 
-    def _has_multiple_partner_addresses(self, room: Room) -> bool:
-        assert self._raiden_service is not None, "_raiden_service not set"
-        joined_addresses = set()
-        for user in room.get_joined_members():
-            address = validate_userid_signature(user)
-            if address != self._raiden_service.address:
-                joined_addresses.add(address)
-                # if address is None it means a false displayname, should leave
-                if len(joined_addresses) > 1 or address is None:
-                    return True
-        return False
-
     def _reject_invite(self, room_id: RoomID, state: dict) -> None:
         """Handle an invite request.
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -427,8 +427,6 @@ class MatrixTransport(Runnable):
         self._broadcast_event = Event()
         self._prioritize_broadcast_messages: bool = True
 
-        self._invite_queue: List[Tuple[RoomID, dict]] = []
-
         self._client.add_invite_listener(self._reject_invite)
 
         self._counters: Dict[str, CounterType[Tuple[str, MessageID]]] = {}

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -6,7 +6,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from json import JSONDecodeError
 from random import randint
-from typing import TYPE_CHECKING, Counter as CounterType, Union
+from typing import TYPE_CHECKING, Counter as CounterType
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -501,7 +501,6 @@ class MatrixTransport(Runnable):
             raiden_service.address,
             self._process_raiden_messages,
             self._send_raw,
-            _handle_candidates_callback=self._handle_candidates_callback,
             _close_connection_callback=self._handle_closed_connection,
         )
 
@@ -1239,23 +1238,6 @@ class MatrixTransport(Runnable):
             }
             self._send_raw(partner_address, json.dumps(hang_up_message), MatrixMessageType.NOTICE)
             self._web_rtc_manager.close_connection(partner_address)
-
-    def _handle_candidates_callback(
-        self, candidates: List[Dict[str, Union[int, str]]], partner_address: Address
-    ) -> None:
-
-        assert self._raiden_service is not None, "_raiden_service not set"
-
-        if self._stop_event.ready():
-            return
-
-        rtc_partner = self._web_rtc_manager.get_rtc_partner(partner_address)
-        message = {
-            "type": RTCMessageType.CANDIDATES.value,
-            "candidates": candidates,
-            "call_id": rtc_partner.call_id,
-        }
-        self._send_raw(partner_address, json.dumps(message), MatrixMessageType.NOTICE)
 
     def _handle_closed_connection(self, partner_address: Address) -> None:
 

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -419,7 +419,6 @@ class MatrixTransport(Runnable):
         self._broadcast_queue: JoinableQueue[Tuple[str, Message]] = JoinableQueue()
 
         self._started = False
-        self._starting = False
 
         self._stop_event: Event = Event()
         self._stop_event.set()
@@ -488,7 +487,6 @@ class MatrixTransport(Runnable):
             raise RuntimeError(f"{self!r} already started")
         self.log.debug("Matrix starting")
         self._stop_event.clear()
-        self._starting = True
         self._raiden_service = raiden_service
         self._web_rtc_manager = WebRTCManager(
             raiden_service.address, self._process_raiden_messages, self._send_raw, self._stop_event
@@ -532,7 +530,6 @@ class MatrixTransport(Runnable):
                 retrier.start()
 
         super().start()  # start greenlet
-        self._starting = False
         self._started = True
 
         self.log.debug("Matrix started", config=self._config)

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -378,8 +378,6 @@ class ReceivedCallMessage(_ReceivedMessageBase):
 
 
 class MatrixTransport(Runnable):
-    _room_prefix = "raiden"
-    _room_sep = "_"
     log = log
 
     def __init__(self, config: MatrixTransportConfig, environment: Environment) -> None:

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -1373,11 +1373,6 @@ class MatrixTransport(Runnable):
             key in own_caps and own_caps[key] and key in partner_caps and partner_caps[key]
         )
 
-    def _sign(self, data: bytes) -> bytes:
-        """Use eth_sign compatible hasher to sign matrix data"""
-        assert self._raiden_service is not None, "_raiden_service not set"
-        return self._raiden_service.signer.sign(data=data)
-
     def retry_api_call(
         self,
         method_with_api_request: Callable,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -23,7 +23,6 @@ from raiden.constants import (
     EMPTY_SIGNATURE,
     MATRIX_AUTO_SELECT_SERVER,
     WEB_RTC_CHANNEL_TIMEOUT,
-    Capabilities,
     CommunicationMedium,
     DeviceIDs,
     Environment,
@@ -59,7 +58,7 @@ from raiden.network.transport.matrix.utils import (
     validate_userid_signature,
 )
 from raiden.network.transport.utils import timeout_exponential_backoff
-from raiden.settings import CapabilitiesConfig, MatrixTransportConfig
+from raiden.settings import MatrixTransportConfig
 from raiden.storage.serialization import DictSerializer
 from raiden.storage.serialization.serializer import MessageSerializer
 from raiden.transfer import views
@@ -1359,19 +1358,6 @@ class MatrixTransport(Runnable):
         #        with a unique call id for each try this wont be necessary
         gevent.sleep(3)
         self._maybe_initialize_web_rtc(partner_address)
-
-    def _capability_usable(
-        self, capability: Capabilities, partner_capabilities_config: CapabilitiesConfig
-    ) -> bool:
-        """Checks if a given capability is enabled for the local and the partner node"""
-
-        own_caps = capconfig_to_dict(self._config.capabilities_config)
-        partner_caps = capconfig_to_dict(partner_capabilities_config)
-
-        key = capability.value
-        return bool(
-            key in own_caps and own_caps[key] and key in partner_caps and partner_caps[key]
-        )
 
     def retry_api_call(
         self,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -874,19 +874,6 @@ class MatrixTransport(Runnable):
         self._client.message_worker.link_value(on_success)
         self.greenlets = [self._client.sync_worker, self._client.message_worker]
 
-    def _extract_addresses(self, room: Room) -> List[Optional[Address]]:
-        """
-        returns list of address of room members.
-        If address can not be extracted due to false displayname
-        it will include None in the list
-        """
-        assert self._raiden_service is not None, "_raiden_service not set"
-        joined_addresses = set(
-            validate_userid_signature(user) for user in room.get_joined_members()
-        )
-
-        return [address for address in joined_addresses if address != self._raiden_service.address]
-
     def _reject_invite(self, room_id: RoomID, state: dict) -> None:
         """Handle an invite request.
 

--- a/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
+++ b/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
@@ -15,13 +15,12 @@ pytestmark = pytest.mark.asyncio
 
 
 def test_rtc_partner_close() -> None:
+    node_address = make_signer().address
 
     web_rtc_manager = WebRTCManager(
-        None, ignore_web_rtc_messages, ignore_sdp, ignore_candidates, ignore_close
+        node_address, ignore_web_rtc_messages, ignore_sdp, ignore_candidates, ignore_close
     )
 
-    node_address = make_signer().address
-    web_rtc_manager.node_address = node_address
     partner_address = make_signer().address
     rtc_partner = web_rtc_manager.get_rtc_partner(partner_address)
     peer_connection_first = rtc_partner.peer_connection

--- a/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
+++ b/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
@@ -1,11 +1,12 @@
 from typing import Any
 import pytest
+from gevent.event import Event
 
 from raiden.constants import ICEConnectionState
 from raiden.network.transport.matrix.rtc.aiogevent import yield_future
 from raiden.network.transport.matrix.rtc.web_rtc import WebRTCManager
 from raiden.tests.utils.factories import make_signer
-from raiden.tests.utils.transport import ignore_close, ignore_web_rtc_messages
+from raiden.tests.utils.transport import ignore_web_rtc_messages
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,10 +17,9 @@ def _dummy_send(*_args: Any) -> None:
 
 def test_rtc_partner_close() -> None:
     node_address = make_signer().address
+    stop_event = Event()
 
-    web_rtc_manager = WebRTCManager(
-        node_address, ignore_web_rtc_messages, _dummy_send, ignore_close
-    )
+    web_rtc_manager = WebRTCManager(node_address, ignore_web_rtc_messages, _dummy_send, stop_event)
 
     partner_address = make_signer().address
     rtc_partner = web_rtc_manager.get_rtc_partner(partner_address)

--- a/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
+++ b/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
@@ -1,24 +1,24 @@
+from typing import Any
 import pytest
 
 from raiden.constants import ICEConnectionState
 from raiden.network.transport.matrix.rtc.aiogevent import yield_future
 from raiden.network.transport.matrix.rtc.web_rtc import WebRTCManager
 from raiden.tests.utils.factories import make_signer
-from raiden.tests.utils.transport import (
-    ignore_candidates,
-    ignore_close,
-    ignore_sdp,
-    ignore_web_rtc_messages,
-)
+from raiden.tests.utils.transport import ignore_candidates, ignore_close, ignore_web_rtc_messages
 
 pytestmark = pytest.mark.asyncio
+
+
+def _dummy_send(*_args: Any) -> None:
+    pass
 
 
 def test_rtc_partner_close() -> None:
     node_address = make_signer().address
 
     web_rtc_manager = WebRTCManager(
-        node_address, ignore_web_rtc_messages, ignore_sdp, ignore_candidates, ignore_close
+        node_address, ignore_web_rtc_messages, _dummy_send, ignore_candidates, ignore_close
     )
 
     partner_address = make_signer().address

--- a/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
+++ b/raiden/tests/unit/network/rtc/test_web_rtc_manager.py
@@ -5,7 +5,7 @@ from raiden.constants import ICEConnectionState
 from raiden.network.transport.matrix.rtc.aiogevent import yield_future
 from raiden.network.transport.matrix.rtc.web_rtc import WebRTCManager
 from raiden.tests.utils.factories import make_signer
-from raiden.tests.utils.transport import ignore_candidates, ignore_close, ignore_web_rtc_messages
+from raiden.tests.utils.transport import ignore_close, ignore_web_rtc_messages
 
 pytestmark = pytest.mark.asyncio
 
@@ -18,7 +18,7 @@ def test_rtc_partner_close() -> None:
     node_address = make_signer().address
 
     web_rtc_manager = WebRTCManager(
-        node_address, ignore_web_rtc_messages, _dummy_send, ignore_candidates, ignore_close
+        node_address, ignore_web_rtc_messages, _dummy_send, ignore_close
     )
 
     partner_address = make_signer().address

--- a/raiden/tests/utils/transport.py
+++ b/raiden/tests/utils/transport.py
@@ -25,7 +25,11 @@ from synapse.handlers.auth import AuthHandler
 
 from raiden.constants import DeviceIDs, Environment
 from raiden.messages.abstract import Message
-from raiden.network.transport.matrix.client import GMatrixClient, MatrixSyncMessages
+from raiden.network.transport.matrix.client import (
+    GMatrixClient,
+    MatrixSyncMessages,
+    ReceivedRaidenMessage,
+)
 from raiden.network.transport.matrix.transport import MatrixTransport, MessagesQueue
 from raiden.settings import MatrixTransportConfig
 from raiden.tests.utils.factories import make_signer
@@ -74,7 +78,7 @@ def ignore_messages(_matrix_messages: MatrixSyncMessages) -> bool:
     return True
 
 
-def ignore_web_rtc_messages(_message_data: str, _partner_address: Address):
+def ignore_web_rtc_messages(_messages: List[ReceivedRaidenMessage]) -> None:
     pass
 
 


### PR DESCRIPTION
This PR does the following:
- move all WebRTC related things from `MatrixTransport` to `WebRTCManager`, where they belong
- make public methods private as appropriate
- remove unneeded code

This results in improved separation between `MatrixTransport` and `WebRTCManager`.