### PR TITLE
Add asyncio stack debugging to USR1 signal

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -57,7 +57,7 @@ from raiden.tests.fixtures.variables import *  # noqa: F401,F403
 from raiden.tests.integration.exception import RetryTestError
 from raiden.tests.utils.transport import make_requests_insecure
 from raiden.utils.cli import LogLevelConfigType
-from raiden.utils.debugging import enable_gevent_monitoring_signal
+from raiden.utils.debugging import enable_monitoring_signal
 from raiden.utils.ethereum_clients import VersionSupport, is_supported_client
 
 log = structlog.get_logger()
@@ -171,8 +171,8 @@ def check_parity_version_for_tests(blockchain_type):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def auto_enable_gevent_monitoring_signal():
-    enable_gevent_monitoring_signal()
+def auto_enable_monitoring_signal():
+    enable_monitoring_signal()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/raiden/ui/cli.py
+++ b/raiden/ui/cli.py
@@ -67,7 +67,7 @@ from raiden.utils.cli import (
     option,
     option_group,
 )
-from raiden.utils.debugging import IDLE, enable_gevent_monitoring_signal
+from raiden.utils.debugging import IDLE, enable_monitoring_signal
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.system import get_system_spec
 from raiden.utils.typing import MYPY_ANNOTATION, ChainID
@@ -596,7 +596,7 @@ def _run(ctx: Context, **kwargs: Any) -> None:
             set_by = source.name.title() if source else None
             log.debug("Using config file", config_file=kwargs["config_file"], set_by=set_by)
 
-        enable_gevent_monitoring_signal()
+        enable_monitoring_signal()
 
         if ctx.invoked_subcommand is not None:
             return

--- a/raiden/utils/debugging.py
+++ b/raiden/utils/debugging.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import signal
 import time
@@ -17,10 +18,15 @@ LIBEV_HIGH_PRIORITY = 2
 log = structlog.get_logger(__name__)
 
 
-def enable_gevent_monitoring_signal() -> None:
-    """Install a signal handler for SIGUSR1 that executes gevent.util.print_run_info().
-    This can help evaluating the gevent greenlet tree.
-    See http://www.gevent.org/monitoring.html for more information.
+def enable_monitoring_signal() -> None:
+    """Install a signal handler for SIGUSR1 that executes ``gevent.util.print_run_info()`` as well
+    as ``task.print_stack()`` for all asyncio tasks.
+    This can help evaluating the gevent greenlet tree and the asyncio stack, which can be useful
+    when debugging potential deadlocks.
+    See
+    - http://www.gevent.org/monitoring.html
+    - https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.print_stack
+    for more information.
 
     Usage:
         pytest [...]
@@ -30,12 +36,23 @@ def enable_gevent_monitoring_signal() -> None:
 
     def on_signal(signalnum: Any, stack_frame: Any) -> None:  # pylint: disable=unused-argument
         gevent.util.print_run_info()
+        debug_asyncio()
 
     if os.name == "nt":
         # SIGUSR1 not supported on Windows
         return
 
     signal.signal(signal.SIGUSR1, on_signal)
+
+
+def debug_asyncio() -> None:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
+    for task in tasks:
+        task.print_stack()
 
 
 def limit_thread_cpu_usage_by_time() -> None:

--- a/raiden/utils/debugging.py
+++ b/raiden/utils/debugging.py
@@ -50,8 +50,7 @@ def debug_asyncio() -> None:
         asyncio.get_running_loop()
     except RuntimeError:
         return
-    tasks = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
-    for task in tasks:
+    for task in asyncio.all_tasks():
         task.print_stack()
 
 


### PR DESCRIPTION
This adds `print_stack()` calls for all current (if any) `asyncio` tasks
to the already existing debugging signal hook listening for `SIGUSR1`.

For reference: https://github.com/raiden-network/raiden/issues/7141#issuecomment-901757801