### PR TITLE
skip pyenv prompt on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ commands:
               echo "export PYENV_VERSION="'"'"${PYENV_VERSION}"'"' >> ${BASH_ENV}
               eval "$(pyenv init --path)"
               echo "$(pyenv init --path)" >> ${BASH_ENV}
-              env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYENV_VERSION}
+              env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install -s ${PYENV_VERSION}
             fi
             python<< parameters.py-version >> --version | cut -d ' ' -f 2 > /tmp/python-version
             echo "Python version: $(cat /tmp/python-version)"


### PR DESCRIPTION
## Skip pyenv install if version already exists

The change prevents this from happening:

```
pyenv: /Users/distiller/.local-MACOS/.pyenv/versions/3.7.9 already exists
continue with installation? (y/N) 

Too long with no output (exceeded 10m0s): context deadline exceeded
```

 The `-s` flag skips the installation of versions that already exist.