### PR TITLE
Fix up some pytest annoyances

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 # pylint: disable=wrong-import-position,redefined-outer-name,unused-wildcard-import,wildcard-import
 # type: ignore
+
 from gevent import monkey
 
 monkey.patch_all(subprocess=False, thread=False)
@@ -14,19 +15,14 @@ aiortc_pyav_stub.install_as_av()
 
 # isort: split
 
+import pkgutil
 import pytest
 
-# Execute these before the raiden imports because rewrites can't work after the
-# module has been imported.
-pytest.register_assert_rewrite("raiden.tests.utils.cli")
-pytest.register_assert_rewrite("raiden.tests.utils.eth_node")
-pytest.register_assert_rewrite("raiden.tests.utils.factories")
-pytest.register_assert_rewrite("raiden.tests.utils.messages")
-pytest.register_assert_rewrite("raiden.tests.utils.network")
-pytest.register_assert_rewrite("raiden.tests.utils.protocol")
-pytest.register_assert_rewrite("raiden.tests.utils.smartcontracts")
-pytest.register_assert_rewrite("raiden.tests.utils.smoketest")
-pytest.register_assert_rewrite("raiden.tests.utils.transfer")
+# Register pytest assert rewriting on all submodules of `raiden/tests/utils`.
+# This is necessary due to our split fixture setup since pytest doesn't detect these
+# imports automatically.
+for module_info in pkgutil.iter_modules(["raiden/tests/utils"]):
+    pytest.register_assert_rewrite(f"raiden.tests.utils.{module_info.name}")
 
 # isort:split
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ exclude = '''
 testpaths = [
     "raiden/tests",
 ]
+addopts = "--no-success-flaky-report"
 timeout_limit_for_setup_and_call = 240
 timeout_limit_teardown = 15
 norecursedirs = [

--- a/raiden/tests/benchmark/_codespeed.py
+++ b/raiden/tests/benchmark/_codespeed.py
@@ -1,8 +1,8 @@
 import json
 import os
+import warnings
 
 import requests
-
 
 try:
     _CODESPEED_USER = os.environ["CODESPEED_USER"]
@@ -11,7 +11,10 @@ try:
 
     _BENCHMARK_HOST = os.environ["BENCHMARK_HOST"]
 except KeyError:
-    print("Codespeed environment variables not available, posting results would fail.")
+    warnings.warn(
+        "Codespeed environment variables not available, posting results would fail.",
+        RuntimeWarning,
+    )
 
 
 def post_result(codespeed_url, commit_id, branch, bench_name, value):


### PR DESCRIPTION
## Description

- Automatically enable assert rewrites in all modules in `raiden.tests.utils`
  Previously a hard-coded list was used, which was just waiting for a
  newly added module to be forgotten
- Don't output the 'flaky' report on success
- Make the `codespeed` warning an actual warning
