### PR TITLE
legacy hash check of incoming message metadata

### DIFF
--- a/raiden/constants.py
+++ b/raiden/constants.py
@@ -85,6 +85,7 @@ class Capabilities(Enum):
     DELIVERY = "Delivery"  # expects and sends Delivery messages
     WEBRTC = "webRTC"  # supports webRTC messaging
     TODEVICE = "toDevice"  # supports sending and receiving toDevice messages on Matrix
+    IMMUTABLE_METADATA = "immutableMetadata"  # leave metadata unchanged, if 0 also prune route
 
 
 class DeviceIDs(Enum):

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -89,7 +89,7 @@ class Metadata:
     # the initiator of a transfer.
     original_data: Optional[Any] = None
     encrypted_secret: Optional[EncryptedSecret] = None
-    _hash: Optional[MetadataHash] = None
+    _legacy_hash: bool = False
 
     class Meta:
         """
@@ -103,8 +103,8 @@ class Metadata:
 
     @cached_property
     def hash(self) -> MetadataHash:
-        if self._hash is not None:
-            return self._hash
+        if self._legacy_hash:
+            return hash_metadata_v2_0_0(self)
         return MetadataHash(keccak(self._serialize_canonical()))
 
     @post_load(pass_original=True, pass_many=True)
@@ -127,7 +127,7 @@ class Metadata:
         fields as per the Schema
         """
         dumped_data = data.pop("original_data", None) or data
-        dumped_data.pop("_hash", None)
+        dumped_data.pop("_legacy_hash", None)
         return dumped_data
 
     def __repr__(self) -> str:

--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -430,7 +430,10 @@ class LockedTransferBase(EnvelopeMessage):
     ) -> Dict[str, Any]:
 
         metadata = data["metadata"]
-        expected_signer = original_data["peer_address"]
+        expected_signer = original_data.get("peer_address", None)
+        if expected_signer is None:
+            return data
+
         balance_hash = hash_balance_data(
             data["transferred_amount"], data["locked_amount"], data["locksroot"]
         )

--- a/raiden/network/transport/matrix/utils.py
+++ b/raiden/network/transport/matrix/utils.py
@@ -563,7 +563,7 @@ def validate_and_parse_message(data: Any, peer_address: Address) -> List[Message
         if not line:
             continue
         try:
-            message = cached_deserialize(line)
+            message = cached_deserialize(line, peer_address)
         except SerializationError as ex:
             log.warning(
                 "Not a valid Message",

--- a/raiden/settings.py
+++ b/raiden/settings.py
@@ -135,6 +135,7 @@ class CapabilitiesConfig:
     delivery: bool = True
     web_rtc: bool = False
     to_device: bool = True
+    immutable_metadata: bool = True
 
 
 @dataclass

--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -81,7 +81,7 @@ from raiden.utils.typing import (
     WithdrawAmount,
 )
 
-MESSAGE_ENVELOPE_KEY = "message_data"
+MESSAGE_DATA_KEY = "message_data"
 
 
 class IntegerToStringField(marshmallow.fields.Integer):
@@ -332,8 +332,8 @@ class BaseSchema(marshmallow.Schema):
     @pre_load()
     # pylint: disable=W0613,R0201
     def remove_envelope(self, data: Dict[str, Any], many: bool, **kwargs: Any) -> Dict[str, Any]:
-        if MESSAGE_ENVELOPE_KEY in data:
-            return data[MESSAGE_ENVELOPE_KEY]
+        if MESSAGE_DATA_KEY in data:
+            return data[MESSAGE_DATA_KEY]
         return data
 
     @post_dump(pass_original=True)

--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable
 
 import marshmallow
 from eth_utils import to_bytes, to_canonical_address, to_hex
-from marshmallow import EXCLUDE, Schema, SchemaOpts, post_dump
+from marshmallow import EXCLUDE, Schema, SchemaOpts, post_dump, pre_load
 from marshmallow_dataclass import class_schema
 from marshmallow_polyfield import PolyField
 
@@ -55,6 +55,7 @@ from raiden.utils.typing import (
     LockedAmount,
     Locksroot,
     MessageID,
+    MetadataHash,
     MonitoringServiceAddress,
     Nonce,
     OneToNAddress,
@@ -79,6 +80,8 @@ from raiden.utils.typing import (
     UserDepositAddress,
     WithdrawAmount,
 )
+
+MESSAGE_ENVELOPE_KEY = "message_data"
 
 
 class IntegerToStringField(marshmallow.fields.Integer):
@@ -257,6 +260,7 @@ class BaseSchema(marshmallow.Schema):
         BalanceHash: BytesField,
         BlockHash: BytesField,
         Locksroot: BytesField,
+        MetadataHash: BytesField,
         Secret: BytesField,
         SecretHash: BytesField,
         Signature: BytesField,
@@ -324,6 +328,13 @@ class BaseSchema(marshmallow.Schema):
         # Other
         Random: PRNGField,
     }
+
+    @pre_load()
+    # pylint: disable=W0613,R0201
+    def remove_envelope(self, data: Dict[str, Any], many: bool, **kwargs: Any) -> Dict[str, Any]:
+        if MESSAGE_ENVELOPE_KEY in data:
+            return data[MESSAGE_ENVELOPE_KEY]
+        return data
 
     @post_dump(pass_original=True)
     # pylint: disable=W0613,R0201

--- a/raiden/storage/serialization/serializer.py
+++ b/raiden/storage/serialization/serializer.py
@@ -13,7 +13,7 @@ from typing import Optional
 from marshmallow import ValidationError
 
 from raiden.exceptions import SerializationError
-from raiden.storage.serialization.schemas import MESSAGE_ENVELOPE_KEY, BaseSchema, class_schema
+from raiden.storage.serialization.schemas import MESSAGE_DATA_KEY, BaseSchema, class_schema
 from raiden.utils.copy import deepcopy
 from raiden.utils.typing import Address, Any, Dict, List, Mapping
 
@@ -178,7 +178,7 @@ class MessageSerializer(SerializationBase):
 
         try:
             envelope = {
-                MESSAGE_ENVELOPE_KEY: decoded_json,
+                MESSAGE_DATA_KEY: decoded_json,
                 "_type": MESSAGE_NAME_TO_QUALIFIED_NAME[msg_type],
             }
             if address is not None:

--- a/raiden/tests/unit/test_serialization.py
+++ b/raiden/tests/unit/test_serialization.py
@@ -388,7 +388,7 @@ def test_metadata_deserialization_without_expected_address():
     # any hash(legacy or current), it will fallback to assume it is the current version
     # how metadata are hashed
     assert deserialized_message_without_expected_address.sender != signer.address
-    assert deserialized_message_without_expected_address.metadata._hash is None
+    assert deserialized_message_without_expected_address.metadata._legacy_hash is False
 
 
 def test_metadata_backwards_compatibility():

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -68,6 +68,7 @@ from raiden.utils.typing import (
     List,
     Locksroot,
     MessageID,
+    MetadataHash,
     MonitoringServiceAddress,
     NamedTuple,
     NodeNetworkStateMap,
@@ -347,6 +348,12 @@ def make_hop_to_channel(channel_state: NettingChannelState = EMPTY) -> HopState:
     return HopState(channel_state.our_state.address, channel_state.identifier)
 
 
+def make_locked_transfer(_hash: Optional[MetadataHash] = None):
+    metadata = create(MetadataProperties(_hash=_hash))
+    locked_transfer = create(LockedTransferProperties(metadata=metadata))
+    return locked_transfer
+
+
 # CONSTANTS
 # In this module constants are in the bottom because we need some of the
 # factories.
@@ -533,13 +540,14 @@ RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(route=[HOP1, HOP2])
 
 @dataclass(frozen=True)
 class MetadataProperties(Properties):
+    _hash: Optional[MetadataHash] = EMPTY
     routes: List[RouteMetadata] = EMPTY
     original_data: Optional[Any] = EMPTY
     TARGET_TYPE = Metadata
 
 
 MetadataProperties.DEFAULTS = MetadataProperties(
-    routes=[RouteMetadata(route=[HOP1, HOP2])], original_data=None
+    _hash=None, routes=[RouteMetadata(route=[HOP1, HOP2])], original_data=None
 )
 
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -68,7 +68,6 @@ from raiden.utils.typing import (
     List,
     Locksroot,
     MessageID,
-    MetadataHash,
     MonitoringServiceAddress,
     NamedTuple,
     NodeNetworkStateMap,
@@ -348,8 +347,8 @@ def make_hop_to_channel(channel_state: NettingChannelState = EMPTY) -> HopState:
     return HopState(channel_state.our_state.address, channel_state.identifier)
 
 
-def make_locked_transfer(_hash: Optional[MetadataHash] = None):
-    metadata = create(MetadataProperties(_hash=_hash))
+def make_locked_transfer(_legacy_hash: Optional[bool] = False):
+    metadata = create(MetadataProperties(_legacy_hash=_legacy_hash))
     locked_transfer = create(LockedTransferProperties(metadata=metadata))
     return locked_transfer
 
@@ -540,14 +539,14 @@ RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(route=[HOP1, HOP2])
 
 @dataclass(frozen=True)
 class MetadataProperties(Properties):
-    _hash: Optional[MetadataHash] = EMPTY
+    _legacy_hash: Optional[bool] = EMPTY
     routes: List[RouteMetadata] = EMPTY
     original_data: Optional[Any] = EMPTY
     TARGET_TYPE = Metadata
 
 
 MetadataProperties.DEFAULTS = MetadataProperties(
-    _hash=None, routes=[RouteMetadata(route=[HOP1, HOP2])], original_data=None
+    _legacy_hash=False, routes=[RouteMetadata(route=[HOP1, HOP2])], original_data=None
 )
 
 

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -4,11 +4,9 @@ from typing import TYPE_CHECKING
 
 from ecies import encrypt
 from eth_hash.auto import keccak
-
 from eth_utils import decode_hex
 
 from raiden.constants import EMPTY_HASH, LOCKSROOT_OF_NO_LOCKS
-
 from raiden.utils.signer import get_public_key
 from raiden.utils.typing import (
     AddressMetadata,

--- a/raiden/utils/capabilities.py
+++ b/raiden/utils/capabilities.py
@@ -31,6 +31,7 @@ def capdict_to_config(capdict: Dict[str, Any]) -> CapabilitiesConfig:
         delivery=capdict.get(Capabilities.DELIVERY.value, True),
         web_rtc=capdict.get(Capabilities.WEBRTC.value, False),
         to_device=capdict.get(Capabilities.TODEVICE.value, False),
+        immutable_metadata=capdict.get(Capabilities.IMMUTABLE_METADATA.value, False),
     )
     for key in capdict.keys():
         if key not in [_.value for _ in Capabilities]:
@@ -45,11 +46,13 @@ def capconfig_to_dict(config: CapabilitiesConfig) -> Dict[str, Any]:
         Capabilities.DELIVERY.value: config.delivery,
         Capabilities.WEBRTC.value: config.web_rtc,
         Capabilities.TODEVICE.value: config.to_device,
+        Capabilities.IMMUTABLE_METADATA.value: config.immutable_metadata,
     }
     other_keys = [
         key
         for key in config.__dict__.keys()
-        if key not in ["receive", "mediate", "delivery", "web_rtc", "to_device"]
+        if key
+        not in ["receive", "mediate", "delivery", "web_rtc", "to_device", "immutable_metadata"]
     ]
     for key in other_keys:
         if key not in [_.value for _ in Capabilities]:

--- a/raiden/utils/signer.py
+++ b/raiden/utils/signer.py
@@ -45,7 +45,7 @@ def recover(
     """eth_recover address from data hash and signature"""
     public_key = get_public_key(data, signature, hasher)
 
-    return public_key.to_canonical_address()
+    return Address(public_key.to_canonical_address())
 
 
 class Signer(ABC):

--- a/raiden/utils/typing.py
+++ b/raiden/utils/typing.py
@@ -185,6 +185,9 @@ EncodedData = NewType("EncodedData", T_EncodedData)
 T_WithdrawAmount = int
 WithdrawAmount = NewType("WithdrawAmount", T_WithdrawAmount)
 
+T_MetadataHash = bytes
+MetadataHash = NewType("MetadataHash", T_MetadataHash)
+
 NodeNetworkStateMap = Dict[Address, "NetworkState"]
 
 Host = NewType("Host", str)


### PR DESCRIPTION
This PR introduces backwards compatibility for incoming messages, specifically `LockedTransfer`. `LockedTransfer` contains an attribute `Metadata` which is hashed differently in v2.0.0 than now since the change of forwarding metadata. This is reflected in the Capability `immutableMetadata`. When receiving the message and validating the signature (where the correct metadata hash is needed) it is not trivial to fetch capabilities.

Instead the chosen solution was to check both hashes (beginning with the current solution) and validating the signature upon deserialization. When the correct hash is found, it is stored in an private attribute `Metadata._hash`. 

In order to find the correct hashing algorithm we need the expected signer address which was only available in the transport but not during deserialization. This was fixed by introducing an envelope around the message which will also contain the `_type` to find the Marshmallow schema upon deserialization. 

The envelope is introduced in the MessageSerializer with the schema:

```
{
"_type": <fully qualified class name>
"peer_address": <expected peer address recovered from displayname>
"message_data": <message represented as json string>
}
```

If anything unexpected happens, such as missing envelope or an invalid signature, it will fallback to the old deserialization and the raiden state machine will handle an invalid message as before


This is part of #7242 