### PR TITLE
Add serializer to secret encoding

### DIFF
--- a/raiden/message_handler.py
+++ b/raiden/message_handler.py
@@ -42,7 +42,7 @@ from raiden.transfer.state_change import (
     ReceiveWithdrawExpired,
     ReceiveWithdrawRequest,
 )
-from raiden.transfer.utils import decrypt_secret
+from raiden.transfer.utils.secret import decrypt_secret
 from raiden.transfer.views import TransferRole
 from raiden.utils.formatting import to_checksum_address
 from raiden.utils.transfers import random_secret

--- a/raiden/messages/metadata.py
+++ b/raiden/messages/metadata.py
@@ -10,7 +10,7 @@ from raiden.messages.abstract import cached_property
 from raiden.storage.serialization import serializer
 from raiden.transfer.mediated_transfer.events import SendLockedTransfer
 from raiden.transfer.state import get_address_metadata
-from raiden.transfer.utils import encrypt_secret
+from raiden.transfer.utils.secret import encrypt_secret
 from raiden.utils.typing import (
     Address,
     AddressMetadata,

--- a/raiden/storage/serialization/schemas.py
+++ b/raiden/storage/serialization/schemas.py
@@ -232,6 +232,7 @@ class BaseSchemaOpts(SchemaOpts):
         # exclude all optional, not required fields that have value "None"
         # from the dumped dictionary
         self.serialize_missing = getattr(meta, "serialize_missing", True)
+        self.add_class_types = getattr(meta, "add_class_types", True)
 
 
 class BaseSchema(marshmallow.Schema):
@@ -241,6 +242,7 @@ class BaseSchema(marshmallow.Schema):
     class Meta:
         unknown = EXCLUDE
         serialize_missing = True
+        add_class_types = True
 
     TYPE_MAPPING = {
         # Addresses
@@ -341,7 +343,7 @@ class BaseSchema(marshmallow.Schema):
     def __post_dump(self, data: Dict, original_data: Any, many: bool) -> Dict:
         if self.opts.serialize_missing is False:  # type: ignore
             data = self.remove_missing(data)
-        if data:
+        if data and self.opts.add_class_types:  # type: ignore
             data = self.add_class_type(data, original_data)
         return data
 

--- a/raiden/tests/unit/test_utils.py
+++ b/raiden/tests/unit/test_utils.py
@@ -9,7 +9,7 @@ from raiden.api.v1.encoding import CapabilitiesSchema
 from raiden.exceptions import InvalidSignature
 from raiden.network.utils import get_average_http_response_time
 from raiden.settings import CapabilitiesConfig
-from raiden.transfer.utils import decrypt_secret, encrypt_secret
+from raiden.transfer.utils.secret import decrypt_secret, encrypt_secret
 from raiden.utils.capabilities import capconfig_to_dict, capdict_to_config
 from raiden.utils.keys import privatekey_to_publickey
 from raiden.utils.signer import LocalSigner, Signer, recover

--- a/raiden/transfer/utils/__init__.py
+++ b/raiden/transfer/utils/__init__.py
@@ -1,34 +1,20 @@
-import json
 import random
 from random import Random
 from typing import TYPE_CHECKING
 
-from ecies import decrypt, encrypt
 from eth_hash.auto import keccak
-from eth_utils import decode_hex, encode_hex
 
 from raiden.constants import EMPTY_HASH, LOCKSROOT_OF_NO_LOCKS
-from raiden.exceptions import InvalidSecret
-from raiden.utils.signer import get_public_key
 from raiden.utils.typing import (
-    AddressMetadata,
     Any,
     BalanceHash,
-    EncryptedSecret,
     LockedAmount,
     Locksroot,
-    Optional,
-    PaymentAmount,
-    PaymentID,
-    PaymentWithFeeAmount,
-    PrivateKey,
-    Secret,
     SecretHash,
-    Signature,
     TokenAmount,
-    Tuple,
     Union,
 )
+
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -68,42 +54,3 @@ def is_valid_secret_reveal(
     transfer_secrethash: SecretHash,
 ) -> bool:
     return state_change.secrethash == transfer_secrethash
-
-
-def encrypt_secret(
-    secret: Optional[Secret],
-    target_metadata: Optional[AddressMetadata],
-    amount: Union[PaymentAmount, PaymentWithFeeAmount],
-    payment_identifier: PaymentID,
-) -> Optional[EncryptedSecret]:
-    if not target_metadata or not secret:
-        return None
-
-    message = target_metadata["user_id"].encode()
-    signature = Signature(decode_hex(target_metadata["displayname"]))
-
-    public_key = get_public_key(message, signature)
-    encrypted_secret = None
-    if public_key:
-        to_encrypt = {
-            "secret": encode_hex(secret),
-            "amount": amount,
-            "payment_identifier": payment_identifier,
-        }
-        encrypted_secret = EncryptedSecret(
-            encrypt(public_key.to_hex(), json.dumps(to_encrypt).encode())
-        )
-    return encrypted_secret
-
-
-def decrypt_secret(
-    encrypted_secret: EncryptedSecret, private_key: PrivateKey
-) -> Tuple[Secret, PaymentAmount, PaymentID]:
-    try:
-        secret_dict = json.loads(decrypt(private_key, encrypted_secret).decode())
-    except (ValueError, json.JSONDecodeError):
-        raise InvalidSecret
-    secret = Secret(decode_hex(secret_dict["secret"]))
-    amount = PaymentAmount(secret_dict["amount"])
-    payment_id = PaymentID(secret_dict["payment_identifier"])
-    return secret, amount, payment_id

--- a/raiden/transfer/utils/secret.py
+++ b/raiden/transfer/utils/secret.py
@@ -1,0 +1,94 @@
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from json import JSONDecodeError
+
+from ecies import decrypt, encrypt
+from eth_utils import decode_hex
+from marshmallow import ValidationError
+from marshmallow_dataclass import class_schema
+
+from raiden.exceptions import InvalidSecret, SerializationError
+from raiden.storage.serialization.schemas import BaseSchema
+from raiden.storage.serialization.serializer import SerializationBase
+from raiden.utils.signer import get_public_key
+from raiden.utils.typing import (
+    AddressMetadata,
+    EncryptedSecret,
+    Optional,
+    PaymentAmount,
+    PaymentID,
+    PaymentWithFeeAmount,
+    PrivateKey,
+    Secret,
+    Signature,
+    Tuple,
+    Union,
+)
+
+
+@dataclass(frozen=True)
+class _DecryptedSecret:
+    secret: Secret
+    amount: PaymentAmount
+    payment_identifier: PaymentID
+
+    class Meta:
+        add_class_types = False
+
+
+class SecretSerializer(SerializationBase):
+    @staticmethod
+    def serialize(obj: _DecryptedSecret) -> bytes:
+        if not isinstance(obj, _DecryptedSecret):
+            raise SerializationError(f"Can only serialize {_DecryptedSecret.__name__} objects")
+        try:
+            schema = class_schema(_DecryptedSecret, base_schema=BaseSchema)()
+            data = schema.dump(obj)
+            data = json.dumps(data).encode()
+            return data
+        except (AttributeError, TypeError, ValidationError, ValueError, JSONDecodeError) as ex:
+            raise SerializationError(f"Can't serialize: {obj}") from ex
+
+    @staticmethod
+    def deserialize(data: bytes) -> _DecryptedSecret:
+        try:
+            obj = json.loads(data.decode())
+            schema = class_schema(_DecryptedSecret, base_schema=BaseSchema)()
+            return schema.load(deepcopy(obj))
+        except (ValueError, TypeError, ValidationError, JSONDecodeError) as ex:
+            raise SerializationError(f"Can't deserialize: {data!r}") from ex
+
+
+def encrypt_secret(
+    secret: Optional[Secret],
+    target_metadata: Optional[AddressMetadata],
+    amount: Union[PaymentAmount, PaymentWithFeeAmount],
+    payment_identifier: PaymentID,
+) -> Optional[EncryptedSecret]:
+    if not target_metadata or not secret:
+        return None
+
+    message = target_metadata["user_id"].encode()
+    signature = Signature(decode_hex(target_metadata["displayname"]))
+
+    public_key = get_public_key(message, signature)
+    encrypted_secret = None
+    if public_key:
+        decrypted_secret = _DecryptedSecret(
+            secret=secret, amount=PaymentAmount(amount), payment_identifier=payment_identifier
+        )
+        encoded_secret_raw = SecretSerializer.serialize(decrypted_secret)
+        encrypted_secret = EncryptedSecret(encrypt(public_key.to_hex(), encoded_secret_raw))
+    return encrypted_secret
+
+
+def decrypt_secret(
+    encrypted_secret: EncryptedSecret, private_key: PrivateKey
+) -> Tuple[Secret, PaymentAmount, PaymentID]:
+    try:
+        decrypted_secret_raw = decrypt(private_key, encrypted_secret)
+        decrypted_secret = SecretSerializer.deserialize(decrypted_secret_raw)
+    except SerializationError:
+        raise InvalidSecret
+    return decrypted_secret.secret, decrypted_secret.amount, decrypted_secret.payment_identifier


### PR DESCRIPTION
The secret encryption was not compatible with LC nodes because
it was assuming integer values instead of strings.
There was no defensive type-conversion or schema validation in-place.

This commit introduces a SecretSerializer that handles the type
conversions transparently and is built upon our existing
serialization framework `marshmallow`.

Fixes: #7303
