### PR TITLE
Add license checker github action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,7 +591,7 @@ jobs:
           name: Build macOS Binary
           command: |
             pyinstaller --noconfirm --clean raiden.spec
-            zip -9 --junk-paths dist/archive/raiden-${ARCHIVE_TAG}-macOS-x86_64.zip dist/raiden-${ARCHIVE_TAG}-macOS-x86_64
+            zip -9 --junk-paths dist/archive/raiden-${ARCHIVE_TAG}-macOS-x86_64.zip dist/raiden-${ARCHIVE_TAG}-macOS-x86_64 LICENSE
             echo ${RELEASE_TYPE}/raiden-${ARCHIVE_TAG}-macOS-x86_64.zip > dist/archive/_LATEST-${RELEASE_TYPE}-macOS-x86_64.txt
       - run:
           name: Test if Binary can be launched

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,0 +1,30 @@
+name: Check Licenses
+on:
+  pull_request:
+    paths:
+      - 'requirements/requirements.txt'
+      - 'requirements/requirements.in'
+
+jobs:
+  license-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install dependencies
+        run: |
+          python3 -m venv .venv-raiden
+          source .venv-raiden/bin/activate
+          make install
+          pip install liccheck
+      - name: check versions
+        run: |
+          source .venv-raiden/bin/activate
+          liccheck -r requirements/requirements.txt

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+"chardet" is licensed under the LPGL v2.1 license (https://github.com/chardet/chardet/blob/master/LICENSE).
+It's source code can be found at https://github.com/chardet/chardet - you are free to modify it's source code
+and build a bundled version of the Raiden software (https://github.com/raiden-network/raiden) including the changes.
+
+"mirakuru" is licensed under the LPGL v3.0 license: https://github.com/ClearcodeHQ/mirakuru/blob/main/LICENSE
+It's source code can be found at https://github.com/ClearcodeHQ/mirakuru/ - you are free to modify it's source code
+and build a bundled version of the Raiden software (https://github.com/raiden-network/raiden) including the changes.

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,9 @@ bundle-docker:
 	-(docker rm builder)
 	docker create --name builder pyinstallerbuilder
 	mkdir -p dist/archive
-	docker cp builder:/raiden/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar.gz dist/archive/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar.gz
+	docker cp builder:/raiden/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar dist/archive/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar
+	tar -rf dist/archive/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar LICENSE
+	gzip dist/archive/raiden-$(ARCHIVE_TAG)-linux-$(ARCHITECTURE_TAG).tar
 	docker rm builder
 
 bundle:

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -34,5 +34,5 @@ RUN pyinstaller --noconfirm --clean raiden.spec
 # pack result to have a unique name to get it out of the container later
 RUN export FILE_TAG=${ARCHIVE_TAG:-v$(python setup.py --version)} && \
     cd dist && \
-    tar -cvzf ./raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG}.tar.gz raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG} && \
-    mv raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG}.tar.gz ..
+    tar -cvf ./raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG}.tar raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG} && \
+    mv raiden-${FILE_TAG}-linux-${ARCHITECTURE_TAG}.tar ..

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,35 @@ markers = [
     "asyncio: tests that require an asyncio eventloop",
 ]
 junit_family = "xunit1"
+
+[tool.liccheck]
+authorized_licenses = [
+	"apache software",
+	"public domain",
+	"python software foundation",
+	"apache license 2.0",
+	"mit license",
+	"mozilla public license 2.0 (mpl 2.0)",
+	"zope public license",
+	"zope public",
+	"bsd 3-clause",
+	"isc license (iscl)",
+	"bsd",
+	"3-clause bsd license",
+	"3-clause bsd",
+	"apache 2.0",
+	"mit",
+	"historical permission notice and disclaimer (hpnd)",
+]
+unauthorized_licenses = [
+	"gnu lesser general public license v3 or later (lgplv3+)",
+	"gnu library or lesser general public license (lgpl)",
+	"gnu general public license v2 (gplv2)",
+	"gpl v3"
+]
+[tool.liccheck.authorized_packages]
+aiortc-pyav-stub = "0.1"
+graphviz = "0.13"
+marshmallow-dataclass = "8.0"
+chardet = "3.0"
+mirakuru = "2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ markers = [
 junit_family = "xunit1"
 
 [tool.liccheck]
+# This are license strings that will get matched
+# with the package's metadata exactly (case-insensitive).
+# The values of the metadata are not standardized and can be set by
+# the package maintainers.
+# Thus, if a new dependency is added that falls under a license that already exists here,
+# but represents a slightly different version-string, this string can be safely added here.
 authorized_licenses = [
 	"apache software",
 	"public domain",
@@ -53,13 +59,21 @@ authorized_licenses = [
 	"mit",
 	"historical permission notice and disclaimer (hpnd)",
 ]
+
 unauthorized_licenses = [
 	"gnu lesser general public license v3 or later (lgplv3+)",
 	"gnu library or lesser general public license (lgpl)",
 	"gnu general public license v2 (gplv2)",
 	"gpl v3"
 ]
+
 [tool.liccheck.authorized_packages]
+#If a new dependency is added that falls under a LPGL license, the dependency has to be addded to the authorized_packages manually.
+#Additionally, the following text has to be added (with correct parameters) to the LICENSE file:
+
+#        "<package_name>" is licensed under the LPGL v<LGPL version number> license (<link to packages license file>).
+#        It's source code can be found at <package source code> - you are free to modify it's source code
+#        and build a bundled version of the Raiden software (https://github.com/raiden-network/raiden) including the changes.
 aiortc-pyav-stub = "0.1"
 graphviz = "0.13"
 marshmallow-dataclass = "8.0"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,6 +4,9 @@
 #
 #    'requirements/deps compile' (for details see requirements/README)
 #
+# TODO: remove this in the next PR
+# Comment, just to trigger the license checker
+
 aiohttp==3.7.4.post0
     # via web3
 aioice==0.7.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,8 +4,7 @@
 #
 #    'requirements/deps compile' (for details see requirements/README)
 #
-# TODO: remove this in the next PR
-# Comment, just to trigger the license checker
+#
 
 aiohttp==3.7.4.post0
     # via web3


### PR DESCRIPTION
- Adds `liccheck` based license checker github action
- Specifies some license-metadata strings that are allowed by production dependencies
- Specifies some specific dependencies that should pass the license-checker (checked manually)
- Includes the `LICENSE` file in the bundled version of Raiden due to `LGPL` license restrictions 
