### PR TITLE
Don't ignore exceptions in WebRTCManager

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -492,6 +492,7 @@ class MatrixTransport(Runnable):
             self._send_signaling_message,
             self._stop_event,
         )
+        self._web_rtc_manager.greenlet.link_exception(self.on_error)
 
         assert asyncio.get_event_loop().is_running(), "the loop must be running"
         self.log.debug("Asyncio loop is running", running=asyncio.get_event_loop().is_running())


### PR DESCRIPTION
## Description

The `WebRTCManager` is a `Runnable` subclass. In order for exceptions to properly bubble up those either need to have their greenlets (exception-) linked to the parent Runnable or need to be waited upon.

Otherwise exceptions will be silently ignored causing inconsistent state.

This adds an exception link to the MatrixTransport.
