### PR TITLE
Block other greenlets creating RTC connections if lock is set

### DIFF
--- a/raiden/network/transport/matrix/rtc/web_rtc.py
+++ b/raiden/network/transport/matrix/rtc/web_rtc.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import time
 from asyncio import CancelledError, Task
+from collections import defaultdict
 from enum import Enum
 
 import gevent
@@ -483,7 +484,7 @@ class _RTCConnection(_TaskHandler):
 
 class WebRTCManager(Runnable):
 
-    LOCKED_ADDRESSES: Dict[Address, Semaphore] = {}
+    LOCKED_ADDRESSES: Dict[Address, Semaphore] = defaultdict(Semaphore)
 
     def __init__(
         self,

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -984,7 +984,9 @@ class MatrixTransport(Runnable):
         return retrier
 
     def _send_with_retry(self, queue: MessagesQueue) -> None:
-        retrier = self._get_retrier(queue.queue_identifier.recipient)
+        recipient = queue.queue_identifier.recipient
+        retrier = self._get_retrier(recipient)
+        self.health_check_web_rtc(recipient)
         retrier.enqueue(queue_identifier=queue.queue_identifier, messages=queue.messages)
 
     def _multicast_services(
@@ -1034,7 +1036,6 @@ class MatrixTransport(Runnable):
             return
 
         assert self._web_rtc_manager is not None, "must be set"
-        self.health_check_web_rtc(receiver_address)
 
         user_ids: Set[UserID] = set()
         if self._web_rtc_manager.has_ready_channel(receiver_address):

--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -986,8 +986,9 @@ class MatrixTransport(Runnable):
     def _send_with_retry(self, queue: MessagesQueue) -> None:
         recipient = queue.queue_identifier.recipient
         retrier = self._get_retrier(recipient)
-        self.health_check_web_rtc(recipient)
         retrier.enqueue(queue_identifier=queue.queue_identifier, messages=queue.messages)
+        if self.started:
+            self.health_check_web_rtc(recipient)
 
     def _multicast_services(
         self,


### PR DESCRIPTION
Quick Summary of the issue: 

RTC connections can be closed due to various reasons (i.e. Timeout of connection attempt, network errors, received hangup messages, received offer with more recent call id). 

Due to a bug in aiortc we need to wait for a connection to be closed until we can create a new one. We fixed that already by waiting on closing the connection and after the connection is successfully closed we remove the connection from `web_rtc_manager.address_to_connection` which is typically serving as a guard before new connections can be created. 

Additionally, we sometimes want to create a new connection after the old one got closed namely in `initialize_web_rtc` and when we received an offer with a newer call id.

Here comes the problem: 

Waiting on the closing task of the RTC connection in the gevent world has to be done via `yield_future`. `yield_future` can yield because it adds a callback to the task where an event is set and then waits on the event. This unfortunately causes a context switch. In a world with lots of hungry greenlets trying to create a new RTC connection triggered by other points in the code, they could, evil as they are, race before the actual greenlet which waited on the close and peacefully wanted to create a new connection.

In order to prevent that we need to explicitly block other greentlets to be able to create a new connection if we want to create a new connection object out of the same greenlet where we are waiting on the close. We will do this by explicitly adding the address to an locked list raising an assertion error if any evil greenlet tries to create a new RTCConnection object. 
The Author of such a greenlet must handle this case beforehand by checking if the address is locked and handling it gracefully.
