### PR TITLE
Raise web rtc error if partner address changes

### DIFF
--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -534,7 +534,10 @@ class WebRTCManager(Runnable):
             self.close_connection(partner_address)
 
     def _add_connection(self, partner_address: Address, conn: _RTCConnection) -> None:
-        assert partner_address not in self._address_to_connection, "must not be there already"
+        previous_connection = self._address_to_connection.get(partner_address)
+        assert (
+            previous_connection is None or previous_connection != conn
+        ), f"partner address {to_checksum_address(partner_address)} already has a connection"
         self._address_to_connection[partner_address] = conn
 
     def has_ready_channel(self, partner_address: Address) -> bool:


### PR DESCRIPTION
We have noticed that certain scenarios trigger the inclusion of a second connection to an address, which should not happen.

This PR changes the way we treat this case with two possible outcomes: either it's trying to add the same connection to the same address (minor bug, can be investigated later), or it's trying to add a different connection to that address (then we can't continue and should investigate before the release)