### PR TITLE
Add action to build docker images

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'develop'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'develop'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: raiden-network/raiden
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: docker/
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 #
 #   docker build . -t raiden
 
-FROM python:3.7 as builder
+FROM python:3.9 as builder
 
 # use --build-arg RAIDENVERSION=v0.0.3 to build a specific (tagged) version
 ARG REPO=raiden-network/raiden
@@ -29,7 +29,7 @@ WORKDIR /app/raiden
 RUN make install
 
 
-FROM python:3.7-slim as runner
+FROM python:3.9-slim as runner
 
 COPY --from=builder /opt/venv /opt/venv
 


### PR DESCRIPTION


## Description

Fixes: #7410

Add a GH Action worflow to build docker images. This isn't working since docker changed its licensing model.

See https://github.com/docker/metadata-action#basic for docs of the workflow.