### PR TITLE
change encrypted secret format

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -346,7 +346,7 @@ class MessageHandler:
         sender = from_transfer.balance_proof.sender
 
         if message.target == TargetAddress(raiden.address):
-            encrypted_secret = message.metadata.encrypted_secret
+            encrypted_secret = message.metadata.secret
             if encrypted_secret is not None:
                 try:
                     secret = decrypt_secret(encrypted_secret, raiden.rpc_client.privkey)

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -88,7 +88,7 @@ class Metadata:
     # inititally create the Metadata object as part of a message - this is the case when we are
     # the initiator of a transfer.
     original_data: Optional[Any] = None
-    encrypted_secret: Optional[EncryptedSecret] = None
+    secret: Optional[EncryptedSecret] = None
     _legacy_hash: bool = False
 
     class Meta:

--- a/raiden/messages/transfers.py
+++ b/raiden/messages/transfers.py
@@ -387,7 +387,13 @@ class LockedTransferBase(EnvelopeMessage):
             for r in transfer.route_states
         ]
         target_metadata = get_address_metadata(transfer.target, transfer.route_states)
-        encrypted_secret = encrypt_secret(transfer.secret, target_metadata)
+
+        encrypted_secret = encrypt_secret(
+            transfer.secret,
+            target_metadata,
+            event.transfer.lock.amount,
+            event.transfer.payment_identifier,
+        )
 
         # pylint: disable=unexpected-keyword-arg
         return cls(
@@ -407,7 +413,7 @@ class LockedTransferBase(EnvelopeMessage):
             initiator=transfer.initiator,
             signature=EMPTY_SIGNATURE,
             metadata=Metadata(
-                routes=routes, original_data=transfer.metadata, encrypted_secret=encrypted_secret
+                routes=routes, original_data=transfer.metadata, secret=encrypted_secret
             ),
         )
 

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -2,7 +2,6 @@ import gevent
 import pytest
 import requests
 import responses
-from ecies import decrypt
 from eth_keys.exceptions import BadSignature, ValidationError
 from eth_utils import decode_hex, keccak, to_canonical_address
 
@@ -10,7 +9,7 @@ from raiden.api.v1.encoding import CapabilitiesSchema
 from raiden.exceptions import InvalidSignature
 from raiden.network.utils import get_average_http_response_time
 from raiden.settings import CapabilitiesConfig
-from raiden.transfer.utils import encrypt_secret
+from raiden.transfer.utils import decrypt_secret, encrypt_secret
 from raiden.utils.capabilities import capconfig_to_dict, capdict_to_config
 from raiden.utils.keys import privatekey_to_publickey
 from raiden.utils.signer import LocalSigner, Signer, recover
@@ -48,10 +47,10 @@ def test_encrypt_secret():
     signature = signer.sign(message)
 
     encrypted_secret = encrypt_secret(
-        message, {"user_id": UserID(message.decode()), "displayname": signature.hex()}
+        message, {"user_id": UserID(message.decode()), "displayname": signature.hex()}, 0, 0
     )
 
-    assert decrypt(privkey, encrypted_secret) == message
+    assert decrypt_secret(encrypted_secret, privkey) == message
 
 
 def test_recover():

--- a/raiden/utils/logging.py
+++ b/raiden/utils/logging.py
@@ -1,12 +1,16 @@
+from copy import deepcopy
+
 from raiden.utils.typing import Dict
 
 
 def redact_secret(data: Dict) -> Dict:
-    """Modify `data` in-place and replace keys named `secret`."""
+    """Modify `data` and replace keys named `secret`."""
     if not isinstance(data, dict):
         raise ValueError("data must be a dict.")
 
-    stack = [data]
+    # FIXME: assess performance impact of this deepcopy
+    data_copy = deepcopy(data)
+    stack = [data_copy]
 
     while stack:
         current = stack.pop()
@@ -16,4 +20,4 @@ def redact_secret(data: Dict) -> Dict:
         else:
             stack.extend(value for value in current.values() if isinstance(value, dict))
 
-    return data
+    return data_copy


### PR DESCRIPTION
## Comply with the encrypted secret format expected by the Light Client

Fixes: https://github.com/raiden-network/spec/issues/344

This PR fixes names and data being encrypted to carry the unlock secret:
- Instead of just the secret, now a dictionary containing `secret`, `amount` and `payment_identifier` is encrypted
- The metadata field is now called `secret` instead of `encrypted_secret`
- One test has been refactored to include the use of the decryption function.