### PR TITLE
Drop Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ templates:
   parameter-templates: &parameter-templates
     py-version: &py-version-template
       description: "python version to be used in the executor"
-      default: "3.7"
+      default: "3.9"
       type: enum
-      enum: ["3.7", "3.8", "3.9"]
+      enum: ["3.8", "3.9"]
     resource: &resource-type-template
       description: "resource type for underlying VM"
       default: "medium"
@@ -498,7 +498,7 @@ jobs:
   finalize:
     executor:
       name: docker
-      py-version: "3.7"
+      py-version: "3.9"
     steps:
       - run:
           command: "true"
@@ -523,7 +523,7 @@ jobs:
 
     executor:
       name: docker
-      py-version: "3.7"
+      py-version: "3.9"
       resource: << parameters.resource >>
 
     steps:
@@ -572,7 +572,7 @@ jobs:
 
     executor:
       name: macos
-      py-version: "3.7"
+      py-version: "3.9"
 
     steps:
       - attach-and-link:
@@ -608,7 +608,7 @@ jobs:
 
     executor:
       name: docker
-      py-version: "3.7"
+      py-version: "3.9"
 
     steps:
       - add_ssh_keys:
@@ -657,7 +657,7 @@ jobs:
 
     executor:
       name: docker
-      py-version: "3.7"
+      py-version: "3.9"
 
     steps:
       - attach-and-link:
@@ -699,7 +699,7 @@ jobs:
 
     executor:
       name: docker
-      py-version: "3.7"
+      py-version: "3.9"
 
     steps:
       - attach-and-link:
@@ -733,7 +733,7 @@ workflows:
       - prepare-python-linux:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
           requires:
             - prepare-system-linux
 
@@ -745,21 +745,21 @@ workflows:
       - lint:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
           requires:
             - prepare-python-linux-<< matrix.py-version >>
 
       - build-docs:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
           requires:
             - prepare-python-linux-<< matrix.py-version >>
 
       - smoketest:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
               transport-layer: ["matrix"]
               environment-type: ["production", "development"]
               blockchain-type: ["geth", "parity"]
@@ -770,7 +770,7 @@ workflows:
           matrix:
             alias: test
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
               test-type: ["unit", "mocked"]
           requires:
             - lint-<< matrix.py-version >>
@@ -779,7 +779,7 @@ workflows:
           matrix:
             alias: test-fuzz
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
               test-type: ["fuzz"]
           additional-args: "--hypothesis-show-statistics"
           requires:
@@ -796,7 +796,7 @@ workflows:
 
       - scenario-player-integration-test:
           name: scenario-player-integration-test
-          py-version: "3.7"
+          py-version: "3.9"
           requires:
             - smoketest
             - test
@@ -807,7 +807,7 @@ workflows:
           matrix:
             alias: test-integration
             parameters:
-              py-version: ["3.7"]
+              py-version: ["3.9"]
               test-type: ["integration"]
               blockchain-type: ["geth", "parity"]
           resource: "medium+"
@@ -844,14 +844,14 @@ workflows:
             <<: *only-tagged-version-filter
 
       - prepare-python-linux:
-          py-version: '3.7'
+          py-version: '3.9'
           requires:
             - prepare-system-linux
           filters:
             <<: *only-tagged-version-filter
 
       - prepare-python-macos:
-          py-version: '3.7'
+          py-version: '3.9'
           requires:
             - prepare-system-macos
           filters:
@@ -911,7 +911,7 @@ workflows:
       - prepare-python-linux:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
           requires:
           - prepare-system-linux
 
@@ -923,21 +923,21 @@ workflows:
       - lint:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
           requires:
           - prepare-python-linux-<< matrix.py-version >>
 
       - build-docs:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
           requires:
             - prepare-python-linux-<< matrix.py-version >>
 
       - smoketest:
           matrix:
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
               transport-layer: ["matrix"]
               environment-type: ["production", "development"]
               blockchain-type: ["geth", "parity"]
@@ -948,7 +948,7 @@ workflows:
           matrix:
             alias: test
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
               test-type: ["unit", "mocked"]
           requires:
             - lint-<< matrix.py-version >>
@@ -957,7 +957,7 @@ workflows:
           matrix:
             alias: test-fuzz
             parameters:
-              py-version: ["3.7", "3.8", "3.9"]
+              py-version: ["3.8", "3.9"]
               test-type: ["fuzz"]
           additional-args: "--hypothesis-show-statistics"
           requires:
@@ -974,7 +974,7 @@ workflows:
 
       - scenario-player-integration-test:
           name: scenario-player-integration-test
-          py-version: "3.7"
+          py-version: "3.9"
           requires:
             - smoketest
             - test
@@ -985,7 +985,7 @@ workflows:
           matrix:
             alias: test-integration
             parameters:
-              py-version: ["3.7"]
+              py-version: ["3.9"]
               test-type: ["integration"]
               blockchain-type: ["geth", "parity"]
           resource: "medium+"
@@ -1013,15 +1013,15 @@ workflows:
             - checkout
 
       - prepare-python-macos:
-          name: prepare-python-macos-3.7
-          py-version: '3.7'
+          name: prepare-python-macos-3.9
+          py-version: '3.9'
           requires:
             - prepare-system-macos
 
       - build-binary-macos:
           requires:
             - finalize
-            - prepare-python-macos-3.7
+            - prepare-python-macos-3.9
 
       - deploy-digitalocean:
           context: "raiden-py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 #       virtualenvs on first run. See tools/pre-commit/pre-commit-wrapper.py for details.
 
 default_language_version:
-  python: python3.7
+  python: python3.9
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ See [nix.rst](docs/nix.rst).
 
 These are the required external dependencies for development:
 
-- Python >=3.7.
+- Python >=3.8.
 - Ethereum client (Geth recommended).
 - Solidity compiler >=0.4.23.
 - A matrix capable server (Synapse recommended).

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ GITHUB_ACCESS_TOKEN_ARG=--build-arg GITHUB_ACCESS_TOKEN_FRAGMENT=$(GITHUB_ACCESS
 endif
 
 # architecture needs to be asked in docker because docker can be run on remote host to create binary for different architectures
-bundle-docker: ARCHITECTURE_TAG = $(shell docker run --rm python:3.7 uname -m)
+bundle-docker: ARCHITECTURE_TAG = $(shell docker run --rm python:3.9 uname -m)
 bundle-docker: ARCHIVE_TAG ?= v$(shell python setup.py --version)
 bundle-docker:
 	docker build -t pyinstallerbuilder --build-arg ARCHITECTURE_TAG=$(ARCHITECTURE_TAG) --build-arg ARCHIVE_TAG=$(ARCHIVE_TAG) $(GITHUB_ACCESS_TOKEN_ARG) -f docker/build.Dockerfile .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Quicklinks
 
-[![Python 3.7](https://img.shields.io/pypi/pyversions/raiden.svg)](https://raiden-network.readthedocs.io/en/stable/)  [![Chat on Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/raiden-network/raiden?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Python 3.9](https://img.shields.io/pypi/pyversions/raiden.svg)](https://raiden-network.readthedocs.io/en/stable/)  [![Chat on Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/raiden-network/raiden?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 - [Getting Started](#getting-started)
 - [Repositories](#repositories)

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch
+FROM python:3.9-stretch
 
 # install dependencies
 RUN apt-get update

--- a/docs/custom-setups/private_net_tutorial.rst
+++ b/docs/custom-setups/private_net_tutorial.rst
@@ -21,7 +21,7 @@ If ``mkdir`` fails, choose a different name, or move the existing ``priv_chain``
 .. code:: bash
 
  $ cd priv_chain
- $ virtualenv -p python3.7 env
+ $ virtualenv -p python3.9 env
  $ source env/bin/activate
 
 You should now be in the virtual environment, where all Python package installations are separately managed.
@@ -129,8 +129,8 @@ Figure out the value ``CONTRACTS_VERSION``
 .. code:: bash
 
  (env) $ cd raiden
- (env) $ grep 'CONTRACTS_VERSION = ' -r ../env/lib/python3.7/site-packages/raiden_contracts
- ../env/lib/python3.7/site-packages/raiden_contracts/constants.py:CONTRACTS_VERSION = "0.37.0"
+ (env) $ grep 'CONTRACTS_VERSION = ' -r ../env/lib/python3.9/site-packages/raiden_contracts
+ ../env/lib/python3.9/site-packages/raiden_contracts/constants.py:CONTRACTS_VERSION = "0.37.0"
 
 Copy the shown version somewhere.
 

--- a/docs/macos_install_guide.rst
+++ b/docs/macos_install_guide.rst
@@ -41,9 +41,9 @@ The following instructions will guide you from a clean installation of macOS to 
 
     $ sudo pip install virtualenv
 
-#. Create a virtualenv for raiden (requires python3.7)::
+#. Create a virtualenv for raiden (requires python3.8)::
 
-    $ virtualenv --python=python3.7 venv-raiden
+    $ virtualenv --python=python3.8 venv-raiden
 
 #. "Activate" the virtualenv::
 

--- a/docs/overview_and_guide.rst
+++ b/docs/overview_and_guide.rst
@@ -154,7 +154,7 @@ Navigate to the directory::
 
     cd raiden
 
-It's strongly advised to create a virtualenv_ for Raiden (requires python3.7) and install all python dependencies there.
+It's strongly advised to create a virtualenv_ for Raiden (requires python3.8) and install all python dependencies there.
 
 After you have done that you can proceed to install the dependencies::
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
@@ -103,6 +102,6 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=read_requirements("requirements/requirements.txt"),
     tests_require=test_requirements,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points={"console_scripts": ["raiden = raiden.__main__:main"]},
 )


### PR DESCRIPTION
Even debians default version is now higher, so it's safe to drop this.
Also there are the first issues popping up with 3.7, like
typing_extensions problems.

## Description

Fixes: #<issue>

Please, describe what this PR does in detail:
- If it's a bug fix, detail the root cause of the bug and how this PR fixes it.
- If it's a new feature, describe the feature this PR is introducing and design decisions.
- If it's a refactoring, describe why it is necessary. What are its pros and cons in respect to the previous code, and other possible design choices.
