### PR TITLE
raiden: transfer: be a bit flexible when computing expiration block

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,8 @@ commands:
           command: |
             . ${VENV_PATH}/bin/activate
             pip config set global.progress_bar off
-            pip install -U pip wheel pip-tools
+            # Pin pip to 21.2.4, 21.3 is broken, see https://github.com/pypa/pip/issues/10573.
+            pip install -U pip==21.2.4 wheel pip-tools
             pushd requirements
             pip-sync requirements-ci.txt _raiden-dev.txt
             popd

--- a/raiden/transfer/channel.py
+++ b/raiden/transfer/channel.py
@@ -168,9 +168,16 @@ def get_safe_initial_expiration(
     than blockchain.
     """
     if lock_timeout:
-        return BlockExpiration(block_number + lock_timeout)
+        expiration = block_number + lock_timeout
+    else:
+        expiration = block_number + reveal_timeout * 2
 
-    return BlockExpiration(block_number + reveal_timeout * 2)
+    # Other nodes may not see the same block we do, so allow for a difference
+    # of 1 block. A mediator node can fail to use an open channel if the lock
+    # timeout is greater than the settle timeout due to different blocks being
+    # seen between nodes. This delays mediation for at least one block time
+    # and therefore increases payment time.
+    return BlockExpiration(expiration - 1)
 
 
 def get_sender_expiration_threshold(expiration: BlockExpiration) -> BlockExpiration:


### PR DESCRIPTION
Other nodes may not see the same block we do, so allow for a difference
of 1 block. A mediator node can fail to use an open channel if the lock
timeout is greater than the settle timeout due to different blocks being
seen between nodes. This delays mediation for at least one block time
and therefore increases payment time.