### PR TITLE
drop metadata if displayname is invalid

### DIFF
--- a/raiden/network/pathfinding.py
+++ b/raiden/network/pathfinding.py
@@ -569,12 +569,11 @@ def query_address_metadata(
     if response.status_code != 200:
         raise PFSReturnedError.from_response(response_json)
 
-    dummy_route_metadata = RouteMetadata(
-        [Address(user_address)], {Address(user_address): response_json}
-    )
+    # Creating a RoutMetadata object is only used for validation of the metadata
+    route_metadata = RouteMetadata([Address(user_address)], {Address(user_address): response_json})
     if (
-        dummy_route_metadata.address_metadata is not None
-        and Address(user_address) not in dummy_route_metadata.address_metadata
+        route_metadata.address_metadata is not None
+        and Address(user_address) not in route_metadata.address_metadata
     ):
         raise ServiceRequestFailed(
             """Pathfinding Service returned invalid """

--- a/raiden/tests/integration/network/test_pathfinding.py
+++ b/raiden/tests/integration/network/test_pathfinding.py
@@ -203,7 +203,6 @@ def test_query_user():
     metadata_dict = make_address_metadata(signer)
     matrix_user_id = metadata_dict["user_id"]
     capabilities = metadata_dict["capabilities"]
-    print(capabilities)
     pfs_config = PFSConfig(
         info=PFSInfo(
             url="mock-address",

--- a/raiden/tests/unit/test_pfs_integration.py
+++ b/raiden/tests/unit/test_pfs_integration.py
@@ -65,12 +65,15 @@ def assert_checksum_address_in_url(url):
 
 def make_address_metadata(signer: Signer) -> AddressMetadata:
     user_id = make_user_id(signer.address, "homeserver")
+    cap_dict = capconfig_to_dict(CapabilitiesConfig())
+    caps = CapabilitiesSchema().dump({"capabilities": cap_dict})["capabilities"]
+
     signature_bytes = signer.sign(str(user_id).encode())
     signature_hex = encode_hex(signature_bytes)
 
     return dict(
         user_id=user_id,
-        capabilities=CapabilitiesSchema().dump(capconfig_to_dict(CapabilitiesConfig())),
+        capabilities=caps,
         displayname=signature_hex,
     )
 


### PR DESCRIPTION
## Description
Metadata were only validated upon setting them in a route (RouteState or RouteMetadata). But we also query metadata directly from the PFSes endpoint. We also need to validate the displayname here. 


Fixes: #7197 