### PR TITLE
Mark tests as flaky

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
           - "flake8-tuple==0.4.1"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.950
     hooks:
       - id: mypy
         entry: tools/pre-commit/pre-commit-wrapper.py mypy

--- a/raiden/log_config.py
+++ b/raiden/log_config.py
@@ -275,7 +275,7 @@ def configure_logging(
                 },
             },
             "handlers": handlers,
-            "loggers": {"": {"handlers": handlers.keys(), "propagate": True}},
+            "loggers": {"": {"handlers": handlers.keys(), "propagate": True}},  # type: ignore
         }
     )
     structlog.configure(

--- a/raiden/storage/wal.py
+++ b/raiden/storage/wal.py
@@ -225,7 +225,7 @@ class WriteAheadLog(Generic[ST]):
 
                 return events
 
-            def latest_state(self) -> ST:
+            def latest_state(self) -> ST2:
                 return self.state
 
             def write_state_change_and_events(

--- a/raiden/tests/integration/long_running/test_settlement.py
+++ b/raiden/tests/integration/long_running/test_settlement.py
@@ -190,6 +190,7 @@ def test_settle_is_automatically_called(
     )
 
 
+@pytest.mark.flaky
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_coop_settle_is_automatically_called(

--- a/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
+++ b/raiden/tests/integration/network/transport/test_matrix_transport_assumptions.py
@@ -77,6 +77,7 @@ def test_assumption_matrix_userid(local_matrix_servers):
     user.get_display_name()
 
 
+@pytest.mark.flaky
 @raise_on_failure
 @pytest.mark.parametrize("number_of_nodes", [2])
 def test_assumption_broadcast_queue_delays_shutdown(raiden_chain):

--- a/raiden/tests/integration/transfer/test_mediatedtransfer.py
+++ b/raiden/tests/integration/transfer/test_mediatedtransfer.py
@@ -763,6 +763,7 @@ def test_mediated_transfer_with_fees(
     assert_balances(case["expected_transferred_amounts"])
 
 
+@pytest.mark.flaky
 @raise_on_failure
 @pytest.mark.parametrize("channels_per_node", [CHAIN])
 @pytest.mark.parametrize("number_of_nodes", [2])

--- a/raiden/utils/profiling/stack.py
+++ b/raiden/utils/profiling/stack.py
@@ -144,6 +144,7 @@ def get_trace_info(frame):
     # This changes /foo/site-packages/baz/bar.py into baz/bar.py
     try:
         base_filename = sys.modules[module_name.split(".", 1)[0]].__file__
+        assert base_filename, "Could not build basename from module name"
         filename = abs_path.split(base_filename.rsplit("/", 2)[0], 1)[-1].lstrip("/")
     except:  # noqa
         filename = abs_path

--- a/raiden/utils/profiling/timer.py
+++ b/raiden/utils/profiling/timer.py
@@ -25,7 +25,7 @@ class Timer:
 
         assert callable(callback), "callback must be callable"
 
-        signal.signal(timer_signal, self.callback)
+        signal.signal(timer_signal, self.callback)  # type: ignore
         signal.setitimer(timer, interval, interval)
 
         self._callback = callback

--- a/tools/startcluster.py
+++ b/tools/startcluster.py
@@ -88,7 +88,7 @@ def shutdown_handler(_signo: Signals, _stackframe: FrameType) -> None:
 
 
 if __name__ == "__main__":
-    signal(SIGTERM, shutdown_handler)
-    signal(SIGINT, shutdown_handler)
+    signal(SIGTERM, shutdown_handler)  # type: ignore
+    signal(SIGINT, shutdown_handler)  # type: ignore
 
     main()


### PR DESCRIPTION
I have collected a list of tests which I noticed were flaky during the
recent weeks. Having the test runner retry them is more efficient and
convenient than rerunning the CI job.