### PR TITLE
Fix `get_max_withdraw_amount` subtracting on-chain withdraws

### DIFF
--- a/raiden/tests/integration/long_running/test_integration_events.py
+++ b/raiden/tests/integration/long_running/test_integration_events.py
@@ -362,23 +362,6 @@ def test_query_events(
         contract_manager=app0.contract_manager,
     )
 
-    closed_events = get_netting_channel_closed_events(
-        proxy_manager=app0.proxy_manager,
-        token_network_address=token_network_address,
-        netting_channel_identifier=channel_id,
-        contract_manager=contract_manager,
-    )
-
-    closed_event = {
-        "event": ChannelEvent.CLOSED,
-        "args": {
-            "channel_identifier": channel_id,
-            "closing_participant": to_checksum_address(app0.address),
-        },
-    }
-    assert must_have_event(closed_events, closed_event)
-    assert must_have_event(all_netting_channel_events, closed_event)
-
     settle_expiration = app0.rpc_client.block_number() + settle_timeout + 5
     app0.proxy_manager.client.wait_until_block(target_block_number=settle_expiration)
 

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -994,8 +994,8 @@ def is_valid_withdraw_request(
         return SuccessOrError("Invalid participant, it must be the partner address")
     elif withdraw_request.sender != channel_state.partner_state.address:
         return SuccessOrError("Invalid sender, withdraw request must be sent by the partner.")
-    elif withdraw_amount <= 0:
-        return SuccessOrError(f"Total withdraw {withdraw_request.total_withdraw} did not increase")
+    elif withdraw_amount < 0:
+        return SuccessOrError(f"Total withdraw {withdraw_request.total_withdraw} decreased")
     elif balance < withdraw_amount:
         return SuccessOrError(
             f"Insufficient balance: {balance}. Requested {withdraw_amount} for withdraw"


### PR DESCRIPTION
In a refactoring (577b00561), the behavior of `get_max_withdraw_amount`
was changed so that on-chain withdraws were subtracted from the
withdraw amount. This change does not reflect
the calculation of the monotonically increasing total-withdraw.
