### PR TITLE
chore: Prepare 3.0.1

### DIFF
--- a/.bumpversion_client.cfg
+++ b/.bumpversion_client.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.0.1
 commit = False
 tag = False
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* :release:`3.0.1 <2022-01-13>`
+* :support:`7493` Update ``raiden-contracts`` package.
+
 * :release:`3.0.0 <2021-12-23>`
 * :feature:`7196` Send encrypted secret with the initial LockedTransfer message, obviating the need for SecretRequest and SecretReveal messages. This reduces the time needed to complete a payment.
 * :feature:`7195` Enable Raiden Node communication over WebRTC. This will allow payments to complete faster due to direct communication between peers.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ master_doc = "index"
 project = "Raiden Network"
 author = "Raiden Project"
 
-version_string = "3.0.0"
+version_string = "3.0.1"
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.


### PR DESCRIPTION
## Description

Updates `raiden-contracts` so that it can be used in the services.
