### PR TITLE
raiden: proxies: remove contract bytecode checking

### DIFF
--- a/raiden/exceptions.py
+++ b/raiden/exceptions.py
@@ -257,10 +257,6 @@ class UnexpectedChannelState(RaidenRecoverableError):
     """Raised if an operation is attempted on a channel while it is in an unexpected state."""
 
 
-class ContractCodeMismatch(RaidenError):
-    """Raised if the onchain code of the contract differs."""
-
-
 class APIServerPortInUseError(RaidenError):
     """Raised when API server port is already in use"""
 

--- a/raiden/network/proxies/metadata.py
+++ b/raiden/network/proxies/metadata.py
@@ -1,14 +1,6 @@
 from dataclasses import dataclass
 
-from raiden.utils.typing import (
-    ABI,
-    Address,
-    BlockNumber,
-    EVMBytecode,
-    GasMeasurements,
-    Optional,
-    TypeVar,
-)
+from raiden.utils.typing import ABI, Address, BlockNumber, GasMeasurements, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -33,7 +25,6 @@ class SmartContractMetadata:
     address: Address
 
     abi: ABI
-    runtime_bytecode: EVMBytecode
     gas_measurements: GasMeasurements
 
     def __post_init__(self) -> None:

--- a/raiden/network/proxies/monitoring_service.py
+++ b/raiden/network/proxies/monitoring_service.py
@@ -1,5 +1,5 @@
 import structlog
-from eth_utils import decode_hex, is_binary_address, to_canonical_address
+from eth_utils import is_binary_address, to_canonical_address
 
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code_handle_pruned_block
 from raiden.utils.typing import (
@@ -31,9 +31,6 @@ class MonitoringService:
             client=jsonrpc_client,
             address=Address(monitoring_service_address),
             contract_name=CONTRACT_MONITORING_SERVICE,
-            expected_code=decode_hex(
-                contract_manager.get_runtime_hexcode(CONTRACT_MONITORING_SERVICE)
-            ),
             given_block_identifier=block_identifier,
         )
 

--- a/raiden/network/proxies/one_to_n.py
+++ b/raiden/network/proxies/one_to_n.py
@@ -1,5 +1,5 @@
 import structlog
-from eth_utils import decode_hex, is_binary_address
+from eth_utils import is_binary_address
 
 from raiden.network.rpc.client import JSONRPCClient, check_address_has_code_handle_pruned_block
 from raiden.utils.typing import Address, BlockIdentifier, OneToNAddress
@@ -25,7 +25,6 @@ class OneToN:
             client=jsonrpc_client,
             address=Address(one_to_n_address),
             contract_name=CONTRACT_ONE_TO_N,
-            expected_code=decode_hex(contract_manager.get_runtime_hexcode(CONTRACT_ONE_TO_N)),
             given_block_identifier=block_identifier,
         )
 

--- a/raiden/network/proxies/proxy_manager.py
+++ b/raiden/network/proxies/proxy_manager.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from eth_utils import decode_hex, is_binary_address
+from eth_utils import is_binary_address
 from gevent.lock import Semaphore
 
 from raiden.network.proxies.custom_token import CustomToken
@@ -22,7 +22,6 @@ from raiden.utils.typing import (
     BlockNumber,
     ChannelID,
     Dict,
-    EVMBytecode,
     MonitoringServiceAddress,
     OneToNAddress,
     Optional,
@@ -154,13 +153,6 @@ class ProxyManager:
                     deployed_at=self.metadata.token_network_registry_deployed_at,
                     address=Address(address),
                     abi=self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK_REGISTRY),
-                    runtime_bytecode=EVMBytecode(
-                        decode_hex(
-                            self.contract_manager.get_runtime_hexcode(
-                                CONTRACT_TOKEN_NETWORK_REGISTRY
-                            )
-                        )
-                    ),
                     gas_measurements=gas_measurements(self.contract_manager.contracts_version),
                     filters_start_at=self.metadata.filters_start_at,
                 )
@@ -186,11 +178,6 @@ class ProxyManager:
                     deployed_at=None,
                     abi=self.contract_manager.get_contract_abi(CONTRACT_TOKEN_NETWORK),
                     gas_measurements=gas_measurements(self.contract_manager.contracts_version),
-                    runtime_bytecode=EVMBytecode(
-                        decode_hex(
-                            self.contract_manager.get_runtime_hexcode(CONTRACT_TOKEN_NETWORK)
-                        )
-                    ),
                     address=Address(address),
                     token_network_registry_address=None,
                     filters_start_at=self.metadata.filters_start_at,

--- a/raiden/network/proxies/secret_registry.py
+++ b/raiden/network/proxies/secret_registry.py
@@ -2,7 +2,7 @@ from typing import Any, List
 
 import gevent
 import structlog
-from eth_utils import decode_hex, encode_hex, is_binary_address
+from eth_utils import encode_hex, is_binary_address
 from gevent.event import AsyncResult
 from gevent.lock import Semaphore
 
@@ -58,9 +58,6 @@ class SecretRegistry:
             client=jsonrpc_client,
             address=Address(secret_registry_address),
             contract_name=CONTRACT_SECRET_REGISTRY,
-            expected_code=decode_hex(
-                contract_manager.get_runtime_hexcode(CONTRACT_SECRET_REGISTRY)
-            ),
             given_block_identifier=block_identifier,
         )
 

--- a/raiden/network/proxies/service_registry.py
+++ b/raiden/network/proxies/service_registry.py
@@ -2,7 +2,7 @@ from urllib.parse import urlparse
 
 import structlog
 import web3
-from eth_utils import decode_hex, is_binary_address, to_canonical_address
+from eth_utils import is_binary_address, to_canonical_address
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.exceptions import BrokenPreconditionError, RaidenUnrecoverableError
@@ -44,9 +44,6 @@ class ServiceRegistry:
             client=jsonrpc_client,
             address=Address(service_registry_address),
             contract_name=CONTRACT_SERVICE_REGISTRY,
-            expected_code=decode_hex(
-                contract_manager.get_runtime_hexcode(CONTRACT_SERVICE_REGISTRY)
-            ),
             given_block_identifier=block_identifier,
         )
 

--- a/raiden/network/proxies/token.py
+++ b/raiden/network/proxies/token.py
@@ -51,7 +51,6 @@ class Token:
             jsonrpc_client,
             Address(token_address),
             "Token",
-            expected_code=None,
             given_block_identifier=block_identifier,
         )
 

--- a/raiden/network/proxies/token_network.py
+++ b/raiden/network/proxies/token_network.py
@@ -162,7 +162,6 @@ class TokenNetwork:
             client=jsonrpc_client,
             address=Address(metadata.address),
             contract_name=CONTRACT_TOKEN_NETWORK,
-            expected_code=metadata.runtime_bytecode,
             given_block_identifier=block_identifier,
         )
 

--- a/raiden/network/proxies/token_network_registry.py
+++ b/raiden/network/proxies/token_network_registry.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Optional
 
 import structlog
-from eth_utils import decode_hex, to_canonical_address
+from eth_utils import to_canonical_address
 from web3.exceptions import BadFunctionCallOutput
 
 from raiden.constants import BLOCK_ID_LATEST, NULL_ADDRESS_BYTES
@@ -66,7 +66,6 @@ class TokenNetworkRegistry:
             client=rpc_client,
             address=Address(metadata.address),
             contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-            expected_code=metadata.runtime_bytecode,
             given_block_identifier=block_identifier,
         )
 
@@ -303,11 +302,6 @@ class TokenNetworkRegistry:
                     client=self.rpc_client,
                     address=Address(secret_registry_address),
                     contract_name=CONTRACT_SECRET_REGISTRY,
-                    expected_code=decode_hex(
-                        self.proxy_manager.contract_manager.get_runtime_hexcode(
-                            CONTRACT_SECRET_REGISTRY
-                        )
-                    ),
                     given_block_identifier=failed_at_blocknumber,
                 )
 
@@ -428,11 +422,6 @@ class TokenNetworkRegistry:
                 client=self.rpc_client,
                 address=Address(secret_registry_address),
                 contract_name=CONTRACT_SECRET_REGISTRY,
-                expected_code=decode_hex(
-                    self.proxy_manager.contract_manager.get_runtime_hexcode(
-                        CONTRACT_SECRET_REGISTRY
-                    )
-                ),
                 given_block_identifier=failed_at_blocknumber,
             )
 

--- a/raiden/network/proxies/user_deposit.py
+++ b/raiden/network/proxies/user_deposit.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 import structlog
-from eth_utils import decode_hex, is_binary_address, to_canonical_address
+from eth_utils import is_binary_address, to_canonical_address
 from gevent.event import AsyncResult
 from gevent.threading import Lock
 from web3.exceptions import BadFunctionCallOutput
@@ -80,7 +80,6 @@ class UserDeposit:
             client=jsonrpc_client,
             address=Address(user_deposit_address),
             contract_name=CONTRACT_USER_DEPOSIT,
-            expected_code=decode_hex(contract_manager.get_runtime_hexcode(CONTRACT_USER_DEPOSIT)),
             given_block_identifier=block_identifier,
         )
 
@@ -172,16 +171,12 @@ class UserDeposit:
             client=self.client,
             address=Address(monitoring_service_address),
             contract_name=CONTRACT_MONITORING_SERVICE,
-            expected_code=decode_hex(
-                self.contract_manager.get_runtime_hexcode(CONTRACT_MONITORING_SERVICE)
-            ),
             given_block_identifier=given_block_identifier,
         )
         check_address_has_code_handle_pruned_block(
             client=self.client,
             address=Address(one_to_n_address),
             contract_name=CONTRACT_ONE_TO_N,
-            expected_code=decode_hex(self.contract_manager.get_runtime_hexcode(CONTRACT_ONE_TO_N)),
             given_block_identifier=given_block_identifier,
         )
         try:

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -1078,6 +1078,11 @@ class JSONRPCClient:
         """Given a block number, query the chain to get its corresponding block hash"""
         return self.web3.eth.getBlock(block_identifier)
 
+    def sync_nonce(self) -> None:
+        self._available_nonce = discover_next_available_nonce(
+            self.web3, self.eth_node, self.address
+        )
+
     def get_confirmed_blockhash(self) -> BlockHash:
         """Gets the block CONFIRMATION_BLOCKS in the past and returns its block hash"""
         confirmed_block_number = BlockNumber(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -58,7 +58,6 @@ from raiden.constants import (
 )
 from raiden.exceptions import (
     AddressWithoutCode,
-    ContractCodeMismatch,
     EthereumNonceTooLow,
     EthNodeInterfaceError,
     InsufficientEth,
@@ -338,7 +337,6 @@ def check_address_has_code(
     address: Address,
     contract_name: str,
     given_block_identifier: BlockIdentifier,
-    expected_code: bytes = None,
 ) -> None:
     """Checks that the given address contains code.
 
@@ -373,20 +371,12 @@ def check_address_has_code(
             )
         )
 
-    if expected_code is not None and result != expected_code:
-        # The error message is printed to the user from ui/cli.py. Make sure it
-        # is readable.
-        raise ContractCodeMismatch(
-            f"[{contract_name}] Address {to_checksum_address(address)} has wrong code"
-        )
-
 
 def check_address_has_code_handle_pruned_block(
     client: "JSONRPCClient",
     address: Address,
     contract_name: str,
     given_block_identifier: BlockIdentifier,
-    expected_code: bytes = None,
 ) -> None:
     """Checks that the given address contains code.
 
@@ -394,11 +384,9 @@ def check_address_has_code_handle_pruned_block(
     `latest` instead.
     """
     try:
-        check_address_has_code(
-            client, address, contract_name, given_block_identifier, expected_code
-        )
+        check_address_has_code(client, address, contract_name, given_block_identifier)
     except ValueError:
-        check_address_has_code(client, address, contract_name, "latest", expected_code)
+        check_address_has_code(client, address, contract_name, "latest")
 
 
 def get_transaction_data(

--- a/raiden/network/rpc/client.py
+++ b/raiden/network/rpc/client.py
@@ -1078,7 +1078,7 @@ class JSONRPCClient:
         """Given a block number, query the chain to get its corresponding block hash"""
         return self.web3.eth.getBlock(block_identifier)
 
-    def sync_nonce(self) -> None:
+    def _sync_nonce(self) -> None:
         self._available_nonce = discover_next_available_nonce(
             self.web3, self.eth_node, self.address
         )

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -611,6 +611,8 @@ def setup_smoketest(
         stdout_manager = contextlib.redirect_stdout(stdout)  # type: ignore
 
     with stdout_manager, testchain_manager as testchain, matrix_manager as server_urls:
+
+        ethereum_nodes = None
         try:
             raiden_setup = setup_raiden(
                 matrix_server=server_urls[0][0],
@@ -627,7 +629,7 @@ def setup_smoketest(
 
             yield raiden_setup
         finally:
-            if ethereum_nodes:
+            if ethereum_nodes is not None:
                 for node_executor in ethereum_nodes:
                     node = node_executor.process
                     if node is not None:

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -89,8 +89,6 @@ from raiden_contracts.constants import (
     CONTRACT_SERVICE_REGISTRY,
     CONTRACT_TOKEN_NETWORK_REGISTRY,
     CONTRACT_USER_DEPOSIT,
-    LIBRARY_TOKEN_NETWORK_UTILS,
-    LIBRARY_TOKEN_NETWORK_UTILS_LINK_KEY,
     TEST_SETTLE_TIMEOUT_MAX,
     TEST_SETTLE_TIMEOUT_MIN,
 )
@@ -118,10 +116,8 @@ class StepPrinter(Protocol):
         ...
 
 
-def _deploy_contract(
-    deployer: ContractDeployer, name: str, args: list, libs: dict = None
-) -> Address:
-    receipt = deployer.deploy(name, libs=libs, args=args)
+def _deploy_contract(deployer: ContractDeployer, name: str, args: list) -> Address:
+    receipt = deployer.deploy(name, args=args)
     address = receipt["contractAddress"]
     assert address is not None, "must be a valid address"
     return to_canonical_address(address)
@@ -167,6 +163,8 @@ def deploy_smoketest_contracts(
         constructor_parameters=secret_registry_constructor_arguments,
     )
 
+    token_network_registry_address = Address(to_canonical_address(contract_proxy.address))
+
     service_registry_address = _deploy_contract(
         deployer,
         CONTRACT_SERVICE_REGISTRY,
@@ -204,7 +202,7 @@ def deploy_smoketest_contracts(
     # Since the contracts have been deployed without the use of our
     # JSONRPCClient, we need to sync the client's internal nonce so that
     # it reflects the fact that we just sent 7 transactions.
-    client.sync_nonce()
+    client._sync_nonce()
 
     proxy_manager = ProxyManager(
         rpc_client=client,

--- a/raiden/tests/utils/smoketest.py
+++ b/raiden/tests/utils/smoketest.py
@@ -150,20 +150,16 @@ def deploy_smoketest_contracts(
     )
     secret_registry_address = _deploy_contract(deployer, CONTRACT_SECRET_REGISTRY, [])
 
-    secret_registry_constructor_arguments = (
-        to_checksum_address(secret_registry_address),
-        TEST_SETTLE_TIMEOUT_MIN,
-        TEST_SETTLE_TIMEOUT_MAX,
-        UINT256_MAX,
+    token_network_registry_address = _deploy_contract(
+        deployer,
+        CONTRACT_TOKEN_NETWORK_REGISTRY,
+        [
+            to_checksum_address(secret_registry_address),
+            TEST_SETTLE_TIMEOUT_MIN,
+            TEST_SETTLE_TIMEOUT_MAX,
+            UINT256_MAX,
+        ],
     )
-
-    contract_proxy, _ = client.deploy_single_contract(
-        contract_name=CONTRACT_TOKEN_NETWORK_REGISTRY,
-        contract=contract_manager.get_contract(CONTRACT_TOKEN_NETWORK_REGISTRY),
-        constructor_parameters=secret_registry_constructor_arguments,
-    )
-
-    token_network_registry_address = Address(to_canonical_address(contract_proxy.address))
 
     service_registry_address = _deploy_contract(
         deployer,

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -32,7 +32,6 @@ from raiden.exceptions import (
     AddressWithoutCode,
     APIServerPortInUseError,
     ConfigurationError,
-    ContractCodeMismatch,
     EthereumNonceTooLow,
     EthNodeInterfaceError,
     RaidenUnrecoverableError,
@@ -763,13 +762,6 @@ def _run(ctx: Context, **kwargs: Any) -> None:
     except ConfigurationError as e:
         click.secho(str(e), fg="red")
         sys.exit(ReturnCode.RAIDEN_CONFIGURATION_ERROR)
-    except ContractCodeMismatch as e:
-        click.secho(
-            f"{e}. This may happen if Raiden is configured to use an "
-            f"unsupported version of the contracts.",
-            fg="red",
-        )
-        sys.exit(ReturnCode.SMART_CONTRACTS_CONFIGURATION_ERROR)
     except AddressWithoutCode as e:
         click.secho(
             f"{e}. This may happen if an external ERC20 smart contract "


### PR DESCRIPTION
It's not all that useful and it prevents us from working
with split contract code.

See https://github.com/raiden-network/raiden/issues/7203.