### PR TITLE
fix assertion error due to race condition in stop method

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -941,7 +941,11 @@ class MatrixTransport(Runnable):
             call_messages: List of signalling messages
         """
 
+        if self._stop_event.is_set():
+            return
+
         assert self._web_rtc_manager is not None, "must be set"
+
         for received_message in call_messages:
             call_message = received_message.message
             partner_address = received_message.sender


### PR DESCRIPTION
I encountered a flaky test which hit an assertion error in `process_call_messages` where the `web_rtc_manager` was None. 

This is possible though during the call of the transport's `stop()` method which is context switching after the web_rtc_manager was set back to None. Due to the context switch incoming messages can still be processed after the the web rtc manager was set back to None. 

The fix changes the assert to a check agains the stop event, which should always be used to indicate that the transport is not running.

https://app.circleci.com/pipelines/github/raiden-network/raiden/12173/workflows/dee5fe1d-d0d4-4875-aca9-5b2316a5a7e2/jobs/203912