### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/raiden/utils/datastructures.py
+++ b/raiden/utils/datastructures.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 from itertools import zip_longest
 from typing import Iterable, Tuple
 
@@ -6,9 +6,7 @@ from typing import Iterable, Tuple
 def merge_dict(to_update: dict, other_dict: dict) -> None:
     """merges b into a"""
     for key, value in other_dict.items():
-        has_map = isinstance(value, collections.Mapping) and isinstance(
-            to_update.get(key, None), collections.Mapping
-        )
+        has_map = isinstance(value, Mapping) and isinstance(to_update.get(key, None), Mapping)
 
         if has_map:
             merge_dict(to_update[key], value)


### PR DESCRIPTION
## Description

Import ABC from `collections.abc` for Python 3.10 compatibility. Similar to https://github.com/raiden-network/raiden/pull/6887 where deprecation warning became an error in Python 3.10