### PR TITLE
docs: Update the limits for the v0.40 contract deployment

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -386,9 +386,9 @@ The channels endpoints allow you to open channels with other Raiden nodes as wel
 .. warning::
    The maximum deposits per token and node for the Coruscant release are:
 
-   **DAI**: The deposit limit is 1000 worth of DAI per channel participant making the maximum amount of DAI 2000 per channel.
+   **DAI**: The deposit limit is 5000 worth of DAI per channel participant making the maximum amount of DAI 10000 per channel.
 
-   **WETH**: The deposit limit is 4.683 worth of WETH per channel participant making the maximum amount of WETH 9.366 per channel.
+   **WETH**: The deposit limit is around 1.1905 worth of WETH per channel participant making the maximum amount of around WETH 2.3810 per channel.
 
 
 **Information about Channels**

--- a/docs/using-raiden-on-mainnet/whitelisted-tokens-1.inc.rst
+++ b/docs/using-raiden-on-mainnet/whitelisted-tokens-1.inc.rst
@@ -5,8 +5,8 @@ The Raiden Coruscant release puts a certain
 limit on the amount of tokens that can be deposited into a channel. This
 is to minimize potential loss of funds in case of bugs.
 
--  The global limit per token network is approximately **$1000000**.
--  The limit per channel side is approximately **$1000**.
+-  The global limit per token network is approximately **$5000000**.
+-  The limit per channel side is approximately **$5000**.
 
 .. note::
 


### PR DESCRIPTION
Update the channel limits to reflect the new [contract deployment](https://github.com/raiden-network/raiden-contracts/blob/master/raiden_contracts/data_0.40.0/deployment_mainnet.json)