### PR TITLE
raiden: allow exceptions to propagate all the way to the top

### DIFF
--- a/raiden/network/transport/matrix/transport.py
+++ b/raiden/network/transport/matrix/transport.py
@@ -570,9 +570,6 @@ class MatrixTransport(Runnable):
             self._stop_event.set()
             gevent.killall(self.greenlets)  # kill children
             raise  # re-raise to keep killed status
-        except Exception:
-            self.stop()  # ensure cleanup and wait on subtasks
-            raise
 
     def stop(self) -> None:
         """Try to gracefully stop the greenlet synchronously

--- a/raiden/raiden_service.py
+++ b/raiden/raiden_service.py
@@ -508,9 +508,6 @@ class RaidenService(Runnable):
             self.stop_event.set()
             gevent.killall([self.alarm.greenlet, self.transport.greenlet])  # kill children
             raise  # re-raise to keep killed status
-        except Exception:
-            self.stop()
-            raise
 
     def stop(self) -> None:
         """Stop the node gracefully. Raise if any stop-time error occurred on any subtask"""

--- a/raiden/ui/runners.py
+++ b/raiden/ui/runners.py
@@ -93,7 +93,9 @@ def run_services(options: Dict[str, Any]) -> None:
         if signal_received:
             print("\r", end="")  # Reset cursor to overwrite a possibly printed "^C"
             log.info("Signal received. Shutting down.", signal=signal_received)
-    finally:
+    except Exception:
+        raise
+    else:
         for task in gevent_tasks:
             task.kill()
 
@@ -104,5 +106,3 @@ def run_services(options: Dict[str, Any]) -> None:
             raiden_service.config.shutdown_timeout,
             raise_error=True,
         )
-
-        raiden_service.stop()


### PR DESCRIPTION
If an unhandled exception occurs (e.g. an assertion error that should
not have happened), don't try to do a clean shutdown but instead just
let the exception propagate upwards, acrosss greenlets where it will be
logged.  This will also cause the node to die, which is what we want.

Calling methods like stop() in the case of an unhandled exception is
dangerous because we might depend on resources which are not
available/functioning anymore.

