### PR TITLE
Replacing Gitter links with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 #### Quicklinks
 
-[![Python 3.9](https://img.shields.io/pypi/pyversions/raiden.svg)](https://raiden-network.readthedocs.io/en/stable/)  [![Chat on Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/raiden-network/raiden?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Python 3.9](https://img.shields.io/pypi/pyversions/raiden.svg)](https://raiden-network.readthedocs.io/en/stable/)  [![Chat on Discord](https://img.shields.io/discord/948623129796825109.svg)](https://discord.com/invite/nSQDQBq5FC)
 
 - [Getting Started](#getting-started)
 - [Repositories](#repositories)
@@ -98,7 +98,7 @@ Distributed under the [MIT License](./LICENSE).
 
 ## Contact
 
-Dev Chat: [Gitter](https://gitter.im/raiden-network/raiden)
+Dev Chat: [Discord](https://discord.com/invite/nSQDQBq5FC)
 
 Twitter: [@raiden_network](https://twitter.com/raiden_network)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Need help?
 ----------
 If you run into problems or discover bugs, you can:
 
-* Ask for help in the `Raiden gitter chat <https://gitter.im/raiden-network/raiden>`_
+* Ask for help in the `Raiden Discord Server <https://discord.com/invite/nSQDQBq5FC>`_
 * Create a `Github issue <https://github.com/raiden-network/raiden/issues/new/choose>`_ for either a bug report or feature request
 
 Disclaimer

--- a/docs/installation/quick-start/README.rst
+++ b/docs/installation/quick-start/README.rst
@@ -38,8 +38,8 @@ Need help?
 
 If you run into problems or discover bugs, you can:
 
--  Ask for help in the `Raiden gitter
-   chat <https://gitter.im/raiden-network/raiden>`__
+-  Ask for help in the `Raiden Discord
+   Server <https://discord.com/invite/nSQDQBq5FC>`__
 -  Create a `GitHub
    issue <https://github.com/raiden-network/raiden/issues/new/choose>`__
    for either a bug report or feature request

--- a/docs/other/known-issues.rst
+++ b/docs/other/known-issues.rst
@@ -50,4 +50,4 @@ two options:
   :ref:`start over <running_raiden>`.
   This should be true for all usage on testnet and in cases where your channel balances
   are very low on mainnet. Don't hesitate to
-  `ask for help <https://gitter.im/raiden-network/raiden>`__!
+  `ask for help <https://discord.com/invite/nSQDQBq5FC>`__!


### PR DESCRIPTION
## Description

Raiden now have now moved to Discord, this PR replaces Gitter references with a Discord.