### PR TITLE
.circleci: use CIRCLE_PULL_REQUEST

### DIFF
--- a/.circleci/conditional_skip.sh
+++ b/.circleci/conditional_skip.sh
@@ -14,7 +14,7 @@ if [[ -n ${CIRCLE_TAG} ]]; then
 fi
 
 # shellcheck disable=SC2154
-if [[ -z ${CIRCLE_PR_NUMBER} ]]; then
+if [[ -z ${CIRCLE_PULL_REQUEST} ]]; then
     # Not a PR, also never skip
     echo "Not a PR, not skipping build"
     exit 0


### PR DESCRIPTION
CIRCLE_PR_NUMBER is only available on forked PRs, according to CircleCI
docs.
