### PR TITLE
verify amount and payment ID from transfer with valid encrypted secret

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -349,7 +349,14 @@ class MessageHandler:
             encrypted_secret = message.metadata.secret
             if encrypted_secret is not None:
                 try:
-                    secret = decrypt_secret(encrypted_secret, raiden.rpc_client.privkey)
+                    secret, amount, payment_identifier = decrypt_secret(
+                        encrypted_secret, raiden.rpc_client.privkey
+                    )
+                    if (
+                        from_transfer.lock.amount < amount
+                        or from_transfer.payment_identifier != payment_identifier
+                    ):
+                        raise InvalidSecret
                     log.info("Using encrypted secret", sender=to_checksum_address(sender))
                     return [
                         ActionInitTarget(

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -50,7 +50,10 @@ def test_encrypt_secret():
         message, {"user_id": UserID(message.decode()), "displayname": signature.hex()}, 0, 0
     )
 
-    assert decrypt_secret(encrypted_secret, privkey) == message
+    decrypted_message, amount, payment_id = decrypt_secret(encrypted_secret, privkey)
+    assert decrypted_message == message
+    assert amount == 0
+    assert payment_id == 0
 
 
 def test_recover():

--- a/raiden/transfer/utils.py
+++ b/raiden/transfer/utils.py
@@ -25,6 +25,7 @@ from raiden.utils.typing import (
     SecretHash,
     Signature,
     TokenAmount,
+    Tuple,
     Union,
 )
 
@@ -94,10 +95,14 @@ def encrypt_secret(
     return encrypted_secret
 
 
-def decrypt_secret(encrypted_secret: EncryptedSecret, private_key: PrivateKey) -> Secret:
+def decrypt_secret(
+    encrypted_secret: EncryptedSecret, private_key: PrivateKey
+) -> Tuple[Secret, PaymentAmount, PaymentID]:
     try:
         secret_dict = json.loads(decrypt(private_key, encrypted_secret).decode())
-        secret = Secret(decode_hex(secret_dict["secret"]))
     except (ValueError, json.JSONDecodeError):
         raise InvalidSecret
-    return secret
+    secret = Secret(decode_hex(secret_dict["secret"]))
+    amount = PaymentAmount(secret_dict["amount"])
+    payment_id = PaymentID(secret_dict["payment_identifier"])
+    return secret, amount, payment_id


### PR DESCRIPTION
## Payment amount and ID must be verified by the target if a valid encrypted secret was sent

With a valid encrypted secret, we skip the verification that would be done on the initiator's side. Those verifications need to be made by the target before the secret is used to unlock the transfer.