### PR TITLE
docs: Update docs for Coruscant release

### DIFF
--- a/docs/installation/quick-start/README.rst
+++ b/docs/installation/quick-start/README.rst
@@ -6,7 +6,7 @@ Overview
 This quick start section will help you install Raiden and run a Raiden node on the Ethereum mainnet using the Raiden Wizard.
 We will walk through the steps to:
 
--  `Get MetaMask`_
+-  `Get MetaMask (optional)`_
 -  `Get an Infura ID`_
 -  `Download and run the Raiden Wizard`_
 
@@ -23,7 +23,7 @@ In order to use the Raiden Wizard and Raiden you'll need:
 
 -  A computer running **Linux** or **macOS**
 -  `MetaMask <https://metamask.io>`__ and an account with at least
-   ``0.13`` ETH
+   ``0.13`` ETH (optional)
 -  An `Infura <https://infura.io>`__ ID
 
 

--- a/docs/installation/quick-start/download-and-run-the-raiden-wizard.inc.rst
+++ b/docs/installation/quick-start/download-and-run-the-raiden-wizard.inc.rst
@@ -30,7 +30,8 @@ The installation steps of the Raiden Wizard will let you:
 
 -  Create a new Ethereum Account (the "Raiden Account") specifically for
    using with the Wizard.
--  Fund this new Raiden Account with ETH.
+-  Fund this new Raiden Account with ETH, either from your MetaMask 
+   account or by buying ETH via fiat money.
 -  Acquire ``RDN`` tokens for using the pathfinding and monitoring
    services.
 -  Acquire ``DAI`` tokens for making payments in the Raiden Network.

--- a/docs/installation/quick-start/get-metamask.inc.rst
+++ b/docs/installation/quick-start/get-metamask.inc.rst
@@ -1,5 +1,8 @@
-Get MetaMask
-############
+Get MetaMask (optional)
+#######################
+
+Instead of using MetaMask you can buy ETH directly in the Raiden Wizard 
+via fiat money.
 
 Install MetaMask
 ================

--- a/docs/other/safe-usage.rst
+++ b/docs/other/safe-usage.rst
@@ -7,7 +7,7 @@ Safe Usage
 .. warning::
 
    Always keep in mind: Despite the fact that
-   Bespin is more mature and reliable than previous releases, it is still a
+   Coruscant is more mature and reliable than previous releases, it is still a
    beta release. Please make sure to follow the below security notes and
    system requirements to avoid increasing the risk of losing funds. Note
    that the loss of tokens could happen even if you follow these

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -73,15 +73,8 @@ Raiden is also available as a PyPi package and can be installed with ``pip insta
 Raspberry Pi
 ~~~~~~~~~~~~
 
-`Download <https://github.com/raiden-network/raiden/releases>`_ the latest :code:`raiden-<version>-linux-armv7l.tar.gz` or :code:`raiden-<version>-linux-aarch64.tar.gz` for the respective Raspberry Pi Model and extract it::
-
-    tar -xvzf  raiden-<version>-linux-*.tar.gz
-
-The resulting binary will work on any Raspberry Pi from Model 2B onwards without any other
-dependencies.
-
-An Ethereum client is required in both cases. The Raiden binary takes the same command line
-arguments as the ``raiden`` script.
+There is no binary for Raspberry Pi at the moment. However, the installation via pip can be used. 
+See below for the installation instructions.
 
 .. _installation_pip:
 

--- a/docs/raiden-api-1/api-tutorial/1-join-a-token-network.inc.rst
+++ b/docs/raiden-api-1/api-tutorial/1-join-a-token-network.inc.rst
@@ -57,6 +57,6 @@ Raiden node.
 .. warning::
 
    Registering a new token is currently only relevant on the testnets. The
-   tokens allowed on the mainnet for the Bespin release are DAI and W-ETH. At
+   tokens allowed on the mainnet for the Coruscant release are DAI and W-ETH. At
    some point in future, you will be able to register new token networks for
    the Ethereum mainnet, too.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -247,7 +247,7 @@ Tokens
 The tokens endpoints are used for registering new tokens and querying information about already registered tokens.
 
 .. note::
-   For the Bespin release two tokens are registered, DAI and WETH.
+   For the Coruscant release two tokens are registered, DAI and WETH.
 
 **Information about Tokens**
 
@@ -341,7 +341,7 @@ The tokens endpoints are used for registering new tokens and querying informatio
 **Register a Token**
 
 .. warning::
-   For the Bespin release it is not be possible to register more than two tokens, due to security reasons in order to minimise possible loss of funds in the case of bugs.
+   For the Coruscant release it is not be possible to register more than two tokens, due to security reasons in order to minimise possible loss of funds in the case of bugs.
    The two token that are registered are DAI and WETH.
 
 .. http:put:: /api/(version)/tokens/(token_address)
@@ -384,7 +384,7 @@ Channels
 The channels endpoints allow you to open channels with other Raiden nodes as well as closing channels, querying them for information and making deposits or withdrawals.
 
 .. warning::
-   The maximum deposits per token and node for the Bespin release are:
+   The maximum deposits per token and node for the Coruscant release are:
 
    **DAI**: The deposit limit is 1000 worth of DAI per channel participant making the maximum amount of DAI 2000 per channel.
 

--- a/docs/the-raiden-web-interface/join-a-token-network.inc.rst
+++ b/docs/the-raiden-web-interface/join-a-token-network.inc.rst
@@ -60,7 +60,7 @@ You are now ready to :ref:`make your first payment <webui_payment>`!
 Registering a new token
 -----------------------
 
-.. warning:: Registering a new token is only relevant on the testnets. The tokens allowed on mainnet for the Bespin release are DAI and W-ETH.
+.. warning:: Registering a new token is only relevant on the testnets. The tokens allowed on mainnet for the Coruscant release are DAI and W-ETH.
 
 
 If you want to join the network for a token and that token is not

--- a/docs/the-raiden-web-interface/payment.inc.rst
+++ b/docs/the-raiden-web-interface/payment.inc.rst
@@ -37,7 +37,7 @@ After selecting a token network with open channels. Click on the
 
 .. note::
 
-   **How does payment channels work?**
+   **How do payment channels work?**
 
    Payment channels enable parties to exchange tokens off-chain without
    involving the blockchain for every transaction.

--- a/docs/using-raiden-on-mainnet/channel-status.inc.rst
+++ b/docs/using-raiden-on-mainnet/channel-status.inc.rst
@@ -22,6 +22,7 @@ This will return the following response object:
    {
        "token_network_address": "0xE5637F0103794C7e05469A9964E4563089a5E6f2",
        "channel_identifier": "0xa24f51685de3effe829f7c2e94b9db8e9e1b17b137da5",
+       "network_state": "unknown",
        "partner_address": "0x61C808D82A3Ac53231750daDc13c777b59310bD9",
        "token_address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
        "balance": "3958",

--- a/docs/using-raiden-on-mainnet/join-a-token-network-1.inc.rst
+++ b/docs/using-raiden-on-mainnet/join-a-token-network-1.inc.rst
@@ -35,6 +35,7 @@ the following response object:
    {
        "token_network_address": "0x3C158a20b47d9613DDb9409099Be186fC272421a",
        "channel_identifier": "99",
+       "network_state": "unknown",
        "partner_address": "0x61C808D82A3Ac53231750daDc13c777b59310bD9",
        "token_address": "0x9aBa529db3FF2D8409A1da4C9eB148879b046700",
        "balance": "1337",

--- a/docs/using-raiden-on-mainnet/whitelisted-tokens-1.inc.rst
+++ b/docs/using-raiden-on-mainnet/whitelisted-tokens-1.inc.rst
@@ -1,7 +1,7 @@
 Get Whitelisted Tokens
 ======================
 
-The Raiden Bespin release puts a certain
+The Raiden Coruscant release puts a certain
 limit on the amount of tokens that can be deposited into a channel. This
 is to minimize potential loss of funds in case of bugs.
 


### PR DESCRIPTION
## Description

See https://github.com/raiden-network/team/issues/972

This PR will provide minor updates to the docs for the Coruscant release. This removes the install instructions for raspberry pi as we don't have working ARM builds at the moment. The Raiden Wizard installation tutorial is updated for the Ramp integration.