### PR TITLE
add new 'rpc' strategy for gas price parameter

### DIFF
--- a/raiden/utils/cli.py
+++ b/raiden/utils/cli.py
@@ -18,6 +18,7 @@ from click._compat import term_len
 from click.core import ParameterSource, augment_usage_errors  # type: ignore
 from click.formatting import iter_rows, measure_table, wrap_text
 from toml import TomlDecodeError, load
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
 from web3.gas_strategies.time_based import fast_gas_price_strategy
 
 from raiden.constants import ServerListType
@@ -371,10 +372,14 @@ class GasPriceChoiceType(click.Choice):
                 # we assume it is already the correct gas-price-strategies function
                 return value
             gas_price_string = super().convert(value, param, ctx)
-            if gas_price_string == "fast":
-                return faster_gas_price_strategy
-            else:
+            if gas_price_string == "normal":
                 return fast_gas_price_strategy
+            elif gas_price_string == "fast":
+                return faster_gas_price_strategy
+            elif gas_price_string == "rpc":
+                return rpc_gas_price_strategy
+            else:
+                raise ConfigurationError(f"Unknown gas price (strategy): {gas_price_string}")
 
 
 class MatrixServerType(click.Choice):


### PR DESCRIPTION
Extends the `--gas-price` parameter with a new gas strategy that queries the
connected Ethereum RPC node for the current price. This is meant to be used
especially for Arbitrum networks, as the other strategies do not work there. The
gas system works slightly different for such chains.

Furthermore there is no more a default parsing result. This means that the
command-line option still has a default, but the parsing function is strictly
evaluating the passed value.