### PR TITLE
Remove legacy metadata hash support

### DIFF
--- a/raiden/messages/decode.py
+++ b/raiden/messages/decode.py
@@ -42,7 +42,7 @@ def lockedtransfersigned_from_message(message: LockedTransferBase) -> LockedTran
         except ValueError as ex:
             log.warning("Invalid metadata in received route", route=route_metadata, error=str(ex))
 
-    transfer_state = LockedTransferSignedState(
+    return LockedTransferSignedState(
         message_identifier=message.message_identifier,
         payment_identifier=message.payment_identifier,
         token=message.token,
@@ -51,7 +51,5 @@ def lockedtransfersigned_from_message(message: LockedTransferBase) -> LockedTran
         initiator=message.initiator,
         target=message.target,
         route_states=route_states,
-        metadata=message.metadata.original_data,
+        metadata=message.metadata.to_dict(),
     )
-
-    return transfer_state

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -1,14 +1,16 @@
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Union
+from typing import Any
 
 import canonicaljson
-from eth_typing import ChecksumAddress
-from eth_utils import keccak, to_canonical_address, to_checksum_address
+from eth_utils import keccak, to_checksum_address
 from marshmallow import EXCLUDE, post_dump, post_load
 
 from raiden.messages.abstract import cached_property
 from raiden.storage.serialization import serializer
+from raiden.transfer.mediated_transfer.events import SendLockedTransfer
+from raiden.transfer.state import get_address_metadata
+from raiden.transfer.utils import encrypt_secret
 from raiden.utils.typing import (
     Address,
     AddressMetadata,
@@ -66,7 +68,7 @@ class Metadata:
     for mediating nodes.
 
     For mediating / target nodes, the original datastructure as sent out by a previous node
-    is memorized in original_data.
+    is memorized in ``_original_data``.
 
     All other attributes are attributes that our node can use internally.
     If an additional attribute is required (non-`Optional`) this means that our node requires
@@ -75,21 +77,20 @@ class Metadata:
     case that these attributes are lacking.
 
     Note for serialization:
-    If there is `original_data` present in the object, as per the `_post_dump` other attributes
-    on the object (e.g. `routes`) will not get dumped, and thus only the original_data will get
-    persisted, e.g. upon dumping to the WAL!
+    If there is ``_original_data`` present in the object, as per the ``_post_dump`` other
+    attributes on the object (e.g. ``routes``) will not get dumped, and thus only the
+    originally received data will get persisted, e.g. upon dumping to the WAL!
     """
 
     # Providing routes is required for forwarding transfers and as a mediator we don't want to
     # accept transfer where we would have to eventually pay the PFS for a path-request.
     routes: List[RouteMetadata]
-    # `original_data` is the JSON decoded Metadata as received from a node.
+    # `_original_data` is the JSON decoded Metadata as received from a node.
     # The absence of this attribute is implying that we are the ones to
     # inititally create the Metadata object as part of a message - this is the case when we are
     # the initiator of a transfer.
-    original_data: Optional[Any] = None
+    _original_data: Optional[Any] = None
     secret: Optional[EncryptedSecret] = None
-    _legacy_hash: bool = False
 
     class Meta:
         """
@@ -101,17 +102,32 @@ class Metadata:
         unknown = EXCLUDE
         serialize_missing = False
 
+    @classmethod
+    def from_event(cls, event: SendLockedTransfer) -> "Metadata":
+        transfer = event.transfer
+        routes = [
+            RouteMetadata(route=r.route, address_metadata=r.address_to_metadata)
+            for r in transfer.route_states
+        ]
+        target_metadata = get_address_metadata(Address(transfer.target), transfer.route_states)
+        encrypted_secret = encrypt_secret(
+            transfer.secret,
+            target_metadata,
+            event.transfer.lock.amount,
+            event.transfer.payment_identifier,
+        )
+
+        return cls(routes=routes, _original_data=transfer.metadata, secret=encrypted_secret)
+
     @cached_property
     def hash(self) -> MetadataHash:
-        if self._legacy_hash:
-            return hash_metadata_v2_0_0(self)
         return MetadataHash(keccak(self._serialize_canonical()))
 
     @post_load(pass_original=True, pass_many=True)
     def _post_load(  # pylint: disable=no-self-use,unused-argument
         self, data: Dict[str, Any], original_data: Dict[str, Any], many: bool, **kwargs: Any
     ) -> Dict[str, Any]:
-        data["original_data"] = original_data
+        data["_original_data"] = original_data
         return data
 
     @post_dump(pass_many=True)
@@ -119,16 +135,17 @@ class Metadata:
         self, data: Dict[str, Any], many: bool
     ) -> Dict[str, Any]:
         """
-        `original_data` means we received the metadata (Mediator/Target) and read in the data
-        for internal processing, so once we pass them to the next node just dump the data exactly
-        as we received them.
+        If ``_original_data`` are present we received the metadata (we are Mediator/Target) and
+        only deserialize to the Metadata object for internal processing, so once we pass them to
+        the next node just dump the data exactly as we received them.
 
-        Returning `data` means we initially created the Metadata (Initiator), so dump the known
-        fields as per the Schema
+        If no ``_original_data`` are present we are the Initiator and initially created the
+        Metadata, so dump them as per the Schema.
         """
-        dumped_data = data.pop("original_data", None) or data
-        dumped_data.pop("_legacy_hash", None)
-        return dumped_data
+        dumped_data = data.pop("_original_data", None)
+        if dumped_data is not None:
+            return dumped_data
+        return data
 
     def __repr__(self) -> str:
         return f"Metadata: routes: {[repr(route) for route in self.routes]}"
@@ -141,32 +158,3 @@ class Metadata:
     def _serialize_canonical(self) -> bytes:
         data = self.to_dict()
         return canonicaljson.encode_canonical_json(data)
-
-
-def hash_metadata_v2_0_0(metadata: Metadata) -> MetadataHash:
-    legacy_routes = []
-
-    for route_metadata in metadata.routes:
-        route = [
-            to_checksum_address(to_canonical_address(address)) for address in route_metadata.route
-        ]
-        # We add a default value of {} when validating. Normalize this to
-        # no key when signing.
-        canonical_route_dict: Dict[
-            str,
-            Union[
-                List[ChecksumAddress],
-                Dict[ChecksumAddress, AddressMetadata],
-            ],
-        ] = {"route": route}
-        if route_metadata.address_metadata is not None:
-
-            address_metadata = {
-                to_checksum_address(to_canonical_address(address)): metadata
-                for address, metadata in route_metadata.address_metadata.items()
-            }
-            canonical_route_dict["address_metadata"] = address_metadata
-
-        legacy_routes.append(canonical_route_dict)
-
-    return MetadataHash(keccak(canonicaljson.encode_canonical_json({"routes": legacy_routes})))

--- a/raiden/tests/unit/transfer/test_source_routing.py
+++ b/raiden/tests/unit/transfer/test_source_routing.py
@@ -67,8 +67,8 @@ def test_metadata_canonical():
     item_two = ("def", 456)
     first_data = dict(x for x in (item_one, item_two))
     second_data = dict(x for x in (item_two, item_one))
-    first_metadata = factories.create(factories.MetadataProperties(original_data=first_data))
-    second_metadata = factories.create(factories.MetadataProperties(original_data=second_data))
+    first_metadata = factories.create(factories.MetadataProperties(_original_data=first_data))
+    second_metadata = factories.create(factories.MetadataProperties(_original_data=second_data))
     assert first_metadata._serialize_canonical() == second_metadata._serialize_canonical()
 
 

--- a/raiden/tests/utils/factories.py
+++ b/raiden/tests/utils/factories.py
@@ -347,12 +347,6 @@ def make_hop_to_channel(channel_state: NettingChannelState = EMPTY) -> HopState:
     return HopState(channel_state.our_state.address, channel_state.identifier)
 
 
-def make_locked_transfer(_legacy_hash: Optional[bool] = False):
-    metadata = create(MetadataProperties(_legacy_hash=_legacy_hash))
-    locked_transfer = create(LockedTransferProperties(metadata=metadata))
-    return locked_transfer
-
-
 # CONSTANTS
 # In this module constants are in the bottom because we need some of the
 # factories.
@@ -539,14 +533,13 @@ RouteMetadataProperties.DEFAULTS = RouteMetadataProperties(route=[HOP1, HOP2])
 
 @dataclass(frozen=True)
 class MetadataProperties(Properties):
-    _legacy_hash: Optional[bool] = EMPTY
     routes: List[RouteMetadata] = EMPTY
-    original_data: Optional[Any] = EMPTY
+    _original_data: Optional[Any] = EMPTY
     TARGET_TYPE = Metadata
 
 
 MetadataProperties.DEFAULTS = MetadataProperties(
-    _legacy_hash=False, routes=[RouteMetadata(route=[HOP1, HOP2])], original_data=None
+    routes=[RouteMetadata(route=[HOP1, HOP2])], _original_data=None
 )
 
 
@@ -924,9 +917,9 @@ def _(properties, defaults=None) -> LockedTransferSignedState:
     ]
 
     # Since the signed-state transfer is a received transfer, there always
-    # since the original_data dict will get passed to the next hop unmodified
+    # since the _original_data dict will get passed to the next hop unmodified
     original_metadata = Metadata(routes=routes).to_dict()
-    metadata = Metadata(routes=routes, original_data=original_metadata)
+    metadata = Metadata(routes=routes, _original_data=original_metadata)
     params["metadata"] = metadata
 
     # Create the locked-transfer message first in order to generate the balance proof

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -20,6 +20,7 @@ from raiden.utils.typing import (
     Optional,
     PaymentAmount,
     PaymentID,
+    PaymentWithFeeAmount,
     PrivateKey,
     Secret,
     SecretHash,
@@ -69,9 +70,9 @@ def is_valid_secret_reveal(
 
 
 def encrypt_secret(
-    secret: Secret,
+    secret: Optional[Secret],
     target_metadata: Optional[AddressMetadata],
-    amount: PaymentAmount,
+    amount: Union[PaymentAmount, PaymentWithFeeAmount],
     payment_identifier: PaymentID,
 ) -> Optional[EncryptedSecret]:
     if not target_metadata or not secret:


### PR DESCRIPTION
## Description

Since we will re-deploy the contracts for the next release backwards compatibility with 2.0.0 isn't going to be possible anyway.

This just removes the legacy hash support.
The other improvements remain in place.

- envelope handling in deserialization
- immutable metadata

Also the handling of the immutableMetadata (via `_original_data``) is
now completely internal to the `Metadata` dataclass.

Mavbe-Fixes: #7295
