### PR TITLE
Drop all inbox messages upon first sync

### DIFF
--- a/raiden/tests/mocked/test_matrix_transport.py
+++ b/raiden/tests/mocked/test_matrix_transport.py
@@ -122,9 +122,9 @@ def mock_matrix(
         transport._stop_event,
     )
     transport._stop_event.clear()
-    # XXX-UAM address_mgr acccess was here
-    # transport._address_mgr.add_userid_for_address(Address(factories.HOP1), USERID1)
+
     transport._client.user_id = USERID0
+    transport._started = True
 
     monkeypatch.setattr(transport._raiden_service, "on_messages", mock_on_messages)
     monkeypatch.setattr(GMatrixClient, "get_user_presence", mock_get_user_presence)


### PR DESCRIPTION
This change will drop all messages when the transport is not started yet. This is especially used for the first sync, clearing the inbox of all messages stored in the server during the node was offline. 
In particular this is needed to drop all signalling messages which were attempted during the node's offline time. Since those are most likely outdated it does not make sense to process them. 
The Raiden protocol does not rely on message delivery guarantee since it retries anyways. Thus we can drop all old messages.  